### PR TITLE
fix(engine): make usage-scope cleanup ContextVar-safe on router-control replay

### DIFF
--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -4611,14 +4611,23 @@ class TurnRunner:
                 ),
             )
             router_control_replay_event: RouterControlReplayEvent | None = None
+            # Keep ContextVar token ownership in this task: do not yield the
+            # replay event while the usage scope is still bound, and aclose the
+            # stream consumer here so cleanup is not deferred to another Context.
+            stream = self._stream_consumer_stage.run(stream_inp)
             with bind_usage_accounting_scope(turn_usage_scope):
-                async for event in self._stream_consumer_stage.run(stream_inp):
-                    if isinstance(event, RouterControlReplayEvent):
-                        router_control_replay_event = event
+                try:
+                    async for event in stream:
+                        if isinstance(event, RouterControlReplayEvent):
+                            router_control_replay_event = event
+                            break
                         yield event
-                        break
-                    yield event
+                finally:
+                    close = getattr(stream, "aclose", None)
+                    if callable(close):
+                        await close()
             if router_control_replay_event is not None:
+                yield router_control_replay_event
                 async for replayed_event in self._run_turn(
                     message,
                     session_key,

--- a/src/opensquilla/engine/usage_accounting.py
+++ b/src/opensquilla/engine/usage_accounting.py
@@ -222,11 +222,18 @@ def bind_usage_accounting_scope(scope: UsageAccountingScope | None) -> Iterator[
     if scope is None:
         yield
         return
+    previous = _ACTIVE_USAGE_SCOPE.get()
     token = _ACTIVE_USAGE_SCOPE.set(scope)
     try:
         yield
     finally:
-        _ACTIVE_USAGE_SCOPE.reset(token)
+        try:
+            _ACTIVE_USAGE_SCOPE.reset(token)
+        except ValueError:
+            # Async-generator cleanup can run in a different Context after a
+            # router-control replay interrupt; restore only if we still own it.
+            if _ACTIVE_USAGE_SCOPE.get() is scope:
+                _ACTIVE_USAGE_SCOPE.set(previous)
 
 
 def provider_accounts_physical_usage(provider: object) -> bool:

--- a/tests/test_engine/test_usage_scope_contextvar.py
+++ b/tests/test_engine/test_usage_scope_contextvar.py
@@ -1,0 +1,23 @@
+"""Usage-scope binder restores a clean ContextVar after exit (#1064)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from opensquilla.engine.usage_accounting import (
+    UsageAccountingScope,
+    UsageExecutionContext,
+    bind_usage_accounting_scope,
+    current_usage_accounting_scope,
+)
+
+
+def test_bind_usage_accounting_scope_clears_on_exit() -> None:
+    scope = UsageAccountingScope(
+        sink=MagicMock(),
+        context=UsageExecutionContext(execution_id="s", agent_run_id="run"),
+    )
+    assert current_usage_accounting_scope() is None
+    with bind_usage_accounting_scope(scope):
+        assert current_usage_accounting_scope() is scope
+    assert current_usage_accounting_scope() is None


### PR DESCRIPTION
## Summary
A router-control replay could close the first-turn async generator from a different asyncio Context during usage-scope cleanup.

## Changes
- aclose stream in owning task; yield replay after unbind
- Safe ContextVar reset fallback
- Unit test for bind/unbind cleanup

Fixes #1064