### PR TITLE
fix(mcp): authenticate bridge to token-protected gateways; stamp product version

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,67 @@ settings live in `opensquilla.toml.example`.
 
 ---
 
+## MCP Server
+
+OpenSquilla can run as a Model Context Protocol (MCP) **server**, exposing its
+session workflows to MCP clients such as Claude Desktop, Cursor, Cline, or
+Cherry Studio. This requires the `mcp` extra:
+
+```sh
+pip install "opensquilla[recommended,mcp]"
+```
+
+### Run the server
+
+```sh
+opensquilla mcp-server run --gateway ws://127.0.0.1:18791/ws
+```
+
+The bridge speaks MCP over stdio: the client launches this command as a child
+process and talks to it through stdin/stdout. `--gateway` defaults to
+`ws://localhost:18791/ws`; it must point at the gateway the client can reach,
+so when the gateway binds a non-loopback address (for example
+`opensquilla gateway run --listen 0.0.0.0`), pass that address here as well.
+
+Auth token resolution order: `--token` > `OPENSQUILLA_GATEWAY_TOKEN` >
+`[auth].token` in the OpenSquilla config file.
+
+### Client configuration
+
+Clients that support stdio MCP servers take a command plus arguments. Example
+entry for Claude Desktop / Cursor:
+
+```json
+{
+  "mcpServers": {
+    "opensquilla": {
+      "command": "/absolute/path/to/opensquilla",
+      "args": ["mcp-server", "run", "--gateway", "ws://127.0.0.1:18791/ws"]
+    }
+  }
+}
+```
+
+### Exposed tools and resources
+
+| Kind | Name | Description |
+| --- | --- | --- |
+| tool | `conversations_list` | List sessions visible to the gateway principal |
+| tool | `session_resolve` | Resolve a session key or identifier to metadata |
+| tool | `messages_read` | Read persisted messages for a session |
+| tool | `messages_send` | Send a message to a session (`intent: continue`) |
+| tool | `events_wait` | Wait for live or replayed gateway events |
+| tool | `transcript_export` | Export a full session transcript as JSONL |
+| resource | `opensquilla://sessions` | All sessions |
+| resource (template) | `opensquilla://sessions/{key}` | Session metadata |
+| resource (template) | `opensquilla://sessions/{key}/messages` | Session messages |
+| resource (template) | `opensquilla://sessions/{key}/transcript.jsonl` | Session transcript |
+
+Resources with a `{key}` placeholder are MCP **resource templates**; clients
+enumerate them via `resources/templates/list` rather than `resources/list`.
+
+---
+
 ## What's New in 0.5.0
 
 OpenSquilla 0.5.0 is the first stable release of the 0.5 line, collecting

--- a/src/opensquilla/__init__.py
+++ b/src/opensquilla/__init__.py
@@ -2,15 +2,53 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _resolve_version
+from importlib.metadata import version as _dist_version
 
-try:
-    __version__ = _resolve_version("opensquilla")
-except PackageNotFoundError:  # pragma: no cover - source tree without dist metadata
-    # Editable/source checkouts without installed distribution metadata fall
-    # back to a sentinel rather than a hardcoded semver that silently goes
-    # stale (the bug this module exists to prevent).
-    __version__ = "0.0.0+unknown"
+
+def _pyproject_version() -> str | None:
+    """Return the ``version`` field from the nearest ``pyproject.toml``.
+
+    Editable/source checkouts run from the repository tree, whose
+    ``pyproject.toml`` is authoritative; installed dist metadata for editable
+    installs can lag behind the source (the stale-version bug this fixes).
+    """
+    here = Path(__file__).resolve().parent
+    # Cover both src-layout (repo root is two levels up) and flat-layout
+    # (repo root is one level up) source checkouts.
+    for candidate in (here, here.parent, here.parent.parent):
+        pyproject = candidate / "pyproject.toml"
+        if not pyproject.is_file():
+            continue
+        try:
+            import tomllib
+        except ImportError:  # pragma: no cover - Python < 3.11
+            return None
+        try:
+            data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+            version = (data.get("project") or {}).get("version")
+            if isinstance(version, str) and version:
+                return version
+        except (OSError, ValueError):  # pragma: no cover - unreadable/invalid TOML
+            return None
+        return None
+    return None
+
+
+def _resolve_version() -> str:
+    """Resolve the effective OpenSquilla version for this checkout."""
+    source_version = _pyproject_version()
+    if source_version:
+        return source_version
+    try:
+        return _dist_version("opensquilla")
+    except PackageNotFoundError:  # pragma: no cover - source tree without dist metadata
+        # Fall back to a sentinel rather than a hardcoded semver that silently
+        # goes stale (the bug this module exists to prevent).
+        return "0.0.0+unknown"
+
+
+__version__ = _resolve_version()
 
 __all__ = ["__version__"]

