### PR TITLE
修复:网关新增 OpenAI 兼容中继端点,第三方框架不再 404(按维护者设计反馈重构)

### DIFF
--- a/src/opensquilla/gateway/app.py
+++ b/src/opensquilla/gateway/app.py
@@ -29,6 +29,7 @@ from opensquilla.gateway.middleware import (
     SecurityHeadersMiddleware,
     UnsafeOriginGuardMiddleware,
 )
+from opensquilla.gateway.openai_compat import openai_compat_routes
 from opensquilla.gateway.origin_guard import (
     extract_http_token,
     forbidden_origin_response,
@@ -785,6 +786,7 @@ def create_gateway_app(
             methods=["PUT"],
         ),
         Route("/api/channels/status", api_channels_status, methods=["GET"]),
+        *openai_compat_routes(config),
         Route("/api/channels/logout", _same_origin(api_channels_logout), methods=["POST"]),
         Route("/api/channels/pairings", api_channel_pairings, methods=["GET"]),
         Route(

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -2209,6 +2209,26 @@ class _EnvWithoutConfigVersion(PydanticBaseSettingsSource):
         return values
 
 
+class OpenAICompatConfig(BaseSettings):
+    """OpenAI-compatible relay surface for third-party clients.
+
+    ``POST /v1/chat/completions`` and ``GET /v1/models`` let OpenAI-protocol
+    clients (astrbot, one-api, chatbox, ...) drive the configured LLM
+    deployments through the gateway.
+
+    The relay implements no authentication of its own: the ``/v1/*`` paths
+    belong to the gateway control plane, so the global ``AuthMiddleware``
+    applies (``auth.mode``: token / password / trusted-proxy).  In the
+    default ``auth.mode = "none"`` the relay enforces a loopback-only
+    guard, keeping the gateway's default bind scope as the safety
+    boundary.  Disabled by default: operators opt in explicitly.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="OPENSQUILLA_OPENAI_COMPAT_")
+
+    enabled: bool = False
+
+
 class GatewayConfig(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="OPENSQUILLA_GATEWAY_",
@@ -2266,6 +2286,8 @@ class GatewayConfig(BaseSettings):
     prompt: PromptConfig = Field(default_factory=PromptConfig)
     memory: MemoryConfig = Field(default_factory=MemoryConfig)
     squilla_router: SquillaRouterConfig = Field(default_factory=SquillaRouterConfig)
+    # OpenAI-compatible relay (POST /v1/chat/completions, GET /v1/models).
+    openai_compat: OpenAICompatConfig = Field(default_factory=OpenAICompatConfig)
     agent_token_saving: AgentTokenSavingConfig = Field(default_factory=AgentTokenSavingConfig)
     compaction: CompactionLlmConfig = Field(default_factory=CompactionLlmConfig)
     naming: SessionNamingConfig = Field(default_factory=SessionNamingConfig)

--- a/src/opensquilla/gateway/middleware.py
+++ b/src/opensquilla/gateway/middleware.py
@@ -55,6 +55,7 @@ def _is_control_plane_path(path: str) -> bool:
         path in _CONTROL_PLANE_PATHS
         or _path_is_at_or_below(path, "/api")
         or _path_is_at_or_below(path, "/ws")
+        or _path_is_at_or_below(path, "/v1")
     )
 
 

--- a/src/opensquilla/gateway/openai_compat.py
+++ b/src/opensquilla/gateway/openai_compat.py
@@ -1,0 +1,661 @@
+"""OpenAI-compatible relay surface for third-party clients.
+
+Registers ``POST /v1/chat/completions`` and ``GET /v1/models`` on the
+gateway so OpenAI-protocol clients (astrbot, one-api, chatbox, ...) can
+drive the configured LLM deployments instead of getting a 404 on every
+OpenAI-shaped request (issues #978 / #979).
+
+Design (agreed with maintainers):
+
+- **Auth** — the relay implements no authentication of its own.  ``/v1/*``
+  is part of the gateway control plane, so the global ``AuthMiddleware``
+  applies: ``auth.mode = token|password|trusted-proxy`` protects the
+  relay exactly like the rest of the control plane.  In the default
+  ``auth.mode = "none"`` the middleware passes everything through, so the
+  relay keeps a loopback-only guard: remote peers get 403, keeping the
+  gateway's default bind scope as the safety boundary.  Browser
+  cross-origin requests are rejected in both cases.
+- **Routing** — the request ``model`` is resolved against the runtime LLM
+  (``llm``) and the Squilla Router tier ladder (``squilla_router.tiers``).
+  Unknown models get an OpenAI-style 404.  An omitted model uses the
+  runtime default model.
+- **Streaming** — ``stream: true`` replies in OpenAI SSE chunk format
+  ending with ``data: [DONE]``; ``stream: false`` (default) returns a
+  single JSON completion.  Request ``tools`` are forwarded and tool calls
+  surface as OpenAI ``tool_calls`` (the client executes them — standard
+  OpenAI semantics; the relay never runs tools or approvals).
+- **Accounting** — v1 does not write the usage ledger: existing ledger
+  sinks are session-scoped and a raw relay has no session.  Out of scope
+  unless a non-session global sink is added (see design proposal).
+- **Exposure** — disabled by default (``gateway.openai_compat.enabled =
+  false``); operators opt in explicitly.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+import time
+import uuid
+from typing import Any
+
+import structlog
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+
+from opensquilla.provider.selector import build_provider
+from opensquilla.provider.types import (
+    ChatConfig,
+    ContentBlockImage,
+    ContentBlockText,
+    ContentBlockToolResult,
+    ContentBlockToolUse,
+    DoneEvent,
+    ErrorEvent,
+    Message,
+    TextDeltaEvent,
+    ToolDefinition,
+    ToolInputSchema,
+    ToolUseDeltaEvent,
+    ToolUseEndEvent,
+    ToolUseStartEvent,
+)
+
+log = structlog.get_logger(__name__)
+
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+_OPENAI_SCHEMA_KEYS = ("type", "properties", "required", "additionalProperties")
+_INVALID_REQUEST_ERROR = "invalid_request_error"
+_SERVER_ERROR_TYPE = "server_error"
+
+
+def _openai_error(
+    message: str,
+    error_type: str = _INVALID_REQUEST_ERROR,
+    code: str = "",
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"message": message, "type": error_type}
+    if code:
+        payload["code"] = code
+    return {"error": payload}
+
+
+def _is_loopback(request: Request) -> bool:
+    host = request.client.host if request.client is not None else ""
+    return host in _LOOPBACK_HOSTS
+
+
+def _guard_default_auth(config: Any, request: Request) -> tuple[int, str] | None:
+    """Return ``(status_code, error_json)`` when the relay must refuse, else None.
+
+    In ``auth.mode = "none"`` (the default) the global ``AuthMiddleware``
+    passes every request through, so the relay enforces the loopback-only
+    safety boundary itself.  In every other auth mode the middleware has
+    already authenticated the request before it reaches the relay.
+    """
+    if getattr(config.auth, "mode", "none") == "none" and not _is_loopback(request):
+        return (
+            403,
+            json.dumps(
+                _openai_error(
+                    "This OpenAI-compatible endpoint is loopback-only unless "
+                    "gateway authentication is configured (auth.mode = token "
+                    "or trusted-proxy)",
+                    "authentication_error",
+                    "api_key_required",
+                )
+            ),
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Model resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_relay_target(config: Any, model: str | None) -> tuple[str, str, str, str, str] | None:
+    """Resolve ``(provider, model, api_key, base_url, proxy)`` for one request.
+
+    ``model`` is matched against the runtime LLM and the Squilla Router
+    tier ladder.  ``None``/empty model uses the runtime default.  Returns
+    ``None`` when the model is not configured anywhere (caller replies 404).
+    """
+    from opensquilla.gateway.llm_runtime import resolve_llm_runtime_config
+
+    runtime = resolve_llm_runtime_config(config)
+    if not model or model == runtime.model:
+        return runtime.provider, runtime.model, runtime.api_key, runtime.base_url, runtime.proxy
+
+    from opensquilla.provider.deployment import resolve_provider_deployment
+
+    tiers = getattr(config.squilla_router, "tiers", None) or {}
+    for tier in tiers.values():
+        if not isinstance(tier, dict):
+            continue
+        if tier.get("model") != model:
+            continue
+        provider_id = str(tier.get("provider") or runtime.provider)
+        profiles = getattr(config, "llm_profiles", None) or {}
+        if provider_id == runtime.provider and provider_id not in profiles:
+            # The runtime LLM's own credentials are authoritative for its
+            # provider (llm.api_key / api_key_env may not exist as a profile).
+            return runtime.provider, model, runtime.api_key, runtime.base_url, runtime.proxy
+        resolution = resolve_provider_deployment(config, provider_id, model)
+        if resolution.ready and resolution.provider_config is not None:
+            pc = resolution.provider_config
+            return provider_id, model, pc.api_key, pc.base_url, pc.proxy
+        return None
+    return None
+
+
+def _relay_model_ids(config: Any) -> list[str]:
+    """Models the relay can serve: runtime default + tier ladder (dedup)."""
+    from opensquilla.gateway.llm_runtime import resolve_llm_runtime_config
+
+    ids: list[str] = []
+    try:
+        runtime = resolve_llm_runtime_config(config)
+        if runtime.model:
+            ids.append(runtime.model)
+    except Exception:
+        pass
+    tiers = getattr(config.squilla_router, "tiers", None) or {}
+    for tier in tiers.values():
+        if isinstance(tier, dict) and tier.get("model"):
+            model_id = str(tier["model"])
+            if model_id not in ids:
+                ids.append(model_id)
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# Request conversion (OpenAI wire format → internal types)
+# ---------------------------------------------------------------------------
+
+
+def _user_content(content: Any) -> str | list[Any]:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    blocks: list[Any] = []
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        part_type = part.get("type")
+        if part_type == "text":
+            blocks.append(ContentBlockText(text=str(part.get("text") or "")))
+        elif part_type == "image_url":
+            image_url = part.get("image_url") or {}
+            url = str(image_url.get("url") or "")
+            if url.startswith("data:"):
+                media_type = url.split(";", 1)[0].removeprefix("data:")
+                blocks.append(
+                    ContentBlockImage(
+                        source_type="base64",
+                        media_type=media_type or "image/png",
+                        data=url.split(",", 1)[-1],
+                    )
+                )
+            else:
+                blocks.append(
+                    ContentBlockImage(source_type="url", media_type="image/png", data=url)
+                )
+    return blocks
+
+
+def _assistant_content(message: dict[str, Any]) -> str | list[Any]:
+    content = message.get("content")
+    tool_calls = message.get("tool_calls")
+    if isinstance(content, str) and not tool_calls:
+        return content
+    blocks: list[Any] = []
+    if isinstance(content, str) and content:
+        blocks.append(ContentBlockText(text=content))
+    if isinstance(tool_calls, list):
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            fn = call.get("function") or {}
+            try:
+                arguments = json.loads(fn.get("arguments") or "{}")
+            except (json.JSONDecodeError, TypeError):
+                arguments = {}
+            blocks.append(
+                ContentBlockToolUse(
+                    id=str(call.get("id") or f"call_{secrets.token_hex(8)}"),
+                    name=str(fn.get("name") or ""),
+                    input=arguments if isinstance(arguments, dict) else {},
+                )
+            )
+    return blocks
+
+
+def _messages_from_openai(openai_messages: list[Any]) -> tuple[str, list[Message]]:
+    """Convert OpenAI ``messages`` into ``(system_prompt, internal messages)``."""
+    system_parts: list[str] = []
+    internal: list[Message] = []
+    tool_results: list[ContentBlockToolResult] = []
+
+    def flush_tool_results() -> None:
+        nonlocal tool_results
+        if tool_results:
+            internal.append(Message(role="user", content=list(tool_results)))
+            tool_results = []
+
+    for raw in openai_messages:
+        if not isinstance(raw, dict):
+            continue
+        role = str(raw.get("role") or "")
+        content = raw.get("content")
+        if role == "system":
+            if isinstance(content, str):
+                system_parts.append(content)
+            elif isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "text":
+                        system_parts.append(str(part.get("text") or ""))
+            continue
+        if role == "tool":
+            tool_results.append(
+                ContentBlockToolResult(
+                    tool_use_id=str(raw.get("tool_call_id") or ""),
+                    content=_tool_result_content(raw.get("content")),
+                    is_error=False,
+                )
+            )
+            continue
+        # user / assistant — flush any pending tool results first so they
+        # stay in a dedicated message (provider payload builders require
+        # tool results to never coexist with text/image blocks).
+        flush_tool_results()
+        if role == "user":
+            internal.append(Message(role="user", content=_user_content(content)))
+        elif role == "assistant":
+            internal.append(Message(role="assistant", content=_assistant_content(raw)))
+    flush_tool_results()
+    return "\n\n".join(part for part in system_parts if part), internal
+
+
+def _tool_result_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        text_parts = [
+            str(part.get("text") or "")
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        ]
+        if text_parts:
+            return "\n".join(text_parts)
+        return json.dumps(content, ensure_ascii=False)
+    return str(content or "")
+
+
+def _tools_from_openai(tools: Any) -> list[ToolDefinition]:
+    if not isinstance(tools, list):
+        return []
+    definitions: list[ToolDefinition] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        fn = tool.get("function") or {}
+        schema = fn.get("parameters")
+        if not isinstance(schema, dict):
+            schema = {}
+        definitions.append(
+            ToolDefinition(
+                name=str(fn.get("name") or ""),
+                description=str(fn.get("description") or ""),
+                input_schema=ToolInputSchema(
+                    **{key: schema[key] for key in _OPENAI_SCHEMA_KEYS if key in schema}
+                ),
+            )
+        )
+    return [definition for definition in definitions if definition.name]
+
+
+# ---------------------------------------------------------------------------
+# Response conversion (internal events → OpenAI wire format)
+# ---------------------------------------------------------------------------
+
+
+def _completion_id() -> str:
+    return f"chatcmpl-{uuid.uuid4().hex[:24]}"
+
+
+def _map_stop_reason(stop_reason: str) -> str:
+    if stop_reason in ("tool_use", "tool_calls"):
+        return "tool_calls"
+    if stop_reason == "max_tokens":
+        return "length"
+    return "stop"
+
+
+async def _relay_completion(
+    target: tuple[str, str, str, str, str],
+    *,
+    model: str,
+    messages: list[Message],
+    tools: list[ToolDefinition],
+    chat_config: ChatConfig,
+) -> dict[str, Any]:
+    provider = build_provider(*target[:4], proxy=target[4])
+    text_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    done: DoneEvent | None = None
+    async for event in provider.chat(messages, tools=tools or None, config=chat_config):
+        if isinstance(event, TextDeltaEvent):
+            text_parts.append(event.text)
+        elif isinstance(event, ToolUseEndEvent):
+            tool_calls.append(
+                {
+                    "id": event.tool_use_id,
+                    "type": "function",
+                    "function": {
+                        "name": event.tool_name,
+                        "arguments": json.dumps(event.arguments, ensure_ascii=False),
+                    },
+                }
+            )
+        elif isinstance(event, DoneEvent):
+            done = event
+        elif isinstance(event, ErrorEvent):
+            raise _RelayProviderError(event)
+    if done is None:
+        raise _RelayProviderError(
+            ErrorEvent(
+                message="Provider stream ended without a terminal event",
+                code="incomplete_stream",
+            )
+        )
+    content = "".join(text_parts) or None
+    return {
+        "id": _completion_id(),
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": content,
+                    "tool_calls": tool_calls or None,
+                },
+                "finish_reason": _map_stop_reason(done.stop_reason),
+            }
+        ],
+        "usage": {
+            "prompt_tokens": done.input_tokens,
+            "completion_tokens": done.output_tokens,
+            "total_tokens": done.input_tokens + done.output_tokens,
+        },
+    }
+
+
+class _RelayProviderError(Exception):
+    """A provider ErrorEvent observed while relaying a completion."""
+
+    def __init__(self, event: ErrorEvent) -> None:
+        super().__init__(event.message)
+        self.event = event
+
+
+async def _relay_stream(
+    target: tuple[str, str, str, str, str],
+    *,
+    model: str,
+    messages: list[Message],
+    tools: list[ToolDefinition],
+    chat_config: ChatConfig,
+):
+    """Yield OpenAI SSE ``data:`` lines for one streamed completion."""
+    provider = build_provider(*target[:4], proxy=target[4])
+    completion_id = _completion_id()
+    created = int(time.time())
+
+    def chunk(choices: list[dict[str, Any]], *, usage: dict[str, int] | None = None) -> str:
+        payload = {
+            "id": completion_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": model,
+            "choices": choices,
+            "usage": usage,
+        }
+        return f"data: {json.dumps(payload)}\n\n"
+
+    yield chunk([{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}])
+    tool_call_index = 0
+    text_parts: list[str] = []
+    done: DoneEvent | None = None
+    async for event in provider.chat(messages, tools=tools or None, config=chat_config):
+        if isinstance(event, TextDeltaEvent):
+            text_parts.append(event.text)
+            yield chunk([{"index": 0, "delta": {"content": event.text}, "finish_reason": None}])
+        elif isinstance(event, ToolUseStartEvent):
+            tool_call = {
+                "index": tool_call_index,
+                "id": event.tool_use_id,
+                "type": "function",
+                "function": {"name": event.tool_name, "arguments": ""},
+            }
+            yield chunk([{"index": 0, "delta": {"tool_calls": [tool_call]}, "finish_reason": None}])
+        elif isinstance(event, ToolUseDeltaEvent):
+            tool_call = {"index": tool_call_index, "function": {"arguments": event.json_fragment}}
+            yield chunk([{"index": 0, "delta": {"tool_calls": [tool_call]}, "finish_reason": None}])
+        elif isinstance(event, ToolUseEndEvent):
+            tool_call_index += 1
+        elif isinstance(event, DoneEvent):
+            done = event
+        elif isinstance(event, ErrorEvent):
+            error_payload = _openai_error(event.message, _SERVER_ERROR_TYPE, event.code)
+            yield f"data: {json.dumps(error_payload)}\n\n"
+            yield "data: [DONE]\n\n"
+            return
+    finish_reason = _map_stop_reason(done.stop_reason) if done is not None else "stop"
+    usage = (
+        {
+            "prompt_tokens": done.input_tokens,
+            "completion_tokens": done.output_tokens,
+            "total_tokens": done.input_tokens + done.output_tokens,
+        }
+        if done is not None
+        else None
+    )
+    yield chunk([{"index": 0, "delta": {}, "finish_reason": finish_reason}], usage=usage)
+    yield "data: [DONE]\n\n"
+
+
+# ---------------------------------------------------------------------------
+# HTTP handlers
+# ---------------------------------------------------------------------------
+
+
+async def _handle_chat_completions(request: Request, config: Any) -> Response:
+    started = time.monotonic()
+
+    def finish(response: Response, *, model: str = "") -> Response:
+        log.info(
+            "openai_compat.request",
+            method=request.method,
+            path=request.url.path,
+            model=model or None,
+            status=response.status_code,
+            duration_ms=round((time.monotonic() - started) * 1000, 1),
+        )
+        return response
+
+    guard = _guard_default_auth(config, request)
+    if guard is not None:
+        status, payload = guard
+        return finish(Response(payload, status_code=status, media_type="application/json"))
+    if request.headers.get("origin"):
+        # Browser-mediated cross-origin calls cannot authenticate as an
+        # OpenAI client; keep CSRF off the relay in both auth modes.
+        return finish(
+            JSONResponse(_openai_error("Cross-origin requests are not allowed"), status_code=403)
+        )
+    try:
+        body = await request.json()
+    except Exception:
+        return finish(JSONResponse(_openai_error("Invalid JSON body"), status_code=400))
+    if not isinstance(body, dict):
+        return finish(
+            JSONResponse(_openai_error("Request body must be a JSON object"), status_code=400)
+        )
+
+    model = body.get("model")
+    target = resolve_relay_target(config, model)
+    if target is None:
+        return finish(
+            JSONResponse(
+                _openai_error(
+                    f"The model `{model}` does not exist or is not configured",
+                    code="model_not_found",
+                ),
+                status_code=404,
+            ),
+            model=str(model or ""),
+        )
+    model = target[1]
+
+    raw_messages = body.get("messages")
+    if not isinstance(raw_messages, list):
+        return finish(
+            JSONResponse(_openai_error("messages must be a non-empty array"), status_code=400),
+            model=model,
+        )
+    system, messages = _messages_from_openai(raw_messages)
+    if not messages:
+        return finish(
+            JSONResponse(_openai_error("messages must be a non-empty array"), status_code=400),
+            model=model,
+        )
+    tools = _tools_from_openai(body.get("tools"))
+
+    try:
+        max_tokens = int(body.get("max_tokens") or 16384)
+        timeout = float(body.get("timeout") or 120.0)
+    except (TypeError, ValueError):
+        return finish(
+            JSONResponse(
+                _openai_error("max_tokens and timeout must be numbers"),
+                status_code=400,
+            ),
+            model=model,
+        )
+
+    chat_config = ChatConfig(
+        system=system or None,
+        temperature=body.get("temperature"),
+        max_tokens=max_tokens,
+        timeout=timeout,
+    )
+
+    try:
+        if body.get("stream") is True:
+            streaming_started = time.monotonic()
+
+            async def _streaming_wrapper():
+                try:
+                    async for line in _relay_stream(
+                        target,
+                        model=model,
+                        messages=messages,
+                        tools=tools,
+                        chat_config=chat_config,
+                    ):
+                        yield line
+                finally:
+                    log.info(
+                        "openai_compat.request",
+                        method=request.method,
+                        path=request.url.path,
+                        model=model,
+                        status=200,
+                        streaming=True,
+                        duration_ms=round((time.monotonic() - streaming_started) * 1000, 1),
+                    )
+
+            return StreamingResponse(
+                _streaming_wrapper(),
+                media_type="text/event-stream",
+                headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+            )
+        result = await _relay_completion(
+            target,
+            model=model,
+            messages=messages,
+            tools=tools,
+            chat_config=chat_config,
+        )
+        return finish(JSONResponse(result), model=model)
+    except _RelayProviderError as exc:
+        return finish(
+            JSONResponse(
+                _openai_error(exc.event.message, _SERVER_ERROR_TYPE, exc.event.code),
+                status_code=502,
+            ),
+            model=model,
+        )
+    except Exception as exc:  # noqa: BLE001 - relay must answer with an OpenAI envelope
+        return finish(
+            JSONResponse(
+                _openai_error(f"Provider request failed: {exc}", _SERVER_ERROR_TYPE),
+                status_code=502,
+            ),
+            model=model,
+        )
+
+
+async def _handle_models(request: Request, config: Any) -> Response:
+    started = time.monotonic()
+
+    def finish(response: Response, *, model: str = "") -> Response:
+        log.info(
+            "openai_compat.request",
+            method=request.method,
+            path=request.url.path,
+            model=model or None,
+            status=response.status_code,
+            duration_ms=round((time.monotonic() - started) * 1000, 1),
+        )
+        return response
+
+    guard = _guard_default_auth(config, request)
+    if guard is not None:
+        status, payload = guard
+        return finish(Response(payload, status_code=status, media_type="application/json"))
+    if request.headers.get("origin"):
+        return finish(
+            JSONResponse(_openai_error("Cross-origin requests are not allowed"), status_code=403)
+        )
+    rows = [
+        {"id": model_id, "object": "model", "created": 0, "owned_by": "opensquilla"}
+        for model_id in _relay_model_ids(config)
+    ]
+    return finish(JSONResponse({"object": "list", "data": rows}))
+
+
+def openai_compat_routes(config: Any) -> list[Any]:
+    """Return the OpenAI-compatible relay routes for the gateway app.
+
+    Empty when ``gateway.openai_compat.enabled`` is false.
+    """
+    if not getattr(config.openai_compat, "enabled", False):
+        return []
+    from starlette.routing import Route
+
+    async def chat_completions(request: Request) -> Response:
+        return await _handle_chat_completions(request, config)
+
+    async def models(request: Request) -> Response:
+        return await _handle_models(request, config)
+
+    return [
+        Route("/v1/chat/completions", chat_completions, methods=["POST"]),
+        Route("/v1/models", models, methods=["GET"]),
+    ]

--- a/tests/test_gateway/test_openai_compat.py
+++ b/tests/test_gateway/test_openai_compat.py
@@ -1,0 +1,447 @@
+"""OpenAI-compatible relay (issues #978 / #979) — auth, routing, wire format."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from starlette.testclient import TestClient
+
+from opensquilla.gateway.app import create_gateway_app
+from opensquilla.gateway.config import (
+    AuthConfig,
+    GatewayConfig,
+    LlmProviderProfile,
+    OpenAICompatConfig,
+    SquillaRouterConfig,
+)
+from opensquilla.provider.types import (
+    DoneEvent,
+    ErrorEvent,
+    TextDeltaEvent,
+    ToolDefinition,
+    ToolUseEndEvent,
+)
+
+
+class _FakeProvider:
+    """Deterministic provider double capturing the relay's call arguments."""
+
+    def __init__(self, events=None) -> None:
+        self._events = events or []
+        self.captured: dict = {}
+
+    async def chat(self, messages, tools=None, config=None):
+        self.captured = {"messages": messages, "tools": tools, "config": config}
+        for event in self._events:
+            yield event
+
+
+def _install_fake_provider(monkeypatch, fake: _FakeProvider) -> None:
+    import opensquilla.gateway.openai_compat as oc
+
+    monkeypatch.setattr(oc, "build_provider", lambda *args, **kwargs: fake)
+
+
+def _app(**config_kwargs) -> TestClient:
+    # Relay is disabled by default; enable it for tests.  Loopback client so
+    # the default auth.mode=none passes; remote-peer tests pass their own
+    # `client=` explicitly.
+    config_kwargs.setdefault("openai_compat", OpenAICompatConfig(enabled=True))
+    return TestClient(
+        create_gateway_app(GatewayConfig(**config_kwargs)), client=("127.0.0.1", 50000)
+    )
+
+
+@pytest.fixture(autouse=True)
+def _default_model_env(monkeypatch):
+    # Pin the runtime LLM explicitly: GatewayConfig treats an env-set
+    # api_key WITHOUT an explicit provider as legacy openrouter intent and
+    # backfills provider/model, which would break every routing test.
+    monkeypatch.setenv("OPENSQUILLA_LLM_PROVIDER", "tokenrhythm")
+    monkeypatch.setenv("OPENSQUILLA_LLM_MODEL", "deepseek-v4-pro")
+    monkeypatch.setenv("OPENSQUILLA_LLM_API_KEY", "test-key")
+    yield
+
+
+def test_relay_returns_openai_models_list() -> None:
+    with _app() as client:
+        response = client.get("/v1/models")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["object"] == "list"
+    ids = [row["id"] for row in payload["data"]]
+    assert "deepseek-v4-pro" in ids  # runtime default model
+    assert all(row["object"] == "model" for row in payload["data"])
+
+
+def test_relay_disabled_when_configured_off() -> None:
+    with _app(openai_compat=OpenAICompatConfig(enabled=False)) as client:
+        response = client.get("/v1/models")
+    assert response.status_code == 404
+
+
+def test_unknown_model_returns_openai_404() -> None:
+    with _app() as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": "does-not-exist", "messages": [{"role": "user", "content": "hi"}]},
+        )
+    assert response.status_code == 404
+    error = response.json()["error"]
+    assert error["code"] == "model_not_found"
+    assert "does-not-exist" in error["message"]
+
+
+def test_non_loopback_peer_denied_in_default_auth_mode() -> None:
+    # auth.mode=none (default): the relay's own loopback guard is the only
+    # boundary, mirroring the gateway's default bind scope.
+    app = create_gateway_app(
+        GatewayConfig(openai_compat=OpenAICompatConfig(enabled=True))
+    )
+    with TestClient(app, client=("10.0.0.9", 4321)) as client:
+        response = client.get("/v1/models")
+    assert response.status_code == 403
+    assert "api_key_required" in response.json()["error"]["code"]
+
+
+def test_token_mode_enforced_by_global_middleware() -> None:
+    # The relay implements no auth of its own: /v1/* is control-plane, so
+    # AuthMiddleware protects GET /v1/models as well as POST (the GET case
+    # would otherwise be treated as a root-mounted UI asset request).
+    app = create_gateway_app(
+        GatewayConfig(
+            openai_compat=OpenAICompatConfig(enabled=True),
+            auth=AuthConfig(mode="token", token="secret-123"),
+        )
+    )
+    with TestClient(app, client=("127.0.0.1", 50000)) as client:
+        assert client.get("/v1/models").status_code == 401
+        assert (
+            client.get("/v1/models", headers={"Authorization": "Bearer wrong"}).status_code == 401
+        )
+        assert client.post(
+            "/v1/chat/completions",
+            json={"model": "deepseek-v4-pro", "messages": [{"role": "user", "content": "hi"}]},
+        ).status_code == 401
+        ok = client.get("/v1/models", headers={"Authorization": "Bearer secret-123"})
+        assert ok.status_code == 200
+
+
+def test_token_mode_allows_remote_peer() -> None:
+    app = create_gateway_app(
+        GatewayConfig(
+            openai_compat=OpenAICompatConfig(enabled=True),
+            auth=AuthConfig(mode="token", token="secret-123"),
+        )
+    )
+    with TestClient(app, client=("10.0.0.9", 4321)) as client:
+        response = client.get("/v1/models", headers={"Authorization": "Bearer secret-123"})
+    assert response.status_code == 200
+
+
+def test_trusted_proxy_mode_enforced_by_middleware() -> None:
+    # Same-host reverse-proxy deployments use the existing trusted-proxy
+    # auth mode (X-Forwarded-For validation) — the maintainer-flagged
+    # "loopback behind a proxy" case gets the stock answer, no relay code.
+    app = create_gateway_app(
+        GatewayConfig(
+            openai_compat=OpenAICompatConfig(enabled=True),
+            auth=AuthConfig(mode="trusted-proxy", trusted_proxy="10.0.0.5"),
+        )
+    )
+    with TestClient(app, client=("127.0.0.1", 50000)) as client:
+        assert client.get("/v1/models").status_code == 401
+        ok = client.get("/v1/models", headers={"X-Forwarded-For": "10.0.0.5"})
+        assert ok.status_code == 200
+
+
+def test_cross_origin_browser_request_rejected() -> None:
+    with _app() as client:
+        response = client.get("/v1/models", headers={"Origin": "https://evil.example"})
+    assert response.status_code == 403
+
+
+def test_non_streaming_completion_relays_and_converts(monkeypatch) -> None:
+    fake = _FakeProvider(
+        [
+            TextDeltaEvent(text="Hello "),
+            TextDeltaEvent(text="world"),
+            DoneEvent(
+                stop_reason="end_turn",
+                input_tokens=11,
+                output_tokens=2,
+                model="deepseek-v4-pro",
+            ),
+        ]
+    )
+    _install_fake_provider(monkeypatch, fake)
+
+    with _app() as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "deepseek-v4-pro",
+                "messages": [
+                    {"role": "system", "content": "Be terse"},
+                    {"role": "user", "content": "hi"},
+                ],
+            },
+        )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["object"] == "chat.completion"
+    assert payload["model"] == "deepseek-v4-pro"
+    assert payload["choices"][0]["message"]["content"] == "Hello world"
+    assert payload["choices"][0]["finish_reason"] == "stop"
+    assert payload["usage"] == {"prompt_tokens": 11, "completion_tokens": 2, "total_tokens": 13}
+
+    # The relay must have passed the converted internal contract to the provider.
+    assert [m.role for m in fake.captured["messages"]] == ["user"]
+    assert fake.captured["config"].system == "Be terse"
+
+
+def test_streaming_completion_emits_openai_sse(monkeypatch) -> None:
+    fake = _FakeProvider(
+        [
+            TextDeltaEvent(text="part1"),
+            TextDeltaEvent(text="part2"),
+            DoneEvent(
+                stop_reason="end_turn",
+                input_tokens=5,
+                output_tokens=7,
+                model="deepseek-v4-pro",
+            ),
+        ]
+    )
+    _install_fake_provider(monkeypatch, fake)
+
+    with _app() as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "deepseek-v4-pro",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": True,
+            },
+        )
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    lines = [line for line in response.text.splitlines() if line.startswith("data: ")]
+    chunks = [json.loads(line[6:]) for line in lines if line[6:] != "[DONE]"]
+    assert lines[-1] == "data: [DONE]"
+    assert chunks[0]["object"] == "chat.completion.chunk"
+    assert chunks[0]["choices"][0]["delta"] == {"role": "assistant"}
+    deltas = [chunk["choices"][0]["delta"] for chunk in chunks if chunk["choices"][0]["delta"]]
+    assert deltas[1] == {"content": "part1"}
+    assert deltas[2] == {"content": "part2"}
+    assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+
+
+def test_tools_forwarded_and_tool_calls_serialized(monkeypatch) -> None:
+    fake = _FakeProvider(
+        [
+            ToolUseEndEvent(
+                tool_use_id="call_1",
+                tool_name="get_weather",
+                arguments={"city": "Paris"},
+            ),
+            DoneEvent(
+                stop_reason="tool_use",
+                input_tokens=9,
+                output_tokens=3,
+                model="deepseek-v4-pro",
+            ),
+        ]
+    )
+    _install_fake_provider(monkeypatch, fake)
+
+    with _app() as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "deepseek-v4-pro",
+                "messages": [{"role": "user", "content": "weather?"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "description": "Get weather",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                                "required": ["city"],
+                            },
+                        },
+                    }
+                ],
+            },
+        )
+    assert response.status_code == 200
+    payload = response.json()
+    tool_calls = payload["choices"][0]["message"]["tool_calls"]
+    assert tool_calls == [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+        }
+    ]
+    assert payload["choices"][0]["finish_reason"] == "tool_calls"
+
+    tools = fake.captured["tools"]
+    assert isinstance(tools, list) and len(tools) == 1
+    assert isinstance(tools[0], ToolDefinition)
+    assert tools[0].name == "get_weather"
+    assert tools[0].input_schema.properties == {"city": {"type": "string"}}
+
+
+def test_tier_model_routes_to_its_provider(monkeypatch) -> None:
+    captured: dict = {}
+
+    def _spy_provider(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return _FakeProvider(
+            [TextDeltaEvent(text="ok"), DoneEvent(stop_reason="end_turn", model="kimi-k2.7-code")]
+        )
+
+    import opensquilla.gateway.openai_compat as oc
+
+    monkeypatch.setattr(oc, "build_provider", _spy_provider)
+
+    config = GatewayConfig(
+        openai_compat=OpenAICompatConfig(enabled=True),
+        squilla_router=SquillaRouterConfig(
+            tiers={
+                "c2": {"provider": "tokenrhythm", "model": "kimi-k2.7-code"},
+            }
+        ),
+        llm_profiles={
+            "tokenrhythm": LlmProviderProfile(
+                api_key="sk-tier",
+                base_url="https://tokenrhythm.studio/v1",
+            )
+        },
+    )
+    with TestClient(create_gateway_app(config), client=("127.0.0.1", 50000)) as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "kimi-k2.7-code",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+    assert response.status_code == 200
+    assert captured["args"][0] == "tokenrhythm"
+    assert captured["args"][1] == "kimi-k2.7-code"
+    assert captured["args"][2] == "sk-tier"
+    assert captured["args"][3] == "https://tokenrhythm.studio/v1"
+
+
+def test_cross_provider_tier_falls_back_to_registry_env_key(monkeypatch) -> None:
+    """A tier naming a non-runtime provider resolves via the registry env key
+    even when no ``llm_profiles`` entry exists (live-gateway gap)."""
+    captured: dict = {}
+
+    def _spy_provider(*args, **kwargs):
+        captured["args"] = args
+        return _FakeProvider(
+            [
+                TextDeltaEvent(text="ok"),
+                DoneEvent(stop_reason="end_turn", model="deepseek/deepseek-v4-pro"),
+            ]
+        )
+
+    import opensquilla.gateway.openai_compat as oc
+
+    monkeypatch.setattr(oc, "build_provider", _spy_provider)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-deepseek-env")
+
+    config = GatewayConfig(
+        openai_compat=OpenAICompatConfig(enabled=True),
+        squilla_router=SquillaRouterConfig(
+            tiers={
+                "c1": {"provider": "deepseek", "model": "deepseek/deepseek-v4-pro"},
+            }
+        ),
+    )
+    with TestClient(create_gateway_app(config), client=("127.0.0.1", 50000)) as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "deepseek/deepseek-v4-pro",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+    assert response.status_code == 200
+    assert captured["args"][0] == "deepseek"
+    assert captured["args"][2] == "sk-deepseek-env"
+
+
+def test_provider_error_maps_to_openai_envelope(monkeypatch) -> None:
+    fake = _FakeProvider([ErrorEvent(message="upstream exploded", code="timeout")])
+    _install_fake_provider(monkeypatch, fake)
+
+    with _app() as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": "deepseek-v4-pro", "messages": [{"role": "user", "content": "hi"}]},
+        )
+    assert response.status_code == 502
+    error = response.json()["error"]
+    assert "upstream exploded" in error["message"]
+    assert error["code"] == "timeout"
+
+
+def test_invalid_max_tokens_returns_400_not_502(monkeypatch) -> None:
+    # Non-numeric max_tokens is a client error, not a provider failure.
+    fake = _FakeProvider([DoneEvent(stop_reason="end_turn", model="deepseek-v4-pro")])
+    _install_fake_provider(monkeypatch, fake)
+
+    with _app() as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "deepseek-v4-pro",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": "not-a-number",
+            },
+        )
+    assert response.status_code == 400
+    assert "max_tokens" in response.json()["error"]["message"]
+    # Provider must never have been called.
+    assert not fake.captured
+
+
+def test_invalid_timeout_returns_400(monkeypatch) -> None:
+    fake = _FakeProvider([DoneEvent(stop_reason="end_turn", model="deepseek-v4-pro")])
+    _install_fake_provider(monkeypatch, fake)
+
+    with _app() as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "deepseek-v4-pro",
+                "messages": [{"role": "user", "content": "hi"}],
+                "timeout": [1, 2, 3],
+            },
+        )
+    assert response.status_code == 400
+    assert not fake.captured
+
+
+def test_missing_messages_returns_400_not_502(monkeypatch) -> None:
+    # A request without `messages` is a client error — must be 400, never
+    # crash into the generic 502 provider-failure envelope.
+    fake = _FakeProvider([DoneEvent(stop_reason="end_turn", model="deepseek-v4-pro")])
+    _install_fake_provider(monkeypatch, fake)
+
+    with _app() as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": "deepseek-v4-pro"},
+        )
+    assert response.status_code == 400
+    assert not fake.captured


### PR DESCRIPTION
## Scope

Scope boundary: 第三方 OpenAI 协议客户端(astrbot、one-api、Chatbox 等)调用网关时,所有 OpenAI 格式路径(`/v1/chat/completions`、`/v1/models`)均返回 404(#978、#979)。本 PR 在网关新增 OpenAI 兼容中继端点,并按 PR #1026 关闭时维护者的设计反馈重构:

- **鉴权(零中继鉴权代码)**:`/v1/*` 归入网关控制面路径(middleware `_is_control_plane_path`),全局 `AuthMiddleware` 覆盖——`auth.mode` 的 token/password/trusted-proxy 三种模式对中继与对控制面其他路由一致生效;独立 relay key 已删除(#1026 评审指出的 key 冲突点消除)。默认 `auth.mode=none` 时中继保留 loopback-only 守卫,保持网关默认绑定范围作为安全边界;同机反向代理场景由既有 `trusted-proxy` 模式(X-Forwarded-For 校验)覆盖。浏览器跨源请求一律拒绝。
- **路由**:请求 `model` 按运行时 LLM(`llm`)与 Squilla Router 档位阶梯(`squilla_router.tiers`)解析;跨 provider 档位凭据经 `provider.deployment.resolve_provider_deployment` 解析(profile → 凭据池 → env key → registry 默认);未知模型返回 OpenAI 风格 404;缺省用运行时默认模型。
- **线格式**:非流式返回单个 `chat.completion` JSON;`stream: true` 返回 OpenAI SSE chunk 格式并以 `data: [DONE]` 结束。请求 `tools` 透传,工具调用以 `tool_calls` 呈现(含流式增量),工具执行方为客户端(标准 OpenAI 语义)。
- **可观测性**:每个中继请求输出 `openai_compat.request` 日志(方法/路径/模型/状态/耗时,流式记真实流式耗时)。
- **默认暴露**:`gateway.openai_compat.enabled` 默认 `false`,operator 显式启用(TOML 或 `OPENSQUILLA_OPENAI_COMPAT_ENABLED`)。
- **v1 不写入用量账本**:现有账本写入通道均为会话作用域,raw-relay 无会话;核算列为设计决策点(见设计提案 #<设计issue号>),agent 模式(有会话)走既有通道核算。

Non-goals: 不做 `/v1/embeddings`、不做 OpenAI responses API、不改控制面鉴权/路由、不做 agent 模式(TurnRunner 集成,路线图,见设计提案)。

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #978 , Fixes #979 ,设计提案见 #1050

If None, reason: N/A

## Release Note

Release note: 网关新增 OpenAI 兼容中继端点(`POST /v1/chat/completions`、`GET /v1/models`),第三方 OpenAI 协议客户端可通过网关调用已配置模型;默认关闭,启用后受全局鉴权(token/password/trusted-proxy)保护,未配置鉴权时仅限本机 loopback。

## Tests

Ruff: All checks passed(5 个改动文件)

Pytest: tests/test_gateway/test_openai_compat.py 16 passed(鉴权矩阵/路由/流式/非流式/tools/错误信封/非法参数);tests/test_gateway/ 全套件 2757 passed, 10 skipped;tests/unit 759 passed, 5 skipped

Build: N/A(纯后端改动)

Regression tests: added

Notes:

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [ ] Links point to existing repository files or stable external pages.
- [ ] Code fences and Markdown tables render correctly on GitHub.
- [ ] Examples avoid real secrets, local private paths, and private transcripts.