### PR TITLE
Fix profile-scoped managed Gateway targeting

### DIFF
--- a/src/opensquilla/cli/doctor_cmd.py
+++ b/src/opensquilla/cli/doctor_cmd.py
@@ -14,7 +14,11 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from opensquilla.cli.gateway_rpc import default_gateway_url, gateway_url_from_config
+from opensquilla.cli.gateway_rpc import (
+    GatewayTarget,
+    default_gateway_target,
+    gateway_url_from_config,
+)
 from opensquilla.cli.output import print_json
 from opensquilla.cli.url_utils import normalize_gateway_url
 from opensquilla.health.model import (
@@ -709,16 +713,21 @@ def _implicit_existing_config_path() -> Path | None:
     return None
 
 
-def _target_url_for_doctor(
+def _target_for_doctor(
     *,
     gateway_url: str | None,
     config_path: Path | None,
-) -> str:
+) -> GatewayTarget:
     if gateway_url is not None:
-        return normalize_gateway_url(gateway_url)
+        return GatewayTarget(normalize_gateway_url(gateway_url))
     if config_path is not None:
-        return gateway_url_from_config(config_path)
-    return default_gateway_url()
+        return GatewayTarget(
+            gateway_url_from_config(config_path),
+            config_path,
+            config_owns_target=True,
+        )
+    return default_gateway_target()
+
 
 def _requested_config_path(
     config_path: Path | None,
@@ -771,10 +780,17 @@ def doctor_command(
         else normalize_gateway_url("ws://localhost:18791/ws")
     )
     try:
-        target_url = _target_url_for_doctor(
+        target = _target_for_doctor(
             gateway_url=gateway_url,
             config_path=config_path,
         )
+        target_url = target.url
+        requested_config_path = (
+            str(target.config_path)
+            if target.config_path is not None
+            else _requested_config_path(config_path, gateway_url=gateway_url)
+        )
+        config_owns_gateway_target = target.config_owns_target
         report = asyncio.run(
             _fetch_report(
                 gateway_url=target_url,

--- a/src/opensquilla/cli/doctor_cmd.py
+++ b/src/opensquilla/cli/doctor_cmd.py
@@ -718,8 +718,6 @@ def _target_url_for_doctor(
         return normalize_gateway_url(gateway_url)
     if config_path is not None:
         return gateway_url_from_config(config_path)
-    if implicit_config_path := _implicit_existing_config_path():
-        return gateway_url_from_config(implicit_config_path)
     return default_gateway_url()
 
 def _requested_config_path(

--- a/src/opensquilla/cli/gateway_lifecycle.py
+++ b/src/opensquilla/cli/gateway_lifecycle.py
@@ -779,6 +779,45 @@ class GatewayLifecycleManager:
         return datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
+def active_managed_gateway_url() -> str | None:
+    """Return the active managed Gateway URL for the selected profile.
+
+    ``gateway start`` records its effective runtime target in the profile-local
+    lifecycle file.  That record is authoritative when a one-off ``--port`` or
+    ``--listen`` override differs from the persisted config, but only while the
+    recorded process is still alive and serving a healthy Gateway.
+    """
+
+    lifecycle = GatewayLifecycleManager()
+    record, error = lifecycle._read_pidfile()
+    if error is not None or record is None:
+        return None
+
+    host = record.get("host")
+    if not isinstance(host, str) or not host.strip():
+        return None
+    host = host.strip()
+    try:
+        port = int(record.get("port"))
+    except (TypeError, ValueError):
+        return None
+    if not 1 <= port <= 65535:
+        return None
+
+    config_path = record.get("configPath")
+    if not isinstance(config_path, str) or not config_path.strip():
+        config_path = None
+    lifecycle = GatewayLifecycleManager(
+        host=host,
+        port=port,
+        config_path=config_path,
+    )
+    status = lifecycle.status()
+    if status.state != "running" or not status.managed:
+        return None
+    return normalize_gateway_url(f"ws://{_format_url_host(lifecycle.probe_host)}:{port}/ws")
+
+
 def _health_probe_host(host: str) -> str:
     if host == "0.0.0.0":
         return "127.0.0.1"

--- a/src/opensquilla/cli/gateway_lifecycle.py
+++ b/src/opensquilla/cli/gateway_lifecycle.py
@@ -166,6 +166,14 @@ class GatewayLifecycleResult:
         return payload
 
 
+@dataclass(frozen=True)
+class ManagedGatewayTarget:
+    """Connection target recorded for a profile-managed Gateway."""
+
+    url: str
+    config_path: str | None = None
+
+
 class GatewayLifecycleManager:
     def __init__(
         self,
@@ -779,13 +787,15 @@ class GatewayLifecycleManager:
         return datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
-def active_managed_gateway_url() -> str | None:
-    """Return the active managed Gateway URL for the selected profile.
+def active_managed_gateway_target() -> ManagedGatewayTarget | None:
+    """Return the active managed Gateway target for the selected profile.
 
     ``gateway start`` records its effective runtime target in the profile-local
     lifecycle file.  That record is authoritative when a one-off ``--port`` or
-    ``--listen`` override differs from the persisted config, but only while the
-    recorded process is still alive and serving a healthy Gateway.
+    ``--listen`` override differs from the persisted config while the recorded
+    process is still alive.  An unhealthy managed process remains authoritative
+    so callers fail against the selected profile instead of silently falling
+    back to another Gateway.
     """
 
     lifecycle = GatewayLifecycleManager()
@@ -797,9 +807,12 @@ def active_managed_gateway_url() -> str | None:
     if not isinstance(host, str) or not host.strip():
         return None
     host = host.strip()
+    raw_port = record.get("port")
+    if not isinstance(raw_port, (str, int)) or isinstance(raw_port, bool):
+        return None
     try:
-        port = int(record.get("port"))
-    except (TypeError, ValueError):
+        port = int(raw_port)
+    except ValueError:
         return None
     if not 1 <= port <= 65535:
         return None
@@ -813,9 +826,17 @@ def active_managed_gateway_url() -> str | None:
         config_path=config_path,
     )
     status = lifecycle.status()
-    if status.state != "running" or not status.managed:
+    if status.state not in {"running", "unhealthy"} or not status.managed:
         return None
-    return normalize_gateway_url(f"ws://{_format_url_host(lifecycle.probe_host)}:{port}/ws")
+    url = normalize_gateway_url(f"ws://{_format_url_host(lifecycle.probe_host)}:{port}/ws")
+    return ManagedGatewayTarget(url=url, config_path=config_path)
+
+
+def active_managed_gateway_url() -> str | None:
+    """Return the active managed Gateway URL for the selected profile."""
+
+    target = active_managed_gateway_target()
+    return target.url if target is not None else None
 
 
 def _health_probe_host(host: str) -> str:

--- a/src/opensquilla/cli/gateway_rpc.py
+++ b/src/opensquilla/cli/gateway_rpc.py
@@ -19,6 +19,13 @@ def default_gateway_url() -> str:
 
     if gateway_url := os.environ.get("OPENSQUILLA_GATEWAY_URL"):
         return normalize_gateway_url(gateway_url)
+    try:
+        from opensquilla.cli.gateway_lifecycle import active_managed_gateway_url
+
+        if managed_gateway_url := active_managed_gateway_url():
+            return managed_gateway_url
+    except Exception:  # noqa: BLE001 - fall back to config-derived target.
+        pass
     if config_path := os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH"):
         return gateway_url_from_config(config_path)
     try:

--- a/src/opensquilla/cli/gateway_rpc.py
+++ b/src/opensquilla/cli/gateway_rpc.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -14,29 +15,55 @@ from opensquilla.cli.output import emit_error
 from opensquilla.cli.url_utils import normalize_gateway_url
 
 
-def default_gateway_url() -> str:
-    """Return the configured gateway WebSocket URL."""
+@dataclass(frozen=True)
+class GatewayTarget:
+    """A Gateway URL paired with the config used for its credentials."""
+
+    url: str
+    config_path: str | Path | None = None
+    config_owns_target: bool = False
+
+
+def default_gateway_target() -> GatewayTarget:
+    """Resolve the default Gateway target and its configuration provenance."""
 
     if gateway_url := os.environ.get("OPENSQUILLA_GATEWAY_URL"):
-        return normalize_gateway_url(gateway_url)
+        return GatewayTarget(
+            normalize_gateway_url(gateway_url),
+            os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH") or None,
+        )
+    if config_path := os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH"):
+        return GatewayTarget(
+            gateway_url_from_config(config_path),
+            config_path,
+            config_owns_target=True,
+        )
     try:
-        from opensquilla.cli.gateway_lifecycle import active_managed_gateway_url
+        from opensquilla.cli.gateway_lifecycle import active_managed_gateway_target
 
-        if managed_gateway_url := active_managed_gateway_url():
-            return managed_gateway_url
+        if managed_target := active_managed_gateway_target():
+            return GatewayTarget(managed_target.url, managed_target.config_path)
     except Exception:  # noqa: BLE001 - fall back to config-derived target.
         pass
-    if config_path := os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH"):
-        return gateway_url_from_config(config_path)
     try:
         from opensquilla.onboarding.config_store import resolve_config_path
 
         implicit_config_path, _source = resolve_config_path(None)
         if implicit_config_path.is_file():
-            return gateway_url_from_config(implicit_config_path)
+            return GatewayTarget(
+                gateway_url_from_config(implicit_config_path),
+                implicit_config_path,
+                config_owns_target=True,
+            )
     except Exception:  # noqa: BLE001 - fall back to release default.
         pass
-    return normalize_gateway_url("ws://localhost:18791/ws")
+    return GatewayTarget(normalize_gateway_url("ws://localhost:18791/ws"))
+
+
+def default_gateway_url() -> str:
+    """Return the configured gateway WebSocket URL."""
+
+    return default_gateway_target().url
 
 
 def _client_host(host: str) -> str:
@@ -63,19 +90,27 @@ def gateway_url_from_config(config_path: str | Path) -> str:
     return normalize_gateway_url(f"ws://{host}:{int(config.port)}/ws")
 
 
-def _target_gateway_url(
+def _target_gateway(
     *,
     gateway_url: str | None,
     config_path: str | Path | None,
-) -> str:
+) -> GatewayTarget:
     if gateway_url is not None:
-        return normalize_gateway_url(gateway_url)
+        return GatewayTarget(normalize_gateway_url(gateway_url), config_path)
     if config_path is not None:
-        return gateway_url_from_config(config_path)
-    return default_gateway_url()
+        return GatewayTarget(
+            gateway_url_from_config(config_path),
+            config_path,
+            config_owns_target=True,
+        )
+    return default_gateway_target()
 
 
-def default_gateway_token(config_path: str | Path | None = None) -> str | None:
+def default_gateway_token(
+    config_path: str | Path | None = None,
+    *,
+    discover_target: bool = True,
+) -> str | None:
     """Resolve the auth token used to connect to the gateway.
 
     Resolution order (matches the gateway's own config-loading
@@ -98,11 +133,17 @@ def default_gateway_token(config_path: str | Path | None = None) -> str | None:
     try:
         from opensquilla.gateway.config import GatewayConfig
 
-        effective_config_path = (
-            str(config_path)
-            if config_path is not None
-            else os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH", "").strip()
-        )
+        effective_config_path = str(config_path) if config_path is not None else ""
+        if not effective_config_path:
+            effective_config_path = os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH", "").strip()
+        if (
+            discover_target
+            and not effective_config_path
+            and not os.environ.get("OPENSQUILLA_GATEWAY_URL")
+        ):
+            target_config_path = default_gateway_target().config_path
+            if target_config_path is not None:
+                effective_config_path = str(target_config_path)
         cfg = GatewayConfig.load(effective_config_path or None)
         token = getattr(getattr(cfg, "auth", None), "token", None)
         if isinstance(token, str) and token.strip():
@@ -136,8 +177,11 @@ async def run_gateway_call(
 
     client = gateway_client_module.GatewayClient()
     try:
-        target_url = _target_gateway_url(gateway_url=gateway_url, config_path=config_path)
-        await client.connect(target_url, token=default_gateway_token(config_path))
+        target = _target_gateway(gateway_url=gateway_url, config_path=config_path)
+        await client.connect(
+            target.url,
+            token=default_gateway_token(target.config_path, discover_target=False),
+        )
         return await action(client)
     except SystemExit as exc:
         message = str(exc)

--- a/tests/test_cli/test_cli_product_completeness.py
+++ b/tests/test_cli/test_cli_product_completeness.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from typer.testing import CliRunner
 
+from opensquilla.cli import gateway_lifecycle
 from opensquilla.cli.main import app
 
 runner = CliRunner()
@@ -682,6 +683,56 @@ def test_sessions_list_json_filters_client_side(monkeypatch):
     payload = json.loads(result.stdout)
     assert payload["count"] == 1
     assert payload["sessions"][0]["key"] == "a"
+
+
+def test_sessions_list_uses_active_profile_managed_gateway_runtime_port(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    fake = _install_fake_gateway(monkeypatch)
+    fake.sessions_payload = {
+        "sessions": [{"key": "qa-session", "status": "active"}],
+        "count": 1,
+    }
+    home = tmp_path / "profile"
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(home))
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_URL", raising=False)
+    config = home / "config.toml"
+    config.parent.mkdir(parents=True)
+    config.write_text('host = "127.0.0.1"\nport = 18791\n', encoding="utf-8")
+    lifecycle = home / "state" / "gateway" / "gateway.json"
+    lifecycle.parent.mkdir(parents=True)
+    lifecycle.write_text(
+        json.dumps(
+            {
+                "pid": 4242,
+                "host": "127.0.0.1",
+                "port": 18792,
+                "url": "http://127.0.0.1:18792",
+                "healthUrl": "http://127.0.0.1:18792/health",
+                "startedAt": "2026-08-10T00:00:00Z",
+                "argv": ["opensquilla", "gateway", "run", "--port", "18792"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        gateway_lifecycle.GatewayLifecycleManager,
+        "_pid_running",
+        lambda self, pid: True,
+    )
+    monkeypatch.setattr(
+        gateway_lifecycle.GatewayLifecycleManager,
+        "_probe_health",
+        lambda self: True,
+    )
+
+    result = runner.invoke(app, ["sessions", "list", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    assert ("connect", "ws://127.0.0.1:18792/ws") in fake.calls
+    assert json.loads(result.stdout)["sessions"][0]["key"] == "qa-session"
 
 
 def test_sessions_show_json_resolves_and_previews(monkeypatch):

--- a/tests/test_cli/test_doctor_cmd.py
+++ b/tests/test_cli/test_doctor_cmd.py
@@ -294,6 +294,50 @@ def test_doctor_prefers_active_profile_managed_gateway_runtime_port(
     assert payload["configPath"] == str(config)
 
 
+def test_doctor_reports_managed_gateway_recorded_config_path(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    _FakeGatewayClient.calls = []
+    home = tmp_path / "profile"
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(home))
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_URL", raising=False)
+    custom_config = tmp_path / "custom.toml"
+    custom_config.write_text('host = "127.0.0.1"\nport = 18791\n', encoding="utf-8")
+    lifecycle = home / "state" / "gateway" / "gateway.json"
+    lifecycle.parent.mkdir(parents=True)
+    lifecycle.write_text(
+        json.dumps(
+            {
+                "pid": 4242,
+                "host": "127.0.0.1",
+                "port": 18792,
+                "configPath": str(custom_config),
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        gateway_lifecycle.GatewayLifecycleManager,
+        "_pid_running",
+        lambda self, pid: True,
+    )
+    monkeypatch.setattr(
+        gateway_lifecycle.GatewayLifecycleManager,
+        "_probe_health",
+        lambda self: True,
+    )
+    monkeypatch.setattr("opensquilla.cli.gateway_client.GatewayClient", _FakeGatewayClient)
+
+    result = runner.invoke(app, ["doctor", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["gatewayUrl"] == "ws://127.0.0.1:18792/ws"
+    assert payload["configPath"] == str(custom_config)
+
+
 def test_doctor_config_scopes_gateway_recovery_commands(tmp_path, monkeypatch) -> None:
     _FakeGatewayClient.calls = []
     target = tmp_path / "custom.toml"

--- a/tests/test_cli/test_doctor_cmd.py
+++ b/tests/test_cli/test_doctor_cmd.py
@@ -7,6 +7,7 @@ from typing import Any
 from typer.testing import CliRunner
 
 from opensquilla.cli import doctor_cmd as _doctor_cmd
+from opensquilla.cli import gateway_lifecycle
 from opensquilla.cli.main import app
 
 runner = CliRunner()
@@ -242,6 +243,55 @@ def test_doctor_targets_env_config_without_explicit_config(
         "opensquilla providers configure openrouter --api-key YOUR_API_KEY "
         f"--config {_config_arg(target)}"
     ]
+
+
+def test_doctor_prefers_active_profile_managed_gateway_runtime_port(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    _FakeGatewayClient.calls = []
+    home = tmp_path / "profile"
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(home))
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_URL", raising=False)
+    config = home / "config.toml"
+    config.parent.mkdir(parents=True)
+    config.write_text('host = "127.0.0.1"\nport = 18791\n', encoding="utf-8")
+    lifecycle = home / "state" / "gateway" / "gateway.json"
+    lifecycle.parent.mkdir(parents=True)
+    lifecycle.write_text(
+        json.dumps(
+            {
+                "pid": 4242,
+                "host": "127.0.0.1",
+                "port": 18792,
+                "url": "http://127.0.0.1:18792",
+                "healthUrl": "http://127.0.0.1:18792/health",
+                "startedAt": "2026-08-10T00:00:00Z",
+                "argv": ["opensquilla", "gateway", "run", "--port", "18792"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        gateway_lifecycle.GatewayLifecycleManager,
+        "_pid_running",
+        lambda self, pid: True,
+    )
+    monkeypatch.setattr(
+        gateway_lifecycle.GatewayLifecycleManager,
+        "_probe_health",
+        lambda self: True,
+    )
+    monkeypatch.setattr("opensquilla.cli.gateway_client.GatewayClient", _FakeGatewayClient)
+
+    result = runner.invoke(app, ["doctor", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert ("connect", "ws://127.0.0.1:18792/ws") in _FakeGatewayClient.calls
+    assert payload["gatewayUrl"] == "ws://127.0.0.1:18792/ws"
+    assert payload["configPath"] == str(config)
 
 
 def test_doctor_config_scopes_gateway_recovery_commands(tmp_path, monkeypatch) -> None:

--- a/tests/test_cli/test_gateway_rpc.py
+++ b/tests/test_cli/test_gateway_rpc.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 import json
+from pathlib import Path
+from typing import Any
 
 from opensquilla.cli import gateway_lifecycle
-from opensquilla.cli.gateway_rpc import default_gateway_token, default_gateway_url
+from opensquilla.cli.gateway_rpc import (
+    default_gateway_token,
+    default_gateway_url,
+    run_gateway_call,
+)
 
 
 def test_default_gateway_url_uses_implicit_home_config(tmp_path, monkeypatch) -> None:
@@ -27,21 +34,27 @@ port = 18790
     assert default_gateway_url() == "ws://127.0.0.1:18790/ws"
 
 
-def _write_managed_gateway_record(home, *, port: int = 18792) -> None:
+def _write_managed_gateway_record(
+    home,
+    *,
+    port: int = 18792,
+    config_path: Path | None = None,
+) -> None:
     target = home / "state" / "gateway" / "gateway.json"
     target.parent.mkdir(parents=True)
+    record: dict[str, Any] = {
+        "pid": 4242,
+        "host": "127.0.0.1",
+        "port": port,
+        "url": f"http://127.0.0.1:{port}",
+        "healthUrl": f"http://127.0.0.1:{port}/health",
+        "startedAt": "2026-08-10T00:00:00Z",
+        "argv": ["opensquilla", "gateway", "run", "--port", str(port)],
+    }
+    if config_path is not None:
+        record["configPath"] = str(config_path)
     target.write_text(
-        json.dumps(
-            {
-                "pid": 4242,
-                "host": "127.0.0.1",
-                "port": port,
-                "url": f"http://127.0.0.1:{port}",
-                "healthUrl": f"http://127.0.0.1:{port}/health",
-                "startedAt": "2026-08-10T00:00:00Z",
-                "argv": ["opensquilla", "gateway", "run", "--port", str(port)],
-            }
-        ),
+        json.dumps(record),
         encoding="utf-8",
     )
 
@@ -93,11 +106,108 @@ def test_default_gateway_url_explicit_url_wins_over_profile_managed_target(
     monkeypatch.setenv("OPENSQUILLA_GATEWAY_URL", "wss://squilla.example.com/ws")
     monkeypatch.setattr(
         gateway_lifecycle,
-        "active_managed_gateway_url",
+        "active_managed_gateway_target",
         lambda: (_ for _ in ()).throw(AssertionError("managed target must not be read")),
     )
 
     assert default_gateway_url() == "wss://squilla.example.com/ws"
+
+
+def test_default_gateway_url_explicit_config_wins_over_profile_managed_target(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_URL", raising=False)
+    config = tmp_path / "explicit.toml"
+    config.write_text(
+        'host = "127.0.0.1"\nport = 18800\n[auth]\nmode = "token"\ntoken = "explicit-token"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(config))
+    monkeypatch.setattr(
+        gateway_lifecycle,
+        "active_managed_gateway_target",
+        lambda: (_ for _ in ()).throw(AssertionError("managed target must not be read")),
+    )
+
+    assert default_gateway_url() == "ws://127.0.0.1:18800/ws"
+    assert default_gateway_token() == "explicit-token"
+
+
+def test_default_gateway_url_keeps_unhealthy_managed_target_authoritative(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_URL", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+    home = tmp_path / "profile"
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(home))
+    config = home / "config.toml"
+    config.parent.mkdir(parents=True)
+    config.write_text('host = "127.0.0.1"\nport = 18791\n', encoding="utf-8")
+    _write_managed_gateway_record(home)
+    monkeypatch.setattr(
+        gateway_lifecycle.GatewayLifecycleManager,
+        "_pid_running",
+        lambda self, pid: True,
+    )
+    monkeypatch.setattr(
+        gateway_lifecycle.GatewayLifecycleManager,
+        "_probe_health",
+        lambda self: False,
+    )
+
+    assert default_gateway_url() == "ws://127.0.0.1:18792/ws"
+
+
+def test_gateway_call_pairs_managed_target_with_recorded_config_token(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_URL", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_TOKEN", raising=False)
+    home = tmp_path / "profile"
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(home))
+    custom_config = tmp_path / "custom.toml"
+    custom_config.write_text(
+        'host = "127.0.0.1"\nport = 18791\n[auth]\nmode = "token"\ntoken = "managed-token"\n',
+        encoding="utf-8",
+    )
+    _write_managed_gateway_record(home, config_path=custom_config)
+    monkeypatch.setattr(
+        gateway_lifecycle.GatewayLifecycleManager,
+        "_pid_running",
+        lambda self, pid: True,
+    )
+    monkeypatch.setattr(
+        gateway_lifecycle.GatewayLifecycleManager,
+        "_probe_health",
+        lambda self: True,
+    )
+
+    class RecordingGatewayClient:
+        connection: tuple[str, str | None] | None = None
+
+        async def connect(self, url: str, *, token: str | None = None) -> None:
+            type(self).connection = (url, token)
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "opensquilla.cli.gateway_client.GatewayClient",
+        RecordingGatewayClient,
+    )
+
+    async def action(client: Any) -> str:
+        return "ok"
+
+    assert asyncio.run(run_gateway_call(action)) == "ok"
+    assert RecordingGatewayClient.connection == (
+        "ws://127.0.0.1:18792/ws",
+        "managed-token",
+    )
 
 
 def test_default_gateway_token_uses_explicit_config_path(tmp_path, monkeypatch) -> None:

--- a/tests/test_cli/test_gateway_rpc.py
+++ b/tests/test_cli/test_gateway_rpc.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+
+from opensquilla.cli import gateway_lifecycle
 from opensquilla.cli.gateway_rpc import default_gateway_token, default_gateway_url
 
 
@@ -22,6 +25,79 @@ port = 18790
     )
 
     assert default_gateway_url() == "ws://127.0.0.1:18790/ws"
+
+
+def _write_managed_gateway_record(home, *, port: int = 18792) -> None:
+    target = home / "state" / "gateway" / "gateway.json"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        json.dumps(
+            {
+                "pid": 4242,
+                "host": "127.0.0.1",
+                "port": port,
+                "url": f"http://127.0.0.1:{port}",
+                "healthUrl": f"http://127.0.0.1:{port}/health",
+                "startedAt": "2026-08-10T00:00:00Z",
+                "argv": ["opensquilla", "gateway", "run", "--port", str(port)],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_default_gateway_url_prefers_active_profile_managed_target(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_URL", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+    home = tmp_path / "profile"
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(home))
+    config = home / "config.toml"
+    config.parent.mkdir(parents=True)
+    config.write_text('host = "127.0.0.1"\nport = 18791\n', encoding="utf-8")
+    _write_managed_gateway_record(home)
+    monkeypatch.setattr(
+        gateway_lifecycle.GatewayLifecycleManager,
+        "_pid_running",
+        lambda self, pid: True,
+    )
+    monkeypatch.setattr(
+        gateway_lifecycle.GatewayLifecycleManager,
+        "_probe_health",
+        lambda self: True,
+    )
+
+    assert default_gateway_url() == "ws://127.0.0.1:18792/ws"
+
+
+def test_default_gateway_url_ignores_stale_profile_managed_target(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_URL", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+    home = tmp_path / "profile"
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(home))
+    config = home / "config.toml"
+    config.parent.mkdir(parents=True)
+    config.write_text('host = "127.0.0.1"\nport = 18791\n', encoding="utf-8")
+    _write_managed_gateway_record(home)
+    monkeypatch.setattr(
+        gateway_lifecycle.GatewayLifecycleManager,
+        "_pid_running",
+        lambda self, pid: False,
+    )
+
+    assert default_gateway_url() == "ws://127.0.0.1:18791/ws"
+
+
+def test_default_gateway_url_explicit_url_wins_over_profile_managed_target(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_URL", "wss://squilla.example.com/ws")
+    monkeypatch.setattr(
+        gateway_lifecycle,
+        "active_managed_gateway_url",
+        lambda: (_ for _ in ()).throw(AssertionError("managed target must not be read")),
+    )
+
+    assert default_gateway_url() == "wss://squilla.example.com/ws"
 
 
 def test_default_gateway_token_uses_explicit_config_path(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- prefer the selected profile managed Gateway lifecycle target over its persisted config target, including unhealthy-but-live managed processes
- preserve explicit Gateway URL and config precedence
- pair a managed Gateway URL with its recorded config path so RPC authentication and doctor context use the same target
- make `doctor` use the shared default target resolver so it follows runtime `--port` overrides
- cover active, stale, unhealthy, explicit URL/config, recorded-config token, doctor, and sessions-list behavior

## Root cause

`gateway start --port` intentionally records the effective port as runtime state without persisting it to `config.toml`. CLI RPC resolution only read the persisted config, so a named profile started on a non-default port could silently connect to the default profile Gateway on port 18791.

The target resolver now treats the profile-local managed lifecycle record as authoritative while its recorded process remains alive. It carries the recorded config path with the URL, preventing credentials or doctor context from being loaded from a different Gateway config. Explicit URL and config overrides remain authoritative.

Closes #1117.

## Validation

- `uv run ruff check src tests`
- `uv run mypy src` — 928 source files checked
- `uv run pytest tests/test_cli -q` — 819 passed, 1 skipped
- focused Gateway/doctor/lifecycle suite — 149 passed
- an earlier full `uv run pytest -q` progressed to 3429 passed / 66 skipped before being stopped after one unrelated pre-existing failure: `tests/test_ci/test_router_artifact_manifest.py::test_router_artifact_manifest_is_fresh`; this branch does not modify Router artifacts or their manifest
