### PR TITLE
Avoid PowerShell module loading in packaged Windows checks

### DIFF
--- a/desktop/electron/src/desktop-gateway-ownership.ts
+++ b/desktop/electron/src/desktop-gateway-ownership.ts
@@ -431,13 +431,18 @@ function windowsProcessStartIdentity(pid: number): string | null {
   // GetProcessTimes creation time, via the .NET filetime round-trip. The
   // query needs only limited-information access; a denied or missing process
   // yields null and the caller stays on the conservative path.
+  const processId = Math.trunc(pid)
+  const command = [
+    "$ErrorActionPreference='Stop'",
+    `[System.Diagnostics.Process]::GetProcessById(${processId}).StartTime.ToFileTime()`,
+  ].join('; ')
   const result = spawnSync(
     'powershell.exe',
     [
       '-NoProfile',
       '-NonInteractive',
       '-Command',
-      `$ErrorActionPreference='Stop'; (Get-Process -Id ${Math.trunc(pid)}).StartTime.ToFileTime()`,
+      command,
     ],
     { windowsHide: true, timeout: 2000, encoding: 'utf8' },
   )

--- a/src/opensquilla/sandbox/upgrade_migration.py
+++ b/src/opensquilla/sandbox/upgrade_migration.py
@@ -64,10 +64,11 @@ foreach ($sidText in $allowed) {
 }
 if ($isDirectory) {
     [System.IO.Directory]::SetAccessControl($target, $acl)
+    $verified = [System.IO.Directory]::GetAccessControl($target)
 } else {
     [System.IO.File]::SetAccessControl($target, $acl)
+    $verified = [System.IO.File]::GetAccessControl($target)
 }
-$verified = Get-Acl -LiteralPath $target
 if (-not $verified.AreAccessRulesProtected) {
     throw "DACL inheritance remains enabled"
 }

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -2461,6 +2461,18 @@ def test_desktop_gateway_ownership_control_dir_is_outside_profile_data_state() -
     assert "record.pid" not in launch_match
 
 
+def test_windows_process_start_identity_avoids_powershell_module_autoload() -> None:
+    ownership = _read("desktop/electron/src/desktop-gateway-ownership.ts")
+    windows_probe = _section(
+        ownership,
+        "function windowsProcessStartIdentity",
+        "function posixProcessStartIdentity",
+    )
+
+    assert "Get-Process" not in windows_probe
+    assert "[System.Diagnostics.Process]::GetProcessById" in windows_probe
+
+
 def test_desktop_orphan_recovery_has_a_real_electron_process_flow() -> None:
     package_json = json.loads(_read("desktop/electron/package.json"))
     script = _read(

--- a/tests/test_migration/test_sandbox_direct_update.py
+++ b/tests/test_migration/test_sandbox_direct_update.py
@@ -141,6 +141,14 @@ def _mock_windows_acl(
     monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
 
 
+def test_windows_acl_script_does_not_require_powershell_module_autoload() -> None:
+    script = upgrade_migration._WINDOWS_PRIVATE_ACL_SCRIPT
+
+    assert "Get-Acl" not in script
+    assert "[System.IO.Directory]::GetAccessControl($target)" in script
+    assert "[System.IO.File]::GetAccessControl($target)" in script
+
+
 def test_frozen_windows_acl_process_restores_packaged_dll_directory(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Scope

Read back Windows snapshot ACLs through the same .NET framework APIs used to write them, instead of the module-backed `Get-Acl` command. Add a platform-neutral contract test that prevents reintroducing PowerShell module autoload into the packaged startup path.

## Branch target

`main`

## Linked issue

None — found by the artifact-only Release Assets packaged gateway smoke test.

## Release note

Windows desktop builds can complete first-start gateway migration even when the build shell and system PowerShell expose different module paths.

## Tests

- Ruff on changed files — passed
- Mypy on `upgrade_migration.py` — passed
- Migration, recovery journal, release hygiene, and release consistency tests — 66 passed, 1 skipped
- `git diff --check` — passed

Platform assessment: Windows-only embedded PowerShell script change; Linux and macOS are unchanged.

Upgrade compatibility: no config, persisted state, schema, RPC, or public interface changes.

## Safety notes

ACL construction and verification semantics are unchanged; only the API used to retrieve the applied ACL changes. No credentials, private data, or runtime artifacts are included.

## Third-party origin

None; no third-party code was copied.