### PR TITLE
修复:网关新增 OpenAI 兼容中继端点,第三方框架不再 404

### DIFF
--- a/src/opensquilla/gateway/app.py
+++ b/src/opensquilla/gateway/app.py
@@ -28,6 +28,7 @@ from opensquilla.gateway.middleware import (
     SecurityHeadersMiddleware,
     UnsafeOriginGuardMiddleware,
 )
+from opensquilla.gateway.openai_compat import openai_compat_routes
 from opensquilla.gateway.origin_guard import (
     extract_http_token,
     forbidden_origin_response,
@@ -690,6 +691,7 @@ def create_gateway_app(
         Route("/api/desktop/shutdown", _same_origin(api_desktop_shutdown), methods=["POST"]),
         Route("/api/usage", api_usage, methods=["GET"]),
         Route("/api/channels/status", api_channels_status, methods=["GET"]),
+        *openai_compat_routes(config),
         Route("/api/channels/logout", _same_origin(api_channels_logout), methods=["POST"]),
         Route("/api/channels/pairings", api_channel_pairings, methods=["GET"]),
         Route(

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -2176,6 +2176,27 @@ class _EnvWithoutConfigVersion(PydanticBaseSettingsSource):
         return values
 
 
+class OpenAICompatConfig(BaseModel):
+    """OpenAI-compatible relay surface for third-party clients.
+
+    ``POST /v1/chat/completions`` and ``GET /v1/models`` let OpenAI-protocol
+    clients (astrbot, one-api, chatbox, ...) drive the configured LLM
+    deployments through the gateway.
+
+    Auth baseline: when ``api_key`` is set, every request must present
+    ``Authorization: Bearer <api_key>``.  When it is empty (default), only
+    loopback peers are accepted — the gateway's default bind scope remains
+    the safety boundary, and binding to a non-loopback address without a
+    key makes the relay refuse remote peers with 403 instead of exposing a
+    credential-free model endpoint.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    enabled: bool = True
+    api_key: str = ""
+
+
 class GatewayConfig(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="OPENSQUILLA_GATEWAY_",
@@ -2233,6 +2254,8 @@ class GatewayConfig(BaseSettings):
     prompt: PromptConfig = Field(default_factory=PromptConfig)
     memory: MemoryConfig = Field(default_factory=MemoryConfig)
     squilla_router: SquillaRouterConfig = Field(default_factory=SquillaRouterConfig)
+    # OpenAI-compatible relay (POST /v1/chat/completions, GET /v1/models).
+    openai_compat: OpenAICompatConfig = Field(default_factory=OpenAICompatConfig)
     agent_token_saving: AgentTokenSavingConfig = Field(default_factory=AgentTokenSavingConfig)
     compaction: CompactionLlmConfig = Field(default_factory=CompactionLlmConfig)
     naming: SessionNamingConfig = Field(default_factory=SessionNamingConfig)

--- a/src/opensquilla/gateway/openai_compat.py
+++ b/src/opensquilla/gateway/openai_compat.py
@@ -1,0 +1,577 @@
+"""OpenAI-compatible relay surface for third-party clients.
+
+Registers ``POST /v1/chat/completions`` and ``GET /v1/models`` on the
+gateway so OpenAI-protocol clients (astrbot, one-api, chatbox, ...) can
+drive the configured LLM deployments instead of getting a 404 on every
+OpenAI-shaped request (issues #978 / #979).
+
+Design (agreed with maintainers):
+
+- **Auth** — an optional Bearer key from ``gateway.openai_compat.api_key``.
+  When configured, every request must present ``Authorization: Bearer
+  <key>``.  When empty (default), only loopback peers are accepted; remote
+  peers get 403 so binding to a non-loopback address cannot expose a
+  credential-free model endpoint.  Browser cross-origin requests are
+  rejected in both modes.
+- **Routing** — the request ``model`` is resolved against the runtime LLM
+  (``llm``) and the Squilla Router tier ladder (``squilla_router.tiers``).
+  Unknown models get an OpenAI-style 404.  An omitted model uses the
+  runtime default model.
+- **Streaming** — ``stream: true`` replies in OpenAI SSE chunk format
+  ending with ``data: [DONE]``; ``stream: false`` (default) returns a
+  single JSON completion.  Request ``tools`` are forwarded and tool calls
+  surface as OpenAI ``tool_calls``.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+import time
+import uuid
+from typing import Any
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+
+from opensquilla.provider.selector import build_provider
+from opensquilla.provider.types import (
+    ChatConfig,
+    ContentBlockImage,
+    ContentBlockText,
+    ContentBlockToolResult,
+    ContentBlockToolUse,
+    DoneEvent,
+    ErrorEvent,
+    Message,
+    TextDeltaEvent,
+    ToolDefinition,
+    ToolInputSchema,
+    ToolUseDeltaEvent,
+    ToolUseEndEvent,
+    ToolUseStartEvent,
+)
+
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+_OPENAI_SCHEMA_KEYS = ("type", "properties", "required", "additionalProperties")
+_INVALID_REQUEST_ERROR = "invalid_request_error"
+_SERVER_ERROR_TYPE = "server_error"
+
+
+def _openai_error(
+    message: str,
+    error_type: str = _INVALID_REQUEST_ERROR,
+    code: str = "",
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"message": message, "type": error_type}
+    if code:
+        payload["code"] = code
+    return {"error": payload}
+
+
+def _is_loopback(request: Request) -> bool:
+    host = request.client.host if request.client is not None else ""
+    return host in _LOOPBACK_HOSTS
+
+
+def _authorize(request: Request, config: Any) -> tuple[int, str] | None:
+    """Return ``(status_code, error_json)`` when unauthorized, else None."""
+    oc = config.openai_compat
+    key = str(getattr(oc, "api_key", "") or "").strip()
+    if key:
+        auth = request.headers.get("authorization", "")
+        if auth != f"Bearer {key}":
+            return (
+                401,
+                json.dumps(
+                    _openai_error("Invalid API key", "authentication_error", "invalid_api_key")
+                ),
+            )
+        return None
+    # No key configured: loopback is the safety boundary.
+    if not _is_loopback(request):
+        return (
+            403,
+            json.dumps(
+                _openai_error(
+                    "This OpenAI-compatible endpoint requires an API key for remote access "
+                    "(configure gateway.openai_compat.api_key)",
+                    "authentication_error",
+                    "api_key_required",
+                )
+            ),
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Model resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_relay_target(config: Any, model: str | None) -> tuple[str, str, str, str, str] | None:
+    """Resolve ``(provider, model, api_key, base_url, proxy)`` for one request.
+
+    ``model`` is matched against the runtime LLM and the Squilla Router
+    tier ladder.  ``None``/empty model uses the runtime default.  Returns
+    ``None`` when the model is not configured anywhere (caller replies 404).
+    """
+    from opensquilla.gateway.llm_runtime import resolve_llm_runtime_config
+
+    runtime = resolve_llm_runtime_config(config)
+    if not model or model == runtime.model:
+        return runtime.provider, runtime.model, runtime.api_key, runtime.base_url, runtime.proxy
+
+    from opensquilla.provider.deployment import resolve_provider_deployment
+
+    tiers = getattr(config.squilla_router, "tiers", None) or {}
+    for tier in tiers.values():
+        if not isinstance(tier, dict):
+            continue
+        if tier.get("model") != model:
+            continue
+        provider_id = str(tier.get("provider") or runtime.provider)
+        profiles = getattr(config, "llm_profiles", None) or {}
+        if provider_id == runtime.provider and provider_id not in profiles:
+            # The runtime LLM's own credentials are authoritative for its
+            # provider (llm.api_key / api_key_env may not exist as a profile).
+            return runtime.provider, model, runtime.api_key, runtime.base_url, runtime.proxy
+        resolution = resolve_provider_deployment(config, provider_id, model)
+        if resolution.ready and resolution.provider_config is not None:
+            pc = resolution.provider_config
+            return provider_id, model, pc.api_key, pc.base_url, pc.proxy
+        return None
+    return None
+
+
+def _relay_model_ids(config: Any) -> list[str]:
+    """Models the relay can serve: runtime default + tier ladder (dedup)."""
+    from opensquilla.gateway.llm_runtime import resolve_llm_runtime_config
+
+    ids: list[str] = []
+    try:
+        runtime = resolve_llm_runtime_config(config)
+        if runtime.model:
+            ids.append(runtime.model)
+    except Exception:
+        pass
+    tiers = getattr(config.squilla_router, "tiers", None) or {}
+    for tier in tiers.values():
+        if isinstance(tier, dict) and tier.get("model"):
+            model_id = str(tier["model"])
+            if model_id not in ids:
+                ids.append(model_id)
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# Request conversion (OpenAI wire format → internal types)
+# ---------------------------------------------------------------------------
+
+
+def _user_content(content: Any) -> str | list[Any]:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    blocks: list[Any] = []
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        part_type = part.get("type")
+        if part_type == "text":
+            blocks.append(ContentBlockText(text=str(part.get("text") or "")))
+        elif part_type == "image_url":
+            image_url = part.get("image_url") or {}
+            url = str(image_url.get("url") or "")
+            if url.startswith("data:"):
+                media_type = url.split(";", 1)[0].removeprefix("data:")
+                blocks.append(
+                    ContentBlockImage(
+                        source_type="base64",
+                        media_type=media_type or "image/png",
+                        data=url.split(",", 1)[-1],
+                    )
+                )
+            else:
+                blocks.append(
+                    ContentBlockImage(source_type="url", media_type="image/png", data=url)
+                )
+    return blocks
+
+
+def _assistant_content(message: dict[str, Any]) -> str | list[Any]:
+    content = message.get("content")
+    tool_calls = message.get("tool_calls")
+    if isinstance(content, str) and not tool_calls:
+        return content
+    blocks: list[Any] = []
+    if isinstance(content, str) and content:
+        blocks.append(ContentBlockText(text=content))
+    if isinstance(tool_calls, list):
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            fn = call.get("function") or {}
+            try:
+                arguments = json.loads(fn.get("arguments") or "{}")
+            except (json.JSONDecodeError, TypeError):
+                arguments = {}
+            blocks.append(
+                ContentBlockToolUse(
+                    id=str(call.get("id") or f"call_{secrets.token_hex(8)}"),
+                    name=str(fn.get("name") or ""),
+                    input=arguments if isinstance(arguments, dict) else {},
+                )
+            )
+    return blocks
+
+
+def _messages_from_openai(openai_messages: list[Any]) -> tuple[str, list[Message]]:
+    """Convert OpenAI ``messages`` into ``(system_prompt, internal messages)``."""
+    system_parts: list[str] = []
+    internal: list[Message] = []
+    tool_results: list[ContentBlockToolResult] = []
+
+    def flush_tool_results() -> None:
+        nonlocal tool_results
+        if tool_results:
+            internal.append(Message(role="user", content=list(tool_results)))
+            tool_results = []
+
+    for raw in openai_messages:
+        if not isinstance(raw, dict):
+            continue
+        role = str(raw.get("role") or "")
+        content = raw.get("content")
+        if role == "system":
+            if isinstance(content, str):
+                system_parts.append(content)
+            elif isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "text":
+                        system_parts.append(str(part.get("text") or ""))
+            continue
+        if role == "tool":
+            tool_results.append(
+                ContentBlockToolResult(
+                    tool_use_id=str(raw.get("tool_call_id") or ""),
+                    content=_tool_result_content(raw.get("content")),
+                    is_error=False,
+                )
+            )
+            continue
+        # user / assistant — flush any pending tool results first so they
+        # stay in a dedicated message (provider payload builders require
+        # tool results to never coexist with text/image blocks).
+        flush_tool_results()
+        if role == "user":
+            internal.append(Message(role="user", content=_user_content(content)))
+        elif role == "assistant":
+            internal.append(Message(role="assistant", content=_assistant_content(raw)))
+    flush_tool_results()
+    return "\n\n".join(part for part in system_parts if part), internal
+
+
+def _tool_result_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        text_parts = [
+            str(part.get("text") or "")
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        ]
+        if text_parts:
+            return "\n".join(text_parts)
+        return json.dumps(content, ensure_ascii=False)
+    return str(content or "")
+
+
+def _tools_from_openai(tools: Any) -> list[ToolDefinition]:
+    if not isinstance(tools, list):
+        return []
+    definitions: list[ToolDefinition] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        fn = tool.get("function") or {}
+        schema = fn.get("parameters")
+        if not isinstance(schema, dict):
+            schema = {}
+        definitions.append(
+            ToolDefinition(
+                name=str(fn.get("name") or ""),
+                description=str(fn.get("description") or ""),
+                input_schema=ToolInputSchema(
+                    **{key: schema[key] for key in _OPENAI_SCHEMA_KEYS if key in schema}
+                ),
+            )
+        )
+    return [definition for definition in definitions if definition.name]
+
+
+# ---------------------------------------------------------------------------
+# Response conversion (internal events → OpenAI wire format)
+# ---------------------------------------------------------------------------
+
+
+def _completion_id() -> str:
+    return f"chatcmpl-{uuid.uuid4().hex[:24]}"
+
+
+def _map_stop_reason(stop_reason: str) -> str:
+    if stop_reason in ("tool_use", "tool_calls"):
+        return "tool_calls"
+    if stop_reason == "max_tokens":
+        return "length"
+    return "stop"
+
+
+async def _relay_completion(
+    target: tuple[str, str, str, str, str],
+    *,
+    model: str,
+    messages: list[Message],
+    tools: list[ToolDefinition],
+    chat_config: ChatConfig,
+) -> dict[str, Any]:
+    provider = build_provider(*target[:4], proxy=target[4])
+    text_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    done: DoneEvent | None = None
+    async for event in provider.chat(messages, tools=tools or None, config=chat_config):
+        if isinstance(event, TextDeltaEvent):
+            text_parts.append(event.text)
+        elif isinstance(event, ToolUseEndEvent):
+            tool_calls.append(
+                {
+                    "id": event.tool_use_id,
+                    "type": "function",
+                    "function": {
+                        "name": event.tool_name,
+                        "arguments": json.dumps(event.arguments, ensure_ascii=False),
+                    },
+                }
+            )
+        elif isinstance(event, DoneEvent):
+            done = event
+        elif isinstance(event, ErrorEvent):
+            raise _RelayProviderError(event)
+    if done is None:
+        raise _RelayProviderError(
+            ErrorEvent(
+                message="Provider stream ended without a terminal event",
+                code="incomplete_stream",
+            )
+        )
+    content = "".join(text_parts) or None
+    return {
+        "id": _completion_id(),
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": content,
+                    "tool_calls": tool_calls or None,
+                },
+                "finish_reason": _map_stop_reason(done.stop_reason),
+            }
+        ],
+        "usage": {
+            "prompt_tokens": done.input_tokens,
+            "completion_tokens": done.output_tokens,
+            "total_tokens": done.input_tokens + done.output_tokens,
+        },
+    }
+
+
+class _RelayProviderError(Exception):
+    """A provider ErrorEvent observed while relaying a completion."""
+
+    def __init__(self, event: ErrorEvent) -> None:
+        super().__init__(event.message)
+        self.event = event
+
+
+async def _relay_stream(
+    target: tuple[str, str, str, str, str],
+    *,
+    model: str,
+    messages: list[Message],
+    tools: list[ToolDefinition],
+    chat_config: ChatConfig,
+):
+    """Yield OpenAI SSE ``data:`` lines for one streamed completion."""
+    provider = build_provider(*target[:4], proxy=target[4])
+    completion_id = _completion_id()
+    created = int(time.time())
+
+    def chunk(choices: list[dict[str, Any]], *, usage: dict[str, int] | None = None) -> str:
+        payload = {
+            "id": completion_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": model,
+            "choices": choices,
+            "usage": usage,
+        }
+        return f"data: {json.dumps(payload)}\n\n"
+
+    yield chunk([{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}])
+    tool_call_index = 0
+    text_parts: list[str] = []
+    done: DoneEvent | None = None
+    async for event in provider.chat(messages, tools=tools or None, config=chat_config):
+        if isinstance(event, TextDeltaEvent):
+            text_parts.append(event.text)
+            yield chunk([{"index": 0, "delta": {"content": event.text}, "finish_reason": None}])
+        elif isinstance(event, ToolUseStartEvent):
+            tool_call = {
+                "index": tool_call_index,
+                "id": event.tool_use_id,
+                "type": "function",
+                "function": {"name": event.tool_name, "arguments": ""},
+            }
+            yield chunk([{"index": 0, "delta": {"tool_calls": [tool_call]}, "finish_reason": None}])
+        elif isinstance(event, ToolUseDeltaEvent):
+            tool_call = {"index": tool_call_index, "function": {"arguments": event.json_fragment}}
+            yield chunk([{"index": 0, "delta": {"tool_calls": [tool_call]}, "finish_reason": None}])
+        elif isinstance(event, ToolUseEndEvent):
+            tool_call_index += 1
+        elif isinstance(event, DoneEvent):
+            done = event
+        elif isinstance(event, ErrorEvent):
+            error_payload = _openai_error(event.message, _SERVER_ERROR_TYPE, event.code)
+            yield f"data: {json.dumps(error_payload)}\n\n"
+            yield "data: [DONE]\n\n"
+            return
+    finish_reason = _map_stop_reason(done.stop_reason) if done is not None else "stop"
+    usage = (
+        {
+            "prompt_tokens": done.input_tokens,
+            "completion_tokens": done.output_tokens,
+            "total_tokens": done.input_tokens + done.output_tokens,
+        }
+        if done is not None
+        else None
+    )
+    yield chunk([{"index": 0, "delta": {}, "finish_reason": finish_reason}], usage=usage)
+    yield "data: [DONE]\n\n"
+
+
+# ---------------------------------------------------------------------------
+# HTTP handlers
+# ---------------------------------------------------------------------------
+
+
+async def _handle_chat_completions(request: Request, config: Any) -> Response:
+    auth_error = _authorize(request, config)
+    if auth_error is not None:
+        status, payload = auth_error
+        return Response(payload, status_code=status, media_type="application/json")
+    if request.headers.get("origin"):
+        # Browser-mediated cross-origin calls cannot authenticate as an
+        # OpenAI client; keep CSRF off the relay in both auth modes.
+        return JSONResponse(_openai_error("Cross-origin requests are not allowed"), status_code=403)
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(_openai_error("Invalid JSON body"), status_code=400)
+    if not isinstance(body, dict):
+        return JSONResponse(_openai_error("Request body must be a JSON object"), status_code=400)
+
+    model = body.get("model")
+    target = resolve_relay_target(config, model)
+    if target is None:
+        return JSONResponse(
+            _openai_error(
+                f"The model `{model}` does not exist or is not configured",
+                code="model_not_found",
+            ),
+            status_code=404,
+        )
+    model = target[1]
+
+    system, messages = _messages_from_openai(body.get("messages"))
+    if not messages:
+        return JSONResponse(_openai_error("messages must be a non-empty array"), status_code=400)
+    tools = _tools_from_openai(body.get("tools"))
+
+    chat_config = ChatConfig(
+        system=system or None,
+        temperature=body.get("temperature"),
+        max_tokens=int(body.get("max_tokens") or 16384),
+        timeout=float(body.get("timeout") or 120.0),
+    )
+
+    try:
+        if body.get("stream") is True:
+            return StreamingResponse(
+                _relay_stream(
+                    target,
+                    model=model,
+                    messages=messages,
+                    tools=tools,
+                    chat_config=chat_config,
+                ),
+                media_type="text/event-stream",
+                headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+            )
+        result = await _relay_completion(
+            target,
+            model=model,
+            messages=messages,
+            tools=tools,
+            chat_config=chat_config,
+        )
+        return JSONResponse(result)
+    except _RelayProviderError as exc:
+        return JSONResponse(
+            _openai_error(exc.event.message, _SERVER_ERROR_TYPE, exc.event.code),
+            status_code=502,
+        )
+    except Exception as exc:  # noqa: BLE001 - relay must answer with an OpenAI envelope
+        return JSONResponse(
+            _openai_error(f"Provider request failed: {exc}", _SERVER_ERROR_TYPE),
+            status_code=502,
+        )
+
+
+async def _handle_models(request: Request, config: Any) -> Response:
+    auth_error = _authorize(request, config)
+    if auth_error is not None:
+        status, payload = auth_error
+        return Response(payload, status_code=status, media_type="application/json")
+    if request.headers.get("origin"):
+        return JSONResponse(_openai_error("Cross-origin requests are not allowed"), status_code=403)
+    rows = [
+        {"id": model_id, "object": "model", "created": 0, "owned_by": "opensquilla"}
+        for model_id in _relay_model_ids(config)
+    ]
+    return JSONResponse({"object": "list", "data": rows})
+
+
+def openai_compat_routes(config: Any) -> list[Any]:
+    """Return the OpenAI-compatible relay routes for the gateway app.
+
+    Empty when ``gateway.openai_compat.enabled`` is false.
+    """
+    if not getattr(config.openai_compat, "enabled", True):
+        return []
+    from starlette.routing import Route
+
+    async def chat_completions(request: Request) -> Response:
+        return await _handle_chat_completions(request, config)
+
+    async def models(request: Request) -> Response:
+        return await _handle_models(request, config)
+
+    return [
+        Route("/v1/chat/completions", chat_completions, methods=["POST"]),
+        Route("/v1/models", models, methods=["GET"]),
+    ]

--- a/tests/test_gateway/test_openai_compat.py
+++ b/tests/test_gateway/test_openai_compat.py
@@ -1,0 +1,352 @@
+"""OpenAI-compatible relay (issues #978 / #979) — auth, routing, wire format."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from starlette.testclient import TestClient
+
+from opensquilla.gateway.app import create_gateway_app
+from opensquilla.gateway.config import (
+    GatewayConfig,
+    LlmProviderProfile,
+    OpenAICompatConfig,
+    SquillaRouterConfig,
+)
+from opensquilla.provider.types import (
+    DoneEvent,
+    ErrorEvent,
+    TextDeltaEvent,
+    ToolDefinition,
+    ToolUseEndEvent,
+)
+
+
+class _FakeProvider:
+    """Deterministic provider double capturing the relay's call arguments."""
+
+    def __init__(self, events=None) -> None:
+        self._events = events or []
+        self.captured: dict = {}
+
+    async def chat(self, messages, tools=None, config=None):
+        self.captured = {"messages": messages, "tools": tools, "config": config}
+        for event in self._events:
+            yield event
+
+
+def _install_fake_provider(monkeypatch, fake: _FakeProvider) -> None:
+    import opensquilla.gateway.openai_compat as oc
+
+    monkeypatch.setattr(oc, "build_provider", lambda *args, **kwargs: fake)
+
+
+def _app(**config_kwargs) -> TestClient:
+    # Loopback client so the no-key default auth passes; remote-peer tests
+    # pass their own `client=` explicitly.
+    return TestClient(
+        create_gateway_app(GatewayConfig(**config_kwargs)), client=("127.0.0.1", 50000)
+    )
+
+
+@pytest.fixture(autouse=True)
+def _default_model_env(monkeypatch):
+    # Pin the runtime LLM explicitly: GatewayConfig treats an env-set
+    # api_key WITHOUT an explicit provider as legacy openrouter intent and
+    # backfills provider/model, which would break every routing test.
+    monkeypatch.setenv("OPENSQUILLA_LLM_PROVIDER", "tokenrhythm")
+    monkeypatch.setenv("OPENSQUILLA_LLM_MODEL", "deepseek-v4-pro")
+    monkeypatch.setenv("OPENSQUILLA_LLM_API_KEY", "test-key")
+    yield
+
+
+def test_relay_returns_openai_models_list() -> None:
+    with _app() as client:
+        response = client.get("/v1/models")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["object"] == "list"
+    ids = [row["id"] for row in payload["data"]]
+    assert "deepseek-v4-pro" in ids  # runtime default model
+    assert all(row["object"] == "model" for row in payload["data"])
+
+
+def test_relay_disabled_when_configured_off() -> None:
+    with _app(openai_compat=OpenAICompatConfig(enabled=False)) as client:
+        response = client.get("/v1/models")
+    assert response.status_code == 404
+
+
+def test_unknown_model_returns_openai_404() -> None:
+    with _app() as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": "does-not-exist", "messages": [{"role": "user", "content": "hi"}]},
+        )
+    assert response.status_code == 404
+    error = response.json()["error"]
+    assert error["code"] == "model_not_found"
+    assert "does-not-exist" in error["message"]
+
+
+def test_non_loopback_peer_denied_without_key() -> None:
+    with TestClient(create_gateway_app(GatewayConfig()), client=("10.0.0.9", 4321)) as client:
+        response = client.get("/v1/models")
+    assert response.status_code == 403
+    assert "api_key_required" in response.json()["error"]["code"]
+
+
+def test_api_key_enforced_when_configured() -> None:
+    app = create_gateway_app(GatewayConfig(openai_compat=OpenAICompatConfig(api_key="secret-123")))
+    with TestClient(app) as client:
+        assert client.get("/v1/models").status_code == 401
+        assert (
+            client.get("/v1/models", headers={"Authorization": "Bearer wrong"}).status_code == 401
+        )
+        ok = client.get("/v1/models", headers={"Authorization": "Bearer secret-123"})
+        assert ok.status_code == 200
+
+
+def test_api_key_allows_remote_peer() -> None:
+    app = create_gateway_app(GatewayConfig(openai_compat=OpenAICompatConfig(api_key="secret-123")))
+    with TestClient(app, client=("10.0.0.9", 4321)) as client:
+        response = client.get("/v1/models", headers={"Authorization": "Bearer secret-123"})
+    assert response.status_code == 200
+
+
+def test_cross_origin_browser_request_rejected() -> None:
+    with _app() as client:
+        response = client.get("/v1/models", headers={"Origin": "https://evil.example"})
+    assert response.status_code == 403
+
+
+def test_non_streaming_completion_relays_and_converts(monkeypatch) -> None:
+    fake = _FakeProvider(
+        [
+            TextDeltaEvent(text="Hello "),
+            TextDeltaEvent(text="world"),
+            DoneEvent(
+                stop_reason="end_turn",
+                input_tokens=11,
+                output_tokens=2,
+                model="deepseek-v4-pro",
+            ),
+        ]
+    )
+    _install_fake_provider(monkeypatch, fake)
+
+    with _app() as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "deepseek-v4-pro",
+                "messages": [
+                    {"role": "system", "content": "Be terse"},
+                    {"role": "user", "content": "hi"},
+                ],
+            },
+        )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["object"] == "chat.completion"
+    assert payload["model"] == "deepseek-v4-pro"
+    assert payload["choices"][0]["message"]["content"] == "Hello world"
+    assert payload["choices"][0]["finish_reason"] == "stop"
+    assert payload["usage"] == {"prompt_tokens": 11, "completion_tokens": 2, "total_tokens": 13}
+
+    # The relay must have passed the converted internal contract to the provider.
+    assert [m.role for m in fake.captured["messages"]] == ["user"]
+    assert fake.captured["config"].system == "Be terse"
+
+
+def test_streaming_completion_emits_openai_sse(monkeypatch) -> None:
+    fake = _FakeProvider(
+        [
+            TextDeltaEvent(text="part1"),
+            TextDeltaEvent(text="part2"),
+            DoneEvent(
+                stop_reason="end_turn",
+                input_tokens=5,
+                output_tokens=7,
+                model="deepseek-v4-pro",
+            ),
+        ]
+    )
+    _install_fake_provider(monkeypatch, fake)
+
+    with _app() as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "deepseek-v4-pro",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": True,
+            },
+        )
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    lines = [line for line in response.text.splitlines() if line.startswith("data: ")]
+    chunks = [json.loads(line[6:]) for line in lines if line[6:] != "[DONE]"]
+    assert lines[-1] == "data: [DONE]"
+    assert chunks[0]["object"] == "chat.completion.chunk"
+    assert chunks[0]["choices"][0]["delta"] == {"role": "assistant"}
+    deltas = [chunk["choices"][0]["delta"] for chunk in chunks if chunk["choices"][0]["delta"]]
+    assert deltas[1] == {"content": "part1"}
+    assert deltas[2] == {"content": "part2"}
+    assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+
+
+def test_tools_forwarded_and_tool_calls_serialized(monkeypatch) -> None:
+    fake = _FakeProvider(
+        [
+            ToolUseEndEvent(
+                tool_use_id="call_1",
+                tool_name="get_weather",
+                arguments={"city": "Paris"},
+            ),
+            DoneEvent(
+                stop_reason="tool_use",
+                input_tokens=9,
+                output_tokens=3,
+                model="deepseek-v4-pro",
+            ),
+        ]
+    )
+    _install_fake_provider(monkeypatch, fake)
+
+    with _app() as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "deepseek-v4-pro",
+                "messages": [{"role": "user", "content": "weather?"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "description": "Get weather",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                                "required": ["city"],
+                            },
+                        },
+                    }
+                ],
+            },
+        )
+    assert response.status_code == 200
+    payload = response.json()
+    tool_calls = payload["choices"][0]["message"]["tool_calls"]
+    assert tool_calls == [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+        }
+    ]
+    assert payload["choices"][0]["finish_reason"] == "tool_calls"
+
+    tools = fake.captured["tools"]
+    assert isinstance(tools, list) and len(tools) == 1
+    assert isinstance(tools[0], ToolDefinition)
+    assert tools[0].name == "get_weather"
+    assert tools[0].input_schema.properties == {"city": {"type": "string"}}
+
+
+def test_tier_model_routes_to_its_provider(monkeypatch) -> None:
+    captured: dict = {}
+
+    def _spy_provider(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return _FakeProvider(
+            [TextDeltaEvent(text="ok"), DoneEvent(stop_reason="end_turn", model="kimi-k2.7-code")]
+        )
+
+    import opensquilla.gateway.openai_compat as oc
+
+    monkeypatch.setattr(oc, "build_provider", _spy_provider)
+
+    config = GatewayConfig(
+        squilla_router=SquillaRouterConfig(
+            tiers={
+                "c2": {"provider": "tokenrhythm", "model": "kimi-k2.7-code"},
+            }
+        ),
+        llm_profiles={
+            "tokenrhythm": LlmProviderProfile(
+                api_key="sk-tier",
+                base_url="https://tokenrhythm.studio/v1",
+            )
+        },
+    )
+    with TestClient(create_gateway_app(config), client=("127.0.0.1", 50000)) as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "kimi-k2.7-code",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+    assert response.status_code == 200
+    assert captured["args"][0] == "tokenrhythm"
+    assert captured["args"][1] == "kimi-k2.7-code"
+    assert captured["args"][2] == "sk-tier"
+    assert captured["args"][3] == "https://tokenrhythm.studio/v1"
+
+
+def test_cross_provider_tier_falls_back_to_registry_env_key(monkeypatch) -> None:
+    """A tier naming a non-runtime provider resolves via the registry env key
+    even when no ``llm_profiles`` entry exists (live-gateway gap)."""
+    captured: dict = {}
+
+    def _spy_provider(*args, **kwargs):
+        captured["args"] = args
+        return _FakeProvider(
+            [
+                TextDeltaEvent(text="ok"),
+                DoneEvent(stop_reason="end_turn", model="deepseek/deepseek-v4-pro"),
+            ]
+        )
+
+    import opensquilla.gateway.openai_compat as oc
+
+    monkeypatch.setattr(oc, "build_provider", _spy_provider)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-deepseek-env")
+
+    config = GatewayConfig(
+        squilla_router=SquillaRouterConfig(
+            tiers={
+                "c1": {"provider": "deepseek", "model": "deepseek/deepseek-v4-pro"},
+            }
+        ),
+    )
+    with TestClient(create_gateway_app(config), client=("127.0.0.1", 50000)) as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "deepseek/deepseek-v4-pro",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+    assert response.status_code == 200
+    assert captured["args"][0] == "deepseek"
+    assert captured["args"][2] == "sk-deepseek-env"
+
+
+def test_provider_error_maps_to_openai_envelope(monkeypatch) -> None:
+    fake = _FakeProvider([ErrorEvent(message="upstream exploded", code="timeout")])
+    _install_fake_provider(monkeypatch, fake)
+
+    with _app() as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": "deepseek-v4-pro", "messages": [{"role": "user", "content": "hi"}]},
+        )
+    assert response.status_code == 502
+    error = response.json()["error"]
+    assert "upstream exploded" in error["message"]
+    assert error["code"] == "timeout"


