### PR TITLE
Restore desktop follow-system theme behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1041,6 +1041,7 @@ jobs:
                 'gateway-ownership:scripts/test-desktop-gateway-ownership.mjs'
                 'gateway-orphan-recovery-flow:scripts/test-desktop-gateway-orphan-recovery-flow.mjs'
                 'window-background-flow:scripts/test-desktop-window-background-flow.mjs'
+                'theme-flow:scripts/test-desktop-theme-flow.mjs'
                 'native-workbench-surface:scripts/test-native-workbench-surface-electron.mjs'
                 'desktop-zoom-shortcuts:scripts/test-desktop-zoom-shortcuts.mjs'
                 'native-workbench-v2:scripts/test-native-workbench-v2-electron.mjs'
@@ -1060,6 +1061,7 @@ jobs:
                 'gateway-ownership:scripts/test-desktop-gateway-ownership.mjs'
                 'gateway-orphan-recovery-flow:scripts/test-desktop-gateway-orphan-recovery-flow.mjs'
                 'window-background-flow:scripts/test-desktop-window-background-flow.mjs'
+                'theme-flow:scripts/test-desktop-theme-flow.mjs'
               )
               ;;
             workbench)

--- a/desktop/electron/package.json
+++ b/desktop/electron/package.json
@@ -34,6 +34,7 @@
     "test:gateway-lifecycle": "npm run build && node scripts/test-desktop-gateway-lifecycle.mjs",
     "test:window-lifecycle": "npm run build && node scripts/test-desktop-window-lifecycle.mjs",
     "test:window-background-flow": "npm run build && node scripts/test-desktop-window-background-flow.mjs",
+    "test:theme-flow": "npm run build && node scripts/test-desktop-theme-flow.mjs",
     "test:deep-link": "npm run build && node scripts/test-desktop-deep-link.mjs",
     "test:gateway-orphan-recovery-flow": "npm run build && node scripts/test-desktop-gateway-orphan-recovery-flow.mjs",
     "test:profile-substrate": "npm run build && node scripts/test-desktop-profile-substrate.mjs && node scripts/test-desktop-profile-consolidation.mjs",

