### PR TITLE
Fix packaged Windows gateway migration startup

### DIFF
--- a/src/opensquilla/sandbox/upgrade_migration.py
+++ b/src/opensquilla/sandbox/upgrade_migration.py
@@ -10,9 +10,13 @@ import os
 import shutil
 import stat
 import subprocess
+import sys
 import tempfile
+import threading
 import time
 import tomllib
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -98,19 +102,48 @@ foreach ($sidText in $allowed) {
 _WINDOWS_PRIVATE_ACL_ENCODED = base64.b64encode(
     _WINDOWS_PRIVATE_ACL_SCRIPT.encode("utf-16-le")
 ).decode("ascii")
+_WINDOWS_DLL_DIRECTORY_LOCK = threading.Lock()
 
 
 def _running_on_windows() -> bool:
     return os.name == "nt"
 
 
+def _set_windows_dll_directory(path: str | None) -> None:
+    import ctypes
+
+    kernel32 = getattr(ctypes, "WinDLL")("kernel32", use_last_error=True)
+    setter = kernel32.SetDllDirectoryW
+    setter.argtypes = [ctypes.c_wchar_p]
+    setter.restype = ctypes.c_bool
+    if not setter(path):
+        error_code = int(getattr(ctypes, "get_last_error")())
+        raise OSError(error_code, "SetDllDirectoryW failed")
+
+
+@contextmanager
+def _system_windows_process_context() -> Iterator[None]:
+    bundle_root = getattr(sys, "_MEIPASS", None)
+    if not _running_on_windows() or not getattr(sys, "frozen", False) or not bundle_root:
+        yield
+        return
+
+    with _WINDOWS_DLL_DIRECTORY_LOCK:
+        _set_windows_dll_directory(None)
+        try:
+            yield
+        finally:
+            _set_windows_dll_directory(str(bundle_root))
+
+
 def _current_windows_user_sid() -> str:
-    completed = subprocess.run(
-        ["whoami", "/user", "/fo", "csv", "/nh"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    with _system_windows_process_context():
+        completed = subprocess.run(
+            ["whoami", "/user", "/fo", "csv", "/nh"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
     if completed.returncode != 0:
         raise OSError("cannot resolve the current Windows user SID")
     try:
@@ -144,21 +177,24 @@ def _protect_private_path(
             "OPENSQUILLA_UPGRADE_ACL_USER_SID": windows_user_sid,
             "OPENSQUILLA_UPGRADE_ACL_IS_DIRECTORY": "1" if directory else "0",
         }
-        completed = subprocess.run(
-            [
-                "powershell",
-                "-NoProfile",
-                "-NonInteractive",
-                "-EncodedCommand",
-                _WINDOWS_PRIVATE_ACL_ENCODED,
-            ],
-            env=environment,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        with _system_windows_process_context():
+            completed = subprocess.run(
+                [
+                    "powershell",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-EncodedCommand",
+                    _WINDOWS_PRIVATE_ACL_ENCODED,
+                ],
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
         if completed.returncode != 0:
-            raise OSError(f"cannot protect upgrade snapshot path: {path}")
+            detail = " ".join((completed.stderr or completed.stdout).strip().split())
+            suffix = f" ({detail[-500:]})" if detail else ""
+            raise OSError(f"cannot protect upgrade snapshot path: {path}{suffix}")
         return
 
     mode = 0o700 if directory else 0o600

--- a/tests/test_migration/test_sandbox_direct_update.py
+++ b/tests/test_migration/test_sandbox_direct_update.py
@@ -141,6 +141,76 @@ def _mock_windows_acl(
     monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
 
 
+def test_frozen_windows_acl_process_restores_packaged_dll_directory(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    events: list[tuple[str, str | None]] = []
+    monkeypatch.setattr(upgrade_migration, "_running_on_windows", lambda: True)
+    monkeypatch.setattr(upgrade_migration.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(
+        upgrade_migration.sys,
+        "_MEIPASS",
+        "C:/synthetic/bundle/_internal",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        upgrade_migration,
+        "_set_windows_dll_directory",
+        lambda path: events.append(("dll", path)),
+    )
+
+    def run(_command: list[str], **_kwargs: object) -> SimpleNamespace:
+        events.append(("run", None))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
+
+    upgrade_migration._protect_private_path(
+        snapshot,
+        directory=True,
+        windows_user_sid="S-1-5-21-1234",
+    )
+
+    assert events == [
+        ("dll", None),
+        ("run", None),
+        ("dll", "C:/synthetic/bundle/_internal"),
+    ]
+
+
+def test_frozen_windows_acl_process_restores_dll_directory_after_launch_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[str, str | None]] = []
+    monkeypatch.setattr(upgrade_migration, "_running_on_windows", lambda: True)
+    monkeypatch.setattr(upgrade_migration.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(
+        upgrade_migration.sys,
+        "_MEIPASS",
+        "C:/synthetic/bundle/_internal",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        upgrade_migration,
+        "_set_windows_dll_directory",
+        lambda path: events.append(("dll", path)),
+    )
+
+    with pytest.raises(OSError, match="synthetic launch failure"):
+        with upgrade_migration._system_windows_process_context():
+            events.append(("run", None))
+            raise OSError("synthetic launch failure")
+
+    assert events == [
+        ("dll", None),
+        ("run", None),
+        ("dll", "C:/synthetic/bundle/_internal"),
+    ]
+
+
 def test_windows_snapshot_acl_is_applied_in_copy_and_promotion_order(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Scope

Restore the default Windows DLL search path while the frozen gateway launches system ACL helpers, then restore the packaged search path immediately afterward. Include bounded helper failure detail and regression coverage for restoration on success and error.

## Branch target

`main`

## Linked issue

None — found by the release-artifact packaged gateway smoke test.

## Release note

Windows desktop builds no longer fail during first-start sandbox migration when the packaged gateway invokes system helpers.

## Tests

- `ruff check` on changed Python files
- `mypy src/opensquilla/sandbox/upgrade_migration.py --show-error-codes`
- `pytest tests/test_migration/test_sandbox_direct_update.py tests/test_recovery/test_sandbox_upgrade_journal.py -q` — 19 passed, 1 skipped
- `pytest tests/test_public_release_hygiene.py tests/test_release_consistency.py -q` — 46 passed
- `git diff --check`

Platform assessment: the runtime change is gated to frozen Windows builds. Source runs, Linux, and macOS retain their existing behavior.

Upgrade compatibility: no config, state, schema, RPC, or public interface changes. Existing Windows profiles continue through the same idempotent migration.

## Safety notes

The DLL-directory change is held under a process lock and restored in `finally`, including when helper launch fails. No credentials, private data, or runtime artifacts are included.

## Third-party origin

Behavior follows the documented PyInstaller Windows subprocess isolation contract; no third-party code was copied.