### PR TITLE
Restore post-#804 experiment runtime controls

### DIFF
--- a/docs/features/LLM-ensemble-design.md
+++ b/docs/features/LLM-ensemble-design.md
@@ -220,6 +220,12 @@ candidate body comes only from the last successful attempt, while trace and
 usage accounting retain every started attempt, including zero-usage rows marked
 `usage_receipt_missing = true`.
 
+The aggregator already retries bounded transient upstream failures in place.
+It also retries a timeout or a stream that ends before `DoneEvent` when that
+attempt has emitted no text, reasoning, or tool delta, reusing the completed
+proposer drafts. Once any user-visible delta has been emitted, the attempt is
+terminal so a retry cannot duplicate text or tool activity downstream.
+
 Proposers never own an executable tool boundary. By default they receive no
 current tool schemas. Setting `proposer_tools = true` exposes those schemas only
 as advisory vocabulary: native or textual tool-shaped output is converted into

--- a/docs/features/LLM-ensemble-design.md
+++ b/docs/features/LLM-ensemble-design.md
@@ -188,6 +188,8 @@ not a public configuration field:
 | Parameter | Legacy (`router_dynamic`) | Fixed-lineup default |
 |-----------|---------------------------|----------------------|
 | `min_successful_proposers` | 1 | 3 (presets) / `N-1` (custom, "all but one") |
+| `target_successful_proposers` | unset (same as minimum) | unset (same as minimum) |
+| `proposer_max_retries` | 0 | 0 |
 | `proposer_timeout_seconds` | 3600 | 300 |
 | `aggregator_timeout_seconds` | 3600 | 480 |
 | `shuffle_candidates` | `True` | `False` |
@@ -201,6 +203,22 @@ The legacy value `0` disables quorum early-exit and waits for every proposer; it
 does not mean an immediate, zero-delay cutoff. Fixed lineups instead allow ten
 seconds after reaching quorum so a nearly complete final draft can still join
 the fusion without waiting for the full proposer timeout.
+
+For score-oriented runs, `target_successful_proposers` separates the preferred
+draft count from the minimum acceptance floor. For example, `target = 4` and
+`min = 3` waits for all four fixed B5 proposers. If one proposer exhausts its
+configured retries, the remaining three may still be aggregated; two or fewer
+still follow `all_failed_policy`. The fixed-lineup grace starts only after the
+target is reached. A target above the fixed four-member lineup, or above a
+custom lineup's proposer count, is rejected as a configuration error.
+
+`proposer_max_retries` is the number of in-place attempts after the initial
+request. When non-zero, transient 429/5xx/transport failures, blank completed
+outputs, and `length` completions without visible candidate text are retried.
+Every attempt receives its own `proposer_timeout_seconds` budget. The accepted
+candidate body comes only from the last successful attempt, while trace and
+usage accounting retain every started attempt, including zero-usage rows marked
+`usage_receipt_missing = true`.
 
 Proposers never own an executable tool boundary. By default they receive no
 current tool schemas. Setting `proposer_tools = true` exposes those schemas only
@@ -260,7 +278,23 @@ Static presets expose no lineup tuning — the models are fixed in code. Custom
 lineups are tuned entirely through the `candidates` list (subject to the bounds
 above). Both share the fixed-lineup runtime defaults, which an operator may
 still override explicitly (`min_successful_proposers`,
+`target_successful_proposers`, `proposer_max_retries`,
 `proposer_timeout_seconds`, `aggregator_timeout_seconds`, `shuffle_candidates`).
+
+A resilient score-oriented fixed-lineup posture is:
+
+```toml
+[llm_ensemble]
+enabled = true
+selection_mode = "static_openrouter_b5"
+min_successful_proposers = 3
+target_successful_proposers = 4
+proposer_max_retries = 2
+all_failed_policy = "error"
+```
+
+This never falls back to a single model: four successful drafts are preferred,
+three are accepted after retries, and two or fewer terminate the ensemble turn.
 
 ---
 
@@ -458,6 +492,10 @@ What operators can tune:
   anchor and configured router tiers.
 - `llm_ensemble.min_successful_proposers` — desired minimum successful
   proposers (clamped per-turn as described above).
+- `llm_ensemble.target_successful_proposers` — preferred successful proposer
+  count above the minimum floor (clamped per-turn for dynamic templates).
+- `llm_ensemble.proposer_max_retries` — opt-in per-proposer retries; zero keeps
+  the historical single-attempt behavior.
 - `squilla_router.tiers[*].model` — indirectly expands the candidate pool and
   determines which model becomes the anchor for a given tier.
 

--- a/docs/features/LLM-ensemble-design.md
+++ b/docs/features/LLM-ensemble-design.md
@@ -484,6 +484,14 @@ value exceeds how many proposer slots the tier's template actually produced
 an effective minimum of 2. Both the configured and effective values are
 recorded in `selection_plan` for debugging.
 
