### PR TITLE
fix(webui): chat header shows the renamed session title (#1119)

### DIFF
--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -397,10 +397,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, provide, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { routeTitle } from './router'
+import { chatSessionTitlesKey } from '@/composables/chat/useChatSessionTitles'
 import { getPlatform } from '@/platform'
 import { useAppStore, type ThemeMode, type PendingApproval } from './stores/app'
 import { useRpcStore } from './stores/rpc'
@@ -595,6 +596,21 @@ const localChatSessions = ref<Record<string, { effectiveAgentId: string; title: 
 // Pending optimistic renames, keyed by session key; cleared after the next list
 // reload returns the backend's canonical title.
 const renameOverrides = ref<Record<string, string>>({})
+
+// Chat header title source: the backend session list (display_name first) plus
+// local drafts and the optimistic rename override, so the active chat header
+// and the sidebar stay on the same title while a rename is in flight.
+const chatSessionTitles = computed<Record<string, string>>(() => {
+  const titles: Record<string, string> = {}
+  for (const item of allSessions.value) {
+    if (item.key && item.title) titles[item.key] = item.title
+  }
+  for (const [key, local] of Object.entries(localChatSessions.value)) {
+    if (local.title) titles[key] = local.title
+  }
+  return { ...titles, ...renameOverrides.value }
+})
+provide(chatSessionTitlesKey, chatSessionTitles)
 
 const brandMarkUrl = computed(() => {
   if (import.meta.env.DEV) return '/opensquilla-mark.png'

--- a/opensquilla-webui/src/composables/chat/useChatSessionTitles.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionTitles.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isSensibleChatTitle,
+  looksLikeRawSessionId,
+  resolveChatHeaderTitle,
+  type ChatHeaderMessage,
+} from './useChatSessionTitles'
+
+const stripTimePrefix = (text: string) => String(text || '').replace(/^\d{2}:\d{2} /, '')
+
+function userMessage(text: string): ChatHeaderMessage {
+  return { role: 'user', text }
+}
+
+describe('looksLikeRawSessionId', () => {
+  it('flags raw agent session keys and bare UUIDs', () => {
+    expect(looksLikeRawSessionId('agent:main:webchat:a1b2c3d4')).toBe(true)
+    expect(looksLikeRawSessionId('550e8400-e29b-41d4-a716-446655440000')).toBe(true)
+    expect(looksLikeRawSessionId('cron:midnight')).toBe(true)
+  })
+
+  it('accepts human titles', () => {
+    expect(looksLikeRawSessionId('QA Browser Session')).toBe(false)
+    expect(looksLikeRawSessionId('agent review')).toBe(false)
+  })
+})
+
+describe('isSensibleChatTitle', () => {
+  it('accepts non-empty human titles', () => {
+    expect(isSensibleChatTitle('QA Browser Session')).toBe(true)
+    expect(isSensibleChatTitle('New chat')).toBe(true)
+  })
+
+  it('rejects empty and raw-key titles', () => {
+    expect(isSensibleChatTitle('')).toBe(false)
+    expect(isSensibleChatTitle('   ')).toBe(false)
+    expect(isSensibleChatTitle('agent:main:webchat:a1b2c3d4')).toBe(false)
+  })
+})
+
+describe('resolveChatHeaderTitle', () => {
+  const titles: Record<string, string> = {}
+
+  it('uses the stored session title (manual rename / derived) when present', () => {
+    const sessionTitles = { 'agent:main:webchat:abc': 'QA Browser Session' }
+    const result = resolveChatHeaderTitle(
+      'agent:main:webchat:abc',
+      sessionTitles,
+      [userMessage('Reply with QA_OK and do not use tools.')],
+      stripTimePrefix,
+    )
+    expect(result).toBe('QA Browser Session')
+  })
+
+  it('truncates a long stored title to the header width', () => {
+    const long = 'A session title that far exceeds the header display width limit'
+    const sessionTitles = { 'agent:main:webchat:abc': long }
+    const result = resolveChatHeaderTitle('agent:main:webchat:abc', sessionTitles, [], stripTimePrefix)
+    expect(result).toBe(long.slice(0, 28) + '…')
+  })
+
+  it('falls back to the first user message when the stored title is a raw key', () => {
+    const sessionTitles = { 'agent:main:webchat:abc': 'agent:main:webchat:abc' }
+    const result = resolveChatHeaderTitle(
+      'agent:main:webchat:abc',
+      sessionTitles,
+      [userMessage('Reply with QA_OK')],
+      stripTimePrefix,
+    )
+    expect(result).toBe('Reply with QA_OK')
+  })
+
+  it('falls back to the first user message when the session has no stored title', () => {
+    const result = resolveChatHeaderTitle(
+      'agent:main:webchat:abc',
+      titles,
+      [userMessage('14:07 Reply with QA_OK')],
+      stripTimePrefix,
+    )
+    expect(result).toBe('Reply with QA_OK')
+  })
+
+  it('collapses whitespace and strips time prefixes in the message fallback', () => {
+    const result = resolveChatHeaderTitle(
+      'agent:main:webchat:abc',
+      titles,
+      [userMessage('09:15  Two  spaces   and more')],
+      stripTimePrefix,
+    )
+    expect(result).toBe('Two spaces and more')
+  })
+
+  it('ignores tool-only turns (no user text) before the first user message', () => {
+    const result = resolveChatHeaderTitle(
+      'agent:main:webchat:abc',
+      titles,
+      [
+        { role: 'assistant', text: 'Let me check.' },
+        userMessage('The first user message'),
+      ],
+      stripTimePrefix,
+    )
+    expect(result).toBe('The first user message')
+  })
+
+  it('shows "New chat" for an empty session key', () => {
+    expect(resolveChatHeaderTitle('', titles, [], stripTimePrefix)).toBe('New chat')
+  })
+
+  it('shows "New chat" for a default-suffix key with no messages', () => {
+    expect(resolveChatHeaderTitle('agent:main:webchat:default', titles, [], stripTimePrefix)).toBe('New chat')
+  })
+
+  it('shows a suffix-based placeholder for a key with no messages or title', () => {
+    expect(resolveChatHeaderTitle('agent:main:webchat:sandbox', titles, [], stripTimePrefix)).toBe('Chat sandbox')
+  })
+})

--- a/opensquilla-webui/src/composables/chat/useChatSessionTitles.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionTitles.ts
@@ -1,0 +1,58 @@
+import type { ComputedRef, InjectionKey } from 'vue'
+import { truncate } from '@/composables/chat/useChatRenderedMessages'
+
+/**
+ * 会话标题映射（key -> 展示标题）的注入 key。
+ *
+ * App.vue 以 sessions 列表（后端 display_name 优先）为主源，叠加本地草稿
+ * 与重命名的乐观覆盖后 provide；ChatView 等深层路由组件注入后，chat header
+ * 与 sidebar 使用同一份标题数据，重命名后 header 立即跟随，不再停留在
+ * 首条消息摘要。
+ */
+export const chatSessionTitlesKey: InjectionKey<ComputedRef<Record<string, string>>> = Symbol('chat-session-titles')
+
+// Raw session keys (agent:…:…) and bare UUIDs must never render in the header,
+// mirroring the sidebar's filter in App.vue.
+const RAW_SESSION_KEY_PATTERN = /\bagent:[a-z0-9_-]+:[a-z0-9_-]+:/i
+const UUID_PATTERN = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
+
+export function looksLikeRawSessionId(value: string): boolean {
+  return RAW_SESSION_KEY_PATTERN.test(value) || UUID_PATTERN.test(value) || /^(agent|cron):/i.test(value)
+}
+
+/** True when a stored title is meaningful enough to show in the chat header. */
+export function isSensibleChatTitle(title: string): boolean {
+  const text = String(title || '').trim()
+  return !!text && !looksLikeRawSessionId(text)
+}
+
+const CHAT_HEADER_MAX = 28
+
+export interface ChatHeaderMessage {
+  role: string
+  text?: string | null
+}
+
+/**
+ * Resolve the chat header title. The session's stored title (manual rename /
+ * LLM-generated, display_name first) wins; the first user message summary is
+ * only a fallback for sessions that carry no meaningful title yet (drafts,
+ * sessions outside the sidebar list window).
+ */
+export function resolveChatHeaderTitle(
+  sessionKey: string,
+  sessionTitles: Record<string, string>,
+  messages: ChatHeaderMessage[],
+  stripTimePrefix: (text: string) => string,
+): string {
+  const named = sessionKey ? sessionTitles[sessionKey] : ''
+  if (isSensibleChatTitle(named)) return truncate(named, CHAT_HEADER_MAX)
+
+  const firstUser = messages.find((msg) => msg.role === 'user' && stripTimePrefix(msg.text || '').trim())
+  if (firstUser) {
+    return truncate(stripTimePrefix(firstUser.text || '').replace(/\s+/g, ' ').trim(), CHAT_HEADER_MAX)
+  }
+  const suffix = sessionKey.split(':').pop() || ''
+  if (!suffix || suffix === 'default') return 'New chat'
+  return `Chat ${suffix}`
+}

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -680,8 +680,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, nextTick, watch, watchEffect } from 'vue'
+import { ref, computed, inject, onMounted, onUnmounted, nextTick, watch, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { chatSessionTitlesKey, resolveChatHeaderTitle } from '@/composables/chat/useChatSessionTitles'
 import { useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { useRpcStore } from '@/stores/rpc'
@@ -744,7 +745,6 @@ import type { ShareExportTheme } from '@/composables/chat/useChatShareExport'
 import { useMediaQuery } from '@/composables/chat/useMediaQuery'
 import {
   fmtTok,
-  truncate,
   useChatRenderedMessages,
 } from '@/composables/chat/useChatRenderedMessages'
 import { useChatRouterDecisionRuntime } from '@/composables/chat/useChatRouterDecisionRuntime'
@@ -3221,15 +3221,13 @@ function setCollaborationMode(mode: CollaborationMode) {
   void chatPlans.setMode(mode)
 }
 
-const currentChatTitle = computed(() => {
-  const firstUser = messages.value.find(msg => msg.role === 'user' && stripTimePrefix(msg.text || '').trim())
-  if (firstUser) {
-    return truncate(stripTimePrefix(firstUser.text).replace(/\s+/g, ' ').trim(), 28)
-  }
-  const suffix = sessionKey.value.split(':').pop() || ''
-  if (!suffix || suffix === 'default') return t('chat.newChat')
-  return t('chat.chatWithSuffix', { suffix })
-})
+// The session's stored title (manual rename / LLM-generated, display_name
+// first) wins via the App-provided map; the first user message summary is
+// only a fallback for sessions without a meaningful title yet.
+const sessionTitles = inject(chatSessionTitlesKey, computed<Record<string, string>>(() => ({})))
+const currentChatTitle = computed(() =>
+  resolveChatHeaderTitle(sessionKey.value, sessionTitles.value, messages.value, stripTimePrefix)
+)
 
 const chatMarkdownExport = useChatMarkdownExport({
   messages: renderedMessages,


### PR DESCRIPTION
## Scope

Renaming a session (Recents → Rename) updates the sidebar immediately but the active chat header keeps showing a truncated first-message summary until the session is reopened. `ChatView.currentChatTitle` computed its title purely from the first user message and never read the session's stored title (`display_name` / `derived_title`).

Fix: the chat header now prefers the session's stored title — provided by `App.vue` from the same `sessions.list` data the sidebar renders (backend `_title()` already gives `display_name` top precedence) plus the optimistic rename override, so the header follows a rename in flight. The first user message summary remains the fallback for sessions without a meaningful title yet (drafts, sessions outside the 200-row list window).

Non-goals: sidebar behavior unchanged (already correct); backend unchanged (`sessions.patch` already persists `display_name` and `sessions.list` returns it as `title`); the header's 28-char truncation style unchanged.

## Branch

Base branch: dev

Main exception: N/A

## Issue

Linked issue: Fixes #1119

## Release Note

NONE

## Tests

Ruff: N/A (frontend-only change)

Pytest: N/A (no Python changes)

Build: `npm run build` passes locally (vue-tsc + vite build)

Regression tests: added — 13 unit tests in `opensquilla-webui/src/composables/chat/useChatSessionTitles.test.ts` covering stored-title precedence, raw-key fallback, first-message fallback, and draft/suffix placeholders. Full suite: 173 tests passed. `npm run typecheck` (incl. architecture guards) passes.

Notes: the backend data chain was verified against a throwaway gateway — `sessions.create` → `sessions.patch {displayName: "QA Browser Session"}` → `sessions.list` returns `title: "QA Browser Session"`, which is the exact list entry the header now consumes. Browser-level rendering was not exercised locally (Windows, no Playwright browser run); the header resolution logic is fully covered by the unit tests.

## Maintainer Live Check

Maintainer live check: no

Surface: browser

Maintainer-only note: none.

## Safety

No secrets or local artifacts committed.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [ ] Links point to existing repository files or stable external pages.
- [ ] Code fences and Markdown tables render correctly on GitHub.
- [ ] Examples avoid real secrets, local private paths, and private transcripts.