--- a/src/opensquilla/cli/gateway_rpc.py
+++ b/src/opensquilla/cli/gateway_rpc.py
@@ -68,41 +68,7 @@ def _target_gateway_url(
     return default_gateway_url()
 
 
-def default_gateway_token(config_path: str | Path | None = None) -> str | None:
-    """Resolve the auth token used to connect to the gateway.
-
-    Resolution order (matches the gateway's own config-loading
-    precedence, so a single ``opensquilla.toml`` works for both ends):
-
-      1. ``OPENSQUILLA_GATEWAY_TOKEN`` env var (explicit override)
-      2. ``GatewayConfig.auth.token`` (from the explicit CLI config path,
-         ``OPENSQUILLA_GATEWAY_CONFIG_PATH`` env var,
-         ``./opensquilla.toml``, or ``~/.opensquilla/config.toml``)
-      3. ``None`` — the connect handshake omits ``auth`` and only
-         works against ``[auth] mode = "none"`` deployments.
-
-    Returns ``None`` instead of raising on any load failure so the
-    CLI still tries to connect (UNAUTHORIZED is more informative than
-    a config-loader crash).
-    """
-    env = os.environ.get("OPENSQUILLA_GATEWAY_TOKEN", "").strip()
-    if env:
-        return env
-    try:
-        from opensquilla.gateway.config import GatewayConfig
-
-        effective_config_path = (
-            str(config_path)
-            if config_path is not None
-            else os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH", "").strip()
-        )
-        cfg = GatewayConfig.load(effective_config_path or None)
-        token = getattr(getattr(cfg, "auth", None), "token", None)
-        if isinstance(token, str) and token.strip():
-            return token.strip()
-    except Exception:  # noqa: BLE001 — config-loader robustness
-        pass
-    return None
+from opensquilla.gateway_client import default_gateway_token  # noqa: F401  # re-exported: moved to opensquilla.gateway_client
 
 
 def rpc_error_exit_code(code: str | None) -> int:

--- a/src/opensquilla/cli/main.py
+++ b/src/opensquilla/cli/main.py
@@ -60,6 +60,29 @@ def _profile_from_top_level_argv(argv: list[str]) -> str | None:
     return None
 
 
+def _early_version_flag(argv: list[str]) -> bool:
+    """Return True when a top-level ``--version``/``-V`` precedes any command.
+
+    Typer/click do not reliably surface callback-only options on apps with
+    ``no_args_is_help=True`` (click >= 8.2 reports "Missing command"), so the
+    version flag is handled here before Typer parses anything.
+    """
+
+    index = 1
+    while index < len(argv):
+        value = argv[index]
+        if value in ("--version", "-V"):
+            return True
+        if value == "--profile":
+            index += 2
+            continue
+        if value.startswith("-"):
+            index += 1
+            continue
+        return False
+    return False
+
+
 def _is_offline_import_verification(argv: list[str]) -> bool:
     """Recognize the internal receipt verifier before dotenv bootstrap."""
 
@@ -106,6 +129,12 @@ def _load_env_for_active_home() -> None:
     load_env(cwd=cwd, home=home)
     _LOADED_ENV_CONTEXTS.add(context)
 
+
+if _early_version_flag(sys.argv):
+    from opensquilla import __version__
+
+    typer.echo(__version__)
+    raise SystemExit(0)
 
 _preactivate_profile_from_argv(sys.argv)
 
@@ -173,7 +202,22 @@ def _main_callback(
         envvar="OPENSQUILLA_PROFILE",
         help="Use a named OpenSquilla profile home.",
     ),
+    version: bool = typer.Option(
+        False,
+        "--version",
+        "-V",
+        help="Show the installed OpenSquilla version and exit.",
+    ),
 ) -> None:
