### PR TITLE
Add stable CLI agent progress events and isolated state guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,13 @@ opensquilla chat                       # interactive REPL
 opensquilla agent -m "your prompt"     # one-shot, automation-friendly
 ```
 
+For subprocess progress, add `--event-stream-stderr`. The final result keeps
+its existing stdout format, while stderr receives incrementally flushed,
+privacy-bounded v1 JSONL events. Consumers must drain stderr continuously and
+only treat objects with `"_event": true` as events because ordinary diagnostics
+can share the stream. See [docs/cli.md](docs/cli.md#agent-progress-event-stream)
+for the versioned schema and compatibility contract.
+
 > **Development-only OpenTUI terminal UI.** Release installs continue to use
 > the Python-native chat. The richer full-screen frontend currently runs only
 > from a [Develop from source](#develop-from-source) checkout; no companion host

--- a/README.md
+++ b/README.md
@@ -572,6 +572,24 @@ only treat objects with `"_event": true` as events because ordinary diagnostics
 can share the stream. See [docs/cli.md](docs/cli.md#agent-progress-event-stream)
 for the versioned schema and compatibility contract.
 
+Parallel agent subprocesses must use separate profile homes and persistent
+state roots. Set both variables for every child:
+
+```sh
+OPENSQUILLA_STATE_DIR=/tmp/agent-a \
+OPENSQUILLA_GATEWAY_STATE_DIR=/tmp/agent-a/state \
+  opensquilla agent -m "task A" --json --event-stream-stderr &
+OPENSQUILLA_STATE_DIR=/tmp/agent-b \
+OPENSQUILLA_GATEWAY_STATE_DIR=/tmp/agent-b/state \
+  opensquilla agent -m "task B" --json --event-stream-stderr &
+wait
+```
+
+On Windows, set both values in each child process environment. If an
+orchestrator copies `config.toml` or `.env`, remove or rewrite every `state_dir`
+or `OPENSQUILLA_GATEWAY_STATE_DIR` value as well. Explicitly shared session DB,
+workspace, scratch, transcript, and usage paths remain shared by design.
+
 > **Development-only OpenTUI terminal UI.** Release installs continue to use
 > the Python-native chat. The richer full-screen frontend currently runs only
 > from a [Develop from source](#develop-from-source) checkout; no companion host

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -146,6 +146,27 @@ future engine events. Unsupported internal events are skipped. Consumers may
 use the stable top-level fields above and must ignore additional fields that a
 future compatible v1 producer may add.
 
+### Concurrent Agent Subprocesses
+
+Each write-capable agent holds a profile-wide writer lease. Calls that share an
+`OPENSQUILLA_STATE_DIR` therefore conflict instead of writing the same profile
+concurrently. An orchestrator that needs parallel agents must give every child
+both a distinct profile home and a distinct gateway state root:
+
+```sh
+OPENSQUILLA_STATE_DIR=/tmp/agent-a \
+OPENSQUILLA_GATEWAY_STATE_DIR=/tmp/agent-a/state \
+  opensquilla agent -m "task A" --json &
+```
+
+`OPENSQUILLA_STATE_DIR` alone does not override a `state_dir` from a
+current-directory `opensquilla.toml`, an explicit gateway config, or a copied
+profile. When copying `config.toml` or `.env`, remove or rewrite `state_dir` and
+`OPENSQUILLA_GATEWAY_STATE_DIR`. Also choose distinct `--session-db-path`,
+workspace, scratch, transcript, and usage paths when those outputs must be
+isolated. On Windows, pass both environment variables in each child process
+rather than relying on POSIX inline assignment syntax.
+
 ## Coding Mode and Code-Task
 
 Coding mode routes code modification work through the `code-task` workflow. It

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -107,7 +107,44 @@ Useful automation flags:
 | `--permissions` | Select restricted, bypass, or full permission posture. |
 | `--transcript-path` | Write a JSONL transcript for automation. |
 | `--usage-path` | Write usage JSON. |
+| `--event-stream-stderr` | Stream stable v1 progress-event JSONL on stderr. |
 | `--session-db-path` | Persist session replay across invocations. |
+
+### Agent Progress Event Stream
+
+`--event-stream-stderr` is opt-in. It does not change the final stdout payload
+or exit status. Each supported event is flushed to stderr as one compact JSON
+object with this envelope:
+
+```json
+{"_event":true,"schema_version":1,"kind":"thinking"}
+```
+
+stderr can also contain ordinary diagnostics. Subprocess consumers must drain
+it continuously, parse it line by line, and accept only objects whose `_event`
+value is `true`. A closed or unwritable stderr disables further progress events
+without failing an otherwise successful agent run.
+
+The v1 event fields are intentionally smaller and more stable than the engine's
+internal event dataclasses:
+
+| `kind` | Additional fields |
+| --- | --- |
+| `router_decision` | `tier`, `model`, `source` |
+| `thinking` | None |
+| `text_delta` | `presentation` |
+| `run_heartbeat` | `phase`, `elapsed_ms`, `idle_ms` |
+| `tool_use_start` | `tool_use_id`, `tool_name`, `started_at` |
+| `tool_result` | `tool_use_id`, `tool_name`, `is_error` |
+| `warning`, `error` | `code`, redacted and bounded `message` |
+| `artifact` | `id`, `name`, `mime`, `size` |
+| `done` | None; read the final result from stdout |
+
+The stream does not expose reasoning text, answer text, tool arguments, tool
+results, internal routing probabilities, session paths, or fields added to
+future engine events. Unsupported internal events are skipped. Consumers may
+use the stable top-level fields above and must ignore additional fields that a
+future compatible v1 producer may add.
 
 ## Coding Mode and Code-Task
 

--- a/src/opensquilla/cli/agent_cmd.py
+++ b/src/opensquilla/cli/agent_cmd.py
@@ -17,6 +17,7 @@ from rich.panel import Panel
 from rich.text import Text
 from typer.models import OptionInfo
 
+from opensquilla.cli.agent_event_stream import AgentEventSink, StderrAgentEventSink
 from opensquilla.cli.attachments import attachments_from_paths
 from opensquilla.cli.ui import console
 
@@ -135,6 +136,7 @@ async def run_agent_once(
     length_capped_continuations: int | None = None,
     transcript_path: str | None = None,
     usage_path: str | None = None,
+    event_sink: AgentEventSink | None = None,
     config: Any | None = None,
     session_db_path: str = ":memory:",
     no_memory_capture: bool = False,
@@ -391,6 +393,9 @@ async def run_agent_once(
             attachments=run_attachments,
             bootstrap_context_mode=bootstrap_context_mode,
         ):
+            if event_sink is not None:
+                event_sink(event)
+
             if isinstance(event, TextDeltaEvent):
                 text_parts.append(event.text)
             elif isinstance(event, ErrorEvent):
@@ -852,6 +857,11 @@ def run_agent_command(
         "", "--transcript-path", help="Write benchmark-compatible JSONL transcript"
     ),
     usage_path: str = typer.Option("", "--usage-path", help="Write usage JSON to this file"),
+    event_stream_stderr: bool = typer.Option(
+        False,
+        "--event-stream-stderr",
+        help="Write stable v1 progress event JSONL to stderr",
+    ),
     session_db_path: str = typer.Option(
         ":memory:",
         "--session-db-path",
@@ -921,6 +931,7 @@ def run_agent_command(
     thinking = _unwrap_typer_default(thinking)
     transcript_path = _unwrap_typer_default(transcript_path)
     usage_path = _unwrap_typer_default(usage_path)
+    event_stream_stderr = _unwrap_typer_default(event_stream_stderr)
     session_db_path = _unwrap_typer_default(session_db_path)
     no_memory_capture = _unwrap_typer_default(no_memory_capture)
     file_paths = _unwrap_typer_default(file_paths)
@@ -953,6 +964,7 @@ def run_agent_command(
             length_capped_continuations=length_capped_continuations,
             transcript_path=transcript_path or None,
             usage_path=usage_path or None,
+            event_sink=StderrAgentEventSink() if event_stream_stderr else None,
             session_db_path=session_db_path,
             no_memory_capture=no_memory_capture,
             attachment_paths=list(file_paths or []),

--- a/src/opensquilla/cli/agent_event_stream.py
+++ b/src/opensquilla/cli/agent_event_stream.py
@@ -1,0 +1,158 @@
+"""Stable stderr progress events for one-shot CLI automation."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, TextIO
+
+from opensquilla.engine.types import (
+    AgentEvent,
+    ArtifactEvent,
+    DoneEvent,
+    ErrorEvent,
+    RouterDecisionEvent,
+    RunHeartbeatEvent,
+    TextDeltaEvent,
+    ThinkingEvent,
+    ToolResultEvent,
+    ToolUseStartEvent,
+    WarningEvent,
+)
+from opensquilla.redaction import redact_error_text
+from opensquilla.session.terminal_reply import sanitize_agent_error
+
+AGENT_EVENT_STREAM_SCHEMA_VERSION = 1
+_EVENT_MESSAGE_MAX_CHARS = 4096
+_STREAM_DISABLED_DIAGNOSTIC = (
+    "Warning: agent progress event stream disabled after an encoding or stderr write failure.\n"
+)
+
+AgentEventSink = Callable[[AgentEvent], None]
+
+
+def _base_event(kind: str) -> dict[str, Any]:
+    return {
+        "_event": True,
+        "schema_version": AGENT_EVENT_STREAM_SCHEMA_VERSION,
+        "kind": kind,
+    }
+
+
+def _safe_text(value: object, *, max_len: int = _EVENT_MESSAGE_MAX_CHARS) -> str:
+    return redact_error_text(str(value or ""), max_len=max_len)
+
+
+def project_agent_event_v1(event: AgentEvent | object) -> dict[str, Any] | None:
+    """Project an internal engine event onto the stable, low-sensitivity v1 schema."""
+
+    if isinstance(event, RouterDecisionEvent):
+        return {
+            **_base_event(event.kind),
+            "tier": event.tier,
+            "model": event.model,
+            "source": event.source,
+        }
+    if isinstance(event, ThinkingEvent):
+        return _base_event(event.kind)
+    if isinstance(event, TextDeltaEvent):
+        return {**_base_event(event.kind), "presentation": event.presentation}
+    if isinstance(event, RunHeartbeatEvent):
+        return {
+            **_base_event(event.kind),
+            "phase": event.phase,
+            "elapsed_ms": event.elapsed_ms,
+            "idle_ms": event.idle_ms,
+        }
+    if isinstance(event, ToolUseStartEvent):
+        return {
+            **_base_event(event.kind),
+            "tool_use_id": event.tool_use_id,
+            "tool_name": event.tool_name,
+            "started_at": event.started_at,
+        }
+    if isinstance(event, ToolResultEvent):
+        return {
+            **_base_event(event.kind),
+            "tool_use_id": event.tool_use_id,
+            "tool_name": event.tool_name,
+            "is_error": event.is_error,
+        }
+    if isinstance(event, WarningEvent):
+        return {
+            **_base_event(event.kind),
+            "code": _safe_text(event.code, max_len=200),
+            "message": _safe_text(event.message),
+        }
+    if isinstance(event, ErrorEvent):
+        safe_code, safe_message = sanitize_agent_error(
+            event,
+            fallback_error_class=event.code or None,
+            fallback_error_message="Agent error",
+        )
+        return {
+            **_base_event(event.kind),
+            "code": _safe_text(safe_code or event.code, max_len=200),
+            "message": _safe_text(safe_message),
+        }
+    if isinstance(event, ArtifactEvent):
+        return {
+            **_base_event(event.kind),
+            "id": event.id,
+            "name": event.name,
+            "mime": event.mime,
+            "size": event.size,
+        }
+    if isinstance(event, DoneEvent):
+        return _base_event(event.kind)
+    return None
+
+
+def agent_event_to_jsonl(event: AgentEvent | object) -> str | None:
+    """Serialize one supported event as strict, compact JSONL payload text."""
+
+    payload = project_agent_event_v1(event)
+    if payload is None:
+        return None
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+    )
+
+
+@dataclass
+class StderrAgentEventSink:
+    """Best-effort stderr writer that disables itself after its first failure."""
+
+    stream: TextIO = field(default_factory=lambda: sys.stderr)
+    active: bool = field(default=True, init=False)
+
+    def __call__(self, event: AgentEvent) -> None:
+        if not self.active:
+            return
+        try:
+            line = agent_event_to_jsonl(event)
+            if line is None:
+                return
+            self.stream.write(f"{line}\n")
+            self.stream.flush()
+        except Exception:
+            self.active = False
+            try:
+                self.stream.write(_STREAM_DISABLED_DIAGNOSTIC)
+                self.stream.flush()
+            except Exception:
+                pass
+
+
+__all__ = [
+    "AGENT_EVENT_STREAM_SCHEMA_VERSION",
+    "AgentEventSink",
+    "StderrAgentEventSink",
+    "agent_event_to_jsonl",
+    "project_agent_event_v1",
+]

--- a/src/opensquilla/cli/main.py
+++ b/src/opensquilla/cli/main.py
@@ -1015,6 +1015,11 @@ def agent(
         "", "--transcript-path", help="Write benchmark-compatible JSONL transcript"
     ),
     usage_path: str = typer.Option("", "--usage-path", help="Write usage JSON to this file"),
+    event_stream_stderr: bool = typer.Option(
+        False,
+        "--event-stream-stderr",
+        help="Write stable v1 progress event JSONL to stderr",
+    ),
     session_db_path: str = typer.Option(
         ":memory:",
         "--session-db-path",
@@ -1088,6 +1093,7 @@ def agent(
             length_capped_continuations=length_capped_continuations,
             transcript_path=transcript_path,
             usage_path=usage_path,
+            event_stream_stderr=event_stream_stderr,
             session_db_path=session_db_path,
             no_memory_capture=no_memory_capture,
             file_paths=file_paths,

--- a/tests/test_cli/test_agent_cmd.py
+++ b/tests/test_cli/test_agent_cmd.py
@@ -17,7 +17,7 @@ from opensquilla.cli.agent_cmd import (
     run_agent_command,
     run_agent_once,
 )
-from opensquilla.engine.types import ArtifactEvent, DoneEvent
+from opensquilla.engine.types import ArtifactEvent, DoneEvent, ThinkingEvent
 from opensquilla.gateway.config import AgentEntryConfig, GatewayConfig, PermissionsConfig
 from opensquilla.project_workspaces import (
     ProjectWorkspaceStateError,
@@ -282,6 +282,51 @@ async def test_run_agent_once_collects_artifact_events(
     assert result.artifacts[0]["download_url"] == "/api/v1/artifacts/art-cli"
 
 
+@pytest.mark.asyncio
+async def test_run_agent_once_continues_when_stderr_event_sink_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.cli.agent_event_stream import StderrAgentEventSink
+
+    class FakeTurnRunner:
+        async def run(self, message: str, session_key: str, **kwargs: Any):
+            yield ThinkingEvent(text="private")
+            yield DoneEvent(text="ok")
+
+    async def fake_build_services(*, config: GatewayConfig, **kwargs: Any) -> _FakeServices:
+        return _FakeServices(config)
+
+    class BrokenStream:
+        def __init__(self) -> None:
+            self.write_calls = 0
+
+        def write(self, _value: str) -> int:
+            self.write_calls += 1
+            raise BrokenPipeError("synthetic closed stderr")
+
+        def flush(self) -> None:
+            raise AssertionError("flush must not follow a failed write")
+
+    stream = BrokenStream()
+    sink = StderrAgentEventSink(stream=stream)  # type: ignore[arg-type]
+    monkeypatch.setattr("opensquilla.gateway.build_services", fake_build_services)
+    monkeypatch.setattr(
+        "opensquilla.gateway.build_turn_runner_from_services",
+        lambda _services: FakeTurnRunner(),
+    )
+
+    result = await run_agent_once(
+        message="hello",
+        config=GatewayConfig(),
+        event_sink=sink,
+    )
+
+    assert result.status == "ok"
+    assert result.text == "ok"
+    assert sink.active is False
+    assert stream.write_calls == 2
+
+
 def test_run_agent_command_json_includes_artifacts(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -360,6 +405,7 @@ def test_run_agent_command_direct_call_normalizes_typer_defaults(
     assert captured["thinking"] is None
     assert captured["transcript_path"] is None
     assert captured["usage_path"] is None
+    assert captured["event_sink"] is None
     assert captured["session_db_path"] == ":memory:"
     assert captured["no_memory_capture"] is False
     assert captured["attachment_paths"] == []
@@ -367,6 +413,31 @@ def test_run_agent_command_direct_call_normalizes_typer_defaults(
     assert captured["stateless"] is False
     assert captured["stateless_keep_project_rules"] is False
     assert captured["permissions"] is None
+
+
+def test_run_agent_command_enables_stderr_event_sink(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.cli.agent_event_stream import StderrAgentEventSink
+
+    captured: dict[str, Any] = {}
+
+    async def fake_run_agent_once(**kwargs: Any) -> AgentRunResult:
+        captured.update(kwargs)
+        return AgentRunResult(
+            status="ok",
+            agent_id="main",
+            session_key="agent:main:main",
+            text="ok",
+            usage={},
+            errors=[],
+        )
+
+    monkeypatch.setattr("opensquilla.cli.agent_cmd.run_agent_once", fake_run_agent_once)
+
+    run_agent_command(message="hello", event_stream_stderr=True)
+
+    assert isinstance(captured["event_sink"], StderrAgentEventSink)
 
 
 def test_run_agent_command_json_includes_routing(
@@ -1649,6 +1720,27 @@ def test_top_level_agent_command_accepts_automation_options(
         "reports/*.txt, tmp/**",
         "generated/**",
     ]
+
+
+def test_top_level_agent_command_accepts_event_stream_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.cli.main import app
+
+    captured: dict[str, Any] = {}
+
+    def fake_run_agent_command(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr("opensquilla.cli.main.run_agent_command", fake_run_agent_command)
+
+    result = CliRunner().invoke(
+        app,
+        ["agent", "--message", "hello", "--json", "--event-stream-stderr"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["event_stream_stderr"] is True
 
 
 def test_top_level_agent_command_accepts_length_capped_continuations(

--- a/tests/test_cli/test_agent_event_stream.py
+++ b/tests/test_cli/test_agent_event_stream.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import json
+import os
+import queue
+import shutil
+import subprocess
+import sys
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from opensquilla.cli.agent_event_stream import (
+    AGENT_EVENT_STREAM_SCHEMA_VERSION,
+    StderrAgentEventSink,
+    agent_event_to_jsonl,
+    project_agent_event_v1,
+)
+from opensquilla.engine.types import (
+    ArtifactEvent,
+    DoneEvent,
+    ErrorEvent,
+    RouterDecisionEvent,
+    RunHeartbeatEvent,
+    TextDeltaEvent,
+    ThinkingEvent,
+    ToolResultEvent,
+    ToolUseDeltaEvent,
+    ToolUseStartEvent,
+    WarningEvent,
+)
+
+
+def _strict_json_loads(line: str) -> dict[str, Any]:
+    def reject_constant(value: str) -> None:
+        raise ValueError(f"non-standard JSON constant: {value}")
+
+    payload = json.loads(line, parse_constant=reject_constant)
+    assert isinstance(payload, dict)
+    return payload
+
+
+@pytest.mark.parametrize(
+    ("event", "expected"),
+    [
+        (
+            RouterDecisionEvent(
+                tier="c1",
+                model="synthetic/model",
+                source="router",
+                confidence=float("nan"),
+                probs=[float("inf")],
+            ),
+            {"tier": "c1", "model": "synthetic/model", "source": "router"},
+        ),
+        (ThinkingEvent(text="private reasoning"), {}),
+        (
+            TextDeltaEvent(text="private answer", presentation="intermediate"),
+            {"presentation": "intermediate"},
+        ),
+        (
+            RunHeartbeatEvent(
+                phase="tool",
+                elapsed_ms=1200,
+                idle_ms=200,
+                message="private status",
+            ),
+            {"phase": "tool", "elapsed_ms": 1200, "idle_ms": 200},
+        ),
+        (
+            ToolUseStartEvent(
+                tool_use_id="call-1",
+                tool_name="read_file",
+                synthetic_from_text=True,
+                started_at=42,
+            ),
+            {"tool_use_id": "call-1", "tool_name": "read_file", "started_at": 42},
+        ),
+        (
+            ToolResultEvent(
+                tool_use_id="call-1",
+                tool_name="read_file",
+                result="private result",
+                arguments={"path": "/private/path"},
+                is_error=False,
+            ),
+            {"tool_use_id": "call-1", "tool_name": "read_file", "is_error": False},
+        ),
+        (
+            ArtifactEvent(
+                id="artifact-1",
+                name="report.txt",
+                mime="text/plain",
+                size=12,
+                session_id="private-session",
+                download_url="/private/path",
+            ),
+            {"id": "artifact-1", "name": "report.txt", "mime": "text/plain", "size": 12},
+        ),
+        (DoneEvent(text="private final", cost_usd=float("inf")), {}),
+    ],
+)
+def test_project_agent_event_v1_has_an_explicit_field_allowlist(
+    event: object,
+    expected: dict[str, Any],
+) -> None:
+    payload = project_agent_event_v1(event)
+
+    assert payload == {
+        "_event": True,
+        "schema_version": AGENT_EVENT_STREAM_SCHEMA_VERSION,
+        "kind": event.kind,
+        **expected,
+    }
+    line = agent_event_to_jsonl(event)
+    assert line is not None
+    assert _strict_json_loads(line) == payload
+    assert "NaN" not in line
+    assert "Infinity" not in line
+
+
+def test_project_agent_event_v1_redacts_and_bounds_user_visible_messages() -> None:
+    secret = "sk-test-super-secret"
+    event = ErrorEvent(
+        code="provider_error",
+        message=f"Bearer {secret} api_key={secret} " + ("x" * 5000),
+    )
+
+    payload = project_agent_event_v1(event)
+
+    assert payload is not None
+    assert payload["code"] == "provider_error"
+    assert secret not in payload["message"]
+    assert "Bearer ***" in payload["message"]
+    assert len(payload["message"]) <= 4096
+
+    warning = project_agent_event_v1(
+        WarningEvent(code="credential_warning", message=f"token={secret}")
+    )
+    assert warning is not None
+    assert warning["message"] == "token=***"
+
+
+def test_project_agent_event_v1_skips_unversioned_internal_events() -> None:
+    assert project_agent_event_v1(ToolUseDeltaEvent(json_fragment='{"private":')) is None
+
+    @dataclass
+    class FutureEngineEvent:
+        kind: str = "future_event"
+        sensitive_value: str = "private"
+
+    assert project_agent_event_v1(FutureEngineEvent()) is None
+    assert agent_event_to_jsonl(FutureEngineEvent()) is None
+
+
+class _BrokenStream:
+    def __init__(self) -> None:
+        self.write_calls = 0
+
+    def write(self, _value: str) -> int:
+        self.write_calls += 1
+        raise BrokenPipeError("synthetic closed stderr")
+
+    def flush(self) -> None:
+        raise AssertionError("flush must not follow a failed write")
+
+
+def test_stderr_event_sink_disables_itself_after_first_write_failure() -> None:
+    stream = _BrokenStream()
+    sink = StderrAgentEventSink(stream=stream)  # type: ignore[arg-type]
+
+    sink(ThinkingEvent(text="private"))
+    sink(DoneEvent(text="private"))
+
+    assert sink.active is False
+    assert stream.write_calls == 2
+
+
+def test_stderr_event_sink_disables_itself_after_strict_json_failure() -> None:
+    class RecordingStream:
+        def __init__(self) -> None:
+            self.values: list[str] = []
+
+        def write(self, value: str) -> int:
+            self.values.append(value)
+            return len(value)
+
+        def flush(self) -> None:
+            return None
+
+    event = RunHeartbeatEvent(elapsed_ms=float("nan"))  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        agent_event_to_jsonl(event)
+
+    stream = RecordingStream()
+    sink = StderrAgentEventSink(stream=stream)  # type: ignore[arg-type]
+    sink(event)
+    sink(DoneEvent())
+
+    assert sink.active is False
+    assert stream.values == [
+        "Warning: agent progress event stream disabled after an encoding or "
+        "stderr write failure.\n"
+    ]
+
+
+def test_stderr_event_sink_flushes_each_supported_event() -> None:
+    class RecordingStream:
+        def __init__(self) -> None:
+            self.values: list[str] = []
+            self.flush_count = 0
+
+        def write(self, value: str) -> int:
+            self.values.append(value)
+            return len(value)
+
+        def flush(self) -> None:
+            self.flush_count += 1
+
+    stream = RecordingStream()
+    sink = StderrAgentEventSink(stream=stream)  # type: ignore[arg-type]
+
+    sink(ThinkingEvent(text="private"))
+    sink(ToolUseDeltaEvent(json_fragment="private"))
+    sink(DoneEvent(text="private"))
+
+    assert stream.flush_count == 2
+    assert len(stream.values) == 2
+    assert [_strict_json_loads(value)["kind"] for value in stream.values] == [
+        "thinking",
+        "done",
+    ]
+
+
+def test_stderr_event_stream_is_incremental_and_stdout_stays_final_only() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    pythonpath = [str(repo_root / "src"), env.get("PYTHONPATH", "")]
+    env["PYTHONPATH"] = os.pathsep.join(value for value in pythonpath if value)
+    script = """
+import json
+import sys
+
+from opensquilla.cli.agent_event_stream import StderrAgentEventSink
+from opensquilla.engine.types import DoneEvent, RouterDecisionEvent
+
+sink = StderrAgentEventSink()
+sink(RouterDecisionEvent(tier="c1", model="synthetic/model", source="test"))
+sys.stdin.readline()
+sink(DoneEvent(text="private final"))
+print(json.dumps({"status": "ok", "text": "final"}), flush=True)
+"""
+    process = subprocess.Popen(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert process.stdout is not None
+    assert process.stderr is not None
+    assert process.stdin is not None
+
+    stdout_queue: queue.Queue[str] = queue.Queue()
+    stdout_reader = threading.Thread(
+        target=lambda: stdout_queue.put(process.stdout.readline()),
+        daemon=True,
+    )
+    stdout_reader.start()
+
+    first_event_line = process.stderr.readline()
+    assert _strict_json_loads(first_event_line)["kind"] == "router_decision"
+    assert process.poll() is None
+    assert stdout_queue.empty()
+
+    process.stdin.write("continue\n")
+    process.stdin.flush()
+    process.stdin.close()
+    final_stdout = stdout_queue.get(timeout=10)
+    stdout_reader.join(timeout=10)
+    process.wait(timeout=10)
+    remaining_stderr = process.stderr.read()
+
+    assert process.returncode == 0
+    assert json.loads(final_stdout) == {"status": "ok", "text": "final"}
+    assert process.stdout.read() == ""
+    event_lines = [first_event_line, *remaining_stderr.splitlines()]
+    event_lines = [line.strip() for line in event_lines if line.strip()]
+    assert [_strict_json_loads(line)["kind"] for line in event_lines] == [
+        "router_decision",
+        "done",
+    ]
+
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for the JavaScript JSON.parse compatibility check")
+    completed = subprocess.run(
+        [
+            node,
+            "-e",
+            (
+                'const fs=require("fs");'
+                'for(const line of fs.readFileSync(0,"utf8").trim().split(/\\r?\\n/)) {'
+                "const value=JSON.parse(line);"
+                "if(value._event!==true||value.schema_version!==1)process.exit(2);"
+                "}"
+            ),
+        ],
+        input="\n".join(event_lines),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr

--- a/tests/test_cli/test_stdio_encoding.py
+++ b/tests/test_cli/test_stdio_encoding.py
@@ -5,7 +5,9 @@ from io import BytesIO, TextIOWrapper
 
 import typer
 
+from opensquilla.cli.agent_event_stream import StderrAgentEventSink
 from opensquilla.cli.stdio import configure_stdio_for_unicode
+from opensquilla.engine.types import ErrorEvent
 
 
 def test_configure_stdio_for_unicode_allows_typer_echo_on_gbk_stream(
@@ -20,3 +22,20 @@ def test_configure_stdio_for_unicode_allows_typer_echo_on_gbk_stream(
     stream.flush()
 
     assert raw.getvalue().decode("utf-8").strip() == "hello 🦐"
+
+
+def test_configure_stdio_for_unicode_keeps_stderr_event_jsonl_utf8(
+    monkeypatch,
+) -> None:
+    raw = BytesIO()
+    stream = TextIOWrapper(raw, encoding="cp936", errors="strict")
+    monkeypatch.setattr(sys, "stderr", stream)
+
+    configure_stdio_for_unicode()
+    StderrAgentEventSink()(ErrorEvent(code="测试", message="你好🙂"))
+    stream.flush()
+
+    assert raw.getvalue().decode("utf-8").strip() == (
+        '{"_event":true,"schema_version":1,"kind":"error",'
+        '"code":"测试","message":"你好🙂"}'
+    )

--- a/tests/test_recovery/test_runtime_writer_guard.py
+++ b/tests/test_recovery/test_runtime_writer_guard.py
@@ -43,6 +43,46 @@ def _hold_runtime_writer(
         raise
 
 
+def _hold_isolated_runtime_writer(
+    home: str,
+    gateway_state: str,
+    user_state: str,
+    cwd: str,
+    label: str,
+    ready: Any,
+    release: Any,
+) -> None:
+    """Resolve child-local state and hold its universal writer lease."""
+
+    os.environ["OPENSQUILLA_STATE_DIR"] = home
+    os.environ["OPENSQUILLA_GATEWAY_STATE_DIR"] = gateway_state
+    os.environ["OPENSQUILLA_USER_STATE_DIR"] = user_state
+    os.environ["OPENSQUILLA_TEST_PROFILE_LOCK_ROOT"] = "1"
+    os.environ.pop("OPENSQUILLA_GATEWAY_CONFIG_PATH", None)
+    os.environ.pop("OPENSQUILLA_PROFILE_KIND", None)
+    os.environ.pop("OPENSQUILLA_DESKTOP", None)
+    os.chdir(cwd)
+
+    from opensquilla.gateway.config import GatewayConfig
+    from opensquilla.recovery import guarded_desktop_profile
+
+    try:
+        config = GatewayConfig.load()
+        with guarded_desktop_profile(Path(home)):
+            ready.put(
+                {
+                    "label": label,
+                    "home": home,
+                    "state_dir": config.state_dir,
+                }
+            )
+            if not release.wait(timeout=15):
+                raise TimeoutError("test did not release the isolated runtime writer")
+    except BaseException as exc:
+        ready.put({"label": label, "error": f"{type(exc).__name__}:{exc}"})
+        raise
+
+
 def _profile(home: Path) -> None:
     workspace = home / "workspace"
     workspace.mkdir(parents=True)
@@ -229,3 +269,68 @@ def test_runtime_writer_lock_keeps_read_only_cli_available_and_rejects_agent(
             writer.join(timeout=5)
 
     assert writer.exitcode == 0
+
+
+def test_distinct_profile_and_gateway_state_dirs_run_concurrently_across_processes(
+    tmp_path: Path,
+) -> None:
+    """Per-child home and gateway-state overrides bypass a shared cwd state path."""
+
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "opensquilla.toml").write_text(
+        'state_dir = "shared-state"\n',
+        encoding="utf-8",
+    )
+    user_state = tmp_path / "user-state"
+    profiles = {
+        "a": (tmp_path / "profile-a", tmp_path / "profile-a" / "state"),
+        "b": (tmp_path / "profile-b", tmp_path / "profile-b" / "state"),
+    }
+    context = multiprocessing.get_context("spawn" if sys.platform == "win32" else "fork")
+    ready = context.Queue()
+    release = context.Event()
+    writers = [
+        context.Process(
+            target=_hold_isolated_runtime_writer,
+            args=(
+                str(home),
+                str(gateway_state),
+                str(user_state),
+                str(project),
+                label,
+                ready,
+                release,
+            ),
+        )
+        for label, (home, gateway_state) in profiles.items()
+    ]
+
+    for writer in writers:
+        writer.start()
+
+    try:
+        resolved = [ready.get(timeout=15), ready.get(timeout=15)]
+        assert all("error" not in result for result in resolved), resolved
+        assert {result["label"] for result in resolved} == set(profiles)
+        assert {
+            result["label"]: Path(result["state_dir"])
+            for result in resolved
+        } == {
+            label: gateway_state
+            for label, (_home, gateway_state) in profiles.items()
+        }
+        assert all(writer.is_alive() for writer in writers)
+        assert project / "shared-state" not in {
+            Path(result["state_dir"])
+            for result in resolved
+        }
+    finally:
+        release.set()
+        for writer in writers:
+            writer.join(timeout=10)
+            if writer.is_alive():
+                writer.terminate()
+                writer.join(timeout=5)
+
+    assert [writer.exitcode for writer in writers] == [0, 0]


### PR DESCRIPTION
## Scope

Replace and supersede #790 with a conflict-free implementation on current
`main` while preserving the original contributor's authorship.

1. Add opt-in `opensquilla agent --event-stream-stderr` progress events.
2. Define a stable, strict-JSON v1 CLI projection instead of exposing raw
   engine dataclasses.
3. Keep stdout and the normal CLI path unchanged when the flag is absent.
4. Document and process-test concurrent isolation using both
   `OPENSQUILLA_STATE_DIR` and `OPENSQUILLA_GATEWAY_STATE_DIR`.

The v1 stream explicitly omits reasoning text, answer text, tool arguments,
tool results, session paths, and unversioned engine fields. Event encoding or
stderr write failures disable the optional stream without failing the agent.

Non-goals: no shared `TurnRunner` behavior changes, no event-type migration, no
new writer-lock implementation, and no database/config migration.

## Contributor Attribution

This work originated in #790 from @phloglucinol. Their proposal, initial CLI
event-stream implementation, state-isolation investigation, documentation, and
tests established the direction for this replacement. Both commits retain
`Co-authored-by: phologlucinol <15521120143@163.com>` trailers so contributor
credit remains in the replacement PR and eventual squash commit.

The replacement PR is necessary because the old fork branch became conflicting
and the upstream maintainer account could not push the rebased commits to that
fork despite the PR's maintainer-edit flag.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Refs #1061

Supersedes: #790

## Release Note

Release note: Added an opt-in, versioned `opensquilla agent
--event-stream-stderr` progress protocol while preserving final stdout output,
and documented complete per-process state isolation for parallel agent calls.

## Tests

Ruff: `.venv/bin/ruff check src tests` — passed.

Mypy: `.venv/bin/mypy src/opensquilla --show-error-codes` — passed for 927
source files.

Focused regression suite:

- CLI protocol, subprocess, stdio, and recovery/locking tests — 151 passed,
  22 platform-conditional skips.
- JavaScript `JSON.parse` compatibility executes when Node is available and
  passed locally.
- Real subprocess coverage verifies incremental stderr delivery before exit and
  final-result-only stdout.
- Cross-process coverage verifies two isolated profile/state roots can hold
  writer leases concurrently despite a shared cwd config.

Full local suite: 20,593 passed and 227 skipped. Thirty unrelated local
capability/baseline tests failed because this checkout lacked the OpenTUI Bun
host during the run, shell tests assumed a `python` alias or GNU `sed`, real
sandbox conditions differed, and the hydrated router artifacts did not match
the checked-in manifest. No failure was in a changed file; GitHub required CI
remains the cross-platform merge gate.

Build:

- `opensquilla-webui`: typecheck, architecture guards, artifact build, and
  artifact verification passed.
- `uv build --wheel --no-cache`: passed.
- The built wheel's `agent --help` exposes `--event-stream-stderr`.

Regression tests: added.

## Maintainer Live Check

Maintainer live check: no

Surface: offline CLI protocol, subprocess I/O, and profile locking.

Maintainer-only note: merge only after required CI is green and the latest diff
has received independent review.

## Safety

The public stream is an explicit field allowlist. It does not serialize raw
dataclasses or include reasoning, answer text, tool arguments/results, session
paths, provider credentials, transcripts, or internal routing probabilities.
Error and warning messages use the repository redaction helper and are bounded.

No secrets, real user data, local artifacts, private prompts/transcripts,
channel identifiers, or machine-specific paths are committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A. #790 is an in-project contributor proposal and is
credited above. The downstream subagent package is a motivating consumer; no
external implementation code or fixtures were copied.

## Documentation Changes

- [x] CLI v1 envelope and supported fields are documented.
- [x] Consumers are told to drain stderr and filter `_event: true` records.
- [x] POSIX and Windows state-isolation requirements are described.
- [x] Copied config and explicitly shared output-path hazards are documented.
