### PR TITLE
Isolate ensemble proposer state and enable Qwen prompt caching

### DIFF
--- a/src/opensquilla/provider/compat_policy.py
+++ b/src/opensquilla/provider/compat_policy.py
@@ -545,6 +545,7 @@ _POLICIES_BY_KIND: dict[str, OpenAICompatPolicy] = {
     "tokenrhythm": OpenAICompatPolicy(
         display_name="TokenRhythm",
         official_host="tokenrhythm.studio",
+        supports_explicit_prompt_cache=True,
         supports_native_json_schema_output=False,
         text_tool_profile=TextToolCompatProfile(
             model_rules=(

--- a/src/opensquilla/provider/ensemble.py
+++ b/src/opensquilla/provider/ensemble.py
@@ -868,6 +868,15 @@ def _member_budget_key(member: EnsembleMemberConfig) -> tuple[str, str, str]:
     )
 
 
+def _proposer_provider_config(member: EnsembleMemberConfig) -> ProviderConfig:
+    """Return the provider boundary used by every proposer-side operation."""
+
+    return replace(
+        member.provider_config,
+        replay_provider_state=False,
+    )
+
+
 _ENSEMBLE_CORRELATION_PHASES = frozenset(
     {
         "proposer",
@@ -2199,7 +2208,7 @@ class EnsembleProvider:
                 role="proposer",
             ).model_copy(update=proposer_updates)
             _require_projection(
-                _build_provider(member.provider_config),
+                _build_provider(_proposer_provider_config(member)),
                 member_config,
                 synthetic_messages=additional_messages,
             )
@@ -2944,7 +2953,11 @@ class EnsembleProvider:
                     ),
                 )
             return result
-        provider = _build_provider(member.provider_config)
+        # Proposers consume the visible conversation as independent candidate
+        # generators. Provider-private continuity state (reasoning_content,
+        # thinking blocks, thought signatures) belongs to the model that
+        # minted it and must not be replayed into any proposer physical call.
+        provider = _build_provider(_proposer_provider_config(member))
         text_parts: list[str] = []
         got_done = False
 

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -2257,6 +2257,12 @@ def _dashscope_model_likely_supports_explicit_prompt_cache(model: str) -> bool:
     )
 
 
+def _tokenrhythm_model_supports_explicit_prompt_cache(model: str) -> bool:
+    """Return True only for TokenRhythm models with live cache-control proof."""
+
+    return model.rsplit("/", 1)[-1].strip().lower() == "qwen3.7-max"
+
+
 def _supports_explicit_prompt_cache(
     provider_kind: str,
     model: str,
@@ -2268,6 +2274,8 @@ def _supports_explicit_prompt_cache(
         return cache_mode == "on" or _openrouter_model_likely_supports_explicit_prompt_cache(model)
     if provider_kind == "dashscope":
         return cache_mode == "on" or _dashscope_model_likely_supports_explicit_prompt_cache(model)
+    if provider_kind == "tokenrhythm":
+        return _tokenrhythm_model_supports_explicit_prompt_cache(model)
     return False
 
 
@@ -2383,7 +2391,7 @@ def _log_provider_cache_usage(
     cache_write_tokens: int,
     cache_shape: Mapping[str, Any],
 ) -> None:
-    if provider_kind != "dashscope":
+    if provider_kind not in {"dashscope", "tokenrhythm"}:
         return
     log.info(
         f"{provider_kind}.prompt_cache_usage",
@@ -3133,7 +3141,9 @@ def _build_openai_wire_messages(
             content_blocks = _build_cache_breakpoint_blocks(
                 cfg.cache_breakpoints,
                 max_cache_markers=(
-                    _DASHSCOPE_MAX_CACHE_MARKERS if provider_kind == "dashscope" else None
+                    _DASHSCOPE_MAX_CACHE_MARKERS
+                    if provider_kind in {"dashscope", "tokenrhythm"}
+                    else None
                 ),
             )
             openai_messages.append({"role": "system", "content": content_blocks})
@@ -3213,7 +3223,11 @@ def _build_openai_wire_messages(
                         (_reasoning_replay_signature(built_message), suppressed_units)
                     )
         openai_messages.extend(built_messages)
-    if provider_kind == "dashscope" and cfg.cache_mode == "on":
+    if (
+        provider_kind in {"dashscope", "tokenrhythm"}
+        and cfg.cache_mode == "on"
+        and explicit_cache_supported
+    ):
         _attach_cache_control_to_latest_text_messages(
             openai_messages,
             max_cache_markers=_DASHSCOPE_MAX_CACHE_MARKERS,

--- a/tests/test_provider_ensemble.py
+++ b/tests/test_provider_ensemble.py
@@ -1911,6 +1911,47 @@ async def test_control_wins_if_it_arrives_with_primary_failure(
 
 
 @pytest.mark.asyncio
+async def test_proposer_physical_calls_disable_provider_private_state_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = _FakeRegistry(
+        {
+            "p1": _FakePlan(
+                [
+                    TextDeltaEvent(text="draft"),
+                    DoneEvent(input_tokens=1, output_tokens=1, model="p1"),
+                ]
+            ),
+            "agg": _FakePlan(
+                [
+                    TextDeltaEvent(text="final"),
+                    DoneEvent(input_tokens=1, output_tokens=1, model="agg"),
+                ]
+            ),
+        }
+    )
+    built_configs: list[ProviderConfig] = []
+
+    def build_provider(cfg: ProviderConfig) -> _FakeProvider:
+        built_configs.append(cfg)
+        return registry.provider_for(cfg)
+
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", build_provider)
+    provider = EnsembleProvider(
+        profile_name="private-state-boundary",
+        proposers=[_member("p1")],
+        aggregator=_member("agg"),
+        min_successful_proposers=1,
+        shuffle_candidates=False,
+    )
+
+    await _collect(provider)
+
+    replay_by_model = {cfg.model: cfg.replay_provider_state for cfg in built_configs}
+    assert replay_by_model == {"p1": False, "agg": True}
+
+
+@pytest.mark.asyncio
 async def test_ensemble_proposer_tool_events_violate_inert_candidate_contract(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_provider_openai_prompt_cache.py
+++ b/tests/test_provider_openai_prompt_cache.py
@@ -157,6 +157,105 @@ def test_dashscope_qwen36_flash_auto_cache_adds_message_cache_control(monkeypatc
     assert payload["messages"][1] == {"role": "user", "content": "hi"}
 
 
+def test_tokenrhythm_qwen37_max_on_adds_message_cache_control(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+    _patch_openai_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="qwen3.7-max",
+        base_url="https://tokenrhythm.studio/v1",
+        provider_kind="tokenrhythm",
+    )
+    cfg = ChatConfig(
+        system="stable base",
+        cache_breakpoints=[{"text": "stable base", "cache": "true"}],
+        cache_mode="on",
+    )
+
+    done = _collect_done(provider, cfg)
+
+    assert done.cached_tokens == 5
+    payload = captured["payload"]
+    assert "cache_control" not in payload
+    assert payload["messages"] == [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "stable base",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "hi",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
+    ]
+
+
+def test_tokenrhythm_qwen37_max_auto_enables_system_cache_control(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+    _patch_openai_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="qwen3.7-max",
+        base_url="https://tokenrhythm.studio/v1",
+        provider_kind="tokenrhythm",
+    )
+    cfg = ChatConfig(
+        system="stable base",
+        cache_breakpoints=[{"text": "stable base", "cache": "true"}],
+        cache_mode="auto",
+    )
+
+    _collect_done(provider, cfg)
+
+    assert captured["payload"]["messages"] == [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "stable base",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
+        {"role": "user", "content": "hi"},
+    ]
+
+
+def test_tokenrhythm_non_qwen_cache_on_does_not_add_cache_control(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+    _patch_openai_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="glm-5.2",
+        base_url="https://tokenrhythm.studio/v1",
+        provider_kind="tokenrhythm",
+    )
+    cfg = ChatConfig(
+        system="stable base",
+        cache_breakpoints=[{"text": "stable base", "cache": "true"}],
+        cache_mode="on",
+    )
+
+    _collect_done(provider, cfg)
+
+    assert captured["payload"]["messages"] == [
+        {"role": "system", "content": "stable base"},
+        {"role": "user", "content": "hi"},
+    ]
+
+
 def test_openrouter_qwen36_flash_auto_cache_adds_alibaba_message_cache_control(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- disable provider-private state replay for every ensemble proposer physical call while leaving aggregator and standalone model behavior unchanged
- enable explicit prompt-cache passthrough for live-verified TokenRhythm qwen3.7-max requests
- enable Qwen system-prefix caching under the gateway default auto mode; on mode adds bounded moving-tail markers
- fail closed for all other TokenRhythm models

## Scope

Scope boundary: Ensemble proposer provider-state isolation and TokenRhythm qwen3.7-max explicit prompt caching, plus regression tests.

Non-goals: Prefix-hash monitoring, aggregator behavior changes, standalone model behavior changes, and cache passthrough for other TokenRhythm models.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Focused provider correctness and cache-efficiency fix discovered during ensemble cache investigation.

## Release Note

Release note: Ensemble proposers no longer replay provider-private reasoning state, and TokenRhythm qwen3.7-max can use explicit prompt caching by default.

## Tests

Ruff: passed for every changed Python file.

Pytest: 308 targeted provider, ensemble, compatibility, and prompt-cache tests passed. Full provider suite reported 1,589 passed and 2 request-proof budget failures; both failures reproduce unchanged on origin/main in the same environment.

Build: not needed; Python provider-only change.

Regression tests: added

Notes: Live TokenRhythm verification wrote 17,114 cache tokens on the first request and hit 17,114 cache tokens on the identical second request. The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: A contributor-side live provider check was completed; no maintainer credential is required to review the offline regression tests.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents are not committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No documentation files changed.
- [x] Tests and PR notes avoid real secrets, local private paths, and private transcripts.