### PR TITLE
fix(webui): show the reminder text a finished cron job delivered

### DIFF
--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -433,6 +433,10 @@ import { useSidebarLayout } from './composables/useSidebarLayout'
 import { useDocumentEvent } from './composables/useDocumentEvent'
 import { useDialogLayer } from './composables/useDialogA11y'
 import { provideArtifactImageLightbox } from './composables/chat/useArtifactImageLightbox'
+import {
+  cronRunFinishedToast,
+  type CronRunFinishedEvent,
+} from './composables/cron/cronRunToast'
 import { useAgentOptions } from './composables/useAgentOptions'
 import { useSessionListSubscription } from './composables/useSessionListSubscription'
 import { useSessionTaskAttention } from './composables/useSessionTaskAttention'
@@ -557,32 +561,15 @@ watch(
 const { enabled: bgmEnabled } = useBgm()
 const webConfigEnabled = getPlatform().capabilities.hasWebConfig
 
-interface AppCronRunFinishedPayload {
-  jobId?: string
-  jobName?: string
-  runId?: string
-  success?: boolean
-}
-
 let unsubscribeCronFinished: (() => void) | null = null
 
 function handleCronRunFinished(payload: unknown) {
   if (!payload || typeof payload !== 'object') return
-  const event = payload as AppCronRunFinishedPayload
+  const event = payload as CronRunFinishedEvent
   const runId = typeof event.runId === 'string' ? event.runId : ''
-  const jobName = event.jobName?.trim() || t('cronSkills.jobs.unnamedTask')
   markCronFinishNotified(runId)
-  if (event.success === false) {
-    pushToast(t('cronSkills.jobs.toastBackgroundFailed', { name: jobName }), {
-      tone: 'danger',
-      duration: 9_000,
-    })
-    return
-  }
-  pushToast(t('cronSkills.jobs.toastBackgroundComplete', { name: jobName }), {
-    tone: 'ok',
-    duration: 7_000,
-  })
+  const toast = cronRunFinishedToast(event, (key, params) => t(key, params ?? {}))
+  pushToast(toast.message, { tone: toast.tone, duration: toast.duration })
 }
 
 installSessionNavigationDiagConsole()

--- a/opensquilla-webui/src/composables/cron/cronRunToast.test.ts
+++ b/opensquilla-webui/src/composables/cron/cronRunToast.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+
+import { cronRunFinishedToast, cronToastSummary } from './cronRunToast'
+
+// Mirrors vue-i18n's interpolation closely enough to assert on the rendered
+// string rather than on which key was picked.
+function t(key: string, params: Record<string, unknown> = {}): string {
+  const templates: Record<string, string> = {
+    'cronSkills.jobs.unnamedTask': 'Unnamed task',
+    'cronSkills.jobs.toastBackgroundComplete':
+      'Task “{name}” completed. View the result in run history.',
+    'cronSkills.jobs.toastBackgroundCompleteWithSummary': 'Task “{name}” completed: {summary}',
+    'cronSkills.jobs.toastBackgroundFailed':
+      'Task “{name}” failed. Use the retry button on its card.',
+  }
+  const template = templates[key]
+  if (template === undefined) throw new Error(`missing translation: ${key}`)
+  return template.replace(/\{(\w+)\}/g, (_match, name: string) => String(params[name] ?? ''))
+}
+
+describe('cronRunFinishedToast', () => {
+  it('shows the reminder text a static-reminder job exists to deliver', () => {
+    // The scheduler sends the configured text as the run summary. Reporting only
+    // "completed" and pointing at run history hides the one thing the user
+    // scheduled.
+    const toast = cronRunFinishedToast(
+      { jobName: 'Standup', success: true, summary: 'Post the standup notes' },
+      t,
+    )
+
+    expect(toast.message).toBe('Task “Standup” completed: Post the standup notes')
+    expect(toast.tone).toBe('ok')
+  })
+
+  it('keeps the history wording when the run carried no summary', () => {
+    const toast = cronRunFinishedToast({ jobName: 'Nightly', success: true }, t)
+
+    expect(toast.message).toBe('Task “Nightly” completed. View the result in run history.')
+    expect(toast.tone).toBe('ok')
+  })
+
+  it('treats a blank or non-string summary as absent', () => {
+    for (const summary of ['', '   ', '\n\t', undefined, null, 42]) {
+      const toast = cronRunFinishedToast(
+        { jobName: 'Nightly', success: true, summary: summary as string | undefined },
+        t,
+      )
+      expect(toast.message).toBe('Task “Nightly” completed. View the result in run history.')
+    }
+  })
+
+  it('flattens a multi-line reminder into one toast line', () => {
+    const toast = cronRunFinishedToast(
+      { jobName: 'Standup', success: true, summary: '  Call the vet\n\nthen book a slot  ' },
+      t,
+    )
+
+    expect(toast.message).toBe('Task “Standup” completed: Call the vet then book a slot')
+  })
+
+  it('trims a long summary instead of letting it fill the screen', () => {
+    const toast = cronRunFinishedToast(
+      { jobName: 'Digest', success: true, summary: 'x'.repeat(500) },
+      t,
+    )
+    const rendered = toast.message.replace('Task “Digest” completed: ', '')
+
+    expect(rendered).toHaveLength(160)
+    expect(rendered.endsWith('…')).toBe(true)
+  })
+
+  it('leaves the failure path reporting the retry affordance', () => {
+    // A failed run's summary is not the user's reminder, and an error string is
+    // its own decision; this change deliberately does not touch that copy.
+    const toast = cronRunFinishedToast(
+      { jobName: 'Nightly', success: false, summary: 'boom' },
+      t,
+    )
+
+    expect(toast.message).toBe('Task “Nightly” failed. Use the retry button on its card.')
+    expect(toast.tone).toBe('danger')
+    expect(toast.duration).toBe(9_000)
+  })
+
+  it('falls back to the unnamed-task label without dropping the summary', () => {
+    const toast = cronRunFinishedToast({ success: true, summary: 'Water the plants' }, t)
+
+    expect(toast.message).toBe('Task “Unnamed task” completed: Water the plants')
+  })
+})
+
+describe('cronToastSummary', () => {
+  it('returns an empty string for everything that is not usable text', () => {
+    for (const value of [undefined, null, 0, false, {}, [], '   ']) {
+      expect(cronToastSummary(value)).toBe('')
+    }
+  })
+
+  it('passes a short single-line summary through untouched', () => {
+    expect(cronToastSummary('Take the bins out')).toBe('Take the bins out')
+  })
+})

--- a/opensquilla-webui/src/composables/cron/cronRunToast.ts
+++ b/opensquilla-webui/src/composables/cron/cronRunToast.ts
@@ -1,0 +1,71 @@
+/** Toast copy for the scheduler's terminal `cron.run.finished` event.
+ *
+ * Kept out of `App.vue` so the decision this makes — which of the two success
+ * strings to use, and how much of the summary survives — is testable without
+ * mounting the shell.
+ */
+
+export interface CronRunFinishedEvent {
+  jobId?: string
+  jobName?: string
+  runId?: string
+  success?: boolean
+  /** The scheduler's result summary. For a reminder job this *is* the payload:
+   *  `make_static_message_handler` sends the configured text as the summary. */
+  summary?: string
+}
+
+export interface CronRunToast {
+  message: string
+  tone: 'ok' | 'danger'
+  duration: number
+}
+
+type Translate = (key: string, params?: Record<string, unknown>) => string
+
+// The scheduler caps summaries at 500 characters, which is still far more than
+// a toast should carry. A reminder is normally one short line and survives
+// whole; a long agent summary is trimmed here and stays complete in run
+// history.
+const SUMMARY_MAX_CHARS = 160
+
+const SUCCESS_DURATION_MS = 7_000
+const FAILURE_DURATION_MS = 9_000
+
+/** Collapse a summary into one toast-sized line, or "" when there is nothing. */
+export function cronToastSummary(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  // Newlines would otherwise stretch the toast; the full text stays in history.
+  const text = value.replace(/\s+/g, ' ').trim()
+  if (!text) return ''
+  if (text.length <= SUMMARY_MAX_CHARS) return text
+  return `${text.slice(0, SUMMARY_MAX_CHARS - 1).trimEnd()}…`
+}
+
+export function cronRunFinishedToast(
+  event: CronRunFinishedEvent,
+  t: Translate,
+): CronRunToast {
+  const jobName = event.jobName?.trim() || t('cronSkills.jobs.unnamedTask')
+  if (event.success === false) {
+    return {
+      message: t('cronSkills.jobs.toastBackgroundFailed', { name: jobName }),
+      tone: 'danger',
+      duration: FAILURE_DURATION_MS,
+    }
+  }
+  // A reminder's whole point is the text it carries. Pointing the user at run
+  // history for a single line they asked to be shown is the reason this event
+  // felt broken.
+  const summary = cronToastSummary(event.summary)
+  return {
+    message: summary
+      ? t('cronSkills.jobs.toastBackgroundCompleteWithSummary', {
+          name: jobName,
+          summary,
+        })
+      : t('cronSkills.jobs.toastBackgroundComplete', { name: jobName }),
+    tone: 'ok',
+    duration: SUCCESS_DURATION_MS,
+  }
+}

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -2611,6 +2611,7 @@
       "toastConnectionRecovered": "Verbindung wiederhergestellt und Aufgabenstatus aktualisiert",
       "toastConnectionRetry": "Verbindung noch nicht wiederhergestellt. Bitte die Seite später aktualisieren.",
       "toastBackgroundComplete": "Aufgabe „{name}“ abgeschlossen. Das Ergebnis ist im Ausführungsverlauf verfügbar.",
+      "toastBackgroundCompleteWithSummary": "Aufgabe „{name}“ abgeschlossen: {summary}",
       "toastBackgroundFailed": "Aufgabe „{name}“ fehlgeschlagen. Bitte die Schaltfläche zum erneuten Versuch verwenden.",
       "unnamedTask": "Unbenannte Aufgabe",
       "toastDeleted": "Job gelöscht",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -2662,6 +2662,7 @@
       "toastConnectionRecovered": "Connection restored and task status refreshed",
       "toastConnectionRetry": "Connection is not restored yet. Refresh the page shortly.",
       "toastBackgroundComplete": "Task “{name}” completed. View the result in run history.",
+      "toastBackgroundCompleteWithSummary": "Task \u201c{name}\u201d completed: {summary}",
       "toastBackgroundFailed": "Task “{name}” failed. Use the retry button on its card.",
       "unnamedTask": "Unnamed task",
       "toastDeleted": "Job deleted",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -2611,6 +2611,7 @@
       "toastConnectionRecovered": "Conexión restablecida y estado de tareas actualizado",
       "toastConnectionRetry": "La conexión aún no se ha restablecido. Actualiza la página en breve.",
       "toastBackgroundComplete": "La tarea «{name}» terminó. Consulta el resultado en el historial.",
+      "toastBackgroundCompleteWithSummary": "Tarea «{name}» completada: {summary}",
       "toastBackgroundFailed": "La tarea «{name}» falló. Usa el botón Reintentar de su tarjeta.",
       "unnamedTask": "Tarea sin nombre",
       "toastDeleted": "Tarea eliminada",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -2611,6 +2611,7 @@
       "toastConnectionRecovered": "Connexion rétablie et état des tâches actualisé",
       "toastConnectionRetry": "La connexion n’est pas encore rétablie. Actualisez bientôt la page.",
       "toastBackgroundComplete": "La tâche « {name} » est terminée. Consultez le résultat dans l’historique.",
+      "toastBackgroundCompleteWithSummary": "Tâche « {name} » terminée : {summary}",
       "toastBackgroundFailed": "La tâche « {name} » a échoué. Utilisez le bouton Réessayer de sa carte.",
       "unnamedTask": "Tâche sans nom",
       "toastDeleted": "Tâche supprimée",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -2611,6 +2611,7 @@
       "toastConnectionRecovered": "接続が復旧し、タスク状態を更新しました",
       "toastConnectionRetry": "接続はまだ復旧していません。しばらくしてからページを更新してください。",
       "toastBackgroundComplete": "タスク「{name}」が完了しました。実行履歴で結果を確認できます。",
+      "toastBackgroundCompleteWithSummary": "タスク「{name}」が完了しました：{summary}",
       "toastBackgroundFailed": "タスク「{name}」が失敗しました。カードの再試行ボタンを使用してください。",
       "unnamedTask": "名称未設定のタスク",
       "toastDeleted": "ジョブを削除しました",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -2662,6 +2662,7 @@
       "toastConnectionRecovered": "连接已恢复，任务状态已自动刷新",
       "toastConnectionRetry": "连接尚未恢复，请稍后刷新页面",
       "toastBackgroundComplete": "任务“{name}”已完成，可在运行历史中查看结果",
+      "toastBackgroundCompleteWithSummary": "任务“{name}”已完成：{summary}",
       "toastBackgroundFailed": "任务“{name}”运行失败，请点击卡片上的重试按钮",
       "unnamedTask": "未命名任务",
       "toastDeleted": "任务已删除",


### PR DESCRIPTION
## Scope

Scope boundary: The Web UI's `cron.run.finished` toast, plus the six locale
strings it needs.

Non-goals: No scheduler or delivery change — the text was already on the
wire. The failure toast is left alone.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #1090

## Release Note

Release note: A finished reminder job now shows its reminder text in the
completion toast instead of only "task completed".

## Tests

Ruff: N/A (no Python changed)

Pytest: N/A (no Python changed)

Build: `npm run typecheck` — all 11 architecture guards pass, including
i18n key parity across the six locales

Regression tests: added

Notes:
- 3033 frontend tests pass
- 9 new tests; 4 of them fail against a build that drops the summary,
  including the reporter's reminder case
- The backend contract is already pinned by
  `test_rpc_cron_current_session.py`, which asserts the terminal WS payload
  carries the summary

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

No secrets or private artifacts.

## Third-Party Origin

Third-party origin: none