### PR TITLE
fix(cron): 静态提醒完成时在 toast 中展示提醒内容

### DIFF
--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -560,6 +560,8 @@ const webConfigEnabled = getPlatform().capabilities.hasWebConfig
 interface AppCronRunFinishedPayload {
   jobId?: string
   jobName?: string
+  handlerKey?: string
+  summary?: string
   runId?: string
   success?: boolean
 }
@@ -576,6 +578,16 @@ function handleCronRunFinished(payload: unknown) {
     pushToast(t('cronSkills.jobs.toastBackgroundFailed', { name: jobName }), {
       tone: 'danger',
       duration: 9_000,
+    })
+    return
+  }
+  // Static reminders deliver the configured reminder text as the summary;
+  // surface that text directly in the completion toast so the user can see
+  // what the reminder actually said without opening run history.
+  if (event.handlerKey === 'static_message' && typeof event.summary === 'string' && event.summary.trim()) {
+    pushToast(t('cronSkills.jobs.toastBackgroundReminder', { name: jobName, text: event.summary.trim() }), {
+      tone: 'ok',
+      duration: 7_000,
     })
     return
   }

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -2611,6 +2611,7 @@
       "toastConnectionRecovered": "Verbindung wiederhergestellt und Aufgabenstatus aktualisiert",
       "toastConnectionRetry": "Verbindung noch nicht wiederhergestellt. Bitte die Seite später aktualisieren.",
       "toastBackgroundComplete": "Aufgabe „{name}“ abgeschlossen. Das Ergebnis ist im Ausführungsverlauf verfügbar.",
+      "toastBackgroundReminder": "Erinnerung „{name}“: {text}",
       "toastBackgroundFailed": "Aufgabe „{name}“ fehlgeschlagen. Bitte die Schaltfläche zum erneuten Versuch verwenden.",
       "unnamedTask": "Unbenannte Aufgabe",
       "toastDeleted": "Job gelöscht",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -2662,6 +2662,7 @@
       "toastConnectionRecovered": "Connection restored and task status refreshed",
       "toastConnectionRetry": "Connection is not restored yet. Refresh the page shortly.",
       "toastBackgroundComplete": "Task “{name}” completed. View the result in run history.",
+      "toastBackgroundReminder": "Reminder “{name}”: {text}",
       "toastBackgroundFailed": "Task “{name}” failed. Use the retry button on its card.",
       "unnamedTask": "Unnamed task",
       "toastDeleted": "Job deleted",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -2611,6 +2611,7 @@
       "toastConnectionRecovered": "Conexión restablecida y estado de tareas actualizado",
       "toastConnectionRetry": "La conexión aún no se ha restablecido. Actualiza la página en breve.",
       "toastBackgroundComplete": "La tarea «{name}» terminó. Consulta el resultado en el historial.",
+      "toastBackgroundReminder": "Recordatorio «{name}»: {text}",
       "toastBackgroundFailed": "La tarea «{name}» falló. Usa el botón Reintentar de su tarjeta.",
       "unnamedTask": "Tarea sin nombre",
       "toastDeleted": "Tarea eliminada",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -2611,6 +2611,7 @@
       "toastConnectionRecovered": "Connexion rétablie et état des tâches actualisé",
       "toastConnectionRetry": "La connexion n’est pas encore rétablie. Actualisez bientôt la page.",
       "toastBackgroundComplete": "La tâche « {name} » est terminée. Consultez le résultat dans l’historique.",
+      "toastBackgroundReminder": "Rappel « {name} » : {text}",
       "toastBackgroundFailed": "La tâche « {name} » a échoué. Utilisez le bouton Réessayer de sa carte.",
       "unnamedTask": "Tâche sans nom",
       "toastDeleted": "Tâche supprimée",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -2611,6 +2611,7 @@
       "toastConnectionRecovered": "接続が復旧し、タスク状態を更新しました",
       "toastConnectionRetry": "接続はまだ復旧していません。しばらくしてからページを更新してください。",
       "toastBackgroundComplete": "タスク「{name}」が完了しました。実行履歴で結果を確認できます。",
+      "toastBackgroundReminder": "リマインダー「{name}」: {text}",
       "toastBackgroundFailed": "タスク「{name}」が失敗しました。カードの再試行ボタンを使用してください。",
       "unnamedTask": "名称未設定のタスク",
       "toastDeleted": "ジョブを削除しました",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -2662,6 +2662,7 @@
       "toastConnectionRecovered": "连接已恢复，任务状态已自动刷新",
       "toastConnectionRetry": "连接尚未恢复，请稍后刷新页面",
       "toastBackgroundComplete": "任务“{name}”已完成，可在运行历史中查看结果",
+      "toastBackgroundReminder": "任务“{name}”提醒：{text}",
       "toastBackgroundFailed": "任务“{name}”运行失败，请点击卡片上的重试按钮",
       "unnamedTask": "未命名任务",
       "toastDeleted": "任务已删除",

--- a/src/opensquilla/scheduler/delivery.py
+++ b/src/opensquilla/scheduler/delivery.py
@@ -425,6 +425,7 @@ class DeliveryChain:
         payload = {
             "jobId": job.id,
             "jobName": job.name,
+            "handlerKey": job.handler_key,
             "success": success,
             "summary": summary,
             "error": error,


### PR DESCRIPTION
## 背景

当定时任务模式设置为「静态提醒」并触发执行后，弹出的 toast 只显示「任务完成」，没有展示用户配置的提醒文本内容，导致用户无法在任务完成时看到提醒的具体内容。

## 根因

后端在 `cron.run.finished` 事件负载中已经携带了提醒文本（`summary` 字段），但前端 `handleCronRunFinished` 只读取了 `jobName`，完全丢弃了 `summary`，导致 toast 只显示泛化的「任务完成」文案。

## 改动内容

### 后端
- `src/opensquilla/scheduler/delivery.py`
  - 在 `cron.run.finished` 事件负载中新增 `handlerKey` 字段，使前端能区分静态提醒任务（`static_message`）与其他任务类型。

### 前端
- `opensquilla-webui/src/App.vue`
  - 在 `AppCronRunFinishedPayload` 接口中新增 `handlerKey`、`summary` 字段。
  - 当任务为静态提醒且存在提醒文本时，将提醒内容直接拼进完成 toast 展示；agent 任务仍走原有泛化文案。

### 语言包
- 在 `zh-Hans` / `en` / `de` / `es` / `fr` / `ja` 6 种语言中新增 `toastBackgroundReminder` 文案。
  - 中文示例：`任务"{name}"提醒：{text}`

## 行为变化

- 静态提醒完成 toast：`任务"喝水提醒"提醒：记得喝水`（展示配置的提醒文本）
- 其他任务完成 toast：保持原有 `任务"xxx"已完成，可在运行历史中查看结果` 不变
<img width="428" height="165" alt="图片" src="https://github.com/user-attachments/assets/533c49ad-3138-4a52-9c86-f3d507317cbf" />

