### PR TITLE
fix(tools): surface ToolError messages instead of generic internal error

### DIFF
--- a/src/opensquilla/tools/envelope.py
+++ b/src/opensquilla/tools/envelope.py
@@ -24,7 +24,7 @@ import os
 import re
 from typing import Any, Final
 
-from opensquilla.tools.types import SafeToolUserMessage
+from opensquilla.tools.types import SafeToolUserMessage, ToolError
 
 # Class names whose instances represent transient infrastructure problems.
 # The list is intentionally conservative — subclass matching is handled by
@@ -163,6 +163,19 @@ def _sanitise_user_message(tool_name: str, exc: BaseException) -> str:
         return SafeToolUserMessage.user_message
     if class_name in _USER_MESSAGES:
         return _USER_MESSAGES[class_name]
+
+    # ToolError is raised by tool authors for invalid tool inputs; its message
+    # is authored for the user/model (e.g. cron "job_id required for add").
+    # Unlike unknown runtime exceptions it is safe to surface, but it still
+    # passes through the same sanitisation: traceback frames stripped and the
+    # message truncated.
+    if isinstance(exc, ToolError):
+        # Strip traceback frames BEFORE trimming whitespace: the frame regex
+        # requires leading whitespace (^\s+File ...), which .strip() would
+        # remove and silently disable the sanitisation.
+        message = _TRACEBACK_FRAME_RE.sub("", str(exc)).strip()
+        if message:
+            return message[:_USER_MESSAGE_MAX_CHARS]
 
     # Unknown classes: render a generic line that names the tool. Do NOT
     # interpolate str(exc) / repr(exc) — operators may have put secrets in

--- a/tests/test_tools/test_tool_failure_envelope.py
+++ b/tests/test_tools/test_tool_failure_envelope.py
@@ -6,7 +6,66 @@ import httpx
 
 from opensquilla.sandbox.types import SandboxBackendError
 from opensquilla.tools.envelope import build_tool_failure_envelope
-from opensquilla.tools.types import RetryableToolInputError, SafeToolError
+from opensquilla.tools.types import (
+    RetryableToolInputError,
+    SafeToolError,
+    ToolError,
+)
+
+
+def test_tool_error_message_is_exposed_instead_of_generic_internal_error() -> None:
+    """ToolError carries a user-authored input error that must not be swallowed."""
+    envelope = build_tool_failure_envelope(
+        ToolError("job_id required for add"),
+        "cron",
+    )
+
+    assert envelope["status"] == "error"
+    assert envelope["error_class"] == "ToolError"
+    assert envelope["user_message"] == "job_id required for add"
+    assert "internal error" not in envelope["user_message"]
+
+
+def test_tool_error_traceback_frames_are_stripped_from_message() -> None:
+    """A traceback leaked into a ToolError message must still be sanitised."""
+    message = (
+        '  File "C:\\\\repo\\\\src\\\\opensquilla\\\\tools\\\\builtin\\\\admin.py", '
+        "line 357, in <module>\n"
+        "    raise ToolError(\"'schedule' and 'task' required for add\")"
+    )
+    envelope = build_tool_failure_envelope(ToolError(message), "cron")
+
+    assert "File" not in envelope["user_message"]
+    assert "line 357" not in envelope["user_message"]
+    assert "required for add" in envelope["user_message"]
+
+
+def test_tool_error_long_message_is_truncated() -> None:
+    """Long ToolError messages are truncated like other sanitised messages."""
+    envelope = build_tool_failure_envelope(
+        ToolError("x" * 2000),
+        "cron",
+    )
+
+    assert len(envelope["user_message"]) <= 500
+
+
+def test_empty_tool_error_message_falls_back_to_generic() -> None:
+    """An empty ToolError message still yields a generic, tool-naming line."""
+    envelope = build_tool_failure_envelope(ToolError("   "), "cron")
+
+    assert "internal error" in envelope["user_message"]
+    assert "'cron'" in envelope["user_message"]
+
+
+def test_safe_tool_error_still_prefers_curated_message() -> None:
+    """SafeToolError (subclass of ToolError) keeps its curated message."""
+    envelope = build_tool_failure_envelope(
+        SafeToolError("curated user guidance"),
+        "write_file",
+    )
+
+    assert envelope["user_message"] == "curated user guidance"
 
 
 def test_type_error_tool_failure_is_model_retriable_without_raw_traceback() -> None:


### PR DESCRIPTION
## Problem

`ToolError` is raised by tool authors for invalid tool inputs (e.g. cron
"job_id required for add", "Invalid action: ..."). Its message is authored
for the user/model to read. But the failure envelope sanitizer treats it as
an unknown exception and swallows the message into the generic line:

```
The tool 'cron' failed with an internal error.
```

This made input-validation failures opaque: the model/user cannot see what
input was wrong, only that "an internal error" happened. (SafeToolError, the
curated-message subclass, was unaffected.)

## Fix

In `_sanitise_user_message()`, add a `ToolError` branch before the
unknown-class fallback that surfaces `str(exc)`, with the same
sanitisation guarantees as everything else:

- traceback frames are stripped **before** whitespace trimming (the frame
  regex `^\s+File ...` requires leading whitespace, so trimming first would
  silently disable it)
- the message is truncated to `_USER_MESSAGE_MAX_CHARS` (500)
- empty messages still fall back to the generic tool-naming line
- `SafeToolError` (a `ToolError` subclass) keeps its curated-message path
  unchanged, since the `SafeToolUserMessage` check runs first

## Verification

- 5 new unit tests in `tests/test_tools/test_tool_failure_envelope.py`:
  message exposure, traceback stripping, truncation, empty-message fallback,
  and SafeToolError precedence
- Red-test confirmed: the exposure test fails against the unfixed code
- Envelope-related suites: 119/119 passed
- Full `tests/test_tools/`: 1243 passed. The 13 failures in
  `test_workspace_write_deny_*` are environment-dependent (sandbox/shell
  availability) and reproduce identically on the unmodified baseline.
