### PR TITLE
Fix Windows runtime archive extraction

### DIFF
--- a/desktop/electron/scripts/fetch-bundled-runtimes.mjs
+++ b/desktop/electron/scripts/fetch-bundled-runtimes.mjs
@@ -184,6 +184,18 @@ function runChecked(command, args, options = {}) {
   }
 }
 
+export function tarExtractArgs(
+  archive,
+  destination,
+  stripComponents,
+  platform = process.platform,
+) {
+  const args = platform === 'win32' ? ['--force-local'] : []
+  args.push('-xf', archive, '-C', destination)
+  if (stripComponents > 0) args.push(`--strip-components=${stripComponents}`)
+  return args
+}
+
 async function extractAsset(asset, archive, destination) {
   await rm(destination, { recursive: true, force: true })
   await mkdir(destination, { recursive: true })
@@ -209,9 +221,7 @@ async function extractAsset(asset, archive, destination) {
     }
     return
   }
-  const args = ['-xf', archive, '-C', destination]
-  if (asset.stripComponents > 0) args.push(`--strip-components=${asset.stripComponents}`)
-  runChecked('tar', args)
+  runChecked('tar', tarExtractArgs(archive, destination, asset.stripComponents))
 }
 
 function targetAssets(manifest, target) {

--- a/desktop/electron/scripts/test-bundled-runtimes.mjs
+++ b/desktop/electron/scripts/test-bundled-runtimes.mjs
@@ -34,17 +34,17 @@ try {
   )
   assert.deepEqual(
     tarExtractArgs(
-      String.raw`D:\a\opensquilla\.runtime-cache\python.tar.gz`,
-      String.raw`D:\a\opensquilla\runtime\python.staging`,
+      String.raw`Z:\fixture\.runtime-cache\python.tar.gz`,
+      String.raw`Z:\fixture\runtime\python.staging`,
       1,
       'win32',
     ),
     [
       '--force-local',
       '-xf',
-      String.raw`D:\a\opensquilla\.runtime-cache\python.tar.gz`,
+      String.raw`Z:\fixture\.runtime-cache\python.tar.gz`,
       '-C',
-      String.raw`D:\a\opensquilla\runtime\python.staging`,
+      String.raw`Z:\fixture\runtime\python.staging`,
       '--strip-components=1',
     ],
     'GNU tar must treat Windows drive-letter paths as local archives',

--- a/desktop/electron/scripts/test-bundled-runtimes.mjs
+++ b/desktop/electron/scripts/test-bundled-runtimes.mjs
@@ -12,6 +12,7 @@ import {
   downloadVerifiedAsset,
   loadRuntimeManifest,
   packagedRuntimeTarget,
+  tarExtractArgs,
   validateRuntimeManifest,
 } from './fetch-bundled-runtimes.mjs'
 
@@ -30,6 +31,28 @@ try {
     defaultRuntimeCacheRoot.startsWith(defaultRuntimeRoot),
     false,
     'download archives must stay outside packaged runtime resources',
+  )
+  assert.deepEqual(
+    tarExtractArgs(
+      String.raw`D:\a\opensquilla\.runtime-cache\python.tar.gz`,
+      String.raw`D:\a\opensquilla\runtime\python.staging`,
+      1,
+      'win32',
+    ),
+    [
+      '--force-local',
+      '-xf',
+      String.raw`D:\a\opensquilla\.runtime-cache\python.tar.gz`,
+      '-C',
+      String.raw`D:\a\opensquilla\runtime\python.staging`,
+      '--strip-components=1',
+    ],
+    'GNU tar must treat Windows drive-letter paths as local archives',
+  )
+  assert.deepEqual(
+    tarExtractArgs('/tmp/python.tar.gz', '/tmp/python.staging', 0, 'darwin'),
+    ['-xf', '/tmp/python.tar.gz', '-C', '/tmp/python.staging'],
+    'non-Windows tar arguments must stay portable',
   )
   const releaseManifest = await loadRuntimeManifest(defaultManifestPath)
   const requiredTargets = [


### PR DESCRIPTION
## Scope

- Treat Windows drive-letter archive paths as local when invoking GNU tar.
- Keep macOS and Linux tar arguments unchanged.
- Add regression coverage for both Windows and non-Windows argument construction.

## Branch target

main

## Linked issue

None

## Release note status

No user-facing release note needed; this repairs the client artifact build workflow.

## Verification

- npm run test:bundled-runtimes
- git diff --check
- Release Assets failure reproduced in run 31028104840 before this fix.

## Safety and compatibility

Build-time packaging change only. No persisted config, public API, runtime state, or existing client upgrade contract is changed. Windows behavior is corrected; macOS and Linux behavior remains byte-for-byte equivalent at the argument level.

## Third-party origin

None.