### PR TITLE
Fix TokenRhythm V4 reasoning and refresh catalog metadata

### DIFF
--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -2438,7 +2438,7 @@ def _chat_config_with_thinking_disabled(chat_cfg: ChatConfig) -> ChatConfig:
         output_json_schema=chat_cfg.output_json_schema,
         output_json_schema_strict=chat_cfg.output_json_schema_strict,
         model_capabilities=chat_cfg.model_capabilities,
-        thinking_level=None,
+        thinking_level=ThinkingLevel.OFF,
         provider_request_max_chars=chat_cfg.provider_request_max_chars,
         context_window_tokens_global_override=(
             chat_cfg.context_window_tokens_global_override

--- a/src/opensquilla/provider/catalog_overrides.toml
+++ b/src/opensquilla/provider/catalog_overrides.toml
@@ -680,12 +680,12 @@ reasoning_format = "qwen_token_plan"
 # provider/live_catalog.py). Windows, output limits, and prices below are
 # that listing's published values (refreshed 2026-08; CNY per Mtok
 # converted at ~6.975 CNY/USD) so offline boots budget close to the
-# platform. Every served model streams DeepSeek-style reasoning_content
-# unconditionally, but the endpoint rejects thinking-toggle payloads
-# (UNKNOWN_FIELD 400), so reasoning_format stays "none": display-side
-# parsing needs no format, and "none" keeps the request builder from
-# injecting a deepseek thinking object. Vision is published for the kimi
-# rows and qwen3.8-max; explicit API declarations remain authoritative.
+# platform. Every served model streams DeepSeek-style reasoning_content,
+# while the mixed-family catalog keeps reasoning_format="none" so metadata
+# alone cannot grant one request dialect to every model. Exact official V4
+# compatibility rules own their thinking controls and bounded replay without
+# changing this neutral catalog shape. Vision is published for the kimi rows
+# and qwen3.8-max; explicit API declarations remain authoritative.
 
 [tokenrhythm."deepseek-v4-flash"]
 context_window = 1000000
@@ -697,6 +697,18 @@ reasoning_format = "none"
 input_cost_per_mtok = 0.14336917562724014
 output_cost_per_mtok = 0.2867383512544803
 cache_read_cost_per_mtok = 0.02867383512544803
+
+[tokenrhythm."deepseek-v4-flash-0731"]
+context_window = 1000000
+max_output_tokens = 384000
+supports_reasoning = true
+supports_tools = true
+supports_vision = false
+reasoning_format = "none"
+status = "testing"
+input_cost_per_mtok = 0.14336917562724014
+output_cost_per_mtok = 0.2867383512544803
+cache_read_cost_per_mtok = 0.002867383512544803
 
 [tokenrhythm."deepseek-v4-pro"]
 context_window = 1000000

--- a/src/opensquilla/provider/compat_policy.py
+++ b/src/opensquilla/provider/compat_policy.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from fnmatch import fnmatchcase
 from typing import Literal
+from urllib.parse import urlsplit
 
 from .model_identity import DEEPSEEK_V4_MODEL_IDS
 from .qwen_token_plan import (
@@ -31,6 +32,7 @@ from .qwen_token_plan import (
 )
 
 TextToolDialect = Literal["qwen_tag", "minimax_xml", "plain_json", "deepseek_dsml"]
+ReasoningReplayScope = Literal["all_assistant", "tool_call_assistant"]
 
 TEXT_TOOL_DIALECT_QWEN_TAG: TextToolDialect = "qwen_tag"
 TEXT_TOOL_DIALECT_MINIMAX_XML: TextToolDialect = "minimax_xml"
@@ -52,6 +54,24 @@ _TOKENRHYTHM_DSML_MODEL_IDS = (
     "tokenrhythm/deepseek-v4-flash",
     "tokenrhythm/deepseek-v4-flash-0731",
     "tokenrhythm/deepseek-v4-pro",
+)
+_TOKENRHYTHM_V4_MODEL_IDS = frozenset(
+    {
+        "deepseek-v4-flash",
+        "deepseek-v4-flash-0731",
+        "deepseek-v4-pro",
+        "tokenrhythm/deepseek-v4-flash",
+        "tokenrhythm/deepseek-v4-flash-0731",
+        "tokenrhythm/deepseek-v4-pro",
+    }
+)
+_TOKENRHYTHM_V4_FLASH_MODEL_IDS = frozenset(
+    {
+        "deepseek-v4-flash",
+        "deepseek-v4-flash-0731",
+        "tokenrhythm/deepseek-v4-flash",
+        "tokenrhythm/deepseek-v4-flash-0731",
+    }
 )
 _OPENROUTER_DSML_MODEL_IDS = (
     "deepseek/deepseek-v4-flash",
@@ -94,6 +114,52 @@ class TextToolCompatProfile:
     @property
     def enabled(self) -> bool:
         return bool(self.dialects or self.model_rules)
+
+
+@dataclass(frozen=True)
+class ReasoningModelRule:
+    """Exact, endpoint-scoped reasoning request compatibility.
+
+    Reasoning history is provider state, but it is still untrusted request
+    data with provider-specific wire limits.  These rules only shape the
+    physical request view; callers retain the original ``Message`` objects.
+    """
+
+    model_ids: frozenset[str]
+    endpoint_hosts: frozenset[str] = frozenset()
+    endpoint_paths: frozenset[str] = frozenset()
+    replay_scope: ReasoningReplayScope = "all_assistant"
+    require_reasoning_content: bool = False
+    max_reasoning_content_utf16_units: int | None = None
+    reasoning_format: str = ""
+    low_effort_model_ids: frozenset[str] = frozenset()
+    thinking_tool_choice_auto_only: bool = False
+    prefer_pinned_tool_choice_over_thinking: bool = False
+
+    def matches(self, model: str, base_url: str) -> bool:
+        """Match only a trusted raw model id and an exact HTTPS API root."""
+
+        if model.strip().lower() not in self.model_ids:
+            return False
+        if not self.endpoint_hosts:
+            return True
+        try:
+            parsed = urlsplit(str(base_url or "").strip())
+            host = (parsed.hostname or "").lower()
+            port = parsed.port
+        except (UnicodeError, ValueError):
+            return False
+        path = parsed.path.rstrip("/")
+        return bool(
+            parsed.scheme.lower() == "https"
+            and host in self.endpoint_hosts
+            and (port is None or port == 443)
+            and parsed.username is None
+            and parsed.password is None
+            and not parsed.query
+            and not parsed.fragment
+            and path in self.endpoint_paths
+        )
 
 
 @dataclass(frozen=True)
@@ -183,6 +249,11 @@ class OpenAICompatPolicy:
     # Reasoning continuity: replay assistant reasoning_content when the model
     # capabilities declare this reasoning format.
     replay_reasoning_format: str = ""
+
+    # Exact model/endpoint rules take precedence over the legacy basename
+    # fields below.  They are used when an aggregator has a narrower replay
+    # contract than the upstream model family it exposes.
+    reasoning_model_rules: tuple[ReasoningModelRule, ...] = ()
 
     # Reasoning format assumed when no model capabilities are available.
     default_reasoning_format: str = ""
@@ -423,14 +494,11 @@ _POLICIES_BY_KIND: dict[str, OpenAICompatPolicy] = {
         replay_reasoning_format="tencent_tokenhub",
         require_reasoning_content_model_ids=_TOKENHUB_HY3_MODEL_IDS,
     ),
-    # TokenRhythm relays the DeepSeek/GLM/MiniMax/Kimi/MiMo/Qwen families
-    # behind one host, and every served model streams DeepSeek-style
-    # reasoning_content unconditionally (the parse side needs no config).
-    # The endpoint rejects unknown request fields — a DeepSeek ``thinking``
-    # toggle is an UNKNOWN_FIELD 400 — so no default_reasoning_format and no
-    # thinking_toggle_model_ids here, and the packaged catalog rows pin
-    # reasoning_format="none" to keep dialect injection off. The V4 ids keep
-    # only the reasoning_content replay requirement (live-verified accepted).
+    # TokenRhythm relays several model families behind one host.  Its V4
+    # request contract is deliberately endpoint- and raw-id-scoped: ordinary
+    # assistant reasoning is withheld, tool-call reasoning is echoed only
+    # within the gateway's field limit, and controls use the DeepSeek-shaped
+    # wire dialect without changing catalog capabilities.
     "tokenrhythm": OpenAICompatPolicy(
         display_name="TokenRhythm",
         official_host="tokenrhythm.studio",
@@ -451,7 +519,26 @@ _POLICIES_BY_KIND: dict[str, OpenAICompatPolicy] = {
                 ),
             ),
         ),
-        require_reasoning_content_model_ids=DEEPSEEK_V4_MODEL_IDS,
+        reasoning_model_rules=(
+            ReasoningModelRule(
+                model_ids=_TOKENRHYTHM_V4_MODEL_IDS,
+                endpoint_hosts=frozenset({"tokenrhythm.studio"}),
+                endpoint_paths=frozenset({"", "/v1"}),
+                replay_scope="tool_call_assistant",
+                require_reasoning_content=True,
+                max_reasoning_content_utf16_units=50_000,
+                reasoning_format="deepseek",
+                low_effort_model_ids=_TOKENRHYTHM_V4_FLASH_MODEL_IDS,
+                thinking_tool_choice_auto_only=True,
+                prefer_pinned_tool_choice_over_thinking=True,
+            ),
+            # Custom endpoints keep the previous exact-id replay behavior but
+            # do not inherit TokenRhythm's official controls or field limit.
+            ReasoningModelRule(
+                model_ids=_TOKENRHYTHM_V4_MODEL_IDS,
+                require_reasoning_content=True,
+            ),
+        ),
         allow_post_terminal_noop_choice=True,
         allow_post_terminal_null_usage_noop_choice=True,
         post_terminal_metadata_keys=frozenset(

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -9,8 +9,9 @@ import math
 import os
 import re
 import sys
+from collections import Counter
 from collections.abc import AsyncIterator, Iterator, Mapping
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from typing import Any, cast
 from urllib.parse import urlparse
@@ -37,6 +38,7 @@ from .compat_policy import (
     TEXT_TOOL_DIALECT_PLAIN_JSON,
     TEXT_TOOL_DIALECT_QWEN_TAG,
     OpenAICompatPolicy,
+    ReasoningModelRule,
     compat_policy_for_kind,
 )
 from .context_capabilities import supports_openrouter_explicit_prompt_cache
@@ -495,8 +497,8 @@ def _openai_reasoning_fragments(payload: Mapping[str, Any]) -> tuple[str, ...]:
             text = detail.get("text")
             if isinstance(text, str) and text:
                 fragments.append(text)
-    for field in _OPENAI_REASONING_TEXT_FIELDS:
-        text = payload.get(field)
+    for reasoning_field in _OPENAI_REASONING_TEXT_FIELDS:
+        text = payload.get(reasoning_field)
         if isinstance(text, str) and text:
             fragments.append(text)
             break
@@ -841,6 +843,7 @@ def _apply_compat_request_constraints(
     payload: dict[str, Any],
     *,
     policy: OpenAICompatPolicy,
+    reasoning_rule: ReasoningModelRule | None,
     model: str,
     cfg: ChatConfig,
     has_tools: bool,
@@ -852,10 +855,32 @@ def _apply_compat_request_constraints(
     if force_thinking:
         payload["enable_thinking"] = True
 
+    thinking_object = payload.get("thinking")
+    thinking_enabled = payload.get("enable_thinking") is True or bool(
+        isinstance(thinking_object, Mapping)
+        and thinking_object.get("type") == "enabled"
+    )
+    thinking_unspecified = bool(
+        reasoning_rule
+        and reasoning_rule.reasoning_format
+        and "thinking" not in payload
+        and "enable_thinking" not in payload
+    )
+    tool_choice_auto_only = policy.thinking_tool_choice_auto_only or bool(
+        reasoning_rule and reasoning_rule.thinking_tool_choice_auto_only
+    )
+    prefer_pinned_over_thinking = (
+        policy.prefer_pinned_tool_choice_over_thinking
+        or bool(
+            reasoning_rule
+            and reasoning_rule.prefer_pinned_tool_choice_over_thinking
+        )
+    )
     if (
-        policy.thinking_tool_choice_auto_only
+        tool_choice_auto_only
         and (
-            payload.get("enable_thinking") is True
+            thinking_enabled
+            or thinking_unspecified
             or model_name in policy.implicit_thinking_tool_choice_model_ids
         )
         and "tool_choice" in payload
@@ -870,17 +895,25 @@ def _apply_compat_request_constraints(
         if tool_choice_type in {"auto", "none"}:
             payload["tool_choice"] = tool_choice_type
         elif (
-            policy.prefer_pinned_tool_choice_over_thinking
+            prefer_pinned_over_thinking
             and pinned_tool_choice
             and not force_thinking
         ):
-            payload["enable_thinking"] = False
+            if reasoning_rule and reasoning_rule.reasoning_format:
+                apply_reasoning_disable(
+                    payload,
+                    reasoning_rule.reasoning_format,
+                    ReasoningDisableArgs(model=model),
+                )
+            else:
+                payload["enable_thinking"] = False
             payload.pop("thinking_budget", None)
             payload.pop("reasoning_effort", None)
             payload.pop("preserve_thinking", None)
-            for message in payload.get("messages", ()):
-                if isinstance(message, dict):
-                    message.pop("reasoning_content", None)
+            if reasoning_rule is None:
+                for message in payload.get("messages", ()):
+                    if isinstance(message, dict):
+                        message.pop("reasoning_content", None)
         else:
             # The endpoint rejects required/pinned choices while thinking.
             # Preserve the requested reasoning mode and degrade the selector
@@ -2600,6 +2633,95 @@ def _attach_reasoning_content(
     return payload
 
 
+@dataclass(slots=True)
+class _ReasoningReplayStats:
+    limit_utf16_units: int | None = None
+    replay_candidates: list[tuple[str, int | None]] = field(
+        default_factory=list
+    )
+
+
+def _retained_reasoning_replay_units(
+    payload: Mapping[str, Any],
+    stats: _ReasoningReplayStats,
+) -> list[int]:
+    """Return only over-limit suppressions still present in the final payload."""
+
+    if not stats.replay_candidates:
+        return []
+    retained_signatures: Counter[str] = Counter()
+    messages = payload.get("messages")
+    if not isinstance(messages, list):
+        return []
+    for message in messages:
+        if (
+            not isinstance(message, Mapping)
+            or message.get("role") != "assistant"
+            or message.get("reasoning_content") != ""
+        ):
+            continue
+        tool_calls = message.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        if any(
+            isinstance(tool_call, Mapping) and tool_call.get("id")
+            for tool_call in tool_calls
+        ):
+            retained_signatures[_reasoning_replay_signature(message)] += 1
+
+    # Count only suppressions that are provably retained. Identical naturally
+    # empty tool messages make provenance ambiguous after context shaping, so
+    # consume those first and conservatively under-count instead of emitting a
+    # false transport metric.
+    candidates_by_signature: dict[str, list[int | None]] = {}
+    for signature, units in stats.replay_candidates:
+        candidates_by_signature.setdefault(signature, []).append(units)
+    retained_units: list[int] = []
+    for signature, final_count in retained_signatures.items():
+        candidates = candidates_by_signature.get(signature, [])
+        natural_count = sum(units is None for units in candidates)
+        guaranteed_suppressed = max(0, final_count - natural_count)
+        if guaranteed_suppressed <= 0:
+            continue
+        suppressed_units = [units for units in candidates if units is not None]
+        if final_count >= len(candidates):
+            retained_units.extend(suppressed_units)
+        elif len(set(suppressed_units)) == 1:
+            retained_units.extend(suppressed_units[:guaranteed_suppressed])
+    return retained_units
+
+
+def _reasoning_replay_signature(message: Mapping[str, Any]) -> str:
+    """Return a full in-memory digest used only for conservative telemetry."""
+
+    raw = json.dumps(message, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _reasoning_rule_for_request(
+    policy: OpenAICompatPolicy,
+    *,
+    model: str,
+    base_url: str,
+) -> ReasoningModelRule | None:
+    for rule in policy.reasoning_model_rules:
+        if rule.matches(model, base_url):
+            return rule
+    return None
+
+
+def _utf16_code_units(value: str) -> int:
+    """Count provider-side JavaScript string units without allocating a copy."""
+
+    return sum(2 if ord(character) > 0xFFFF else 1 for character in value)
+
+
+def _message_contains_tool_use(message: Message) -> bool:
+    return not isinstance(message.content, str) and any(
+        block.type == "tool_use" for block in message.content
+    )
+
+
 _REASONING_ECHO_TURNS_ENV = "OPENSQUILLA_REASONING_ECHO_TURNS"
 
 
@@ -2647,7 +2769,10 @@ def _requires_assistant_reasoning_content(
     model: str,
     *,
     thinking: bool = False,
+    reasoning_rule: ReasoningModelRule | None = None,
 ) -> bool:
+    if reasoning_rule is not None:
+        return reasoning_rule.require_reasoning_content
     model_name = model_basename(model)
     return model_name in policy.require_reasoning_content_model_ids or (
         thinking
@@ -2684,7 +2809,10 @@ def _should_replay_reasoning_content(
     model: str,
     caps: ModelCapabilities | None,
     thinking: bool = False,
+    reasoning_rule: ReasoningModelRule | None = None,
 ) -> bool:
+    if reasoning_rule is not None:
+        return reasoning_rule.require_reasoning_content
     model_name = model_basename(model)
     effective_thinking = _effective_policy_thinking(
         policy, model, thinking=thinking
@@ -2856,6 +2984,8 @@ def _build_openai_wire_messages(
     replay_provider_state: bool,
     reasoning_echo_turns: int | None,
     logical_index_map: dict[int, int] | None = None,
+    reasoning_rule: ReasoningModelRule | None = None,
+    reasoning_replay_stats: _ReasoningReplayStats | None = None,
 ) -> list[dict[str, Any]]:
     """Build the exact OpenAI-compatible wire-message array, without I/O."""
     openai_messages: list[dict[str, Any]] = []
@@ -2866,6 +2996,7 @@ def _build_openai_wire_messages(
             model=model,
             caps=caps,
             thinking=cfg.thinking,
+            reasoning_rule=reasoning_rule,
         )
     )
     explicit_cache_supported = False
@@ -2898,27 +3029,69 @@ def _build_openai_wire_messages(
         effective_thinking = _effective_policy_thinking(
             policy, model, thinking=cfg.thinking
         )
-        openai_messages.extend(
-            _build_openai_messages(
-                message,
-                include_reasoning_content=(
-                    include_reasoning_content
-                    if reasoning_echo_allowed is None
-                    else message_index in reasoning_echo_allowed
-                ),
-                require_assistant_reasoning_content=(
-                    _requires_assistant_reasoning_content(
-                        policy, model, thinking=effective_thinking
-                    )
-                ),
-                require_tool_call_reasoning_content=(
-                    _requires_tool_call_reasoning_content(
-                        policy, model, thinking=effective_thinking
-                    )
-                ),
-                replay_provider_state=replay_provider_state,
-            )
+        message_replays_reasoning = (
+            include_reasoning_content
+            if reasoning_echo_allowed is None
+            else message_index in reasoning_echo_allowed
         )
+        if (
+            reasoning_rule is not None
+            and reasoning_rule.replay_scope == "tool_call_assistant"
+            and not _message_contains_tool_use(message)
+        ):
+            message_replays_reasoning = False
+        limit = (
+            reasoning_rule.max_reasoning_content_utf16_units
+            if reasoning_rule is not None
+            else None
+        )
+        suppressed_units: int | None = None
+        if (
+            message_replays_reasoning
+            and limit is not None
+            and message.role == "assistant"
+            and message.reasoning_content
+        ):
+            observed_units = _utf16_code_units(message.reasoning_content)
+            if observed_units > limit:
+                message_replays_reasoning = False
+                if reasoning_replay_stats is not None:
+                    reasoning_replay_stats.limit_utf16_units = limit
+                    suppressed_units = observed_units
+        built_messages = _build_openai_messages(
+            message,
+            include_reasoning_content=message_replays_reasoning,
+            require_assistant_reasoning_content=(
+                _requires_assistant_reasoning_content(
+                    policy,
+                    model,
+                    thinking=effective_thinking,
+                    reasoning_rule=reasoning_rule,
+                )
+            ),
+            require_tool_call_reasoning_content=(
+                _requires_tool_call_reasoning_content(
+                    policy, model, thinking=effective_thinking
+                )
+            ),
+            replay_provider_state=replay_provider_state,
+        )
+        if reasoning_replay_stats is not None and limit is not None:
+            for built_message in built_messages:
+                tool_calls = built_message.get("tool_calls")
+                if (
+                    built_message.get("role") == "assistant"
+                    and built_message.get("reasoning_content") == ""
+                    and isinstance(tool_calls, list)
+                    and any(
+                        isinstance(tool_call, Mapping) and tool_call.get("id")
+                        for tool_call in tool_calls
+                    )
+                ):
+                    reasoning_replay_stats.replay_candidates.append(
+                        (_reasoning_replay_signature(built_message), suppressed_units)
+                    )
+        openai_messages.extend(built_messages)
     if provider_kind == "dashscope" and cfg.cache_mode == "on":
         _attach_cache_control_to_latest_text_messages(
             openai_messages,
@@ -3085,6 +3258,11 @@ class OpenAIProvider:
             raise ValueError("additional_messages must be a non-negative integer")
         cfg = config or ChatConfig()
         wire_cfg = _prompt_json_schema_config(cfg, policy=self._compat)
+        reasoning_rule = _reasoning_rule_for_request(
+            self._compat,
+            model=self._model,
+            base_url=self._base_url,
+        )
         wire_messages = _build_openai_wire_messages(
             messages,
             wire_cfg,
@@ -3093,6 +3271,7 @@ class OpenAIProvider:
             model=self._model,
             replay_provider_state=self._replay_provider_state,
             reasoning_echo_turns=self._reasoning_echo_turns,
+            reasoning_rule=reasoning_rule,
         )
         return ProviderMessageCountProjection(
             actual_wire_messages=len(wire_messages) + additional_messages,
@@ -3114,16 +3293,28 @@ class OpenAIProvider:
         messages: list[Message],
         tools: list[ToolDefinition] | None,
         cfg: ChatConfig,
-    ) -> tuple[dict[str, Any], int | None, str | None]:
+    ) -> tuple[
+        dict[str, Any],
+        int | None,
+        str | None,
+        _ReasoningReplayStats,
+    ]:
         wire_cfg = _prompt_json_schema_config(cfg, policy=self._compat)
         caps = cfg.model_capabilities
+        reasoning_rule = _reasoning_rule_for_request(
+            self._compat,
+            model=self._model,
+            base_url=self._base_url,
+        )
         include_reasoning_content = _should_replay_reasoning_content(
             policy=self._compat,
             model=self._model,
             caps=caps,
             thinking=cfg.thinking,
+            reasoning_rule=reasoning_rule,
         )
         logical_index_map: dict[int, int] = {}
+        reasoning_replay_stats = _ReasoningReplayStats()
         openai_messages = _build_openai_wire_messages(
             messages,
             wire_cfg,
@@ -3133,6 +3324,8 @@ class OpenAIProvider:
             replay_provider_state=self._replay_provider_state,
             reasoning_echo_turns=self._reasoning_echo_turns,
             logical_index_map=logical_index_map,
+            reasoning_rule=reasoning_rule,
+            reasoning_replay_stats=reasoning_replay_stats,
         )
         wire_active_user_index = (
             logical_index_map.get(cfg.active_user_message_index)
@@ -3233,17 +3426,34 @@ class OpenAIProvider:
                         "allow_fallbacks": True,
                     }
 
-        thinking_toggle_model = (
-            self._model.strip().lower() in self._compat.thinking_toggle_model_ids
+        thinking_toggle_model = bool(
+            (reasoning_rule and reasoning_rule.reasoning_format)
+            or self._model.strip().lower()
+            in self._compat.thinking_toggle_model_ids
         )
         if (caps and caps.supports_reasoning and cfg.thinking) or (
             thinking_toggle_model and cfg.thinking
         ):
             reasoning_format = (
-                caps.reasoning_format
-                if caps is not None
-                else self._compat.default_reasoning_format
+                reasoning_rule.reasoning_format
+                if reasoning_rule and reasoning_rule.reasoning_format
+                else (
+                    caps.reasoning_format
+                    if caps is not None
+                    else self._compat.default_reasoning_format
+                )
             )
+            reasoning_effort_override: str | None = None
+            if reasoning_rule and reasoning_rule.reasoning_format:
+                level = getattr(cfg.thinking_level, "value", "")
+                if (
+                    self._model.strip().lower()
+                    in reasoning_rule.low_effort_model_ids
+                    and level in {"minimal", "low"}
+                ):
+                    reasoning_effort_override = "low"
+                else:
+                    reasoning_effort_override = "high"
             apply_reasoning_enable(
                 payload,
                 reasoning_format,
@@ -3254,6 +3464,7 @@ class OpenAIProvider:
                     thinking_budget_explicit=bool(
                         cfg.thinking_budget_explicit
                     ),
+                    reasoning_effort_override=reasoning_effort_override,
                 ),
             )
             if reasoning_format == "dashscope":
@@ -3273,7 +3484,23 @@ class OpenAIProvider:
         ):
             pass
         elif thinking_toggle_model:
-            payload["thinking"] = {"type": "disabled"}
+            if reasoning_rule and reasoning_rule.reasoning_format:
+                configured_level = getattr(
+                    cfg.thinking_level,
+                    "value",
+                    cfg.thinking_level,
+                )
+                if str(configured_level or "").strip().lower() in {
+                    "none",
+                    "off",
+                }:
+                    apply_reasoning_disable(
+                        payload,
+                        reasoning_rule.reasoning_format,
+                        ReasoningDisableArgs(model=self._model),
+                    )
+            else:
+                payload["thinking"] = {"type": "disabled"}
         elif caps and caps.supports_reasoning:
             apply_reasoning_disable(
                 payload,
@@ -3289,6 +3516,7 @@ class OpenAIProvider:
         _apply_compat_request_constraints(
             payload,
             policy=self._compat,
+            reasoning_rule=reasoning_rule,
             model=self._model,
             cfg=cfg,
             has_tools=bool(tools),
@@ -3298,7 +3526,12 @@ class OpenAIProvider:
             if any(message.get("role") == "tool" for message in openai_messages)
             else None
         )
-        return payload, wire_active_user_index, fallback_reason
+        return (
+            payload,
+            wire_active_user_index,
+            fallback_reason,
+            reasoning_replay_stats,
+        )
 
     def project_final_request(
         self,
@@ -3311,7 +3544,12 @@ class OpenAIProvider:
         """Project the exact Chat Completions payload without I/O or shaping."""
 
         cfg = config or ChatConfig()
-        payload, wire_active_user_index, fallback_reason = self._build_payload(
+        (
+            payload,
+            wire_active_user_index,
+            fallback_reason,
+            _reasoning_replay_stats,
+        ) = self._build_payload(
             messages,
             tools,
             cfg,
@@ -3380,7 +3618,12 @@ class OpenAIProvider:
             and cfg.physical_attempt_limit != 1
             and non_stream_fallback_allowed
         )
-        payload, wire_active_user_index, fallback_reason = self._build_payload(
+        (
+            payload,
+            wire_active_user_index,
+            fallback_reason,
+            reasoning_replay_stats,
+        ) = self._build_payload(
             messages,
             tools,
             cfg,
@@ -3469,6 +3712,20 @@ class OpenAIProvider:
                 code="provider_request_budget_exhausted",
             )
             return
+        retained_replay_units = _retained_reasoning_replay_units(
+            payload,
+            reasoning_replay_stats,
+        )
+        if retained_replay_units:
+            log.info(
+                "provider.reasoning_content_withheld",
+                provider=self._provider_kind,
+                model=self._model,
+                reason="reasoning_content_limit",
+                withheld_count=len(retained_replay_units),
+                max_observed_utf16_units=max(retained_replay_units),
+                limit_utf16_units=reasoning_replay_stats.limit_utf16_units,
+            )
 
         headers: dict[str, str] = {
             "Content-Type": "application/json",

--- a/src/opensquilla/provider/presets/tokenrhythm.toml
+++ b/src/opensquilla/provider/presets/tokenrhythm.toml
@@ -3,8 +3,9 @@
 # tokenrhythm id never becomes a squilla_router.tier_profile value (the
 # accepted set stays pinned to the legacy nine — downgrade contract), so
 # provider saves and boot defaults apply these tiers inline instead.
-# No thinking_level on purpose: the endpoint rejects thinking-toggle request
-# fields, and every served model streams reasoning unconditionally.
+# No thinking_level on purpose: packaged routes preserve the provider-declared
+# default. Explicit turn settings may control exact official V4 models without
+# assigning the same reasoning dialect to the other families in this ladder.
 [preset]
 id = "tokenrhythm"
 provider = "tokenrhythm"

--- a/src/opensquilla/provider/reasoning_dialects.py
+++ b/src/opensquilla/provider/reasoning_dialects.py
@@ -89,6 +89,7 @@ class ReasoningEnableArgs:
     thinking_budget_tokens: int
     model: str = ""
     thinking_budget_explicit: bool = False
+    reasoning_effort_override: str | None = None
 
     @property
     def effort(self) -> str:
@@ -119,7 +120,10 @@ def _enable_reasoning_effort(payload: dict[str, Any], args: ReasoningEnableArgs)
 
 def _enable_deepseek(payload: dict[str, Any], args: ReasoningEnableArgs) -> None:
     payload["thinking"] = {"type": "enabled"}
-    payload["reasoning_effort"] = _resolve_deepseek_reasoning_effort(args.thinking_level)
+    payload["reasoning_effort"] = (
+        args.reasoning_effort_override
+        or _resolve_deepseek_reasoning_effort(args.thinking_level)
+    )
 
 
 def _enable_tencent_tokenhub(payload: dict[str, Any], args: ReasoningEnableArgs) -> None:

--- a/tests/test_engine/test_reasoning_retry_and_deadline_thinking_levers.py
+++ b/tests/test_engine/test_reasoning_retry_and_deadline_thinking_levers.py
@@ -262,7 +262,10 @@ async def test_deadline_thinking_off_disables_thinking_when_margin_reached() -> 
     events = [event async for event in agent.run_turn("fix the bug")]
 
     assert any(event.kind == "done" for event in events)
-    assert provider.calls[0]["config"].thinking is False
+    disabled_config = provider.calls[0]["config"]
+    assert disabled_config.thinking is False
+    assert disabled_config.thinking_budget_tokens == 0
+    assert disabled_config.thinking_level is ThinkingLevel.OFF
 
 
 @pytest.mark.asyncio
@@ -285,8 +288,11 @@ async def test_deadline_thinking_off_stays_off_for_subsequent_calls() -> None:
     assert any(event.kind == "done" for event in events)
     assert len(provider.calls) == 2
     # Sticky: every call after arming runs with thinking off.
-    assert provider.calls[0]["config"].thinking is False
-    assert provider.calls[1]["config"].thinking is False
+    for call in provider.calls:
+        disabled_config = call["config"]
+        assert disabled_config.thinking is False
+        assert disabled_config.thinking_budget_tokens == 0
+        assert disabled_config.thinking_level is ThinkingLevel.OFF
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/test_selector_fallback_routed_model.py
+++ b/tests/test_engine/test_selector_fallback_routed_model.py
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 from typing import Any
 
 from opensquilla.context_budget import ContextBudgetGovernor
+from opensquilla.engine import ToolResult
 from opensquilla.engine.agent import Agent
 from opensquilla.engine.agent_injection import ListPendingInputProvider
 from opensquilla.engine.pipeline import TurnContext
@@ -33,7 +34,12 @@ from opensquilla.provider import (
     ModelCapabilities,
     ProviderRequestCorrelation,
     TextDeltaEvent,
+    ToolDefinition,
+    ToolInputSchema,
+    ToolUseEndEvent,
+    ToolUseStartEvent,
 )
+from opensquilla.provider.openai import OpenAIProvider
 from opensquilla.tools.types import CallerKind, ToolContext
 
 
@@ -616,6 +622,116 @@ class _ChainProvider:
         return []
 
 
+class _ProjectingScriptProvider:
+    """Script one physical leg while using its real wire projection."""
+
+    def __init__(
+        self,
+        *,
+        provider_name: str,
+        wire_provider: OpenAIProvider,
+        streams: list[list[Any]],
+    ) -> None:
+        self.provider_name = provider_name
+        self._wire_provider = wire_provider
+        self._streams = streams
+        self.calls: list[dict[str, Any]] = []
+
+    def project_final_request(
+        self,
+        messages: list[Message],
+        tools: Any = None,
+        config: ChatConfig | None = None,
+        *,
+        message_limit: int | None = None,
+    ) -> Any:
+        return self._wire_provider.project_final_request(
+            messages,
+            tools,
+            config,
+            message_limit=message_limit,
+        )
+
+    def project_message_count(
+        self,
+        messages: list[Message],
+        config: ChatConfig | None = None,
+        *,
+        additional_messages: int = 0,
+    ) -> Any:
+        return self._wire_provider.project_message_count(
+            messages,
+            config,
+            additional_messages=additional_messages,
+        )
+
+    def chat(
+        self,
+        messages: list[Message],
+        tools: Any = None,
+        config: ChatConfig | None = None,
+    ) -> AsyncIterator[Any]:
+        canonical_before = [message.model_dump(mode="json") for message in messages]
+        projection = self.project_final_request(messages, tools, config)
+        canonical_after = [message.model_dump(mode="json") for message in messages]
+        call_index = len(self.calls)
+        self.calls.append(
+            {
+                "messages": messages,
+                "canonical_before": canonical_before,
+                "canonical_after": canonical_after,
+                "payload": projection.payload,
+            }
+        )
+        events = self._streams[call_index]
+        return self._stream(events)
+
+    async def _stream(self, events: list[Any]) -> AsyncIterator[Any]:
+        for event in events:
+            yield event
+
+    async def list_models(self) -> list[Any]:
+        return []
+
+
+class _ProjectingFallbackSelector:
+    def __init__(
+        self,
+        primary: _ProjectingScriptProvider,
+        fallback: _ProjectingScriptProvider,
+    ) -> None:
+        self.primary = primary
+        self.fallback = fallback
+        self.current_config = SimpleNamespace(
+            provider="tokenrhythm",
+            model="deepseek-v4-flash",
+            base_url="https://tokenrhythm.studio/v1",
+        )
+        self._remaining_chain = [
+            self.current_config,
+            SimpleNamespace(
+                provider="deepseek",
+                model="deepseek-v4-flash",
+                base_url="https://api.deepseek.com",
+            ),
+        ]
+
+    @property
+    def active_provider_id(self) -> str:
+        return str(self.current_config.provider)
+
+    def remaining_chain(self) -> list[SimpleNamespace]:
+        return list(self._remaining_chain)
+
+    def next_fallback_after_failure(
+        self,
+        _exc: Exception,
+    ) -> _ProjectingScriptProvider:
+        self.current_config = self._remaining_chain[1]
+        self._remaining_chain = self._remaining_chain[1:]
+        return self.fallback
+
+
 class _ChainSelector:
     """Two-link chain selector: primary fails, one fallback hop remains."""
 
@@ -672,6 +788,123 @@ async def test_physical_attempt_limit_prevents_selector_internal_fallback() -> N
     assert any(isinstance(event, ErrorEvent) for event in events)
     assert not any(isinstance(event, TextDeltaEvent) for event in events)
     assert selector.current_config.model == PRIMARY_MODEL
+
+
+async def test_tokenrhythm_tool_reasoning_fallback_rebuilds_from_canonical_history() -> None:
+    long_reasoning = "r" * 50_001
+    primary = _ProjectingScriptProvider(
+        provider_name="tokenrhythm",
+        wire_provider=OpenAIProvider(
+            api_key="synthetic-tokenrhythm-key",
+            model="deepseek-v4-flash",
+            base_url="https://tokenrhythm.studio/v1",
+            provider_kind="tokenrhythm",
+            provider_id="tokenrhythm",
+        ),
+        streams=[
+            [
+                ToolUseStartEvent(tool_use_id="tool-1", tool_name="echo"),
+                ToolUseEndEvent(
+                    tool_use_id="tool-1",
+                    tool_name="echo",
+                    arguments={"value": "once"},
+                ),
+                DoneEvent(
+                    stop_reason="tool_use",
+                    input_tokens=3,
+                    output_tokens=1,
+                    reasoning_tokens=1,
+                    reasoning_content=long_reasoning,
+                ),
+            ],
+            [ErrorEvent(message="upstream unavailable", code="503")],
+        ],
+    )
+    fallback = _ProjectingScriptProvider(
+        provider_name="deepseek",
+        wire_provider=OpenAIProvider(
+            api_key="synthetic-deepseek-key",
+            model="deepseek-v4-flash",
+            base_url="https://api.deepseek.com",
+            provider_kind="deepseek",
+            provider_id="deepseek",
+        ),
+        streams=[
+            [
+                TextDeltaEvent(text="done"),
+                DoneEvent(
+                    stop_reason="stop",
+                    model="deepseek-v4-flash",
+                    input_tokens=4,
+                    output_tokens=1,
+                ),
+            ]
+        ],
+    )
+    selector = _ProjectingFallbackSelector(primary, fallback)
+    provider = _SelectorFallbackProvider(primary, selector)
+    tool_handler_calls = 0
+
+    async def tool_handler(call: Any) -> ToolResult:
+        nonlocal tool_handler_calls
+        tool_handler_calls += 1
+        return ToolResult(
+            tool_use_id=call.tool_use_id,
+            tool_name=call.tool_name,
+            content="tool result",
+        )
+
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            max_iterations=2,
+            max_provider_retries=0,
+            model_id="deepseek-v4-flash",
+        ),
+        tool_definitions=[
+            ToolDefinition(
+                name="echo",
+                description="Echo once.",
+                input_schema=ToolInputSchema(
+                    properties={"value": {"type": "string"}},
+                    required=["value"],
+                ),
+            )
+        ],
+        tool_handler=tool_handler,
+    )
+
+    events = [event async for event in agent.run_turn("run the tool once")]
+
+    assert tool_handler_calls == 1
+    assert len(primary.calls) == 2
+    assert len(fallback.calls) == 1
+    primary_post_tool = primary.calls[1]
+    fallback_post_tool = fallback.calls[0]
+    assert primary_post_tool["canonical_before"] == primary_post_tool["canonical_after"]
+    assert fallback_post_tool["canonical_before"] == fallback_post_tool["canonical_after"]
+    assert fallback_post_tool["canonical_before"] == primary_post_tool["canonical_before"]
+
+    canonical_tool_call = next(
+        message
+        for message in primary_post_tool["messages"]
+        if message.role == "assistant" and message.reasoning_content == long_reasoning
+    )
+    assert canonical_tool_call.reasoning_content == long_reasoning
+
+    primary_wire_tool_call = next(
+        message
+        for message in primary_post_tool["payload"]["messages"]
+        if message.get("role") == "assistant" and message.get("tool_calls")
+    )
+    fallback_wire_tool_call = next(
+        message
+        for message in fallback_post_tool["payload"]["messages"]
+        if message.get("role") == "assistant" and message.get("tool_calls")
+    )
+    assert primary_wire_tool_call["reasoning_content"] == ""
+    assert fallback_wire_tool_call["reasoning_content"] == long_reasoning
+    assert any(event.kind == "done" and event.text == "done" for event in events)
 
 
 async def test_local_admission_failure_escalates_to_larger_authorized_leg(

--- a/tests/test_model_router_defaults.py
+++ b/tests/test_model_router_defaults.py
@@ -402,8 +402,8 @@ def test_example_toml_enables_runtime_router_defaults() -> None:
     assert squilla_router["require_router_runtime"] is True
 
     tiers = squilla_router["tiers"]
-    # TokenRhythm rejects thinking-toggle request fields, so the example
-    # ladder deliberately carries no thinking_level.
+    # The packaged mixed-family ladder preserves provider defaults; explicit
+    # turn-level V4 controls do not become tier-wide settings.
     for name in ("c0", "c1", "c2", "c3", "image_model"):
         assert tiers[name]["provider"] == "tokenrhythm"
         assert "thinking_level" not in tiers[name]

--- a/tests/test_provider/golden/_harness.py
+++ b/tests/test_provider/golden/_harness.py
@@ -58,8 +58,9 @@ _NEUTRAL_MODEL = "test-chat-model"
 # kind -> (model id, reasoning dialect resolved when thinking is requested).
 # Model ids are derived from the code paths that trigger each dialect —
 # ModelCatalog.get_capabilities prefix ladders and compat_policy model-id
-# sets — never invented. "none" kinds freeze the omission: a thinking
-# request must serialize with no reasoning field at all.
+# sets — never invented. "none" normally freezes omission; an exact
+# endpoint/model compat rule may deliberately override neutral catalog
+# metadata, which its request golden then freezes explicitly.
 COMPAT_THINKING_MODELS: dict[str, tuple[str, str]] = {
     # api.openai.com host + gpt-5 prefix ladder (model_catalog) -> "openai";
     # gpt-5.4 is also in max_completion_tokens and omit-temperature-when-
@@ -104,11 +105,9 @@ COMPAT_THINKING_MODELS: dict[str, tuple[str, str]] = {
     # "tencent_tokenhub" dialect; the policy also requires assistant
     # reasoning_content replay for the hy3 ids, frozen by the tools golden.
     "tencent_tokenhub": ("hy3", "tencent_tokenhub"),
-    # [tokenrhythm."deepseek-v4-flash"] corrections row pins
-    # reasoning_format="none": the relay streams reasoning_content on its
-    # own but 400s on any thinking payload, so the thinking golden freezes
-    # the omission. The id is also in require_reasoning_content_model_ids,
-    # so the tools golden freezes assistant reasoning_content replay.
+    # The mixed-family catalog remains neutral, while the exact official V4
+    # request rule supplies DeepSeek-shaped thinking control and tool-call-only
+    # bounded reasoning replay. The request goldens freeze that override.
     "tokenrhythm": ("deepseek-v4-flash", "none"),
     "lm_studio": (_NEUTRAL_MODEL, "none"),
     "ovms": (_NEUTRAL_MODEL, "none"),

--- a/tests/test_provider/golden/requests/openai_compat/tokenrhythm__plain.json
+++ b/tests/test_provider/golden/requests/openai_compat/tokenrhythm__plain.json
@@ -13,7 +13,7 @@
       },
       {
         "content": "Canberra.",
-        "reasoning_content": "The capital is Canberra, not Sydney.",
+        "reasoning_content": "",
         "role": "assistant"
       },
       {

--- a/tests/test_provider/golden/requests/openai_compat/tokenrhythm__thinking.json
+++ b/tests/test_provider/golden/requests/openai_compat/tokenrhythm__thinking.json
@@ -13,7 +13,7 @@
       },
       {
         "content": "Canberra.",
-        "reasoning_content": "The capital is Canberra, not Sydney.",
+        "reasoning_content": "",
         "role": "assistant"
       },
       {
@@ -31,11 +31,15 @@
       }
     ],
     "model": "deepseek-v4-flash",
+    "reasoning_effort": "high",
     "stream": true,
     "stream_options": {
       "include_usage": true
     },
-    "temperature": 0.7
+    "temperature": 0.7,
+    "thinking": {
+      "type": "enabled"
+    }
   },
   "content_type": "application/json",
   "method": "POST",

--- a/tests/test_provider/test_capability_ladder_parity.py
+++ b/tests/test_provider/test_capability_ladder_parity.py
@@ -721,10 +721,10 @@ _EXPECTED_CAPS: dict[tuple[str, str, str], tuple[bool, bool, bool, str]] = {
     ("tencent_tokenhub_intl", "gpt-5.5", ""): (False, True, True, "none"),
     ("tencent_tokenhub_intl", "hy3", ""): (False, True, False, "none"),
     ("tencent_tokenhub_intl", "hy3-preview", ""): (False, True, False, "none"),
-    # tokenrhythm: the [tokenrhythm.*] corrections rows pin
-    # reasoning_format="none" (the relay streams reasoning_content on its
-    # own but rejects thinking toggles), so effective supports_reasoning is
-    # False everywhere; vision only on the live-verified kimi rows.
+    # tokenrhythm: the mixed-family catalog stays at reasoning_format="none",
+    # so effective catalog supports_reasoning remains False. Exact official V4
+    # request controls live in compat policy instead; vision is limited to the
+    # live-verified kimi rows.
     ("tokenrhythm", "totally-unknown-model-x1", ""): (False, True, False, "none"),
     ("tokenrhythm", "gpt-4o", ""): (False, True, False, "none"),
     ("tokenrhythm", "deepseek-r1", ""): (False, True, False, "none"),

--- a/tests/test_provider/test_live_catalog.py
+++ b/tests/test_provider/test_live_catalog.py
@@ -327,9 +327,9 @@ def test_scoped_live_entries_outrank_corrections_without_leaking() -> None:
 
 
 def test_scoped_live_keeps_corrections_reasoning_dialect() -> None:
-    # The relay rejects thinking-toggle payloads, so its corrections rows
-    # pin reasoning_format="none". Live ingest claims no reasoning fields;
-    # capabilities must stay exactly as the ladder decided them.
+    # The mixed-family catalog remains neutral at reasoning_format="none";
+    # exact official V4 wire controls do not mutate catalog capabilities.
+    # Live ingest claims no reasoning fields, so the ladder remains unchanged.
     catalog = ModelCatalog()
     catalog.set_live_provider_entries(
         "tokenrhythm",

--- a/tests/test_provider/test_preset_registry.py
+++ b/tests/test_provider/test_preset_registry.py
@@ -160,9 +160,13 @@ def test_tokenrhythm_curated_ladder() -> None:
     for name, model in expected_models.items():
         assert tiers[name]["provider"] == "tokenrhythm", name
         assert tiers[name]["model"] == model, name
-        # The endpoint rejects thinking-toggle request fields, so the curated
-        # ladder must not carry a thinking_level for the request builder.
+        # Packaged routes preserve the provider default; explicit turn-level
+        # controls remain separate from this mixed-family router ladder.
         assert "thinking_level" not in tiers[name], name
+    assert "deepseek-v4-flash-0731" not in {
+        preset.default_model,
+        *(entry["model"] for entry in tiers.values()),
+    }
     assert tiers["image_model"]["supports_image"] is True
     assert tiers["image_model"]["image_only"] is True
 

--- a/tests/test_provider/test_tokenrhythm_catalog.py
+++ b/tests/test_provider/test_tokenrhythm_catalog.py
@@ -623,6 +623,21 @@ def test_merge_uses_auth_as_entitlement_and_filters_known_non_chat_or_offline() 
     assert merged["auth-only"].metadata.published is None
 
 
+def test_v4_flash_0731_public_metadata_does_not_grant_entitlement() -> None:
+    model_id = "deepseek-v4-flash-0731"
+    published = parse_tokenrhythm_published(
+        {"data": [_published_row(id=model_id, name="DeepSeek V4 Flash 0731")]}
+    )
+
+    assert merge_tokenrhythm_catalog(published, {}) == {}
+
+    declared = parse_tokenrhythm_declared({"data": [{"id": model_id}]})
+    merged = merge_tokenrhythm_catalog(published, declared)
+    assert set(merged) == {model_id}
+    assert merged[model_id].metadata.published is published[model_id]
+    assert merged[model_id].metadata.declared is declared[model_id]
+
+
 def test_testing_model_projects_raw_catalog_value_but_runtime_policy_is_scoped() -> None:
     published = parse_tokenrhythm_published(
         {

--- a/tests/test_provider_compat_policy.py
+++ b/tests/test_provider_compat_policy.py
@@ -72,15 +72,31 @@ def test_api_url_absorbs_any_version_suffix() -> None:
         assert provider._api_url("/v1/chat/completions") == expected, base
 
 
-def test_tokenrhythm_never_toggles_thinking_but_replays_v4_reasoning() -> None:
-    """TokenRhythm rejects unknown request fields (a DeepSeek ``thinking``
-    toggle is an UNKNOWN_FIELD 400), so the policy must never declare toggle
-    ids or a default reasoning format; the V4 ids keep only the
-    reasoning_content replay requirement."""
+def test_tokenrhythm_v4_reasoning_is_exact_and_endpoint_scoped() -> None:
     policy = compat_policy_for_kind("tokenrhythm")
     assert policy.thinking_toggle_model_ids == frozenset()
     assert policy.default_reasoning_format == ""
     assert policy.replay_reasoning_format == ""
+    assert len(policy.reasoning_model_rules) == 2
+    official, custom = policy.reasoning_model_rules
+    assert official.matches(
+        "deepseek-v4-flash", "https://tokenrhythm.studio/v1"
+    )
+    assert not official.matches(
+        "tokenrhythm/deepseek-v4-flash-0731",
+        "https://api.tokenrhythm.studio/v1",
+    )
+    assert not official.matches(
+        "untrusted/deepseek-v4-flash", "https://tokenrhythm.studio/v1"
+    )
+    assert not official.matches(
+        "deepseek-v4-flash", "https://tokenrhythm.studio.evil.example/v1"
+    )
+    assert official.replay_scope == "tool_call_assistant"
+    assert official.max_reasoning_content_utf16_units == 50_000
+    assert official.reasoning_format == "deepseek"
+    assert custom.matches("deepseek-v4-flash", "https://custom.example/v1")
+    assert custom.reasoning_format == ""
     assert policy.supports_native_json_schema_output is False
     # cost_cny is CNY — booking it as USD would corrupt cost rollups.
     assert policy.trust_billed_cost is False
@@ -94,10 +110,16 @@ def test_tokenrhythm_never_toggles_thinking_but_replays_v4_reasoning() -> None:
         }
     )
     assert _should_replay_reasoning_content(
-        policy=policy, model="deepseek-v4-flash", caps=None
+        policy=policy,
+        model="deepseek-v4-flash",
+        caps=None,
+        reasoning_rule=official,
     )
     assert _should_replay_reasoning_content(
-        policy=policy, model="deepseek-v4-flash-0731", caps=None
+        policy=policy,
+        model="deepseek-v4-flash-0731",
+        caps=None,
+        reasoning_rule=official,
     )
     assert not _should_replay_reasoning_content(
         policy=policy, model="glm-5", caps=None

--- a/tests/test_provider_model_catalog.py
+++ b/tests/test_provider_model_catalog.py
@@ -54,6 +54,33 @@ def test_provider_scoped_corrections_budget_outranks_snapshot_merge() -> None:
     assert catalog.resolve_context_window("deepseek-v4-flash", "deepseek") == 1_000_000
 
 
+def test_tokenrhythm_v4_flash_0731_offline_metadata_is_exact_and_scoped() -> None:
+    catalog = ModelCatalog()
+
+    entry = catalog.resolve_entry("deepseek-v4-flash-0731", provider="tokenrhythm")
+    assert entry.context_window == 1_000_000
+    assert entry.max_output_tokens == 384_000
+    assert entry.supports_reasoning is True
+    assert entry.supports_tools is True
+    assert entry.supports_vision is False
+    assert entry.reasoning_format == "none"
+    assert entry.status == "testing"
+    assert entry.input_cost_per_mtok == pytest.approx(0.14336917562724014)
+    assert entry.output_cost_per_mtok == pytest.approx(0.2867383512544803)
+    assert entry.cache_read_cost_per_mtok == pytest.approx(0.002867383512544803)
+    assert catalog.resolve_context_window(
+        "deepseek-v4-flash-0731", provider="tokenrhythm"
+    ) == 1_000_000
+    assert catalog.resolve_max_tokens(
+        "deepseek-v4-flash-0731", provider="tokenrhythm"
+    ) == 384_000
+
+    direct = catalog.resolve_entry("deepseek-v4-flash-0731", provider="deepseek")
+    assert direct.input_cost_per_mtok is None
+    assert direct.output_cost_per_mtok is None
+    assert direct.cache_read_cost_per_mtok is None
+
+
 def test_direct_profile_windows_resolve_from_models_dev_snapshot() -> None:
     catalog = ModelCatalog()
 

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -1491,7 +1491,7 @@ def test_openrouter_deepseek_v4_returns_reasoning_content_from_details(
     assert done.reasoning_content == "I considered the request."
 
 
-def test_tokenrhythm_stream_normalizes_reasoning_alias_for_replay(
+def test_tokenrhythm_stream_normalizes_reasoning_alias_but_withholds_text_replay(
     monkeypatch: Any,
 ) -> None:
     captured_payloads: list[dict[str, Any]] = []
@@ -1570,7 +1570,7 @@ def test_tokenrhythm_stream_normalizes_reasoning_alias_for_replay(
     assert captured_payloads[1]["messages"][0] == {
         "role": "assistant",
         "content": "ok",
-        "reasoning_content": "supplier-specific reasoning",
+        "reasoning_content": "",
     }
 
 

--- a/tests/test_provider_tokenrhythm_v4_wire_policy.py
+++ b/tests/test_provider_tokenrhythm_v4_wire_policy.py
@@ -1,0 +1,643 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import httpx
+import pytest
+import structlog.testing
+
+from opensquilla.engine.agent import _chat_config_with_thinking_disabled
+from opensquilla.engine.types import ThinkingLevel
+from opensquilla.provider.openai import (
+    OpenAIProvider,
+    _reasoning_replay_signature,
+    _ReasoningReplayStats,
+    _retained_reasoning_replay_units,
+)
+from opensquilla.provider.types import (
+    ChatConfig,
+    ContentBlockToolResult,
+    ContentBlockToolUse,
+    ErrorEvent,
+    Message,
+    ModelCapabilities,
+    ToolDefinition,
+    ToolInputSchema,
+)
+
+TOKENRHYTHM_V4_MODELS = (
+    "deepseek-v4-flash",
+    "deepseek-v4-flash-0731",
+    "deepseek-v4-pro",
+    "tokenrhythm/deepseek-v4-flash",
+    "tokenrhythm/deepseek-v4-flash-0731",
+    "tokenrhythm/deepseek-v4-pro",
+)
+TOKENRHYTHM_REASONING_LIMIT_UTF16_UNITS = 50_000
+
+
+@pytest.fixture(autouse=True)
+def _clear_reasoning_echo_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENSQUILLA_REASONING_ECHO_TURNS", raising=False)
+
+
+def _provider(
+    *,
+    model: str = "deepseek-v4-flash",
+    base_url: str = "https://tokenrhythm.studio/v1",
+    provider_kind: str = "tokenrhythm",
+) -> OpenAIProvider:
+    return OpenAIProvider(
+        api_key="synthetic-tokenrhythm-key",
+        model=model,
+        base_url=base_url,
+        provider_kind=provider_kind,
+    )
+
+
+def _tokenrhythm_caps() -> ModelCapabilities:
+    # This is the catalog shape used by TokenRhythm today. The exact V4 wire
+    # policy, not a falsely advertised catalog dialect, owns the compatibility
+    # behavior under test.
+    return ModelCapabilities(
+        supports_reasoning=True,
+        supports_tools=True,
+        reasoning_format="none",
+    )
+
+
+def _config(
+    *,
+    thinking: bool = True,
+    thinking_level: ThinkingLevel | None = ThinkingLevel.HIGH,
+    tool_choice: Any | None = None,
+) -> ChatConfig:
+    return ChatConfig(
+        thinking=thinking,
+        thinking_level=thinking_level,
+        tool_choice=tool_choice,
+        model_capabilities=_tokenrhythm_caps(),
+    )
+
+
+def _payload(
+    provider: OpenAIProvider,
+    messages: list[Message],
+    *,
+    config: ChatConfig | None = None,
+    tools: list[ToolDefinition] | None = None,
+) -> dict[str, Any]:
+    return provider.project_final_request(
+        messages,
+        tools=tools,
+        config=config or _config(),
+    ).payload
+
+
+def _text_history(reasoning: str) -> list[Message]:
+    return [
+        Message(
+            role="assistant",
+            content="A prior assistant answer.",
+            reasoning_content=reasoning,
+        ),
+        Message(role="user", content="Continue."),
+    ]
+
+
+def _tool_history(reasoning: str | None) -> list[Message]:
+    return [
+        Message(
+            role="assistant",
+            content=[
+                ContentBlockToolUse(
+                    id="call_lookup",
+                    name="lookup",
+                    input={"key": "synthetic"},
+                )
+            ],
+            reasoning_content=reasoning,
+        ),
+        Message(
+            role="user",
+            content=[
+                ContentBlockToolResult(
+                    tool_use_id="call_lookup",
+                    content="synthetic result",
+                )
+            ],
+        ),
+        Message(role="user", content="Continue."),
+    ]
+
+
+def _reasoning_with_utf16_units(kind: str, units: int) -> str:
+    if kind == "ascii":
+        value = "a" * units
+    elif kind == "cjk":
+        value = "界" * units
+    elif kind == "emoji":
+        value = "🧠" * (units // 2) + ("a" if units % 2 else "")
+    else:  # pragma: no cover - the parametrization is closed
+        raise AssertionError(f"unsupported fixture kind: {kind}")
+    assert len(value.encode("utf-16-le")) // 2 == units
+    return value
+
+
+LOOKUP_TOOL = ToolDefinition(
+    name="lookup",
+    description="Look up a synthetic value.",
+    input_schema=ToolInputSchema(
+        properties={"key": {"type": "string"}},
+        required=["key"],
+    ),
+)
+
+
+@pytest.mark.parametrize("model", TOKENRHYTHM_V4_MODELS)
+def test_tokenrhythm_v4_text_assistant_withholds_real_reasoning(model: str) -> None:
+    reasoning = "private provider reasoning"
+    messages = _text_history(reasoning)
+    canonical_before = [message.model_dump(mode="json") for message in messages]
+
+    payload = _payload(_provider(model=model), messages)
+
+    assert payload["messages"][0]["reasoning_content"] == ""
+    assert [message.model_dump(mode="json") for message in messages] == canonical_before
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    (
+        "https://tokenrhythm.studio",
+        "https://tokenrhythm.studio/v1",
+        "https://TOKENRHYTHM.STUDIO:443/v1/",
+    ),
+)
+def test_tokenrhythm_v4_policy_accepts_only_supported_service_endpoints(
+    base_url: str,
+) -> None:
+    payload = _payload(
+        _provider(base_url=base_url),
+        _text_history("must be hidden on the supported service endpoint"),
+    )
+
+    assert payload["messages"][0]["reasoning_content"] == ""
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    (
+        "http://tokenrhythm.studio/v1",
+        "https://api.tokenrhythm.studio/v1",
+        "https://tokenrhythm.studio.evil.example/v1",
+        "https://customer-proxy.example/v1",
+        "https://tokenrhythm.studio/v1/custom",
+        "https://tokenrhythm.studio:8443/v1",
+        "https://user@tokenrhythm.studio/v1",
+        "https://tokenrhythm.studio/v1?tenant=x",
+        "https://tokenrhythm.studio/v1#fragment",
+    ),
+)
+def test_tokenrhythm_v4_policy_does_not_grant_custom_or_lookalike_endpoints(
+    base_url: str,
+) -> None:
+    reasoning = "legacy replay remains outside the official endpoint gate"
+
+    payload = _payload(_provider(base_url=base_url), _text_history(reasoning))
+
+    assert payload["messages"][0]["reasoning_content"] == reasoning
+    assert "thinking" not in payload
+    assert "reasoning_effort" not in payload
+
+
+def test_tokenrhythm_custom_endpoint_keeps_legacy_unbounded_tool_replay() -> None:
+    reasoning = _reasoning_with_utf16_units(
+        "emoji",
+        TOKENRHYTHM_REASONING_LIMIT_UTF16_UNITS + 1,
+    )
+
+    payload = _payload(
+        _provider(base_url="https://customer-proxy.example/v1"),
+        _tool_history(reasoning),
+    )
+
+    assert payload["messages"][0]["reasoning_content"] == reasoning
+    assert "thinking" not in payload
+    assert "reasoning_effort" not in payload
+
+
+def test_tokenrhythm_v4_policy_requires_exact_provider_kind() -> None:
+    payload = _payload(
+        _provider(provider_kind="openai"),
+        _text_history("must not gain TokenRhythm behavior from the hostname alone"),
+    )
+
+    assert "reasoning_content" not in payload["messages"][0]
+    assert "thinking" not in payload
+    assert "reasoning_effort" not in payload
+
+
+@pytest.mark.parametrize(
+    "model",
+    (
+        "deepseek-v3.2",
+        "deepseek-v4-flash-preview",
+        "untrusted/deepseek-v4-flash",
+        "tokenrhythm/deepseek-v4-flash-preview",
+    ),
+)
+def test_tokenrhythm_v4_policy_does_not_change_non_exact_model_ids(model: str) -> None:
+    payload = _payload(
+        _provider(model=model),
+        _text_history("non-V4 history keeps its existing wire behavior"),
+    )
+
+    assert "reasoning_content" not in payload["messages"][0]
+    assert "thinking" not in payload
+    assert "reasoning_effort" not in payload
+
+
+@pytest.mark.parametrize("model", TOKENRHYTHM_V4_MODELS[:3])
+@pytest.mark.parametrize("kind", ("ascii", "cjk", "emoji"))
+@pytest.mark.parametrize(
+    ("units", "is_preserved"),
+    (
+        (TOKENRHYTHM_REASONING_LIMIT_UTF16_UNITS, True),
+        (TOKENRHYTHM_REASONING_LIMIT_UTF16_UNITS + 1, False),
+    ),
+)
+def test_tokenrhythm_v4_tool_reasoning_uses_utf16_unit_boundary(
+    model: str,
+    kind: str,
+    units: int,
+    is_preserved: bool,
+) -> None:
+    reasoning = _reasoning_with_utf16_units(kind, units)
+    messages = _tool_history(reasoning)
+    canonical_before = [message.model_dump(mode="json") for message in messages]
+
+    payload = _payload(_provider(model=model), messages)
+
+    expected = reasoning if is_preserved else ""
+    assert payload["messages"][0]["reasoning_content"] == expected
+    assert [message.model_dump(mode="json") for message in messages] == canonical_before
+
+
+def test_tokenrhythm_v4_tool_reasoning_missing_value_is_sent_as_empty() -> None:
+    payload = _payload(_provider(), _tool_history(None))
+
+    assert payload["messages"][0]["reasoning_content"] == ""
+
+
+def test_tokenrhythm_projection_does_not_emit_transport_withheld_metric() -> None:
+    reasoning = _reasoning_with_utf16_units(
+        "ascii",
+        TOKENRHYTHM_REASONING_LIMIT_UTF16_UNITS + 1,
+    )
+
+    with structlog.testing.capture_logs() as logs:
+        payload = _payload(_provider(), _tool_history(reasoning))
+
+    assert payload["messages"][0]["reasoning_content"] == ""
+    assert not any(
+        event.get("event") == "provider.reasoning_content_withheld"
+        for event in logs
+    )
+
+
+@pytest.mark.parametrize(
+    ("model", "thinking_level", "expected_effort"),
+    (
+        ("deepseek-v4-flash", ThinkingLevel.MINIMAL, "low"),
+        ("deepseek-v4-flash", ThinkingLevel.LOW, "low"),
+        ("deepseek-v4-flash", ThinkingLevel.MEDIUM, "high"),
+        ("deepseek-v4-flash", ThinkingLevel.HIGH, "high"),
+        ("deepseek-v4-flash", ThinkingLevel.XHIGH, "high"),
+        ("deepseek-v4-flash", ThinkingLevel.ADAPTIVE, "high"),
+        ("deepseek-v4-flash-0731", ThinkingLevel.MINIMAL, "low"),
+        ("deepseek-v4-flash-0731", ThinkingLevel.LOW, "low"),
+        ("deepseek-v4-flash-0731", ThinkingLevel.XHIGH, "high"),
+        ("deepseek-v4-pro", ThinkingLevel.MINIMAL, "high"),
+        ("deepseek-v4-pro", ThinkingLevel.LOW, "high"),
+        ("deepseek-v4-pro", ThinkingLevel.XHIGH, "high"),
+        ("deepseek-v4-pro", ThinkingLevel.ADAPTIVE, "high"),
+        ("deepseek-v4-flash", None, "high"),
+        ("tokenrhythm/deepseek-v4-flash", ThinkingLevel.LOW, "low"),
+        ("tokenrhythm/deepseek-v4-flash-0731", ThinkingLevel.LOW, "low"),
+        ("tokenrhythm/deepseek-v4-pro", ThinkingLevel.LOW, "high"),
+    ),
+)
+def test_tokenrhythm_v4_thinking_uses_conservative_model_effort_mapping(
+    model: str,
+    thinking_level: ThinkingLevel | None,
+    expected_effort: str,
+) -> None:
+    payload = _payload(
+        _provider(model=model),
+        [Message(role="user", content="Think about this.")],
+        config=_config(thinking=True, thinking_level=thinking_level),
+    )
+
+    assert payload["thinking"] == {"type": "enabled"}
+    assert payload["reasoning_effort"] == expected_effort
+
+
+@pytest.mark.parametrize("model", TOKENRHYTHM_V4_MODELS[:3])
+def test_tokenrhythm_v4_thinking_off_sends_explicit_disabled(model: str) -> None:
+    payload = _payload(
+        _provider(model=model),
+        [Message(role="user", content="Answer directly.")],
+        config=_config(thinking=False, thinking_level=ThinkingLevel.OFF),
+    )
+
+    assert payload["thinking"] == {"type": "disabled"}
+    assert "reasoning_effort" not in payload
+
+
+def test_tokenrhythm_v4_unspecified_thinking_keeps_provider_default() -> None:
+    payload = _payload(
+        _provider(),
+        [Message(role="user", content="Use the provider default.")],
+        config=_config(thinking=False, thinking_level=None),
+    )
+
+    assert "thinking" not in payload
+    assert "reasoning_effort" not in payload
+
+
+def test_tokenrhythm_v4_runtime_thinking_fallback_sends_explicit_disabled() -> None:
+    fallback_config = _chat_config_with_thinking_disabled(
+        _config(thinking=True, thinking_level=ThinkingLevel.HIGH)
+    )
+
+    payload = _payload(
+        _provider(),
+        [Message(role="user", content="Finish without more reasoning.")],
+        config=fallback_config,
+    )
+
+    assert payload["thinking"] == {"type": "disabled"}
+    assert "reasoning_effort" not in payload
+
+
+def test_tokenrhythm_v4_unspecified_thinking_degrades_required_tool_choice() -> None:
+    payload = _payload(
+        _provider(),
+        [Message(role="user", content="Use a tool.")],
+        config=_config(
+            thinking=False,
+            thinking_level=None,
+            tool_choice="required",
+        ),
+        tools=[LOOKUP_TOOL],
+    )
+
+    assert payload["tool_choice"] == "auto"
+    assert "thinking" not in payload
+    assert "reasoning_effort" not in payload
+
+
+def test_tokenrhythm_v4_unspecified_thinking_named_pin_disables_thinking() -> None:
+    named_pin = {"type": "function", "function": {"name": "lookup"}}
+    payload = _payload(
+        _provider(),
+        [Message(role="user", content="Call the selected tool.")],
+        config=_config(
+            thinking=False,
+            thinking_level=None,
+            tool_choice=named_pin,
+        ),
+        tools=[LOOKUP_TOOL],
+    )
+
+    assert payload["tool_choice"] == named_pin
+    assert payload["thinking"] == {"type": "disabled"}
+    assert "reasoning_effort" not in payload
+
+
+@pytest.mark.parametrize("tool_choice", ("auto", "none"))
+def test_tokenrhythm_v4_thinking_preserves_supported_tool_choices(
+    tool_choice: str,
+) -> None:
+    payload = _payload(
+        _provider(),
+        [Message(role="user", content="Use a tool if appropriate.")],
+        config=_config(tool_choice=tool_choice),
+        tools=[LOOKUP_TOOL],
+    )
+
+    assert payload["tool_choice"] == tool_choice
+    assert payload["thinking"] == {"type": "enabled"}
+    assert payload["reasoning_effort"] == "high"
+
+
+def test_tokenrhythm_v4_thinking_degrades_required_tool_choice_to_auto() -> None:
+    payload = _payload(
+        _provider(),
+        [Message(role="user", content="Use a tool.")],
+        config=_config(tool_choice="required"),
+        tools=[LOOKUP_TOOL],
+    )
+
+    assert payload["tool_choice"] == "auto"
+    assert payload["thinking"] == {"type": "enabled"}
+    assert payload["reasoning_effort"] == "high"
+
+
+def test_tokenrhythm_v4_named_tool_pin_wins_over_thinking() -> None:
+    named_pin = {"type": "function", "function": {"name": "lookup"}}
+    payload = _payload(
+        _provider(),
+        [Message(role="user", content="Call the selected tool.")],
+        config=_config(tool_choice=named_pin),
+        tools=[LOOKUP_TOOL],
+    )
+
+    assert payload["tool_choice"] == named_pin
+    assert payload["thinking"] == {"type": "disabled"}
+    assert "reasoning_effort" not in payload
+
+
+def test_tokenrhythm_field_limit_400_is_not_retried_reactively(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(
+            400,
+            headers={"content-type": "application/json"},
+            json={
+                "error": {
+                    "code": "BAD_REQUEST",
+                    "message": "messages.0.reasoning_content exceeds provider field limit",
+                }
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "opensquilla.provider.openai.httpx.AsyncClient",
+        patched_async_client,
+    )
+    private_marker = "synthetic-private-reasoning-marker"
+    reasoning = private_marker + "a" * (
+        TOKENRHYTHM_REASONING_LIMIT_UTF16_UNITS + 1 - len(private_marker)
+    )
+    messages = _tool_history(reasoning)
+
+    async def run() -> list[ErrorEvent]:
+        errors: list[ErrorEvent] = []
+        async for event in _provider().chat(messages, config=_config()):
+            if isinstance(event, ErrorEvent):
+                errors.append(event)
+        return errors
+
+    with structlog.testing.capture_logs() as logs:
+        errors = asyncio.run(run())
+
+    assert len(requests) == 1
+    assert requests[0]["messages"][0]["reasoning_content"] == ""
+    assert len(errors) == 1
+    withheld = [
+        event
+        for event in logs
+        if event.get("event") == "provider.reasoning_content_withheld"
+    ]
+    assert withheld == [
+        {
+            "event": "provider.reasoning_content_withheld",
+            "log_level": "info",
+            "provider": "tokenrhythm",
+            "model": "deepseek-v4-flash",
+            "reason": "reasoning_content_limit",
+            "withheld_count": 1,
+            "max_observed_utf16_units": 50_001,
+            "limit_utf16_units": 50_000,
+        }
+    ]
+    assert private_marker not in json.dumps(logs, ensure_ascii=False)
+
+
+def test_budget_rejection_does_not_report_a_transport_withheld_metric(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ForbiddenClient:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            raise AssertionError("budget-limited request must not reach transport")
+
+    monkeypatch.setattr(
+        "opensquilla.provider.openai.httpx.AsyncClient",
+        ForbiddenClient,
+    )
+    reasoning = _reasoning_with_utf16_units(
+        "ascii",
+        TOKENRHYTHM_REASONING_LIMIT_UTF16_UNITS + 1,
+    )
+    config = _config()
+    config.provider_request_max_chars = 100
+
+    async def run() -> list[ErrorEvent]:
+        return [
+            event
+            async for event in _provider().chat(
+                _tool_history(reasoning),
+                config=config,
+            )
+            if isinstance(event, ErrorEvent)
+        ]
+
+    with structlog.testing.capture_logs() as logs:
+        errors = asyncio.run(run())
+
+    assert len(errors) == 1
+    assert errors[0].code == "provider_request_budget_exhausted"
+    assert not any(
+        event.get("event") == "provider.reasoning_content_withheld"
+        for event in logs
+    )
+
+
+def test_retained_withheld_metric_skips_ambiguous_duplicate_lengths() -> None:
+    message = {
+        "role": "assistant",
+        "content": None,
+        "reasoning_content": "",
+        "tool_calls": [
+            {
+                "id": "duplicate_call_id",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": "{}"},
+            }
+        ],
+    }
+    signature = _reasoning_replay_signature(message)
+    stats = _ReasoningReplayStats(
+        replay_candidates=[
+            (signature, TOKENRHYTHM_REASONING_LIMIT_UTF16_UNITS + 1),
+            (signature, TOKENRHYTHM_REASONING_LIMIT_UTF16_UNITS + 2),
+        ]
+    )
+    payload = {"messages": [message]}
+
+    assert _retained_reasoning_replay_units(payload, stats) == []
+
+
+def test_retained_withheld_metric_counts_identical_duplicate_lengths_once() -> None:
+    message = {
+        "role": "assistant",
+        "content": None,
+        "reasoning_content": "",
+        "tool_calls": [
+            {
+                "id": "duplicate_call_id",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": "{}"},
+            }
+        ],
+    }
+    signature = _reasoning_replay_signature(message)
+    stats = _ReasoningReplayStats(
+        replay_candidates=[
+            (signature, TOKENRHYTHM_REASONING_LIMIT_UTF16_UNITS + 1),
+            (signature, TOKENRHYTHM_REASONING_LIMIT_UTF16_UNITS + 1),
+        ]
+    )
+
+    assert _retained_reasoning_replay_units({"messages": [message]}, stats) == [
+        50_001
+    ]
+
+
+def test_retained_withheld_metric_does_not_claim_ambiguous_natural_empty() -> None:
+    message = {
+        "role": "assistant",
+        "content": None,
+        "reasoning_content": "",
+        "tool_calls": [
+            {
+                "id": "reused_call_id",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": "{}"},
+            }
+        ],
+    }
+    signature = _reasoning_replay_signature(message)
+    stats = _ReasoningReplayStats(
+        replay_candidates=[
+            (signature, TOKENRHYTHM_REASONING_LIMIT_UTF16_UNITS + 1),
+            (signature, None),
+        ]
+    )
+
+    assert _retained_reasoning_replay_units({"messages": [message]}, stats) == []


### PR DESCRIPTION
## Scope

- add the TokenRhythm DeepSeek V4 reasoning wire policy while preserving the current reasoning-alias normalization path
- refresh the packaged TokenRhythm V4 catalog and routing preset metadata
- represent explicit thinking disablement as `ThinkingLevel.OFF` with a zero budget, without changing the default MEDIUM retry behavior

## Target

- Base branch: `main`
- Linked issue: None

## Release note

TokenRhythm DeepSeek V4 requests now use the provider-specific reasoning replay and thinking controls, with refreshed catalog metadata.

## Verification

- 1,080 Provider, selector, catalog, reasoning-lever, and compatibility tests passed
- 106 request/stream golden tests passed
- full Ruff check passed
- full mypy check passed (922 source files)
- full offline pytest attempt: 21,277 passed, 240 skipped; 19 unrelated local-environment failures require optional system libraries, a `python` PATH alias, or platform-specific shell behavior and are left for clean CI validation
- diff and sensitive-path/credential scans passed

## Safety and compatibility

- no Goal, WebUI, migration, RPC, or persisted-state changes
- non-TokenRhythm providers retain their existing compatibility policies
- explicit thinking OFF is isolated from the default large-context reasoning retry policy
- platform-neutral production change; no filesystem, subprocess, signal, or sandbox behavior is changed

## Third-party origin

No third-party source code, comments, fixtures, or identifiers were copied. The change is implemented against OpenSquilla's existing provider abstraction and synthetic offline fixtures.
