### PR TITLE
feat(openai-bridge): expose gateway agents as an OpenAI-compatible HTTP API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 requires-python = ">=3.12"
 dependencies = [
     "starlette>=0.40",
+    "fastapi>=0.115",
     "python-multipart>=0.0.20",
     "uvicorn[standard]>=0.30",
     "pydantic>=2.0",

--- a/src/opensquilla/cli/main.py
+++ b/src/opensquilla/cli/main.py
@@ -141,6 +141,7 @@ from opensquilla.cli.doctor_cmd import doctor_command  # noqa: E402
 from opensquilla.cli.ensemble_cmd import ensemble_app  # noqa: E402
 from opensquilla.cli.init_cmd import init_command  # noqa: E402
 from opensquilla.cli.mcp_server_cmd import app as mcp_server_app  # noqa: E402
+from opensquilla.cli.openai_bridge_cmd import app as openai_bridge_app  # noqa: E402
 from opensquilla.cli.memory_flush_cmd import memory_flush_session_cmd  # noqa: E402
 from opensquilla.cli.migrate_cmd import migrate_app  # noqa: E402
 from opensquilla.cli.models_cmd import app as models_app  # noqa: E402
@@ -192,8 +193,9 @@ app.add_typer(cost_app, name="cost")
 app.add_typer(diagnostics_app, name="diagnostics")
 app.add_typer(cron_app, name="cron")
 app.add_typer(dist_app, name="dist")
-app.add_typer(mcp_server_app, name="mcp-server")
-app.add_typer(migrate_app, name="migrate")
+app.add_typer(mcp_server_app, name="mcp-server")             
+app.add_typer(openai_bridge_app, name="openai-bridge")        
+app.add_typer(migrate_app, name="migrate")                   
 app.add_typer(recovery_app, name="recovery")
 app.add_typer(models_app, name="models")
 app.add_typer(ensemble_app, name="ensemble")

--- a/src/opensquilla/cli/openai_bridge_cmd.py
+++ b/src/opensquilla/cli/openai_bridge_cmd.py
@@ -1,0 +1,77 @@
+"""CLI commands for running the OpenAI-compatible HTTP bridge."""
+
+from __future__ import annotations
+
+import typer
+
+app = typer.Typer(help="Run the OpenAI-compatible HTTP bridge.")
+
+
+@app.command("run")
+def run_openai_bridge(
+    host: str = typer.Option(
+        "127.0.0.1",
+        "--host",
+        envvar="OPENAI_BRIDGE_HOST",
+        help="监听地址（默认 127.0.0.1）。",
+    ),
+    port: int = typer.Option(
+        8787,
+        "--port",
+        envvar="OPENAI_BRIDGE_PORT",
+        help="监听端口（默认 8787）。",
+    ),
+    gateway_url: str = typer.Option(
+        "ws://localhost:18791/ws",
+        "--gateway",
+        envvar="OPENAI_BRIDGE_GATEWAY_URL",
+        help="OpenSquilla gateway WebSocket 地址。",
+    ),
+    token: str | None = typer.Option(
+        None,
+        "--token",
+        envvar="OPENAI_BRIDGE_TOKEN",
+        help="适配层 API Key（缺省自动生成随机值）。",
+    ),
+    no_auth: bool = typer.Option(
+        False,
+        "--no-auth",
+        envvar="OPENAI_BRIDGE_NO_AUTH",
+        help="跳过适配层认证（仅限本地调试）。",
+    ),
+    session_mode: str = typer.Option(
+        "persistent",
+        "--session-mode",
+        envvar="OPENAI_BRIDGE_SESSION_MODE",
+        help="persistent=每模型常驻会话（agent 有记忆）；stateless=每请求新会话。",
+    ),
+    display_model: str = typer.Option(
+        "OpenSquilla",
+        "--display-model",
+        envvar="OPENAI_BRIDGE_MODEL",
+        help="对外暴露的模型名（默认 OpenSquilla），内部映射到 main agent。",
+    ),
+    timeout: float = typer.Option(
+        180,
+        "--timeout",
+        envvar="OPENAI_BRIDGE_TIMEOUT",
+        help="非流式响应最长等待秒数（默认 180）。",
+    ),
+) -> None:
+    """启动 OpenAI 兼容 HTTP 桥接服务。
+
+    将 OpenSquilla gateway 的 agent 能力暴露为 /v1/chat/completions，
+    任何支持 OpenAI SDK 的客户端均可直接接入。
+    """
+    from opensquilla.openai_bridge import run_server
+
+    run_server(
+        host=host,
+        port=port,
+        gateway_url=gateway_url,
+        bridge_token=token,
+        no_auth=no_auth,
+        session_mode=session_mode,
+        display_model=display_model,
+        timeout_s=timeout,
+    )

--- a/src/opensquilla/gateway_client.py
+++ b/src/opensquilla/gateway_client.py
@@ -82,7 +82,12 @@ class GatewayRPCClient:
         self._connection_error: ConnectionError | None = None
         self._closing = False
 
-    async def connect(self, url: str = "ws://localhost:18791/ws") -> None:
+    async def connect(
+        self,
+        url: str = "ws://localhost:18791/ws",
+        *,
+        token: str | None = None,
+    ) -> None:
         if self._ws is not None:
             await self.close()
         self._closing = False
@@ -105,18 +110,21 @@ class GatewayRPCClient:
                 raise RuntimeError(f"Unexpected gateway handshake frame: {challenge}")
 
             req_id = str(uuid.uuid4())
+            connect_params: dict[str, Any] = {
+                "minProtocol": 1,
+                "maxProtocol": 3,
+                "role": "operator",
+                "scopes": self.scopes,
+            }
+            if token:
+                connect_params["auth"] = {"token": token}
             await self._ws.send(
                 json.dumps(
                     {
                         "type": "req",
                         "id": req_id,
                         "method": "connect",
-                        "params": {
-                            "minProtocol": 1,
-                            "maxProtocol": 3,
-                            "role": "operator",
-                            "scopes": self.scopes,
-                        },
+                        "params": connect_params,
                     }
                 )
             )

--- a/src/opensquilla/openai_bridge/__init__.py
+++ b/src/opensquilla/openai_bridge/__init__.py
@@ -1,0 +1,10 @@
+"""OpenAI 兼容 HTTP 桥接层。
+
+将 OpenSquilla gateway 的 agent 能力以 OpenAI 兼容端点（/v1/chat/completions）
+暴露给任何支持 OpenAI SDK 的平台/工具。
+
+直接启动： ``python -m opensquilla.openai_bridge.server``
+CLI 启动： ``opensquilla openai-bridge run``
+"""
+
+from opensquilla.openai_bridge.server import create_app, run_server  # noqa: F401

--- a/src/opensquilla/openai_bridge/server.py
+++ b/src/opensquilla/openai_bridge/server.py
@@ -1,0 +1,570 @@
+"""OpenAI 兼容 HTTP 适配层：将 OpenSquilla gateway 暴露为 /v1/chat/completions。
+
+架构：
+    OpenAI 客户端 ──HTTP /v1/*──▶ 本适配层 ──WebSocket RPC──▶ OpenSquilla Gateway ──▶ Agent
+
+设计要点：
+    * 复用 OpenSquilla 自带的 GatewayRPCClient（已含 auth 握手补丁），不重复实现协议。
+    * 单连接原子化执行：subscribe → send → 收事件至终止帧，避免双连接的事件竞争。
+    * 流式输出直接转发 gateway 的 session.event.text_delta 增量。
+
+环境变量：
+    OPENAI_BRIDGE_HOST            监听地址（默认 127.0.0.1）
+    OPENAI_BRIDGE_PORT            监听端口（默认 8787）
+    OPENAI_BRIDGE_TOKEN           适配层 API Key（缺省自动生成随机值并打印到日志）
+    OPENAI_BRIDGE_NO_AUTH         设为 1 时跳过适配层认证（仅限本地调试）
+    OPENAI_BRIDGE_GATEWAY_URL     gateway WebSocket 地址（默认 ws://localhost:18791/ws）
+    OPENAI_BRIDGE_SESSION_MODE    persistent（默认，每模型一个常驻会话，agent 有记忆）
+                                  | stateless（每请求新建会话）
+    OPENAI_BRIDGE_TIMEOUT         非流式响应最长等待秒数（默认 180）
+
+请求头：
+    X-OpenSquilla-Session         指定会话 key（默认 persistent key）
+    X-OpenSquilla-New-Session     设为 1 强制新建会话
+    X-OpenSquilla-Route           路由钉选：auto（自动路由）/ tier:c2（或裸 c2）等；
+                                  仅作用于当前请求，turn 结束自动恢复自动路由
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import secrets
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+import uvicorn
+from fastapi import Depends, FastAPI, Header, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+from opensquilla.cli.gateway_rpc import default_gateway_token
+from opensquilla.gateway_client import GatewayRPCClient, GatewayRPCError
+
+# --------------------------------------------------------------------------
+# 配置
+# --------------------------------------------------------------------------
+HOST = os.environ.get("OPENAI_BRIDGE_HOST", "127.0.0.1")
+PORT = int(os.environ.get("OPENAI_BRIDGE_PORT", "8787"))
+GATEWAY_URL = os.environ.get(
+    "OPENAI_BRIDGE_GATEWAY_URL", "ws://localhost:18791/ws"
+)
+SESSION_MODE = os.environ.get("OPENAI_BRIDGE_SESSION_MODE", "persistent").strip().lower()
+TIMEOUT_S = float(os.environ.get("OPENAI_BRIDGE_TIMEOUT", "180"))
+NO_AUTH = os.environ.get("OPENAI_BRIDGE_NO_AUTH", "") == "1"
+
+# 对外模型显示名：OpenAI 客户端看到的名字（默认 OpenSquilla），内部映射回 agent id。
+DISPLAY_MODEL = os.environ.get("OPENAI_BRIDGE_MODEL", "OpenSquilla").strip() or "OpenSquilla"
+_MODEL_TO_AGENT = {DISPLAY_MODEL.casefold(): "main"}
+
+
+def _resolve_agent_id(model: str) -> str:
+    """把请求中的模型名映射为 gateway agent id（兼容 agent: 前缀）。"""
+    name = str(model).removeprefix("agent:")
+    return _MODEL_TO_AGENT.get(name.casefold(), name)
+BRIDGE_TOKEN = os.environ.get("OPENAI_BRIDGE_TOKEN", "").strip() or (
+    None if NO_AUTH else secrets.token_hex(16)
+)
+
+# 与 mcp_server/bridge.py 同源的终止事件集合
+_TERMINAL_EVENTS = {
+    "session.event.done",
+    "session.event.error",
+    "task.cancelled",
+    "task.failed",
+    "task.timeout",
+    "task.abandoned",
+}
+_TEXT_DELTA = "session.event.text_delta"
+_STREAM_FRAME_TIMEOUT_S = 300.0
+
+
+def _normalize_event_frame(frame: dict[str, Any]) -> dict[str, Any]:
+    if "event" in frame and "payload" in frame:
+        return frame
+    return {"event": frame.get("event"), "payload": frame.get("payload") or frame}
+
+
+def _gateway_token() -> str:
+    token = os.environ.get("OPENSQUILLA_GATEWAY_TOKEN", "").strip()
+    if not token:
+        try:
+            token = default_gateway_token() or ""
+        except Exception:  # noqa: BLE001 - 配置缺失时回退
+            token = ""
+    return token.strip()
+
+
+async def _new_client() -> GatewayRPCClient:
+    client = GatewayRPCClient()
+    token = _gateway_token()
+    await client.connect(GATEWAY_URL, auth={"token": token} if token else None)
+    return client
+
+
+# --------------------------------------------------------------------------
+# 会话管理
+# --------------------------------------------------------------------------
+# persistent 模式：sessions.create 不接受自定义 key（gateway 自动生成
+# ``agent:{agent_id}:{hex}``），因此把创建返回的真实 key 落盘缓存，之后
+# 请求优先复用缓存 key（resolve 失败则重建）。修复 v1 "每次请求都新建
+# 会话" 导致记忆丢失、孤儿会话堆积的问题。
+_SESSION_CACHE_DIR = Path(__file__).resolve().parent / ".session_cache"
+
+
+def _persistent_key_file(agent_id: str) -> Path:
+    safe = agent_id.replace(":", "_").replace("/", "_").replace("\\", "_")
+    return _SESSION_CACHE_DIR / f"{safe}.json"
+
+
+def _read_cached_key(agent_id: str) -> str | None:
+    try:
+        data = json.loads(_persistent_key_file(agent_id).read_text(encoding="utf-8"))
+        key = data.get("key") if isinstance(data, dict) else None
+        return key if isinstance(key, str) and key else None
+    except Exception:  # noqa: BLE001 - 缓存缺失/损坏时退回新建
+        return None
+
+
+def _write_cached_key(agent_id: str, key: str) -> None:
+    try:
+        _SESSION_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        _persistent_key_file(agent_id).write_text(
+            json.dumps({"agent_id": agent_id, "key": key}, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+    except Exception:  # noqa: BLE001 - 缓存写失败不阻断请求
+        print(f"[openai-bridge] persistent key 缓存失败: {key}")
+
+
+async def _create_session(client: GatewayRPCClient, agent_id: str) -> str:
+    result = await client.call(
+        "sessions.create",
+        {"agentId": agent_id, "displayName": f"OpenAI bridge ({agent_id})"},
+    )
+    key = result.get("key") if isinstance(result, dict) else None
+    if not key:
+        raise RuntimeError(f"sessions.create 未返回 key: {result!r}")
+    return key
+
+
+async def _resolve_or_create_session(
+    client: GatewayRPCClient, agent_id: str, *, explicit_key: str | None, force_new: bool
+) -> str:
+    if explicit_key:
+        try:
+            await client.resolve_session(explicit_key)
+            return explicit_key
+        except GatewayRPCError as exc:
+            raise HTTPException(404, f"会话不存在或不可用: {exc}") from exc
+    if SESSION_MODE == "stateless":
+        return await _create_session(client, agent_id)
+    if force_new:
+        key = await _create_session(client, agent_id)
+        _write_cached_key(agent_id, key)
+        return key
+    # persistent：优先复用缓存 key
+    cached = _read_cached_key(agent_id)
+    if cached:
+        try:
+            await client.resolve_session(cached)
+            return cached
+        except GatewayRPCError:
+            pass  # 缓存失效（会话被删/清库），重建
+    key = await _create_session(client, agent_id)
+    _write_cached_key(agent_id, key)
+    return key
+
+
+# 同一会话同时只允许一个 turn 在途，防止事件流互相串扰
+_session_locks: dict[str, asyncio.Lock] = {}
+_session_locks_guard = asyncio.Lock()
+
+
+async def _get_session_lock(key: str) -> asyncio.Lock:
+    async with _session_locks_guard:
+        lock = _session_locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            _session_locks[key] = lock
+        return lock
+
+
+# --------------------------------------------------------------------------
+# 消息与请求组装
+# --------------------------------------------------------------------------
+def _extract_text_content(content: Any) -> str | None:
+    if isinstance(content, str):
+        return content if content.strip() else None
+    if isinstance(content, list):
+        parts: list[str] = []
+        for seg in content:
+            if isinstance(seg, dict) and seg.get("type") == "text":
+                t = seg.get("text")
+                if isinstance(t, str) and t.strip():
+                    parts.append(t.strip())
+        return "\n".join(parts) if parts else None
+    return None
+
+
+def _build_user_message(messages: list[dict[str, Any]]) -> str:
+    """取最后一条 user 消息；system 消息作为前缀拼入（v1 简化策略）。"""
+    prefix_parts: list[str] = []
+    last_user: str | None = None
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        text = _extract_text_content(msg.get("content"))
+        if not text:
+            continue
+        if role == "system":
+            prefix_parts.append(text)
+        elif role == "user":
+            last_user = text
+    if last_user is None:
+        raise HTTPException(400, "messages 中缺少 user 消息")
+    if prefix_parts:
+        return "System:\n" + "\n\n".join(prefix_parts) + "\n\nUser:\n" + last_user
+    return last_user
+
+
+def _extract_final_text(events: list[dict[str, Any]]) -> str:
+    parts: list[str] = []
+    for ev in events:
+        if ev.get("event") == _TEXT_DELTA:
+            t = ev.get("payload", {}).get("text")
+            if isinstance(t, str) and t:
+                parts.append(t)
+    return "".join(parts)
+
+
+# --------------------------------------------------------------------------
+# 路由钉选（X-OpenSquilla-Route）
+# --------------------------------------------------------------------------
+# 通过 gateway 的 routing.hold.set/clear RPC 实现 tier 钉选：turn 前设置
+# hold（仅当前请求，turns=1），turn 结束后无论成败都恢复自动路由。
+# 目标值支持 auto / tier:c2 / 裸 c2 等（routing.hold.set 内部会规范化）。
+AUTO_TARGET = "auto"
+
+
+async def _apply_route_hold(client: GatewayRPCClient, key: str, route: str | None) -> None:
+    """Turn 前应用路由钉选；route 为空或 auto 时跳过。"""
+    if not route or route.strip().lower() == AUTO_TARGET:
+        return
+    target = route.strip()
+    try:
+        await client.call(
+            "routing.hold.set",
+            {"sessionKey": key, "target": target, "turns": 1},
+        )
+    except GatewayRPCError as exc:
+        # 钉选失败不阻断请求：回退自动路由并如实告警
+        print(f"[openai-bridge] routing.hold.set 失败，回退自动路由: {exc}")
+
+
+async def _clear_route_hold(client: GatewayRPCClient, key: str, route: str | None) -> None:
+    """Turn 结束后恢复自动路由；失败仅告警不影响返回。"""
+    if not route or route.strip().lower() == AUTO_TARGET:
+        return
+    try:
+        await client.call("routing.hold.clear", {"sessionKey": key})
+    except GatewayRPCError as exc:
+        print(f"[openai-bridge] routing.hold.clear 失败: {exc}")
+
+
+# --------------------------------------------------------------------------
+# 单连接 turn 执行（subscribe → send → 收事件至终止）
+# --------------------------------------------------------------------------
+async def _run_turn(
+    key: str, user_message: str, route: str | None = None
+) -> list[dict[str, Any]]:
+    client = await _new_client()
+    try:
+        await _apply_route_hold(client, key, route)
+        await client.call(
+            "sessions.messages.subscribe", {"key": key, "since_stream_seq": None}
+        )
+        await client.call(
+            "sessions.send",
+            {
+                "key": key,
+                "message": user_message,
+                "attachments": [],
+                "intent": "continue",
+                "_source": {
+                    "caller_kind": "cli",
+                    "channel_kind": "cli",
+                    "channel_id": "openai-bridge",
+                    "source_kind": "openai_bridge",
+                    "source_name": "openai_bridge",
+                },
+            },
+        )
+        events: list[dict[str, Any]] = []
+        while True:
+            frame = await client.recv_event(timeout=_STREAM_FRAME_TIMEOUT_S)
+            norm = _normalize_event_frame(frame)
+            payload = norm.get("payload")
+            if not isinstance(payload, dict) or payload.get("session_key") != key:
+                continue
+            name = str(norm.get("event") or "")
+            events.append({"event": name, "payload": payload})
+            if name in _TERMINAL_EVENTS:
+                break
+        return events
+    finally:
+        await _clear_route_hold(client, key, route)
+        await client.close()
+
+
+# --------------------------------------------------------------------------
+# 响应组装
+# --------------------------------------------------------------------------
+def _chat_completion(chat_id: str, created: int, model: str, content: str) -> dict[str, Any]:
+    return {
+        "id": chat_id,
+        "object": "chat.completion",
+        "created": created,
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+        # 说明：gateway 事件未暴露 token 统计，置零占位
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    }
+
+
+def _chunk(chat_id: str, created: int, model: str, delta: dict[str, Any], finish: str | None) -> str:
+    data = {
+        "id": chat_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": model,
+        "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+    }
+    return f"data: {json_dumps(data)}\n\n"
+
+
+def json_dumps(obj: Any) -> str:
+    import json
+
+    return json.dumps(obj, ensure_ascii=False)
+
+
+# --------------------------------------------------------------------------
+# FastAPI 应用
+# --------------------------------------------------------------------------
+app = FastAPI(title="OpenSquilla OpenAI Bridge", version="0.1.0")
+
+
+async def require_bridge_token(authorization: str | None = Header(None)) -> str | None:
+    if NO_AUTH:
+        return None
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(
+            401,
+            detail={
+                "error": {
+                    "message": "缺少或非法的 Authorization 头",
+                    "type": "invalid_request_error",
+                    "code": "invalid_api_key",
+                }
+            },
+        )
+    token = authorization[len("Bearer "):].strip()
+    if not BRIDGE_TOKEN or token != BRIDGE_TOKEN:
+        raise HTTPException(
+            401,
+            detail={
+                "error": {
+                    "message": "API Key 无效",
+                    "type": "invalid_request_error",
+                    "code": "invalid_api_key",
+                }
+            },
+        )
+    return token
+
+
+@app.get("/v1/models")
+async def list_models(_: str | None = Depends(require_bridge_token)) -> dict[str, Any]:
+    # 对外只暴露显示名（默认 OpenSquilla），内部由 _resolve_agent_id 映射回 agent id。
+    ids = [DISPLAY_MODEL]
+    return {
+        "object": "list",
+        "data": [
+            {"id": i, "object": "model", "created": int(time.time()), "owned_by": "opensquilla"}
+            for i in ids
+        ],
+    }
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(
+    request: Request,
+    _: str | None = Depends(require_bridge_token),
+) -> Any:
+    try:
+        body = await request.json()
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(400, "请求体不是合法 JSON") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(400, "请求体必须是 JSON 对象")
+
+    model = str(body.get("model") or DISPLAY_MODEL)
+    agent_id = _resolve_agent_id(model)
+    stream = bool(body.get("stream", False))
+    messages = body.get("messages")
+    if not isinstance(messages, list) or not messages:
+        raise HTTPException(400, "messages 必须是非空数组")
+
+    user_message = _build_user_message(messages)
+
+    explicit_key = request.headers.get("X-OpenSquilla-Session")
+    force_new = request.headers.get("X-OpenSquilla-New-Session", "") == "1"
+    route = request.headers.get("X-OpenSquilla-Route")
+
+    # 解析/创建会话 key
+    client = await _new_client()
+    try:
+        key = await _resolve_or_create_session(
+            client, agent_id, explicit_key=explicit_key, force_new=force_new
+        )
+    finally:
+        await client.close()
+
+    chat_id = f"chatcmpl-{uuid.uuid4().hex}"
+    created = int(time.time())
+
+    lock = await _get_session_lock(key)
+
+    if stream:
+
+        async def event_stream():
+            # 锁在生成器内部持有：流被消费的整个生命周期内互斥
+            async with lock:
+                c = await _new_client()
+                try:
+                    await _apply_route_hold(c, key, route)
+                    await c.call(
+                        "sessions.messages.subscribe",
+                        {"key": key, "since_stream_seq": None},
+                    )
+                    await c.call(
+                        "sessions.send",
+                        {
+                            "key": key,
+                            "message": user_message,
+                            "attachments": [],
+                            "intent": "continue",
+                            "_source": {
+                                "caller_kind": "cli",
+                                "channel_kind": "cli",
+                                "channel_id": "openai-bridge",
+                                "source_kind": "openai_bridge",
+                                "source_name": "openai_bridge",
+                            },
+                        },
+                    )
+                    yield _chunk(chat_id, created, model, {"role": "assistant"}, None)
+                    while True:
+                        frame = await c.recv_event(timeout=_STREAM_FRAME_TIMEOUT_S)
+                        norm = _normalize_event_frame(frame)
+                        payload = norm.get("payload")
+                        if not isinstance(payload, dict) or payload.get("session_key") != key:
+                            continue
+                        name = str(norm.get("event") or "")
+                        if name == _TEXT_DELTA:
+                            t = payload.get("text")
+                            if isinstance(t, str) and t:
+                                yield _chunk(chat_id, created, model, {"content": t}, None)
+                        if name in _TERMINAL_EVENTS:
+                            yield _chunk(chat_id, created, model, {}, "stop")
+                            yield "data: [DONE]\n\n"
+                            return
+                finally:
+                    await _clear_route_hold(c, key, route)
+                    await c.close()
+
+        return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+    # 非流式：同一会话串行执行
+    async with lock:
+        try:
+            events = await asyncio.wait_for(
+                _run_turn(key, user_message, route=route), timeout=TIMEOUT_S
+            )
+        except asyncio.TimeoutError as exc:
+            raise HTTPException(504, f"agent 响应超时（>{TIMEOUT_S:g}s）") from exc
+        content = _extract_final_text(events)
+        return _chat_completion(chat_id, created, model, content)
+
+
+def create_app(
+    *,
+    gateway_url: str | None = None,
+    bridge_token: str | None = None,
+    no_auth: bool | None = None,
+    session_mode: str | None = None,
+    display_model: str | None = None,
+    timeout_s: float | None = None,
+) -> FastAPI:
+    """创建 FastAPI 应用（可注入配置覆盖环境变量，便于测试）。
+
+    参数全部可选，缺省从环境变量读取。返回已注册路由的 app 实例。
+    """
+    global GATEWAY_URL, BRIDGE_TOKEN, NO_AUTH, SESSION_MODE, DISPLAY_MODEL, TIMEOUT_S  # noqa: PLW0603
+    if gateway_url is not None:
+        GATEWAY_URL = gateway_url
+    if bridge_token is not None:
+        BRIDGE_TOKEN = bridge_token
+    if no_auth is not None:
+        NO_AUTH = no_auth
+    if session_mode is not None:
+        SESSION_MODE = session_mode.strip().lower()
+    if display_model is not None:
+        DISPLAY_MODEL = display_model.strip() or "OpenSquilla"
+        _MODEL_TO_AGENT.clear()
+        _MODEL_TO_AGENT[DISPLAY_MODEL.casefold()] = "main"
+    if timeout_s is not None:
+        TIMEOUT_S = float(timeout_s)
+    return app
+
+
+def run_server(
+    *,
+    host: str | None = None,
+    port: int | None = None,
+    gateway_url: str | None = None,
+    bridge_token: str | None = None,
+    no_auth: bool | None = None,
+    session_mode: str | None = None,
+    display_model: str | None = None,
+    timeout_s: float | None = None,
+    log_level: str = "info",
+) -> None:
+    """启动 uvicorn HTTP 服务。"""
+    create_app(
+        gateway_url=gateway_url,
+        bridge_token=bridge_token,
+        no_auth=no_auth,
+        session_mode=session_mode,
+        display_model=display_model,
+        timeout_s=timeout_s,
+    )
+    if BRIDGE_TOKEN and not NO_AUTH:
+        print(f"[openai-bridge] API Key: {BRIDGE_TOKEN}")
+    print(f"[openai-bridge] listening on http://{HOST}:{PORT}")
+    print(f"[openai-bridge] gateway: {GATEWAY_URL} | session mode: {SESSION_MODE}")
+    uvicorn.run(app, host=host or HOST, port=port or PORT, log_level=log_level)
+
+
+if __name__ == "__main__":
+    run_server()

--- a/src/opensquilla/openai_bridge/server.py
+++ b/src/opensquilla/openai_bridge/server.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import secrets
 import time
 import uuid
@@ -38,7 +39,7 @@ from typing import Any
 
 import uvicorn
 from fastapi import Depends, FastAPI, Header, HTTPException, Request
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from opensquilla.cli.gateway_rpc import default_gateway_token
 from opensquilla.gateway_client import GatewayRPCClient, GatewayRPCError
@@ -79,6 +80,40 @@ _TERMINAL_EVENTS = {
 }
 _TEXT_DELTA = "session.event.text_delta"
 _STREAM_FRAME_TIMEOUT_S = 300.0
+
+# Agent 内部的路由标记（[[reply_to_current]] / [[reply_to:<id>]]）不属于
+# OpenAI 协议内容，必须在输出边界剥除，否则外部客户端会把它当正文渲染。
+_REPLY_TAG_RE = re.compile(r"\[\[reply_to[^\]]*\]\]")
+
+
+def _strip_reply_tags(text: str) -> str:
+    return _REPLY_TAG_RE.sub("", text)
+
+
+def _filter_stream_delta(carry: str, chunk: str) -> tuple[str, str]:
+    """跨 SSE 增量剥除路由标记，返回 (可输出文本, 新 carry)。
+
+    gateway 的 text_delta 可能在标记中间切分（实测出现过 '[[reply_to' +
+    '_current]]' 分两个增量到达），因此对未闭合的 '[[' 尾部做暂存，
+    等下一个增量到达再判定；已闭合但非路由标记的 [[...]] 原样放行。
+    """
+    carry += chunk
+    out_parts: list[str] = []
+    while True:
+        m = _REPLY_TAG_RE.search(carry)
+        if m:
+            out_parts.append(carry[: m.start()])
+            carry = carry[m.end():]
+            continue
+        idx = carry.rfind("[[")
+        if idx == -1 or "]]" in carry[idx:]:
+            out_parts.append(carry)
+            carry = ""
+        else:
+            out_parts.append(carry[:idx])
+            carry = carry[idx:]
+        break
+    return "".join(out_parts), carry
 
 
 def _normalize_event_frame(frame: dict[str, Any]) -> dict[str, Any]:
@@ -238,7 +273,7 @@ def _extract_final_text(events: list[dict[str, Any]]) -> str:
             t = ev.get("payload", {}).get("text")
             if isinstance(t, str) and t:
                 parts.append(t)
-    return "".join(parts)
+    return _strip_reply_tags("".join(parts))
 
 
 # --------------------------------------------------------------------------
@@ -364,6 +399,26 @@ def json_dumps(obj: Any) -> str:
 app = FastAPI(title="OpenSquilla OpenAI Bridge", version="0.1.0")
 
 
+@app.exception_handler(HTTPException)
+async def openai_error_envelope(_: Request, exc: HTTPException) -> JSONResponse:
+    """按 OpenAI 协议输出错误体（{"error": {...}}）。
+
+    FastAPI 默认的 {"detail": ...} 形状会让按 error.message 解析的
+    SDK 类客户端（Cherry Studio 等）拿不到失败原因。
+    """
+    if isinstance(exc.detail, dict) and "error" in exc.detail:
+        payload = exc.detail
+    else:
+        payload = {
+            "error": {
+                "message": str(exc.detail),
+                "type": "invalid_request_error" if exc.status_code < 500 else "server_error",
+                "code": "invalid_api_key" if exc.status_code == 401 else None,
+            }
+        }
+    return JSONResponse(status_code=exc.status_code, content=payload)
+
+
 async def require_bridge_token(authorization: str | None = Header(None)) -> str | None:
     if NO_AUTH:
         return None
@@ -474,6 +529,7 @@ async def chat_completions(
                         },
                     )
                     yield _chunk(chat_id, created, model, {"role": "assistant"}, None)
+                    carry = ""
                     while True:
                         frame = await c.recv_event(timeout=_STREAM_FRAME_TIMEOUT_S)
                         norm = _normalize_event_frame(frame)
@@ -484,8 +540,14 @@ async def chat_completions(
                         if name == _TEXT_DELTA:
                             t = payload.get("text")
                             if isinstance(t, str) and t:
-                                yield _chunk(chat_id, created, model, {"content": t}, None)
+                                clean, carry = _filter_stream_delta(carry, t)
+                                if clean:
+                                    yield _chunk(chat_id, created, model, {"content": clean}, None)
                         if name in _TERMINAL_EVENTS:
+                            if carry:
+                                tail = _strip_reply_tags(carry)
+                                if tail:
+                                    yield _chunk(chat_id, created, model, {"content": tail}, None)
                             yield _chunk(chat_id, created, model, {}, "stop")
                             yield "data: [DONE]\n\n"
                             return

--- a/src/opensquilla/openai_bridge/server.py
+++ b/src/opensquilla/openai_bridge/server.py
@@ -78,6 +78,9 @@ _TERMINAL_EVENTS = {
     "task.timeout",
     "task.abandoned",
 }
+# 正常完成的终止事件；其余终止事件视为失败，必须透传错误而不是伪装成功
+_SUCCESS_TERMINAL_EVENTS = {"session.event.done"}
+_FAILURE_TERMINAL_EVENTS = _TERMINAL_EVENTS - _SUCCESS_TERMINAL_EVENTS
 _TEXT_DELTA = "session.event.text_delta"
 _STREAM_FRAME_TIMEOUT_S = 300.0
 
@@ -274,6 +277,45 @@ def _extract_final_text(events: list[dict[str, Any]]) -> str:
             if isinstance(t, str) and t:
                 parts.append(t)
     return _strip_reply_tags("".join(parts))
+
+
+def _event_error_message(payload: dict[str, Any]) -> str:
+    """从终止事件 payload 提取可透传的错误描述。
+
+    优先级 error_message > message > 兑底（附 code）。gateway 的
+    _normalize_terminal_event_payload 会同时产出这两个字段，前者是
+    净化后的原始错误，后者是给用户看的 terminal 消息。
+    """
+    if not isinstance(payload, dict):
+        return "Agent error"
+    for field in ("error_message", "message"):
+        val = payload.get(field)
+        if isinstance(val, str) and val:
+            return val
+    code = payload.get("code")
+    return f"Agent error ({code})" if code else "Agent error"
+
+
+def _map_error_event(payload: dict[str, Any]) -> dict[str, str | None]:
+    """把失败终止事件映射为 OpenAI 错误信封字段。
+
+    gateway 侧 code 形如 agent_error / stream_idle_timeout /
+    provider_request_too_large；terminal_reason 为 timeout/failed/error。
+    """
+    message = _event_error_message(payload)
+    code = str(payload.get("code") or payload.get("error_class") or "agent_error")
+    reason = str(payload.get("terminal_reason") or "")
+    if reason == "timeout" or "timeout" in code.lower():
+        return {"message": message, "type": "timeout", "code": code}
+    return {"message": message, "type": "server_error", "code": code}
+
+
+def _collect_terminal_error(events: list[dict[str, Any]]) -> str | None:
+    """返回非流式事件序列中的失败描述；无失败返回 None。"""
+    for ev in events:
+        if ev.get("event") in _FAILURE_TERMINAL_EVENTS:
+            return _event_error_message(ev.get("payload") or {})
+    return None
 
 
 # --------------------------------------------------------------------------
@@ -548,7 +590,15 @@ async def chat_completions(
                                 tail = _strip_reply_tags(carry)
                                 if tail:
                                     yield _chunk(chat_id, created, model, {"content": tail}, None)
-                            yield _chunk(chat_id, created, model, {}, "stop")
+                            if name in _SUCCESS_TERMINAL_EVENTS:
+                                yield _chunk(chat_id, created, model, {}, "stop")
+                            else:
+                                # 失败终止：发错误 chunk（OpenAI SSE 错误形状）而非伪装 stop
+                                yield (
+                                    "data: "
+                                    + json_dumps({"error": _map_error_event(payload)})
+                                    + "\n\n"
+                                )
                             yield "data: [DONE]\n\n"
                             return
                 finally:
@@ -565,6 +615,18 @@ async def chat_completions(
             )
         except asyncio.TimeoutError as exc:
             raise HTTPException(504, f"agent 响应超时（>{TIMEOUT_S:g}s）") from exc
+        error_text = _collect_terminal_error(events)
+        if error_text:
+            raise HTTPException(
+                502,
+                detail={
+                    "error": {
+                        "message": error_text,
+                        "type": "server_error",
+                        "code": "agent_error",
+                    }
+                },
+            )
         content = _extract_final_text(events)
         return _chat_completion(chat_id, created, model, content)
 

--- a/src/opensquilla/openai_bridge/server.py
+++ b/src/opensquilla/openai_bridge/server.py
@@ -100,7 +100,7 @@ def _gateway_token() -> str:
 async def _new_client() -> GatewayRPCClient:
     client = GatewayRPCClient()
     token = _gateway_token()
-    await client.connect(GATEWAY_URL, auth={"token": token} if token else None)
+    await client.connect(GATEWAY_URL, token=token or None)
     return client
 
 

--- a/tests/test_openai_bridge/test_server.py
+++ b/tests/test_openai_bridge/test_server.py
@@ -1,0 +1,97 @@
+"""Tests for the OpenAI-compatible HTTP bridge."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from opensquilla.openai_bridge import server as bridge_server
+from opensquilla.openai_bridge.server import create_app, _resolve_agent_id
+
+
+def test_resolve_agent_id_default_mapping() -> None:
+    """默认显示名 OpenSquilla 映射回 main agent，大小写不敏感，直传 main 兼容。"""
+    assert _resolve_agent_id("OpenSquilla") == "main"
+    assert _resolve_agent_id("opensquilla") == "main"
+    assert _resolve_agent_id("main") == "main"
+    assert _resolve_agent_id("agent:OpenSquilla") == "main"
+
+
+def test_resolve_agent_id_custom_display_model() -> None:
+    """自定义显示名后映射仍正确，且不影响直传 agent id。"""
+    create_app(no_auth=True, bridge_token="sk-test", display_model="MyAgent")
+    try:
+        assert bridge_server._resolve_agent_id("MyAgent") == "main"
+        assert bridge_server._resolve_agent_id("myagent") == "main"
+        assert bridge_server._resolve_agent_id("other") == "other"
+    finally:
+        # 恢复默认（create_app 仅覆盖非 None 参数，必须显式传回默认值）
+        create_app(no_auth=True, bridge_token="sk-test", display_model="OpenSquilla")
+
+
+def test_app_routes_registered() -> None:
+    """核心路由必须存在。"""
+    app = create_app(no_auth=True, bridge_token="sk-test")
+    paths = {r.path for r in app.routes if hasattr(r, "path")}
+    assert "/v1/models" in paths
+    assert "/v1/chat/completions" in paths
+
+
+def test_models_requires_auth() -> None:
+    """无 Authorization 头必须 401。"""
+    app = create_app(no_auth=False, bridge_token="sk-test-1234")
+    client = TestClient(app)
+    resp = client.get("/v1/models")
+    assert resp.status_code == 401
+
+
+def test_models_returns_display_model() -> None:
+    """/v1/models 返回对外显示名 OpenSquilla。"""
+    app = create_app(no_auth=False, bridge_token="sk-test-1234")
+    client = TestClient(app)
+    resp = client.get("/v1/models", headers={"Authorization": "Bearer sk-test-1234"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["object"] == "list"
+    ids = [m["id"] for m in data["data"]]
+    assert ids == ["OpenSquilla"]
+
+
+def test_chat_completions_requires_auth() -> None:
+    """无 Authorization 头必须 401。"""
+    app = create_app(no_auth=False, bridge_token="sk-test-1234")
+    client = TestClient(app)
+    resp = client.post("/v1/chat/completions", json={"model": "OpenSquilla", "messages": []})
+    assert resp.status_code == 401
+
+
+def test_chat_completions_validates_messages() -> None:
+    """messages 缺失/为空必须 400（不触达 gateway）。"""
+    app = create_app(no_auth=True, bridge_token="sk-test-1234")
+    client = TestClient(app)
+    headers = {"Authorization": "Bearer sk-test-1234"}
+
+    resp = client.post("/v1/chat/completions", json={}, headers=headers)
+    assert resp.status_code == 400
+
+    resp = client.post(
+        "/v1/chat/completions", json={"model": "OpenSquilla", "messages": []}, headers=headers
+    )
+    assert resp.status_code == 400
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={"model": "OpenSquilla", "messages": "not-a-list"},
+        headers=headers,
+    )
+    assert resp.status_code == 400
+
+
+def test_chat_completions_no_auth_mode() -> None:
+    """OPENAI_BRIDGE_NO_AUTH=1 时跳过认证，请求进入业务校验。"""
+    app = create_app(no_auth=True, bridge_token="sk-test-1234")
+    client = TestClient(app)
+    # 无 token 也允许访问（no_auth 模式），但 messages 校验仍生效
+    resp = client.post(
+        "/v1/chat/completions", json={"model": "OpenSquilla", "messages": []}
+    )
+    assert resp.status_code == 400  # 走到消息校验而非 401

--- a/tests/test_openai_bridge/test_server.py
+++ b/tests/test_openai_bridge/test_server.py
@@ -6,7 +6,10 @@ from fastapi.testclient import TestClient
 
 from opensquilla.openai_bridge import server as bridge_server
 from opensquilla.openai_bridge.server import (
+    _collect_terminal_error,
+    _event_error_message,
     _filter_stream_delta,
+    _map_error_event,
     _resolve_agent_id,
     _strip_reply_tags,
     create_app,
@@ -126,6 +129,44 @@ def test_filter_stream_delta_passthrough_cases() -> None:
     assert _filter_stream_delta("", "plain text") == ("plain text", "")
     assert _filter_stream_delta("", "keep [[bold]]") == ("keep [[bold]]", "")
     assert _filter_stream_delta("", "a[[reply_to_current]]b") == ("ab", "")
+
+
+def test_event_error_message_extraction() -> None:
+    """错误描述提取优先级：error_message > message > 兑底。"""
+    assert _event_error_message({"message": "boom", "code": "x"}) == "boom"
+    assert (
+        _event_error_message({"error_message": "raw", "message": "terminal", "code": "x"})
+        == "raw"
+    )
+    assert _event_error_message({"code": "abc"}) == "Agent error (abc)"
+    assert _event_error_message({}) == "Agent error"
+
+
+def test_map_error_event_timeout_and_generic() -> None:
+    """timeout 类错误映射为 type=timeout，其余为 server_error 并透传 code。"""
+    mapped = _map_error_event(
+        {"message": "Stream idle timeout", "code": "stream_idle_timeout", "terminal_reason": "timeout"}
+    )
+    assert mapped["type"] == "timeout"
+    assert mapped["code"] == "stream_idle_timeout"
+    mapped = _map_error_event({"message": "llm ensemble had 3 successful proposer(s)", "code": "agent_error"})
+    assert mapped["type"] == "server_error"
+    assert mapped["code"] == "agent_error"
+    assert "llm ensemble" in str(mapped["message"])
+
+
+def test_collect_terminal_error() -> None:
+    """仅失败终止事件返回错误描述；正常 done 不误报。"""
+    ok = [
+        {"event": "session.event.text_delta", "payload": {"text": "hi"}},
+        {"event": "session.event.done", "payload": {}},
+    ]
+    assert _collect_terminal_error(ok) is None
+    failed = [
+        {"event": "session.event.text_delta", "payload": {"text": "hi"}},
+        {"event": "session.event.error", "payload": {"message": "boom", "code": "x"}},
+    ]
+    assert _collect_terminal_error(failed) == "boom"
 
 
 def test_error_body_follows_openai_envelope() -> None:

--- a/tests/test_openai_bridge/test_server.py
+++ b/tests/test_openai_bridge/test_server.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 from opensquilla.openai_bridge import server as bridge_server
-from opensquilla.openai_bridge.server import create_app, _resolve_agent_id
+from opensquilla.openai_bridge.server import (
+    _filter_stream_delta,
+    _resolve_agent_id,
+    _strip_reply_tags,
+    create_app,
+)
 
 
 def test_resolve_agent_id_default_mapping() -> None:
@@ -95,3 +100,50 @@ def test_chat_completions_no_auth_mode() -> None:
         "/v1/chat/completions", json={"model": "OpenSquilla", "messages": []}
     )
     assert resp.status_code == 400  # 走到消息校验而非 401
+
+
+def test_strip_reply_tags_removes_internal_markers() -> None:
+    """路由标记必须被剥除，且不误伤其他 [[...]] 内容。"""
+    assert _strip_reply_tags("[[reply_to_current]]pong") == "pong"
+    assert _strip_reply_tags("[[reply_to:msg_1]] hello") == " hello"
+    assert _strip_reply_tags("[[reply_to]]x") == "x"
+    assert _strip_reply_tags("no tags here") == "no tags here"
+    assert _strip_reply_tags("[[bold]] kept") == "[[bold]] kept"
+
+
+def test_filter_stream_delta_handles_split_marker() -> None:
+    """实测切分：'[[reply_to' 与 '_current]]' 分属两个增量。"""
+    out, carry = _filter_stream_delta("", "[[reply_to")
+    assert (out, carry) == ("", "[[reply_to")
+    out, carry = _filter_stream_delta(carry, "_current]]")
+    assert (out, carry) == ("", "")
+    out, carry = _filter_stream_delta(carry, "\n1\n2")
+    assert (out, carry) == ("\n1\n2", "")
+
+
+def test_filter_stream_delta_passthrough_cases() -> None:
+    """普通文本、非标记的闭合括号、同增量内的标记均正确处理。"""
+    assert _filter_stream_delta("", "plain text") == ("plain text", "")
+    assert _filter_stream_delta("", "keep [[bold]]") == ("keep [[bold]]", "")
+    assert _filter_stream_delta("", "a[[reply_to_current]]b") == ("ab", "")
+
+
+def test_error_body_follows_openai_envelope() -> None:
+    """错误响应必须是 {"error": {...}} 而非 FastAPI 的 {"detail": ...}。"""
+    app = create_app(no_auth=False, bridge_token="sk-test-1234")
+    client = TestClient(app)
+    resp = client.get("/v1/models")
+    assert resp.status_code == 401
+    body = resp.json()
+    assert "error" in body and "detail" not in body
+    assert body["error"]["code"] == "invalid_api_key"
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={"model": "OpenSquilla", "messages": []},
+        headers={"Authorization": "Bearer sk-test-1234"},
+    )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert "error" in body and "detail" not in body
+    assert body["error"]["type"] == "invalid_request_error"

--- a/uv.lock
+++ b/uv.lock
@@ -760,6 +760,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.141.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
+]
+
+[[package]]
 name = "fastcore"
 version = "1.13.8"
 source = { registry = "https://pypi.org/simple" }
