### PR TITLE
Extract MetaSkill setup state and recovery storage

### DIFF
--- a/opensquilla-webui/src/composables/chat/metaSetupMachine.test.ts
+++ b/opensquilla-webui/src/composables/chat/metaSetupMachine.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest'
+
+import type { MetaSetupJob, MetaSetupReadiness, MetaSetupState } from '@/types/metaSetup'
+
+import {
+  META_SETUP_PROVIDER_HANDOFF_TTL_MS,
+  createMetaSetupConfirmationState,
+  metaSetupResumeRequestId,
+  projectMetaSetupJob,
+  transitionMetaSetupState,
+  validMetaSetupProviderHandoff,
+} from './metaSetupMachine'
+
+const SESSION = 'agent:main:webchat:setup-machine'
+
+function readiness(overrides: Partial<MetaSetupReadiness> = {}): MetaSetupReadiness {
+  return {
+    ready: false,
+    status: 'needs_setup',
+    setup_actions: [{ id: 'install-tool', available: true }],
+    ...overrides,
+  }
+}
+
+function state(overrides: Partial<MetaSetupState> = {}): MetaSetupState {
+  return {
+    name: 'meta-paper-write',
+    sessionKey: SESSION,
+    launchText: '/meta meta-paper-write -- topic',
+    phase: 'confirm',
+    readiness: readiness(),
+    actionIds: ['install-tool'],
+    completedActions: [],
+    ...overrides,
+  }
+}
+
+function job(overrides: Partial<MetaSetupJob> = {}): MetaSetupJob {
+  return {
+    job_id: 'job-1',
+    name: 'meta-paper-write',
+    sessionKey: SESSION,
+    action_ids: ['install-tool'],
+    status: 'running',
+    phase: 'installing',
+    completed_actions: [],
+    readiness: null,
+    ...overrides,
+  }
+}
+
+describe('meta setup state machine', () => {
+  it('derives confirm and blocked states from readiness without side effects', () => {
+    const confirm = createMetaSetupConfirmationState(
+      'meta-paper-write',
+      readiness(),
+      SESSION,
+      '/meta meta-paper-write -- topic',
+    )
+    expect(confirm).toMatchObject({
+      phase: 'confirm',
+      actionIds: ['install-tool'],
+      launchText: '/meta meta-paper-write -- topic',
+    })
+
+    const blocked = createMetaSetupConfirmationState(
+      'meta-paper-write',
+      { reasons: ['Connect a provider'] },
+      SESSION,
+      '/meta meta-paper-write unsafe trailing text',
+    )
+    expect(blocked).toMatchObject({
+      phase: 'blocked',
+      blockedReason: 'no_actions',
+      retryMode: 'readiness',
+      error: 'Connect a provider',
+      launchText: '/meta meta-paper-write',
+    })
+  })
+
+  it('moves through install, verify, failure, and session-change states immutably', () => {
+    const initial = state({ message: 'old', error: 'old', retryMode: 'install' })
+    const installing = transitionMetaSetupState(initial, { type: 'install_started' })
+    const verifying = transitionMetaSetupState(installing, {
+      type: 'verification_started',
+      readiness: { ready: true },
+    })
+    const failed = transitionMetaSetupState(verifying, {
+      type: 'failed',
+      error: 'launch failed',
+      retryMode: 'launch',
+    })
+    const blocked = transitionMetaSetupState(failed, {
+      type: 'session_changed',
+      clearRetryMode: true,
+    })
+
+    expect(initial.phase).toBe('confirm')
+    expect(installing).toMatchObject({ phase: 'installing', message: '', error: '' })
+    expect(verifying).toMatchObject({ phase: 'verifying', readiness: { ready: true } })
+    expect(failed).toMatchObject({ phase: 'failed', retryMode: 'launch' })
+    expect(blocked).toMatchObject({ phase: 'blocked', blockedReason: 'session_changed' })
+    expect(blocked.retryMode).toBeUndefined()
+  })
+
+  it('preserves the durable request identity across provider handoff cancellation', () => {
+    const handoff = {
+      kind: 'provider_settings' as const,
+      providerId: 'openai',
+      startedAtMs: 100,
+      clientRequestId: 'request-1',
+    }
+    const handedOff = transitionMetaSetupState(
+      state({ suppressAutoResume: true }),
+      { type: 'provider_handoff_started', handoff },
+    )
+    const cancelled = transitionMetaSetupState(handedOff, {
+      type: 'provider_handoff_cancelled',
+    })
+
+    expect(handedOff.suppressAutoResume).toBeUndefined()
+    expect(metaSetupResumeRequestId(handedOff)).toBe('request-1')
+    expect(cancelled.providerHandoff).toBeUndefined()
+    expect(cancelled.resumeRequestId).toBe('request-1')
+  })
+
+  it('accepts only current, available provider handoffs', () => {
+    const providerReadiness = readiness({
+      manual_setup_actions: [{
+        id: 'connect-provider',
+        kind: 'provider_connection',
+        provider_id: 'OpenAI',
+        available: true,
+      }],
+    })
+    const now = 1_000_000
+    const handoff = {
+      kind: 'provider_settings',
+      providerId: 'OPENAI',
+      startedAtMs: now - META_SETUP_PROVIDER_HANDOFF_TTL_MS,
+      clientRequestId: ' request-1 ',
+    }
+
+    expect(validMetaSetupProviderHandoff(handoff, providerReadiness, now)).toEqual({
+      kind: 'provider_settings',
+      providerId: 'openai',
+      startedAtMs: handoff.startedAtMs,
+      clientRequestId: 'request-1',
+    })
+    expect(validMetaSetupProviderHandoff(
+      { ...handoff, startedAtMs: handoff.startedAtMs - 1 },
+      providerReadiness,
+      now,
+    )).toBeUndefined()
+  })
+
+  it('projects active and completed server jobs while retaining setup coordinates', () => {
+    const active = projectMetaSetupJob(
+      state(),
+      job({ downloaded_bytes: 12, download_total_bytes: 20 }),
+      '/meta meta-paper-write -- topic',
+    )
+    expect(active).toMatchObject({
+      kind: 'active',
+      state: {
+        phase: 'installing',
+        jobId: 'job-1',
+        downloadedBytes: 12,
+        downloadTotalBytes: 20,
+      },
+    })
+
+    const completed = projectMetaSetupJob(
+      active.state,
+      job({ status: 'completed', phase: 'completed', completed_actions: ['install-tool'] }),
+      '/meta meta-paper-write -- topic',
+    )
+    expect(completed).toMatchObject({
+      kind: 'completed',
+      state: { phase: 'verifying', completedActions: ['install-tool'], error: '' },
+    })
+  })
+
+  it('projects blocked and failed jobs with the correct recovery mode', () => {
+    const identified = state({
+      resumeRequestId: 'request-1',
+      providerHandoff: {
+        kind: 'provider_settings',
+        providerId: 'openai',
+        startedAtMs: 100,
+        clientRequestId: 'request-1',
+      },
+    })
+    const blocked = projectMetaSetupJob(
+      identified,
+      job({
+        status: 'blocked',
+        phase: 'blocked',
+        readiness: { manual_setup_actions: [] },
+        error: 'Provider still missing',
+      }),
+      '/meta meta-paper-write -- topic',
+    )
+    expect(blocked).toMatchObject({
+      kind: 'blocked',
+      state: {
+        blockedReason: 'requirements_remaining',
+        resumeRequestId: 'request-1',
+        error: 'Provider still missing',
+      },
+    })
+
+    const failed = projectMetaSetupJob(
+      state(),
+      job({
+        status: 'failed',
+        phase: 'failed',
+        completed_actions: [],
+        error: 'Install failed',
+      }),
+      '/meta meta-paper-write -- topic',
+    )
+    expect(failed).toMatchObject({
+      kind: 'failed',
+      state: { phase: 'failed', retryMode: 'install', error: 'Install failed' },
+    })
+  })
+})