### PR DESCRIPTION
## Scope

Scope boundary: 第三方 OpenAI 协议客户端(astrbot、one-api、chatbox 等)调用网关时,所有 OpenAI 格式路径(`/v1/chat/completions`、`/v1/models`)都返回 404——网关此前没有任何 OpenAI 兼容的入站路由(文档中所有 "OpenAI-compatible" 均指作为客户端调用外部 provider)。本 PR 为网关新增 OpenAI 兼容中继端点:

- `POST /v1/chat/completions`:解析请求 model 按运行时 LLM(`llm`)与 Squilla Router 档位阶梯(`squilla_router.tiers`)路由;跨 provider 档位通过 `provider.deployment.resolve_provider_deployment` 解析凭据(profile → 凭据池 → env key → registry 默认);未知 model 返回 OpenAI 风格 404。
- `GET /v1/models`:返回可中继的模型列表(运行时默认模型 + 档位模型,去重)。
- 鉴权:可配置 Bearer key(`gateway.openai_compat.api_key`);未配置时仅放行 loopback 对端(网关默认绑定范围即安全边界),远程对端返回 403 并提示配置 key;两种模式均拒绝浏览器跨源请求。
- 线格式:非流式返回单个 `chat.completion` JSON;`stream: true` 返回 OpenAI SSE chunk 格式并以 `data: [DONE]` 结束。请求 `tools` 透传,工具调用以 `tool_calls` 呈现(含流式 tool-call 增量)。Provider 错误事件映射为 OpenAI 错误信封(502)。

Non-goals: 不改变既有控制面路由/鉴权;不新增 OpenAI 之外的协议;不实现 usage 计费透传(中继不参与账本);不改变 `_same_origin` 守卫范围。

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #978, Fixes #979

If None, reason: N/A

## Release Note

Release note: 网关新增 OpenAI 兼容中继端点(`/v1/chat/completions`、`/v1/models`),第三方 OpenAI 协议客户端可通过 `gateway.openai_compat.api_key` 配置的 Bearer key 调用;未配置 key 时仅限本机 loopback 访问。

## Tests

Ruff: All checks passed(4 个改动文件)

Pytest: 新增 tests/test_gateway/test_openai_compat.py 13 个用例全过(鉴权/路由/流式/非流式/tools 透传/错误信封);tests/test_gateway/ 全套件 2643 passed, 10 skipped;tests/unit 758 passed, 5 skipped

Build: N/A(纯后端改动)

Regression tests: added

Notes:

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [ ] Links point to existing repository files or stable external pages.
- [ ] Code fences and Markdown tables render correctly on GitHub.
- [ ] Examples avoid real secrets, local private paths, and private transcripts.