### PR TITLE
fix(webui): sync renamed session title in chat header

### DIFF
--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -397,11 +397,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, provide, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { routeTitle } from './router'
-import { chatSessionTitlesKey } from '@/composables/chat/useChatSessionTitles'
 import { getPlatform } from '@/platform'
 import { useAppStore, type ThemeMode, type PendingApproval } from './stores/app'
 import { useRpcStore } from './stores/rpc'
@@ -462,6 +461,11 @@ import {
   optionalSessionRpcCallOptions,
 } from './composables/chat/sessionBootstrapAdmission'
 import { markCronFinishNotified } from './utils/cron/notifications'
+import {
+  buildChatSessionTitles,
+  isSensibleChatTitle,
+  provideChatSessionTitles,
+} from './composables/chat/useChatSessionTitles'
 
 const appStore = useAppStore()
 const rpcStore = useRpcStore()
@@ -597,20 +601,10 @@ const localChatSessions = ref<Record<string, { effectiveAgentId: string; title: 
 // reload returns the backend's canonical title.
 const renameOverrides = ref<Record<string, string>>({})
 
-// Chat header title source: the backend session list (display_name first) plus
-// local drafts and the optimistic rename override, so the active chat header
-// and the sidebar stay on the same title while a rename is in flight.
-const chatSessionTitles = computed<Record<string, string>>(() => {
-  const titles: Record<string, string> = {}
-  for (const item of allSessions.value) {
-    if (item.key && item.title) titles[item.key] = item.title
-  }
-  for (const [key, local] of Object.entries(localChatSessions.value)) {
-    if (local.title) titles[key] = local.title
-  }
-  return { ...titles, ...renameOverrides.value }
-})
-provide(chatSessionTitlesKey, chatSessionTitles)
+const chatSessionTitles = computed(() => (
+  buildChatSessionTitles(allSessions.value, renameOverrides.value)
+))
+provideChatSessionTitles(chatSessionTitles)
 
 const brandMarkUrl = computed(() => {
   if (import.meta.env.DEV) return '/opensquilla-mark.png'
@@ -779,18 +773,10 @@ function agentDisplayName(agentId: string): string {
   return agent?.name || (agentId === 'main' ? 'Main Agent' : agentId)
 }
 
-// Raw session keys (agent:…:…) and bare UUIDs must never render in the sidebar.
-const RAW_SESSION_KEY_PATTERN = /\bagent:[a-z0-9_-]+:[a-z0-9_-]+:/i
-const UUID_PATTERN = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
-
-function looksLikeRawSessionId(value: string): boolean {
-  return RAW_SESSION_KEY_PATTERN.test(value) || UUID_PATTERN.test(value) || /^(agent|cron):/i.test(value)
-}
-
 function sidebarConversationTitle(item: SessionItem): string {
   for (const candidate of [item.title, item.subtitle, item.groupLabel]) {
     const text = String(candidate || '').trim()
-    if (text && !looksLikeRawSessionId(text)) return text
+    if (isSensibleChatTitle(text)) return text
   }
   return t('shared.sidebar.untitledTask')
 }

--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -397,10 +397,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, provide, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { routeTitle } from './router'
+import { chatSessionTitlesKey } from '@/composables/chat/useChatSessionTitles'
 import { getPlatform } from '@/platform'
 import { useAppStore, type ThemeMode, type PendingApproval } from './stores/app'
 import { useRpcStore } from './stores/rpc'
@@ -595,6 +596,21 @@ const localChatSessions = ref<Record<string, { effectiveAgentId: string; title: 
 // Pending optimistic renames, keyed by session key; cleared after the next list
 // reload returns the backend's canonical title.
 const renameOverrides = ref<Record<string, string>>({})
+
+// Chat header title source: the backend session list (display_name first) plus
+// local drafts and the optimistic rename override, so the active chat header
+// and the sidebar stay on the same title while a rename is in flight.
+const chatSessionTitles = computed<Record<string, string>>(() => {
+  const titles: Record<string, string> = {}
+  for (const item of allSessions.value) {
+    if (item.key && item.title) titles[item.key] = item.title
+  }
+  for (const [key, local] of Object.entries(localChatSessions.value)) {
+    if (local.title) titles[key] = local.title
+  }
+  return { ...titles, ...renameOverrides.value }
+})
+provide(chatSessionTitlesKey, chatSessionTitles)
 
 const brandMarkUrl = computed(() => {
   if (import.meta.env.DEV) return '/opensquilla-mark.png'

--- a/opensquilla-webui/src/composables/chat/useChatSessionTitles.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionTitles.test.ts
@@ -1,118 +1,92 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  buildChatSessionTitles,
   isSensibleChatTitle,
   looksLikeRawSessionId,
   resolveChatHeaderTitle,
   type ChatHeaderMessage,
 } from './useChatSessionTitles'
 
-const stripTimePrefix = (text: string) => String(text || '').replace(/^\d{2}:\d{2} /, '')
-
-function userMessage(text: string): ChatHeaderMessage {
-  return { role: 'user', text }
+const labels = {
+  newChat: 'Localized new chat',
+  chatWithSuffix: (suffix: string) => `Localized chat ${suffix}`,
 }
+const stripTimePrefix = (text: string) => text.replace(/^\d{2}:\d{2} /, '')
+const userMessage = (text: string): ChatHeaderMessage => ({ role: 'user', text })
 
-describe('looksLikeRawSessionId', () => {
-  it('flags raw agent session keys and bare UUIDs', () => {
+describe('chat session title validation', () => {
+  it('rejects raw session identifiers without rejecting human titles', () => {
     expect(looksLikeRawSessionId('agent:main:webchat:a1b2c3d4')).toBe(true)
     expect(looksLikeRawSessionId('550e8400-e29b-41d4-a716-446655440000')).toBe(true)
     expect(looksLikeRawSessionId('cron:midnight')).toBe(true)
-  })
-
-  it('accepts human titles', () => {
     expect(looksLikeRawSessionId('QA Browser Session')).toBe(false)
-    expect(looksLikeRawSessionId('agent review')).toBe(false)
   })
-})
 
-describe('isSensibleChatTitle', () => {
-  it('accepts non-empty human titles', () => {
+  it('requires a non-empty, human-readable title', () => {
     expect(isSensibleChatTitle('QA Browser Session')).toBe(true)
-    expect(isSensibleChatTitle('New chat')).toBe(true)
-  })
-
-  it('rejects empty and raw-key titles', () => {
-    expect(isSensibleChatTitle('')).toBe(false)
     expect(isSensibleChatTitle('   ')).toBe(false)
     expect(isSensibleChatTitle('agent:main:webchat:a1b2c3d4')).toBe(false)
   })
 })
 
-describe('resolveChatHeaderTitle', () => {
-  const titles: Record<string, string> = {}
+describe('buildChatSessionTitles', () => {
+  it('uses the canonical session-list title when no rename is pending', () => {
+    expect(buildChatSessionTitles(
+      [{ key: 'agent:main:webchat:abc', title: 'Stored title' }],
+      {},
+    )).toEqual({ 'agent:main:webchat:abc': 'Stored title' })
+  })
 
-  it('uses the stored session title (manual rename / derived) when present', () => {
-    const sessionTitles = { 'agent:main:webchat:abc': 'QA Browser Session' }
-    const result = resolveChatHeaderTitle(
+  it('applies an optimistic rename over the session-list title', () => {
+    expect(buildChatSessionTitles(
+      [{ key: 'agent:main:webchat:abc', title: 'Old title' }],
+      { 'agent:main:webchat:abc': 'QA Browser Session' },
+    )).toEqual({ 'agent:main:webchat:abc': 'QA Browser Session' })
+  })
+})
+
+describe('resolveChatHeaderTitle', () => {
+  it('prefers a renamed session title over the first user message', () => {
+    expect(resolveChatHeaderTitle(
       'agent:main:webchat:abc',
-      sessionTitles,
+      { 'agent:main:webchat:abc': 'QA Browser Session' },
       [userMessage('Reply with QA_OK and do not use tools.')],
       stripTimePrefix,
-    )
-    expect(result).toBe('QA Browser Session')
+      labels,
+    )).toBe('QA Browser Session')
   })
 
-  it('truncates a long stored title to the header width', () => {
-    const long = 'A session title that far exceeds the header display width limit'
-    const sessionTitles = { 'agent:main:webchat:abc': long }
-    const result = resolveChatHeaderTitle('agent:main:webchat:abc', sessionTitles, [], stripTimePrefix)
-    expect(result).toBe(long.slice(0, 28) + '…')
-  })
-
-  it('falls back to the first user message when the stored title is a raw key', () => {
-    const sessionTitles = { 'agent:main:webchat:abc': 'agent:main:webchat:abc' }
-    const result = resolveChatHeaderTitle(
+  it('truncates a long stored title to the existing header limit', () => {
+    const title = 'A session title that exceeds the chat header display width'
+    expect(resolveChatHeaderTitle(
       'agent:main:webchat:abc',
-      sessionTitles,
-      [userMessage('Reply with QA_OK')],
+      { 'agent:main:webchat:abc': title },
+      [],
       stripTimePrefix,
-    )
-    expect(result).toBe('Reply with QA_OK')
+      labels,
+    )).toBe(`${title.slice(0, 28)}…`)
   })
 
-  it('falls back to the first user message when the session has no stored title', () => {
-    const result = resolveChatHeaderTitle(
+  it('falls back to the first user message for missing or raw titles', () => {
+    expect(resolveChatHeaderTitle(
       'agent:main:webchat:abc',
-      titles,
-      [userMessage('14:07 Reply with QA_OK')],
+      { 'agent:main:webchat:abc': 'agent:main:webchat:abc' },
+      [userMessage('09:15  First   user message')],
       stripTimePrefix,
-    )
-    expect(result).toBe('Reply with QA_OK')
+      labels,
+    )).toBe('First user message')
   })
 
-  it('collapses whitespace and strips time prefixes in the message fallback', () => {
-    const result = resolveChatHeaderTitle(
-      'agent:main:webchat:abc',
-      titles,
-      [userMessage('09:15  Two  spaces   and more')],
+  it('preserves localized empty-session fallbacks', () => {
+    expect(resolveChatHeaderTitle('', {}, [], stripTimePrefix, labels))
+      .toBe('Localized new chat')
+    expect(resolveChatHeaderTitle(
+      'agent:main:webchat:sandbox',
+      {},
+      [],
       stripTimePrefix,
-    )
-    expect(result).toBe('Two spaces and more')
-  })
-
-  it('ignores tool-only turns (no user text) before the first user message', () => {
-    const result = resolveChatHeaderTitle(
-      'agent:main:webchat:abc',
-      titles,
-      [
-        { role: 'assistant', text: 'Let me check.' },
-        userMessage('The first user message'),
-      ],
-      stripTimePrefix,
-    )
-    expect(result).toBe('The first user message')
-  })
-
-  it('shows "New chat" for an empty session key', () => {
-    expect(resolveChatHeaderTitle('', titles, [], stripTimePrefix)).toBe('New chat')
-  })
-
-  it('shows "New chat" for a default-suffix key with no messages', () => {
-    expect(resolveChatHeaderTitle('agent:main:webchat:default', titles, [], stripTimePrefix)).toBe('New chat')
-  })
-
-  it('shows a suffix-based placeholder for a key with no messages or title', () => {
-    expect(resolveChatHeaderTitle('agent:main:webchat:sandbox', titles, [], stripTimePrefix)).toBe('Chat sandbox')
+      labels,
+    )).toBe('Localized chat sandbox')
   })
 })

--- a/opensquilla-webui/src/composables/chat/useChatSessionTitles.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionTitles.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isSensibleChatTitle,
+  looksLikeRawSessionId,
+  resolveChatHeaderTitle,
+  type ChatHeaderMessage,
+} from './useChatSessionTitles'
+
+const stripTimePrefix = (text: string) => String(text || '').replace(/^\d{2}:\d{2} /, '')
+
+function userMessage(text: string): ChatHeaderMessage {
+  return { role: 'user', text }
+}
+
+describe('looksLikeRawSessionId', () => {
+  it('flags raw agent session keys and bare UUIDs', () => {
+    expect(looksLikeRawSessionId('agent:main:webchat:a1b2c3d4')).toBe(true)
+    expect(looksLikeRawSessionId('550e8400-e29b-41d4-a716-446655440000')).toBe(true)
+    expect(looksLikeRawSessionId('cron:midnight')).toBe(true)
+  })
+
+  it('accepts human titles', () => {
+    expect(looksLikeRawSessionId('QA Browser Session')).toBe(false)
+    expect(looksLikeRawSessionId('agent review')).toBe(false)
+  })
+})
+
+describe('isSensibleChatTitle', () => {
+  it('accepts non-empty human titles', () => {
+    expect(isSensibleChatTitle('QA Browser Session')).toBe(true)
+    expect(isSensibleChatTitle('New chat')).toBe(true)
+  })
+
+  it('rejects empty and raw-key titles', () => {
+    expect(isSensibleChatTitle('')).toBe(false)
+    expect(isSensibleChatTitle('   ')).toBe(false)
+    expect(isSensibleChatTitle('agent:main:webchat:a1b2c3d4')).toBe(false)
+  })
+})
+
+describe('resolveChatHeaderTitle', () => {
+  const titles: Record<string, string> = {}
+
+  it('uses the stored session title (manual rename / derived) when present', () => {
+    const sessionTitles = { 'agent:main:webchat:abc': 'QA Browser Session' }
+    const result = resolveChatHeaderTitle(
+      'agent:main:webchat:abc',
+      sessionTitles,
+      [userMessage('Reply with QA_OK and do not use tools.')],
+      stripTimePrefix,
+    )
+    expect(result).toBe('QA Browser Session')
+  })
+
+  it('truncates a long stored title to the header width', () => {
+    const long = 'A session title that far exceeds the header display width limit'
+    const sessionTitles = { 'agent:main:webchat:abc': long }
+    const result = resolveChatHeaderTitle('agent:main:webchat:abc', sessionTitles, [], stripTimePrefix)
+    expect(result).toBe(long.slice(0, 28) + '…')
+  })
+
+  it('falls back to the first user message when the stored title is a raw key', () => {
+    const sessionTitles = { 'agent:main:webchat:abc': 'agent:main:webchat:abc' }
+    const result = resolveChatHeaderTitle(
+      'agent:main:webchat:abc',
+      sessionTitles,
+      [userMessage('Reply with QA_OK')],
+      stripTimePrefix,
+    )
+    expect(result).toBe('Reply with QA_OK')
+  })
+
+  it('falls back to the first user message when the session has no stored title', () => {
+    const result = resolveChatHeaderTitle(
+      'agent:main:webchat:abc',
+      titles,
+      [userMessage('14:07 Reply with QA_OK')],
+      stripTimePrefix,
+    )
+    expect(result).toBe('Reply with QA_OK')
+  })
+
+  it('collapses whitespace and strips time prefixes in the message fallback', () => {
+    const result = resolveChatHeaderTitle(
+      'agent:main:webchat:abc',
+      titles,
+      [userMessage('09:15  Two  spaces   and more')],
+      stripTimePrefix,
+    )
+    expect(result).toBe('Two spaces and more')
+  })
+
+  it('ignores tool-only turns (no user text) before the first user message', () => {
+    const result = resolveChatHeaderTitle(
+      'agent:main:webchat:abc',
+      titles,
+      [
+        { role: 'assistant', text: 'Let me check.' },
+        userMessage('The first user message'),
+      ],
+      stripTimePrefix,
+    )
+    expect(result).toBe('The first user message')
+  })
+
+  it('shows "New chat" for an empty session key', () => {
+    expect(resolveChatHeaderTitle('', titles, [], stripTimePrefix)).toBe('New chat')
+  })
+
+  it('shows "New chat" for a default-suffix key with no messages', () => {
+    expect(resolveChatHeaderTitle('agent:main:webchat:default', titles, [], stripTimePrefix)).toBe('New chat')
+  })
+
+  it('shows a suffix-based placeholder for a key with no messages or title', () => {
+    expect(resolveChatHeaderTitle('agent:main:webchat:sandbox', titles, [], stripTimePrefix)).toBe('Chat sandbox')
+  })
+})

--- a/opensquilla-webui/src/composables/chat/useChatSessionTitles.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionTitles.ts
@@ -1,0 +1,58 @@
+import type { ComputedRef, InjectionKey } from 'vue'
+import { truncate } from '@/composables/chat/useChatRenderedMessages'
+
+/**
+ * 会话标题映射（key -> 展示标题）的注入 key。
+ *
+ * App.vue 以 sessions 列表（后端 display_name 优先）为主源，叠加本地草稿
+ * 与重命名的乐观覆盖后 provide；ChatView 等深层路由组件注入后，chat header
+ * 与 sidebar 使用同一份标题数据，重命名后 header 立即跟随，不再停留在
+ * 首条消息摘要。
+ */
+export const chatSessionTitlesKey: InjectionKey<ComputedRef<Record<string, string>>> = Symbol('chat-session-titles')
+
+// Raw session keys (agent:…:…) and bare UUIDs must never render in the header,
+// mirroring the sidebar's filter in App.vue.
+const RAW_SESSION_KEY_PATTERN = /\bagent:[a-z0-9_-]+:[a-z0-9_-]+:/i
+const UUID_PATTERN = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
+
+export function looksLikeRawSessionId(value: string): boolean {
+  return RAW_SESSION_KEY_PATTERN.test(value) || UUID_PATTERN.test(value) || /^(agent|cron):/i.test(value)
+}
+
+/** True when a stored title is meaningful enough to show in the chat header. */
+export function isSensibleChatTitle(title: string): boolean {
+  const text = String(title || '').trim()
+  return !!text && !looksLikeRawSessionId(text)
+}
+
+const CHAT_HEADER_MAX = 28
+
+export interface ChatHeaderMessage {
+  role: string
+  text?: string | null
+}
+
+/**
+ * Resolve the chat header title. The session's stored title (manual rename /
+ * LLM-generated, display_name first) wins; the first user message summary is
+ * only a fallback for sessions that carry no meaningful title yet (drafts,
+ * sessions outside the sidebar list window).
+ */
+export function resolveChatHeaderTitle(
+  sessionKey: string,
+  sessionTitles: Record<string, string>,
+  messages: ChatHeaderMessage[],
+  stripTimePrefix: (text: string) => string,
+): string {
+  const named = sessionKey ? sessionTitles[sessionKey] : ''
+  if (isSensibleChatTitle(named)) return truncate(named, CHAT_HEADER_MAX)
+
+  const firstUser = messages.find((msg) => msg.role === 'user' && stripTimePrefix(msg.text || '').trim())
+  if (firstUser) {
+    return truncate(stripTimePrefix(firstUser.text || '').replace(/\s+/g, ' ').trim(), CHAT_HEADER_MAX)
+  }
+  const suffix = sessionKey.split(':').pop() || ''
+  if (!suffix || suffix === 'default') return 'New chat'
+  return `Chat ${suffix}`
+}

--- a/opensquilla-webui/src/composables/chat/useChatSessionTitles.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionTitles.ts
@@ -1,58 +1,91 @@
-import type { ComputedRef, InjectionKey } from 'vue'
+import {
+  computed,
+  inject,
+  provide,
+  type ComputedRef,
+  type InjectionKey,
+} from 'vue'
+
 import { truncate } from '@/composables/chat/useChatRenderedMessages'
 
-/**
- * 会话标题映射（key -> 展示标题）的注入 key。
- *
- * App.vue 以 sessions 列表（后端 display_name 优先）为主源，叠加本地草稿
- * 与重命名的乐观覆盖后 provide；ChatView 等深层路由组件注入后，chat header
- * 与 sidebar 使用同一份标题数据，重命名后 header 立即跟随，不再停留在
- * 首条消息摘要。
- */
-export const chatSessionTitlesKey: InjectionKey<ComputedRef<Record<string, string>>> = Symbol('chat-session-titles')
+export type ChatSessionTitles = Readonly<Record<string, string>>
 
-// Raw session keys (agent:…:…) and bare UUIDs must never render in the header,
-// mirroring the sidebar's filter in App.vue.
+const chatSessionTitlesKey: InjectionKey<ComputedRef<ChatSessionTitles>> = Symbol('chat-session-titles')
+
+export function provideChatSessionTitles(titles: ComputedRef<ChatSessionTitles>) {
+  provide(chatSessionTitlesKey, titles)
+}
+
+export function useChatSessionTitles(): ComputedRef<ChatSessionTitles> {
+  return inject(chatSessionTitlesKey, computed<ChatSessionTitles>(() => ({})))
+}
+
 const RAW_SESSION_KEY_PATTERN = /\bagent:[a-z0-9_-]+:[a-z0-9_-]+:/i
 const UUID_PATTERN = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
 
 export function looksLikeRawSessionId(value: string): boolean {
-  return RAW_SESSION_KEY_PATTERN.test(value) || UUID_PATTERN.test(value) || /^(agent|cron):/i.test(value)
+  return RAW_SESSION_KEY_PATTERN.test(value)
+    || UUID_PATTERN.test(value)
+    || /^(agent|cron):/i.test(value)
 }
 
-/** True when a stored title is meaningful enough to show in the chat header. */
-export function isSensibleChatTitle(title: string): boolean {
-  const text = String(title || '').trim()
-  return !!text && !looksLikeRawSessionId(text)
+export function isSensibleChatTitle(value: string): boolean {
+  const title = String(value || '').trim()
+  return !!title && !looksLikeRawSessionId(title)
 }
 
-const CHAT_HEADER_MAX = 28
+interface ChatSessionTitleItem {
+  key: string
+  title: string
+}
+
+export function buildChatSessionTitles(
+  sessions: readonly ChatSessionTitleItem[],
+  renameOverrides: ChatSessionTitles,
+): ChatSessionTitles {
+  const titles: Record<string, string> = {}
+  for (const session of sessions) {
+    if (session.key && isSensibleChatTitle(session.title)) {
+      titles[session.key] = session.title.trim()
+    }
+  }
+  for (const [key, title] of Object.entries(renameOverrides)) {
+    if (key && isSensibleChatTitle(title)) titles[key] = title.trim()
+  }
+  return titles
+}
 
 export interface ChatHeaderMessage {
   role: string
   text?: string | null
 }
 
-/**
- * Resolve the chat header title. The session's stored title (manual rename /
- * LLM-generated, display_name first) wins; the first user message summary is
- * only a fallback for sessions that carry no meaningful title yet (drafts,
- * sessions outside the sidebar list window).
- */
+interface ChatHeaderLabels {
+  newChat: string
+  chatWithSuffix: (suffix: string) => string
+}
+
 export function resolveChatHeaderTitle(
   sessionKey: string,
-  sessionTitles: Record<string, string>,
-  messages: ChatHeaderMessage[],
+  sessionTitles: ChatSessionTitles,
+  messages: readonly ChatHeaderMessage[],
   stripTimePrefix: (text: string) => string,
+  labels: ChatHeaderLabels,
 ): string {
-  const named = sessionKey ? sessionTitles[sessionKey] : ''
-  if (isSensibleChatTitle(named)) return truncate(named, CHAT_HEADER_MAX)
+  const storedTitle = sessionKey ? sessionTitles[sessionKey] || '' : ''
+  if (isSensibleChatTitle(storedTitle)) return truncate(storedTitle.trim(), 28)
 
-  const firstUser = messages.find((msg) => msg.role === 'user' && stripTimePrefix(msg.text || '').trim())
+  const firstUser = messages.find(message => (
+    message.role === 'user' && stripTimePrefix(message.text || '').trim()
+  ))
   if (firstUser) {
-    return truncate(stripTimePrefix(firstUser.text || '').replace(/\s+/g, ' ').trim(), CHAT_HEADER_MAX)
+    return truncate(
+      stripTimePrefix(firstUser.text || '').replace(/\s+/g, ' ').trim(),
+      28,
+    )
   }
+
   const suffix = sessionKey.split(':').pop() || ''
-  if (!suffix || suffix === 'default') return 'New chat'
-  return `Chat ${suffix}`
+  if (!suffix || suffix === 'default') return labels.newChat
+  return labels.chatWithSuffix(suffix)
 }

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -680,8 +680,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, nextTick, watch, watchEffect } from 'vue'
+import { ref, computed, inject, onMounted, onUnmounted, nextTick, watch, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { chatSessionTitlesKey, resolveChatHeaderTitle } from '@/composables/chat/useChatSessionTitles'
 import { useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { useRpcStore } from '@/stores/rpc'
@@ -744,7 +745,6 @@ import type { ShareExportTheme } from '@/composables/chat/useChatShareExport'
 import { useMediaQuery } from '@/composables/chat/useMediaQuery'
 import {
   fmtTok,
-  truncate,
   useChatRenderedMessages,
 } from '@/composables/chat/useChatRenderedMessages'
 import { useChatRouterDecisionRuntime } from '@/composables/chat/useChatRouterDecisionRuntime'
@@ -3222,15 +3222,13 @@ function setCollaborationMode(mode: CollaborationMode) {
   void chatPlans.setMode(mode)
 }
 
-const currentChatTitle = computed(() => {
-  const firstUser = messages.value.find(msg => msg.role === 'user' && stripTimePrefix(msg.text || '').trim())
-  if (firstUser) {
-    return truncate(stripTimePrefix(firstUser.text).replace(/\s+/g, ' ').trim(), 28)
-  }
-  const suffix = sessionKey.value.split(':').pop() || ''
-  if (!suffix || suffix === 'default') return t('chat.newChat')
-  return t('chat.chatWithSuffix', { suffix })
-})
+// The session's stored title (manual rename / LLM-generated, display_name
+// first) wins via the App-provided map; the first user message summary is
+// only a fallback for sessions without a meaningful title yet.
+const sessionTitles = inject(chatSessionTitlesKey, computed<Record<string, string>>(() => ({})))
+const currentChatTitle = computed(() =>
+  resolveChatHeaderTitle(sessionKey.value, sessionTitles.value, messages.value, stripTimePrefix)
+)
 
 const chatMarkdownExport = useChatMarkdownExport({
   messages: renderedMessages,

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -680,9 +680,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, inject, onMounted, onUnmounted, nextTick, watch, watchEffect } from 'vue'
+import { ref, computed, onMounted, onUnmounted, nextTick, watch, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { chatSessionTitlesKey, resolveChatHeaderTitle } from '@/composables/chat/useChatSessionTitles'
 import { useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { useRpcStore } from '@/stores/rpc'
@@ -731,6 +730,10 @@ import { useChatFeatureToggles } from '@/composables/chat/useChatFeatureToggles'
 import { useChatHistory } from '@/composables/chat/useChatHistory'
 import { useChatMarkdownExport } from '@/composables/chat/useChatMarkdownExport'
 import { useChatMessageActions } from '@/composables/chat/useChatMessageActions'
+import {
+  resolveChatHeaderTitle,
+  useChatSessionTitles,
+} from '@/composables/chat/useChatSessionTitles'
 import {
   createChatMetaDraftRecovery,
   listServerMetaDrafts,
@@ -3222,13 +3225,19 @@ function setCollaborationMode(mode: CollaborationMode) {
   void chatPlans.setMode(mode)
 }
 
-// The session's stored title (manual rename / LLM-generated, display_name
-// first) wins via the App-provided map; the first user message summary is
-// only a fallback for sessions without a meaningful title yet.
-const sessionTitles = inject(chatSessionTitlesKey, computed<Record<string, string>>(() => ({})))
-const currentChatTitle = computed(() =>
-  resolveChatHeaderTitle(sessionKey.value, sessionTitles.value, messages.value, stripTimePrefix)
-)
+const sessionTitles = useChatSessionTitles()
+const currentChatTitle = computed(() => {
+  return resolveChatHeaderTitle(
+    sessionKey.value,
+    sessionTitles.value,
+    messages.value,
+    stripTimePrefix,
+    {
+      newChat: t('chat.newChat'),
+      chatWithSuffix: suffix => t('chat.chatWithSuffix', { suffix }),
+    },
+  )
+})
 
 const chatMarkdownExport = useChatMarkdownExport({
   messages: renderedMessages,


### PR DESCRIPTION
## Scope

Scope boundary:

- Make the active chat header consume the same stored session title used by Recents.
- Preserve optimistic rename updates, raw-key filtering, first-message fallback, localization, and the existing 28-character header limit.
- Add focused unit coverage for title-map precedence and header fallback behavior.

Non-goals:

- No backend, persistence, RPC contract, or sidebar interaction changes.
- No change to session-title generation or truncation policy.

## Branch

Base branch: main

Target exception: N/A

## Commit Lineage

- Replays the implementation commit from #1122 on the latest `main`, preserving author attribution and the original `910c4911` SHA in the cherry-pick footer.
- Applies the #1124 refinements as a follow-up commit: centralized title resolution, localized fallbacks, shared raw-key filtering, and focused precedence coverage.

## Issue

Linked issue: Fixes #1119

## Release Note

Release note: NONE

## Tests

Ruff: N/A (frontend-only change)

Pytest: N/A (frontend-only change)

Build: production Vite build and artifact verification passed; architecture, chat-security, theme, i18n, and vue-tsc checks passed.

Regression tests: added

Notes:

- Full WebUI unit suite: 288 files / 3053 tests passed on the latest `main`.
- Focused regression suite: 8 tests passed after rebasing onto the latest main.
- The updated UI loaded in a local browser, but the separately running Gateway WebSocket was unavailable, so no credentialed/manual session rename was performed.
- The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: browser

Maintainer-only note: A maintainer may optionally confirm that renaming the active session updates both Recents and the chat header immediately and after reload.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents were not committed.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.