+    # The --version/-V flag is normally short-circuited by _early_version_flag
+    # before Typer parses (click >= 8.2 mishandles callback-only options with
+    # no_args_is_help=True). Keeping the option here surfaces it in --help and
+    # acts as a fallback for direct app invocation (e.g. CliRunner tests).
+    if version:
+        from opensquilla import __version__
+
+        typer.echo(__version__)
+        raise typer.Exit()
     # Route structlog output on CLI paths to stderr (WARNING+) so command
     # stdout stays clean; the gateway bridge and interactive TUI install
     # their own richer configurations over this default when they run.

--- a/src/opensquilla/cli/mcp_server_cmd.py
+++ b/src/opensquilla/cli/mcp_server_cmd.py
@@ -17,13 +17,22 @@ def run_mcp_server(
         envvar="OPENSQUILLA_GATEWAY_URL",
         help="OpenSquilla gateway URL to bridge to.",
     ),
+    token: str | None = typer.Option(
+        None,
+        "--token",
+        envvar="OPENSQUILLA_GATEWAY_TOKEN",
+        help="Gateway auth token (defaults to OPENSQUILLA_GATEWAY_TOKEN or config [auth].token).",
+    ),
 ) -> None:
     """Run a stdio MCP server exposing OpenSquilla session workflows."""
 
     from opensquilla.mcp_server.bridge import OpenSquillaMCPBridge
     from opensquilla.mcp_server.server import create_mcp_server
 
-    bridge = OpenSquillaMCPBridge(gateway_url=normalize_gateway_url(gateway_url))
+    bridge = OpenSquillaMCPBridge(
+        gateway_url=normalize_gateway_url(gateway_url),
+        auth_token=token,
+    )
     try:
         mcp = create_mcp_server(bridge)
     except RuntimeError as exc:

--- a/src/opensquilla/gateway_client.py
+++ b/src/opensquilla/gateway_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import uuid
 from typing import Any, cast
 from urllib.parse import urlparse, urlunparse
@@ -82,7 +83,12 @@ class GatewayRPCClient:
         self._connection_error: ConnectionError | None = None
         self._closing = False
 
-    async def connect(self, url: str = "ws://localhost:18791/ws") -> None:
+    async def connect(
+        self,
+        url: str = "ws://localhost:18791/ws",
+        *,
+        auth: dict[str, Any] | None = None,
+    ) -> None:
         if self._ws is not None:
             await self.close()
         self._closing = False
@@ -105,18 +111,21 @@ class GatewayRPCClient:
                 raise RuntimeError(f"Unexpected gateway handshake frame: {challenge}")
 
             req_id = str(uuid.uuid4())
+            params: dict[str, Any] = {
+                "minProtocol": 1,
+                "maxProtocol": 3,
+                "role": "operator",
+                "scopes": self.scopes,
+            }
+            if auth is not None:
+                params["auth"] = auth
             await self._ws.send(
                 json.dumps(
                     {
                         "type": "req",
                         "id": req_id,
                         "method": "connect",
-                        "params": {
-                            "minProtocol": 1,
-                            "maxProtocol": 3,
-                            "role": "operator",
-                            "scopes": self.scopes,
-                        },
+                        "params": params,
                     }
                 )
             )
@@ -292,3 +301,40 @@ def _heartbeat_interval_from_policy(policy: dict[str, Any]) -> float:
         keepalive_s = 120.0
     minimum = 15.0 if keepalive_s > 15.0 else 0.05
     return max(minimum, keepalive_s * 0.4)