--- a/opensquilla-webui/src/composables/chat/metaSetupMachine.ts
+++ b/opensquilla-webui/src/composables/chat/metaSetupMachine.ts
@@ -1,0 +1,317 @@
+import type {
+  MetaSetupJob,
+  MetaSetupProviderHandoff,
+  MetaSetupReadiness,
+  MetaSetupRetryMode,
+  MetaSetupState,
+} from '@/types/metaSetup'
+
+// Deterministic setup policy belongs here. Keep Vue refs, timers, RPC calls,
+// browser storage, and user-visible side effects in their adapter/repository.
+const PROVIDER_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/
+const CLIENT_REQUEST_ID_PATTERN = /^\S{1,256}$/
+
+export const META_SETUP_PROVIDER_HANDOFF_TTL_MS = 15 * 60 * 1000
+
+export function normalizeMetaLaunchText(name: string, candidate?: string): string {
+  const legacy = `/meta ${name}`
+  const launchText = String(candidate || '').trim()
+  if (launchText === legacy) return launchText
+  const suffix = launchText.startsWith(legacy) ? launchText.slice(legacy.length) : ''
+  if (/^\s+--(?:\s+[\s\S]*)?$/.test(suffix)) return launchText
+  return legacy
+}
+
+export function availableMetaSetupActionIds(readiness: MetaSetupReadiness): string[] {
+  return (readiness.setup_actions || [])
+    .filter(action => action.available !== false && Boolean(action.id))
+    .map(action => action.id)
+}
+
+export function normalizeMetaSetupProviderId(candidate: unknown): string {
+  const providerId = typeof candidate === 'string' ? candidate.trim().toLowerCase() : ''
+  return PROVIDER_ID_PATTERN.test(providerId) ? providerId : ''
+}
+
+export function availableMetaSetupProviderIds(readiness: MetaSetupReadiness): string[] {
+  const providerIds = (readiness.manual_setup_actions || [])
+    .filter(action => action.kind === 'provider_connection' && action.available !== false)
+    .map(action => normalizeMetaSetupProviderId(action.provider_id))
+    .filter(Boolean)
+  return [...new Set(providerIds)]
+}
+
+export function normalizeMetaSetupClientRequestId(candidate: unknown): string {
+  const clientRequestId = typeof candidate === 'string' ? candidate.trim() : ''
+  return CLIENT_REQUEST_ID_PATTERN.test(clientRequestId) ? clientRequestId : ''
+}
+
+export function validMetaSetupProviderHandoff(
+  candidate: unknown,
+  readiness: MetaSetupReadiness,
+  nowMs = Date.now(),
+): MetaSetupProviderHandoff | undefined {
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return undefined
+  const value = candidate as Partial<MetaSetupProviderHandoff>
+  const providerId = normalizeMetaSetupProviderId(value.providerId)
+  const clientRequestId = normalizeMetaSetupClientRequestId(value.clientRequestId)
+  const startedAtMs = value.startedAtMs
+  if (typeof startedAtMs !== 'number') return undefined
+  const ageMs = nowMs - startedAtMs
+  if (
+    value.kind !== 'provider_settings'
+    || !providerId
+    || !clientRequestId
+    || !availableMetaSetupProviderIds(readiness).includes(providerId)
+    || !Number.isFinite(startedAtMs)
+    || ageMs < 0
+    || ageMs > META_SETUP_PROVIDER_HANDOFF_TTL_MS
+  ) {
+    return undefined
+  }
+  return { kind: 'provider_settings', providerId, startedAtMs, clientRequestId }
+}
+
+export function metaSetupErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error || 'Unknown setup error')
+}
+
+export function isMissingMetaSetupJobError(error: unknown): boolean {
+  return /(?:not found|404|unknown (?:meta )?setup job|setup job (?:is )?unknown)/i
+    .test(metaSetupErrorMessage(error))
+}
+
+export function isBusyMetaSetupState(state: MetaSetupState): boolean {
+  return state.phase === 'installing' || state.phase === 'verifying'
+}
+
+export function metaSetupResumeRequestId(
+  current: MetaSetupState | null | undefined,
+): string {
+  return normalizeMetaSetupClientRequestId(
+    current?.resumeRequestId || current?.providerHandoff?.clientRequestId,
+  )
+}
+
+export function createMetaSetupConfirmationState(
+  name: string,
+  readiness: MetaSetupReadiness,
+  sessionKey: string,
+  launchText: string,
+): MetaSetupState {
+  const actionIds = availableMetaSetupActionIds(readiness)
+  const providerIds = availableMetaSetupProviderIds(readiness)
+  if (actionIds.length === 0 && providerIds.length === 0) {
+    return {
+      name,
+      sessionKey,
+      launchText: normalizeMetaLaunchText(name, launchText),
+      phase: 'blocked',
+      readiness,
+      actionIds,
+      completedActions: [],
+      error: readiness.reasons?.join('; ') || '',
+      blockedReason: 'no_actions',
+      retryMode: 'readiness',
+    }
+  }
+  return {
+    name,
+    sessionKey,
+    launchText: normalizeMetaLaunchText(name, launchText),
+    phase: 'confirm',
+    readiness,
+    actionIds,
+    completedActions: [],
+    retryMode: actionIds.length === 0 ? 'readiness' : undefined,
+  }
+}
+
+export type MetaSetupMachineEvent =
+  | { type: 'failed'; error: string; retryMode: MetaSetupRetryMode }
+  | { type: 'install_started' }
+  | {
+    type: 'verification_started'
+    readiness?: MetaSetupReadiness
+    clearSuppressAutoResume?: boolean
+  }
+  | { type: 'launch_queued' }
+  | { type: 'session_changed'; clearRetryMode?: boolean }
+  | { type: 'provider_handoff_started'; handoff: MetaSetupProviderHandoff }
+  | { type: 'provider_handoff_cancelled' }
+
+export function transitionMetaSetupState(
+  current: MetaSetupState,
+  event: MetaSetupMachineEvent,
+): MetaSetupState {
+  if (event.type === 'failed') {
+    return {
+      ...current,
+      phase: 'failed',
+      error: event.error,
+      retryMode: event.retryMode,
+    }
+  }
+  if (event.type === 'install_started') {
+    return {
+      ...current,
+      phase: 'installing',
+      message: '',
+      error: '',
+      retryMode: undefined,
+    }
+  }
+  if (event.type === 'verification_started') {
+    const next = {
+      ...current,
+      phase: 'verifying' as const,
+      ...(event.readiness ? { readiness: event.readiness } : {}),
+      ...(event.clearSuppressAutoResume ? { suppressAutoResume: undefined } : {}),
+      message: '',
+      error: '',
+      retryMode: undefined,
+    }
+    return next
+  }
+  if (event.type === 'launch_queued') {
+    return {
+      ...current,
+      phase: 'verifying',
+      message: '',
+      error: '',
+      retryMode: undefined,
+    }
+  }
+  if (event.type === 'session_changed') {
+    return {
+      ...current,
+      phase: 'blocked',
+      blockedReason: 'session_changed',
+      ...(event.clearRetryMode ? { retryMode: undefined } : {}),
+    }
+  }
+  if (event.type === 'provider_handoff_started') {
+    const { suppressAutoResume: _suppressAutoResume, ...resumable } = current
+    return {
+      ...resumable,
+      resumeRequestId: event.handoff.clientRequestId,
+      providerHandoff: event.handoff,
+    }
+  }
+  const { providerHandoff: _providerHandoff, ...next } = current
+  return next
+}
+
+export function failMetaSetupState(
+  current: MetaSetupState,
+  error: string,
+  retryMode: MetaSetupRetryMode,
+): MetaSetupState {
+  return transitionMetaSetupState(current, { type: 'failed', error, retryMode })
+}
+
+export type MetaSetupJobProjection = {
+  kind: 'completed' | 'blocked' | 'failed' | 'active'
+  state: MetaSetupState
+}
+
+export function projectMetaSetupJob(
+  current: MetaSetupState,
+  job: MetaSetupJob,
+  launchText: string,
+): MetaSetupJobProjection {
+  const completedActions = [...(job.completed_actions || [])]
+  const remainingActionIds = (job.action_ids || current.actionIds)
+    .filter(actionId => !completedActions.includes(actionId))
+  const readiness = job.readiness || current.readiness
+
+  if (job.status === 'completed' || job.phase === 'completed') {
+    return {
+      kind: 'completed',
+      state: {
+        ...current,
+        name: job.name,
+        launchText,
+        phase: 'verifying',
+        readiness,
+        jobId: job.job_id,
+        jobStatus: job.status,
+        message: job.message || '',
+        currentAction: '',
+        downloadedBytes: job.downloaded_bytes || 0,
+        downloadTotalBytes: job.download_total_bytes || 0,
+        completedActions,
+        error: '',
+      },
+    }
+  }
+
+  if (job.status === 'blocked' || job.phase === 'blocked') {
+    const next = createMetaSetupConfirmationState(
+      job.name,
+      readiness,
+      job.sessionKey,
+      launchText,
+    )
+    return {
+      kind: 'blocked',
+      state: {
+        ...next,
+        jobId: job.job_id,
+        jobStatus: job.status,
+        message: job.message || '',
+        currentAction: '',
+        downloadedBytes: job.downloaded_bytes || 0,
+        downloadTotalBytes: job.download_total_bytes || 0,
+        completedActions,
+        error: job.error || next.error || '',
+        blockedReason: next.phase === 'blocked' ? 'requirements_remaining' : undefined,
+        providerHandoff: current.providerHandoff,
+        resumeRequestId: metaSetupResumeRequestId(current) || undefined,
+      },
+    }
+  }
+
+  if (job.status === 'failed' || job.phase === 'failed') {
+    return {
+      kind: 'failed',
+      state: {
+        ...current,
+        name: job.name,
+        launchText,
+        phase: 'failed',
+        actionIds: remainingActionIds,
+        jobId: job.job_id,
+        jobStatus: job.status,
+        message: job.message || '',
+        currentAction: '',
+        downloadedBytes: job.downloaded_bytes || 0,
+        downloadTotalBytes: job.download_total_bytes || 0,
+        completedActions,
+        error: job.error || job.message || 'Setup failed',
+        retryMode: remainingActionIds.length ? 'install' : 'status',
+      },
+    }
+  }
+
+  return {
+    kind: 'active',
+    state: {
+      ...current,
+      name: job.name,
+      launchText,
+      phase: job.phase === 'verifying' ? 'verifying' : 'installing',
+      readiness,
+      actionIds: job.action_ids || current.actionIds,
+      jobId: job.job_id,
+      jobStatus: job.status,
+      message: job.message || '',
+      currentAction: job.current_action || '',
+      downloadedBytes: job.downloaded_bytes || 0,
+      downloadTotalBytes: job.download_total_bytes || 0,
+      completedActions,
+      error: '',
+      retryMode: undefined,
+    },
+  }
+}

