### PR TITLE
Bound the one-time tiktoken encoding load

### DIFF
--- a/src/opensquilla/token_estimation.py
+++ b/src/opensquilla/token_estimation.py
@@ -11,8 +11,8 @@ import structlog
 
 log = structlog.get_logger(__name__)
 
+_ENCODING_UNAVAILABLE = object()
 _encoding = None
-_tiktoken_available: bool | None = None
 _TOKENIZER_CHUNK_CHARS = 100_000
 _ENCODING_LOAD_TIMEOUT_SECONDS = 5.0
 _ENCODING_LOAD_TIMEOUT_MAX_SECONDS = min(60.0, threading.TIMEOUT_MAX)
@@ -59,14 +59,14 @@ def _load_encoding():
 
 
 def _get_encoding():
-    global _encoding, _tiktoken_available
-    if _tiktoken_available is False:
+    global _encoding
+    if _encoding is _ENCODING_UNAVAILABLE:
         return None
     if _encoding is not None:
         return _encoding
     with _load_lock:
         # Re-check under the lock; a concurrent caller may have settled it.
-        if _tiktoken_available is False:
+        if _encoding is _ENCODING_UNAVAILABLE:
             return None
         if _encoding is not None:
             return _encoding
@@ -94,25 +94,24 @@ def _get_encoding():
             # Thread exhaustion and platform timeout errors must preserve the
             # estimator's historical fallback contract rather than escape into
             # request admission or gateway coroutines.
-            _tiktoken_available = False
+            _encoding = _ENCODING_UNAVAILABLE
             log.warning("tiktoken_encoding_load_worker_failed", error=str(exc))
             return None
 
         if worker.is_alive():
             # The daemon may finish later and populate tiktoken's own cache, but
             # this process keeps a stable fallback verdict until restart.
-            _tiktoken_available = False
+            _encoding = _ENCODING_UNAVAILABLE
             log.warning("tiktoken_encoding_load_timeout", timeout_seconds=timeout)
             return None
         if "encoding" in outcome:
             _encoding = outcome["encoding"]
-            _tiktoken_available = True
             return _encoding
         if "import_error" in outcome:
-            _tiktoken_available = False
+            _encoding = _ENCODING_UNAVAILABLE
             log.info("tiktoken_unavailable_fallback")
             return None
-        _tiktoken_available = False
+        _encoding = _ENCODING_UNAVAILABLE
         log.warning(
             "tiktoken_encoding_unavailable_fallback",
             error=str(outcome.get("error")),

--- a/src/opensquilla/token_estimation.py
+++ b/src/opensquilla/token_estimation.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import math
+import os
+import threading
 from collections.abc import Iterator
 
 import structlog
@@ -11,8 +14,48 @@ log = structlog.get_logger(__name__)
 _encoding = None
 _tiktoken_available: bool | None = None
 _TOKENIZER_CHUNK_CHARS = 100_000
+_ENCODING_LOAD_TIMEOUT_SECONDS = 5.0
+_ENCODING_LOAD_TIMEOUT_MAX_SECONDS = min(60.0, threading.TIMEOUT_MAX)
+_ENCODING_LOAD_TIMEOUT_ENV = "OPENSQUILLA_TIKTOKEN_LOAD_TIMEOUT_SECONDS"
+_load_lock = threading.Lock()
 
 TokenEstimateSource = str
+
+
+def _reset_load_lock_after_fork() -> None:
+    """Discard a possibly orphaned loader lock in a forked child."""
+
+    global _load_lock
+    _load_lock = threading.Lock()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_load_lock_after_fork)
+
+
+def _load_timeout_seconds() -> float:
+    """Return a finite, platform-safe budget for the one-time encoding load."""
+
+    raw = os.environ.get(_ENCODING_LOAD_TIMEOUT_ENV) or ""
+    try:
+        value = float(raw.strip())
+    except ValueError:
+        return _ENCODING_LOAD_TIMEOUT_SECONDS
+    if (
+        not math.isfinite(value)
+        or value <= 0
+        or value > _ENCODING_LOAD_TIMEOUT_MAX_SECONDS
+    ):
+        return _ENCODING_LOAD_TIMEOUT_SECONDS
+    return value
+
+
+def _load_encoding():
+    """Import tiktoken and resolve cl100k_base. May block on network I/O."""
+
+    import tiktoken
+
+    return tiktoken.get_encoding("cl100k_base")
 
 
 def _get_encoding():
