### PR TITLE
fix(scheduler): honor disabled cron creation

### DIFF
--- a/opensquilla-webui/src/composables/cron/useCronForm.test.ts
+++ b/opensquilla-webui/src/composables/cron/useCronForm.test.ts
@@ -80,6 +80,21 @@ describe('cron form default schedule', () => {
     expect(payload.schedule).toMatchObject({ kind: 'cron', expr: DEFAULT_CRON_EXPRESSION })
   })
 
+  it('posts the disabled state selected for a new job', async () => {
+    const form = cronForm()
+    form.openPanel(null)
+    form.form.name = 'Paused reminder'
+    form.form.message = 'stand up'
+    form.form.enabled = false
+
+    await form.saveJob()
+
+    expect(rpcCall).toHaveBeenCalledTimes(1)
+    const [method, payload] = rpcCall.mock.calls[0] as [string, Record<string, unknown>]
+    expect(method).toBe('cron.create')
+    expect(payload.enabled).toBe(false)
+  })
+
   it('renders the schedule preview immediately instead of the empty placeholder', () => {
     const form = cronForm()
     form.openPanel(null)

--- a/src/opensquilla/gateway/rpc_cron.py
+++ b/src/opensquilla/gateway/rpc_cron.py
@@ -727,6 +727,10 @@ async def _finalize_cron_add(
         jitter_seconds = 0.0
     job = await scheduler.add_job(
         name=params.get("name") or text,
+        # Only an explicit JSON false changes the legacy create default.  This
+        # keeps missing or malformed values backward-compatible while making
+        # the Control UI's Enabled switch effective on the initial write.
+        enabled=params.get("enabled") is not False,
         handler_key=_handler_key_for_payload_kind(payload_kind_name),
         payload=payload,
         session_target=session_target,

--- a/src/opensquilla/scheduler/engine.py
+++ b/src/opensquilla/scheduler/engine.py
@@ -121,6 +121,7 @@ class SchedulerEngine:
         schedule_kind: ScheduleKind | str,
         schedule_value: str,
         schedule_tz: str = "",
+        enabled: bool = True,
         handler_key: str = "agent_run",
         payload: dict | None = None,
         session_target: SessionTarget = SessionTarget.ISOLATED,
@@ -148,6 +149,7 @@ class SchedulerEngine:
         """
         job = await self._ops.add(
             name=name,
+            enabled=enabled,
             handler_key=handler_key,
             payload=payload,
             session_target=session_target,

--- a/src/opensquilla/scheduler/ops.py
+++ b/src/opensquilla/scheduler/ops.py
@@ -160,6 +160,7 @@ class SchedulerOps:
         schedule_kind: ScheduleKind | str,
         schedule_value: str,
         schedule_tz: str = "",
+        enabled: bool = True,
         handler_key: str = "",
         payload: dict | None = None,
         session_target: SessionTarget = SessionTarget.ISOLATED,
@@ -241,6 +242,8 @@ class SchedulerOps:
 
         job = CronJob(
             name=name,
+            status=JobStatus.PENDING if enabled else JobStatus.PAUSED,
+            enabled=enabled,
             schedule_raw=schedule_raw,
             schedule_kind=kind,
             cron_expr=cron_expr,

--- a/tests/test_gateway/test_rpc_cron_update_enabled.py
+++ b/tests/test_gateway/test_rpc_cron_update_enabled.py
@@ -1,11 +1,11 @@
-"""cron.update ``enabled`` toggles revive auto-stopped jobs and keep sibling fields."""
+"""Cron create/update ``enabled`` behavior stays effective and composable."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
 from opensquilla.gateway.rpc import RpcContext
-from opensquilla.gateway.rpc_cron import _handle_cron_update
+from opensquilla.gateway.rpc_cron import _handle_cron_add, _handle_cron_update
 from opensquilla.scheduler.engine import SchedulerEngine
 from opensquilla.scheduler.jobs import apply_result
 from opensquilla.scheduler.payloads import make_agent_turn_payload, payload_text
@@ -33,6 +33,42 @@ async def _add_recurring_job(engine: SchedulerEngine):
 
 def _ctx(engine: SchedulerEngine) -> RpcContext:
     return RpcContext(conn_id="test", cron_scheduler=engine)
+
+
+async def test_create_enabled_false_is_persisted_as_paused(tmp_path: Path) -> None:
+    engine, store = await _make_engine(tmp_path)
+    try:
+        result = await _handle_cron_add(
+            {
+                "name": "paused reminder",
+                "schedule": {"kind": "cron", "expr": "0 9 * * *"},
+                "payloadKind": "reminder",
+                "text": "stand up",
+                "agentId": "main",
+                "enabled": False,
+            },
+            _ctx(engine),
+        )
+
+        assert result["enabled"] is False
+        assert result["status"] == JobStatus.PAUSED.value
+        job_id = result["id"]
+        stored = await store.get(job_id)
+        assert stored is not None
+        assert stored.enabled is False
+        assert stored.status == JobStatus.PAUSED
+    finally:
+        await store.close()
+
+    reopened = JobStore(str(tmp_path / "cron.db"))
+    await reopened.open()
+    try:
+        persisted = await reopened.get(job_id)
+        assert persisted is not None
+        assert persisted.enabled is False
+        assert persisted.status == JobStatus.PAUSED
+    finally:
+        await reopened.close()
 
 
 async def test_update_enabled_true_revives_auto_disabled_job(tmp_path: Path) -> None:


### PR DESCRIPTION
## Scope

Scope boundary: Honor an explicit `enabled: false` on `cron.create`, persist the job atomically as paused, and cover the WebUI-to-Gateway contract plus SQLite persistence.

Non-goals: No RPC schema, database schema, scheduling semantics, or cron form production-code changes.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #1128

If None, reason: N/A

## Release Note

Release note: Cron schedules created with the Enabled switch off now remain paused.

## Tests

Ruff: passed for all modified Python files.

Pytest: 332 passed across scheduler, Gateway cron, CLI, policy, skill, and admin cron coverage; focused suite 24 passed.

Build: WebUI production code is unchanged; `vue-tsc --noEmit` passed.

Regression tests: added

Notes: `useCronForm.test.ts` passed 9/9, including the new disabled-create payload assertion. `git diff --check` passed.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: No credentialed or environment-specific behavior is involved.

## Safety

No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are included.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No documentation changes are required.
- [x] No links, code fences, tables, secrets, private paths, or private transcripts were added.