--- a/opensquilla-webui/src/composables/chat/metaSetupRepository.test.ts
+++ b/opensquilla-webui/src/composables/chat/metaSetupRepository.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest'
+
+import type { MetaSetupState } from '@/types/metaSetup'
+
+import { META_SETUP_PROVIDER_HANDOFF_TTL_MS } from './metaSetupMachine'
+import {
+  createMetaSetupRepository,
+  metaSetupLaunchStorageKey,
+  metaSetupManualStorageKey,
+  metaSetupStorageKey,
+  type MetaSetupStorage,
+} from './metaSetupRepository'
+
+const SESSION = 'agent:main:webchat:setup repository'
+
+function memoryStorage(initial: Record<string, string> = {}) {
+  const values = new Map(Object.entries(initial))
+  const storage: MetaSetupStorage = {
+    getItem: key => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+    removeItem: key => values.delete(key),
+  }
+  return { storage, values }
+}
+
+function checkpoint(overrides: Partial<MetaSetupState> = {}): MetaSetupState {
+  return {
+    name: 'meta-paper-write',
+    sessionKey: SESSION,
+    launchText: '/meta meta-paper-write -- topic',
+    phase: 'installing',
+    readiness: {
+      setup_actions: [{ id: 'install-tool', available: true }],
+      manual_setup_actions: [{
+        id: 'connect-provider',
+        kind: 'provider_connection',
+        provider_id: 'openai',
+        available: true,
+      }],
+    },
+    actionIds: ['install-tool'],
+    jobId: 'ephemeral-job',
+    jobStatus: 'running',
+    message: 'Installing',
+    currentAction: 'install-tool',
+    completedActions: [],
+    ...overrides,
+  }
+}
+
+describe('meta setup repository', () => {
+  it('keeps the existing encoded storage-key contract', () => {
+    expect(metaSetupStorageKey(SESSION)).toBe(
+      'opensquilla.chat.metaSetupJob:agent%3Amain%3Awebchat%3Asetup%20repository',
+    )
+    expect(metaSetupLaunchStorageKey(SESSION)).toContain('metaSetupLaunch:agent%3Amain')
+    expect(metaSetupManualStorageKey(SESSION)).toContain('metaSetupManual:agent%3Amain')
+  })
+
+  it('persists only stable replay coordinates, never server job progress', () => {
+    const { storage, values } = memoryStorage()
+    const repository = createMetaSetupRepository(storage)
+    const current = checkpoint({
+      resumeRequestId: 'request-1',
+      providerHandoff: {
+        kind: 'provider_settings',
+        providerId: 'openai',
+        startedAtMs: Date.now(),
+        clientRequestId: 'request-1',
+      },
+    })
+
+    expect(repository.persistCheckpoint(current)).toBe(true)
+    const persisted = JSON.parse(values.get(metaSetupManualStorageKey(SESSION)) || '{}')
+    expect(persisted).toEqual({
+      name: current.name,
+      launchText: current.launchText,
+      readiness: current.readiness,
+      providerHandoff: current.providerHandoff,
+      resumeRequestId: 'request-1',
+    })
+    expect(persisted).not.toHaveProperty('jobId')
+    expect(persisted).not.toHaveProperty('currentAction')
+  })
+
+  it('sanitizes an expired provider handoff but preserves its durable request identity', () => {
+    const startedAtMs = Date.now() - META_SETUP_PROVIDER_HANDOFF_TTL_MS - 1
+    const original = checkpoint({
+      resumeRequestId: 'request-1',
+      providerHandoff: {
+        kind: 'provider_settings',
+        providerId: 'openai',
+        startedAtMs,
+        clientRequestId: 'request-1',
+      },
+    })
+    const { storage, values } = memoryStorage({
+      [metaSetupManualStorageKey(SESSION)]: JSON.stringify({
+        name: original.name,
+        launchText: original.launchText,
+        readiness: original.readiness,
+        providerHandoff: original.providerHandoff,
+        resumeRequestId: original.resumeRequestId,
+      }),
+    })
+    const restored = createMetaSetupRepository(storage).readCheckpoint(SESSION)
+
+    expect(restored?.providerHandoff).toBeUndefined()
+    expect(restored?.resumeRequestId).toBe('request-1')
+    expect(restored?.suppressAutoResume).toBe(true)
+    const sanitized = values.get(metaSetupManualStorageKey(SESSION)) || ''
+    expect(sanitized).not.toContain('providerHandoff')
+    expect(sanitized).toContain('suppressAutoResume')
+  })
+
+  it('clears only the missing job pointer and restores a stable checkpoint', () => {
+    const current = checkpoint({ phase: 'confirm', jobId: undefined })
+    const { storage, values } = memoryStorage({
+      [metaSetupStorageKey(SESSION)]: 'missing-job',
+      [metaSetupManualStorageKey(SESSION)]: JSON.stringify({
+        name: current.name,
+        launchText: current.launchText,
+        readiness: current.readiness,
+        resumeRequestId: 'request-1',
+      }),
+    })
+    const restored = createMetaSetupRepository(storage).recoverFromMissingJob(SESSION)
+
+    expect(values.has(metaSetupStorageKey(SESSION))).toBe(false)
+    expect(values.has(metaSetupManualStorageKey(SESSION))).toBe(true)
+    expect(restored).toMatchObject({
+      name: 'meta-paper-write',
+      launchText: '/meta meta-paper-write -- topic',
+      resumeRequestId: 'request-1',
+    })
+  })
+
+  it('upgrades a legacy launch-only record into a readiness checkpoint', () => {
+    const launchText = '/meta meta-paper-write -- legacy topic'
+    const { storage, values } = memoryStorage({
+      [metaSetupStorageKey(SESSION)]: 'missing-job',
+      [metaSetupLaunchStorageKey(SESSION)]: launchText,
+    })
+    const restored = createMetaSetupRepository(storage).recoverFromMissingJob(SESSION)
+
+    expect(restored).toMatchObject({
+      name: 'meta-paper-write',
+      phase: 'blocked',
+      retryMode: 'readiness',
+      launchText,
+    })
+    expect(values.has(metaSetupManualStorageKey(SESSION))).toBe(true)
+  })
+
+  it('fails open when browser storage is unavailable', () => {
+    const storage: MetaSetupStorage = {
+      getItem: () => { throw new Error('blocked') },
+      setItem: () => { throw new Error('blocked') },
+      removeItem: () => { throw new Error('blocked') },
+    }
+    const repository = createMetaSetupRepository(storage)
+
+    expect(repository.readJob(SESSION)).toBe('')
+    expect(repository.readCheckpoint(SESSION)).toBeNull()
+    expect(repository.persistCheckpoint(checkpoint())).toBe(false)
+    expect(() => repository.clearJob(SESSION)).not.toThrow()
+  })
+})

