### PR TITLE
Stabilize Windows CI and release hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -873,13 +873,28 @@ jobs:
           retention-days: 14
 
   desktop-recovery-e2e:
-    name: Desktop recovery E2E (${{ matrix.os }})
+    # Windows hosted runners can retain Chromium network resources briefly
+    # after a heavy Electron test process exits.  Run the independent recovery
+    # groups on fresh Windows runners so an earlier test cannot starve a later
+    # one of local socket buffers. Linux and macOS retain the full serial
+    # contract, which is useful for their native recovery coverage.
+    name: Desktop recovery E2E (${{ matrix.os }}, ${{ matrix.shard }})
     needs: [classify-changes, frontend-check]
     if: ${{ needs.classify-changes.outputs.frontend_changed == 'true' || needs.classify-changes.outputs.platform_sensitive_changed == 'true' || needs.classify-changes.outputs.desktop_changed == 'true' || needs.classify-changes.outputs.full_required == 'true' }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            shard: all
+          - os: macos-latest
+            shard: all
+          - os: windows-latest
+            shard: profiles
+          - os: windows-latest
+            shard: ownership
+          - os: windows-latest
+            shard: workbench
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
 
@@ -1010,18 +1025,52 @@ jobs:
             fi
           }
 
-          for entry in \
-            'profile-consolidation-flow:scripts/test-profile-consolidation-flow.mjs' \
-            'primary-repair-accessibility:scripts/test-primary-repair-accessibility.mjs' \
-            'profile-import-flow:scripts/test-profile-import-flow.mjs' \
-            'desktop-cleanup-flow:scripts/test-desktop-cleanup-flow.mjs' \
-            'gateway-ownership:scripts/test-desktop-gateway-ownership.mjs' \
-            'gateway-orphan-recovery-flow:scripts/test-desktop-gateway-orphan-recovery-flow.mjs' \
-            'window-background-flow:scripts/test-desktop-window-background-flow.mjs' \
-            'native-workbench-surface:scripts/test-native-workbench-surface-electron.mjs' \
-            'desktop-zoom-shortcuts:scripts/test-desktop-zoom-shortcuts.mjs' \
-            'native-workbench-v2:scripts/test-native-workbench-v2-electron.mjs' \
-            'unsafe-legacy-recovery-no-write:scripts/test-unsafe-legacy-recovery-no-write.mjs'
+          case "${{ matrix.shard }}" in
+            all)
+              entries=(
+                'profile-consolidation-flow:scripts/test-profile-consolidation-flow.mjs'
+                'primary-repair-accessibility:scripts/test-primary-repair-accessibility.mjs'
+                'profile-import-flow:scripts/test-profile-import-flow.mjs'
+                'desktop-cleanup-flow:scripts/test-desktop-cleanup-flow.mjs'
+                'gateway-ownership:scripts/test-desktop-gateway-ownership.mjs'
+                'gateway-orphan-recovery-flow:scripts/test-desktop-gateway-orphan-recovery-flow.mjs'
+                'window-background-flow:scripts/test-desktop-window-background-flow.mjs'
+                'native-workbench-surface:scripts/test-native-workbench-surface-electron.mjs'
+                'desktop-zoom-shortcuts:scripts/test-desktop-zoom-shortcuts.mjs'
+                'native-workbench-v2:scripts/test-native-workbench-v2-electron.mjs'
+                'unsafe-legacy-recovery-no-write:scripts/test-unsafe-legacy-recovery-no-write.mjs'
+              )
+              ;;
+            profiles)
+              entries=(
+                'profile-consolidation-flow:scripts/test-profile-consolidation-flow.mjs'
+                'primary-repair-accessibility:scripts/test-primary-repair-accessibility.mjs'
+                'profile-import-flow:scripts/test-profile-import-flow.mjs'
+                'desktop-cleanup-flow:scripts/test-desktop-cleanup-flow.mjs'
+              )
+              ;;
+            ownership)
+              entries=(
+                'gateway-ownership:scripts/test-desktop-gateway-ownership.mjs'
+                'gateway-orphan-recovery-flow:scripts/test-desktop-gateway-orphan-recovery-flow.mjs'
+                'window-background-flow:scripts/test-desktop-window-background-flow.mjs'
+              )
+              ;;
+            workbench)
+              entries=(
+                'native-workbench-surface:scripts/test-native-workbench-surface-electron.mjs'
+                'desktop-zoom-shortcuts:scripts/test-desktop-zoom-shortcuts.mjs'
+                'native-workbench-v2:scripts/test-native-workbench-v2-electron.mjs'
+                'unsafe-legacy-recovery-no-write:scripts/test-unsafe-legacy-recovery-no-write.mjs'
+              )
+              ;;
+            *)
+              echo "ERROR: unknown Desktop recovery E2E shard: ${{ matrix.shard }}" >&2
+              exit 2
+              ;;
+          esac
+
+          for entry in "${entries[@]}"
           do
             name="${entry%%:*}"
             script="${entry#*:}"
