### PR TITLE
Extract Windows runtime zip archives natively

### DIFF
--- a/desktop/electron/scripts/fetch-bundled-runtimes.mjs
+++ b/desktop/electron/scripts/fetch-bundled-runtimes.mjs
@@ -198,6 +198,49 @@ export function tarExtractArgs(
   return args
 }
 
+export function windowsZipExtractSpec(archive, destination) {
+  return {
+    command: 'powershell.exe',
+    args: [
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      'Expand-Archive -LiteralPath $env:OPENSQUILLA_RUNTIME_ARCHIVE '
+        + '-DestinationPath $env:OPENSQUILLA_RUNTIME_DESTINATION -Force',
+    ],
+    environment: {
+      OPENSQUILLA_RUNTIME_ARCHIVE: archive,
+      OPENSQUILLA_RUNTIME_DESTINATION: destination,
+    },
+  }
+}
+
+export async function stripExtractedComponents(destination, count) {
+  if (count === 0) return
+  let source = destination
+  for (let index = 0; index < count; index += 1) {
+    const entries = await readdir(source, { withFileTypes: true })
+    if (entries.length !== 1 || !entries[0].isDirectory()) {
+      throw new Error(`cannot strip ${count} component(s) from ${destination}`)
+    }
+    source = join(source, entries[0].name)
+  }
+
+  const flattened = `${destination}.flattened-${process.pid}`
+  await rm(flattened, { recursive: true, force: true })
+  await mkdir(flattened, { recursive: true })
+  try {
+    for (const entry of await readdir(source)) {
+      await rename(join(source, entry), join(flattened, entry))
+    }
+    await rm(destination, { recursive: true, force: true })
+    await rename(flattened, destination)
+  } finally {
+    await rm(flattened, { recursive: true, force: true })
+  }
+}
+
 async function extractAsset(asset, archive, destination) {
   await rm(destination, { recursive: true, force: true })
   await mkdir(destination, { recursive: true })
@@ -221,6 +264,14 @@ async function extractAsset(asset, archive, destination) {
       }
       await rm(wrapper, { recursive: true, force: true })
     }
+    return
+  }
+  if (process.platform === 'win32' && asset.archiveType === 'zip') {
+    const spec = windowsZipExtractSpec(archive, destination)
+    runChecked(spec.command, spec.args, {
+      env: { ...process.env, ...spec.environment },
+    })
+    await stripExtractedComponents(destination, asset.stripComponents)
     return
   }
   runChecked('tar', tarExtractArgs(archive, destination, asset.stripComponents))

--- a/desktop/electron/scripts/test-bundled-runtimes.mjs
+++ b/desktop/electron/scripts/test-bundled-runtimes.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -12,8 +12,10 @@ import {
   downloadVerifiedAsset,
   loadRuntimeManifest,
   packagedRuntimeTarget,
+  stripExtractedComponents,
   tarExtractArgs,
   validateRuntimeManifest,
+  windowsZipExtractSpec,
 } from './fetch-bundled-runtimes.mjs'
 
 const root = await mkdtemp(join(tmpdir(), 'opensquilla-runtime-test-'))
@@ -54,6 +56,33 @@ try {
     ['-xf', '/tmp/python.tar.gz', '-C', '/tmp/python.staging'],
     'non-Windows tar arguments must stay portable',
   )
+  assert.deepEqual(
+    windowsZipExtractSpec(
+      String.raw`Z:\fixture\.runtime-cache\node.zip`,
+      String.raw`Z:\fixture\runtime\node.staging`,
+    ),
+    {
+      command: 'powershell.exe',
+      args: [
+        '-NoLogo',
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        'Expand-Archive -LiteralPath $env:OPENSQUILLA_RUNTIME_ARCHIVE '
+          + '-DestinationPath $env:OPENSQUILLA_RUNTIME_DESTINATION -Force',
+      ],
+      environment: {
+        OPENSQUILLA_RUNTIME_ARCHIVE: String.raw`Z:\fixture\.runtime-cache\node.zip`,
+        OPENSQUILLA_RUNTIME_DESTINATION: String.raw`Z:\fixture\runtime\node.staging`,
+      },
+    },
+    'Windows zip extraction must use the system archive command with literal paths',
+  )
+  const extracted = join(root, 'extracted')
+  await mkdir(join(extracted, 'node-wrapper', 'bin'), { recursive: true })
+  await writeFile(join(extracted, 'node-wrapper', 'bin', 'node.exe'), 'node fixture')
+  await stripExtractedComponents(extracted, 1)
+  assert.equal(await readFile(join(extracted, 'bin', 'node.exe'), 'utf8'), 'node fixture')
   const releaseManifest = await loadRuntimeManifest(defaultManifestPath)
   const requiredTargets = [
     'darwin-arm64',


### PR DESCRIPTION
## Scope

- Use Windows PowerShell Expand-Archive for bundled runtime zip files instead of Git GNU tar.
- Pass archive and destination paths through environment variables so PowerShell treats them as literal paths.
- Apply the manifest strip-components contract after zip extraction.
- Keep tar.gz and PortableGit self-extracting archive behavior unchanged.

## Branch target

main

## Linked issue

None

## Release note status

No user-facing release note needed; this repairs the client artifact build workflow.

## Verification

- npm run test:bundled-runtimes
- uv run pytest tests/test_public_release_hygiene.py tests/test_release_consistency.py -q (46 passed)
- git diff --check
- GNU tar zip incompatibility reproduced in Release Assets run 31035751251.

## Safety and compatibility

Build-time packaging change only. No persisted config, public API, runtime state, or existing client upgrade contract is changed. Windows zip archives use the operating system archive command; macOS/Linux and non-zip Windows archive behavior remains unchanged.

## Third-party origin

None.