+
+
+def default_gateway_token(config_path: str | Path | None = None) -> str | None:
+    """Resolve the auth token used to connect to the gateway.
+
+    Resolution order (matches the gateway's own config-loading
+    precedence, so a single ``opensquilla.toml`` works for both ends):
+
+      1. ``OPENSQUILLA_GATEWAY_TOKEN`` env var (explicit override)
+      2. ``GatewayConfig.auth.token`` (from the explicit CLI config path,
+         ``OPENSQUILLA_GATEWAY_CONFIG_PATH`` env var,
+         ``./opensquilla.toml``, or ``~/.opensquilla/config.toml``)
+      3. ``None`` — the connect handshake omits ``auth`` and only
+         works against ``[auth] mode = "none"`` deployments.
+
+    Returns ``None`` instead of raising on any load failure so the
+    CLI still tries to connect (UNAUTHORIZED is more informative than
+    a config-loader crash).
+    """
+    env = os.environ.get("OPENSQUILLA_GATEWAY_TOKEN", "").strip()
+    if env:
+        return env
+    try:
+        from opensquilla.gateway.config import GatewayConfig
+
+        effective_config_path = (
+            str(config_path)
+            if config_path is not None
+            else os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH", "").strip()
+        )
+        cfg = GatewayConfig.load(effective_config_path or None)
+        token = getattr(getattr(cfg, "auth", None), "token", None)
+        if isinstance(token, str) and token.strip():
+            return token.strip()
+    except Exception:  # noqa: BLE001 — config-loader robustness
+        pass
+    return None

--- a/src/opensquilla/mcp_server/bridge.py
+++ b/src/opensquilla/mcp_server/bridge.py
@@ -8,11 +8,13 @@ import time
 from collections.abc import Callable
 from typing import Any, Protocol
 
-from opensquilla.gateway_client import normalize_gateway_url
+from opensquilla.gateway_client import default_gateway_token, normalize_gateway_url
 
 
 class GatewayClientLike(Protocol):
-    async def connect(self, url: str) -> None: ...
+    async def connect(
+        self, url: str, *, auth: dict[str, Any] | None = None
+    ) -> None: ...
 
     async def close(self) -> None: ...
 
@@ -33,6 +35,15 @@ def _default_gateway_client() -> GatewayClientLike:
     return GatewayRPCClient()
 
 
+def _resolve_auth(auth_token: str | None) -> dict[str, Any] | None:
+    """Resolve the gateway auth payload: explicit token -> env/config -> None."""
+
+    token = (auth_token or "").strip()
+    if not token:
+        token = (default_gateway_token() or "").strip()
+    return {"token": token} if token else None
+
+
 class OpenSquillaMCPBridge:
     """Small product bridge from MCP tools/resources to existing gateway RPCs."""
 
@@ -41,6 +52,7 @@ class OpenSquillaMCPBridge:
         *,
         gateway_url: str | None = None,
         gateway_client_factory: Callable[[], GatewayClientLike] = _default_gateway_client,
