### PR TITLE
Retry transient Windows toolchain promotion locks

### DIFF
--- a/src/opensquilla/skills/toolchains/manager.py
+++ b/src/opensquilla/skills/toolchains/manager.py
@@ -38,6 +38,8 @@ _PROBE_TIMEOUT_SECONDS = 30.0
 _CODESIGN_PATH = Path("/usr/bin/codesign")
 _POST_INSTALL_TIMEOUT_SECONDS = 600.0
 _INSTALL_LOCK_TIMEOUT_SECONDS = 900.0
+_WINDOWS_PROMOTION_RETRY_DELAYS_SECONDS = (0.05, 0.1, 0.2, 0.4, 0.8, 1.0, 1.0, 1.0)
+_WINDOWS_TRANSIENT_REPLACE_ERRORS = frozenset({5, 32, 33})
 _SAFE_COMPONENT_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 _SAFE_RECEIPT_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 _PAYLOAD_MANIFEST_VERSION = 1
@@ -1968,6 +1970,29 @@ def _quarantine_package(package: Path) -> Path:
     return quarantine
 
 
+def _promote_package_payload(payload: Path, package: Path) -> None:
+    """Atomically publish a verified payload, tolerating transient Windows locks.
+
+    Windows can briefly hold a freshly extracted executable open for indexing or
+    antivirus scanning. The component lock still guarantees that no competing
+    OpenSquilla installer can observe or replace the payload. Only the three
+    documented transient sharing/access errors are retried; all other failures
+    remain immediate and leave the staging payload intact for cleanup.
+    """
+    for delay in (*_WINDOWS_PROMOTION_RETRY_DELAYS_SECONDS, None):
+        try:
+            os.replace(payload, package)
+            return
+        except PermissionError as error:
+            if (
+                os.name != "nt"
+                or getattr(error, "winerror", None) not in _WINDOWS_TRANSIENT_REPLACE_ERRORS
+                or delay is None
+            ):
+                raise
+            time.sleep(delay)
+
+
 def _restore_quarantined_package(package: Path, quarantine: Path) -> None:
     if package.exists():
         if package.is_dir() and not package.is_symlink():
@@ -2116,7 +2141,7 @@ def _install_component_unlocked(
                     payload / ".opensquilla-toolchain.json",
                     _package_marker(descriptor, payload),
                 )
-                os.replace(payload, package)
+                _promote_package_payload(payload, package)
 
             active_path = state_root / "active" / f"{descriptor.component_id}.json"
             previous = None if quarantine is not None else _read_json(active_path)
@@ -2241,7 +2266,7 @@ def _install_brew_component(
                     payload / ".opensquilla-toolchain.json",
                     _package_marker(descriptor, payload),
                 )
-                os.replace(payload, package)
+                _promote_package_payload(payload, package)
             previous = (
                 None
                 if quarantine is not None

--- a/tests/test_skills/test_managed_toolchains.py
+++ b/tests/test_skills/test_managed_toolchains.py
@@ -772,6 +772,68 @@ def test_repeated_install_reuses_verified_package_without_downloading(
     assert repaired.package_relpath == first.package_relpath
 
 
+def test_windows_payload_promotion_retries_transient_sharing_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = tmp_path / "payload"
+    package = tmp_path / "package"
+    payload.mkdir()
+    (payload / "ready.txt").write_text("verified", encoding="utf-8")
+    real_replace = os.replace
+    attempts = 0
+    delays: list[float] = []
+
+    class TransientWindowsReplaceError(PermissionError):
+        winerror = 5
+
+    def flaky_replace(source: Path, destination: Path) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise TransientWindowsReplaceError("Windows indexer still has the payload open")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(manager.os, "name", "nt")
+    monkeypatch.setattr(manager.os, "replace", flaky_replace)
+    monkeypatch.setattr(manager.time, "sleep", delays.append)
+
+    manager._promote_package_payload(payload, package)
+
+    assert attempts == 3
+    assert delays == [0.05, 0.1]
+    assert not payload.exists()
+    assert (package / "ready.txt").read_text(encoding="utf-8") == "verified"
+
+
+def test_windows_payload_promotion_does_not_retry_nontransient_denial(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = tmp_path / "payload"
+    package = tmp_path / "package"
+    payload.mkdir()
+    attempts = 0
+
+    class PermanentWindowsReplaceError(PermissionError):
+        winerror = 50
+
+    def denied_replace(_source: Path, _destination: Path) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise PermanentWindowsReplaceError("permanent policy denial")
+
+    monkeypatch.setattr(manager.os, "name", "nt")
+    monkeypatch.setattr(manager.os, "replace", denied_replace)
+
+    with pytest.raises(PermanentWindowsReplaceError, match="permanent policy denial"):
+        manager._promote_package_payload(payload, package)
+
+    assert attempts == 1
+    assert payload.is_dir()
+    assert not package.exists()
+
+
 def test_install_accepts_cataloged_hidden_archive_root(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## What changed

- retries only transient Windows sharing/access failures while atomically promoting a verified managed-toolchain payload
- keeps the component install lock and atomic replacement model unchanged
- covers both retryable and non-retryable Windows errors

## Why

The same Windows CI job failed on `main` and on #1077 at `os.replace(payload, package)` with `WinError 5` after a verified extraction. This is consistent with a short-lived Windows indexer/antivirus lock on freshly extracted executables.

## Impact

Only managed-toolchain package publication on Windows is affected. Permanent access denials and all non-Windows errors still fail immediately.

## Validation

- `uv run --with ruff ruff check src/opensquilla/skills/toolchains/manager.py tests/test_skills/test_managed_toolchains.py`
- `uv run pytest -q tests/test_skills/test_managed_toolchains.py` — 84 passed