### PR TITLE
fix(config): stop a multi-line TOML value from blocking every config patch

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -89,6 +89,7 @@
       "tests/test_engine/turn_runner/test_tool_surface_levers_bootstrap_unit.py",
       "tests/test_execution_status_contract.py",
       "tests/test_github_issue_link_sync.py",
+      "tests/test_lossless_toml.py",
       "tests/test_memory/test_profile_import.py",
       "tests/test_meta_skill_openclaw_lifestyle_comparison.py",
       "tests/test_model_router_behavior.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -541,6 +541,7 @@
     "tests/test_live_multi_provider_matrix.py": 0.01,
     "tests/test_live_tokenrhythm_billing_audit.py": 0.20,
     "tests/test_llm_ensemble_config.py": 0.527,
+    "tests/test_lossless_toml.py": 0.01,
     "tests/test_mcp/test_discovery_lifecycle.py": 0.168,
     "tests/test_mcp/test_sse_client.py": 0.714,
     "tests/test_mcp/test_stdio_client.py": 1.249,

--- a/src/opensquilla/lossless_toml.py
+++ b/src/opensquilla/lossless_toml.py
@@ -116,15 +116,30 @@ def _skip_quoted(text: str, index: int) -> int:
 
 
 def _find_multiline_close(text: str, delimiter: str, start: int) -> int:
+    """Return the end of the closing quote run, or ``-1`` when still open.
+
+    TOML permits one or two quote characters immediately inside a multi-line
+    string delimiter.  A terminal run can therefore contain three, four, or
+    five quotes: the last three close the string and any preceding quotes are
+    content.  Consuming the complete run also keeps a fourth quote from being
+    mistaken for a new single-line string that hides a following ``]``/``}``.
+    """
     literal = delimiter == "'''"
+    quote = delimiter[0]
     index = start
     while index < len(text):
         if not literal and text[index] == "\\":
             index += 2
             continue
-        if text.startswith(delimiter, index):
-            return index
-        index += 1
+        if text[index] != quote:
+            index += 1
+            continue
+        end = index + 1
+        while end < len(text) and text[end] == quote:
+            end += 1
+        if end - index >= len(delimiter):
+            return end
+        index = end
     return -1
 
 
