### PR TITLE
Guard reasoning_content replay against provider per-field limits

### DIFF
--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -2554,6 +2554,9 @@ def _openrouter_non_system_prefix_item_hashes(
     return hashes
 
 
+_REASONING_REPLAY_MAX_CHARS = 32_000
+
+
 def _attach_reasoning_content(
     msg: Message,
     payload: dict[str, Any],
@@ -2562,7 +2565,14 @@ def _attach_reasoning_content(
     require_assistant_reasoning_content: bool = False,
 ) -> dict[str, Any]:
     if include_reasoning_content and msg.role == "assistant" and msg.reasoning_content:
-        payload["reasoning_content"] = msg.reasoning_content
+        if len(msg.reasoning_content) <= _REASONING_REPLAY_MAX_CHARS:
+            payload["reasoning_content"] = msg.reasoning_content
+        elif require_assistant_reasoning_content:
+            # Whole-message drop: an oversized reasoning chain exceeds the
+            # provider's per-field limit and would make the whole request
+            # fail (HTTP 400). Never replay a truncated fragment — a partial
+            # chain has no semantic value and can mislead the model.
+            payload["reasoning_content"] = ""
     elif require_assistant_reasoning_content and msg.role == "assistant":
         # Models that require the key on every assistant message get an
         # empty string whenever the actual reasoning is absent or withheld

--- a/tests/test_cross_provider_tiers.py
+++ b/tests/test_cross_provider_tiers.py
@@ -21,7 +21,11 @@ from opensquilla.provider.anthropic import _build_message_payload
 from opensquilla.provider.compat_policy import compat_policy_for_kind
 from opensquilla.provider.deployment import resolve_provider_deployment
 from opensquilla.provider.environment import environment_value
-from opensquilla.provider.openai import _build_openai_messages, _build_openai_wire_messages
+from opensquilla.provider.openai import (
+    _REASONING_REPLAY_MAX_CHARS,
+    _build_openai_messages,
+    _build_openai_wire_messages,
+)
 from opensquilla.provider.selector import ModelSelector, ProviderConfig, SelectorConfig
 from opensquilla.provider.types import (
     ChatConfig,
@@ -786,3 +790,36 @@ def test_openai_compat_a_to_b_drops_foreign_reasoning_content() -> None:
 
     assert replayed[0]["reasoning_content"] == "provider-a-private-reasoning"
     assert "reasoning_content" not in stripped[0]
+
+
+def test_openai_reasoning_replay_oversized_whole_message_drop() -> None:
+    """Oversized reasoning_content must not be replayed (whole-message drop)."""
+    msg = Message(
+        role="assistant",
+        content="short answer",
+        reasoning_content="x" * (_REASONING_REPLAY_MAX_CHARS + 1),
+    )
+    (payload,) = _build_openai_messages(msg)
+    assert "reasoning_content" not in payload
+
+
+def test_openai_reasoning_replay_under_limit_unchanged() -> None:
+    """Reasoning content within the replay cap is replayed byte-identical."""
+    reasoning = "chain of thought" * 100  # well under the cap
+    msg = Message(role="assistant", content="answer", reasoning_content=reasoning)
+    (payload,) = _build_openai_messages(msg)
+    assert payload["reasoning_content"] == reasoning
+
+
+def test_openai_reasoning_replay_oversized_requires_empty_string() -> None:
+    """Oversized reasoning + require flag degrades to an empty string."""
+    msg = Message(
+        role="assistant",
+        content="answer",
+        reasoning_content="x" * (_REASONING_REPLAY_MAX_CHARS + 1),
+    )
+    (payload,) = _build_openai_messages(
+        msg,
+        require_assistant_reasoning_content=True,
+    )
+    assert payload["reasoning_content"] == ""


### PR DESCRIPTION
## Problem

Assistant reasoning chains are replayed verbatim into provider requests. Providers enforce a per-field length cap on `reasoning_content` and reject the entire request with HTTP 400 when it is exceeded. That 400 is treated as non-retryable, so the session becomes permanently wedged: every subsequent message in that conversation fails with the same error and the user can no longer get a response.

## Fix

In `_attach_reasoning_content`, drop the field (whole-message drop) when the chain exceeds `_REASONING_REPLAY_MAX_CHARS` (32,000 chars) instead of replaying it. A truncated fragment is deliberately never replayed: a partial chain has no semantic value and can mislead the model.

Providers that require the key on every assistant message (`require_assistant_reasoning_content`) still receive an empty string, so their existing contract is preserved.

## Verification

- New regression tests: oversized drop, under-limit byte-identical replay, empty-string degradation for required-reasoning providers.
- Red-test confirmed: with the guard disabled, a 50K-char chain is replayed (fails the new test); with the guard, it is dropped.
- Full related suite: 262 passed, 0 failed.
- The 32K cap is a conservative safe value below a live-observed accepted 33.5K-char chain; the provider's exact limit is undocumented.