### PR TITLE
Gate zai reasoning dialect injection to Zhipu's official host

### DIFF
--- a/src/opensquilla/provider/compat_policy.py
+++ b/src/opensquilla/provider/compat_policy.py
@@ -258,6 +258,11 @@ class OpenAICompatPolicy:
     # Reasoning format assumed when no model capabilities are available.
     default_reasoning_format: str = ""
 
+    # Whether the reasoning dialect's payload (e.g. a vendor-specific
+    # ``thinking`` object) is only valid on this provider's official_host;
+    # off-host requests omit it instead of sending an unrecognized field.
+    reasoning_dialect_requires_official_host: bool = False
+
     # Models that need an explicit thinking enable/disable payload even when
     # no capability profile is available (exact ids, lowercase).
     thinking_toggle_model_ids: frozenset[str] = frozenset()
@@ -477,7 +482,11 @@ _POLICIES_BY_KIND: dict[str, OpenAICompatPolicy] = {
     "mimo": OpenAICompatPolicy(display_name="MiMo"),
     "mistral": OpenAICompatPolicy(display_name="Mistral"),
     "groq": OpenAICompatPolicy(display_name="Groq"),
-    "zhipu": OpenAICompatPolicy(display_name="Zhipu"),
+    "zhipu": OpenAICompatPolicy(
+        display_name="Zhipu",
+        official_host="open.bigmodel.cn",
+        reasoning_dialect_requires_official_host=True,
+    ),
     "qianfan": OpenAICompatPolicy(display_name="Qianfan"),
     "siliconflow": OpenAICompatPolicy(display_name="SiliconFlow"),
     "aihubmix": OpenAICompatPolicy(display_name="AiHubMix"),

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -724,6 +724,19 @@ def _on_official_host(policy: OpenAICompatPolicy, base_url: str) -> bool:
     return bool(policy.official_host) and policy.official_host in base_url.lower()
 
 
+def _effective_reasoning_format(
+    policy: OpenAICompatPolicy,
+    reasoning_format: str,
+    base_url: str,
+) -> str:
+    """Suppress a reasoning dialect that only the official host understands."""
+    if policy.reasoning_dialect_requires_official_host and not _on_official_host(
+        policy, base_url
+    ):
+        return ""
+    return reasoning_format
+
+
 def _uses_max_completion_tokens(
     policy: OpenAICompatPolicy,
     base_url: str,
@@ -3437,10 +3450,14 @@ class OpenAIProvider:
             reasoning_format = (
                 reasoning_rule.reasoning_format
                 if reasoning_rule and reasoning_rule.reasoning_format
-                else (
-                    caps.reasoning_format
-                    if caps is not None
-                    else self._compat.default_reasoning_format
+                else _effective_reasoning_format(
+                    self._compat,
+                    (
+                        caps.reasoning_format
+                        if caps is not None
+                        else self._compat.default_reasoning_format
+                    ),
+                    self._base_url,
                 )
             )
             reasoning_effort_override: str | None = None
@@ -3504,7 +3521,9 @@ class OpenAIProvider:
         elif caps and caps.supports_reasoning:
             apply_reasoning_disable(
                 payload,
-                caps.reasoning_format,
+                _effective_reasoning_format(
+                    self._compat, caps.reasoning_format, self._base_url
+                ),
                 ReasoningDisableArgs(
                     model=self._model,
                     disable_reasoning_by_default_models=(

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -2442,6 +2442,56 @@ def test_zai_non_thinking_sends_provider_disabled_for_default_thinking_model(
     assert captured["payload"]["thinking"] == {"type": "disabled"}
 
 
+def test_zai_thinking_omits_provider_thinking_object_off_official_host(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="glm-5.2",
+        base_url="https://openrouter.ai/api/v1",
+        provider_kind="zhipu",
+    )
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            supports_tools=True,
+            reasoning_format="zai",
+        ),
+    )
+
+    _collect(provider, cfg)
+
+    assert "thinking" not in captured["payload"]
+
+
+def test_zai_non_thinking_omits_provider_thinking_object_off_official_host(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="glm-5.2",
+        base_url="https://openrouter.ai/api/v1",
+        provider_kind="zhipu",
+    )
+    cfg = ChatConfig(
+        thinking=False,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            supports_tools=True,
+            reasoning_format="zai",
+        ),
+    )
+
+    _collect(provider, cfg)
+
+    assert "thinking" not in captured["payload"]
+
+
 def test_dashscope_cache_on_marks_system_and_latest_user(monkeypatch: Any) -> None:
     captured: dict[str, Any] = {}
     _patch_transport(monkeypatch, captured)


### PR DESCRIPTION
## Scope

Scope boundary: gate the `zai` reasoning dialect (Zhipu's `thinking` object) so it is only sent when the request actually goes to Zhipu's official host, `open.bigmodel.cn`.

Non-goals: `deepseek`, `moonshot`, and `volcengine` share the same ungated `official_host=""` shape and likely have the same reachable failure, but only `zhipu`/`glm-5.2` is confirmed in #961. Left untouched here; worth a follow-up once each is confirmed separately.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #961

## Release Note

Release note: any provider configured as `zhipu` (`reasoning_shape="zai"`) with a `base_url` other than `open.bigmodel.cn` no longer sends the vendor-specific `thinking` field, which most relays and aggregators reject with `400 UNKNOWN_FIELD`.

## Tests

Ruff: `uv run ruff check src/opensquilla/provider/openai.py src/opensquilla/provider/compat_policy.py tests/test_provider_openai_compat_payloads.py` clean.

Pytest: `uv run mypy src/opensquilla --show-error-codes` clean; `uv run pytest tests/test_provider_openai_compat_payloads.py tests/test_provider/test_reasoning_dialects.py tests/test_provider_reasoning_stream.py -q` 167 passed. The two new tests fail on unpatched `main` (`AssertionError: assert 'thinking' not in {...}`) and pass on this branch.

Build: not run (backend-only change, no frontend/build surface touched).

Regression tests: added.

Notes: `_on_official_host` already gates two other provider-specific quirks (`max_completion_tokens`, the thinking-temperature omission); this reuses the same primitive rather than adding a new mechanism. Not independently verified against a live relay endpoint, only against the repo's own request-construction tests.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

No secrets, local-only artifacts, or private content in this change.

## Third-Party Origin

Third-party origin: none

## Root cause

`_apply_compat_request_constraints`'s reasoning block (`provider/openai.py`) calls `apply_reasoning_enable`/`apply_reasoning_disable` from the model's declared `reasoning_format` alone, regardless of where `base_url` actually points. `zhipu` binds `reasoning_shape="zai"`, whose dialect writes a bare `thinking: {"type": ...}` object, Zhipu's own API shape. That field is unrecognized by any endpoint that merely resells `glm-5.2` (OpenRouter, DashScope, SiliconFlow, a self-hosted proxy), so every turn against one of those 400s. The codebase already has `_on_official_host(policy, base_url)` for exactly this class of host-scoped quirk; the zai dialect never consulted it, and `zhipu`'s own policy had no `official_host` to check against even if it had.

## Fix

- `compat_policy.py`: give `zhipu` an `official_host="open.bigmodel.cn"`, and add `reasoning_dialect_requires_official_host` (defaults to `False`, so every other provider is unaffected) set `True` for `zhipu`.
- `openai.py`: new `_effective_reasoning_format` helper returns `""` (a no-op for `apply_reasoning_enable`/`apply_reasoning_disable`, per their own doc comments) instead of the real dialect when the policy sets that flag and the request is not on `official_host`. Used at both the enable and disable call sites.