@@ -140,7 +155,7 @@ def _scan_value(text: str, depth: int, pending: str | None) -> tuple[int, str | 
         closing = _find_multiline_close(text, pending, 0)
         if closing < 0:
             return depth, pending
-        index = closing + len(pending)
+        index = closing
         pending = None
     while index < len(text):
         character = text[index]
@@ -152,7 +167,7 @@ def _scan_value(text: str, depth: int, pending: str | None) -> tuple[int, str | 
                 closing = _find_multiline_close(text, delimiter, index + 3)
                 if closing < 0:
                     return depth, delimiter
-                index = closing + 3
+                index = closing
                 continue
             index = _skip_quoted(text, index)
             continue
@@ -173,6 +188,26 @@ def _value_last_line(lines: list[str], start: int, suffix: str) -> int:
         continuation, _newline = _split_newline(lines[last])
         depth, pending = _scan_value(continuation, depth, pending)
     return last
+
+
+def _physical_lines(text: str) -> list[str]:
+    """Split on TOML physical newlines while preserving their exact bytes.
+
+    TOML defines a newline as LF or CRLF.  ``str.splitlines`` additionally
+    treats several legal Unicode string characters (for example U+2028) as
+    line boundaries, which can make the scanner splice an assignment inside a
+    quoted value.
+    """
+    lines: list[str] = []
+    start = 0
+    while start < len(text):
+        end = text.find("\n", start)
+        if end < 0:
+            lines.append(text[start:])
+            break
+        lines.append(text[start : end + 1])
+        start = end + 1
+    return lines
 
 
 def _scan(
@@ -320,7 +355,7 @@ def patch_import_config(
     if original == transformed:
         return raw
 
-    lines = text.splitlines(keepends=True)
+    lines = _physical_lines(text)
     assignments, insertion_points, spanning = _scan(lines)
     original_leaves = _leaves(original)
     transformed_leaves = _leaves(transformed)
@@ -389,10 +424,31 @@ def patch_import_config(
         insertions.setdefault(insertion_points[context], []).append(insertion)
 
     output: list[str] = []
+    has_output = False
+    ends_with_newline = True
     for index in range(len(lines) + 1):
-        output.extend(insertions.get(index, ()))
+        pending_insertions = insertions.get(index, ())
+        if pending_insertions and has_output and not ends_with_newline:
+            output.append(newline)
+            ends_with_newline = True
+        for insertion_index, insertion in enumerate(pending_insertions):
+            fragment = insertion
+            if (
+                index == len(lines)
+                and insertion_index == len(pending_insertions) - 1
+                and text
+                and not text.endswith("\n")
+            ):
+                fragment = insertion[: -len(newline)]
+            output.append(fragment)
+            has_output = True
+            ends_with_newline = fragment.endswith("\n")
         if index < len(lines):
-            output.append(replacements.get(index, lines[index]))
+            fragment = replacements.get(index, lines[index])
+            if fragment:
+                output.append(fragment)
+                has_output = True
+                ends_with_newline = fragment.endswith("\n")
     patched = "".join(output)
     try:
         parsed = tomllib.loads(patched)

--- a/src/opensquilla/lossless_toml.py
+++ b/src/opensquilla/lossless_toml.py
@@ -11,6 +11,7 @@ from typing import Any
 import tomli_w
 
 _BARE_KEY = re.compile(r"[A-Za-z0-9_-]+")
+_MULTILINE_QUOTES = ('"""', "'''")
 
 
 class LosslessTomlPatchError(ValueError):
@@ -99,20 +100,98 @@ def _split_newline(line: str) -> tuple[str, str]:
     return line, ""
 
 
+def _skip_quoted(text: str, index: int) -> int:
+    """Return the index just past the single-line string opening at *index*."""
+    quote = text[index]
+    index += 1
+    while index < len(text):
+        character = text[index]
+        if quote == '"' and character == "\\":
+            index += 2
+            continue
+        if character == quote:
+            return index + 1
+        index += 1
+    return index
+
+
+def _find_multiline_close(text: str, delimiter: str, start: int) -> int:
+    literal = delimiter == "'''"
+    index = start
+    while index < len(text):
+        if not literal and text[index] == "\\":
+            index += 2
+            continue
+        if text.startswith(delimiter, index):
+            return index
+        index += 1
+    return -1
+
+
+def _scan_value(text: str, depth: int, pending: str | None) -> tuple[int, str | None]:
+    """Advance the value scanner across one physical line of a TOML value.
+
+    Returns the collection depth after the line plus the multi-line string
+    delimiter the value is still inside, if any. Either being non-zero/non-None
+    means the value continues on the following line.
+    """
+    index = 0
+    if pending is not None:
+        closing = _find_multiline_close(text, pending, 0)
+        if closing < 0:
+            return depth, pending
+        index = closing + len(pending)
+        pending = None
+    while index < len(text):
+        character = text[index]
+        if character == "#":
+            break
+        if character in {'"', "'"}:
+            delimiter = text[index : index + 3]
+            if delimiter in _MULTILINE_QUOTES:
+                closing = _find_multiline_close(text, delimiter, index + 3)
+                if closing < 0:
+                    return depth, delimiter
+                index = closing + 3
+                continue
+            index = _skip_quoted(text, index)
+            continue
+        if character in "[{":
+            depth += 1
+        elif character in "]}":
+            depth -= 1
+        index += 1
+    return depth, pending
+
+
+def _value_last_line(lines: list[str], start: int, suffix: str) -> int:
+    """Return the index of the physical line on which the value ends."""
+    depth, pending = _scan_value(suffix, 0, None)
+    last = start
+    while (depth > 0 or pending is not None) and last + 1 < len(lines):
+        last += 1
+        continuation, _newline = _split_newline(lines[last])
+        depth, pending = _scan_value(continuation, depth, pending)
+    return last
+
+
 def _scan(
     lines: list[str],
 ) -> tuple[
     dict[tuple[str | int, ...], _Assignment],
     dict[tuple[str | int, ...], int],
+    set[tuple[str | int, ...]],
 ]:
     assignments: dict[tuple[str | int, ...], _Assignment] = {}
     insertion_points: dict[tuple[str | int, ...], int] = {(): len(lines)}
+    spanning: set[tuple[str | int, ...]] = set()
     current: tuple[str | int, ...] = ()
     array_counts: dict[tuple[str, ...], int] = {}
     first_header = len(lines)
 
-    for index, raw_line in enumerate(lines):
-        line, newline = _split_newline(raw_line)
+    index = 0
+    while index < len(lines):
+        line, newline = _split_newline(lines[index])
         stripped = line.strip()
         if stripped.startswith("["):
             comment = _comment_start(stripped)
@@ -131,18 +210,33 @@ def _scan(
                 current = table
             insertion_points[current] = index + 1
             first_header = min(first_header, index)
+            index += 1
             continue
 
         equals = _assignment_equals(line)
         if equals is None:
+            index += 1
             continue
         key_expression = line[:equals].strip()
         if not key_expression:
             raise LosslessTomlPatchError("empty TOML assignment key")
         path = (*current, *_key_path(key_expression))
-        if path in assignments:
+        if path in assignments or path in spanning:
             raise LosslessTomlPatchError(f"duplicate semantic TOML assignment: {path}")
         suffix = line[equals + 1 :]
+
+        # A value may run past this line — an array of inline tables, a nested
+        # array, a triple-quoted string. Such a value cannot be patched in place,
+        # but the scan must still step over its remaining lines: they hold no
+        # assignments of their own, and a bracketed array row is not a table
+        # header. Reading one as either used to abort the whole patch.
+        last = _value_last_line(lines, index, suffix)
+        if last != index:
+            spanning.add(path)
+            insertion_points[current] = last + 1
+            index = last + 1
+            continue
+
         leading = len(suffix) - len(suffix.lstrip())
         comment_relative = _comment_start(suffix)
         value_region = suffix if comment_relative is None else suffix[:comment_relative]
@@ -163,9 +257,22 @@ def _scan(
             indent=indent,
         )
         insertion_points[current] = index + 1
+        index += 1
 
     insertion_points[()] = min(insertion_points.get((), first_header), first_header)
-    return assignments, insertion_points
+    return assignments, insertion_points, spanning
+
+
+def _spanning_owner(
+    path: tuple[str | int, ...],
+    spanning: set[tuple[str | int, ...]],
+) -> tuple[str | int, ...] | None:
+    """Return the multi-line value *path* lives inside, if any."""
+    for length in range(len(path), 0, -1):
+        prefix = path[:length]
+        if prefix in spanning:
+            return prefix
+    return None
 
 
 def _leaves(value: object, path: tuple[str | int, ...] = ()) -> dict[tuple[str | int, ...], Any]:
@@ -214,7 +321,7 @@ def patch_import_config(
         return raw
 
     lines = text.splitlines(keepends=True)
-    assignments, insertion_points = _scan(lines)
+    assignments, insertion_points, spanning = _scan(lines)
     original_leaves = _leaves(original)
     transformed_leaves = _leaves(transformed)
     removed = set(original_leaves) - set(transformed_leaves)
@@ -228,6 +335,11 @@ def patch_import_config(
     for path in sorted(removed, key=repr):
         assignment = assignments.get(path)
         if assignment is None:
+            owner = _spanning_owner(path, spanning)
+            if owner is not None:
+                raise LosslessTomlPatchError(
+                    f"cannot remove {path} inside the multi-line TOML value at {owner}"
+                )
             raise LosslessTomlPatchError(f"cannot remove non-scalar TOML path losslessly: {path}")
         line, _newline = _split_newline(lines[assignment.line_index])
         comment = line[assignment.comment_start :] if assignment.comment_start is not None else ""
@@ -238,6 +350,11 @@ def patch_import_config(
     for path in sorted(changed, key=repr):
         assignment = assignments.get(path)
         if assignment is None:
+            owner = _spanning_owner(path, spanning)
+            if owner is not None:
+                raise LosslessTomlPatchError(
+                    f"cannot replace {path} inside the multi-line TOML value at {owner}"
+                )
             raise LosslessTomlPatchError(f"cannot replace non-scalar TOML path: {path}")
         line, _newline = _split_newline(lines[assignment.line_index])
         replacements[assignment.line_index] = (
@@ -251,6 +368,11 @@ def patch_import_config(
     newline = "\r\n" if "\r\n" in text else "\n"
     contexts = tuple(insertion_points)
     for path in sorted(added, key=repr):
+        owner = _spanning_owner(path, spanning)
+        if owner is not None:
+            raise LosslessTomlPatchError(
+                f"cannot add {path} inside the multi-line TOML value at {owner}"
+            )
         compatible = [
             context
             for context in contexts

--- a/tests/test_lossless_toml.py
+++ b/tests/test_lossless_toml.py
@@ -1,0 +1,226 @@
+"""Contract tests for the comment-preserving TOML patcher.
+
+``patch_import_config`` runs on every Gateway boot (``lossless_patch_sandbox_fields``
+stamps ``sandbox.run_mode``), so a config it refuses to scan is a config the
+Gateway refuses to start on. The scanner is line-oriented, which makes values
+that span several physical lines — arrays of inline tables, nested arrays,
+triple-quoted strings — the interesting cases.
+"""
+
+from __future__ import annotations
+
+import tomllib
+
+import pytest
+
+from opensquilla.lossless_toml import LosslessTomlPatchError, patch_import_config
+
+
+def _patched(raw: bytes, transform) -> str:
+    original = tomllib.loads(raw.decode("utf-8"))
+    transformed = tomllib.loads(raw.decode("utf-8"))
+    transform(transformed)
+    return patch_import_config(raw, original, transformed).decode("utf-8")
+
+
+def _rejects(raw: bytes, transform) -> str:
+    original = tomllib.loads(raw.decode("utf-8"))
+    transformed = tomllib.loads(raw.decode("utf-8"))
+    transform(transformed)
+    with pytest.raises(LosslessTomlPatchError) as excinfo:
+        patch_import_config(raw, original, transformed)
+    return str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Single-line values: the patcher's core contract
+# ---------------------------------------------------------------------------
+
+
+def test_unchanged_payload_returns_the_source_bytes_verbatim() -> None:
+    raw = b'port = 1\n# keep me\nname = "x"\n'
+    original = tomllib.loads(raw.decode("utf-8"))
+    assert patch_import_config(raw, original, dict(original)) is raw
+
+
+def test_scalar_replacement_keeps_layout_and_trailing_comment() -> None:
+    raw = b'# header\nport   =   1   # why\n\n[gateway]\nhost = "127.0.0.1"\n'
+    patched = _patched(raw, lambda payload: payload.update(port=2))
+    assert patched == '# header\nport   =   2   # why\n\n[gateway]\nhost = "127.0.0.1"\n'
+
+
+def test_insertion_lands_in_the_owning_table() -> None:
+    raw = b'[gateway]\nhost = "127.0.0.1"\n'
+    patched = _patched(raw, lambda payload: payload["gateway"].update(port=8080))
+    assert patched == '[gateway]\nhost = "127.0.0.1"\nport = 8080\n'
+
+
+def test_removal_preserves_a_trailing_comment_on_the_removed_line() -> None:
+    raw = b'port = 1  # keep the note\nname = "x"\n'
+
+    def drop_port(payload: dict) -> None:
+        del payload["port"]
+
+    assert _patched(raw, drop_port) == '# keep the note\nname = "x"\n'
+
+
+def test_array_of_tables_headers_still_track_context() -> None:
+    raw = b'[[server]]\nhost = "a"\n\n[[server]]\nhost = "b"\n'
+    patched = _patched(raw, lambda payload: payload["server"][1].update(host="c"))
+    assert patched == '[[server]]\nhost = "a"\n\n[[server]]\nhost = "c"\n'
+
+
+# ---------------------------------------------------------------------------
+# Values that span physical lines (issue #1106 and neighbours)
+# ---------------------------------------------------------------------------
+
+
+AGENTS_CONFIG = b"""# profile config
+port = 18792
+
+agents = [
+    { id = "qa-agent", name = "QA Agent", enabled = true },
+]
+
+[gateway]
+host = "127.0.0.1"
+"""
+
+
+def test_untouched_array_of_inline_tables_does_not_block_the_patch() -> None:
+    """Regression for #1106.
+
+    The Control UI writes ``agents`` as a multi-line array of inline tables. The
+    boot migration only stamps ``sandbox.run_mode``, but the scan aborted on the
+    array's rows before reaching that edit, so the Gateway never started again.
+    """
+    patched = _patched(AGENTS_CONFIG, lambda payload: payload.update(port=18793))
+    assert patched == AGENTS_CONFIG.decode("utf-8").replace("18792", "18793")
+
+
+def test_boot_migration_stamps_run_mode_next_to_an_agents_array() -> None:
+    from opensquilla.sandbox.upgrade_migration import lossless_patch_sandbox_fields
+
+    patched, mode = lossless_patch_sandbox_fields(AGENTS_CONFIG)
+    payload = tomllib.loads(patched.decode("utf-8"))
+    assert payload["sandbox"]["run_mode"] == mode
+    assert payload["agents"] == [{"id": "qa-agent", "name": "QA Agent", "enabled": True}]
+    assert b'{ id = "qa-agent", name = "QA Agent", enabled = true },' in patched
+
+
+def test_nested_multi_line_array_rows_are_not_read_as_table_headers() -> None:
+    raw = b"port = 1\nmatrix = [\n  [1, 2],\n  [3, 4],\n]\n"
+    patched = _patched(raw, lambda payload: payload.update(port=2))
+    assert patched == "port = 2\nmatrix = [\n  [1, 2],\n  [3, 4],\n]\n"
+
+
+def test_multi_line_array_may_close_with_a_trailing_comment() -> None:
+    raw = b'agents = [\n  { id = "a" },\n]  # the roster\nport = 1\n'
+    patched = _patched(raw, lambda payload: payload.update(port=2))
+    assert patched == 'agents = [\n  { id = "a" },\n]  # the roster\nport = 2\n'
+
+
+def test_tables_after_a_multi_line_array_keep_their_own_context() -> None:
+    patched = _patched(
+        AGENTS_CONFIG,
+        lambda payload: payload["gateway"].update(host="0.0.0.0"),
+    )
+    assert patched.endswith('[gateway]\nhost = "0.0.0.0"\n')
+    assert '{ id = "qa-agent"' in patched
+
+
+def test_insertion_after_a_trailing_multi_line_array_lands_below_it() -> None:
+    raw = b'agents = [\n  { id = "a" },\n]\n'
+    patched = _patched(raw, lambda payload: payload.update(port=1))
+    assert patched == 'agents = [\n  { id = "a" },\n]\nport = 1\n'
+
+
+def test_crlf_config_with_a_multi_line_array_keeps_its_line_endings() -> None:
+    raw = AGENTS_CONFIG.replace(b"\n", b"\r\n")
+    patched = _patched(raw, lambda payload: payload.update(port=18793))
+    assert patched == raw.decode("utf-8").replace("18792", "18793")
+    assert "\r\n" in patched
+
+
+# ---------------------------------------------------------------------------
+# Triple-quoted strings: their bodies are not TOML
+# ---------------------------------------------------------------------------
+
+
+def test_assignment_inside_a_multi_line_string_is_not_a_second_assignment() -> None:
+    raw = b'key = "real"\nprompt = """\nkey = "phantom"\n"""\n'
+    patched = _patched(raw, lambda payload: payload.update(key="changed"))
+    assert patched == 'key = "changed"\nprompt = """\nkey = "phantom"\n"""\n'
+
+
+def test_bracketed_line_inside_a_literal_string_is_not_a_table_header() -> None:
+    raw = b"notes = '''\n[not a table]\n'''\nport = 1\n"
+    patched = _patched(raw, lambda payload: payload.update(port=2))
+    assert patched == "notes = '''\n[not a table]\n'''\nport = 2\n"
+
+
+def test_hash_inside_a_multi_line_string_is_not_a_comment() -> None:
+    raw = b'notes = """\n# not a comment\n"""\nport = 1\n'
+    assert tomllib.loads(raw.decode("utf-8"))["notes"] == "# not a comment\n"
+    patched = _patched(raw, lambda payload: payload.update(port=2))
+    assert patched == 'notes = """\n# not a comment\n"""\nport = 2\n'
+
+
+def test_escaped_quotes_do_not_close_a_multi_line_string_early() -> None:
+    raw = b'notes = """\na \\""" b\n"""\nport = 1\n'
+    assert tomllib.loads(raw.decode("utf-8"))["notes"] == 'a """ b\n'
+    patched = _patched(raw, lambda payload: payload.update(port=2))
+    assert patched == 'notes = """\na \\""" b\n"""\nport = 2\n'
+
+
+# ---------------------------------------------------------------------------
+# Edits that reach *into* a multi-line value stay refused — and say why
+# ---------------------------------------------------------------------------
+
+
+def test_replacing_a_leaf_inside_a_multi_line_array_is_refused_by_path() -> None:
+    message = _rejects(
+        AGENTS_CONFIG,
+        lambda payload: payload["agents"][0].update(name="Renamed"),
+    )
+    assert "cannot replace ('agents', 0, 'name')" in message
+    assert "multi-line TOML value at ('agents',)" in message
+
+
+def test_removing_a_leaf_inside_a_multi_line_array_is_refused_by_path() -> None:
+    def drop_name(payload: dict) -> None:
+        del payload["agents"][0]["name"]
+
+    message = _rejects(AGENTS_CONFIG, drop_name)
+    assert "cannot remove ('agents', 0, 'name')" in message
+    assert "multi-line TOML value at ('agents',)" in message
+
+
+def test_adding_a_leaf_inside_a_multi_line_array_is_refused_by_path() -> None:
+    message = _rejects(
+        AGENTS_CONFIG,
+        lambda payload: payload["agents"][0].update(role="reviewer"),
+    )
+    assert "cannot add ('agents', 0, 'role')" in message
+    assert "multi-line TOML value at ('agents',)" in message
+
+
+def test_rewriting_a_multi_line_string_is_refused_rather_than_spliced() -> None:
+    raw = b'prompt = """\nhello\n"""\n'
+    message = _rejects(raw, lambda payload: payload.update(prompt="goodbye"))
+    assert "('prompt',)" in message
+
+
+# ---------------------------------------------------------------------------
+# Guards the patcher already owned
+# ---------------------------------------------------------------------------
+
+
+def test_source_bytes_must_match_the_validated_payload() -> None:
+    with pytest.raises(LosslessTomlPatchError, match="no longer match"):
+        patch_import_config(b"port = 1\n", {"port": 2}, {"port": 3})
+
+
+def test_invalid_source_toml_is_rejected() -> None:
+    with pytest.raises(LosslessTomlPatchError, match="not valid UTF-8 TOML"):
+        patch_import_config(b"port = \n", {}, {"port": 1})

--- a/tests/test_lossless_toml.py
+++ b/tests/test_lossless_toml.py
@@ -143,6 +143,72 @@ def test_crlf_config_with_a_multi_line_array_keeps_its_line_endings() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Configs with no multi-line value must come through untouched
+# ---------------------------------------------------------------------------
+
+
+# The shape the Desktop profile-import E2E writes, including the Windows spelling
+# of its paths: `json.dumps(str(path))` produces doubled backslashes, so the value
+# scanner has to walk string escapes correctly on a line it must not consume.
+DESKTOP_PROFILE_CONFIG = (
+    'workspace_dir = "C:\\\\Users\\\\RUNNER~1\\\\AppData\\\\Local\\\\Temp\\\\p1\\\\workspace"\n'
+    'state_dir = "C:\\\\Users\\\\RUNNER~1\\\\AppData\\\\Local\\\\Temp\\\\p1\\\\state"\n'
+    'search_provider = "duckduckgo"\n'
+    'search_api_key_env = ""\n'
+    "\n"
+    "[llm]\n"
+    'provider = "ollama"\n'
+    'model = "synthetic-source-model"\n'
+    'base_url = "http://127.0.0.1:11434/v1"  # local only\n'
+    'api_key_env = ""\n'
+    "\n"
+    "[squilla_router]\n"
+    "enabled = false\n"
+    'default_tier = "c2"\n'
+    "confidence_threshold = 0.77\n"
+    "\n"
+    "[squilla_router.tiers.c0]\n"
+    'provider = "ollama"\n'
+    'model = "synthetic-source-tier-model"\n'
+    "\n"
+    "[control_ui]\n"
+    "enabled = true\n"
+    'base_path = "/control"\n'
+)
+
+
+@pytest.mark.parametrize("newline", ["\n", "\r\n"])
+def test_boot_stamp_rewrites_one_line_and_no_other_byte(newline: str) -> None:
+    raw = DESKTOP_PROFILE_CONFIG.replace("\n", newline).encode("utf-8")
+    original = tomllib.loads(raw.decode("utf-8"))
+    transformed = tomllib.loads(raw.decode("utf-8"))
+    transformed["squilla_router"]["default_tier"] = "c1"
+
+    patched = patch_import_config(raw, original, transformed).decode("utf-8")
+
+    before = raw.decode("utf-8").split(newline)
+    after = patched.split(newline)
+    assert len(before) == len(after)
+    differing = [i for i, (a, b) in enumerate(zip(before, after)) if a != b]
+    assert differing == [before.index('default_tier = "c2"')]
+    assert after[differing[0]] == 'default_tier = "c1"'
+
+
+@pytest.mark.parametrize("newline", ["\n", "\r\n"])
+def test_escaped_windows_paths_survive_an_insertion(newline: str) -> None:
+    raw = DESKTOP_PROFILE_CONFIG.replace("\n", newline).encode("utf-8")
+    original = tomllib.loads(raw.decode("utf-8"))
+    transformed = tomllib.loads(raw.decode("utf-8"))
+    transformed.setdefault("sandbox", {})["run_mode"] = "full"
+
+    patched = patch_import_config(raw, original, transformed).decode("utf-8")
+
+    for line in raw.decode("utf-8").split(newline):
+        assert line in patched.split(newline)
+    assert tomllib.loads(patched) == transformed
+
+
+# ---------------------------------------------------------------------------
 # Triple-quoted strings: their bodies are not TOML
 # ---------------------------------------------------------------------------
 

--- a/tests/test_lossless_toml.py
+++ b/tests/test_lossless_toml.py
@@ -142,6 +142,102 @@ def test_crlf_config_with_a_multi_line_array_keeps_its_line_endings() -> None:
     assert "\r\n" in patched
 
 
+@pytest.mark.parametrize("quote", ['"', "'"])
+@pytest.mark.parametrize("terminal_quotes", [3, 4, 5])
+def test_terminal_quote_runs_inside_an_array_do_not_hide_the_next_table(
+    quote: str,
+    terminal_quotes: int,
+) -> None:
+    delimiter = quote * 3
+    raw = (
+        "[cors]\n"
+        f"allowed_origins = [{delimiter}https://example.com{quote * terminal_quotes} ]\n"
+        "\n"
+        "[sandbox]\n"
+        "sandbox = true\n"
+    ).encode()
+
+    from opensquilla.sandbox.upgrade_migration import lossless_patch_sandbox_fields
+
+    patched, mode = lossless_patch_sandbox_fields(raw)
+    payload = tomllib.loads(patched.decode("utf-8"))
+    assert mode == "safe"
+    assert payload["sandbox"]["run_mode"] == "safe"
+    assert payload["cors"]["allowed_origins"] == [
+        "https://example.com" + quote * (terminal_quotes - 3)
+    ]
+
+
+@pytest.mark.parametrize("quote", ['"', "'"])
+@pytest.mark.parametrize("opening_quotes", [3, 4, 5])
+def test_opening_quote_runs_inside_an_array_keep_the_collection_close_visible(
+    quote: str,
+    opening_quotes: int,
+) -> None:
+    delimiter = quote * 3
+    raw = (
+        "[cors]\n"
+        f"allowed_origins = [{quote * opening_quotes}example{delimiter} ]\n"
+        "\n"
+        "[sandbox]\n"
+        "sandbox = true\n"
+    ).encode()
+
+    from opensquilla.sandbox.upgrade_migration import lossless_patch_sandbox_fields
+
+    patched, mode = lossless_patch_sandbox_fields(raw)
+    payload = tomllib.loads(patched.decode("utf-8"))
+    assert mode == "safe"
+    assert payload["sandbox"]["run_mode"] == "safe"
+    assert payload["cors"]["allowed_origins"] == [
+        quote * (opening_quotes - 3) + "example"
+    ]
+
+
+@pytest.mark.parametrize("separator", ["\u0085", "\u2028", "\u2029"])
+def test_unicode_string_separators_are_not_toml_physical_lines(separator: str) -> None:
+    raw = f'name = "before{separator}after"\n'.encode()
+    patched = _patched(
+        raw,
+        lambda payload: payload.setdefault("sandbox", {}).update(run_mode="full"),
+    )
+    assert f'before{separator}after' in patched
+    assert tomllib.loads(patched)["sandbox"]["run_mode"] == "full"
+
+
+def test_insertion_after_an_eof_assignment_adds_a_physical_newline() -> None:
+    raw = b"port = 1"
+    patched = _patched(
+        raw,
+        lambda payload: payload.setdefault("sandbox", {}).update(run_mode="full"),
+    )
+    assert patched == 'port = 1\nsandbox.run_mode = "full"'
+
+
+def test_boot_stamp_after_an_eof_table_assignment_adds_a_physical_newline() -> None:
+    from opensquilla.sandbox.upgrade_migration import lossless_patch_sandbox_fields
+
+    raw = b"[sandbox]\nsandbox = true"
+    patched, mode = lossless_patch_sandbox_fields(raw)
+    assert mode == "safe"
+    assert patched == b'[sandbox]\nsandbox = true\nrun_mode = "safe"'
+
+
+def test_multiple_eof_insertions_have_separators_without_adding_a_final_newline() -> None:
+    raw = b"port = 1"
+    patched = _patched(raw, lambda payload: payload.update(alpha=1, beta=2))
+    assert patched == "port = 1\nalpha = 1\nbeta = 2"
+
+
+def test_crlf_eof_insertion_uses_crlf_without_adding_a_final_newline() -> None:
+    from opensquilla.sandbox.upgrade_migration import lossless_patch_sandbox_fields
+
+    raw = b"port = 1\r\n[sandbox]\r\nsandbox = true"
+    patched, mode = lossless_patch_sandbox_fields(raw)
+    assert mode == "safe"
+    assert patched == b'port = 1\r\n[sandbox]\r\nsandbox = true\r\nrun_mode = "safe"'
+
+
 # ---------------------------------------------------------------------------
 # Configs with no multi-line value must come through untouched
 # ---------------------------------------------------------------------------

--- a/tests/test_migration/test_sandbox_direct_update.py
+++ b/tests/test_migration/test_sandbox_direct_update.py
@@ -85,6 +85,50 @@ def test_direct_update_is_idempotent_and_keeps_one_snapshot(tmp_path: Path) -> N
     assert len(list(tmp_path.glob(".sandbox-upgrade-snapshot*"))) == 1
 
 
+def test_prepared_agent_config_retries_to_committed_without_losing_the_agent(
+    tmp_path: Path,
+) -> None:
+    raw = b'''agents = [
+    { id = "qa-agent", name = "QA Agent", enabled = true },
+]
+'''
+    config = tmp_path / "config.toml"
+    config.write_bytes(raw)
+    snapshot = tmp_path / upgrade_migration.SNAPSHOT_NAME
+    snapshot.mkdir()
+    (snapshot / "config.toml").write_bytes(raw)
+    (snapshot / "manifest.json").write_text(
+        json.dumps({"stores": [{"path": "config.toml"}]}) + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / upgrade_migration.JOURNAL_NAME).write_text(
+        json.dumps(
+            {
+                "migrationVersion": upgrade_migration.MIGRATION_VERSION,
+                "status": "prepared",
+                "stores": ["config.toml"],
+                "snapshot": str(snapshot),
+                "error": (
+                    "LosslessTomlPatchError: unsupported TOML key expression: { id"
+                ),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = SandboxUpgradeCoordinator(tmp_path).run()
+
+    assert report.ok is True
+    assert report.status == "committed"
+    assert (snapshot / "config.toml").read_bytes() == raw
+    patched = config.read_bytes()
+    assert b'{ id = "qa-agent", name = "QA Agent", enabled = true },' in patched
+    assert tomllib.loads(patched.decode("utf-8"))["sandbox"]["run_mode"] == "full"
+    journal = json.loads((tmp_path / upgrade_migration.JOURNAL_NAME).read_text())
+    assert journal["status"] == "committed"
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
 def test_direct_update_snapshot_is_owner_only_on_posix(tmp_path: Path) -> None:
     config = tmp_path / "config.toml"


### PR DESCRIPTION
## What breaks

Adding a custom Agent can write a valid multi-line TOML value such as:

```toml
agents = [
    { id = "qa-agent", name = "QA Agent", enabled = true },
]
```

The old lossless scanner treated each physical line containing `=` as a complete assignment. It therefore parsed `{ id` as a key expression and aborted the sandbox-v2 boot migration with `migration_failed_manual_recovery_required`. The profile then remained unable to start until its Agent stanza was removed manually.

Nested arrays and triple-quoted strings could trigger the same scanner assumption.

## What changed

- Track collection depth and open triple-quoted strings so an untouched multi-line value is scanned as one value and skipped safely.
- Keep edits inside a multi-line value fail-closed; only unrelated scalar edits proceed.
- Consume complete three-, four-, and five-quote terminator runs so a content quote cannot hide a following `]` or `}`.
- Split only at TOML physical newlines (LF/CRLF), preserving valid U+0085/U+2028/U+2029 characters inside strings.
- Insert fields safely when the source file has no final newline while preserving its newline convention and final-newline bit.
- Retry an existing `prepared` Agent-profile migration to `committed` without deleting the Agent or replacing the snapshot.

The final `tomllib` parse and exact transformed-payload proof remain in place. Snapshot, journal, and atomic-write behavior are unchanged.

## Scope and compatibility

- Base branch: `main`
- Target exception: not applicable
- Linked issue: Fixes #1106. This removes the trigger behind #1107, but does not change recovery-command readiness validation.
- Persisted-data compatibility: existing affected `prepared` profiles self-heal on the next start; Agent configuration and snapshots are preserved.
- Platform impact: scanner logic is platform-neutral; LF and CRLF behavior are covered explicitly and the Windows shard manifests include the new test module.
- Dependencies and public interfaces: unchanged.

Known pre-existing fail-closed limitations involving typed TOML values (`nan`, date/time metadata) and repeated nested array-of-table subcontexts are out of scope and were verified not to regress.

## Verification

Local verification on the exact rebased head:

- `179 passed, 17 skipped` across lossless TOML, sandbox migration/journal, and recovery consolidation tests.
- `ruff check src tests`: passed.
- `mypy src/opensquilla --show-error-codes`: passed (914 source files).
- Differential corpus: 30,000 valid TOML documents, 88,679 mutations, and 177,358 patch calls; zero `main-pass / candidate-fail` regressions.
- Quote-run cross-product: 864/864 successful comparisons.
- Real Gateway checks:
  - create an Agent through WebSocket RPC, stop, restart, and list the Agent;
  - recover a real `prepared` profile and verify a second restart is idempotent;
  - start with four-quote, Unicode-separator, CRLF, and no-final-newline configurations;
  - verify byte-exact snapshots and expected config changes.

Fresh GitHub Actions checks on the rebased head are required before merge.

## Release note

Adding a custom Agent no longer leaves the Gateway unable to start after restart.

## Third-party origin

None. No copied or vendored code and no new dependency.
