### PR TITLE
fix(scheduler): exempt mode=NONE jobs from skipped-heartbeat delivery errors

### DIFF
--- a/src/opensquilla/scheduler/handlers.py
+++ b/src/opensquilla/scheduler/handlers.py
@@ -106,12 +106,23 @@ def _required_heartbeat_delivery_error(
     """Return an error when pinned heartbeat delivery was required but failed."""
     if job.delivery.best_effort or delivery_override is None:
         return None
+    mode = (
+        job.delivery.mode
+        if isinstance(job.delivery.mode, DeliveryMode)
+        else DeliveryMode(job.delivery.mode)
+    )
     hb_status = getattr(hb_result, "status", "")
     delivery_status = getattr(hb_result, "delivery_status", "")
     reason = getattr(hb_result, "reason", "")
     if delivery_status in {"delivery_failed", "forward_failed"}:
         return str(reason or delivery_status)
     if hb_status == "skipped":
+        # mode=NONE jobs never require delivery (e.g. silent main-session
+        # injection): their heartbeat run is skipped by design, which must
+        # not be reported as a delivery failure.  An actual delivery attempt
+        # that failed is still reported above.
+        if mode == DeliveryMode.NONE:
+            return None
         return str(reason or delivery_status or "delivery skipped")
     return None
 

--- a/tests/test_scheduler/test_mode_none_heartbeat_delivery.py
+++ b/tests/test_scheduler/test_mode_none_heartbeat_delivery.py
@@ -1,0 +1,88 @@
+"""mode=NONE cron jobs must not report a skipped heartbeat as delivery failure.
+
+Jobs whose delivery mode is NONE never request delivery (e.g. silent
+main-session injection). Their heartbeat run is skipped by design, which the
+previous logic surfaced as a hard delivery error, permanently failing the job.
+These tests pin the NONE exemption and guard that delivery-required modes
+still fail loudly.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from opensquilla.scheduler.handlers import _required_heartbeat_delivery_error
+from opensquilla.scheduler.types import (
+    CronJob,
+    DeliveryConfig,
+    DeliveryMode,
+    SessionTarget,
+)
+
+
+def _job(mode: object, *, best_effort: bool = False) -> CronJob:
+    return CronJob(
+        id="job-1",
+        cron_expr="* * * * *",
+        handler_key="system_event",
+        payload={"kind": "system_event", "text": "x", "agent_id": "main"},
+        session_target=SessionTarget.MAIN,
+        delivery=DeliveryConfig(mode=mode, best_effort=best_effort),  # type: ignore[arg-type]
+    )
+
+
+_OVERRIDE = {"channel_name": "feishu", "channel_id": "chat-1"}
+
+
+def _hb(status: str = "skipped", delivery_status: str = "skipped", reason: str = "disabled") -> SimpleNamespace:
+    return SimpleNamespace(status=status, delivery_status=delivery_status, reason=reason)
+
+
+def test_mode_none_skipped_heartbeat_is_not_an_error() -> None:
+    """The fixed path: NONE mode must exempt a skipped heartbeat."""
+    assert (
+        _required_heartbeat_delivery_error(_job(DeliveryMode.NONE), _OVERRIDE, _hb())
+        is None
+    )
+
+
+def test_mode_none_string_is_normalized_and_exempt() -> None:
+    """Jobs restored from persistence may carry the raw string mode."""
+    assert _required_heartbeat_delivery_error(_job("none"), _OVERRIDE, _hb()) is None
+
+
+def test_channel_mode_skipped_heartbeat_still_errors() -> None:
+    """Regression guard: delivery-required modes must still fail loudly."""
+    err = _required_heartbeat_delivery_error(_job(DeliveryMode.CHANNEL), _OVERRIDE, _hb())
+    assert err is not None
+    assert "disabled" in err
+
+
+def test_best_effort_skipped_heartbeat_is_exempt() -> None:
+    """Existing behaviour: best_effort never fails on delivery."""
+    assert (
+        _required_heartbeat_delivery_error(
+            _job(DeliveryMode.CHANNEL, best_effort=True), _OVERRIDE, _hb()
+        )
+        is None
+    )
+
+
+def test_no_override_is_exempt() -> None:
+    """Existing behaviour: no pinned override means nothing is required."""
+    assert _required_heartbeat_delivery_error(_job(DeliveryMode.CHANNEL), None, _hb()) is None
+
+
+def test_mode_none_actual_delivery_failure_still_errors() -> None:
+    """A real delivery attempt that failed must fail even for mode=NONE.
+
+    Only the skipped heartbeat is exempt; if the heartbeat actually tried to
+    deliver and failed, the job must still report the failure loudly.
+    """
+    err = _required_heartbeat_delivery_error(
+        _job(DeliveryMode.NONE),
+        _OVERRIDE,
+        _hb(status="failed", delivery_status="delivery_failed", reason="channel down"),
+    )
+    assert err is not None
+    assert "channel down" in err


### PR DESCRIPTION
## Problem

Cron jobs pinned to `delivery.mode = NONE` (e.g. silent main-session
injection) never request delivery, so their heartbeat run is skipped by
design. `_required_heartbeat_delivery_error()` treated that skipped heartbeat
as a delivery failure and raised `RuntimeError`, permanently failing the job
even though nothing was ever required to be delivered.

## Fix

In `_required_heartbeat_delivery_error()`, exempt `mode=NONE` jobs from the
skipped-heartbeat branch. Only the skipped state is exempt: an actual delivery
attempt that failed (`delivery_failed`/`forward_failed`) is still reported,
and delivery-required modes (channel/origin/webhook) keep failing loudly.

## Verification

- 6 new unit tests in `tests/test_scheduler/test_mode_none_heartbeat_delivery.py`
- Red-test confirmed: the core case fails against the unfixed code
- Full `tests/test_scheduler/` suite: 190/190 passed
