### PR TITLE
Fix runtime log severity parsing

### DIFF
--- a/opensquilla-webui/src/views/LogsView.test.ts
+++ b/opensquilla-webui/src/views/LogsView.test.ts
@@ -302,6 +302,45 @@ describe('LogsView states', () => {
     expect(el.textContent).toContain('No lines match the current filter.')
     expect(el.textContent).not.toContain('No logs have been recorded yet.')
   })
+
+  it('uses bracketed log levels before error-like message text', async () => {
+    rpcMocks.call.mockImplementation(async (method: string) => {
+      if (method === 'logs.status') return normalStatus()
+      if (method === 'logs.tail') {
+        return {
+          lines: [
+            '2026-08-10 [INFO] opensquilla: migrations_applied migration=V019__turn_errors',
+            '2026-08-10 [INFO] opensquilla: skill_catalog.refreshed errors=0',
+            '2026-08-10 [WARNING] opensquilla: github.search_failed error="request failed"',
+            '2026-08-10 [ERROR] opensquilla: actual failure',
+          ],
+          cursor: 4,
+        }
+      }
+      throw new Error(`unexpected RPC method: ${method}`)
+    })
+
+    const { el } = await mountLogs()
+
+    expect(Array.from(el.querySelectorAll('.lg-line__lvl'), level => level.textContent)).toEqual([
+      'INFO',
+      'INFO',
+      'WARN',
+      'ERROR',
+    ])
+    expect(el.querySelector('.lg-level-btn--info .lg-level-btn__count')?.textContent).toBe('2')
+    expect(el.querySelector('.lg-level-btn--warn .lg-level-btn__count')?.textContent).toBe('1')
+    expect(el.querySelector('.lg-level-btn--error .lg-level-btn__count')?.textContent).toBe('1')
+
+    el.querySelector<HTMLButtonElement>('.lg-level-btn--debug')?.click()
+    el.querySelector<HTMLButtonElement>('.lg-level-btn--info')?.click()
+    el.querySelector<HTMLButtonElement>('.lg-level-btn--warn')?.click()
+    await flush()
+
+    const visibleLines = Array.from(el.querySelectorAll('.lg-line'), line => line.textContent)
+    expect(visibleLines).toHaveLength(1)
+    expect(visibleLines[0]).toContain('actual failure')
+  })
 })
 
 describe('LogsView KeepAlive lifecycle', () => {

--- a/opensquilla-webui/src/views/LogsView.vue
+++ b/opensquilla-webui/src/views/LogsView.vue
@@ -657,6 +657,14 @@ function onDetailKeydown(event: KeyboardEvent) {
 // ---------------------------------------------------------------------------
 
 function guessLevel(line: string): string {
+  // debug.log's formatter emits the authoritative level before the free-form
+  // message. Prefer it so fields such as `errors=0` cannot override [INFO].
+  const formattedLevel = line.match(/\[(TRACE|DEBUG|INFO|WARN(?:ING)?|ERROR)\]/i)?.[1]?.toUpperCase()
+  if (formattedLevel === 'WARNING') return 'WARN'
+  if (formattedLevel) return formattedLevel
+
+  // Preserve severity inference for legacy or third-party lines that do not
+  // carry the gateway's canonical bracketed level.
   const u = line.toUpperCase()
   if (u.includes('ERROR')) return 'ERROR'
   if (u.includes('WARN')) return 'WARN'


### PR DESCRIPTION
## Summary

- prefer the canonical bracketed log level before inspecting free-form message text
- normalize Python's `WARNING` level to the Web UI's existing `WARN` filter value
- keep the existing fallback inference for legacy lines without a bracketed level
- add regression coverage for the INFO/WARNING records reported in the issue

Fixes #1129

## Root cause

`LogsView` inferred string log severity by scanning the entire line for `ERROR` before checking `WARN` or `INFO`. Message fields such as `errors=0`, migration names containing `errors`, or `error=...` therefore overrode the authoritative `[INFO]` or `[WARNING]` prefix.

## Scope and non-goals

This is a Web UI-only parsing change. It does not change the `logs.tail` RPC, backend filtering, log formatting, persistence, refresh behavior, or generated Web UI artifacts.

## Validation

- `vitest run src/views/LogsView.test.ts` — 1 file, 7 tests passed
- `npm run test:unit` — 300 files, 3253 tests passed
- `npm run typecheck` — passed, including architecture, chat-security, theme, and i18n guards
- `npm run build` — passed; 787 modules transformed and 196 artifact files verified
- `npm run verify:release-dist` — passed; 196 artifact files verified
- `git diff --check` — passed

## Live-check limitation

The exact issue records are covered by the component regression test. A live Gateway reproduction on Windows 11 with Chrome was not performed.

## Commit lineage

No existing eligible PR or reusable commit was found for #1129. This PR contains one new focused commit based on the latest `main`.