+For OpenRouter-compatible calls, the local LLM trace emits an additive
+`llm.response_headers` event when a valid `x-generation-id` response header
+arrives. The event stores only that value in `response_ids`; arbitrary response
+headers are never retained. This preserves a physical attempt's billing
+identity when a request later errors, is cancelled, or ends without a response
+body. It does not change the request payload, prompt, model, tools, retry
+policy, or fallback behavior.
+
 ## 2.8 Configuration surface
 
 ```toml

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -8793,8 +8793,16 @@ class Agent:
                                 )
                             ):
                                 _attempt_retries_used[_ProviderAttemptKind.REASONING_ONLY] += 1
-                                _thinking_fallback_done = True
-                                _disable_thinking_for_next_provider_call = True
+                                disable_thinking = bool(
+                                    getattr(
+                                        self.config,
+                                        "reasoning_only_thinking_fallback",
+                                        False,
+                                    )
+                                )
+                                if disable_thinking:
+                                    _thinking_fallback_done = True
+                                    _disable_thinking_for_next_provider_call = True
                                 logger.warning(
                                     "provider.large_context_visible_retry",
                                     session_key=self._session_key,
@@ -8813,13 +8821,18 @@ class Agent:
                                     iter_output_tokens=iter_output_tokens,
                                     iter_reasoning_tokens=iter_reasoning_tokens,
                                     reasoning_chars=len(iter_reasoning_content or ""),
+                                    thinking_disabled=disable_thinking,
                                 )
                                 yield WarningEvent(
                                     code="provider_large_context_visible_retry",
                                     message=(
                                         "The provider returned reasoning without visible "
-                                        "content for a large input; retrying once with "
-                                        "thinking disabled."
+                                        "content for a large input; "
+                                        + (
+                                            "retrying once with thinking disabled."
+                                            if disable_thinking
+                                            else "retrying once to request visible content."
+                                        )
                                     ),
                                 )
                                 _call_attempt += 1

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -8233,6 +8233,7 @@ class Agent:
                                 if (
                                     thinking_enabled
                                     and not _thinking_fallback_done
+                                    and self.config.provider_error_thinking_fallback
                                     and ("thinking" in _err_lower or "reasoning" in _err_lower)
                                 ):
                                     _thinking_fallback_done = True
@@ -19685,6 +19686,9 @@ class Agent:
             placeholder_escalation_threshold=self.config.placeholder_escalation_threshold,
             deadline_wrapup_margin_seconds=self.config.deadline_wrapup_margin_seconds,
             reasoning_only_thinking_fallback=self.config.reasoning_only_thinking_fallback,
+            provider_error_thinking_fallback=(
+                self.config.provider_error_thinking_fallback
+            ),
             deadline_thinking_off_margin_seconds=(
                 self.config.deadline_thinking_off_margin_seconds
             ),

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -7582,6 +7582,17 @@ class Agent:
                                     wrapup_margin_seconds > 0
                                     and _total_deadline is not None
                                     and not deadline_wrapup_armed
+                                    # A policy preempt retries the provider call.
+                                    # Composite providers mark that unsafe because
+                                    # replaying the call repeats every child request.
+                                    and (
+                                        getattr(
+                                            self.provider,
+                                            "retry_failed_call_safe",
+                                            True,
+                                        )
+                                        is not False
+                                    )
                                     and not attempt_user_visible_emitted
                                     and not pending_tools
                                     and not tool_calls

--- a/src/opensquilla/engine/turn_runner/agent_bootstrap_stage.py
+++ b/src/opensquilla/engine/turn_runner/agent_bootstrap_stage.py
@@ -333,6 +333,23 @@ def _bool_from_env(name: str, default: bool = False) -> bool:
     return raw.strip().lower() in _TRUE_ENV_VALUES
 
 
+def _strict_bool_from_env(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    normalized = raw.strip().lower()
+    if normalized in _FINALIZE_EVIDENCE_GATE_ON:
+        return True
+    if normalized in _FINALIZE_EVIDENCE_GATE_OFF:
+        return False
+    raise ValueError(
+        f"{name} must be one of: "
+        + ", ".join(
+            sorted(_FINALIZE_EVIDENCE_GATE_ON | _FINALIZE_EVIDENCE_GATE_OFF)
+        )
+    )
+
+
 def _name_tuple_from_env(name: str) -> tuple[str, ...]:
     raw = os.environ.get(name, "")
     return tuple(item.strip() for item in raw.split(",") if item.strip())
@@ -1091,6 +1108,10 @@ class AgentBootstrapStage:
             reasoning_only_thinking_fallback=_bool_from_env(
                 "OPENSQUILLA_REASONING_ONLY_THINKING_FALLBACK",
                 AgentConfig().reasoning_only_thinking_fallback,
+            ),
+            provider_error_thinking_fallback=_strict_bool_from_env(
+                "OPENSQUILLA_PROVIDER_ERROR_THINKING_FALLBACK",
+                AgentConfig().provider_error_thinking_fallback,
             ),
             deadline_thinking_off_margin_seconds=_nonnegative_int_from_env(
                 "OPENSQUILLA_DEADLINE_THINKING_OFF_MARGIN_SECONDS",

--- a/src/opensquilla/engine/types.py
+++ b/src/opensquilla/engine/types.py
@@ -719,6 +719,11 @@ class AgentConfig:
     # default (the retry keeps thinking on). Set via
     # OPENSQUILLA_REASONING_ONLY_THINKING_FALLBACK.
     reasoning_only_thinking_fallback: bool = False
+    # Retry provider errors mentioning thinking/reasoning with thinking
+    # disabled. Historical default on; strict benchmark arms can turn it off
+    # with OPENSQUILLA_PROVIDER_ERROR_THINKING_FALLBACK so every request keeps
+    # the frozen thinking contract.
+    provider_error_thinking_fallback: bool = True
     # Force thinking off for every provider call once remaining wall-clock
     # time drops below this many seconds. 0 = off. Complements the wrap-up
     # directive: the nudge alone leaves thinking enabled, so the model can

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -552,6 +552,14 @@ class LlmEnsembleConfig(BaseSettings):
     # boundary.
     proposer_tools: bool = False
     min_successful_proposers: int = Field(default=1, ge=1)
+    # Optional quality target above the minimum floor. When set, proposer
+    # collection keeps waiting for this many successful drafts; if the target
+    # becomes unreachable, the turn may still aggregate once the minimum
+    # floor is satisfied.
+    target_successful_proposers: int | None = Field(default=None, ge=1)
+    # Number of in-place retries after the initial proposer request. Zero
+    # preserves the historical single-attempt behavior.
+    proposer_max_retries: int = Field(default=0, ge=0, le=10)
     all_failed_policy: Literal["fallback_single", "error"] = "fallback_single"
     model_options: list[str] = Field(default_factory=_default_llm_ensemble_model_options)
     candidates: list[LlmEnsembleCandidateConfig] = Field(default_factory=list)
@@ -572,6 +580,28 @@ class LlmEnsembleConfig(BaseSettings):
             seen_options.add(normalized)
             model_options.append(normalized)
         self.model_options = model_options
+        return self
+
+    @model_validator(mode="after")
+    def _validate_success_targets(self) -> LlmEnsembleConfig:
+        if (
+            self.target_successful_proposers is not None
+            and self.target_successful_proposers < self.min_successful_proposers
+        ):
+            raise ValueError(
+                "llm_ensemble.target_successful_proposers cannot be lower than "
+                "llm_ensemble.min_successful_proposers"
+            )
+        if (
+            self.selection_mode
+            in {"static_openrouter_b5", "static_tokenrhythm_b5"}
+            and self.target_successful_proposers is not None
+            and self.target_successful_proposers > 4
+        ):
+            raise ValueError(
+                "llm_ensemble.target_successful_proposers cannot exceed the "
+                "static B5 proposer count (4)"
+            )
         return self
 
     @model_validator(mode="after")
@@ -622,6 +652,14 @@ class LlmEnsembleConfig(BaseSettings):
         if self.min_successful_proposers > len(proposers):
             raise ValueError(
                 "llm_ensemble.min_successful_proposers cannot exceed the "
+                f"custom_b5 proposer count ({len(proposers)})"
+            )
+        if (
+            self.target_successful_proposers is not None
+            and self.target_successful_proposers > len(proposers)
+        ):
+            raise ValueError(
+                "llm_ensemble.target_successful_proposers cannot exceed the "
                 f"custom_b5 proposer count ({len(proposers)})"
             )
         return self

--- a/src/opensquilla/provider/ensemble.py
+++ b/src/opensquilla/provider/ensemble.py
@@ -340,7 +340,11 @@ class _CandidateResult:
 
     @property
     def ok(self) -> bool:
-        return not self.error and bool(self.text.strip())
+        return (
+            not self.error
+            and str(self.stop_reason or "").strip().lower() != "error"
+            and bool(self.text.strip())
+        )
 
     @property
     def request_count(self) -> int:
@@ -2116,6 +2120,8 @@ class EnsembleProvider:
         if result.ok:
             return ""
         if result.error:
+            if result.error_code == "candidate_error_finish_reason":
+                return "error_finish_reason"
             if result.error_code in {"stream_incomplete", "timeout"}:
                 return "transient_transport"
             if self._member_error_is_retryable(
@@ -2261,6 +2267,9 @@ class EnsembleProvider:
                 result.billing_receipt = event.billing_receipt
                 result.stop_reason = event.stop_reason
                 result.model = event.model or result.model
+                if str(event.stop_reason or "").strip().lower() == "error":
+                    result.error = "proposer terminated with error finish reason"
+                    result.error_code = "candidate_error_finish_reason"
             elif isinstance(event, ErrorEvent):
                 result.error = redact_upstream_error_text(
                     event.message,

--- a/src/opensquilla/provider/ensemble.py
+++ b/src/opensquilla/provider/ensemble.py
@@ -64,7 +64,8 @@ _ENSEMBLE_CANCEL_CLEANUP_TIMEOUT_SECONDS = 5.0
 # this a single 429/5xx blip would discard the whole billed proposer round.
 _ENSEMBLE_AGGREGATOR_MAX_RETRIES = 2
 _ENSEMBLE_AGGREGATOR_RETRY_BACKOFF_SECONDS: tuple[float, ...] = (1.0, 4.0)
-_AGGREGATOR_RETRYABLE_FAILURE_KINDS = frozenset(
+_ENSEMBLE_PROPOSER_RETRY_BACKOFF_SECONDS: tuple[float, ...] = (1.0, 4.0)
+_ENSEMBLE_RETRYABLE_FAILURE_KINDS = frozenset(
     {
         ProviderFailureKind.RATE_LIMITED,
         ProviderFailureKind.PROVIDER_OVERLOADED,
@@ -88,6 +89,16 @@ def _aggregator_retry_backoff_seconds(attempt: int) -> float:
     """Backoff before aggregator retry ``attempt`` (1-indexed)."""
 
     delays = _ENSEMBLE_AGGREGATOR_RETRY_BACKOFF_SECONDS
+    if not delays:
+        return 0.0
+    index = min(max(attempt - 1, 0), len(delays) - 1)
+    return max(0.0, float(delays[index]))
+
+
+def _proposer_retry_backoff_seconds(attempt: int) -> float:
+    """Backoff before proposer retry ``attempt`` (1-indexed)."""
+
+    delays = _ENSEMBLE_PROPOSER_RETRY_BACKOFF_SECONDS
     if not delays:
         return 0.0
     index = min(max(attempt - 1, 0), len(delays) - 1)
@@ -319,10 +330,23 @@ class _CandidateResult:
     execution: dict[str, Any] = field(default_factory=dict)
     usage_reported: bool = False
     request_started: bool = False
+    # Populated only when proposer retries are explicitly enabled. Each child
+    # is one complete upstream attempt; the parent carries the final accepted
+    # body plus token/cost totals across every attempt.
+    attempts: list[_CandidateResult] = field(default_factory=list, repr=False)
+    attempt_index: int = 0
+    retryable: bool = False
+    retry_reason: str = ""
 
     @property
     def ok(self) -> bool:
         return not self.error and bool(self.text.strip())
+
+    @property
+    def request_count(self) -> int:
+        if self.attempts:
+            return sum(1 for attempt in self.attempts if attempt.request_started)
+        return int(self.request_started)
 
     def usage_row(self, *, role: str, profile: str) -> dict[str, Any]:
         row = {
@@ -345,6 +369,22 @@ class _CandidateResult:
         }
         if self.billing_receipt is not None:
             row["billing_receipt"] = self.billing_receipt
+        if self.attempt_index > 0:
+            row.update(
+                {
+                    "attempt_index": self.attempt_index,
+                    "attempt_ok": self.ok,
+                    "request_started": self.request_started,
+                    "usage_reported": self.usage_reported,
+                    "usage_receipt_missing": (
+                        self.request_started and not self.usage_reported
+                    ),
+                    "stop_reason": self.stop_reason,
+                    "error_code": self.error_code,
+                    "retryable": self.retryable,
+                    "retry_reason": self.retry_reason,
+                }
+            )
         return row
 
     def trace_row(self, *, include_text: bool, content_max_chars: int) -> dict[str, Any]:
@@ -370,6 +410,29 @@ class _CandidateResult:
         if self.error:
             row["error"] = self.error
             row["error_code"] = self.error_code
+        if self.attempt_index > 0:
+            row.update(
+                {
+                    "attempt_index": self.attempt_index,
+                    "usage_reported": self.usage_reported,
+                    "usage_receipt_missing": (
+                        self.request_started and not self.usage_reported
+                    ),
+                    "error_code": self.error_code,
+                    "retryable": self.retryable,
+                    "retry_reason": self.retry_reason,
+                }
+            )
+        if self.attempts:
+            row["attempt_count"] = len(self.attempts)
+            row["request_count"] = self.request_count
+            row["attempts"] = [
+                attempt.trace_row(
+                    include_text=include_text,
+                    content_max_chars=content_max_chars,
+                )
+                for attempt in self.attempts
+            ]
         if include_text:
             row["text"] = self.text
         return row
@@ -767,21 +830,34 @@ def _candidate_usage_rows(
     *,
     profile: str,
 ) -> list[dict[str, Any]]:
-    return [
-        candidate.usage_row(role="proposer", profile=profile)
-        for candidate in candidates
-        if _candidate_has_usage(candidate)
-    ]
+    rows: list[dict[str, Any]] = []
+    for candidate in candidates:
+        if candidate.attempts:
+            # Retry-enabled turns retain one auditable row for every started
+            # request. Missing receipts deliberately remain zero-usage rows
+            # and are also counted by usage_missing_count.
+            rows.extend(
+                attempt.usage_row(role="proposer", profile=profile)
+                for attempt in candidate.attempts
+                if attempt.request_started
+            )
+        elif _candidate_has_usage(candidate):
+            rows.append(candidate.usage_row(role="proposer", profile=profile))
+    return rows
 
 
 def _candidate_missing_usage_count(candidates: Sequence[_CandidateResult]) -> int:
     """Count only requests that started but never produced a usage receipt."""
 
-    return sum(
-        1
-        for candidate in candidates
-        if candidate.request_started and not candidate.usage_reported
-    )
+    missing_count = 0
+    for candidate in candidates:
+        attempts = candidate.attempts or [candidate]
+        missing_count += sum(
+            1
+            for attempt in attempts
+            if attempt.request_started and not attempt.usage_reported
+        )
+    return missing_count
 
 
 def _uniform_message_limit_proof(
@@ -878,6 +954,8 @@ class EnsembleProvider:
         fallback_model: str = "",
         fallback_api_key: str = "",
         min_successful_proposers: int = 1,
+        target_successful_proposers: int | None = None,
+        proposer_max_retries: int = 0,
         all_failed_policy: Literal["fallback_single", "error"] = "fallback_single",
         proposer_timeout_seconds: float = 3600.0,
         aggregator_timeout_seconds: float = 3600.0,
@@ -902,6 +980,17 @@ class EnsembleProvider:
         self.fallback_model = str(fallback_model or "")
         self._fallback_api_key = str(fallback_api_key or "")
         self.min_successful_proposers = max(1, int(min_successful_proposers or 1))
+        requested_target = int(
+            target_successful_proposers or self.min_successful_proposers
+        )
+        available_candidates = sum(
+            max(1, int(member.k or 1)) for member in self.proposers
+        )
+        self.target_successful_proposers = min(
+            max(1, available_candidates),
+            max(self.min_successful_proposers, requested_target),
+        )
+        self.proposer_max_retries = max(0, int(proposer_max_retries or 0))
         self.all_failed_policy = all_failed_policy
         self.proposer_timeout_seconds = float(proposer_timeout_seconds or 3600.0)
         self.aggregator_timeout_seconds = float(aggregator_timeout_seconds or 3600.0)
@@ -1249,17 +1338,32 @@ class EnsembleProvider:
                 high = mid - 1
         return best
 
-    def _aggregator_error_is_retryable(self, *, message: str, code: str) -> bool:
-        """True when the aggregator failure is a transient upstream condition."""
+    @staticmethod
+    def _member_error_is_retryable(
+        *,
+        provider_name: str,
+        message: str,
+        code: str,
+    ) -> bool:
+        """True when a member failure is a transient upstream condition."""
 
         raw_code = str(code or "")
         kind = classify_provider_error(
-            provider_name=self.aggregator.provider_config.provider,
+            provider_name=provider_name,
             status_code=int(raw_code) if raw_code.isdigit() else None,
             raw_code=raw_code,
             message=message,
         )
-        return kind in _AGGREGATOR_RETRYABLE_FAILURE_KINDS
+        return kind in _ENSEMBLE_RETRYABLE_FAILURE_KINDS
+
+    def _aggregator_error_is_retryable(self, *, message: str, code: str) -> bool:
+        """True when the aggregator failure is a transient upstream condition."""
+
+        return self._member_error_is_retryable(
+            provider_name=self.aggregator.provider_config.provider,
+            message=message,
+            code=code,
+        )
 
     def provider_metadata(self) -> ProviderMetadata:
         return ProviderMetadata(
@@ -1762,7 +1866,7 @@ class EnsembleProvider:
                     break
                 if (
                     self.quorum_grace_seconds > 0
-                    and successful_count >= self.min_successful_proposers
+                    and successful_count >= self.target_successful_proposers
                 ):
                     break
 
@@ -1842,7 +1946,7 @@ class EnsembleProvider:
         progress: Callable[[EnsembleProgressEvent], None] | None = None,
     ) -> _CandidateResult:
         cfg = member.provider_config
-        started = time.monotonic()
+        overall_started = time.monotonic()
         result = _CandidateResult(
             index=index,
             sample_index=sample_index,
@@ -1862,21 +1966,111 @@ class EnsembleProvider:
                 )
             )
         try:
-            return await asyncio.wait_for(
-                self._collect_candidate_inner(
-                    result=result,
+            max_attempts = self.proposer_max_retries + 1
+            retry_enabled = self.proposer_max_retries > 0
+            for attempt_index in range(1, max_attempts + 1):
+                attempt = (
+                    _CandidateResult(
+                        index=index,
+                        sample_index=sample_index,
+                        label=result.label,
+                        provider=result.provider,
+                        model=cfg.model,
+                        attempt_index=attempt_index,
+                    )
+                    if retry_enabled
+                    else result
+                )
+                attempt_started = time.monotonic()
+                controlled_cancel = False
+                try:
+                    await asyncio.wait_for(
+                        self._collect_candidate_inner(
+                            result=attempt,
+                            member=member,
+                            messages=messages,
+                            tools=tools,
+                            config=config,
+                            started=attempt_started,
+                        ),
+                        timeout=(
+                            self.proposer_timeout_seconds
+                            if self.proposer_timeout_seconds > 0
+                            else None
+                        ),
+                    )
+                except asyncio.CancelledError:
+                    current_task = asyncio.current_task()
+                    code = str(
+                        getattr(
+                            current_task,
+                            "_opensquilla_ensemble_cancel_code",
+                            "",
+                        )
+                        or ""
+                    )
+                    if not code:
+                        raise
+                    attempt.error_code = code
+                    attempt.error = str(
+                        getattr(
+                            current_task,
+                            "_opensquilla_ensemble_cancel_message",
+                            "proposer cancelled after ensemble quorum was reached",
+                        )
+                        or "proposer cancelled after ensemble quorum was reached"
+                    )
+                    controlled_cancel = True
+                except TimeoutError:
+                    attempt.error = (
+                        "proposer timed out after "
+                        f"{self.proposer_timeout_seconds:g}s"
+                    )
+                    attempt.error_code = "timeout"
+                except Exception as exc:  # noqa: BLE001 - diagnostic candidate data
+                    attempt.error = redact_upstream_error_text(
+                        str(exc),
+                        api_key=cfg.api_key,
+                        max_len=2000,
+                    )
+                    attempt.error_code = redact_upstream_error_code(
+                        type(exc).__name__,
+                        api_key=cfg.api_key,
+                    )
+                finally:
+                    attempt.elapsed_ms = int(
+                        (time.monotonic() - attempt_started) * 1000
+                    )
+
+                if not retry_enabled:
+                    return attempt
+
+                retry_reason = self._proposer_retry_reason(
+                    result=attempt,
                     member=member,
-                    messages=messages,
-                    tools=tools,
-                    config=config,
-                    started=started,
-                ),
-                timeout=(
-                    self.proposer_timeout_seconds
-                    if self.proposer_timeout_seconds > 0
-                    else None
-                ),
-            )
+                )
+                attempt.retryable = bool(retry_reason)
+                attempt.retry_reason = retry_reason
+                self._record_candidate_attempt(result, attempt)
+
+                if attempt.ok or controlled_cancel or not retry_reason:
+                    return result
+                if attempt_index >= max_attempts:
+                    return result
+
+                retry_number = attempt_index
+                log.info(
+                    "ensemble.proposer_retry",
+                    profile=self.profile_name,
+                    proposer_label=result.label,
+                    proposer_model=result.model,
+                    attempt_index=attempt_index,
+                    next_attempt_index=attempt_index + 1,
+                    retry_reason=retry_reason,
+                )
+                await asyncio.sleep(
+                    _proposer_retry_backoff_seconds(retry_number)
+                )
         except asyncio.CancelledError:
             current_task = asyncio.current_task()
             code = str(getattr(current_task, "_opensquilla_ensemble_cancel_code", "") or "")
@@ -1891,21 +2085,8 @@ class EnsembleProvider:
                 )
                 or "proposer cancelled after ensemble quorum was reached"
             )
-        except TimeoutError:
-            result.error = f"proposer timed out after {self.proposer_timeout_seconds:g}s"
-            result.error_code = "timeout"
-        except Exception as exc:  # noqa: BLE001 - candidate failures are diagnostic data
-            result.error = redact_upstream_error_text(
-                str(exc),
-                api_key=cfg.api_key,
-                max_len=2000,
-            )
-            result.error_code = redact_upstream_error_code(
-                type(exc).__name__,
-                api_key=cfg.api_key,
-            )
         finally:
-            result.elapsed_ms = int((time.monotonic() - started) * 1000)
+            result.elapsed_ms = int((time.monotonic() - overall_started) * 1000)
             if progress is not None:
                 progress(
                     EnsembleProgressEvent(
@@ -1923,6 +2104,84 @@ class EnsembleProvider:
                     )
                 )
         return result
+
+    def _proposer_retry_reason(
+        self,
+        *,
+        result: _CandidateResult,
+        member: EnsembleMemberConfig,
+    ) -> str:
+        """Return the bounded retry reason for one failed proposer attempt."""
+
+        if result.ok:
+            return ""
+        if result.error:
+            if result.error_code in {"stream_incomplete", "timeout"}:
+                return "transient_transport"
+            if self._member_error_is_retryable(
+                provider_name=member.provider_config.provider,
+                message=result.error,
+                code=result.error_code,
+            ):
+                return "transient_upstream"
+            return ""
+        if not result.text.strip():
+            if str(result.stop_reason or "").strip().lower() == "length":
+                result.error = (
+                    "proposer exhausted its output budget without visible text"
+                )
+                result.error_code = "candidate_length_no_visible_text"
+                return "length_no_visible_text"
+            result.error = "proposer returned no visible candidate text"
+            result.error_code = "candidate_empty_output"
+            return "empty_output"
+        return ""
+
+    @staticmethod
+    def _record_candidate_attempt(
+        candidate: _CandidateResult,
+        attempt: _CandidateResult,
+    ) -> None:
+        """Accept the latest body while preserving all attempt accounting."""
+
+        candidate.attempts.append(attempt)
+        candidate.text = attempt.text
+        candidate.stop_reason = attempt.stop_reason
+        candidate.ttft_ms = attempt.ttft_ms
+        candidate.error = attempt.error
+        candidate.error_code = attempt.error_code
+        candidate.message_limit_proof = attempt.message_limit_proof
+        candidate.execution = dict(attempt.execution)
+        candidate.model = attempt.model
+        candidate.billing_receipt = attempt.billing_receipt
+        candidate.request_started = any(
+            item.request_started for item in candidate.attempts
+        )
+        candidate.usage_reported = any(
+            item.usage_reported for item in candidate.attempts
+        )
+        candidate.input_tokens = sum(item.input_tokens for item in candidate.attempts)
+        candidate.output_tokens = sum(item.output_tokens for item in candidate.attempts)
+        candidate.reasoning_tokens = sum(
+            item.reasoning_tokens for item in candidate.attempts
+        )
+        candidate.cached_tokens = sum(
+            item.cached_tokens for item in candidate.attempts
+        )
+        candidate.cache_write_tokens = sum(
+            item.cache_write_tokens for item in candidate.attempts
+        )
+        candidate.billed_cost = sum(
+            item.billed_cost for item in candidate.attempts
+        )
+        started_rows = [
+            item.usage_row(role="proposer", profile="")
+            for item in candidate.attempts
+            if item.request_started
+        ]
+        candidate.cost_source = (
+            _rollup_cost_source(started_rows) if started_rows else "none"
+        )
 
     async def _collect_candidate_inner(
         self,
@@ -2090,13 +2349,16 @@ class EnsembleProvider:
             "shuffle_candidates": self.shuffle_candidates,
             "record_candidates": self.record_candidates,
             "proposer_tools": self.proposer_tools,
+            "min_successful_proposers": self.min_successful_proposers,
+            "target_successful_proposers": self.target_successful_proposers,
+            "proposer_max_retries": self.proposer_max_retries,
             "proposer_timeout_seconds": self.proposer_timeout_seconds,
             "aggregator_timeout_seconds": self.aggregator_timeout_seconds,
             "quorum_grace_seconds": self.quorum_grace_seconds,
             "content_max_chars": TRACE_CONTENT_MAX_CHARS,
             "final_request_role": final_request_role,
             "llm_request_count": sum(
-                1 for candidate in candidates if candidate.request_started
+                candidate.request_count for candidate in candidates
             ),
             "selected_candidate_count": len(selected),
             "selected_candidate_indexes": [candidate.index for candidate in selected],
@@ -4323,6 +4585,24 @@ def build_ensemble_provider_from_config(
             else _STATIC_B5_DEFAULT_MIN_SUCCESSFUL_PROPOSERS
         )
     min_successful_proposers = min(requested_min_success, max(1, len(proposers)))
+    configured_target_success = getattr(
+        ensemble_cfg,
+        "target_successful_proposers",
+        None,
+    )
+    requested_target_success = (
+        min_successful_proposers
+        if configured_target_success is None
+        else max(min_successful_proposers, int(configured_target_success))
+    )
+    target_successful_proposers = min(
+        requested_target_success,
+        max(1, len(proposers)),
+    )
+    proposer_max_retries = max(
+        0,
+        int(getattr(ensemble_cfg, "proposer_max_retries", 0) or 0),
+    )
     configured_proposer_timeout_seconds = float(
         getattr(ensemble_cfg, "proposer_timeout_seconds", _LEGACY_ENSEMBLE_TIMEOUT_SECONDS)
     )
@@ -4360,6 +4640,15 @@ def build_ensemble_provider_from_config(
     selection_plan["configured_shuffle_candidates"] = configured_shuffle_candidates
     selection_plan["effective_shuffle_candidates"] = shuffle_candidates
     selection_plan["quorum_grace_seconds"] = quorum_grace_seconds
+    if configured_target_success is not None:
+        selection_plan["configured_target_successful_proposers"] = int(
+            configured_target_success
+        )
+        selection_plan["effective_target_successful_proposers"] = (
+            target_successful_proposers
+        )
+    if proposer_max_retries:
+        selection_plan["proposer_max_retries"] = proposer_max_retries
     inherited_provider = str(inherited_provider_config.provider or "").strip().lower()
     cross_provider_lineup = any(
         member.provider_config.provider.strip().lower() != inherited_provider
@@ -4428,6 +4717,8 @@ def build_ensemble_provider_from_config(
         fallback_model=inherited_provider_config.model,
         fallback_api_key=inherited_provider_config.api_key,
         min_successful_proposers=min_successful_proposers,
+        target_successful_proposers=target_successful_proposers,
+        proposer_max_retries=proposer_max_retries,
         all_failed_policy=getattr(ensemble_cfg, "all_failed_policy", "fallback_single"),
         proposer_timeout_seconds=proposer_timeout_seconds,
         aggregator_timeout_seconds=aggregator_timeout_seconds,

--- a/src/opensquilla/provider/ensemble.py
+++ b/src/opensquilla/provider/ensemble.py
@@ -2591,9 +2591,15 @@ class EnsembleProvider:
                     ),
                     code="ensemble_aggregator_timeout",
                 )
-                yield aggregator_progress("aggregator_finish", error=error.message)
-                yield partial_error(error)
-                return
+                if (
+                    not content_streamed
+                    and attempt < _ENSEMBLE_AGGREGATOR_MAX_RETRIES
+                ):
+                    retry_error = error
+                else:
+                    yield aggregator_progress("aggregator_finish", error=error.message)
+                    yield partial_error(error)
+                    return
             except Exception as exc:  # noqa: BLE001 - provider boundary returns ErrorEvent
                 safe_message = redact_upstream_error_text(
                     f"ensemble aggregator failed: {exc}",
@@ -2625,9 +2631,15 @@ class EnsembleProvider:
                     message="ensemble aggregator stream ended before DoneEvent",
                     code="ensemble_aggregator_incomplete",
                 )
-                yield aggregator_progress("aggregator_finish", error=error.message)
-                yield partial_error(error)
-                return
+                if (
+                    not content_streamed
+                    and attempt < _ENSEMBLE_AGGREGATOR_MAX_RETRIES
+                ):
+                    retry_error = error
+                else:
+                    yield aggregator_progress("aggregator_finish", error=error.message)
+                    yield partial_error(error)
+                    return
             close_stream = getattr(heartbeat_stream, "aclose", None)
             if callable(close_stream):
                 with contextlib.suppress(Exception):

--- a/src/opensquilla/provider/ensemble.py
+++ b/src/opensquilla/provider/ensemble.py
@@ -2424,6 +2424,8 @@ class EnsembleProvider:
     ) -> AsyncIterator[StreamEvent]:
         final_text_parts: list[str] = []
         aggregator_started = time.monotonic()
+        retry_rows: list[dict[str, Any]] = []
+        retry_missing_count = 0
 
         def aggregator_progress(
             event_type: str,
@@ -2451,9 +2453,16 @@ class EnsembleProvider:
                 error=error,
             )
 
-        def ensemble_done(event: DoneEvent, *, aggregator_elapsed_ms: int) -> DoneEvent:
-            output_text = "".join(final_text_parts)
-            _attach_final_request_output(trace, event=event, output_text=output_text)
+        def aggregator_usage_row(
+            event: DoneEvent,
+            *,
+            aggregator_elapsed_ms: int,
+            attempt_index: int,
+            attempt_ok: bool,
+            retryable: bool = False,
+            error_code: str = "",
+            retry_reason: str = "",
+        ) -> dict[str, Any]:
             acc = _AggregatorAccumulator(
                 input_tokens=event.input_tokens,
                 output_tokens=event.output_tokens,
@@ -2465,15 +2474,42 @@ class EnsembleProvider:
                 billing_receipt=event.billing_receipt,
                 model=event.model or self.aggregator.provider_config.model,
             )
+            row = acc.usage_row(
+                profile=self.profile_name,
+                member=self.aggregator,
+                role="aggregator",
+                label="aggregator",
+                elapsed_ms=aggregator_elapsed_ms,
+            )
+            if not attempt_ok or attempt_index > 1:
+                row.update(
+                    {
+                        "attempt_index": attempt_index,
+                        "attempt_ok": attempt_ok,
+                        "request_started": True,
+                        "usage_reported": True,
+                        "usage_receipt_missing": False,
+                        "stop_reason": event.stop_reason,
+                        "error_code": error_code,
+                        "retryable": retryable,
+                        "retry_reason": retry_reason,
+                    }
+                )
+            return row
+
+        def ensemble_done(event: DoneEvent, *, aggregator_elapsed_ms: int) -> DoneEvent:
+            output_text = "".join(final_text_parts)
+            _attach_final_request_output(trace, event=event, output_text=output_text)
+            success_row = aggregator_usage_row(
+                event,
+                aggregator_elapsed_ms=aggregator_elapsed_ms,
+                attempt_index=attempt + 1,
+                attempt_ok=True,
+            )
             rows = [
                 *prior_rows,
-                acc.usage_row(
-                    profile=self.profile_name,
-                    member=self.aggregator,
-                    role="aggregator",
-                    label="aggregator",
-                    elapsed_ms=aggregator_elapsed_ms,
-                ),
+                *retry_rows,
+                success_row,
             ]
             return replace(
                 event,
@@ -2483,22 +2519,22 @@ class EnsembleProvider:
                 cached_tokens=_summed_int(rows, "cached_tokens"),
                 cache_write_tokens=_summed_int(rows, "cache_write_tokens"),
                 billed_cost=_summed_float(rows, "billed_cost"),
-                model=acc.model,
+                model=str(success_row.get("model") or event.model),
                 provider=self.aggregator.provider_config.provider,
                 cost_source=_rollup_cost_source(rows),
                 model_usage_breakdown=rows,
                 ensemble_trace=trace,
-                # Each retried aggregator attempt started a request that never
-                # produced a usage receipt.
-                usage_missing_count=prior_missing_count + attempt,
+                usage_missing_count=prior_missing_count + retry_missing_count,
                 billing_receipt=None,
             )
 
         def partial_error(event: ErrorEvent) -> ErrorEvent:
             return replace(
                 event,
-                model_usage_breakdown=list(prior_rows),
-                usage_missing_count=prior_missing_count + attempt + 1,
+                model_usage_breakdown=[*prior_rows, *retry_rows],
+                usage_missing_count=(
+                    prior_missing_count + retry_missing_count + 1
+                ),
             )
 
         yield aggregator_progress("aggregator_start")
@@ -2506,6 +2542,7 @@ class EnsembleProvider:
         while True:
             content_streamed = False
             retry_error: ErrorEvent | None = None
+            retry_usage_reported = False
             heartbeat_stream: AsyncIterator[StreamEvent] | None = None
             try:
                 _mark_final_request_started(trace)
@@ -2526,6 +2563,57 @@ class EnsembleProvider:
                         aggregator_elapsed_ms = int(
                             (time.monotonic() - aggregator_started) * 1000
                         )
+                        if str(event.stop_reason or "").strip().lower() == "error":
+                            _attach_final_request_output(
+                                trace,
+                                event=event,
+                                output_text="".join(final_text_parts),
+                            )
+                            can_retry = (
+                                not content_streamed
+                                and attempt < _ENSEMBLE_AGGREGATOR_MAX_RETRIES
+                            )
+                            failed_row = aggregator_usage_row(
+                                event,
+                                aggregator_elapsed_ms=aggregator_elapsed_ms,
+                                attempt_index=attempt + 1,
+                                attempt_ok=False,
+                                retryable=can_retry,
+                                error_code="aggregator_error_finish_reason",
+                                retry_reason=(
+                                    "error_finish_reason" if can_retry else ""
+                                ),
+                            )
+                            error = ErrorEvent(
+                                message=(
+                                    "ensemble aggregator terminated with error "
+                                    "finish reason"
+                                ),
+                                code="ensemble_aggregator_error_finish_reason",
+                            )
+                            if can_retry:
+                                retry_rows.append(failed_row)
+                                retry_usage_reported = True
+                                retry_error = error
+                                break
+                            terminal_rows = [
+                                *prior_rows,
+                                *retry_rows,
+                                failed_row,
+                            ]
+                            yield aggregator_progress(
+                                "aggregator_finish",
+                                usage=failed_row,
+                                error=error.message,
+                            )
+                            yield replace(
+                                error,
+                                model_usage_breakdown=terminal_rows,
+                                usage_missing_count=(
+                                    prior_missing_count + retry_missing_count
+                                ),
+                            )
+                            return
                         done_event = ensemble_done(
                             event,
                             aggregator_elapsed_ms=aggregator_elapsed_ms,
@@ -2649,6 +2737,8 @@ class EnsembleProvider:
                     yield aggregator_progress("aggregator_finish", error=error.message)
                     yield partial_error(error)
                     return
+            if not retry_usage_reported:
+                retry_missing_count += 1
             close_stream = getattr(heartbeat_stream, "aclose", None)
             if callable(close_stream):
                 with contextlib.suppress(Exception):

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -744,9 +744,13 @@ def _should_send_tool_choice(
 
 _DASHSCOPE_PRESERVE_THINKING_MODEL_IDS = frozenset(
     {
+        "qwen3.6-max-preview",
+    }
+)
+_DASHSCOPE_PRESERVE_THINKING_EXPERIMENT_MODEL_IDS = frozenset(
+    {
         "qwen3.6-flash",
         "qwen3.6-flash-2026-04-16",
-        "qwen3.6-max-preview",
         "qwen3.7-flash",
         "qwen3.7-flash-2026-07-15",
     }
@@ -2666,21 +2670,28 @@ def _should_replay_reasoning_content(
         return True
     if not caps or not caps.supports_reasoning:
         return False
-    if effective_thinking and model_name in policy.preserve_thinking_model_ids:
-        return True
     if caps.reasoning_format == "dashscope":
         if not effective_thinking:
             return False
-        supported = _dashscope_supports_preserve_thinking(model)
+        supported_by_default = (
+            model_name in policy.preserve_thinking_model_ids
+            or _dashscope_supports_preserve_thinking(model)
+        )
         override = _dashscope_preserve_thinking_override_from_env()
         if override is None:
-            return supported
-        if override and not supported:
+            return supported_by_default
+        supported_by_override = (
+            supported_by_default
+            or model_name in _DASHSCOPE_PRESERVE_THINKING_EXPERIMENT_MODEL_IDS
+        )
+        if override and not supported_by_override:
             raise ValueError(
                 f"{_DASHSCOPE_PRESERVE_THINKING_ENV}=on is not supported "
                 f"for DashScope model {model!r}"
             )
         return override
+    if effective_thinking and model_name in policy.preserve_thinking_model_ids:
+        return True
     return bool(policy.replay_reasoning_format) and (
         caps.reasoning_format == policy.replay_reasoning_format
     )

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -593,6 +593,7 @@ _DASHSCOPE_THINKING_BUDGET_ENV = "OPENSQUILLA_DASHSCOPE_THINKING_BUDGET"
 _DASHSCOPE_THINKING_BUDGET_MIN = 1024
 _DASHSCOPE_THINKING_BUDGET_MAX = 38_912
 _DASHSCOPE_PARALLEL_TOOL_CALLS_ENV = "OPENSQUILLA_DASHSCOPE_PARALLEL_TOOL_CALLS"
+_DASHSCOPE_NON_STREAM_FALLBACK_ENV = "OPENSQUILLA_DASHSCOPE_NON_STREAM_FALLBACK"
 
 
 def _dashscope_parallel_tool_calls_from_env() -> bool:
@@ -612,6 +613,27 @@ def _dashscope_parallel_tool_calls_from_env() -> bool:
         return False
     raise ValueError(
         f"{_DASHSCOPE_PARALLEL_TOOL_CALLS_ENV} must be one of "
+        "1/true/yes/on or 0/false/no/off"
+    )
+
+
+def _dashscope_non_stream_fallback_from_env() -> bool:
+    """Return whether DashScope may retry a stream as a non-stream request.
+
+    The historical default is enabled. Invalid values fail closed at request
+    construction so benchmark manifests cannot claim a strict streaming arm
+    while silently retaining the fallback.
+    """
+    raw = os.environ.get(_DASHSCOPE_NON_STREAM_FALLBACK_ENV)
+    if raw is None or not raw.strip():
+        return True
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(
+        f"{_DASHSCOPE_NON_STREAM_FALLBACK_ENV} must be one of "
         "1/true/yes/on or 0/false/no/off"
     )
 
@@ -3258,6 +3280,20 @@ class OpenAIProvider:
         tools: list[ToolDefinition] | None,
         cfg: ChatConfig,
     ) -> AsyncIterator[StreamEvent]:
+        non_stream_fallback_allowed = (
+            self._provider_kind != "dashscope"
+            or _dashscope_non_stream_fallback_from_env()
+        )
+        stream_timeout_fallback = (
+            self._compat.stream_timeout_fallback
+            and cfg.physical_attempt_limit != 1
+            and non_stream_fallback_allowed
+        )
+        empty_stream_fallback = (
+            self._compat.empty_stream_fallback
+            and cfg.physical_attempt_limit != 1
+            and non_stream_fallback_allowed
+        )
         payload, wire_active_user_index, fallback_reason = self._build_payload(
             messages,
             tools,
@@ -3531,10 +3567,7 @@ class OpenAIProvider:
             async with httpx.AsyncClient(
                 timeout=(
                     _stream_timeout(cfg.timeout)
-                    if (
-                        self._compat.stream_timeout_fallback
-                        and cfg.physical_attempt_limit != 1
-                    )
+                    if stream_timeout_fallback
                     else cfg.timeout
                 ),
                 trust_env=_trust_env(),
@@ -4470,8 +4503,7 @@ class OpenAIProvider:
                     has_terminal_evidence = active_choice_seen and choice_terminal_seen
                     if not has_terminal_evidence:
                         if (
-                            self._compat.empty_stream_fallback
-                            and cfg.physical_attempt_limit != 1
+                            empty_stream_fallback
                             and not active_choice_seen
                             and not emitted_stream_event
                             and not assistant_text_parts
@@ -4762,8 +4794,7 @@ class OpenAIProvider:
                         gemini_thought_sig = streamed_thought_signature
 
                     if (
-                        self._compat.empty_stream_fallback
-                        and cfg.physical_attempt_limit != 1
+                        empty_stream_fallback
                         and not emitted_stream_event
                         and not assistant_text_parts
                         and not tools_acc.has_calls
@@ -4852,11 +4883,7 @@ class OpenAIProvider:
                 message=safe_error,
                 metadata={"phase": "stream", "cache_shape": cache_shape},
             )
-            if (
-                self._compat.stream_timeout_fallback
-                and cfg.physical_attempt_limit != 1
-                and not emitted_stream_event
-            ):
+            if stream_timeout_fallback and not emitted_stream_event:
                 event_name = (
                     "openrouter.stream_timeout_fallback_started"
                     if self._provider_kind == "openrouter"

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -592,6 +592,28 @@ def _strip_tool_schema_keywords(value: Any, unsupported: frozenset[str]) -> Any:
 _DASHSCOPE_THINKING_BUDGET_ENV = "OPENSQUILLA_DASHSCOPE_THINKING_BUDGET"
 _DASHSCOPE_THINKING_BUDGET_MIN = 1024
 _DASHSCOPE_THINKING_BUDGET_MAX = 38_912
+_DASHSCOPE_PARALLEL_TOOL_CALLS_ENV = "OPENSQUILLA_DASHSCOPE_PARALLEL_TOOL_CALLS"
+
+
+def _dashscope_parallel_tool_calls_from_env() -> bool:
+    """Return the opt-in DashScope parallel tool-call request setting.
+
+    The default and explicit false forms preserve the historical payload by
+    omitting ``parallel_tool_calls``. Invalid values fail closed so benchmark
+    arms cannot silently become null treatments because of a typo.
+    """
+    raw = os.environ.get(_DASHSCOPE_PARALLEL_TOOL_CALLS_ENV)
+    if raw is None or not raw.strip():
+        return False
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(
+        f"{_DASHSCOPE_PARALLEL_TOOL_CALLS_ENV} must be one of "
+        "1/true/yes/on or 0/false/no/off"
+    )
 
 
 def _thinking_budget_tokens_from_env() -> int | None:
@@ -3082,6 +3104,11 @@ class OpenAIProvider:
                 )
                 for tool in tools
             ]
+            if (
+                self._provider_kind == "dashscope"
+                and _dashscope_parallel_tool_calls_from_env()
+            ):
+                payload["parallel_tool_calls"] = True
             if _should_send_tool_choice(self._provider_kind, cfg, caps):
                 payload["tool_choice"] = cfg.tool_choice
         if self._compat.supports_provider_routing_pin:

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -4872,6 +4872,13 @@ class OpenAIProvider:
                         billing_receipt=billing_receipt,
                     )
 
+        except asyncio.CancelledError:
+            trace.record_error(
+                code="cancelled",
+                message="Provider request cancelled",
+                metadata={"phase": "stream", "cache_shape": cache_shape},
+            )
+            raise
         except httpx.TimeoutException as exc:
             safe_error = redact_upstream_error_text(
                 f"Request timed out: {str(exc) or repr(exc)}",

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -112,6 +112,7 @@ from .types import (
 
 _OPENAI_API_BASE = "https://api.openai.com"
 log = structlog.get_logger(__name__)
+_OPENROUTER_GENERATION_ID_RE = re.compile(r"\Agen-[A-Za-z0-9_-]{1,255}\Z")
 _DASHSCOPE_PARAMETER_RE = re.compile(
     r"<parameter(?:\s[^>]*)?>(?P<body>[\s\S]*?)</parameter>",
     re.IGNORECASE,
@@ -458,6 +459,19 @@ def _base_url_hostname(base_url: str) -> str:
         return (parsed.hostname or "").lower()
     except ValueError:
         return ""
+
+
+def _openrouter_generation_id_from_headers(
+    headers: Mapping[str, Any] | None,
+) -> str | None:
+    """Return only a bounded, official-shaped OpenRouter generation ID."""
+
+    if headers is None:
+        return None
+    value = str(headers.get("x-generation-id") or "").strip()
+    if not _OPENROUTER_GENERATION_ID_RE.fullmatch(value):
+        return None
+    return value
 
 
 def _safe_validation_message(value: object) -> str:
@@ -3512,6 +3526,7 @@ class OpenAIProvider:
         terminal_native_finish_reason_present = False
         terminal_native_finish_reason: Any = None
         active_choice_seen = False
+        response_ids: set[str] = set()
 
         if os.environ.get("OPENSQUILLA_TRACE_ROUTING"):
             print(
@@ -3620,6 +3635,14 @@ class OpenAIProvider:
                     headers=headers,
                     json=payload,
                 ) as response:
+                    response_generation_id = _openrouter_generation_id_from_headers(
+                        response.headers
+                    )
+                    if response_generation_id:
+                        response_ids.add(response_generation_id)
+                        trace.record_response_headers(
+                            response_ids=[response_generation_id]
+                        )
                     if self._compat.attribution_response_headers:
                         attribution = {
                             name: response.headers[name]
@@ -3740,7 +3763,6 @@ class OpenAIProvider:
                         )
                         return
 
-                    response_ids: set[str] = set()
                     trace_tool_calls: list[dict[str, Any]] = []
                     async for line in response.aiter_lines():
                         if not line.startswith("data:"):
@@ -5241,6 +5263,14 @@ class OpenAIProvider:
             yield ErrorEvent(message=safe_error, code="request_error")
             return
 
+        response_ids: set[str] = set()
+        response_generation_id = _openrouter_generation_id_from_headers(
+            response.headers
+        )
+        if response_generation_id:
+            response_ids.add(response_generation_id)
+            trace.record_response_headers(response_ids=[response_generation_id])
+
         if response.status_code != 200:
             safe_response_body = redact_upstream_error_text(
                 response.text,
@@ -5800,6 +5830,9 @@ class OpenAIProvider:
         ):
             reasoning_text = _extract_think_tags("".join(assistant_text_parts)) or None
 
+        response_id = data.get("id")
+        if isinstance(response_id, str) and response_id:
+            response_ids.add(response_id)
         trace.record_response(
             response=data,
             usage={
@@ -5816,7 +5849,7 @@ class OpenAIProvider:
             assistant_text="".join(visible_assistant_text_parts),
             reasoning_content=reasoning_text or None,
             tool_calls=trace_tool_calls,
-            response_ids=[str(data["id"])] if data.get("id") else [],
+            response_ids=sorted(response_ids),
             metadata={"cache_shape": cache_shape},
         )
         if candidate_artifact_text:

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -730,14 +730,37 @@ def _should_send_tool_choice(
 
 _DASHSCOPE_PRESERVE_THINKING_MODEL_IDS = frozenset(
     {
+        "qwen3.6-flash",
+        "qwen3.6-flash-2026-04-16",
         "qwen3.6-max-preview",
+        "qwen3.7-flash",
+        "qwen3.7-flash-2026-07-15",
     }
 )
+_DASHSCOPE_PRESERVE_THINKING_ENV = "OPENSQUILLA_DASHSCOPE_PRESERVE_THINKING"
 
 
 def _dashscope_supports_preserve_thinking(model: str) -> bool:
     model_name = model.rsplit("/", 1)[-1].strip().lower()
     return model_name in _DASHSCOPE_PRESERVE_THINKING_MODEL_IDS
+
+
+def _dashscope_preserve_thinking_override_from_env() -> bool | None:
+    """Return an explicit preserve-thinking treatment, or None for model auto-detection."""
+    raw = os.environ.get(_DASHSCOPE_PRESERVE_THINKING_ENV)
+    if raw is None or not raw.strip():
+        return None
+    normalized = raw.strip().lower()
+    if normalized == "auto":
+        return None
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(
+        f"{_DASHSCOPE_PRESERVE_THINKING_ENV} must be one of "
+        "auto, 1/true/yes/on, or 0/false/no/off"
+    )
 
 
 def _should_send_temperature(
@@ -2634,7 +2657,16 @@ def _should_replay_reasoning_content(
     if caps.reasoning_format == "dashscope":
         if not effective_thinking:
             return False
-        return _dashscope_supports_preserve_thinking(model)
+        supported = _dashscope_supports_preserve_thinking(model)
+        override = _dashscope_preserve_thinking_override_from_env()
+        if override is None:
+            return supported
+        if override and not supported:
+            raise ValueError(
+                f"{_DASHSCOPE_PRESERVE_THINKING_ENV}=on is not supported "
+                f"for DashScope model {model!r}"
+            )
+        return override
     return bool(policy.replay_reasoning_format) and (
         caps.reasoning_format == policy.replay_reasoning_format
     )

--- a/src/opensquilla/provider/trace_recorder.py
+++ b/src/opensquilla/provider/trace_recorder.py
@@ -157,6 +157,23 @@ class LLMTraceRecorder:
             }
         )
 
+    def record_response_headers(
+        self,
+        *,
+        response_ids: list[str] | None = None,
+    ) -> None:
+        """Record response identity without retaining arbitrary HTTP headers."""
+
+        safe_ids = _redact(response_ids or [])
+        if not safe_ids:
+            return
+        self._append(
+            {
+                "event": "llm.response_headers",
+                "response_ids": safe_ids,
+            }
+        )
+
     def record_response(
         self,
         *,

--- a/tests/test_contracts/test_llm_ensemble_preservation.py
+++ b/tests/test_contracts/test_llm_ensemble_preservation.py
@@ -220,6 +220,8 @@ def test_selection_mode_only_upsert_keeps_all_other_keys() -> None:
             "selection_mode": "router_dynamic",
             "model_options": ["custom/model-a"],
             "min_successful_proposers": 2,
+            "target_successful_proposers": 3,
+            "proposer_max_retries": 2,
             "all_failed_policy": "error",
         }
     )
@@ -231,6 +233,8 @@ def test_selection_mode_only_upsert_keeps_all_other_keys() -> None:
     assert ensemble.enabled is False
     assert ensemble.model_options == ["custom/model-a"]
     assert ensemble.min_successful_proposers == 2
+    assert ensemble.target_successful_proposers == 3
+    assert ensemble.proposer_max_retries == 2
     assert ensemble.all_failed_policy == "error"
     assert res.restart_required is False
 

--- a/tests/test_engine/test_agent_invalid_provider_response.py
+++ b/tests/test_engine/test_agent_invalid_provider_response.py
@@ -727,6 +727,7 @@ async def test_reasoning_only_retry_restores_thinking_after_retry_call() -> None
         provider=provider,
         config=AgentConfig(
             thinking=ThinkingLevel.MEDIUM,
+            reasoning_only_thinking_fallback=True,
             max_iterations=3,
             retry_base_backoff_ms=0,
             retry_max_backoff_ms=0,
@@ -871,7 +872,7 @@ async def test_large_reasoning_only_uses_fallback_before_same_model_retry() -> N
 
 
 @pytest.mark.asyncio
-async def test_large_reasoning_only_without_fallback_retries_once_with_thinking_disabled() -> None:
+async def test_large_reasoning_only_without_fallback_keeps_thinking_by_default() -> None:
     provider = _SequenceProvider(
         [
             [_large_reasoning_only_done()],
@@ -895,9 +896,13 @@ async def test_large_reasoning_only_without_fallback_retries_once_with_thinking_
 
     assert len(provider.calls) == 2
     assert provider.calls[0]["config"].thinking is True
-    assert provider.calls[1]["config"].thinking is False
-    assert provider.calls[1]["config"].thinking_level is None
-    assert provider.calls[1]["config"].thinking_budget_tokens == 0
+    assert provider.calls[1]["config"].thinking is True
+    assert provider.calls[1]["config"].thinking_level == ThinkingLevel.MEDIUM
+    assert (
+        provider.calls[1]["config"].thinking_budget_tokens
+        == provider.calls[0]["config"].thinking_budget_tokens
+        == 10_000
+    )
     assert any(
         event.kind == "warning" and event.code == "provider_large_context_visible_retry"
         for event in events
@@ -906,6 +911,13 @@ async def test_large_reasoning_only_without_fallback_retries_once_with_thinking_
         event.kind == "warning" and event.code == "provider_reasoning_only_retry"
         for event in events
     )
+    visible_retry = next(
+        event
+        for event in events
+        if event.kind == "warning"
+        and event.code == "provider_large_context_visible_retry"
+    )
+    assert "thinking disabled" not in visible_retry.message
     assert not any(event.kind == "error" for event in events)
     done = next(event for event in events if event.kind == "done")
     assert done.text == "ok"
@@ -994,6 +1006,7 @@ async def test_repeated_large_dashscope_reasoning_only_disables_thinking_after_n
                 reasoning_format="dashscope",
             ),
             reasoning_prefill_recovery_mode="recover",
+            reasoning_only_thinking_fallback=True,
             retry_base_backoff_ms=0,
             retry_max_backoff_ms=0,
         ),
@@ -1013,6 +1026,49 @@ async def test_repeated_large_dashscope_reasoning_only_disables_thinking_after_n
     assert not any(event.kind == "error" for event in events)
     assert any(event.kind == "done" and event.text == "ok" for event in events)
     assert provider.calls[2]["config"].thinking is False
+
+
+@pytest.mark.asyncio
+async def test_repeated_large_dashscope_reasoning_only_keeps_thinking_when_fallback_off() -> None:
+    provider = _SequenceProvider(
+        [
+            [_large_reasoning_only_done()],
+            [_large_reasoning_only_done()],
+            [
+                ProviderText(text="ok"),
+                ProviderDone(stop_reason="stop", input_tokens=4, output_tokens=1),
+            ],
+        ]
+    )
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            thinking=ThinkingLevel.MEDIUM,
+            model_capabilities=ModelCapabilities(
+                supports_reasoning=True,
+                supports_tools=True,
+                reasoning_format="dashscope",
+            ),
+            reasoning_prefill_recovery_mode="recover",
+            reasoning_only_thinking_fallback=False,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("hello")]
+
+    assert len(provider.calls) == 3
+    assert not any(event.kind == "error" for event in events)
+    assert any(event.kind == "done" and event.text == "ok" for event in events)
+    assert all(call["config"].thinking is True for call in provider.calls)
+    visible_retry = next(
+        event
+        for event in events
+        if event.kind == "warning"
+        and event.code == "provider_large_context_visible_retry"
+    )
+    assert "thinking disabled" not in visible_retry.message
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/test_placeholder_escalation_and_wrapup.py
+++ b/tests/test_engine/test_placeholder_escalation_and_wrapup.py
@@ -69,6 +69,10 @@ class _SequenceProvider:
         return []
 
 
+class _NonRetrySafeSequenceProvider(_SequenceProvider):
+    retry_failed_call_safe = False
+
+
 def _placeholder_tool_call(tool_use_id: str) -> list[Any]:
     return [
         ProviderToolUseStart(tool_use_id=tool_use_id, tool_name="echo"),
@@ -458,6 +462,41 @@ async def test_deadline_wrapup_preempts_reasoning_only_stream() -> None:
         if text.startswith(_WRAPUP_PREFIX)
     ]
     assert len(wrapup_texts) == 1
+
+
+@pytest.mark.asyncio
+async def test_deadline_wrapup_does_not_replay_non_retry_safe_provider() -> None:
+    provider = _NonRetrySafeSequenceProvider(
+        [
+            [
+                ProviderReasoning(text="deep thought"),
+                2.5,
+                ProviderReasoning(text="more thought"),
+                ProviderText(text="composite completed"),
+                ProviderDone(stop_reason="stop", input_tokens=5, output_tokens=2),
+            ],
+            _final_text(),
+        ]
+    )
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            timeout=8.0,
+            deadline_wrapup_margin_seconds=6,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("fix the bug")]
+
+    assert any(event.kind == "done" for event in events)
+    assert len(provider.calls) == 1
+    assert not [
+        text
+        for text in _user_texts(provider.calls[0]["messages"])
+        if text.startswith(_WRAPUP_PREFIX)
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/test_reasoning_retry_and_deadline_thinking_levers.py
+++ b/tests/test_engine/test_reasoning_retry_and_deadline_thinking_levers.py
@@ -27,6 +27,7 @@ from opensquilla.provider import (
     ToolInputSchema,
 )
 from opensquilla.provider import DoneEvent as ProviderDone
+from opensquilla.provider import ErrorEvent as ProviderError
 from opensquilla.provider import ReasoningDeltaEvent as ProviderReasoning
 from opensquilla.provider import TextDeltaEvent as ProviderText
 from opensquilla.provider import ToolUseEndEvent as ProviderToolUseEnd
@@ -193,6 +194,56 @@ async def test_reasoning_only_fallback_restores_thinking_after_retry_call() -> N
     assert provider.calls[0]["config"].thinking is True
     assert provider.calls[1]["config"].thinking is False
     assert provider.calls[2]["config"].thinking is True
+
+
+@pytest.mark.asyncio
+async def test_provider_error_thinking_fallback_default_on_disables_retry() -> None:
+    provider = _SequenceProvider(
+        [
+            [ProviderError(message="reasoning is unavailable", code="400")],
+            _final_text(),
+        ]
+    )
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            thinking=ThinkingLevel.MEDIUM,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("hello")]
+
+    assert any(event.kind == "done" for event in events)
+    assert len(provider.calls) == 2
+    assert provider.calls[0]["config"].thinking is True
+    assert provider.calls[1]["config"].thinking is False
+
+
+@pytest.mark.asyncio
+async def test_provider_error_thinking_fallback_strict_off_never_disables() -> None:
+    provider = _SequenceProvider(
+        [
+            [ProviderError(message="reasoning is unavailable", code="400")],
+            _final_text(),
+        ]
+    )
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            thinking=ThinkingLevel.MEDIUM,
+            provider_error_thinking_fallback=False,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("hello")]
+
+    assert any(event.kind == "error" for event in events)
+    assert provider.calls
+    assert all(call["config"].thinking is True for call in provider.calls)
 
 
 @pytest.mark.asyncio
@@ -808,5 +859,23 @@ def test_agent_config_defaults_keep_both_levers_off() -> None:
     config = AgentConfig()
 
     assert config.reasoning_only_thinking_fallback is False
+    assert config.provider_error_thinking_fallback is True
     assert config.deadline_thinking_off_margin_seconds == 0
     assert config.reasoning_stream_char_cap == 0
+
+
+def test_provider_error_thinking_fallback_env_is_strict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.engine.turn_runner.agent_bootstrap_stage import (
+        _strict_bool_from_env,
+    )
+
+    name = "OPENSQUILLA_PROVIDER_ERROR_THINKING_FALLBACK"
+    monkeypatch.delenv(name, raising=False)
+    assert _strict_bool_from_env(name, True) is True
+    monkeypatch.setenv(name, "off")
+    assert _strict_bool_from_env(name, True) is False
+    monkeypatch.setenv(name, "of")
+    with pytest.raises(ValueError, match=name):
+        _strict_bool_from_env(name, True)

--- a/tests/test_llm_ensemble_config.py
+++ b/tests/test_llm_ensemble_config.py
@@ -21,6 +21,8 @@ def test_llm_ensemble_defaults_to_disabled_for_model_router_first_install() -> N
     assert ensemble.selection_mode == "static_openrouter_b5"
     assert ensemble.proposer_tools is False
     assert ensemble.min_successful_proposers == 1
+    assert ensemble.target_successful_proposers is None
+    assert ensemble.proposer_max_retries == 0
     assert ensemble.model_options == []
     assert ensemble.candidates == []
     assert ensemble.candidate_max_chars == 24_000
@@ -51,6 +53,8 @@ def test_llm_ensemble_defaults_to_disabled_for_model_router_first_install() -> N
     ]
     assert provider.aggregator.provider_config.model == "z-ai/glm-5.2"
     assert provider.min_successful_proposers == 3
+    assert provider.target_successful_proposers == 3
+    assert provider.proposer_max_retries == 0
     assert provider.proposer_timeout_seconds == 300.0
     assert provider.aggregator_timeout_seconds == 480.0
     assert provider.shuffle_candidates is False
@@ -531,6 +535,57 @@ def test_static_openrouter_b5_ensemble_preserves_custom_effective_values() -> No
     assert provider.proposer_timeout_seconds == 180.0
     assert provider.aggregator_timeout_seconds == 900.0
     assert provider.shuffle_candidates is False
+
+
+def test_static_b5_supports_score_target_above_resilient_floor() -> None:
+    cfg = GatewayConfig(
+        llm_ensemble={
+            "enabled": True,
+            "selection_mode": "static_openrouter_b5",
+            "min_successful_proposers": 3,
+            "target_successful_proposers": 4,
+            "proposer_max_retries": 2,
+            "all_failed_policy": "error",
+        }
+    )
+    provider = build_ensemble_provider_from_config(
+        config=cfg,
+        inherited_provider_config=ProviderConfig(
+            provider="openrouter",
+            model="routed/model",
+            api_key="fake",
+            base_url="https://openrouter.example/api/v1",
+        ),
+        fallback_provider=None,
+    )
+
+    assert provider.min_successful_proposers == 3
+    assert provider.target_successful_proposers == 4
+    assert provider.proposer_max_retries == 2
+    assert provider.all_failed_policy == "error"
+    assert provider.selection_plan["configured_target_successful_proposers"] == 4
+    assert provider.selection_plan["effective_target_successful_proposers"] == 4
+    assert provider.selection_plan["proposer_max_retries"] == 2
+
+
+def test_success_target_cannot_be_below_floor() -> None:
+    with pytest.raises(Exception, match="target_successful_proposers"):
+        GatewayConfig(
+            llm_ensemble={
+                "min_successful_proposers": 3,
+                "target_successful_proposers": 2,
+            }
+        )
+
+
+def test_static_success_target_cannot_exceed_fixed_lineup() -> None:
+    with pytest.raises(Exception, match="static B5 proposer count"):
+        GatewayConfig(
+            llm_ensemble={
+                "selection_mode": "static_openrouter_b5",
+                "target_successful_proposers": 5,
+            }
+        )
 
 
 def _custom_b5_config(**overrides: object) -> GatewayConfig:

--- a/tests/test_provider/test_trace_recorder.py
+++ b/tests/test_provider/test_trace_recorder.py
@@ -33,6 +33,7 @@ def test_llm_trace_recorder_redacts_secret_values_in_strings(
         assistant_text=f"debug DASHSCOPE_API_KEY={secret}",
         response={"choices": [{"message": {"content": f"token={secret}"}}]},
     )
+    recorder.record_response_headers(response_ids=[f"gen-{secret}"])
     recorder.record_error(
         code="bad",
         message=f"failed with {secret}",
@@ -47,5 +48,6 @@ def test_llm_trace_recorder_redacts_secret_values_in_strings(
     )
     assert rows[0]["headers"]["Authorization"] == "[REDACTED]"
     assert rows[1]["assistant_text"] == "debug DASHSCOPE_API_KEY=[REDACTED]"
-    assert rows[2]["message"] == "failed with [REDACTED]"
-    assert rows[2]["response_body"] == "OPENROUTER_API_KEY=[REDACTED]"
+    assert secret not in json.dumps(rows[2], sort_keys=True)
+    assert rows[3]["message"] == "failed with [REDACTED]"
+    assert rows[3]["response_body"] == "OPENROUTER_API_KEY=[REDACTED]"

--- a/tests/test_provider_ensemble.py
+++ b/tests/test_provider_ensemble.py
@@ -3551,6 +3551,84 @@ async def test_aggregator_transient_exception_is_retried_in_place(
 
 
 @pytest.mark.asyncio
+async def test_aggregator_empty_incomplete_stream_is_retried_in_place(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, call_count = _flaky_aggregator_harness(
+        monkeypatch,
+        [
+            [],
+            [
+                TextDeltaEvent(text="final"),
+                DoneEvent(input_tokens=2, output_tokens=3, model="agg"),
+            ],
+        ],
+    )
+
+    events = await _collect(_retry_test_provider())
+
+    assert call_count[0] == 2
+    assert not any(isinstance(event, ErrorEvent) for event in events)
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.usage_missing_count == 1
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["final_request"]["retry_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_aggregator_timeout_before_content_is_retried_in_place(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = _FakeRegistry(
+        {"p1": _FakePlan([TextDeltaEvent(text="draft"), DoneEvent(model="p1")])}
+    )
+    call_count = [0]
+
+    class _TimeoutOnceAggregator:
+        provider_name = "fake"
+
+        def chat(
+            self,
+            messages: list[Message],
+            tools: list[ToolDefinition] | None = None,
+            config: ChatConfig | None = None,
+        ) -> AsyncIterator[StreamEvent]:
+            async def _stream() -> AsyncIterator[StreamEvent]:
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    await asyncio.sleep(0.05)
+                yield TextDeltaEvent(text="final")
+                yield DoneEvent(model="agg")
+
+            return _stream()
+
+        async def list_models(self) -> list[Any]:
+            return []
+
+    def build_provider(cfg: ProviderConfig) -> Any:
+        if cfg.model == "agg":
+            return _TimeoutOnceAggregator()
+        return registry.provider_for(cfg)
+
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", build_provider)
+    monkeypatch.setattr(
+        "opensquilla.provider.ensemble._ENSEMBLE_AGGREGATOR_RETRY_BACKOFF_SECONDS",
+        (0.0,),
+    )
+    provider = _retry_test_provider()
+    provider.aggregator_timeout_seconds = 0.01
+
+    events = await _collect(provider)
+
+    assert call_count[0] == 2
+    assert not any(isinstance(event, ErrorEvent) for event in events)
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.usage_missing_count == 1
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["final_request"]["retry_count"] == 1
+
+
+@pytest.mark.asyncio
 async def test_aggregator_non_transient_error_is_not_retried(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3947,7 +4025,8 @@ async def test_ensemble_emits_aggregator_finish_before_terminal_error(
     assert expected_error in aggregator_progress[-1].error
     assert terminal_error.code == expected_code
     assert [row["model"] for row in terminal_error.model_usage_breakdown] == ["p1"]
-    assert terminal_error.usage_missing_count == 1  # aggregator supplied no receipt
+    expected_missing_count = 3 if mode == "timeout" else 1
+    assert terminal_error.usage_missing_count == expected_missing_count
     assert events.index(aggregator_progress[-1]) < events.index(terminal_error)
 
 

--- a/tests/test_provider_ensemble.py
+++ b/tests/test_provider_ensemble.py
@@ -186,7 +186,7 @@ class _AttemptRegistry:
         return _AttemptProvider(cfg, self)
 
 
-class _AttemptProvider:
+class _AttemptProvider(_ExactProjectionMixin):
     """Fake provider whose plan advances on every same-model request."""
 
     provider_name = "fake"
@@ -194,6 +194,7 @@ class _AttemptProvider:
     def __init__(self, cfg: ProviderConfig, registry: _AttemptRegistry) -> None:
         self._cfg = cfg
         self._registry = registry
+        self._projection_model = cfg.model
 
     def chat(
         self,
@@ -3741,7 +3742,7 @@ async def test_aggregator_timeout_before_content_is_retried_in_place(
     )
     call_count = [0]
 
-    class _TimeoutOnceAggregator:
+    class _TimeoutOnceAggregator(_ExactProjectionMixin):
         provider_name = "fake"
 
         def chat(

--- a/tests/test_provider_ensemble.py
+++ b/tests/test_provider_ensemble.py
@@ -4332,6 +4332,238 @@ async def test_empty_and_length_only_attempts_retry_without_losing_usage(
 
 
 @pytest.mark.asyncio
+async def test_visible_error_finish_retries_and_only_final_candidate_reaches_aggregator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipts = [
+        ProviderBillingReceipt(
+            currency="USD",
+            status="confirmed",
+            amount_nanos=index,
+            usd_equivalent_nanos=index,
+            fx_native_per_usd_nanos=1_000_000_000,
+        )
+        for index in (10_000_000, 20_000_000)
+    ]
+    registry = _AttemptRegistry(
+        {
+            "kimi": [
+                _FakePlan(
+                    [
+                        TextDeltaEvent(text="discard partial"),
+                        DoneEvent(
+                            input_tokens=10,
+                            output_tokens=15,
+                            reasoning_tokens=2,
+                            stop_reason="error",
+                            model="kimi",
+                            billed_cost=0.01,
+                            cost_source="provider_billed",
+                            billing_receipt=receipts[0],
+                        ),
+                    ]
+                ),
+                _FakePlan(
+                    [
+                        TextDeltaEvent(text="usable final draft"),
+                        DoneEvent(
+                            input_tokens=20,
+                            output_tokens=25,
+                            reasoning_tokens=3,
+                            stop_reason="stop",
+                            model="kimi",
+                            billed_cost=0.02,
+                            cost_source="provider_billed",
+                            billing_receipt=receipts[1],
+                        ),
+                    ]
+                ),
+            ],
+            "agg": [
+                _FakePlan(
+                    [
+                        TextDeltaEvent(text="final"),
+                        DoneEvent(
+                            input_tokens=5,
+                            output_tokens=6,
+                            model="agg",
+                        ),
+                    ]
+                )
+            ],
+        }
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    monkeypatch.setattr(
+        "opensquilla.provider.ensemble._ENSEMBLE_PROPOSER_RETRY_BACKOFF_SECONDS",
+        (),
+    )
+    provider = EnsembleProvider(
+        profile_name="score-max",
+        proposers=[_member("kimi")],
+        aggregator=_member("agg"),
+        min_successful_proposers=1,
+        target_successful_proposers=1,
+        proposer_max_retries=2,
+        proposer_timeout_seconds=1,
+        aggregator_timeout_seconds=1,
+        all_failed_policy="error",
+        shuffle_candidates=False,
+    )
+
+    events = await _collect(provider)
+
+    assert [call["model"] for call in registry.calls] == ["kimi", "kimi", "agg"]
+    aggregator_prompt = str(registry.calls[-1]["messages"][-1].content)
+    assert "usable final draft" in aggregator_prompt
+    assert "discard partial" not in aggregator_prompt
+
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.input_tokens == 35
+    assert done.output_tokens == 46
+    assert done.reasoning_tokens == 5
+    assert done.billed_cost == pytest.approx(0.03)
+    assert done.usage_missing_count == 0
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["llm_request_count"] == 3
+    kimi_trace = done.ensemble_trace["candidates"][0]
+    assert kimi_trace["ok"] is True
+    assert kimi_trace["content"]["text"] == "usable final draft"
+    assert kimi_trace["attempt_count"] == 2
+    assert [attempt["ok"] for attempt in kimi_trace["attempts"]] == [False, True]
+    assert [attempt["stop_reason"] for attempt in kimi_trace["attempts"]] == [
+        "error",
+        "stop",
+    ]
+    assert [attempt["error_code"] for attempt in kimi_trace["attempts"]] == [
+        "candidate_error_finish_reason",
+        "",
+    ]
+    assert [attempt["retry_reason"] for attempt in kimi_trace["attempts"]] == [
+        "error_finish_reason",
+        "",
+    ]
+
+    proposer_rows = [
+        row
+        for row in done.model_usage_breakdown
+        if row["role"] == "proposer"
+    ]
+    assert [row["attempt_index"] for row in proposer_rows] == [1, 2]
+    assert [row["input_tokens"] for row in proposer_rows] == [10, 20]
+    assert [row["output_tokens"] for row in proposer_rows] == [15, 25]
+    assert [row["billed_cost"] for row in proposer_rows] == pytest.approx(
+        [0.01, 0.02]
+    )
+    assert [row["billing_receipt"] for row in proposer_rows] == receipts
+    assert [row["attempt_ok"] for row in proposer_rows] == [False, True]
+    assert [row["error_code"] for row in proposer_rows] == [
+        "candidate_error_finish_reason",
+        "",
+    ]
+    assert [row["retry_reason"] for row in proposer_rows] == [
+        "error_finish_reason",
+        "",
+    ]
+    assert all(row["usage_receipt_missing"] is False for row in proposer_rows)
+
+
+@pytest.mark.asyncio
+async def test_visible_error_finish_exhaustion_blocks_strict_floor_and_preserves_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipts = [
+        ProviderBillingReceipt(
+            currency="USD",
+            status="confirmed",
+            amount_nanos=index,
+            usd_equivalent_nanos=index,
+            fx_native_per_usd_nanos=1_000_000_000,
+        )
+        for index in (10_000_000, 20_000_000, 30_000_000)
+    ]
+    registry = _AttemptRegistry(
+        {
+            "p1": [
+                _FakePlan(
+                    [
+                        TextDeltaEvent(text=f"discard partial {attempt}"),
+                        DoneEvent(
+                            input_tokens=10 + attempt,
+                            output_tokens=20 + attempt,
+                            reasoning_tokens=attempt,
+                            stop_reason="error",
+                            model="p1",
+                            billed_cost=attempt / 100,
+                            cost_source="provider_billed",
+                            billing_receipt=receipts[attempt - 1],
+                        ),
+                    ]
+                )
+                for attempt in range(1, 4)
+            ],
+            "p2": [_FakePlan([TextDeltaEvent(text="d2"), DoneEvent(model="p2")])],
+            "p3": [_FakePlan([TextDeltaEvent(text="d3"), DoneEvent(model="p3")])],
+            "p4": [_FakePlan([TextDeltaEvent(text="d4"), DoneEvent(model="p4")])],
+            "agg": [_FakePlan([TextDeltaEvent(text="unused"), DoneEvent(model="agg")])],
+        }
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    monkeypatch.setattr(
+        "opensquilla.provider.ensemble._ENSEMBLE_PROPOSER_RETRY_BACKOFF_SECONDS",
+        (),
+    )
+    provider = EnsembleProvider(
+        profile_name="score-max",
+        proposers=[_member("p1"), _member("p2"), _member("p3"), _member("p4")],
+        aggregator=_member("agg"),
+        min_successful_proposers=4,
+        target_successful_proposers=4,
+        proposer_max_retries=2,
+        proposer_timeout_seconds=1,
+        aggregator_timeout_seconds=1,
+        all_failed_policy="error",
+        shuffle_candidates=False,
+    )
+
+    events = await _collect(provider)
+
+    terminal = next(event for event in events if isinstance(event, ErrorEvent))
+    assert terminal.code == "ensemble_insufficient_proposers"
+    assert "requires 4" in terminal.message
+    assert not any(isinstance(event, DoneEvent) for event in events)
+    assert [call["model"] for call in registry.calls].count("p1") == 3
+    assert "agg" not in [call["model"] for call in registry.calls]
+    assert terminal.usage_missing_count == 0
+
+    p1_rows = [
+        row
+        for row in terminal.model_usage_breakdown
+        if row["role"] == "proposer" and row["model"] == "p1"
+    ]
+    assert [row["attempt_index"] for row in p1_rows] == [1, 2, 3]
+    assert [row["input_tokens"] for row in p1_rows] == [11, 12, 13]
+    assert [row["output_tokens"] for row in p1_rows] == [21, 22, 23]
+    assert [row["billed_cost"] for row in p1_rows] == pytest.approx(
+        [0.01, 0.02, 0.03]
+    )
+    assert [row["billing_receipt"] for row in p1_rows] == receipts
+    assert [row["attempt_ok"] for row in p1_rows] == [False, False, False]
+    assert [row["stop_reason"] for row in p1_rows] == ["error", "error", "error"]
+    assert [row["error_code"] for row in p1_rows] == [
+        "candidate_error_finish_reason",
+        "candidate_error_finish_reason",
+        "candidate_error_finish_reason",
+    ]
+    assert [row["retry_reason"] for row in p1_rows] == [
+        "error_finish_reason",
+        "error_finish_reason",
+        "error_finish_reason",
+    ]
+    assert all(row["usage_receipt_missing"] is False for row in p1_rows)
+
+
+@pytest.mark.asyncio
 async def test_floor_not_met_errors_without_single_model_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_provider_ensemble.py
+++ b/tests/test_provider_ensemble.py
@@ -22,6 +22,7 @@ from opensquilla.provider import (
     Message,
     ProviderHeartbeatEvent,
     ProviderRequestCorrelation,
+    ReasoningDeltaEvent,
     TextDeltaEvent,
     ToolDefinition,
     ToolInputSchema,
@@ -174,6 +175,64 @@ class _FakeProvider(_ExactProjectionMixin):
             provider_kind="fake",
             model=self._cfg.model,
         )
+
+
+@dataclass
+class _AttemptRegistry:
+    plans: dict[str, list[_FakePlan]]
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def provider_for(self, cfg: ProviderConfig) -> _AttemptProvider:
+        return _AttemptProvider(cfg, self)
+
+
+class _AttemptProvider:
+    """Fake provider whose plan advances on every same-model request."""
+
+    provider_name = "fake"
+
+    def __init__(self, cfg: ProviderConfig, registry: _AttemptRegistry) -> None:
+        self._cfg = cfg
+        self._registry = registry
+
+    def chat(
+        self,
+        messages: list[Message],
+        tools: list[ToolDefinition] | None = None,
+        config: ChatConfig | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        return self._chat(messages, tools=tools, config=config)
+
+    async def _chat(
+        self,
+        messages: list[Message],
+        *,
+        tools: list[ToolDefinition] | None,
+        config: ChatConfig | None,
+    ) -> AsyncIterator[StreamEvent]:
+        same_model_calls = sum(
+            1 for call in self._registry.calls if call["model"] == self._cfg.model
+        )
+        plans = self._registry.plans[self._cfg.model]
+        plan = plans[min(same_model_calls, len(plans) - 1)]
+        self._registry.calls.append(
+            {
+                "model": self._cfg.model,
+                "messages": messages,
+                "tools": tools,
+                "config": config,
+                "started_at": time.monotonic(),
+            }
+        )
+        if plan.delay > 0:
+            await asyncio.sleep(plan.delay)
+        if plan.failure is not None:
+            raise plan.failure
+        for event in plan.events:
+            yield event
+
+    async def list_models(self) -> list[Any]:
+        return []
 
 
 def _member(model: str, *, thinking: str | None = "high") -> EnsembleMemberConfig:
@@ -3942,6 +4001,292 @@ async def test_ensemble_streams_proposer_progress_live_not_buffered(
         if isinstance(e, EnsembleProgressEvent) and e.event_type == "proposer_finish"
     }
     assert finishes == {"p1", "p2"}
+
+
+@pytest.mark.asyncio
+async def test_target_four_waits_past_floor_three_before_aggregation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fourth_gate = asyncio.Event()
+    aggregator_started = asyncio.Event()
+    registry = _FakeRegistry(
+        {
+            "p1": _FakePlan([TextDeltaEvent(text="d1"), DoneEvent(model="p1")]),
+            "p2": _FakePlan([TextDeltaEvent(text="d2"), DoneEvent(model="p2")]),
+            "p3": _FakePlan([TextDeltaEvent(text="d3"), DoneEvent(model="p3")]),
+            "p4": _FakePlan(
+                [TextDeltaEvent(text="d4"), DoneEvent(model="p4")],
+                gate=fourth_gate,
+            ),
+            "agg": _FakePlan(
+                [TextDeltaEvent(text="final"), DoneEvent(model="agg")],
+                started=aggregator_started,
+            ),
+        }
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    provider = EnsembleProvider(
+        profile_name="score-max",
+        proposers=[_member("p1"), _member("p2"), _member("p3"), _member("p4")],
+        aggregator=_member("agg"),
+        min_successful_proposers=3,
+        target_successful_proposers=4,
+        proposer_timeout_seconds=1,
+        aggregator_timeout_seconds=1,
+        quorum_grace_seconds=0.01,
+        all_failed_policy="error",
+        shuffle_candidates=False,
+    )
+
+    consume_task = asyncio.create_task(_collect(provider))
+    await asyncio.sleep(0.05)
+    assert aggregator_started.is_set() is False
+
+    fourth_gate.set()
+    events = await asyncio.wait_for(consume_task, timeout=1.0)
+
+    assert aggregator_started.is_set() is True
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["successful_proposers"] == 4
+    assert done.ensemble_trace["min_successful_proposers"] == 3
+    assert done.ensemble_trace["target_successful_proposers"] == 4
+    assert done.ensemble_trace["selected_candidate_count"] == 4
+
+
+@pytest.mark.asyncio
+async def test_transient_partial_504_retries_then_degrades_to_floor_three(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = _AttemptRegistry(
+        {
+            "p1": [_FakePlan([TextDeltaEvent(text="d1"), DoneEvent(model="p1")])],
+            "p2": [_FakePlan([TextDeltaEvent(text="d2"), DoneEvent(model="p2")])],
+            "p3": [_FakePlan([TextDeltaEvent(text="d3"), DoneEvent(model="p3")])],
+            "glm": [
+                _FakePlan(
+                    [
+                        TextDeltaEvent(text=f"discard partial {attempt}"),
+                        ErrorEvent(
+                            message="Upstream idle timeout exceeded",
+                            code="504",
+                        ),
+                    ]
+                )
+                for attempt in range(1, 4)
+            ],
+            "agg": [_FakePlan([TextDeltaEvent(text="final"), DoneEvent(model="agg")])],
+        }
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    monkeypatch.setattr(
+        "opensquilla.provider.ensemble._ENSEMBLE_PROPOSER_RETRY_BACKOFF_SECONDS",
+        (),
+    )
+    provider = EnsembleProvider(
+        profile_name="score-max",
+        proposers=[_member("p1"), _member("p2"), _member("p3"), _member("glm")],
+        aggregator=_member("agg"),
+        min_successful_proposers=3,
+        target_successful_proposers=4,
+        proposer_max_retries=2,
+        proposer_timeout_seconds=1,
+        aggregator_timeout_seconds=1,
+        quorum_grace_seconds=0.01,
+        all_failed_policy="error",
+        shuffle_candidates=False,
+    )
+
+    events = await _collect(provider)
+
+    assert [call["model"] for call in registry.calls].count("glm") == 3
+    assert [call["model"] for call in registry.calls][-1] == "agg"
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.usage_missing_count == 3
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["successful_proposers"] == 3
+    assert done.ensemble_trace["selected_candidate_count"] == 3
+    assert done.ensemble_trace["llm_request_count"] == 7
+    glm_trace = next(
+        row
+        for row in done.ensemble_trace["candidates"]
+        if row["model"] == "glm"
+    )
+    assert glm_trace["ok"] is False
+    assert glm_trace["content"]["text"] == "discard partial 3"
+    assert glm_trace["attempt_count"] == 3
+    assert [attempt["retry_reason"] for attempt in glm_trace["attempts"]] == [
+        "transient_upstream",
+        "transient_upstream",
+        "transient_upstream",
+    ]
+    glm_usage = [
+        row
+        for row in done.model_usage_breakdown
+        if row["model"] == "glm"
+    ]
+    assert [row["attempt_index"] for row in glm_usage] == [1, 2, 3]
+    assert all(row["usage_receipt_missing"] is True for row in glm_usage)
+
+
+@pytest.mark.asyncio
+async def test_empty_and_length_only_attempts_retry_without_losing_usage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipts = [
+        ProviderBillingReceipt(
+            currency="USD",
+            status="confirmed",
+            amount_nanos=index,
+            usd_equivalent_nanos=index,
+            fx_native_per_usd_nanos=1_000_000_000,
+        )
+        for index in (10_000_000, 20_000_000, 30_000_000)
+    ]
+    registry = _AttemptRegistry(
+        {
+            "kimi": [
+                _FakePlan(
+                    [
+                        TextDeltaEvent(text=" \n"),
+                        DoneEvent(
+                            input_tokens=10,
+                            output_tokens=62,
+                            stop_reason="tool_calls",
+                            model="kimi",
+                            billed_cost=0.01,
+                            cost_source="provider_billed",
+                            billing_receipt=receipts[0],
+                        ),
+                    ]
+                ),
+                _FakePlan(
+                    [
+                        ReasoningDeltaEvent(text="private reasoning"),
+                        DoneEvent(
+                            input_tokens=20,
+                            output_tokens=8192,
+                            reasoning_tokens=8192,
+                            stop_reason="length",
+                            model="kimi",
+                            billed_cost=0.02,
+                            cost_source="provider_billed",
+                            billing_receipt=receipts[1],
+                        ),
+                    ]
+                ),
+                _FakePlan(
+                    [
+                        TextDeltaEvent(text="usable draft"),
+                        DoneEvent(
+                            input_tokens=30,
+                            output_tokens=40,
+                            reasoning_tokens=20,
+                            stop_reason="stop",
+                            model="kimi",
+                            billed_cost=0.03,
+                            cost_source="provider_billed",
+                            billing_receipt=receipts[2],
+                        ),
+                    ]
+                ),
+            ],
+            "agg": [
+                _FakePlan(
+                    [
+                        TextDeltaEvent(text="final"),
+                        DoneEvent(
+                            input_tokens=5,
+                            output_tokens=6,
+                            model="agg",
+                        ),
+                    ]
+                )
+            ],
+        }
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    monkeypatch.setattr(
+        "opensquilla.provider.ensemble._ENSEMBLE_PROPOSER_RETRY_BACKOFF_SECONDS",
+        (),
+    )
+    provider = EnsembleProvider(
+        profile_name="score-max",
+        proposers=[_member("kimi")],
+        aggregator=_member("agg"),
+        min_successful_proposers=1,
+        target_successful_proposers=1,
+        proposer_max_retries=2,
+        proposer_timeout_seconds=1,
+        aggregator_timeout_seconds=1,
+        all_failed_policy="error",
+        shuffle_candidates=False,
+    )
+
+    events = await _collect(provider)
+
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.input_tokens == 65
+    assert done.output_tokens == 8300
+    assert done.reasoning_tokens == 8212
+    assert done.billed_cost == pytest.approx(0.06)
+    assert done.usage_missing_count == 0
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["llm_request_count"] == 4
+    kimi_trace = done.ensemble_trace["candidates"][0]
+    assert kimi_trace["ok"] is True
+    assert kimi_trace["content"]["text"] == "usable draft"
+    assert [attempt["error_code"] for attempt in kimi_trace["attempts"]] == [
+        "candidate_empty_output",
+        "candidate_length_no_visible_text",
+        "",
+    ]
+    proposer_rows = [
+        row
+        for row in done.model_usage_breakdown
+        if row["role"] == "proposer"
+    ]
+    assert [row["attempt_index"] for row in proposer_rows] == [1, 2, 3]
+    assert [row["output_tokens"] for row in proposer_rows] == [62, 8192, 40]
+    assert [row["billing_receipt"] for row in proposer_rows] == receipts
+    assert all(row["usage_receipt_missing"] is False for row in proposer_rows)
+
+
+@pytest.mark.asyncio
+async def test_floor_not_met_errors_without_single_model_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = _AttemptRegistry(
+        {
+            "p1": [_FakePlan([TextDeltaEvent(text="d1"), DoneEvent(model="p1")])],
+            "p2": [_FakePlan([TextDeltaEvent(text="d2"), DoneEvent(model="p2")])],
+            "p3": [_FakePlan([ErrorEvent(message="unauthorized", code="401")])],
+            "p4": [_FakePlan([ErrorEvent(message="bad request", code="400")])],
+            "agg": [_FakePlan([TextDeltaEvent(text="unused"), DoneEvent(model="agg")])],
+        }
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    provider = EnsembleProvider(
+        profile_name="score-max",
+        proposers=[_member("p1"), _member("p2"), _member("p3"), _member("p4")],
+        aggregator=_member("agg"),
+        min_successful_proposers=3,
+        target_successful_proposers=4,
+        proposer_max_retries=2,
+        proposer_timeout_seconds=1,
+        aggregator_timeout_seconds=1,
+        all_failed_policy="error",
+        shuffle_candidates=False,
+    )
+
+    events = await _collect(provider)
+
+    terminal = next(event for event in events if isinstance(event, ErrorEvent))
+    assert terminal.code == "ensemble_insufficient_proposers"
+    assert "requires 3" in terminal.message
+    assert "agg" not in [call["model"] for call in registry.calls]
+    assert [call["model"] for call in registry.calls].count("p3") == 1
+    assert [call["model"] for call in registry.calls].count("p4") == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_provider_ensemble.py
+++ b/tests/test_provider_ensemble.py
@@ -3458,6 +3458,32 @@ def _retry_test_provider() -> EnsembleProvider:
     )
 
 
+def _aggregator_done_with_receipt(
+    *,
+    scale: int,
+    stop_reason: str,
+) -> DoneEvent:
+    receipt = ProviderBillingReceipt(
+        currency="USD",
+        status="confirmed",
+        amount_nanos=scale * 10_000_000,
+        usd_equivalent_nanos=scale * 10_000_000,
+        fx_native_per_usd_nanos=1_000_000_000,
+    )
+    return DoneEvent(
+        input_tokens=scale * 10,
+        output_tokens=scale * 20,
+        reasoning_tokens=scale * 3,
+        cached_tokens=scale * 4,
+        cache_write_tokens=scale,
+        billed_cost=scale / 100,
+        cost_source="provider_billed",
+        billing_receipt=receipt,
+        stop_reason=stop_reason,
+        model="agg",
+    )
+
+
 @pytest.mark.asyncio
 async def test_aggregator_transient_error_is_retried_in_place(
     monkeypatch: pytest.MonkeyPatch,
@@ -3500,6 +3526,137 @@ async def test_aggregator_transient_error_is_retried_in_place(
     ]
     assert len(finishes) == 1
     assert not finishes[0].error
+
+
+@pytest.mark.asyncio
+async def test_aggregator_error_finish_before_content_retries_and_preserves_receipts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failed = _aggregator_done_with_receipt(scale=1, stop_reason="error")
+    succeeded = _aggregator_done_with_receipt(scale=2, stop_reason="stop")
+    _, call_count = _flaky_aggregator_harness(
+        monkeypatch,
+        [
+            [failed],
+            [TextDeltaEvent(text="final"), succeeded],
+        ],
+    )
+
+    events = await _collect(_retry_test_provider())
+
+    assert call_count[0] == 2
+    assert [event.text for event in events if isinstance(event, TextDeltaEvent)] == [
+        "final"
+    ]
+    assert not any(isinstance(event, ErrorEvent) for event in events)
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    aggregator_rows = [
+        row
+        for row in done.model_usage_breakdown
+        if row["role"] == "aggregator"
+    ]
+    assert [row["attempt_index"] for row in aggregator_rows] == [1, 2]
+    assert [row["stop_reason"] for row in aggregator_rows] == ["error", "stop"]
+    assert [row["input_tokens"] for row in aggregator_rows] == [10, 20]
+    assert [row["output_tokens"] for row in aggregator_rows] == [20, 40]
+    assert [row["billed_cost"] for row in aggregator_rows] == pytest.approx(
+        [0.01, 0.02]
+    )
+    assert [row["billing_receipt"] for row in aggregator_rows] == [
+        failed.billing_receipt,
+        succeeded.billing_receipt,
+    ]
+    assert done.input_tokens == 30
+    assert done.output_tokens == 60
+    assert done.reasoning_tokens == 9
+    assert done.cached_tokens == 12
+    assert done.cache_write_tokens == 3
+    assert done.billed_cost == pytest.approx(0.03)
+    assert done.usage_missing_count == 0
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["final_request"]["retry_count"] == 1
+    assert done.ensemble_trace["llm_request_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_aggregator_error_finish_after_visible_content_is_terminal_without_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failed = _aggregator_done_with_receipt(scale=1, stop_reason="error")
+    _, call_count = _flaky_aggregator_harness(
+        monkeypatch,
+        [
+            [TextDeltaEvent(text="partial answer"), failed],
+            [
+                TextDeltaEvent(text="must not be replayed"),
+                _aggregator_done_with_receipt(scale=2, stop_reason="stop"),
+            ],
+        ],
+    )
+
+    events = await _collect(_retry_test_provider())
+
+    assert call_count[0] == 1
+    assert [event.text for event in events if isinstance(event, TextDeltaEvent)] == [
+        "partial answer"
+    ]
+    assert not any(isinstance(event, DoneEvent) for event in events)
+    terminal = next(event for event in events if isinstance(event, ErrorEvent))
+    aggregator_rows = [
+        row
+        for row in terminal.model_usage_breakdown
+        if row["role"] == "aggregator"
+    ]
+    assert [row["attempt_index"] for row in aggregator_rows] == [1]
+    assert [row["stop_reason"] for row in aggregator_rows] == ["error"]
+    assert [row["input_tokens"] for row in aggregator_rows] == [10]
+    assert [row["output_tokens"] for row in aggregator_rows] == [20]
+    assert [row["billed_cost"] for row in aggregator_rows] == pytest.approx([0.01])
+    assert [row["billing_receipt"] for row in aggregator_rows] == [
+        failed.billing_receipt
+    ]
+    assert terminal.usage_missing_count == 0
+
+
+@pytest.mark.asyncio
+async def test_aggregator_error_finish_retry_exhaustion_preserves_all_receipts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failed_attempts = [
+        _aggregator_done_with_receipt(scale=scale, stop_reason="error")
+        for scale in range(1, 4)
+    ]
+    _, call_count = _flaky_aggregator_harness(
+        monkeypatch,
+        [[event] for event in failed_attempts],
+    )
+
+    events = await _collect(_retry_test_provider())
+
+    assert call_count[0] == 3
+    assert not any(isinstance(event, TextDeltaEvent) for event in events)
+    assert not any(isinstance(event, DoneEvent) for event in events)
+    terminal = next(event for event in events if isinstance(event, ErrorEvent))
+    aggregator_rows = [
+        row
+        for row in terminal.model_usage_breakdown
+        if row["role"] == "aggregator"
+    ]
+    assert [row["attempt_index"] for row in aggregator_rows] == [1, 2, 3]
+    assert [row["stop_reason"] for row in aggregator_rows] == [
+        "error",
+        "error",
+        "error",
+    ]
+    assert [row["input_tokens"] for row in aggregator_rows] == [10, 20, 30]
+    assert [row["output_tokens"] for row in aggregator_rows] == [20, 40, 60]
+    assert [row["billed_cost"] for row in aggregator_rows] == pytest.approx(
+        [0.01, 0.02, 0.03]
+    )
+    assert [row["billing_receipt"] for row in aggregator_rows] == [
+        event.billing_receipt for event in failed_attempts
+    ]
+    assert terminal.usage_missing_count == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -623,6 +623,94 @@ def test_dashscope_stream_timeout_emits_heartbeat_before_non_stream_fallback(
     )
 
 
+def test_dashscope_stream_timeout_strict_off_does_not_fallback(
+    monkeypatch: Any,
+) -> None:
+    class TimeoutStream:
+        async def __aenter__(self) -> Any:
+            raise httpx.ReadTimeout("stream idle")
+
+        async def __aexit__(self, *_exc: Any) -> None:
+            return None
+
+    class TimeoutClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> TimeoutClient:
+            return self
+
+        async def __aexit__(self, *_exc: Any) -> None:
+            return None
+
+        def stream(self, *args: Any, **kwargs: Any) -> TimeoutStream:
+            return TimeoutStream()
+
+    class NoFallbackProvider(OpenAIProvider):
+        async def _complete_non_stream(self, **kwargs: Any):
+            pytest.fail("strict DashScope streaming must not call non-stream fallback")
+            yield  # pragma: no cover
+
+    monkeypatch.setenv("OPENSQUILLA_DASHSCOPE_NON_STREAM_FALLBACK", "off")
+    monkeypatch.setattr("opensquilla.provider.openai.httpx.AsyncClient", TimeoutClient)
+    provider = NoFallbackProvider(
+        api_key="test",
+        model="qwen3.7-flash-2026-07-15",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        provider_kind="dashscope",
+    )
+
+    events = _collect_events(provider, ChatConfig(timeout=1.0))
+
+    assert not any(isinstance(event, ProviderHeartbeatEvent) for event in events)
+    error = next(event for event in events if isinstance(event, ErrorEvent))
+    assert error.code == "timeout"
+
+
+def test_dashscope_empty_stream_strict_off_does_not_fallback(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport_body(monkeypatch, captured, b"data: [DONE]\n\n")
+
+    class NoFallbackProvider(OpenAIProvider):
+        async def _complete_non_stream(self, **kwargs: Any):
+            pytest.fail("strict DashScope streaming must not call non-stream fallback")
+            yield  # pragma: no cover
+
+    monkeypatch.setenv("OPENSQUILLA_DASHSCOPE_NON_STREAM_FALLBACK", "off")
+    provider = NoFallbackProvider(
+        api_key="test",
+        model="qwen3.7-flash-2026-07-15",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        provider_kind="dashscope",
+    )
+
+    events = _collect_events(provider, ChatConfig(timeout=1.0))
+
+    assert not any(isinstance(event, ProviderHeartbeatEvent) for event in events)
+    error = next(event for event in events if isinstance(event, ErrorEvent))
+    assert error.code == "incomplete_stream"
+
+
+def test_dashscope_non_stream_fallback_invalid_value_fails_closed(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_DASHSCOPE_NON_STREAM_FALLBACK", "of")
+    provider = OpenAIProvider(
+        api_key="test",
+        model="qwen3.7-flash-2026-07-15",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        provider_kind="dashscope",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="OPENSQUILLA_DASHSCOPE_NON_STREAM_FALLBACK",
+    ):
+        _collect_events(provider, ChatConfig())
+
+
 @pytest.mark.parametrize(
     ("base_url", "expected_url", "expects_install_id"),
     [

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -1228,8 +1228,10 @@ def test_openrouter_header_generation_id_survives_local_stream_cancellation(
     assert [row["event"] for row in rows] == [
         "llm.request",
         "llm.response_headers",
+        "llm.error",
     ]
     assert rows[1]["response_ids"] == ["gen-cancelled-stream-1"]
+    assert rows[2]["code"] == "cancelled"
 
 
 def test_openrouter_non_stream_header_generation_id_is_joined_to_response(
@@ -3476,16 +3478,13 @@ def test_dashscope_request_logs_qwen_provider_profile(monkeypatch: Any) -> None:
         "qwen3.7-flash-2026-07-15",
     ],
 )
-@pytest.mark.parametrize("env_value", [None, "on"])
-def test_dashscope_documented_preserve_model_replays_reasoning_content(
+def test_dashscope_experimental_preserve_model_replays_reasoning_content(
     monkeypatch: Any,
     model: str,
-    env_value: str | None,
 ) -> None:
     captured: dict[str, Any] = {}
     _patch_transport(monkeypatch, captured)
-    if env_value is not None:
-        monkeypatch.setenv("OPENSQUILLA_DASHSCOPE_PRESERVE_THINKING", env_value)
+    monkeypatch.setenv("OPENSQUILLA_DASHSCOPE_PRESERVE_THINKING", "on")
     provider = OpenAIProvider(
         api_key="test",
         model=model,
@@ -3536,6 +3535,52 @@ def test_dashscope_documented_preserve_model_replays_reasoning_content(
     assert captured["payload"]["messages"][0]["reasoning_content"] == (
         "I chose a minimal patch before calling the tool."
     )
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "qwen3.6-flash",
+        "qwen3.7-flash-2026-07-15",
+    ],
+)
+def test_dashscope_preserve_thinking_unset_keeps_main_default(
+    monkeypatch: Any,
+    model: str,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model=model,
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        provider_kind="dashscope",
+    )
+    messages = [
+        Message(
+            role="assistant",
+            content="previous visible answer",
+            reasoning_content="previous DashScope thinking",
+        ),
+        Message(role="user", content="continue"),
+    ]
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            supports_tools=True,
+            reasoning_format="dashscope",
+        ),
+    )
+
+    async def _run() -> None:
+        async for _ in provider.chat(messages, config=cfg):
+            pass
+
+    asyncio.run(_run())
+
+    assert "preserve_thinking" not in captured["payload"]
+    assert "reasoning_content" not in captured["payload"]["messages"][0]
 
 
 def test_dashscope_preserve_thinking_off_keeps_supported_model_history_hidden(

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -1092,6 +1092,81 @@ def test_openai_compatible_provider_writes_llm_trace(monkeypatch: Any, tmp_path:
     assert rows[-1]["assistant_text"] == "ok"
 
 
+def test_openai_compatible_provider_terminalizes_cancelled_stream_trace(
+    monkeypatch: Any,
+    tmp_path: Any,
+) -> None:
+    trace_path = tmp_path / "cancelled-llm-calls.jsonl"
+    stream_started = asyncio.Event()
+
+    class BlockingResponse:
+        status_code = 200
+        headers: dict[str, str] = {}
+
+        async def aiter_lines(self):
+            stream_started.set()
+            await asyncio.Event().wait()
+            yield ""  # pragma: no cover
+
+    class BlockingStream:
+        async def __aenter__(self) -> BlockingResponse:
+            return BlockingResponse()
+
+        async def __aexit__(self, *_exc: Any) -> None:
+            return None
+
+    class BlockingClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> BlockingClient:
+            return self
+
+        async def __aexit__(self, *_exc: Any) -> None:
+            return None
+
+        def stream(self, *args: Any, **kwargs: Any) -> BlockingStream:
+            return BlockingStream()
+
+    monkeypatch.setenv("OPENSQUILLA_LLM_TRACE_RECORDER", "full")
+    monkeypatch.setenv("OPENSQUILLA_LLM_TRACE_PATH", str(trace_path))
+    monkeypatch.setattr(
+        "opensquilla.provider.openai.httpx.AsyncClient",
+        BlockingClient,
+    )
+    provider = OpenAIProvider(
+        api_key="test",
+        model="qwen3.7-flash-2026-07-15",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        provider_kind="dashscope",
+    )
+
+    async def _run() -> None:
+        consume_task = asyncio.create_task(
+            anext(
+                provider.chat(
+                    [Message(role="user", content="hi")],
+                    config=ChatConfig(),
+                )
+            )
+        )
+        await asyncio.wait_for(stream_started.wait(), timeout=1.0)
+        consume_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await consume_task
+
+    asyncio.run(_run())
+
+    rows = [
+        json.loads(line)
+        for line in trace_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [row["event"] for row in rows] == ["llm.request", "llm.error"]
+    assert rows[0]["call_id"] == rows[1]["call_id"]
+    assert rows[1]["code"] == "cancelled"
+    assert rows[1]["metadata"]["phase"] == "stream"
+
+
 def test_llm_trace_request_metadata_carries_compaction_proof(
     monkeypatch: Any, tmp_path: Any
 ) -> None:

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -3232,14 +3232,26 @@ def test_dashscope_request_logs_qwen_provider_profile(monkeypatch: Any) -> None:
     assert profile["stream_fallback"] == "non_stream_once"
 
 
-def test_dashscope_qwen36_flash_thinking_does_not_replay_reasoning_content(
+@pytest.mark.parametrize(
+    "model",
+    [
+        "qwen3.6-flash",
+        "qwen3.7-flash-2026-07-15",
+    ],
+)
+@pytest.mark.parametrize("env_value", [None, "on"])
+def test_dashscope_documented_preserve_model_replays_reasoning_content(
     monkeypatch: Any,
+    model: str,
+    env_value: str | None,
 ) -> None:
     captured: dict[str, Any] = {}
     _patch_transport(monkeypatch, captured)
+    if env_value is not None:
+        monkeypatch.setenv("OPENSQUILLA_DASHSCOPE_PRESERVE_THINKING", env_value)
     provider = OpenAIProvider(
         api_key="test",
-        model="qwen3.6-flash",
+        model=model,
         base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
         provider_kind="dashscope",
     )
@@ -3283,8 +3295,144 @@ def test_dashscope_qwen36_flash_thinking_does_not_replay_reasoning_content(
     asyncio.run(_run())
 
     assert captured["payload"]["enable_thinking"] is True
+    assert captured["payload"]["preserve_thinking"] is True
+    assert captured["payload"]["messages"][0]["reasoning_content"] == (
+        "I chose a minimal patch before calling the tool."
+    )
+
+
+def test_dashscope_preserve_thinking_off_keeps_supported_model_history_hidden(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    monkeypatch.setenv("OPENSQUILLA_DASHSCOPE_PRESERVE_THINKING", "off")
+    provider = OpenAIProvider(
+        api_key="test",
+        model="qwen3.7-flash-2026-07-15",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        provider_kind="dashscope",
+    )
+    messages = [
+        Message(
+            role="assistant",
+            content="previous visible answer",
+            reasoning_content="previous DashScope thinking",
+        ),
+        Message(role="user", content="continue"),
+    ]
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            supports_tools=True,
+            reasoning_format="dashscope",
+        ),
+    )
+
+    async def _run() -> None:
+        async for _ in provider.chat(messages, config=cfg):
+            pass
+
+    asyncio.run(_run())
+
+    assert captured["payload"]["enable_thinking"] is True
     assert "preserve_thinking" not in captured["payload"]
     assert "reasoning_content" not in captured["payload"]["messages"][0]
+
+
+def test_dashscope_preserve_thinking_invalid_value_fails_closed(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_DASHSCOPE_PRESERVE_THINKING", "treu")
+    provider = OpenAIProvider(
+        api_key="test",
+        model="qwen3.7-flash-2026-07-15",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        provider_kind="dashscope",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="OPENSQUILLA_DASHSCOPE_PRESERVE_THINKING",
+    ):
+        _collect(
+            provider,
+            ChatConfig(
+                thinking=True,
+                model_capabilities=ModelCapabilities(
+                    supports_reasoning=True,
+                    supports_tools=True,
+                    reasoning_format="dashscope",
+                ),
+            ),
+        )
+
+
+def test_dashscope_preserve_thinking_auto_keeps_unsupported_model_history_hidden(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="qwen3-max",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        provider_kind="dashscope",
+    )
+    messages = [
+        Message(
+            role="assistant",
+            content="previous visible answer",
+            reasoning_content="unsupported reasoning history",
+        ),
+        Message(role="user", content="continue"),
+    ]
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            supports_tools=True,
+            reasoning_format="dashscope",
+        ),
+    )
+
+    async def _run() -> None:
+        async for _ in provider.chat(messages, config=cfg):
+            pass
+
+    asyncio.run(_run())
+
+    assert "preserve_thinking" not in captured["payload"]
+    assert "reasoning_content" not in captured["payload"]["messages"][0]
+
+
+def test_dashscope_preserve_thinking_on_rejects_unsupported_model(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_DASHSCOPE_PRESERVE_THINKING", "on")
+    provider = OpenAIProvider(
+        api_key="test",
+        model="qwen3-max",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        provider_kind="dashscope",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="not supported.*qwen3-max",
+    ):
+        _collect(
+            provider,
+            ChatConfig(
+                thinking=True,
+                model_capabilities=ModelCapabilities(
+                    supports_reasoning=True,
+                    supports_tools=True,
+                    reasoning_format="dashscope",
+                ),
+            ),
+        )
 
 
 def test_dashscope_preserve_thinking_model_replays_reasoning_content(

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -2791,6 +2791,88 @@ def test_dashscope_thinking_omits_implicit_level_budget(monkeypatch: Any) -> Non
 
 
 _DASHSCOPE_BUDGET_ENV = "OPENSQUILLA_DASHSCOPE_THINKING_BUDGET"
+_DASHSCOPE_PARALLEL_TOOL_CALLS_ENV = "OPENSQUILLA_DASHSCOPE_PARALLEL_TOOL_CALLS"
+
+
+def _dashscope_tool_payload(
+    monkeypatch: Any,
+    *,
+    provider_kind: str = "dashscope",
+) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="qwen3.7-flash-2026-07-15",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        provider_kind=provider_kind,
+    )
+    tool = ToolDefinition(
+        name="read_file",
+        description="Read a file",
+        input_schema={
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+    )
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            supports_tools=True,
+            reasoning_format="dashscope",
+        ),
+    )
+
+    _collect_events(provider, cfg, tools=[tool])
+    return captured["payload"]
+
+
+@pytest.mark.parametrize("value", [None, "", "0", "false", "no", "off"])
+def test_dashscope_parallel_tool_calls_false_forms_omit_field(
+    monkeypatch: Any,
+    value: str | None,
+) -> None:
+    if value is None:
+        monkeypatch.delenv(_DASHSCOPE_PARALLEL_TOOL_CALLS_ENV, raising=False)
+    else:
+        monkeypatch.setenv(_DASHSCOPE_PARALLEL_TOOL_CALLS_ENV, value)
+
+    payload = _dashscope_tool_payload(monkeypatch)
+
+    assert "parallel_tool_calls" not in payload
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", " ON "])
+def test_dashscope_parallel_tool_calls_true_forms_send_true(
+    monkeypatch: Any,
+    value: str,
+) -> None:
+    monkeypatch.setenv(_DASHSCOPE_PARALLEL_TOOL_CALLS_ENV, value)
+
+    payload = _dashscope_tool_payload(monkeypatch)
+
+    assert payload["parallel_tool_calls"] is True
+
+
+def test_dashscope_parallel_tool_calls_invalid_value_fails_closed(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv(_DASHSCOPE_PARALLEL_TOOL_CALLS_ENV, "treu")
+
+    with pytest.raises(ValueError, match="OPENSQUILLA_DASHSCOPE_PARALLEL_TOOL_CALLS"):
+        _dashscope_tool_payload(monkeypatch)
+
+
+def test_non_dashscope_provider_ignores_parallel_tool_calls_env(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv(_DASHSCOPE_PARALLEL_TOOL_CALLS_ENV, "on")
+
+    payload = _dashscope_tool_payload(monkeypatch, provider_kind="openrouter")
+
+    assert "parallel_tool_calls" not in payload
 
 
 def test_dashscope_env_thinking_budget_absent_leaves_payload_inert(

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -1062,6 +1062,243 @@ def test_openrouter_http_error_names_provider_request(monkeypatch: Any) -> None:
     assert error.message == "OpenRouter chat request failed (HTTP 500): Internal Server Error"
 
 
+def test_openrouter_stream_header_generation_id_is_traced_and_joined_to_response(
+    monkeypatch: Any,
+    tmp_path: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    trace_path = tmp_path / "llm_calls.jsonl"
+    monkeypatch.setenv("OPENSQUILLA_LLM_TRACE_RECORDER", "full")
+    monkeypatch.setenv("OPENSQUILLA_LLM_TRACE_PATH", str(trace_path))
+    _patch_transport_response(
+        monkeypatch,
+        captured,
+        httpx.Response(
+            200,
+            headers={
+                "content-type": "text/event-stream",
+                "x-generation-id": "gen-stream-header-1",
+                "x-debug-secret": "must-not-be-traced",
+            },
+            content=_sse_body("deepseek/deepseek-v4-flash"),
+            request=httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions"),
+        ),
+    )
+    provider = OpenAIProvider(
+        api_key="test",
+        model="deepseek/deepseek-v4-flash",
+        base_url="https://openrouter.ai/api/v1",
+        provider_kind="openrouter",
+    )
+
+    events = _collect_events(provider, ChatConfig())
+
+    assert any(isinstance(event, DoneEvent) for event in events)
+    rows = [
+        json.loads(line)
+        for line in trace_path.read_text(encoding="utf-8").splitlines()
+    ]
+    header_row = next(row for row in rows if row["event"] == "llm.response_headers")
+    assert header_row["response_ids"] == ["gen-stream-header-1"]
+    assert next(row for row in rows if row["event"] == "llm.response")[
+        "response_ids"
+    ] == ["gen-stream-header-1"]
+    assert "x-debug-secret" not in json.dumps(rows, sort_keys=True).lower()
+    assert "must-not-be-traced" not in json.dumps(rows, sort_keys=True)
+
+
+def test_openrouter_http_error_header_generation_id_is_traced_without_other_headers(
+    monkeypatch: Any,
+    tmp_path: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    trace_path = tmp_path / "llm_calls.jsonl"
+    monkeypatch.setenv("OPENSQUILLA_LLM_TRACE_RECORDER", "full")
+    monkeypatch.setenv("OPENSQUILLA_LLM_TRACE_PATH", str(trace_path))
+    _patch_transport_response(
+        monkeypatch,
+        captured,
+        httpx.Response(
+            503,
+            headers={
+                "x-generation-id": "gen-http-error-1",
+                "x-debug-secret": "must-not-be-traced",
+            },
+            content=b"provider unavailable",
+            request=httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions"),
+        ),
+    )
+    provider = OpenAIProvider(
+        api_key="test",
+        model="deepseek/deepseek-v4-flash",
+        base_url="https://openrouter.ai/api/v1",
+        provider_kind="openrouter",
+    )
+
+    events = _collect_events(provider, ChatConfig())
+
+    assert next(event for event in events if isinstance(event, ErrorEvent)).code == "503"
+    rows = [
+        json.loads(line)
+        for line in trace_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [row["event"] for row in rows] == [
+        "llm.request",
+        "llm.response_headers",
+        "llm.error",
+    ]
+    assert rows[1]["response_ids"] == ["gen-http-error-1"]
+    serialized = json.dumps(rows, sort_keys=True)
+    assert "x-debug-secret" not in serialized.lower()
+    assert "must-not-be-traced" not in serialized
+
+
+def test_openrouter_header_generation_id_survives_local_stream_cancellation(
+    monkeypatch: Any,
+    tmp_path: Any,
+) -> None:
+    class BlockingStream(httpx.AsyncByteStream):
+        def __init__(self) -> None:
+            self.started = False
+
+        async def __aiter__(self):
+            self.started = True
+            await asyncio.Future()
+            yield b""  # pragma: no cover - cancellation is the test terminal
+
+        async def aclose(self) -> None:
+            return None
+
+    stream = BlockingStream()
+    trace_path = tmp_path / "llm_calls.jsonl"
+    monkeypatch.setenv("OPENSQUILLA_LLM_TRACE_RECORDER", "full")
+    monkeypatch.setenv("OPENSQUILLA_LLM_TRACE_PATH", str(trace_path))
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={
+                "content-type": "text/event-stream",
+                "x-generation-id": "gen-cancelled-stream-1",
+            },
+            stream=stream,
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "opensquilla.provider.openai.httpx.AsyncClient", patched_async_client
+    )
+    provider = OpenAIProvider(
+        api_key="test",
+        model="deepseek/deepseek-v4-flash",
+        base_url="https://openrouter.ai/api/v1",
+        provider_kind="openrouter",
+    )
+
+    async def run_and_cancel() -> None:
+        async def consume() -> None:
+            async for _event in provider.chat(
+                [Message(role="user", content="hi")],
+                config=ChatConfig(timeout=60.0),
+            ):
+                pass
+
+        task = asyncio.create_task(consume())
+        for _ in range(100):
+            if stream.started:
+                break
+            await asyncio.sleep(0.001)
+        assert stream.started
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(run_and_cancel())
+
+    rows = [
+        json.loads(line)
+        for line in trace_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [row["event"] for row in rows] == [
+        "llm.request",
+        "llm.response_headers",
+    ]
+    assert rows[1]["response_ids"] == ["gen-cancelled-stream-1"]
+
+
+def test_openrouter_non_stream_header_generation_id_is_joined_to_response(
+    monkeypatch: Any,
+    tmp_path: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    trace_path = tmp_path / "llm_calls.jsonl"
+    monkeypatch.setenv("OPENSQUILLA_LLM_TRACE_RECORDER", "full")
+    monkeypatch.setenv("OPENSQUILLA_LLM_TRACE_PATH", str(trace_path))
+    _patch_transport_response(
+        monkeypatch,
+        captured,
+        httpx.Response(
+            200,
+            headers={"x-generation-id": "gen-non-stream-1"},
+            json={
+                "model": "deepseek/deepseek-v4-flash",
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": {"role": "assistant", "content": "ok"},
+                    }
+                ],
+                "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+            },
+            request=httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions"),
+        ),
+    )
+    provider = OpenAIProvider(
+        api_key="test",
+        model="deepseek/deepseek-v4-flash",
+        base_url="https://openrouter.ai/api/v1",
+        provider_kind="openrouter",
+    )
+
+    async def collect_fallback() -> list[Any]:
+        return [
+            event
+            async for event in provider._complete_non_stream(
+                payload={
+                    "model": "deepseek/deepseek-v4-flash",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": True,
+                },
+                headers={"Authorization": "Bearer test"},
+                cfg=ChatConfig(timeout=60.0),
+                tools=None,
+                timeout_exc=httpx.ReadTimeout("empty stream"),
+            )
+        ]
+
+    events = asyncio.run(collect_fallback())
+
+    assert any(isinstance(event, DoneEvent) for event in events)
+    rows = [
+        json.loads(line)
+        for line in trace_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [row["event"] for row in rows] == [
+        "llm.request",
+        "llm.response_headers",
+        "llm.response",
+    ]
+    assert rows[1]["response_ids"] == ["gen-non-stream-1"]
+    assert rows[2]["response_ids"] == ["gen-non-stream-1"]
+
+
 def test_openai_compatible_provider_writes_llm_trace(monkeypatch: Any, tmp_path: Any) -> None:
     captured: dict[str, Any] = {}
     trace_path = tmp_path / "llm_calls.jsonl"

--- a/tests/test_provider_trace_recorder.py
+++ b/tests/test_provider_trace_recorder.py
@@ -37,6 +37,7 @@ def test_llm_trace_recorder_writes_full_payload_and_redacts_headers(
             "X-OpenSquilla-Call-Kind": "agent.chat",
         },
     )
+    recorder.record_response_headers(response_ids=["gen-safe-1"])
     recorder.record_chunk({"id": "chatcmpl-1", "choices": [{"delta": {"content": "ok"}}]})
     recorder.record_response(
         usage={"input_tokens": 3, "cached_tokens": 2},
@@ -49,6 +50,7 @@ def test_llm_trace_recorder_writes_full_payload_and_redacts_headers(
     rows = _jsonl(path)
     assert [row["event"] for row in rows] == [
         "llm.request",
+        "llm.response_headers",
         "llm.response_chunk",
         "llm.response",
     ]
@@ -65,7 +67,20 @@ def test_llm_trace_recorder_writes_full_payload_and_redacts_headers(
     assert "turn-1" not in serialized
     assert "execution-1" not in serialized
     assert "agent.chat" not in serialized
-    assert rows[2]["usage"]["cached_tokens"] == 2
+    assert rows[1]["response_ids"] == ["gen-safe-1"]
+    assert set(rows[1]) == {
+        "base_url",
+        "call_id",
+        "call_index",
+        "created_at",
+        "endpoint",
+        "event",
+        "model",
+        "provider",
+        "response_ids",
+        "stream",
+    }
+    assert rows[3]["usage"]["cached_tokens"] == 2
 
 
 def test_llm_trace_recorder_off_does_not_write(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## What changed

- ports the Qwen 3.7 experiment controls for DashScope parallel tool calls, strict fallback behavior, reasoning fallback, cancellation trace terminalization, and explicit preserve-thinking A/B
- ports the score-max ensemble target, bounded proposer retries, aggregator retry/error handling, OpenRouter generation-ID receipts, and non-retry-safe deadline protection
- keeps all experiment treatments opt-in and preserves the current main defaults when their environment/config controls are unset
- adapts the historical tests to current main's provider-request budget admission contract

## Why

The later Qwen 3.7 and score-max/Lite80/full350 ensemble runs were frozen on experiment heads `8adde4ce` and `5813c701`, after the runtime sync merged in #804. Those runtime capabilities were therefore still reproducible only from server-local experiment branches.

## User and developer impact

Normal Chat behavior remains unchanged by default. The Qwen preserve-thinking A/B only activates through `OPENSQUILLA_DASHSCOPE_PRESERVE_THINKING=on|off`; the ensemble quality target and proposer retries retain their historical disabled defaults. The experiment configurations can now be reproduced from a branch based on current main.

## Validation

Validated again on refreshed head `c02911d5` after merging current `main`:

- `415 passed`: provider, ensemble, reasoning/deadline, trace, and configuration suites
- `1567 passed, 1 skipped`: backend Chat, CLI, and TUI suites
- Ruff passed for all touched source and test files
- default Qwen 3.6/3.7 Flash request payloads were byte-compared against `origin/main` with all experiment variables unset and were identical