--- a/desktop/electron/scripts/test-desktop-theme-flow.mjs
+++ b/desktop/electron/scripts/test-desktop-theme-flow.mjs
@@ -1,0 +1,286 @@
+import { strict as assert } from 'node:assert'
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+import { fileURLToPath } from 'node:url'
+import { _electron as electron } from 'playwright'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const packageRoot = resolve(scriptDir, '..')
+const repoRoot = resolve(packageRoot, '../..')
+
+async function waitFor(check, label, timeoutMs = 60_000) {
+  const startedAt = Date.now()
+  let lastError
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const value = await check()
+      if (value) return value
+    } catch (error) {
+      lastError = error
+    }
+    await delay(200)
+  }
+  const suffix = lastError ? ` Last error: ${lastError.message || lastError}` : ''
+  throw new Error(`Timed out waiting for ${label}.${suffix}`)
+}
+
+async function themeSnapshot(app, page) {
+  const [native, renderer] = await Promise.all([
+    app.evaluate(({ nativeTheme }) => ({
+      source: nativeTheme.themeSource,
+      shouldUseDarkColors: nativeTheme.shouldUseDarkColors,
+    })),
+    page.evaluate(() => ({
+      dataTheme: document.documentElement.getAttribute('data-theme'),
+      prefersDark: window.matchMedia('(prefers-color-scheme: dark)').matches,
+      storedTheme: localStorage.getItem('opensquilla-theme'),
+      selectedTheme: document.querySelector(
+        'input[name="appearance-theme"]:checked',
+      )?.value ?? null,
+    })),
+  ])
+  return { native, renderer }
+}
+
+async function waitForThemeState(
+  app,
+  page,
+  {
+    label,
+    source,
+    storedTheme,
+    selectedTheme,
+    dataTheme,
+    followsSystem = false,
+    shouldUseDarkColors,
+  },
+) {
+  // Do not accept a transient match before the renderer's fire-and-forget IPC
+  // reaches the main process. The regression briefly exposed `system` at boot,
+  // then pinned Electron to the resolved light/dark value a tick later.
+  let matchingSince = 0
+  const snapshot = await waitFor(async () => {
+    const current = await themeSnapshot(app, page)
+    const expectedNativeTheme = current.native.shouldUseDarkColors ? 'dark' : 'light'
+    const expectedRendererTheme = current.renderer.prefersDark ? 'dark' : 'light'
+    const matches = current.native.source === source
+      && current.renderer.storedTheme === storedTheme
+      && (selectedTheme === undefined || current.renderer.selectedTheme === selectedTheme)
+      && (dataTheme === undefined || current.renderer.dataTheme === dataTheme)
+      && (
+        !followsSystem
+        || (
+          current.renderer.dataTheme === expectedRendererTheme
+          && expectedRendererTheme === expectedNativeTheme
+        )
+      )
+      && (
+        shouldUseDarkColors === undefined
+        || current.native.shouldUseDarkColors === shouldUseDarkColors
+      )
+
+    if (!matches) {
+      matchingSince = 0
+      throw new Error(JSON.stringify(current))
+    }
+    if (!matchingSince) matchingSince = Date.now()
+    return Date.now() - matchingSince >= 400 ? current : null
+  }, label)
+
+  assert.equal(snapshot.native.source, source, `${label}: native source`)
+  assert.equal(snapshot.renderer.storedTheme, storedTheme, `${label}: persisted theme`)
+  if (selectedTheme !== undefined) {
+    assert.equal(snapshot.renderer.selectedTheme, selectedTheme, `${label}: selected theme`)
+  }
+  if (dataTheme !== undefined) {
+    assert.equal(snapshot.renderer.dataTheme, dataTheme, `${label}: DOM theme`)
+  }
+  if (followsSystem) {
+    assert.equal(
+      snapshot.renderer.dataTheme,
+      snapshot.renderer.prefersDark ? 'dark' : 'light',
+      `${label}: DOM theme must resolve from the renderer media query`,
+    )
+    assert.equal(
+      snapshot.renderer.prefersDark,
+      snapshot.native.shouldUseDarkColors,
+      `${label}: renderer media query must reflect Electron's system appearance`,
+    )
+  }
+  if (shouldUseDarkColors !== undefined) {
+    assert.equal(
+      snapshot.native.shouldUseDarkColors,
+      shouldUseDarkColors,
+      `${label}: native dark appearance`,
+    )
+  }
+  return snapshot
+}
+
+async function selectTheme(page, theme) {
+  const input = page.locator(`input[name="appearance-theme"][value="${theme}"]`)
+  await input.waitFor({ state: 'attached', timeout: 20_000 })
+  await input.check({ force: true })
+}
+
+const isolationRoot = await mkdtemp(join(tmpdir(), 'opensquilla-electron-theme-test-'))
+const userDataDir = join(isolationRoot, 'chromium-user-data')
+const isolatedHome = join(isolationRoot, 'home')
+let desktopApp
+let page
+
+try {
+  await mkdir(userDataDir, { recursive: true })
+  await mkdir(isolatedHome, { recursive: true })
+
+  // Use a synthetic keyless profile so the theme flow reaches the real Control
+  // UI without reading developer credentials or requiring an external model.
+  const now = new Date().toISOString()
+  await writeFile(join(userDataDir, 'desktop-credential.json'), JSON.stringify({
+    provider: 'ollama',
+    model: 'opensquilla-theme-test-model',
+    baseUrl: 'http://127.0.0.1:11434',
+    apiKeyEnv: '',
+    encryptedApiKey: '',
+    modelRoutingMode: 'direct',
+    routerMode: 'disabled',
+    routerDefaultTier: 'c1',
+    routerTiers: {},
+    searchProvider: 'duckduckgo',
+    searchApiKeyEnv: '',
+    encryptedSearchApiKey: '',
+    encryption: 'plain',
+    disableNetworkObservability: false,
+    createdAt: now,
+    updatedAt: now,
+  }, null, 2), { mode: 0o600 })
+
+  desktopApp = await electron.launch({
+    args: [
+      '--use-mock-keychain',
+      `--user-data-dir=${userDataDir}`,
+      packageRoot,
+    ],
+    env: {
+      ...process.env,
+      HOME: isolatedHome,
+      USERPROFILE: isolatedHome,
+      OPENSQUILLA_DESKTOP_REPO_ROOT: repoRoot,
+      OPENSQUILLA_DESKTOP_SECRET_STORAGE: 'plain',
+      OPENSQUILLA_DESKTOP_DISABLE_AUTO_UPDATE: '1',
+    },
+  })
+
+  const runtimeIsolation = await desktopApp.evaluate(({ app }) => ({
+    userData: app.getPath('userData'),
+    platform: process.platform,
+  }))
+  assert.equal(await realpath(runtimeIsolation.userData), await realpath(userDataDir))
+
+  page = await desktopApp.firstWindow({ timeout: 60_000 })
+  // Playwright contexts default colorScheme to light, including Electron pages.
+  // Clear that test-only override so prefers-color-scheme once again reflects
+  // Electron nativeTheme; otherwise a dark host reports native dark while the
+  // renderer is artificially held on light.
+  await page.emulateMedia({ colorScheme: null })
+  await page.waitForLoadState('domcontentloaded', { timeout: 60_000 }).catch(() => {})
+  await waitFor(
+    async () => page.url().includes('/control/chat'),
+    'Control UI to load on Chat',
+  )
+  await page.waitForSelector('html[data-theme]', { timeout: 20_000 })
+
+  // A fresh profile has no saved choice, so the renderer starts in System. It
+  // must leave Electron on `system`, rather than pinning the launch-time result.
+  const initialSystem = await waitForThemeState(desktopApp, page, {
+    label: 'initial System theme',
+    source: 'system',
+    storedTheme: null,
+    followsSystem: true,
+  })
+
+  const settingsUrl = new URL('/control/settings/appearance', page.url()).href
+  await page.goto(settingsUrl)
+  await page.waitForSelector('input[name="appearance-theme"][value="system"]', {
+    timeout: 20_000,
+  })
+
+  await selectTheme(page, 'dark')
+  await waitForThemeState(desktopApp, page, {
+    label: 'explicit Dark theme',
+    source: 'dark',
+    storedTheme: 'dark',
+    selectedTheme: 'dark',
+    dataTheme: 'dark',
+    shouldUseDarkColors: true,
+  })
+
+  // Electron's explicit Dark source makes this a same-colour transition on every
+  // host. Watching only the resolved DOM value must not prevent the semantic
+  // System change reaching Electron and clearing its explicit override.
+  await selectTheme(page, 'system')
+  const darkToSystem = await waitForThemeState(desktopApp, page, {
+    label: 'Dark to System transition',
+    source: 'system',
+    storedTheme: 'system',
+    selectedTheme: 'system',
+    followsSystem: true,
+  })
+
+  await selectTheme(page, 'crt-green')
+  await waitForThemeState(desktopApp, page, {
+    label: 'explicit CRT Green theme',
+    source: 'dark',
+    storedTheme: 'crt-green',
+    selectedTheme: 'crt-green',
+    dataTheme: 'crt-green',
+    shouldUseDarkColors: true,
+  })
+
+  await selectTheme(page, 'system')
+  const crtGreenToSystem = await waitForThemeState(desktopApp, page, {
+    label: 'CRT Green to System transition',
+    source: 'system',
+    storedTheme: 'system',
+    selectedTheme: 'system',
+    followsSystem: true,
+  })
+
+  console.log(JSON.stringify({
+    ok: true,
+    platform: runtimeIsolation.platform,
+    initialSystem,
+    darkToSystem,
+    crtGreenToSystem,
+  }, null, 2))
+} catch (error) {
+  const currentTheme = desktopApp && page
+    ? await themeSnapshot(desktopApp, page).catch(() => null)
+    : null
+  const windows = desktopApp
+    ? await desktopApp.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().map(
+        (window) => ({
+          destroyed: window.isDestroyed(),
+          title: window.getTitle(),
+          url: window.webContents.getURL(),
+          visible: window.isVisible(),
+        }),
+      )).catch(() => [])
+    : []
+  const desktopLog = await readFile(
+    join(userDataDir, 'logs', 'desktop.log'),
+    'utf8',
+  ).catch(() => '')
+  console.error(JSON.stringify({
+    error: error instanceof Error ? error.message : String(error),
+    currentTheme,
+    windows,
+    desktopLog,
+  }, null, 2))
+  throw error
+} finally {
+  await desktopApp?.close().catch(() => {})
+  await rm(isolationRoot, { recursive: true, force: true }).catch(() => {})
+}