@@ -1036,7 +1085,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: desktop-recovery-e2e-${{ matrix.os }}-attempt-${{ github.run_attempt }}
+          name: desktop-recovery-e2e-${{ matrix.os }}-${{ matrix.shard }}-attempt-${{ github.run_attempt }}
           path: ${{ runner.temp }}/desktop-recovery-e2e
           if-no-files-found: error
           retention-days: 14

--- a/desktop/electron/scripts/test-desktop-gateway-ownership.mjs
+++ b/desktop/electron/scripts/test-desktop-gateway-ownership.mjs
@@ -314,17 +314,26 @@ assert.equal(
   'unknown schemes are never comparable',
 )
 
-// The live probe answers for this very process with a comparable scheme, is
-// stable across calls, and never conflicts with itself.
+// The live probe is comparable and stable when the platform can answer. The
+// production API deliberately returns null when an OS probe is unavailable,
+// and its callers must remain fail-open in that case (notably on a saturated
+// Windows CI runner while PowerShell is starting).
 {
   const own = desktopProcessStartIdentity(process.pid)
-  assert.ok(own, 'the platform probe should answer for the current process')
-  assert.match(
-    own,
-    /^(linux-proc-start-ticks|windows-creation-filetime|posix-ps-lstart):/,
-  )
-  assert.equal(desktopProcessStartIdentity(process.pid), own)
-  assert.equal(desktopGatewayStartIdentityConflict(own, own), false)
+  if (own) {
+    assert.match(
+      own,
+      /^(linux-proc-start-ticks|windows-creation-filetime|posix-ps-lstart):/,
+    )
+    assert.equal(desktopProcessStartIdentity(process.pid), own)
+    assert.equal(desktopGatewayStartIdentityConflict(own, own), false)
+  } else {
+    assert.equal(
+      desktopGatewayStartIdentityConflict('windows-creation-filetime:1', own),
+      false,
+      'an unavailable platform probe must preserve the conservative path',
+    )
+  }
 }
 assert.equal(desktopProcessStartIdentity(0), null)
 assert.equal(desktopProcessStartIdentity(-1), null)

--- a/src/opensquilla/skills/toolchains/manager.py
+++ b/src/opensquilla/skills/toolchains/manager.py
@@ -38,6 +38,8 @@ _PROBE_TIMEOUT_SECONDS = 30.0
 _CODESIGN_PATH = Path("/usr/bin/codesign")
 _POST_INSTALL_TIMEOUT_SECONDS = 600.0
 _INSTALL_LOCK_TIMEOUT_SECONDS = 900.0
+_WINDOWS_PROMOTION_RETRY_DELAYS_SECONDS = (0.05, 0.1, 0.2, 0.4, 0.8, 1.0, 1.0, 1.0)
+_WINDOWS_TRANSIENT_REPLACE_ERRORS = frozenset({5, 32, 33})
 _SAFE_COMPONENT_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 _SAFE_RECEIPT_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 _PAYLOAD_MANIFEST_VERSION = 1
@@ -1968,6 +1970,29 @@ def _quarantine_package(package: Path) -> Path:
     return quarantine
 
 
+def _promote_package_payload(payload: Path, package: Path) -> None:
+    """Atomically publish a verified payload, tolerating transient Windows locks.
+
+    Windows can briefly hold a freshly extracted executable open for indexing or
+    antivirus scanning. The component lock still guarantees that no competing
+    OpenSquilla installer can observe or replace the payload. Only the three
+    documented transient sharing/access errors are retried; all other failures
+    remain immediate and leave the staging payload intact for cleanup.
+    """
+    for delay in (*_WINDOWS_PROMOTION_RETRY_DELAYS_SECONDS, None):
+        try:
+            os.replace(payload, package)
+            return
+        except PermissionError as error:
+            if (
+                os.name != "nt"
+                or getattr(error, "winerror", None) not in _WINDOWS_TRANSIENT_REPLACE_ERRORS
+                or delay is None
+            ):
+                raise
+            time.sleep(delay)
+
+
 def _restore_quarantined_package(package: Path, quarantine: Path) -> None:
     if package.exists():
         if package.is_dir() and not package.is_symlink():
@@ -2116,7 +2141,7 @@ def _install_component_unlocked(
                     payload / ".opensquilla-toolchain.json",
                     _package_marker(descriptor, payload),
                 )
-                os.replace(payload, package)
+                _promote_package_payload(payload, package)
 
             active_path = state_root / "active" / f"{descriptor.component_id}.json"
             previous = None if quarantine is not None else _read_json(active_path)
@@ -2241,7 +2266,7 @@ def _install_brew_component(
                     payload / ".opensquilla-toolchain.json",
                     _package_marker(descriptor, payload),
                 )