@@ -2007,6 +2023,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "dingtalk-stream" },
     { name = "duckduckgo-search" },
+    { name = "fastapi" },
     { name = "html2text" },
     { name = "httpx" },
     { name = "jinja2" },
@@ -2103,6 +2120,7 @@ requires-dist = [
     { name = "dingtalk-stream", specifier = ">=0.24.3,<0.25" },
     { name = "duckduckgo-search", specifier = ">=8.1.1" },
     { name = "extract-msg", marker = "extra == 'msg'", specifier = ">=0.48" },
+    { name = "fastapi", specifier = ">=0.115" },
     { name = "html2text", specifier = ">=2024.2" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "jieba", marker = "extra == 'memory'", specifier = ">=0.42" },


### PR DESCRIPTION
## Summary

Expose OpenSquilla gateway agents as an OpenAI-compatible HTTP API
(`/v1/chat/completions` + `/v1/models`), so any OpenAI SDK-compatible client
(Cherry Studio, Cursor, Hermes, n8n, Dify, etc.) can converse with OpenSquilla
agents without MCP.

This branch carries the feature commit plus three protocol-correctness fixes
that surfaced during live end-to-end testing.

## Feature

- `GET /v1/models` and `POST /v1/chat/completions` (streaming SSE + non-streaming)
- Reuses `GatewayRPCClient` over the gateway WebSocket: auth handshake,
  single-connection atomic turn execution (subscribe → send → consume until
  terminal event)
- Persistent session mode with disk-cached session keys (agent memory),
  `stateless` mode as an alternative
- `X-OpenSquilla-Route` header for per-request tier hold
- `X-OpenSquilla-Session` / `X-OpenSquilla-New-Session` for session targeting
- CLI entry: `opensquilla openai-bridge run`, env-configurable
- 8 initial unit tests

## Fixes included (in dependency order)

1. **Auth handshake** — `GatewayRPCClient.connect()` now accepts a `token`
   and injects `{"auth": {"token": ...}}` into the connect params (same
   convention as the CLI gateway client). Without this, every chat completion
   raised a `TypeError` because the bridge called the old `auth=` keyword.
2. **Strip internal reply tags** — agent-internal routing markers
   (`[[reply_to_current]]`, `[[reply_to:<id>]]`) were leaking verbatim into
   the OpenAI `content` field (streaming deltas and non-streaming). Removed
   with a cross-chunk state machine so markers split across deltas are
   handled; non-reply `[[...]]` content is untouched.
3. **Surface agent failures** — every terminal event was previously treated
   as success: a `session.event.error` (or task failure/timeout) produced an
   empty successful completion (non-streaming) or a `finish_reason: stop`
   chunk (streaming), so clients could not detect failed turns. Failure
   terminal events now raise HTTP 502 (non-streaming) or emit an OpenAI SSE
   error chunk with a timeout-aware type before `[DONE]` (streaming).
4. **OpenAI error envelope** — errors use `{"error": {message, type, code}}`
   instead of FastAPI's `{"detail": ...}`, which OpenAI SDK clients fail to
   parse. 401 → `invalid_api_key`; 4xx/5xx → `invalid_request_error` /
   `server_error`.

## Verification

- `pytest tests/test_openai_bridge` — 15/15 pass
- Live end-to-end: `/v1/models`, non-streaming + streaming completions
  (no reply-tag leakage), wrong-token 401, malformed-request 400, all
  verified against a running gateway.