--- a/opensquilla-webui/src/stores/app.theme.test.ts
+++ b/opensquilla-webui/src/stores/app.theme.test.ts
@@ -5,24 +5,65 @@ import { createPinia, setActivePinia } from 'pinia'
 import { useAppStore } from './app'
 
 const THEME_KEY = 'opensquilla-theme'
+const DARK_SCHEME_QUERY = '(prefers-color-scheme: dark)'
 
-function stubMatchMedia(matches = false) {
-  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
-    matches,
-    media: query,
+function stubMatchMedia(initialMatches = false) {
+  type ChangeListener = (event: MediaQueryListEvent) => void
+
+  let matches = initialMatches
+  const modernListeners = new Set<ChangeListener>()
+  const legacyListeners = new Set<ChangeListener>()
+  const addEventListener = vi.fn((type: string, listener: EventListener) => {
+    if (type === 'change') modernListeners.add(listener as ChangeListener)
+  })
+  const removeEventListener = vi.fn((type: string, listener: EventListener) => {
+    if (type === 'change') modernListeners.delete(listener as ChangeListener)
+  })
+  const addListener = vi.fn((listener: ChangeListener) => legacyListeners.add(listener))
+  const removeListener = vi.fn((listener: ChangeListener) => legacyListeners.delete(listener))
+  const mediaQuery = {
+    get matches() { return matches },
+    media: DARK_SCHEME_QUERY,
     onchange: null,
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  })) as unknown as typeof window.matchMedia
+    addEventListener,
+    removeEventListener,
+    addListener,
+    removeListener,
+    dispatchEvent: vi.fn(() => true),
+  } as unknown as MediaQueryList
+
+  // Return one stable MediaQueryList object, like a browser-owned subscription,
+  // so tests can drive the exact object the store listened to.
+  window.matchMedia = vi.fn(() => mediaQuery) as unknown as typeof window.matchMedia
+
+  return {
+    addEventListener,
+    removeEventListener,
+    listenerCount: () => modernListeners.size + legacyListeners.size,
+    setMatches(next: boolean) {
+      if (matches === next) return
+      matches = next
+      const event = { matches, media: DARK_SCHEME_QUERY } as MediaQueryListEvent
+      for (const listener of [...modernListeners, ...legacyListeners]) listener(event)
+    },
+  }
+}
+
+function stubDesktopThemeBridge() {
+  const setNativeTheme = vi.fn(
+    async (_payload: { source: 'light' | 'dark' | 'system' }) => undefined,
+  )
+  ;(window as unknown as {
+    opensquillaDesktop?: { setNativeTheme: typeof setNativeTheme }
+  }).opensquillaDesktop = { setNativeTheme }
+  return setNativeTheme
 }
 
 describe('app store — theme persistence + legacy id migration', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
     ;(window as unknown as { opensquillaDesktop?: unknown }).opensquillaDesktop = undefined
     // Default OS preference to light so an unmigrated fallback would resolve to
     // 'light' (distinct from the renamed dark themes under test).
@@ -70,10 +111,7 @@ describe('app store — theme persistence + legacy id migration', () => {
   })
 
   it('syncs the Electron native shell theme when the app theme changes', async () => {
-    const setNativeTheme = vi.fn(async () => undefined)
-    ;(window as unknown as { opensquillaDesktop?: { setNativeTheme: typeof setNativeTheme } }).opensquillaDesktop = {
-      setNativeTheme,
-    }
+    const setNativeTheme = stubDesktopThemeBridge()
 
     localStorage.setItem(THEME_KEY, 'dark')
     const store = useAppStore()
@@ -86,5 +124,135 @@ describe('app store — theme persistence + legacy id migration', () => {
     expect(setNativeTheme).toHaveBeenLastCalledWith({ source: 'light' })
 
     store.destroyTheme()
+  })
+
+  it('keeps Electron on its system source during a cold system-theme startup', async () => {
+    const media = stubMatchMedia(true)
+    const setNativeTheme = stubDesktopThemeBridge()
+    localStorage.setItem(THEME_KEY, 'system')
+
+    const store = useAppStore()
+    store.initTheme()
+    await nextTick()
+
+    expect(store.theme).toBe('system')
+    expect(store.resolvedTheme).toBe('dark')
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+    expect(setNativeTheme).toHaveBeenLastCalledWith({ source: 'system' })
+    expect(media.addEventListener).toHaveBeenCalledWith('change', expect.any(Function))
+    expect(media.addEventListener.mock.invocationCallOrder[0]).toBeLessThan(
+      setNativeTheme.mock.invocationCallOrder[0],
+    )
+
+    store.destroyTheme()
+  })
+
+  it.each(['dark', 'vapor'] as const)(
+    'releases a fixed %s theme back to Electron system control',
+    async (initialTheme) => {
+      stubMatchMedia(true)
+      const setNativeTheme = stubDesktopThemeBridge()
+      localStorage.setItem(THEME_KEY, initialTheme)
+
+      const store = useAppStore()
+      store.initTheme()
+      await nextTick()
+      expect(setNativeTheme).toHaveBeenLastCalledWith({ source: 'dark' })
+
+      store.setTheme('system')
+      await nextTick()
+
+      expect(store.theme).toBe('system')
+      expect(store.resolvedTheme).toBe('dark')
+      expect(localStorage.getItem(THEME_KEY)).toBe('system')
+      expect(setNativeTheme).toHaveBeenLastCalledWith({ source: 'system' })
+
+      store.destroyTheme()
+    },
+  )
+
+  it('tracks live OS scheme changes while retaining Electron system control', async () => {
+    const media = stubMatchMedia(true)
+    const setNativeTheme = stubDesktopThemeBridge()
+    localStorage.setItem(THEME_KEY, 'system')
+
+    const store = useAppStore()
+    store.initTheme()
+    await nextTick()
+    setNativeTheme.mockClear()
+
+    media.setMatches(false)
+    await nextTick()
+
+    expect(store.resolvedTheme).toBe('light')
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light')
+    expect(setNativeTheme).toHaveBeenCalledTimes(1)
+    expect(setNativeTheme).toHaveBeenLastCalledWith({ source: 'system' })
+
+    store.destroyTheme()
+  })
+
+  it.each(['dark', 'vapor'] as const)(
+    'isolates a fixed %s theme from OS media-query changes',
+    async (fixedTheme) => {
+      const media = stubMatchMedia(false)
+      const setNativeTheme = stubDesktopThemeBridge()
+      localStorage.setItem(THEME_KEY, fixedTheme)
+
+      const store = useAppStore()
+      store.initTheme()
+      await nextTick()
+      setNativeTheme.mockClear()
+
+      media.setMatches(true)
+      await nextTick()
+
+      expect(store.resolvedTheme).toBe(fixedTheme)
+      expect(document.documentElement.getAttribute('data-theme')).toBe(fixedTheme)
+      expect(setNativeTheme).not.toHaveBeenCalled()
+
+      store.destroyTheme()
+    },
+  )
+
+  it('cleans up idempotently and re-snapshots one MQL listener on re-init', async () => {
+    const media = stubMatchMedia(false)
+    const setNativeTheme = stubDesktopThemeBridge()
+    localStorage.setItem(THEME_KEY, 'system')
+    const store = useAppStore()
+
+    store.initTheme()
+    await nextTick()
+    expect(media.listenerCount()).toBe(1)
+    expect(media.addEventListener).toHaveBeenCalledTimes(1)
+
+    store.destroyTheme()
+    store.destroyTheme()
+    expect(media.listenerCount()).toBe(0)
+    expect(media.removeEventListener).toHaveBeenCalledTimes(1)
+
+    setNativeTheme.mockClear()
+    media.setMatches(true)
+    await nextTick()
+    expect(store.resolvedTheme).toBe('light')
+    expect(setNativeTheme).not.toHaveBeenCalled()
+
+    store.initTheme()
+    await nextTick()
+    expect(media.listenerCount()).toBe(1)
+    expect(media.addEventListener).toHaveBeenCalledTimes(2)
+    expect(store.resolvedTheme).toBe('dark')
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+    expect(setNativeTheme).toHaveBeenLastCalledWith({ source: 'system' })
+
+    setNativeTheme.mockClear()
+    media.setMatches(false)
+    await nextTick()
+    expect(setNativeTheme).toHaveBeenCalledTimes(1)
+
+    store.destroyTheme()
+    store.destroyTheme()
+    expect(media.listenerCount()).toBe(0)
+    expect(media.removeEventListener).toHaveBeenCalledTimes(2)
   })
 })

--- a/opensquilla-webui/src/stores/app.ts
+++ b/opensquilla-webui/src/stores/app.ts
@@ -107,11 +107,17 @@ export const useAppStore = defineStore('app', () => {
     return systemDark.value ? 'dark' : 'light'
   })
 
-  const desktopNativeThemeSource = computed<'light' | 'dark'>(() => {
-    const colorScheme = getManifest(resolvedTheme.value)?.capabilities.colorScheme
+  const desktopNativeThemeSource = computed<'light' | 'dark' | 'system'>(() => {
+    // Keep Electron on its native system source while the UI is in system mode.
+    // Resolving that choice to a fixed light/dark source would override the OS,
+    // which in turn freezes the renderer's prefers-color-scheme media query.
+    if (theme.value === 'system') return 'system'
+    const colorScheme = getManifest(theme.value)?.capabilities.colorScheme
     if (colorScheme === 'light') return 'light'
     if (colorScheme === 'dark') return 'dark'
-    return systemDark.value ? 'dark' : 'light'
+    // A theme that supports both schemes (or omits the capability) should leave
+    // native chrome under OS control instead of snapshotting the current scheme.
+    return 'system'
   })
 
   let mq: MediaQueryList | null = null
@@ -128,7 +134,9 @@ export const useAppStore = defineStore('app', () => {
     // Lazily bring in the theme's global "world" layer (structure/type/texture)
     // if it has one; flat value themes have no world and this is a no-op.
     void ensureThemeWorld(resolvedTheme.value)
-    void platform.setNativeTheme({ source: desktopNativeThemeSource.value })
+    void platform
+      .setNativeTheme({ source: desktopNativeThemeSource.value })
+      .catch(() => undefined)
   }
 
   function initTheme() {
@@ -159,19 +167,33 @@ export const useAppStore = defineStore('app', () => {
       // ignore
     }
 
+    // Wire the OS listener before the immediate apply. On desktop, applying a
+    // fixed theme also changes Electron's prefers-color-scheme; listening first
+    // ensures that feedback cannot land between the initial apply and setup.
+    if (!mq) {
+      mq = window.matchMedia('(prefers-color-scheme: dark)')
+      mqHandler = (e: MediaQueryListEvent) => {
+        systemDark.value = e.matches
+      }
+      if (mq.addEventListener) mq.addEventListener('change', mqHandler)
+      else if (mq.addListener) mq.addListener(mqHandler)
+    }
+    // Re-snapshot on every init so destroy/re-init cannot retain a stale OS
+    // preference from the previous listener lifetime.
+    systemDark.value = mq.matches
+
     if (!themeWatchStop) {
-      themeWatchStop = watch(resolvedTheme, applyTheme, { immediate: true })
+      // Both axes matter: dark -> system can leave resolvedTheme at "dark" but
+      // must still send source:"system" to Electron. Conversely, an OS change
+      // in system mode changes resolvedTheme while the native source stays system.
+      themeWatchStop = watch(
+        [resolvedTheme, desktopNativeThemeSource],
+        applyTheme,
+        { immediate: true },
+      )
     } else {
       applyTheme()
     }
-
-    if (mq) return // idempotent
-    mq = window.matchMedia('(prefers-color-scheme: dark)')
-    mqHandler = (e: MediaQueryListEvent) => {
-      systemDark.value = e.matches
-    }
-    if (mq.addEventListener) mq.addEventListener('change', mqHandler)
-    else if (mq.addListener) mq.addListener(mqHandler)
   }
 
   function destroyTheme() {

--- a/tests/test_skills_hot_reload.py
+++ b/tests/test_skills_hot_reload.py
@@ -5,9 +5,11 @@ import os
 import sys
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+from opensquilla.skills import loader as skill_loader_module
 from opensquilla.skills.loader import MAX_SKILL_FILE_BYTES, SkillLoader
 
 
@@ -592,6 +594,12 @@ def test_mutation_guard_hides_in_progress_write_until_next_access(tmp_path: Path
 def test_load_all_compatibility_probe_is_monotonic_throttled(
     tmp_path: Path, monkeypatch
 ) -> None:
+    monotonic_now = 10.0
+    monkeypatch.setattr(
+        skill_loader_module,
+        "time",
+        SimpleNamespace(monotonic=lambda: monotonic_now),
+    )
     root = tmp_path / "skills"
     _write_skill(root, "alpha")
     loader = _loader(root, tmp_path)
@@ -610,7 +618,7 @@ def test_load_all_compatibility_probe_is_monotonic_throttled(
     loader.load_all()
     assert calls == 0
 
-    loader._last_probe_at = 0.0
+    monotonic_now += skill_loader_module._COMPAT_PROBE_INTERVAL_SECONDS
     loader.load_all()
     assert calls == 1
 


### PR DESCRIPTION
## Scope

Scope boundary:
Restore the desktop **System** appearance mode so Electron keeps its native system theme source and the Web UI follows live OS light/dark changes. Update the app theme watcher and media-query lifecycle, add focused Store regression coverage, and add a real Electron/preload IPC flow to the existing cross-platform CI matrix.

Make the existing skill-loader monotonic-throttle test deterministic with a controlled clock after repeated slow Windows runners crossed its real-time 250 ms window.

Non-goals:
No visual redesign, palette changes, settings UI changes, persistence migration, Gateway/backend changes, or Electron main/preload protocol changes.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: User-reported desktop regression; no public issue was filed.

## Release Note

Release note: Fixed the desktop System appearance mode so it follows OS light and dark theme changes again.

## Tests

Ruff: passed (`tests/test_skills_hot_reload.py`)

Pytest: passed (`tests/test_skills_hot_reload.py`: 33 passed, 1 skipped)

Build: passed (`opensquilla-webui` production build and Electron TypeScript build)

Regression tests: added

Notes:
- `npm run test:unit` — 302 files and 3281 tests passed.
- Focused browser System-theme Playwright test — passed.
- `npm run test:theme-flow` — passed on macOS using real Electron, preload IPC, and production WebUI assets.
- Theme Store regression tests — 12/12 passed.
- `node --check`, `actionlint`, TypeScript checks, and staged diff checks — passed.
- The existing skill-loader throttle test now verifies the exact 250 ms boundary against a controlled monotonic clock instead of wall-clock runner speed.
- The full browser `theme.spec.ts` run was 13/14; its unrelated existing radius assertion expects `8px` while the current foundation token is `10px`.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: browser

Maintainer-only note: A credential-free local Electron integration flow passed. Contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

The runtime change is client-only appearance behavior; the Python change affects one test only. There are no backend, Gateway, provider, database, config, or public protocol changes. The existing `opensquilla-theme` localStorage key and values remain compatible, so upgrades require no migration. No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are included.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

No documentation changes.

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