@@ -21,19 +64,59 @@ def _get_encoding():
         return None
     if _encoding is not None:
         return _encoding
-    try:
-        import tiktoken
+    with _load_lock:
+        # Re-check under the lock; a concurrent caller may have settled it.
+        if _tiktoken_available is False:
+            return None
+        if _encoding is not None:
+            return _encoding
 
-        _encoding = tiktoken.get_encoding("cl100k_base")
-        _tiktoken_available = True
-        return _encoding
-    except ImportError:
+        outcome: dict[str, object] = {}
+
+        def _work() -> None:
+            try:
+                outcome["encoding"] = _load_encoding()
+            except ImportError as exc:
+                outcome["import_error"] = exc
+            except Exception as exc:  # noqa: BLE001
+                outcome["error"] = exc
+
+        timeout = _load_timeout_seconds()
+        worker = threading.Thread(
+            target=_work,
+            name="opensquilla-tiktoken-load",
+            daemon=True,
+        )
+        try:
+            worker.start()
+            worker.join(timeout)
+        except Exception as exc:  # noqa: BLE001
+            # Thread exhaustion and platform timeout errors must preserve the
+            # estimator's historical fallback contract rather than escape into
+            # request admission or gateway coroutines.
+            _tiktoken_available = False
+            log.warning("tiktoken_encoding_load_worker_failed", error=str(exc))
+            return None
+
+        if worker.is_alive():
+            # The daemon may finish later and populate tiktoken's own cache, but
+            # this process keeps a stable fallback verdict until restart.
+            _tiktoken_available = False
+            log.warning("tiktoken_encoding_load_timeout", timeout_seconds=timeout)
+            return None
+        if "encoding" in outcome:
+            _encoding = outcome["encoding"]
+            _tiktoken_available = True
+            return _encoding
+        if "import_error" in outcome:
+            _tiktoken_available = False
+            log.info("tiktoken_unavailable_fallback")
+            return None
         _tiktoken_available = False
-        log.info("tiktoken_unavailable_fallback")
-        return None
-    except Exception as exc:  # noqa: BLE001
-        _tiktoken_available = False
-        log.warning("tiktoken_encoding_unavailable_fallback", error=str(exc))
+        log.warning(
+            "tiktoken_encoding_unavailable_fallback",
+            error=str(outcome.get("error")),
+        )
         return None
 
 

