### PR TITLE
Handle busy agent profile locks cleanly

### DIFF
--- a/src/opensquilla/cli/main.py
+++ b/src/opensquilla/cli/main.py
@@ -1068,40 +1068,55 @@ def agent(
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
 ) -> None:
     """Run a single agent turn for automation."""
-    from opensquilla.recovery import guarded_desktop_profile
+    from opensquilla.cli.output import emit_error
+    from opensquilla.recovery import ProfileLockBusyError, guarded_desktop_profile
 
-    with guarded_desktop_profile():
-        run_agent_command(
-            message=message,
-            agent_id=agent_id,
-            session_id=session_id,
-            model=model,
-            workspace=workspace,
-            workspace_strict=workspace_strict,
-            workspace_lockdown=workspace_lockdown,
-            workspace_lockdown_deny_paths=workspace_lockdown_deny_paths,
-            scratch_dir=scratch_dir,
-            thinking=thinking,
-            timeout=timeout,
-            max_iterations=max_iterations,
-            iteration_timeout_seconds=iteration_timeout_seconds,
-            tool_timeout_seconds=tool_timeout_seconds,
-            request_timeout_seconds=request_timeout_seconds,
-            max_provider_retries=max_provider_retries,
-            length_capped_continuations=length_capped_continuations,
-            transcript_path=transcript_path,
-            usage_path=usage_path,
-            event_stream_stderr=event_stream_stderr,
-            session_db_path=session_db_path,
-            no_memory_capture=no_memory_capture,
-            file_paths=file_paths,
-            unattended=unattended,
-            stateless=stateless,
-            clean_room=clean_room,
-            stateless_keep_project_rules=stateless_keep_project_rules,
-            permissions=permissions,
+    try:
+        with guarded_desktop_profile():
+            run_agent_command(
+                message=message,
+                agent_id=agent_id,
+                session_id=session_id,
+                model=model,
+                workspace=workspace,
+                workspace_strict=workspace_strict,
+                workspace_lockdown=workspace_lockdown,
+                workspace_lockdown_deny_paths=workspace_lockdown_deny_paths,
+                scratch_dir=scratch_dir,
+                thinking=thinking,
+                timeout=timeout,
+                max_iterations=max_iterations,
+                iteration_timeout_seconds=iteration_timeout_seconds,
+                tool_timeout_seconds=tool_timeout_seconds,
+                request_timeout_seconds=request_timeout_seconds,
+                max_provider_retries=max_provider_retries,
+                length_capped_continuations=length_capped_continuations,
+                transcript_path=transcript_path,
+                usage_path=usage_path,
+                event_stream_stderr=event_stream_stderr,
+                session_db_path=session_db_path,
+                no_memory_capture=no_memory_capture,
+                file_paths=file_paths,
+                unattended=unattended,
+                stateless=stateless,
+                clean_room=clean_room,
+                stateless_keep_project_rules=stateless_keep_project_rules,
+                permissions=permissions,
+                json_output=json_output,
+            )
+    except ProfileLockBusyError:
+        emit_error(
+            "This profile is already in use by another OpenSquilla writer. "
+            "The standalone 'opensquilla agent' command cannot share a profile with "
+            "another writer, including an active Desktop Gateway. To use a running "
+            "Gateway, use a Gateway-backed command such as 'opensquilla chat' (set "
+            "OPENSQUILLA_GATEWAY_URL and OPENSQUILLA_GATEWAY_TOKEN when needed); "
+            "otherwise, set both OPENSQUILLA_STATE_DIR and "
+            "OPENSQUILLA_GATEWAY_STATE_DIR to isolated directories for this agent run.",
             json_output=json_output,
+            code="profile_lock_busy",
         )
+        raise typer.Exit(code=1) from None
 
 
 @app.command("chat")

--- a/tests/test_recovery/test_runtime_writer_guard.py
+++ b/tests/test_recovery/test_runtime_writer_guard.py
@@ -205,7 +205,6 @@ def test_runtime_writer_lock_keeps_read_only_cli_available_and_rejects_agent(
     try:
         from opensquilla.cli import gateway_cmd, models_cmd
         from opensquilla.cli import main as cli_main
-        from opensquilla.recovery import ProfileLockBusyError
 
         status_calls: list[dict[str, object]] = []
 
@@ -259,7 +258,26 @@ def test_runtime_writer_lock_keeps_read_only_cli_available_and_rejects_agent(
             ["agent", "--message", "must not reach a provider", "--json"],
         )
         assert competing_agent.exit_code == 1
-        assert isinstance(competing_agent.exception, ProfileLockBusyError)
+        assert isinstance(competing_agent.exception, SystemExit)
+        assert competing_agent.stdout == ""
+        error = json.loads(competing_agent.stderr)
+        assert error["error"]["code"] == "profile_lock_busy"
+        assert "opensquilla chat" in error["error"]["message"]
+        assert "OPENSQUILLA_STATE_DIR" in error["error"]["message"]
+        assert str(home) not in competing_agent.stderr
+        assert "Traceback" not in competing_agent.stderr
+
+        competing_agent_human = runner.invoke(
+            cli_main.app,
+            ["agent", "--message", "must not reach a provider"],
+        )
+        assert competing_agent_human.exit_code == 1
+        assert isinstance(competing_agent_human.exception, SystemExit)
+        assert "Error:" in competing_agent_human.stderr
+        assert "opensquilla chat" in competing_agent_human.stderr
+        assert "OPENSQUILLA_GATEWAY_STATE_DIR" in competing_agent_human.stderr
+        assert str(home) not in competing_agent_human.stderr
+        assert "Traceback" not in competing_agent_human.stderr
         assert agent_calls == []
     finally:
         release.set()


### PR DESCRIPTION
## Scope

Scope boundary:

- Translate the expected `ProfileLockBusyError` at the `opensquilla agent` CLI boundary into a concise actionable error.
- Preserve exit code 1, emit the stable `profile_lock_busy` JSON error code for `--json`, and avoid exposing the profile path or traceback.
- Keep the profile writer lease authoritative and add cross-process regression coverage for JSON and human-readable output.

Non-goals: no automatic Gateway fallback, no `agent --gateway` mode, and no changes to profile locking, Gateway RPC, authentication, configuration, persistence, or Desktop lifecycle.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #1131

## Release Note

Release note: `opensquilla agent` now reports an actionable, machine-readable error instead of an unhandled traceback when another writer owns the selected profile.

## Tests

Ruff: passed on both changed files.

Pytest: `112 passed` across `tests/test_recovery/test_runtime_writer_guard.py`, `tests/test_cli/test_agent_cmd.py`, and `tests/test_cli/test_gateway_cmd.py`.

Build: N/A (Python CLI-only error handling; no packaging, dependency, or frontend changes).

Regression tests: added

Notes:

- Mypy passed for `src/opensquilla/cli/main.py`.
- Python syntax compilation and `git diff --check` passed.
- The cross-process regression runs for both Desktop-primary and ordinary CLI profiles, proves the agent runtime is not entered, checks JSON and human-readable errors, and asserts that neither a traceback nor the sensitive profile path is emitted.
- Validation used the existing local environment and cached tooling after live PyPI DNS resolution was unavailable.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: yes

Surface: release

Maintainer-only note: On Windows with Desktop 0.5.2-style profile ownership, run the bundled CLI against the active Desktop state directory and confirm `agent --json` exits 1 with a `profile_lock_busy` JSON error and no PyInstaller unhandled-exception banner. No provider call or credentials are required because the lock fails before Agent startup.

## Safety

The writer lock remains authoritative. The handler catches only `ProfileLockBusyError`; recovery gates and unknown failures still fail through their existing paths. The emitted message is constant and does not include the exception text or profile path.

No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A.

## Documentation Changes

No documentation files changed. The emitted error is self-contained and points to the existing Gateway-backed chat and isolated-state mechanisms.