--- a/opensquilla-webui/src/composables/chat/metaSetupRepository.ts
+++ b/opensquilla-webui/src/composables/chat/metaSetupRepository.ts
@@ -1,0 +1,297 @@
+import type { MetaSetupReadiness, MetaSetupState } from '@/types/metaSetup'
+
+import {
+  createMetaSetupConfirmationState,
+  metaSetupResumeRequestId,
+  normalizeMetaLaunchText,
+  normalizeMetaSetupClientRequestId,
+  validMetaSetupProviderHandoff,
+} from './metaSetupMachine'
+
+// These key names and checkpoint fields are an upgrade contract. The
+// repository deliberately persists recovery inputs, never live job progress.
+const STORAGE_PREFIX = 'opensquilla.chat.metaSetupJob:'
+const LAUNCH_STORAGE_PREFIX = 'opensquilla.chat.metaSetupLaunch:'
+const MANUAL_STORAGE_PREFIX = 'opensquilla.chat.metaSetupManual:'
+
+export interface MetaSetupStorage {
+  getItem: (key: string) => string | null
+  setItem: (key: string, value: string) => void
+  removeItem: (key: string) => void
+}
+
+export function metaSetupStorageKey(sessionKey: string): string {
+  return `${STORAGE_PREFIX}${encodeURIComponent(sessionKey)}`
+}
+
+export function metaSetupLaunchStorageKey(sessionKey: string): string {
+  return `${LAUNCH_STORAGE_PREFIX}${encodeURIComponent(sessionKey)}`
+}
+
+export function metaSetupManualStorageKey(sessionKey: string): string {
+  return `${MANUAL_STORAGE_PREFIX}${encodeURIComponent(sessionKey)}`
+}
+
+export function defaultMetaSetupStorage(): MetaSetupStorage | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.sessionStorage
+  } catch {
+    return null
+  }
+}
+
+export function defaultMetaSetupDiscardStorage(): MetaSetupStorage | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+export interface MetaSetupRepository {
+  readJob: (sessionKey: string) => string
+  persistJob: (sessionKey: string, jobId: string) => void
+  readLaunch: (sessionKey: string) => string
+  persistLaunch: (sessionKey: string, launchText: string) => void
+  clearJob: (sessionKey: string) => void
+  clearLaunch: (sessionKey: string) => void
+  clearCheckpoint: (sessionKey: string) => void
+  persistCheckpoint: (current: MetaSetupState) => boolean
+  readCheckpoint: (sessionKey: string) => MetaSetupState | null
+  recoverFromMissingJob: (
+    sessionKey: string,
+    fallback?: MetaSetupState,
+  ) => MetaSetupState | null
+}
+
+export function createMetaSetupRepository(
+  storage: MetaSetupStorage | null,
+): MetaSetupRepository {
+  function readJob(sessionKey: string): string {
+    if (!storage || !sessionKey) return ''
+    try {
+      return String(storage.getItem(metaSetupStorageKey(sessionKey)) || '')
+    } catch {
+      return ''
+    }
+  }
+
+  function persistJob(sessionKey: string, jobId: string): void {
+    if (!storage || !sessionKey || !jobId) return
+    try {
+      storage.setItem(metaSetupStorageKey(sessionKey), jobId)
+    } catch {
+      // A blocked sessionStorage must not prevent setup from completing.
+    }
+  }
+
+  function readLaunch(sessionKey: string): string {
+    if (!storage || !sessionKey) return ''
+    try {
+      return String(storage.getItem(metaSetupLaunchStorageKey(sessionKey)) || '')
+    } catch {
+      return ''
+    }
+  }
+
+  function persistLaunch(sessionKey: string, launchText: string): void {
+    if (!storage || !sessionKey || !launchText) return
+    try {
+      storage.setItem(metaSetupLaunchStorageKey(sessionKey), launchText)
+    } catch {
+      // A blocked sessionStorage must not prevent setup from completing.
+    }
+  }
+
+  function clearJob(sessionKey: string): void {
+    if (!storage || !sessionKey) return
+    try {
+      storage.removeItem(metaSetupStorageKey(sessionKey))
+    } catch {
+      // Best-effort cleanup only.
+    }
+  }
+
+  function clearLaunch(sessionKey: string): void {
+    if (!storage || !sessionKey) return
+    try {
+      storage.removeItem(metaSetupLaunchStorageKey(sessionKey))
+    } catch {
+      // Best-effort cleanup only.
+    }
+  }
+
+  function clearCheckpoint(sessionKey: string): void {
+    if (!storage || !sessionKey) return
+    try {
+      storage.removeItem(metaSetupManualStorageKey(sessionKey))
+    } catch {
+      // Best-effort cleanup only.
+    }
+  }
+
+  function persistCheckpoint(current: MetaSetupState): boolean {
+    // Persist only stable recovery inputs, never server-owned progress. Keeping
+    // this checkpoint while a job is active lets the UI recover the original
+    // readiness and launch after a Gateway restart invalidates the job id.
+    if (!storage || !current.sessionKey) return false
+    try {
+      const providerHandoff = validMetaSetupProviderHandoff(
+        current.providerHandoff,
+        current.readiness,
+      )
+      const resumeRequestId = normalizeMetaSetupClientRequestId(
+        current.resumeRequestId || providerHandoff?.clientRequestId,
+      )
+      storage.setItem(metaSetupManualStorageKey(current.sessionKey), JSON.stringify({
+        name: current.name,
+        launchText: normalizeMetaLaunchText(current.name, current.launchText),
+        readiness: current.readiness,
+        ...(providerHandoff ? { providerHandoff } : {}),
+        ...(resumeRequestId ? { resumeRequestId } : {}),
+        ...(current.suppressAutoResume ? { suppressAutoResume: true } : {}),
+      }))
+      return true
+    } catch {
+      // The card still works for the current route when sessionStorage is unavailable.
+      return false
+    }
+  }
+
+  function readCheckpoint(sessionKey: string): MetaSetupState | null {
+    if (!storage || !sessionKey) return null
+    try {
+      const raw = storage.getItem(metaSetupManualStorageKey(sessionKey))
+      if (!raw) return null
+      const parsed = JSON.parse(raw) as {
+        name?: unknown
+        launchText?: unknown
+        readiness?: unknown
+        providerHandoff?: unknown
+        resumeRequestId?: unknown
+        suppressAutoResume?: unknown
+      }
+      if (
+        typeof parsed.name !== 'string'
+        || !parsed.name
+        || typeof parsed.readiness !== 'object'
+        || parsed.readiness === null
+        || Array.isArray(parsed.readiness)
+      ) {
+        clearCheckpoint(sessionKey)
+        return null
+      }
+      const restored = createMetaSetupConfirmationState(
+        parsed.name,
+        parsed.readiness as MetaSetupReadiness,
+        sessionKey,
+        typeof parsed.launchText === 'string' ? parsed.launchText : `/meta ${parsed.name}`,
+      )
+      const providerHandoff = validMetaSetupProviderHandoff(
+        parsed.providerHandoff,
+        restored.readiness,
+      )
+      const resumeRequestId = normalizeMetaSetupClientRequestId(parsed.resumeRequestId)
+      const providerMatchesResume = Boolean(
+        providerHandoff
+        && (!resumeRequestId || providerHandoff.clientRequestId === resumeRequestId),
+      )
+      if (providerHandoff && providerMatchesResume) {
+        restored.providerHandoff = providerHandoff
+        restored.resumeRequestId = resumeRequestId || providerHandoff.clientRequestId
+      } else if (resumeRequestId) {
+        restored.resumeRequestId = resumeRequestId
+        restored.suppressAutoResume = Boolean(
+          parsed.suppressAutoResume === true || parsed.providerHandoff !== undefined,
+        )
+      }
+      if (
+        (parsed.providerHandoff !== undefined && !providerMatchesResume)
+        || (
+          parsed.suppressAutoResume !== undefined
+          && parsed.suppressAutoResume !== restored.suppressAutoResume
+        )
+        || (parsed.resumeRequestId !== undefined && !resumeRequestId)
+      ) {
+        persistCheckpoint(restored)
+      }
+      return restored
+    } catch {
+      clearCheckpoint(sessionKey)
+      return null
+    }
+  }
+
+  function readLegacyCheckpoint(sessionKey: string): MetaSetupState | null {
+    const launchText = readLaunch(sessionKey)
+    const match = /^\/meta\s+([^\s]+)(?:\s|$)/.exec(launchText)
+    const name = match?.[1] || ''
+    if (!name) return null
+    const checkpoint = createMetaSetupConfirmationState(name, {}, sessionKey, launchText)
+    persistCheckpoint(checkpoint)
+    return checkpoint
+  }
+
+  function recoverFromMissingJob(
+    sessionKey: string,
+    fallback?: MetaSetupState,
+  ): MetaSetupState | null {
+    // Gateway setup jobs are process-local. Keep the stable checkpoint when a
+    // restart makes the short-lived job pointer unknown.
+    clearJob(sessionKey)
+    const persisted = readCheckpoint(sessionKey)
+    if (persisted) {
+      const fallbackRequestId = metaSetupResumeRequestId(fallback)
+      const persistedRequestId = metaSetupResumeRequestId(persisted)
+      if (
+        fallback
+        && fallbackRequestId
+        && persisted.name === fallback.name
+        && normalizeMetaLaunchText(persisted.name, persisted.launchText)
+          === normalizeMetaLaunchText(fallback.name, fallback.launchText)
+        && (!persistedRequestId || persistedRequestId === fallbackRequestId)
+      ) {
+        const merged = {
+          ...persisted,
+          resumeRequestId: fallbackRequestId,
+          providerHandoff: fallback.providerHandoff || persisted.providerHandoff,
+        }
+        persistCheckpoint(merged)
+        return merged
+      }
+      return persisted
+    }
+
+    if (fallback && fallback.name && fallback.name !== 'MetaSkill') {
+      const checkpoint = createMetaSetupConfirmationState(
+        fallback.name,
+        fallback.readiness,
+        sessionKey,
+        fallback.launchText || readLaunch(sessionKey),
+      )
+      checkpoint.resumeRequestId = fallback.resumeRequestId
+      checkpoint.providerHandoff = fallback.providerHandoff
+      persistCheckpoint(checkpoint)
+      return checkpoint
+    }
+
+    // Older clients persisted only a job id plus launch text. Preserve that
+    // upgrade path as a readiness-recheck card when the old job disappeared.
+    return readLegacyCheckpoint(sessionKey)
+  }
+
+  return {
+    readJob,
+    persistJob,
+    readLaunch,
+    persistLaunch,
+    clearJob,
+    clearLaunch,
+    clearCheckpoint,
+    persistCheckpoint,
+    readCheckpoint,
+    recoverFromMissingJob,
+  }
+}