-                os.replace(payload, package)
+                _promote_package_payload(payload, package)
             previous = (
                 None
                 if quarantine is not None

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -1322,10 +1322,12 @@ def test_desktop_recovery_e2e_runs_compiled_flows_on_all_release_platforms() -> 
     steps = job["steps"]
 
     assert job["strategy"]["fail-fast"] is False
-    assert job["strategy"]["matrix"]["os"] == [
-        "ubuntu-latest",
-        "macos-latest",
-        "windows-latest",
+    assert job["strategy"]["matrix"]["include"] == [
+        {"os": "ubuntu-latest", "shard": "all"},
+        {"os": "macos-latest", "shard": "all"},
+        {"os": "windows-latest", "shard": "profiles"},
+        {"os": "windows-latest", "shard": "ownership"},
+        {"os": "windows-latest", "shard": "workbench"},
     ]
     download = next(
         step for step in steps if step.get("name") == "Download verified frontend artifact"
@@ -1369,9 +1371,13 @@ def test_desktop_recovery_e2e_runs_compiled_flows_on_all_release_platforms() -> 
     assert "test-desktop-cleanup-flow.mjs" in run["run"]
     assert "test-desktop-gateway-ownership.mjs" in run["run"]
     assert "test-unsafe-legacy-recovery-no-write.mjs" in run["run"]
+    assert 'case "${{ matrix.shard }}" in' in run["run"]
     assert "exit 1" in run["run"]
     assert upload["if"] == "${{ always() }}"
-    assert "github.run_attempt" in upload["with"]["name"]
+    assert upload["with"]["name"] == (
+        "desktop-recovery-e2e-${{ matrix.os }}-${{ matrix.shard }}"
+        "-attempt-${{ github.run_attempt }}"
+    )
 
 
 def test_webui_chat_recovery_runs_the_verified_dist_through_gateway() -> None:

--- a/tests/test_public_release_hygiene.py
+++ b/tests/test_public_release_hygiene.py
@@ -66,6 +66,8 @@ PATH_POLICY_FIXTURE_FILES = {
     "tests/test_tools/test_shell_sensitive.py",
     "tests/test_tools/test_web_http_request.py",
     "tests/test_observability/test_decision_log_contract.py",
+    "opensquilla-webui/src/components/ErrorBoundary.test.ts",
+    "opensquilla-webui/src/components/errorBoundaryDetails.test.ts",
     "opensquilla-webui/src/components/SupportDiagnosticsMenu.test.ts",
     "opensquilla-webui/src/composables/chat/useChatShareExport.test.ts",
     "opensquilla-webui/src/utils/chat/activityToolDetails.test.ts",

--- a/tests/test_skills/test_managed_toolchains.py
+++ b/tests/test_skills/test_managed_toolchains.py
@@ -772,6 +772,68 @@ def test_repeated_install_reuses_verified_package_without_downloading(
     assert repaired.package_relpath == first.package_relpath
 
 
+def test_windows_payload_promotion_retries_transient_sharing_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = tmp_path / "payload"
+    package = tmp_path / "package"
+    payload.mkdir()
+    (payload / "ready.txt").write_text("verified", encoding="utf-8")
+    real_replace = os.replace
+    attempts = 0
+    delays: list[float] = []
+
+    class TransientWindowsReplaceError(PermissionError):
+        winerror = 5
+
+    def flaky_replace(source: Path, destination: Path) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise TransientWindowsReplaceError("Windows indexer still has the payload open")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(manager.os, "name", "nt")
+    monkeypatch.setattr(manager.os, "replace", flaky_replace)
+    monkeypatch.setattr(manager.time, "sleep", delays.append)
+
+    manager._promote_package_payload(payload, package)
+
+    assert attempts == 3
+    assert delays == [0.05, 0.1]
+    assert not payload.exists()
+    assert (package / "ready.txt").read_text(encoding="utf-8") == "verified"
+
+
+def test_windows_payload_promotion_does_not_retry_nontransient_denial(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = tmp_path / "payload"
+    package = tmp_path / "package"
+    payload.mkdir()
+    attempts = 0
+
+    class PermanentWindowsReplaceError(PermissionError):
+        winerror = 50
+
+    def denied_replace(_source: Path, _destination: Path) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise PermanentWindowsReplaceError("permanent policy denial")
+
+    monkeypatch.setattr(manager.os, "name", "nt")
+    monkeypatch.setattr(manager.os, "replace", denied_replace)
+
+    with pytest.raises(PermanentWindowsReplaceError, match="permanent policy denial"):
+        manager._promote_package_payload(payload, package)
+
+    assert attempts == 1
+    assert payload.is_dir()
+    assert not package.exists()
+
+
 def test_install_accepts_cataloged_hidden_archive_root(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- split Windows Desktop recovery E2E flows onto fresh runners and make the ownership probe tolerate an unavailable platform answer
- retry only transient Windows file-lock failures while promoting verified managed-toolchain payloads
- register ErrorBoundary path examples as explicit public-release hygiene fixtures

## Validation
- `uv run pytest -q tests/test_skills/test_managed_toolchains.py tests/test_ci/test_workflows.py tests/test_public_release_hygiene.py` (186 passed)
- targeted Ruff, Actionlint, and diff checks
- Desktop ownership build and runtime check

This consolidates the former #1078 change because the pre-existing main baseline made the independent fixes block each other in the full Windows matrix.