--- a/tests/test_engine/test_t3_upgrade_compaction.py
+++ b/tests/test_engine/test_t3_upgrade_compaction.py
@@ -427,10 +427,6 @@ async def test_t3_budget_check_counts_full_tool_call_replay(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import opensquilla.session.compaction as compaction_module
-    from opensquilla.session.compaction import (
-        estimate_entry_model_replay_tokens,
-        estimate_entry_replay_tokens,
-    )
 
     monkeypatch.setattr(
         compaction_module,
@@ -438,8 +434,10 @@ async def test_t3_budget_check_counts_full_tool_call_replay(
         lambda text: max(1, len(text) // 4),
     )
     transcript = _tool_heavy_transcript()
-    summarized = sum(estimate_entry_replay_tokens(e) for e in transcript)
-    model_replay = sum(estimate_entry_model_replay_tokens(e) for e in transcript)
+    summarized = sum(compaction_module.estimate_entry_replay_tokens(e) for e in transcript)
+    model_replay = sum(
+        compaction_module.estimate_entry_model_replay_tokens(e) for e in transcript
+    )
     # Derive the window from the estimators instead of hard-coding a token
     # count. This assertion is about WHICH estimator the budget check consults,
     # not about an incidental absolute token count. The midpoint of the valid

--- a/tests/test_engine/test_t3_upgrade_compaction.py
+++ b/tests/test_engine/test_t3_upgrade_compaction.py
@@ -423,18 +423,32 @@ async def test_t3_within_budget_skips_flush_and_compact() -> None:
 
 
 @pytest.mark.asyncio
-async def test_t3_budget_check_counts_full_tool_call_replay() -> None:
+async def test_t3_budget_check_counts_full_tool_call_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import opensquilla.session.compaction as compaction_module
     from opensquilla.session.compaction import (
         estimate_entry_model_replay_tokens,
         estimate_entry_replay_tokens,
     )
 
+    monkeypatch.setattr(
+        compaction_module,
+        "_estimate_tokens",
+        lambda text: max(1, len(text) // 4),
+    )
     transcript = _tool_heavy_transcript()
-    window = 30_000
     summarized = sum(estimate_entry_replay_tokens(e) for e in transcript)
     model_replay = sum(estimate_entry_model_replay_tokens(e) for e in transcript)
+    # Derive the window from the estimators instead of hard-coding a token
+    # count. This assertion is about WHICH estimator the budget check consults,
+    # not about an incidental absolute token count. The midpoint of the valid
+    # band keeps margin on both sides while deterministic token math keeps the
+    # test offline.
+    safety_margin = 1.2
+    window = int((summarized + model_replay) * safety_margin / 2)
     # The summarized estimate looks within budget while the model replay overflows.
-    assert summarized * 1.2 <= window < model_replay * 1.2
+    assert summarized * safety_margin <= window < model_replay * safety_margin
 
     sm = _FakeSessionManager(transcript)
     fs = _FakeFlushService()

--- a/tests/test_session/test_compaction_dispatcher.py
+++ b/tests/test_session/test_compaction_dispatcher.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import pytest
 
+import opensquilla.session.compaction as compaction_module
 from opensquilla.session.compaction import (
     CompactionConfig,
     CompactionRequest,
@@ -167,8 +168,19 @@ async def test_new_avoids_mid_turn_cut_for_agent_flattened_tool_blocks():
 
 
 @pytest.mark.asyncio
-async def test_new_skips_when_only_cut_would_orphan_tool_result():
-    """If no clean boundary exists, compaction must not split tool state."""
+async def test_new_skips_when_only_cut_would_orphan_tool_result(monkeypatch):
+    """If no clean boundary exists, compaction must not split tool state.
+
+    The branch under test sits in a two-token-wide window band: one token
+    higher and the transcript is within budget, one lower and a cut is found
+    and the quality gate rejects it. Pin token math so the band — and this test
+    — stay deterministic and offline instead of loading an optional tokenizer.
+    """
+    monkeypatch.setattr(
+        compaction_module,
+        "_estimate_tokens",
+        lambda text: max(1, len(text) // 4),
+    )
     entries = [
         {
             "role": "assistant",
@@ -188,7 +200,7 @@ async def test_new_skips_when_only_cut_would_orphan_tool_result():
     request = CompactionRequest(
         session_id="boundary-start-test",
         entries=entries,
-        context_window_tokens=26,
+        context_window_tokens=23,
         config=CompactionConfig(safety_margin=1.0),
     )
 

--- a/tests/test_session/test_compaction_dispatcher.py
+++ b/tests/test_session/test_compaction_dispatcher.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import pytest
 
-import opensquilla.session.compaction as compaction_module
 from opensquilla.session.compaction import (
     CompactionConfig,
     CompactionRequest,
@@ -177,8 +176,7 @@ async def test_new_skips_when_only_cut_would_orphan_tool_result(monkeypatch):
     — stay deterministic and offline instead of loading an optional tokenizer.
     """
     monkeypatch.setattr(
-        compaction_module,
-        "_estimate_tokens",
+        "opensquilla.session.compaction._estimate_tokens",
         lambda text: max(1, len(text) // 4),
     )
     entries = [

--- a/tests/test_session/test_tokenizer.py
+++ b/tests/test_session/test_tokenizer.py
@@ -1,6 +1,12 @@
+"""Tests for the shared bounded token estimator."""
+
 from __future__ import annotations
 
+import threading
+import time
 from typing import Any
+
+import pytest
 
 from opensquilla import token_estimation
 from opensquilla.session import tokenizer
@@ -12,6 +18,20 @@ class _SizedTokens:
 
     def __len__(self) -> int:
         return self._size
+
+
+class _FakeEncoding:
+    def __init__(self, chars_per_token: int = 2) -> None:
+        self._chars_per_token = chars_per_token
+
+    def encode(
+        self,
+        text: str,
+        *,
+        disallowed_special: tuple[Any, ...] = (),
+    ) -> _SizedTokens:
+        del disallowed_special
+        return _SizedTokens(len(text) // self._chars_per_token)
 
 
 class _RecordingEncoding:
@@ -28,8 +48,65 @@ class _RecordingEncoding:
         return _SizedTokens((len(text) + 9) // 10)
 
 
+@pytest.fixture(autouse=True)
+def _reset_tokenizer_state(monkeypatch: pytest.MonkeyPatch):
+    """Keep the process-wide loader verdict isolated between tests."""
+
+    monkeypatch.setattr(token_estimation, "_encoding", None)
+    monkeypatch.setattr(token_estimation, "_tiktoken_available", None)
+    monkeypatch.setattr(token_estimation, "_load_lock", threading.Lock())
+    monkeypatch.delenv(token_estimation._ENCODING_LOAD_TIMEOUT_ENV, raising=False)
+    yield
+
+
+def test_estimate_tokens_uses_the_encoding_when_it_loads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(token_estimation, "_load_encoding", lambda: _FakeEncoding(2))
+
+    assert tokenizer.estimate_tokens("abcdefgh") == 4
+    assert token_estimation._tiktoken_available is True
+
+
+def test_estimate_tokens_falls_back_when_tiktoken_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _missing():
+        raise ImportError("no tiktoken")
+
+    monkeypatch.setattr(token_estimation, "_load_encoding", _missing)
+
+    assert tokenizer.estimate_tokens_with_source("a" * 400) == (
+        200,
+        "utf8_unicode_conservative",
+    )
+    assert token_estimation._tiktoken_available is False
+
+
+def test_estimate_tokens_falls_back_when_the_encoding_fetch_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _offline():
+        raise OSError("Tunnel connection failed: 403 Forbidden")
+
+    monkeypatch.setattr(token_estimation, "_load_encoding", _offline)
+
+    assert tokenizer.estimate_tokens_with_source("a" * 400) == (
+        200,
+        "utf8_unicode_conservative",
+    )
+    assert token_estimation._tiktoken_available is False
+
+
+def test_estimate_tokens_never_returns_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(token_estimation, "_load_encoding", lambda: _FakeEncoding(2))
+
+    assert tokenizer.estimate_tokens("") == 1
+    assert tokenizer.estimate_tokens("a") == 1
+
+
 def test_large_text_uses_bounded_tokenizer_chunks(
-    monkeypatch: Any,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     encoding = _RecordingEncoding()
     monkeypatch.setattr(token_estimation, "_get_encoding", lambda: encoding)
@@ -43,7 +120,7 @@ def test_large_text_uses_bounded_tokenizer_chunks(
 
 
 def test_unicode_fallback_uses_utf8_density_instead_of_chars_div_four(
-    monkeypatch: Any,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(token_estimation, "_get_encoding", lambda: None)
 
@@ -61,7 +138,9 @@ def test_unicode_fallback_uses_utf8_density_instead_of_chars_div_four(
     } == {"utf8_unicode_conservative"}
 
 
-def test_integer_only_api_remains_backward_compatible(monkeypatch: Any) -> None:
+def test_integer_only_api_remains_backward_compatible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(
         tokenizer,
         "estimate_tokens_with_source",
@@ -69,3 +148,216 @@ def test_integer_only_api_remains_backward_compatible(monkeypatch: Any) -> None:
     )
 
     assert tokenizer.estimate_tokens("payload") == 37
+
+
+def test_a_wedged_encoding_load_returns_within_the_configured_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release = threading.Event()
+    entered = threading.Event()
+    completed = threading.Event()
+
+    def _wedged():
+        entered.set()
+        release.wait(30)
+        completed.set()
+        return _FakeEncoding(2)
+
+    monkeypatch.setattr(token_estimation, "_load_encoding", _wedged)
+    monkeypatch.setenv(token_estimation._ENCODING_LOAD_TIMEOUT_ENV, "0.05")
+
+    started = time.monotonic()
+    try:
+        estimate = tokenizer.estimate_tokens_with_source("a" * 400)
+        elapsed = time.monotonic() - started
+
+        assert entered.is_set()
+        assert estimate == (200, "utf8_unicode_conservative")
+        assert elapsed < 0.5
+        assert token_estimation._tiktoken_available is False
+    finally:
+        release.set()
+        assert completed.wait(1)
+
+
+def test_a_timed_out_load_is_sticky_and_is_not_retried(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release = threading.Event()
+    completed = threading.Event()
+    calls: list[int] = []
+
+    def _wedged():
+        calls.append(1)
+        release.wait(30)
+        completed.set()
+        return _FakeEncoding(2)
+
+    monkeypatch.setattr(token_estimation, "_load_encoding", _wedged)
+    monkeypatch.setenv(token_estimation._ENCODING_LOAD_TIMEOUT_ENV, "0.05")
+
+    try:
+        first = tokenizer.estimate_tokens_with_source("a" * 400)
+        release.set()
+        assert completed.wait(1)
+        second = tokenizer.estimate_tokens_with_source("a" * 400)
+
+        assert first == second == (200, "utf8_unicode_conservative")
+        assert len(calls) == 1
+        assert token_estimation._encoding is None
+    finally:
+        release.set()
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "   ",
+        "not-a-number",
+        "0",
+        "-1",
+        "inf",
+        "-inf",
+        "nan",
+        str(token_estimation._ENCODING_LOAD_TIMEOUT_MAX_SECONDS + 1),
+    ],
+)
+def test_unusable_timeout_overrides_fall_back_to_the_default(
+    monkeypatch: pytest.MonkeyPatch,
+    raw: str,
+) -> None:
+    monkeypatch.setenv(token_estimation._ENCODING_LOAD_TIMEOUT_ENV, raw)
+
+    assert (
+        token_estimation._load_timeout_seconds()
+        == token_estimation._ENCODING_LOAD_TIMEOUT_SECONDS
+    )
+
+
+def test_valid_timeout_override_is_honored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(token_estimation._ENCODING_LOAD_TIMEOUT_ENV, "1.5")
+
+    assert token_estimation._load_timeout_seconds() == 1.5
+
+
+def test_concurrent_callers_load_the_encoding_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[int] = []
+
+    def _slow_load():
+        calls.append(1)
+        time.sleep(0.05)
+        return _FakeEncoding(2)
+
+    monkeypatch.setattr(token_estimation, "_load_encoding", _slow_load)
+    results: list[int] = []
+
+    def _worker() -> None:
+        results.append(tokenizer.estimate_tokens("abcdefgh"))
+
+    threads = [threading.Thread(target=_worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(2)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert results == [4] * 8
+    assert len(calls) == 1
+
+
+def test_concurrent_callers_share_one_timed_out_load(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release = threading.Event()
+    completed = threading.Event()
+    start = threading.Event()
+    calls: list[int] = []
+    results: list[tuple[int, str]] = []
+
+    def _wedged():
+        calls.append(1)
+        release.wait(30)
+        completed.set()
+        return _FakeEncoding(2)
+
+    def _caller() -> None:
+        start.wait()
+        results.append(tokenizer.estimate_tokens_with_source("a" * 400))
+
+    monkeypatch.setattr(token_estimation, "_load_encoding", _wedged)
+    monkeypatch.setenv(token_estimation._ENCODING_LOAD_TIMEOUT_ENV, "0.05")
+    threads = [threading.Thread(target=_caller) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+
+    started = time.monotonic()
+    try:
+        start.set()
+        for thread in threads:
+            thread.join(2)
+        elapsed = time.monotonic() - started
+
+        assert all(not thread.is_alive() for thread in threads)
+        assert results == [(200, "utf8_unicode_conservative")] * 8
+        assert len(calls) == 1
+        assert elapsed < 0.5
+    finally:
+        release.set()
+        assert completed.wait(1)
+
+
+def test_thread_start_failure_is_sticky_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    constructed: list[int] = []
+
+    class _UnstartableThread:
+        def __init__(self, **_kwargs: Any) -> None:
+            constructed.append(1)
+
+        def start(self) -> None:
+            raise RuntimeError("cannot start new thread")
+
+    monkeypatch.setattr(token_estimation.threading, "Thread", _UnstartableThread)
+
+    first = tokenizer.estimate_tokens_with_source("a" * 400)
+    second = tokenizer.estimate_tokens_with_source("a" * 400)
+
+    assert first == second == (200, "utf8_unicode_conservative")
+    assert constructed == [1]
+    assert token_estimation._tiktoken_available is False
+
+
+def test_join_failure_is_sticky_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _UnjoinableThread:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        def start(self) -> None:
+            pass
+
+        def join(self, _timeout: float) -> None:
+            raise OverflowError("timeout too large")
+
+    monkeypatch.setattr(token_estimation.threading, "Thread", _UnjoinableThread)
+
+    assert tokenizer.estimate_tokens_with_source("a" * 400) == (
+        200,
+        "utf8_unicode_conservative",
+    )
+    assert token_estimation._tiktoken_available is False
+
+
+def test_fork_child_resets_a_possibly_orphaned_loader_lock() -> None:
+    inherited_lock = token_estimation._load_lock
+    inherited_lock.acquire()
+    try:
+        token_estimation._reset_load_lock_after_fork()
+        assert token_estimation._load_lock is not inherited_lock
+        assert token_estimation._load_lock.acquire(blocking=False)
+        token_estimation._load_lock.release()
+    finally:
+        inherited_lock.release()

--- a/tests/test_session/test_tokenizer.py
+++ b/tests/test_session/test_tokenizer.py
@@ -53,7 +53,6 @@ def _reset_tokenizer_state(monkeypatch: pytest.MonkeyPatch):
     """Keep the process-wide loader verdict isolated between tests."""
 
     monkeypatch.setattr(token_estimation, "_encoding", None)
-    monkeypatch.setattr(token_estimation, "_tiktoken_available", None)
     monkeypatch.setattr(token_estimation, "_load_lock", threading.Lock())
     monkeypatch.delenv(token_estimation._ENCODING_LOAD_TIMEOUT_ENV, raising=False)
     yield
@@ -65,7 +64,7 @@ def test_estimate_tokens_uses_the_encoding_when_it_loads(
     monkeypatch.setattr(token_estimation, "_load_encoding", lambda: _FakeEncoding(2))
 
     assert tokenizer.estimate_tokens("abcdefgh") == 4
-    assert token_estimation._tiktoken_available is True
+    assert isinstance(token_estimation._encoding, _FakeEncoding)
 
 
 def test_estimate_tokens_falls_back_when_tiktoken_is_missing(
@@ -80,7 +79,7 @@ def test_estimate_tokens_falls_back_when_tiktoken_is_missing(
         200,
         "utf8_unicode_conservative",
     )
-    assert token_estimation._tiktoken_available is False
+    assert token_estimation._encoding is token_estimation._ENCODING_UNAVAILABLE
 
 
 def test_estimate_tokens_falls_back_when_the_encoding_fetch_fails(
@@ -95,7 +94,7 @@ def test_estimate_tokens_falls_back_when_the_encoding_fetch_fails(
         200,
         "utf8_unicode_conservative",
     )
-    assert token_estimation._tiktoken_available is False
+    assert token_estimation._encoding is token_estimation._ENCODING_UNAVAILABLE
 
 
 def test_estimate_tokens_never_returns_zero(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -174,7 +173,7 @@ def test_a_wedged_encoding_load_returns_within_the_configured_budget(
         assert entered.is_set()
         assert estimate == (200, "utf8_unicode_conservative")
         assert elapsed < 0.5
-        assert token_estimation._tiktoken_available is False
+        assert token_estimation._encoding is token_estimation._ENCODING_UNAVAILABLE
     finally:
         release.set()
         assert completed.wait(1)
@@ -204,7 +203,7 @@ def test_a_timed_out_load_is_sticky_and_is_not_retried(
 
         assert first == second == (200, "utf8_unicode_conservative")
         assert len(calls) == 1
-        assert token_estimation._encoding is None
+        assert token_estimation._encoding is token_estimation._ENCODING_UNAVAILABLE
     finally:
         release.set()
 
@@ -328,7 +327,7 @@ def test_thread_start_failure_is_sticky_fallback(
 
     assert first == second == (200, "utf8_unicode_conservative")
     assert constructed == [1]
-    assert token_estimation._tiktoken_available is False
+    assert token_estimation._encoding is token_estimation._ENCODING_UNAVAILABLE
 
 
 def test_join_failure_is_sticky_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -348,7 +347,7 @@ def test_join_failure_is_sticky_fallback(monkeypatch: pytest.MonkeyPatch) -> Non
         200,
         "utf8_unicode_conservative",
     )
-    assert token_estimation._tiktoken_available is False
+    assert token_estimation._encoding is token_estimation._ENCODING_UNAVAILABLE
 
 
 def test_fork_child_resets_a_possibly_orphaned_loader_lock() -> None:


### PR DESCRIPTION
Scope

Move the bounded one-time `cl100k_base` load from the stale session implementation in #814 to the current shared `opensquilla.token_estimation` owner. Preserve the current estimator-source labels, Unicode-conservative fallback, large-text chunking, and session compatibility exports.

The loader now uses one process-wide attempt, a finite configurable wait, sticky fallback after timeout or worker failure, and a fork-child lock reset. Timeout overrides are capped at 60 seconds and remain below the platform `threading.TIMEOUT_MAX`.

Branch

Base branch: main

Target exception: N/A

Issue

Linked issue: None

If None, reason: This replaces stale PR #814 on the current shared token-estimation architecture. The liveness defect was discovered while investigating #782, but it is not the cause of that issue's GLM `max_tokens` rejection.

Release Note

Release note: Token estimation now falls back within a bounded time instead of risking an indefinite gateway stall when the tiktoken encoding cannot be downloaded.

Tests

- `uv run pytest tests/test_session/test_tokenizer.py tests/test_engine/test_t3_upgrade_compaction.py tests/test_session/test_compaction_dispatcher.py -q` — 67 passed.
- `uv run pytest tests/test_gateway/test_context_overflow.py tests/test_gateway/test_rpc_usage.py tests/test_provider_auxiliary_budget.py tests/test_provider_request_proof.py tests/test_session/test_compaction.py tests/test_session/test_manager.py -q` — 259 passed, 1 skipped.
- `uv run ruff check src tests` — passed.
- `uv run mypy src/opensquilla/token_estimation.py src/opensquilla/session/tokenizer.py --show-error-codes` — passed.
- Full local `uv run pytest tests -q` was attempted but stopped after unrelated real-terminal tests failed because `@opentui/core` is not installed in the local checkout.
- Local wheel build reached the existing WebUI artifact gate and could not proceed because `src/opensquilla/gateway/static/dist` has not been generated. CI provides the complete build environment.

Regression tests: added and tightened for successful single-flight loading, concurrent timeout, sticky late completion, invalid and excessive timeout overrides, worker start/join failure, fork-child lock recovery, and deterministic offline compaction budgets.

Compatibility

No database, RPC, persisted configuration, public protocol, or client schema changes. The historical integer-only session tokenizer API remains a compatibility wrapper over the shared estimator. The implementation is platform-neutral except for the guarded POSIX fork callback; ordinary threading behavior is covered by the Windows/Linux/macOS CI matrix.

Maintainer Live Check

Maintainer live check: no

Surface: N/A

Safety

No secrets, transcripts, prompts, channel identifiers, local paths, or private fixtures are included. Generic tiktoken failures retain the existing sanitized warning shape; timeout logs contain only the numeric budget.

Third-Party Origin

Third-party origin: none

Details if non-none: N/A. `tiktoken` remains an existing optional dependency.

Documentation Changes

- [x] No public configuration schema changed; the advanced timeout environment variable is described in the PR scope and release note.
- [x] Tests and examples use synthetic offline data only.