--- a/opensquilla-webui/src/composables/chat/useMetaSkillSetup.ts
+++ b/opensquilla-webui/src/composables/chat/useMetaSkillSetup.ts
@@ -5,7 +5,6 @@ import type {
   MetaSetupInstallResponse,
   MetaSetupJob,
   MetaSetupPlanResponse,
-  MetaSetupProviderHandoff,
   MetaSetupReadiness,
   MetaSetupRunResponse,
   MetaSetupState,
@@ -19,15 +18,39 @@ import {
   removePendingMetaDiscard,
 } from '@/utils/chat/metaDiscardOutbox'
 
+import {
+  availableMetaSetupProviderIds as availableProviderIds,
+  createMetaSetupConfirmationState as confirmState,
+  failMetaSetupState as failedState,
+  isBusyMetaSetupState as isBusyPhase,
+  isMissingMetaSetupJobError as isMissingJobError,
+  metaSetupErrorMessage as errorMessage,
+  metaSetupResumeRequestId as setupResumeRequestId,
+  normalizeMetaLaunchText,
+  normalizeMetaSetupClientRequestId as normalizeClientRequestId,
+  normalizeMetaSetupProviderId as normalizeProviderId,
+  projectMetaSetupJob,
+  transitionMetaSetupState,
+  validMetaSetupProviderHandoff as validProviderHandoff,
+} from './metaSetupMachine'
+import {
+  createMetaSetupRepository,
+  defaultMetaSetupDiscardStorage,
+  defaultMetaSetupStorage,
+  type MetaSetupStorage,
+} from './metaSetupRepository'
+
+export { META_SETUP_PROVIDER_HANDOFF_TTL_MS } from './metaSetupMachine'
+export {
+  metaSetupLaunchStorageKey,
+  metaSetupManualStorageKey,
+  metaSetupStorageKey,
+} from './metaSetupRepository'
+export type { MetaSetupStorage } from './metaSetupRepository'
+
 type RpcClient = {
   call: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
   waitForConnection?: (timeoutMs?: number) => Promise<void>
-}
-
-export interface MetaSetupStorage {
-  getItem: (key: string) => string | null
-  setItem: (key: string, value: string) => void
-  removeItem: (key: string) => void
 }
 
 export type MetaDraftDiscardOutcome = 'discarded' | 'accepted' | 'unconfirmed'
@@ -66,59 +89,7 @@ export interface UseMetaSkillSetupOptions {
   forgetHiddenControl?: (sessionKey: string, clientRequestId: string) => void
 }
 
-const STORAGE_PREFIX = 'opensquilla.chat.metaSetupJob:'
-const LAUNCH_STORAGE_PREFIX = 'opensquilla.chat.metaSetupLaunch:'
-const MANUAL_STORAGE_PREFIX = 'opensquilla.chat.metaSetupManual:'
 const DEFAULT_POLL_INTERVAL_MS = 850
-const PROVIDER_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/
-const CLIENT_REQUEST_ID_PATTERN = /^\S{1,256}$/
-
-export const META_SETUP_PROVIDER_HANDOFF_TTL_MS = 15 * 60 * 1000
-
-export function metaSetupStorageKey(sessionKey: string): string {
-  return `${STORAGE_PREFIX}${encodeURIComponent(sessionKey)}`
-}
-
-export function metaSetupLaunchStorageKey(sessionKey: string): string {
-  return `${LAUNCH_STORAGE_PREFIX}${encodeURIComponent(sessionKey)}`
-}
-
-export function metaSetupManualStorageKey(sessionKey: string): string {
-  return `${MANUAL_STORAGE_PREFIX}${encodeURIComponent(sessionKey)}`
-}
-
-function normalizeMetaLaunchText(name: string, candidate?: string): string {
-  const legacy = `/meta ${name}`
-  const launchText = String(candidate || '').trim()
-  if (launchText === legacy) return launchText
-  const suffix = launchText.startsWith(legacy) ? launchText.slice(legacy.length) : ''
-  if (/^\s+--(?:\s+[\s\S]*)?$/.test(suffix)) return launchText
-  return legacy
-}
-
-function availableActionIds(readiness: MetaSetupReadiness): string[] {
-  return (readiness.setup_actions || [])
-    .filter(action => action.available !== false && Boolean(action.id))
-    .map(action => action.id)
-}
-
-function normalizeProviderId(candidate: unknown): string {
-  const providerId = typeof candidate === 'string' ? candidate.trim().toLowerCase() : ''
-  return PROVIDER_ID_PATTERN.test(providerId) ? providerId : ''
-}
-
-function availableProviderIds(readiness: MetaSetupReadiness): string[] {
-  const providerIds = (readiness.manual_setup_actions || [])
-    .filter(action => action.kind === 'provider_connection' && action.available !== false)
-    .map(action => normalizeProviderId(action.provider_id))
-    .filter(Boolean)
-  return [...new Set(providerIds)]
-}
-
-function normalizeClientRequestId(candidate: unknown): string {
-  const clientRequestId = typeof candidate === 'string' ? candidate.trim() : ''
-  return CLIENT_REQUEST_ID_PATTERN.test(clientRequestId) ? clientRequestId : ''
-}
 
 function normalizeDiscardOutcome(candidate: unknown): MetaDraftDiscardOutcome {
   if (candidate === true || candidate === 'discarded') return 'discarded'
@@ -126,70 +97,26 @@ function normalizeDiscardOutcome(candidate: unknown): MetaDraftDiscardOutcome {
   return 'unconfirmed'
 }
 
-function validProviderHandoff(
-  candidate: unknown,
-  readiness: MetaSetupReadiness,
-  nowMs = Date.now(),
-): MetaSetupProviderHandoff | undefined {
-  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return undefined
-  const value = candidate as Partial<MetaSetupProviderHandoff>
-  const providerId = normalizeProviderId(value.providerId)
-  const clientRequestId = normalizeClientRequestId(value.clientRequestId)
-  const startedAtMs = value.startedAtMs
-  if (typeof startedAtMs !== 'number') return undefined
-  const ageMs = nowMs - startedAtMs
-  if (
-    value.kind !== 'provider_settings'
-    || !providerId
-    || !clientRequestId
-    || !availableProviderIds(readiness).includes(providerId)
-    || !Number.isFinite(startedAtMs)
-    || ageMs < 0
-    || ageMs > META_SETUP_PROVIDER_HANDOFF_TTL_MS
-  ) {
-    return undefined
-  }
-  return { kind: 'provider_settings', providerId, startedAtMs, clientRequestId }
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error || 'Unknown setup error')
-}
-
-function isMissingJobError(error: unknown): boolean {
-  return /(?:not found|404|unknown (?:meta )?setup job|setup job (?:is )?unknown)/i
-    .test(errorMessage(error))
-}
-
-function isBusyPhase(state: MetaSetupState): boolean {
-  return state.phase === 'installing' || state.phase === 'verifying'
-}
-
-function defaultStorage(): MetaSetupStorage | null {
-  if (typeof window === 'undefined') return null
-  try {
-    return window.sessionStorage
-  } catch {
-    return null
-  }
-}
-
-function defaultDiscardStorage(): MetaSetupStorage | null {
-  if (typeof window === 'undefined') return null
-  try {
-    return window.localStorage
-  } catch {
-    return null
-  }
-}
-
 export function useMetaSkillSetup(options: UseMetaSkillSetupOptions) {
   const setupState = ref<MetaSetupState | null>(null)
   const pollIntervalMs = Math.max(750, Math.min(1000, options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS))
-  const storage = options.storage === undefined ? defaultStorage() : options.storage
+  const storage = options.storage === undefined ? defaultMetaSetupStorage() : options.storage
   const discardStorage = options.discardStorage === undefined
-    ? defaultDiscardStorage()
+    ? defaultMetaSetupDiscardStorage()
     : options.discardStorage
+  const repository = createMetaSetupRepository(storage)
+  const {
+    clearCheckpoint: clearPersistedManualSetup,
+    clearJob: clearPersistedJobMarker,
+    clearLaunch: clearPersistedLaunch,
+    persistCheckpoint: persistSetupCheckpoint,
+    persistJob,
+    persistLaunch,
+    readCheckpoint: readPersistedSetupCheckpoint,
+    readJob: readPersistedJob,
+    readLaunch: readPersistedLaunch,
+    recoverFromMissingJob,
+  } = repository
 
   let operationToken = 0
   let pollTimer: ReturnType<typeof setTimeout> | null = null
@@ -217,273 +144,6 @@ export function useMetaSkillSetup(options: UseMetaSkillSetupOptions) {
 
   function isCurrent(token: number): boolean {
     return !disposed && token === operationToken
-  }
-
-  function readPersistedJob(sessionKey: string): string {
-    if (!storage || !sessionKey) return ''
-    try {
-      return String(storage.getItem(metaSetupStorageKey(sessionKey)) || '')
-    } catch {
-      return ''
-    }
-  }
-
-  function persistJob(sessionKey: string, jobId: string): void {
-    if (!storage || !sessionKey || !jobId) return
-    try {
-      storage.setItem(metaSetupStorageKey(sessionKey), jobId)
-    } catch {
-      // A blocked sessionStorage must not prevent setup from completing.
-    }
-  }
-
-  function readPersistedLaunch(sessionKey: string): string {
-    if (!storage || !sessionKey) return ''
-    try {
-      return String(storage.getItem(metaSetupLaunchStorageKey(sessionKey)) || '')
-    } catch {
-      return ''
-    }
-  }
-
-  function persistLaunch(sessionKey: string, launchText: string): void {
-    if (!storage || !sessionKey || !launchText) return
-    try {
-      storage.setItem(metaSetupLaunchStorageKey(sessionKey), launchText)
-    } catch {
-      // A blocked sessionStorage must not prevent setup from completing.
-    }
-  }
-
-  function clearPersistedJobMarker(sessionKey: string): void {
-    if (!storage || !sessionKey) return
-    try {
-      storage.removeItem(metaSetupStorageKey(sessionKey))
-    } catch {
-      // Best-effort cleanup only.
-    }
-  }
-
-  function clearPersistedLaunch(sessionKey: string): void {
-    if (!storage || !sessionKey) return
-    try {
-      storage.removeItem(metaSetupLaunchStorageKey(sessionKey))
-    } catch {
-      // Best-effort cleanup only.
-    }
-  }
-
-  function clearPersistedManualSetup(sessionKey: string): void {
-    if (!storage || !sessionKey) return
-    try {
-      storage.removeItem(metaSetupManualStorageKey(sessionKey))
-    } catch {
-      // Best-effort cleanup only.
-    }
-  }
-
-  function confirmState(
-    name: string,
-    readiness: MetaSetupReadiness,
-    sessionKey: string,
-    launchText: string,
-  ): MetaSetupState {
-    const actionIds = availableActionIds(readiness)
-    const providerIds = availableProviderIds(readiness)
-    if (actionIds.length === 0 && providerIds.length === 0) {
-      return {
-        name,
-        sessionKey,
-        launchText: normalizeMetaLaunchText(name, launchText),
-        phase: 'blocked',
-        readiness,
-        actionIds,
-        completedActions: [],
-        error: readiness.reasons?.join('; ') || '',
-        blockedReason: 'no_actions',
-        retryMode: 'readiness',
-      }
-    }
-    return {
-      name,
-      sessionKey,
-      launchText: normalizeMetaLaunchText(name, launchText),
-      phase: 'confirm',
-      readiness,
-      actionIds,
-      completedActions: [],
-      retryMode: actionIds.length === 0 ? 'readiness' : undefined,
-    }
-  }
-
-  function persistSetupCheckpoint(current: MetaSetupState): boolean {
-    // Persist only stable recovery inputs, never server-owned progress. Keeping
-    // this checkpoint while a job is active lets the UI recover the original
-    // readiness and launch after a Gateway restart invalidates the job id.
-    if (!storage || !current.sessionKey) return false
-    try {
-      const providerHandoff = validProviderHandoff(
-        current.providerHandoff,
-        current.readiness,
-      )
-      const resumeRequestId = normalizeClientRequestId(
-        current.resumeRequestId || providerHandoff?.clientRequestId,
-      )
-      storage.setItem(metaSetupManualStorageKey(current.sessionKey), JSON.stringify({
-        name: current.name,
-        launchText: normalizeMetaLaunchText(current.name, current.launchText),
-        readiness: current.readiness,
-        ...(providerHandoff ? { providerHandoff } : {}),
-        ...(resumeRequestId ? { resumeRequestId } : {}),
-        ...(current.suppressAutoResume ? { suppressAutoResume: true } : {}),
-      }))
-      return true
-    } catch {
-      // The card still works for the current route when sessionStorage is unavailable.
-      return false
-    }
-  }
-
-  function readPersistedSetupCheckpoint(sessionKey: string): MetaSetupState | null {
-    if (!storage || !sessionKey) return null
-    try {
-      const raw = storage.getItem(metaSetupManualStorageKey(sessionKey))
-      if (!raw) return null
-      const parsed = JSON.parse(raw) as {
-        name?: unknown
-        launchText?: unknown
-        readiness?: unknown
-        providerHandoff?: unknown
-        resumeRequestId?: unknown
-        suppressAutoResume?: unknown
-      }
-      if (
-        typeof parsed.name !== 'string'
-        || !parsed.name
-        || typeof parsed.readiness !== 'object'
-        || parsed.readiness === null
-        || Array.isArray(parsed.readiness)
-      ) {
-        clearPersistedManualSetup(sessionKey)
-        return null
-      }
-      const restored = confirmState(
-        parsed.name,
-        parsed.readiness as MetaSetupReadiness,
-        sessionKey,
-        typeof parsed.launchText === 'string' ? parsed.launchText : `/meta ${parsed.name}`,
-      )
-      const providerHandoff = validProviderHandoff(
-        parsed.providerHandoff,
-        restored.readiness,
-      )
-      const resumeRequestId = normalizeClientRequestId(parsed.resumeRequestId)
-      const providerMatchesResume = Boolean(
-        providerHandoff
-        && (!resumeRequestId || providerHandoff.clientRequestId === resumeRequestId),
-      )
-      if (providerHandoff && providerMatchesResume) {
-        restored.providerHandoff = providerHandoff
-        restored.resumeRequestId = resumeRequestId || providerHandoff.clientRequestId
-      } else if (resumeRequestId) {
-        restored.resumeRequestId = resumeRequestId
-        restored.suppressAutoResume = Boolean(
-          parsed.suppressAutoResume === true || parsed.providerHandoff !== undefined,
-        )
-      }
-      if (
-        (parsed.providerHandoff !== undefined && !providerMatchesResume)
-        || (
-          parsed.suppressAutoResume !== undefined
-          && parsed.suppressAutoResume !== restored.suppressAutoResume
-        )
-        || (parsed.resumeRequestId !== undefined && !resumeRequestId)
-      ) {
-        persistSetupCheckpoint(restored)
-      }
-      return restored
-    } catch {
-      clearPersistedManualSetup(sessionKey)
-      return null
-    }
-  }
-
-  function readLegacySetupCheckpoint(sessionKey: string): MetaSetupState | null {
-    const launchText = readPersistedLaunch(sessionKey)
-    const match = /^\/meta\s+([^\s]+)(?:\s|$)/.exec(launchText)
-    const name = match?.[1] || ''
-    if (!name) return null
-    const checkpoint = confirmState(name, {}, sessionKey, launchText)
-    persistSetupCheckpoint(checkpoint)
-    return checkpoint
-  }
-
-  function recoverFromMissingJob(
-    sessionKey: string,
-    fallback?: MetaSetupState,
-  ): MetaSetupState | null {
-    // The Gateway owns setup jobs in memory, so a restart legitimately makes
-    // a previously accepted id unknown. Drop only that short-lived pointer;
-    // the stable checkpoint remains the source of truth for user recovery.
-    clearPersistedJobMarker(sessionKey)
-    const persisted = readPersistedSetupCheckpoint(sessionKey)
-    if (persisted) {
-      const fallbackRequestId = setupResumeRequestId(fallback)
-      const persistedRequestId = setupResumeRequestId(persisted)
-      if (
-        fallback
-        && fallbackRequestId
-        && persisted.name === fallback.name
-        && normalizeMetaLaunchText(persisted.name, persisted.launchText)
-          === normalizeMetaLaunchText(fallback.name, fallback.launchText)
-        && (!persistedRequestId || persistedRequestId === fallbackRequestId)
-      ) {
-        const merged = {
-          ...persisted,
-          resumeRequestId: fallbackRequestId,
-          providerHandoff: fallback.providerHandoff || persisted.providerHandoff,
-        }
-        persistSetupCheckpoint(merged)
-        return merged
-      }
-      return persisted
-    }
-
-    if (fallback && fallback.name && fallback.name !== 'MetaSkill') {
-      const checkpoint = confirmState(
-        fallback.name,
-        fallback.readiness,
-        sessionKey,
-        fallback.launchText || readPersistedLaunch(sessionKey),
-      )
-      checkpoint.resumeRequestId = fallback.resumeRequestId
-      checkpoint.providerHandoff = fallback.providerHandoff
-      persistSetupCheckpoint(checkpoint)
-      return checkpoint
-    }
-
-    // Older clients persisted only a job id plus launch text. Preserve that
-    // upgrade path as a readiness-recheck card when the old job disappeared.
-    return readLegacySetupCheckpoint(sessionKey)
-  }
-
-  function failedState(
-    current: MetaSetupState,
-    error: string,
-    retryMode: 'install' | 'status' | 'launch' | 'readiness' | 'discard',
-  ): MetaSetupState {
-    return {
-      ...current,
-      phase: 'failed',
-      error,
-      retryMode,
-    }
-  }
-
-  function setupResumeRequestId(current: MetaSetupState | null | undefined): string {
-    return normalizeClientRequestId(
-      current?.resumeRequestId || current?.providerHandoff?.clientRequestId,
-    )
   }
 
   function dispatchFailureMessage(result: HiddenControlDispatchResult): string {
@@ -533,13 +193,7 @@ export function useMetaSkillSetup(options: UseMetaSkillSetupOptions) {
 
     if (!currentMatches || !current) return
     if (result.status === 'queued') {
-      setupState.value = {
-        ...current,
-        phase: 'verifying',
-        message: '',
-        error: '',
-        retryMode: undefined,
-      }
+      setupState.value = transitionMetaSetupState(current, { type: 'launch_queued' })
       return
     }
     setupState.value = failedState(current, dispatchFailureMessage(result), 'launch')
@@ -604,21 +258,16 @@ export function useMetaSkillSetup(options: UseMetaSkillSetupOptions) {
     persistSetupCheckpoint(identifiedCurrent)
 
     stopPolling()
-    setupState.value = {
-      ...identifiedCurrent,
-      phase: 'verifying',
+    setupState.value = transitionMetaSetupState(identifiedCurrent, {
+      type: 'verification_started',
       readiness,
-      message: '',
-      error: '',
-      retryMode: undefined,
-    }
+    })
 
     if (options.currentSessionKey.value !== sessionKey) {
-      setupState.value = {
-        ...setupState.value,
-        phase: 'blocked',
-        blockedReason: 'session_changed',
-      }
+      setupState.value = transitionMetaSetupState(
+        setupState.value,
+        { type: 'session_changed' },
+      )
       return
     }
 
@@ -632,11 +281,10 @@ export function useMetaSkillSetup(options: UseMetaSkillSetupOptions) {
       if (!isCurrent(token)) return
 
       if (options.currentSessionKey.value !== sessionKey) {
-        setupState.value = {
-          ...setupState.value!,
-          phase: 'blocked',
-          blockedReason: 'session_changed',
-        }
+        setupState.value = transitionMetaSetupState(
+          setupState.value!,
+          { type: 'session_changed' },
+        )
         return
       }
 
@@ -717,9 +365,6 @@ export function useMetaSkillSetup(options: UseMetaSkillSetupOptions) {
     const restoredSetup = Boolean(current.jobId && current.jobId === job.job_id)
     if (!sameSetup && !restoredSetup) return
 
-    const completedActions = [...(job.completed_actions || [])]
-    const remainingActionIds = (job.action_ids || current.actionIds)
-      .filter(actionId => !completedActions.includes(actionId))
     const readiness = job.readiness || current.readiness
     const launchText = normalizeMetaLaunchText(
       job.name,
@@ -737,89 +382,24 @@ export function useMetaSkillSetup(options: UseMetaSkillSetupOptions) {
       })
     }
 
-    if (job.status === 'completed' || job.phase === 'completed') {
-      setupState.value = {
-        ...current,
-        name: job.name,
-        launchText,
-        phase: 'verifying',
-        readiness,
-        jobId: job.job_id,
-        jobStatus: job.status,
-        message: job.message || '',
-        currentAction: '',
-        downloadedBytes: job.downloaded_bytes || 0,
-        downloadTotalBytes: job.download_total_bytes || 0,
-        completedActions,
-        error: '',
-      }
+    const projection = projectMetaSetupJob(current, job, launchText)
+    setupState.value = projection.state
+
+    if (projection.kind === 'completed') {
       await resumeAfterSetup(job.name, job.sessionKey, readiness, token)
       return
     }
 
-    if (job.status === 'blocked' || job.phase === 'blocked') {
+    if (projection.kind === 'blocked') {
       clearPersistedJobMarker(job.sessionKey)
-      const next = confirmState(job.name, readiness, job.sessionKey, launchText)
-      setupState.value = {
-        ...next,
-        jobId: job.job_id,
-        jobStatus: job.status,
-        message: job.message || '',
-        currentAction: '',
-        downloadedBytes: job.downloaded_bytes || 0,
-        downloadTotalBytes: job.download_total_bytes || 0,
-        completedActions,
-        error: job.error || next.error || '',
-        blockedReason: next.phase === 'blocked' ? 'requirements_remaining' : undefined,
-        // The setup job may complete its automatic actions while a provider
-        // requirement remains. Keep the original launch identity across that
-        // transition so provider settings resumes the already-drafted request
-        // instead of allocating a second, independently chargeable launch.
-        providerHandoff: current.providerHandoff,
-        resumeRequestId: setupResumeRequestId(current) || undefined,
-      }
+      // The pure projection keeps the original request identity when automatic
+      // actions finish but provider requirements remain.
       persistSetupCheckpoint(setupState.value!)
       return
     }
 
-    if (job.status === 'failed' || job.phase === 'failed') {
-      setupState.value = {
-        ...current,
-        name: job.name,
-        launchText,
-        phase: 'failed',
-        actionIds: remainingActionIds,
-        jobId: job.job_id,
-        jobStatus: job.status,
-        message: job.message || '',
-        currentAction: '',
-        downloadedBytes: job.downloaded_bytes || 0,
-        downloadTotalBytes: job.download_total_bytes || 0,
-        completedActions,
-        error: job.error || job.message || 'Setup failed',
-        retryMode: remainingActionIds.length ? 'install' : 'status',
-      }
-      return
-    }
+    if (projection.kind === 'failed') return
 
-    const phase = job.phase === 'verifying' ? 'verifying' : 'installing'
-    setupState.value = {
-      ...current,
-      name: job.name,
-      launchText,
-      phase,
-      readiness,
-      actionIds: job.action_ids || current.actionIds,
-      jobId: job.job_id,
-      jobStatus: job.status,
-      message: job.message || '',
-      currentAction: job.current_action || '',
-      downloadedBytes: job.downloaded_bytes || 0,
-      downloadTotalBytes: job.download_total_bytes || 0,
-      completedActions,
-      error: '',
-      retryMode: undefined,
-    }
     persistJob(job.sessionKey, job.job_id)
     schedulePoll(job.job_id, job.sessionKey, token)
   }
@@ -847,24 +427,14 @@ export function useMetaSkillSetup(options: UseMetaSkillSetupOptions) {
   async function startInstall(current: MetaSetupState): Promise<void> {
     if (installInFlight || current.actionIds.length === 0) return
     if (options.currentSessionKey.value !== current.sessionKey) {
-      setupState.value = {
-        ...current,
-        phase: 'blocked',
-        blockedReason: 'session_changed',
-      }
+      setupState.value = transitionMetaSetupState(current, { type: 'session_changed' })
       return
     }
 
     const token = beginOperation()
     installInFlight = true
     persistSetupCheckpoint(current)
-    setupState.value = {
-      ...current,
-      phase: 'installing',
-      message: '',
-      error: '',
-      retryMode: undefined,
-    }
+    setupState.value = transitionMetaSetupState(current, { type: 'install_started' })
     try {
       const result = await rpcCall<MetaSetupInstallResponse>('meta.setup.install', {
         name: current.name,
@@ -1041,17 +611,15 @@ export function useMetaSkillSetup(options: UseMetaSkillSetupOptions) {
     }
 
     const clientRequestId = setupResumeRequestId(current) || createClientRequestId()
-    const { suppressAutoResume: _suppressAutoResume, ...resumableCurrent } = current
-    const next: MetaSetupState = {
-      ...resumableCurrent,
-      resumeRequestId: clientRequestId,
-      providerHandoff: {
+    const next = transitionMetaSetupState(current, {
+      type: 'provider_handoff_started',
+      handoff: {
         kind: 'provider_settings',
         providerId: normalizedProviderId,
         startedAtMs: Date.now(),
         clientRequestId,
       },
-    }
+    })
     // A handoff necessarily unmounts ChatView. Do not leave the page unless its
     // original intent and idempotency identity are durably recoverable.
     if (!persistSetupCheckpoint(next)) return ''
@@ -1074,7 +642,7 @@ export function useMetaSkillSetup(options: UseMetaSkillSetupOptions) {
     // The handoff marker is one-shot navigation state. The resume identity is
     // the durable server draft identity and must survive a cancelled/failed
     // route so a later dismissal can atomically discard that exact request.
-    const { providerHandoff: _providerHandoff, ...next } = current
+    const next = transitionMetaSetupState(current, { type: 'provider_handoff_cancelled' })
     setupState.value = next
     persistSetupCheckpoint(next)
   }
@@ -1102,24 +670,18 @@ export function useMetaSkillSetup(options: UseMetaSkillSetupOptions) {
     clientRequestId = '',
   ): Promise<void> {
     if (options.currentSessionKey.value !== current.sessionKey) {
-      setupState.value = {
-        ...current,
-        phase: 'blocked',
-        blockedReason: 'session_changed',
-        retryMode: undefined,
-      }
+      setupState.value = transitionMetaSetupState(current, {
+        type: 'session_changed',
+        clearRetryMode: true,
+      })
       return
     }
 
     const token = beginOperation()
-    setupState.value = {
-      ...current,
-      suppressAutoResume: undefined,
-      phase: 'verifying',
-      message: '',
-      error: '',
-      retryMode: undefined,
-    }
+    setupState.value = transitionMetaSetupState(current, {
+      type: 'verification_started',
+      clearSuppressAutoResume: true,
+    })
     const stableClientRequestId = normalizeClientRequestId(
       clientRequestId || setupResumeRequestId(current),
     )


### PR DESCRIPTION
## Scope

- Extract deterministic MetaSkill setup transitions and server-job projection into a pure state-machine module.
- Centralize setup job markers, launch text, stable checkpoints, handoff validation, and legacy recovery in a repository module.
- Keep Vue refs, RPC calls, polling, routing checks, and user-facing side effects in the existing composable adapter.
- Add direct contract tests for state transitions, replay identity, checkpoint sanitization, blocked storage, and legacy recovery.

## Branch target

- main
- Builds directly on the MetaSkill production work merged in #770.

## Linked issue

- None

## Release note

- None — internal behavior-preserving refactor.

## Verification

- npm run test:unit — 278 files, 2984 tests passed.
- Focused setup/recovery suite — 5 files, 68 tests passed.
- npm run build — typecheck, architecture/security/i18n guards, Vite production build, bundle guards, and dist verification passed.
- git diff --check passed.

## Safety and compatibility

- No RPC method, request payload, public setup type, storage key, checkpoint JSON field, provider-handoff TTL, or replay acceptance/cleanup ordering changed.
- Existing imports from useMetaSkillSetup remain compatible through re-exports.
- Platform-neutral Web UI change; no OS-specific filesystem, process, or packaging behavior is affected.

## Third-party origin

- None.