### PR TITLE
Normalize Windows tar paths

### DIFF
--- a/desktop/electron/scripts/fetch-bundled-runtimes.mjs
+++ b/desktop/electron/scripts/fetch-bundled-runtimes.mjs
@@ -191,7 +191,9 @@ export function tarExtractArgs(
   platform = process.platform,
 ) {
   const args = platform === 'win32' ? ['--force-local'] : []
-  args.push('-xf', archive, '-C', destination)
+  const archivePath = platform === 'win32' ? archive.replaceAll('\\', '/') : archive
+  const destinationPath = platform === 'win32' ? destination.replaceAll('\\', '/') : destination
+  args.push('-xf', archivePath, '-C', destinationPath)
   if (stripComponents > 0) args.push(`--strip-components=${stripComponents}`)
   return args
 }

--- a/desktop/electron/scripts/test-bundled-runtimes.mjs
+++ b/desktop/electron/scripts/test-bundled-runtimes.mjs
@@ -42,9 +42,9 @@ try {
     [
       '--force-local',
       '-xf',
-      String.raw`Z:\fixture\.runtime-cache\python.tar.gz`,
+      'Z:/fixture/.runtime-cache/python.tar.gz',
       '-C',
-      String.raw`Z:\fixture\runtime\python.staging`,
+      'Z:/fixture/runtime/python.staging',
       '--strip-components=1',
     ],
     'GNU tar must treat Windows drive-letter paths as local archives',


### PR DESCRIPTION
## Scope

- Convert Windows archive and extraction destination paths to forward-slash form before invoking GNU tar.
- Preserve the Windows force-local flag and leave macOS/Linux arguments unchanged.
- Update regression coverage to assert the exact D:/-style argument shape accepted by Git for Windows tar.

## Branch target

main

## Linked issue

None

## Release note status

No user-facing release note needed; this completes the client artifact workflow repair.

## Verification

- npm run test:bundled-runtimes
- uv run pytest tests/test_public_release_hygiene.py -q
- git diff --check
- The remaining destination-path failure was reproduced in Release Assets run 31033854471.

## Safety and compatibility

Build-time packaging change only. No persisted config, public API, runtime state, or existing client upgrade contract is changed. Windows GNU tar receives the path format it already uses successfully in GitHub Actions; macOS and Linux behavior is unchanged.

## Third-party origin

None.