+        auth_token: str | None = None,
     ) -> None:
         raw_url = (
             gateway_url
@@ -50,6 +62,7 @@ class OpenSquillaMCPBridge:
         self.gateway_url = normalize_gateway_url(raw_url)
         self._gateway_client_factory = gateway_client_factory
         self._client: GatewayClientLike | None = None
+        self._auth = _resolve_auth(auth_token)
 
     async def close(self) -> None:
         if self._client is not None:
@@ -59,7 +72,7 @@ class OpenSquillaMCPBridge:
     async def _ensure_client(self) -> GatewayClientLike:
         if self._client is None:
             client = self._gateway_client_factory()
-            await client.connect(self.gateway_url)
+            await client.connect(self.gateway_url, auth=self._auth)
             self._client = client
         return self._client
 
@@ -84,7 +97,7 @@ class OpenSquillaMCPBridge:
         attachments: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         client = self._gateway_client_factory()
-        await client.connect(self.gateway_url)
+        await client.connect(self.gateway_url, auth=self._auth)
         try:
             subscription = await self._subscribe_messages(client, key, since_stream_seq=None)
             result = await client.call(
@@ -121,7 +134,7 @@ class OpenSquillaMCPBridge:
         terminal_only: bool = False,
     ) -> dict[str, Any]:
         client = self._gateway_client_factory()
-        await client.connect(self.gateway_url)
+        await client.connect(self.gateway_url, auth=self._auth)
         try:
             subscription = await self._subscribe_messages(
                 client, key, since_stream_seq=since_stream_seq

--- a/src/opensquilla/mcp_server/server.py
+++ b/src/opensquilla/mcp_server/server.py
@@ -4,7 +4,21 @@ from __future__ import annotations
 
 from typing import Any
 
+from opensquilla import __version__
 from opensquilla.mcp_server.bridge import OpenSquillaMCPBridge
+
+
+def _stamp_server_version(mcp: Any, version: str) -> None:
+    """Stamp the product version onto the low-level MCP server.
+
+    FastMCP does not expose a ``version`` constructor argument; the low-level
+    server otherwise reports the MCP SDK version in ``initialize``, which is
+    misleading. Set the attribute directly when it is still unset.
+    """
+
+    low_level = getattr(mcp, "_mcp_server", None)
+    if low_level is not None and getattr(low_level, "version", None) is None:
+        low_level.version = version
 
 
 def create_mcp_server(
@@ -26,6 +40,7 @@ def create_mcp_server(
 
     bridge = bridge or OpenSquillaMCPBridge()
     mcp = fastmcp_cls(name, json_response=True)
+    _stamp_server_version(mcp, __version__)
 
     @mcp.tool(name="conversations_list")
     async def conversations_list(limit: int = 50) -> dict[str, Any]:

--- a/tests/test_mcp_server/test_bridge.py
+++ b/tests/test_mcp_server/test_bridge.py
@@ -18,8 +18,9 @@ class FakeGatewayClient:
         self.calls: list[tuple[str, dict[str, Any] | None]] = []
         self.events: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
 
-    async def connect(self, url: str) -> None:
+    async def connect(self, url: str, auth: str | None = None) -> None:
         self.connected_url = url
+        self.connected_auth = auth
 
     async def close(self) -> None:
         self.closed = True


### PR DESCRIPTION
## Problem

`opensquilla mcp-server run` against a gateway running `[auth] mode = "token"` connects but **every tool call fails with UNAUTHORIZED**: the MCP bridge's `GatewayRPCClient` handshake never carried an auth token. The MCP server was unusable on token-protected deployments.

Two secondary defects surfaced in the same area:

1. `serverInfo.version` in the `initialize` response reported the **MCP SDK version** (e.g. `1.29.0`) instead of the product version — FastMCP exposes no `version` constructor argument, so the low-level server defaulted to `pkg_version("mcp")`.
2. Editable/source checkouts surfaced a **stale dist-info version** (0.5.1) instead of the source version (0.5.2); `opensquilla --version` errored with "No such option".

## Fix

- `GatewayRPCClient.connect()` accepts an optional `auth` token and includes it in the RPC handshake params.
- `OpenSquillaMCPBridge` resolves the token via `_resolve_auth()` — explicit `--token` > `OPENSQUILLA_GATEWAY_TOKEN` > `[auth].token` from the OpenSquilla config file — and passes it to all connection sites. New `mcp-server run --token` option exposes the explicit override. `default_gateway_token()` moves from `cli/gateway_rpc.py` to `gateway_client.py` (re-exported) so the bridge reuses one resolution path.
- `create_mcp_server()` stamps the product version onto the low-level MCP server when unset, so `serverInfo.version` reports the product version.
- `opensquilla.__version__` prefers the `version` field from `pyproject.toml` (nearest ancestor of the source tree) over installed dist metadata, fixing stale-version reporting on editable installs; a top-level `--version`/`-V` flag is added to the CLI.
- README gains an "MCP Server" section: running the stdio server, auth token resolution order, a client configuration example, and the exposed tools/resources.

## Verification

- MCP `initialize` handshake against the live token-protected gateway succeeds; `conversations_list` returns real session data (previously UNAUTHORIZED).
- `serverInfo` now reports `{name: "OpenSquilla", version: "0.5.2"}` matching `pyproject.toml`; `opensquilla --version` prints 0.5.2.
- Full tool/resource enumeration unchanged: 6 tools, 1 static resource + 3 resource templates.
- `tests/test_mcp_server/` updated and passing (18 passed).