### PR TITLE
fix(session): preserve subagent task titles

### DIFF
--- a/docs/channels.md
+++ b/docs/channels.md
@@ -90,7 +90,7 @@ implemented runtime, not to provider features that the adapter does not expose.
 
 Channel sessions appear in the desktop session list (WebUI sidebar) with the
 same rename and delete actions as chat/cron sessions. Renaming calls
-`sessions.patch` (sets `display_name`), deleting calls `sessions.delete` and
+`sessions.rename` (sets only `display_name`), deleting calls `sessions.delete` and
 quiesces every writer before removing the row. A channel that sends a new
 message after deletion gets a fresh session, as expected.
 

--- a/docs/session-view-contract.md
+++ b/docs/session-view-contract.md
@@ -462,7 +462,7 @@ become the primary UI path.
   "sessionKind": "task",
   "surface": "subagent",
   "conversationKind": "unknown",
-  "title": "Subagent task",
+  "title": "Analyze checkout failures",
   "subtitle": "Spawned from Web chat",
   "groupLabel": "Subagents",
   "updatedAt": 1760000000000,
@@ -478,6 +478,11 @@ become the primary UI path.
   "cron": null
 }
 ```
+
+New subagent sessions should persist a caller-supplied short title, or derive a
+bounded title from the original delegated task when the caller omits it. The
+generic localized `Subagent task` label remains the compatibility fallback for
+legacy or malformed rows with no usable title source.
 
 ### Cron-Owned Isolated Run
 

--- a/opensquilla-webui/src/App.sidebar-contract.test.ts
+++ b/opensquilla-webui/src/App.sidebar-contract.test.ts
@@ -40,6 +40,15 @@ describe('App sidebar chrome contract', () => {
     expect(singleDelete).toContain('appStore.removePendingApprovalsForSessions(deleted)')
   })
 
+  it('uses the write-scoped rename RPC for sidebar session titles', () => {
+    const renameStart = appSource.indexOf('async function onRenameSession')
+    const renameEnd = appSource.indexOf('function removeLocalSessions', renameStart)
+    const renameHandler = appSource.slice(renameStart, renameEnd)
+
+    expect(renameHandler).toContain("rpcStore.call('sessions.rename'")
+    expect(renameHandler).not.toContain("rpcStore.call('sessions.patch'")
+  })
+
   it('bounds automatic sidebar RPCs after chat bootstrap admission', () => {
     expect(appSource).toContain('useSessions(\n  optionalSessionRpcCallOptions,\n)')
     expect(appSource).toContain('useAgentOptions(optionalSessionRpcCallOptions)')

--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -1400,7 +1400,7 @@ function switchToSession(key: string, source = 'app.switchToSession') {
 }
 
 // Optimistic rename: show the new title immediately, then persist via
-// sessions.patch (display_name is the top-precedence title) and reload so the
+// sessions.rename (display_name is the top-precedence title) and reload so the
 // backend's canonical title wins. The override clears once the reload lands.
 async function onRenameSession({ key, title }: { key: string; title: string }) {
   const next = title.trim()
@@ -1409,10 +1409,10 @@ async function onRenameSession({ key, title }: { key: string; title: string }) {
   const local = localChatSessions.value[key]
   if (local) localChatSessions.value[key] = { ...local, title: next }
   try {
-    await rpcStore.call('sessions.patch', { key, displayName: next })
+    await rpcStore.call('sessions.rename', { key, displayName: next })
     pushToast('Session renamed', { tone: 'ok' })
   } catch (err: unknown) {
-    console.warn('[App] sessions.patch error:', errorMessage(err))
+    console.warn('[App] sessions.rename error:', errorMessage(err))
     pushToast('Failed to rename session', { tone: 'danger' })
   } finally {
     await loadSessions()

--- a/opensquilla-webui/src/components/SidebarConversations.bulk-actions.test.ts
+++ b/opensquilla-webui/src/components/SidebarConversations.bulk-actions.test.ts
@@ -121,6 +121,39 @@ describe('SidebarConversations bulk actions', () => {
     expect(menuText).toContain('Delete')
   })
 
+  it('offers rename and delete without pinning for subagent task records', async () => {
+    await mountSidebar({
+      sections: [{
+        family: 'chats',
+        label: 'Tasks',
+        rows: [{
+          rowKind: 'session',
+          key: 'agent:main:subagent:child',
+          title: 'Analyze checkout failures',
+          effectiveAgentId: 'main',
+          agentName: 'Main',
+          sessionKind: 'task',
+          depth: 1,
+          runStatus: 'idle',
+          runLabel: 'Idle',
+          taskAttention: 'none',
+          updatedAt: Date.now(),
+          hasContractGaps: false,
+        }],
+      }],
+    })
+
+    document.body.querySelector<HTMLButtonElement>(
+      '[aria-label="Actions for Analyze checkout failures"]',
+    )?.click()
+    await nextTick()
+
+    const menuItems = Array.from(
+      document.body.querySelectorAll<HTMLElement>('.sidebar-row-menu__item'),
+    ).map(item => item.textContent?.trim())
+    expect(menuItems).toEqual(['Rename', 'Delete'])
+  })
+
   it('does not render the conversations region until a session exists', async () => {
     const root = await mountSidebar({ sections: [] })
 

--- a/opensquilla-webui/src/components/SidebarConversations.vue
+++ b/opensquilla-webui/src/components/SidebarConversations.vue
@@ -1003,7 +1003,7 @@ function onSelectRow(row: SidebarConversationItem) {
               />
             </button>
 
-            <!-- Chat-only ⋯ menu: rename + delete -->
+            <!-- Per-session ⋯ menu: task rows omit pin but keep rename + delete. -->
             <Teleport to="body">
               <div
                 v-if="
@@ -1068,6 +1068,7 @@ function onSelectRow(row: SidebarConversationItem) {
                   row.sessionKind === 'chat'
                   || row.sessionKind === 'cron'
                   || row.sessionKind === 'channel'
+                  || row.sessionKind === 'task'
                 )
                 && !row.provisional
                 && renamingKey !== row.key
@@ -1097,6 +1098,7 @@ function onSelectRow(row: SidebarConversationItem) {
                 @keydown="onMenuKeydown"
               >
                 <button
+                  v-if="row.sessionKind !== 'task'"
                   type="button"
                   class="sidebar-row-menu__item"
                   role="menuitem"

--- a/opensquilla-webui/src/components/sessions/SessionsLedger.vue
+++ b/opensquilla-webui/src/components/sessions/SessionsLedger.vue
@@ -133,12 +133,9 @@ function channel(item: SessionItem): { token: string; trace: string; running: bo
 }
 
 function rowTitle(entry: SessionLedgerEntry): string {
-  // Subagent rows read as lineage ("↳ Subagent · {parent}") instead of a flat
-  // title; forked conversations keep their own (copied) title behind the
-  // lineage arrow; root rows keep their human title.
+  // Child rows keep the lineage arrow while displaying their own durable title.
   if (entry.depth <= 0) return entry.item.title
-  if (entry.item.forkedFromParent) return `↳ ${entry.item.title}`
-  return subagentRowTitle(entry.parentTitle)
+  return subagentRowTitle(entry.item.title)
 }
 
 // Screen readers announce "↳" as "right-pointing arrow" noise; the accessible

--- a/opensquilla-webui/src/components/sessions/sessionDisplay.test.ts
+++ b/opensquilla-webui/src/components/sessions/sessionDisplay.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { sessionAgentIdentity, sessionStatusBadge } from './sessionDisplay'
+import { sessionAgentIdentity, sessionStatusBadge, subagentRowTitle } from './sessionDisplay'
 import type { SessionItem } from '@/composables/useSessions'
 
 function sessionItem(overrides: Partial<SessionItem>): SessionItem {
@@ -64,5 +64,15 @@ describe('sessionAgentIdentity', () => {
       kind: 'known',
       value: 'Main agent',
     })
+  })
+})
+
+describe('subagentRowTitle', () => {
+  it('shows the child title while retaining the lineage marker', () => {
+    expect(subagentRowTitle('Analyze checkout failures')).toBe('↳ Analyze checkout failures')
+  })
+
+  it('keeps the localized compatibility fallback for an empty title', () => {
+    expect(subagentRowTitle('  ')).toBe('↳ Subagent')
   })
 })

--- a/opensquilla-webui/src/components/sessions/sessionDisplay.ts
+++ b/opensquilla-webui/src/components/sessions/sessionDisplay.ts
@@ -109,15 +109,9 @@ export function formatRelativeTime(timestamp: number | null | undefined): string
 /** Back-compat alias; prefer {@link formatRelativeTime} for new call sites. */
 export const sessionRelTime = formatRelativeTime
 
-/**
- * Ledger title for a subagent row: "↳ Subagent · {parent title}" when the
- * parent title is known, otherwise a plain "↳ Subagent" so we never surface a
- * raw key. The arrow + label conveys lineage without rendering UUIDs.
- */
-export function subagentRowTitle(parentTitle: string | null | undefined): string {
+/** Ledger title for a subagent row, preserving its own durable title. */
+export function subagentRowTitle(title: string | null | undefined): string {
   const t = i18n.global.t
-  const parent = (parentTitle || '').trim()
-  return parent
-    ? `↳ ${t('sessions.ledger.subagentWithParent', { parent })}`
-    : `↳ ${t('sessions.ledger.subagent')}`
+  const normalized = (title || '').trim()
+  return normalized ? `↳ ${normalized}` : `↳ ${t('sessions.ledger.subagent')}`
 }

--- a/opensquilla-webui/src/composables/useSessions.sections.test.ts
+++ b/opensquilla-webui/src/composables/useSessions.sections.test.ts
@@ -22,6 +22,22 @@ function sectionFor(sections: SidebarSection[], family: SidebarSection['family']
   return found
 }
 
+describe('normalizeSessionItem subagent titles', () => {
+  it('keeps a durable task title and preserves the legacy grounding-prompt fallback', () => {
+    expect(session({
+      key: 'agent:main:subagent:new',
+      sessionKind: 'task',
+      title: 'Analyze checkout failures',
+    }).title).toBe('Analyze checkout failures')
+
+    expect(session({
+      key: 'agent:main:subagent:legacy',
+      sessionKind: 'task',
+      title: 'You are a subagent. Execute the delegated task',
+    }).title).toBe('Subagent task')
+  })
+})
+
 describe('arrangeSidebarSections — family bucketing', () => {
   it('buckets chat, channel, and cron sessions into their families', () => {
     const sections = arrangeSidebarSections([

--- a/opensquilla-webui/src/composables/useSessions.sections.test.ts
+++ b/opensquilla-webui/src/composables/useSessions.sections.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest'
+import i18n from '@/i18n'
+import zhHans from '@/locales/zh-Hans.json'
 import {
   arrangeSidebarSections,
   normalizeSessionItem,
@@ -35,6 +37,21 @@ describe('normalizeSessionItem subagent titles', () => {
       sessionKind: 'task',
       title: 'You are a subagent. Execute the delegated task',
     }).title).toBe('Subagent task')
+  })
+
+  it('localizes the generic title returned for legacy task rows', () => {
+    i18n.global.setLocaleMessage('zh-Hans', zhHans)
+    i18n.global.locale.value = 'zh-Hans'
+    try {
+      expect(session({
+        key: 'agent:main:subagent:legacy-generic',
+        sessionKind: 'task',
+        title: 'Subagent task',
+      }).title).toBe('子智能体任务')
+    }
+    finally {
+      i18n.global.locale.value = 'en'
+    }
   })
 })
 

--- a/opensquilla-webui/src/composables/useSessions.ts
+++ b/opensquilla-webui/src/composables/useSessions.ts
@@ -298,7 +298,13 @@ export function normalizeSessionItem(item: unknown): SessionItem | null {
   const workspaceLabel = textValue(raw.workspaceLabel)
   const workspaceDisplayPath = textValue(raw.workspaceDisplayPath)
   let title = normalizeRequiredString(raw, 'title', fallbackSessionTitle(raw, key, sessionKind), gaps)
-  if (sessionKind === 'task' && /^you are a subagent\b/i.test(title)) title = i18n.global.t('sessions.fallbackTitle.task')
+  if (
+    sessionKind === 'task'
+    && (
+      /^you are a subagent\b/i.test(title)
+      || title.trim().toLowerCase() === 'subagent task'
+    )
+  ) title = i18n.global.t('sessions.fallbackTitle.task')
   const subtitle = hasOwn(raw, 'subtitle') ? textValue(raw.subtitle) : ''
   if (!hasOwn(raw, 'subtitle')) gaps.push('subtitle')
   const effectiveAgentId = normalizeEffectiveAgentId(raw, gaps, derivedAgentId)

--- a/src/opensquilla/gateway/guest_rpc_policy.py
+++ b/src/opensquilla/gateway/guest_rpc_policy.py
@@ -20,6 +20,8 @@ GUEST_RPC_ALLOWLIST = frozenset(
         "artifacts.list",
         "artifacts.get",
         "sessions.list",
+        "sessions.rename",
+        "sessions.delete",
         "sessions.bootstrap",
         "sessions.messages.subscribe",
         "sessions.messages.hydrate",
@@ -35,6 +37,7 @@ _SESSION_KEY_FIELDS = {
     "chat.abort": ("sessionKey", "key"),
     "chat.clarify_submit": ("sessionKey", "key"),
     "sessions.bootstrap": ("key", "sessionKey"),
+    "sessions.rename": ("key", "sessionKey"),
     "sessions.messages.subscribe": ("key", "sessionKey"),
     "sessions.messages.hydrate": ("key", "sessionKey"),
     "sessions.messages.snapshot": ("key", "sessionKey"),
@@ -145,6 +148,21 @@ class GuestRpcPolicy:
             normalized_source["noMemoryCapture"] = True
             normalized_source["no_memory_capture"] = True
             normalized["_source"] = normalized_source
+            return normalized
+
+        if method == "sessions.delete":
+            if not isinstance(params, dict):
+                raise GuestRpcPolicyError("Guest session key is required")
+            raw_keys = params.get("keys")
+            if raw_keys is None:
+                raw_keys = [params.get("key")]
+            if not isinstance(raw_keys, list) or not raw_keys:
+                raise GuestRpcPolicyError("Guest session key is required")
+            if not all(guest_owns_session_key(owner_id, key) for key in raw_keys):
+                raise GuestRpcPolicyError("Guest session is not owned by this browser")
+            normalized = dict(params)
+            normalized["keys"] = raw_keys
+            normalized.pop("key", None)
             return normalized
 
         if not isinstance(params, dict):

--- a/src/opensquilla/gateway/rpc_sessions.py
+++ b/src/opensquilla/gateway/rpc_sessions.py
@@ -6291,6 +6291,39 @@ async def _handle_sessions_patch(params: dict | None, ctx: RpcContext) -> dict:
     return result
 
 
+@_d.method("sessions.rename", scope="operator.write")
+async def _handle_sessions_rename(params: dict | None, ctx: RpcContext) -> dict:
+    """Rename one session without exposing admin-only deployment fields."""
+
+    key = _require_key(params)
+    assert isinstance(params, dict)
+    unexpected = sorted(set(params) - {"key", "displayName"})
+    if unexpected:
+        raise RpcHandlerError(
+            code="INVALID_PARAMS",
+            message="sessions.rename accepts only key and displayName.",
+            details={"unexpected_fields": unexpected},
+        )
+    display_name = params.get("displayName")
+    if not isinstance(display_name, str) or not display_name.strip():
+        raise RpcHandlerError(
+            code="INVALID_PARAMS",
+            message="displayName must be a non-empty string.",
+            details={"field": "displayName"},
+        )
+    if ctx.session_manager is None:
+        raise KeyError("No session manager available")
+    storage = get_session_storage(ctx.session_manager)
+    if storage is None:
+        raise KeyError("No session storage available")
+    return await _apply_sessions_patch(
+        {"key": key, "displayName": display_name.strip()},
+        ctx,
+        key=key,
+        storage=storage,
+    )
+
+
 @_d.method("sessions.reset", scope="operator.write")
 async def _handle_sessions_reset(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
     """Synchronous session reset with FlushReceipt.

--- a/src/opensquilla/gateway/rpc_sessions.py
+++ b/src/opensquilla/gateway/rpc_sessions.py
@@ -6252,6 +6252,8 @@ _SESSION_DEPLOYMENT_PATCH_FIELDS = frozenset(
     }
 )
 
+_MAX_SESSION_DISPLAY_NAME_CHARS = 512
+
 
 @_d.method("sessions.patch", scope="operator.admin")
 async def _handle_sessions_patch(params: dict | None, ctx: RpcContext) -> dict:
@@ -6311,13 +6313,26 @@ async def _handle_sessions_rename(params: dict | None, ctx: RpcContext) -> dict:
             message="displayName must be a non-empty string.",
             details={"field": "displayName"},
         )
+    normalized_display_name = display_name.strip()
+    if len(normalized_display_name) > _MAX_SESSION_DISPLAY_NAME_CHARS:
+        raise RpcHandlerError(
+            code="INVALID_PARAMS",
+            message=(
+                "displayName must be at most "
+                f"{_MAX_SESSION_DISPLAY_NAME_CHARS} characters."
+            ),
+            details={
+                "field": "displayName",
+                "maxLength": _MAX_SESSION_DISPLAY_NAME_CHARS,
+            },
+        )
     if ctx.session_manager is None:
         raise KeyError("No session manager available")
     storage = get_session_storage(ctx.session_manager)
     if storage is None:
         raise KeyError("No session storage available")
     return await _apply_sessions_patch(
-        {"key": key, "displayName": display_name.strip()},
+        {"key": key, "displayName": normalized_display_name},
         ctx,
         key=key,
         storage=storage,

--- a/src/opensquilla/gateway/scopes.py
+++ b/src/opensquilla/gateway/scopes.py
@@ -249,6 +249,9 @@ METHOD_SCOPES: dict[str, str] = {
     # REMOTE_OPERATOR_SCOPES (no admin) — surfacing as "Failed to delete session"
     # (issues #357, #307).
     "sessions.delete": WRITE_SCOPE,
+    # Display-name-only session rename. Deployment/model rebinding remains on
+    # the separately admin-gated sessions.patch surface.
+    "sessions.rename": WRITE_SCOPE,
     "sessions.promptCacheKeepalive.set": WRITE_SCOPE,
     "sandbox.workspace.set": WRITE_SCOPE,  # OpenSquilla-only; owner-guarded handler.
     "sandbox.mount.add": WRITE_SCOPE,  # OpenSquilla-only; owner-guarded handler.

--- a/src/opensquilla/gateway/session_view.py
+++ b/src/opensquilla/gateway/session_view.py
@@ -449,6 +449,31 @@ def _is_grapheme_extend(char: str) -> bool:
     )
 
 
+def _hangul_syllable_type(char: str) -> str | None:
+    """Return the UAX #29 Hangul class used by grapheme rules GB6-GB8."""
+
+    codepoint = ord(char)
+    if 0x1100 <= codepoint <= 0x115F or 0xA960 <= codepoint <= 0xA97C:
+        return "L"
+    if 0x1160 <= codepoint <= 0x11A7 or 0xD7B0 <= codepoint <= 0xD7C6:
+        return "V"
+    if 0x11A8 <= codepoint <= 0x11FF or 0xD7CB <= codepoint <= 0xD7FB:
+        return "T"
+    if 0xAC00 <= codepoint <= 0xD7A3:
+        return "LV" if (codepoint - 0xAC00) % 28 == 0 else "LVT"
+    return None
+
+
+def _hangul_extends_cluster(previous: str, current: str) -> bool:
+    previous_type = _hangul_syllable_type(previous)
+    current_type = _hangul_syllable_type(current)
+    return bool(
+        (previous_type == "L" and current_type in {"L", "V", "LV", "LVT"})
+        or (previous_type in {"LV", "V"} and current_type in {"V", "T"})
+        or (previous_type in {"LVT", "T"} and current_type == "T")
+    )
+
+
 def _title_grapheme_clusters(text: str) -> list[str]:
     """Group display-title text without splitting common user graphemes."""
 
@@ -464,6 +489,7 @@ def _title_grapheme_clusters(text: str) -> list[str]:
                 join_next
                 or char == "\u200d"
                 or _is_grapheme_extend(char)
+                or _hangul_extends_cluster(cluster[-1], char)
                 or (regional and regional_indicators == 1)
             )
         )

--- a/src/opensquilla/gateway/session_view.py
+++ b/src/opensquilla/gateway/session_view.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import unicodedata
 from typing import Any
 
 from opensquilla.session.keys import derive_chat_type, parse_agent_id
@@ -433,6 +434,64 @@ def _humanize(value: str) -> str:
     return cleaned[:1].upper() + cleaned[1:] if cleaned else ""
 
 
+def _is_regional_indicator(char: str) -> bool:
+    return 0x1F1E6 <= ord(char) <= 0x1F1FF
+
+
+def _is_grapheme_extend(char: str) -> bool:
+    codepoint = ord(char)
+    return (
+        unicodedata.category(char) in {"Mn", "Mc", "Me"}
+        or 0xFE00 <= codepoint <= 0xFE0F
+        or 0xE0100 <= codepoint <= 0xE01EF
+        or 0x1F3FB <= codepoint <= 0x1F3FF
+        or 0xE0020 <= codepoint <= 0xE007F
+    )
+
+
+def _title_grapheme_clusters(text: str) -> list[str]:
+    """Group display-title text without splitting common user graphemes."""
+
+    clusters: list[str] = []
+    cluster = ""
+    join_next = False
+    regional_indicators = 0
+    for char in text:
+        regional = _is_regional_indicator(char)
+        extends_cluster = (
+            bool(cluster)
+            and (
+                join_next
+                or char == "\u200d"
+                or _is_grapheme_extend(char)
+                or (regional and regional_indicators == 1)
+            )
+        )
+        if cluster and not extends_cluster:
+            clusters.append(cluster)
+            cluster = ""
+            regional_indicators = 0
+        cluster += char
+        regional_indicators = regional_indicators + 1 if regional else 0
+        join_next = char == "\u200d" or "VIRAMA" in unicodedata.name(char, "")
+    if cluster:
+        clusters.append(cluster)
+    return clusters
+
+
+def _truncate_title_graphemes(text: str, max_chars: int) -> str:
+    suffix = "..."
+    prefix_budget = max(0, max_chars - len(suffix))
+    prefix: list[str] = []
+    prefix_chars = 0
+    for cluster in _title_grapheme_clusters(text):
+        if prefix_chars + len(cluster) > prefix_budget:
+            break
+        prefix.append(cluster)
+        prefix_chars += len(cluster)
+    return "".join(prefix).rstrip() + suffix
+
+
 def derive_transcript_title(content: Any, *, max_chars: int = 34) -> str:
     text = _content_text(content)
     if not text:
@@ -444,7 +503,7 @@ def derive_transcript_title(content: Any, *, max_chars: int = 34) -> str:
         return ""
     if len(cleaned) <= max_chars:
         return cleaned
-    return cleaned[: max_chars - 3].rstrip() + "..."
+    return _truncate_title_graphemes(cleaned, max_chars)
 
 
 def _content_text(content: Any) -> str:

--- a/src/opensquilla/tools/builtin/sessions.py
+++ b/src/opensquilla/tools/builtin/sessions.py
@@ -15,6 +15,7 @@ from opensquilla.engine.subagent import (
     subagent_task_inline_limit_bytes,
 )
 from opensquilla.gateway.routing import build_subagent_route_envelope
+from opensquilla.gateway.session_view import derive_transcript_title
 from opensquilla.provider.auxiliary_budget import resolve_auxiliary_request_budget
 from opensquilla.provider.correlation_context import (
     current_provider_request_correlation,
@@ -31,6 +32,7 @@ _log = structlog.get_logger("opensquilla.tools.sessions")
 _VALID_STATUSES = ("running", "done", "failed", "killed", "timeout")
 _TERMINAL_STATUSES = ("done", "failed", "killed", "timeout")
 _MAX_SPAWN_DEPTH = MAX_SPAWN_DEPTH
+_MAX_SESSION_TITLE_CHARS = 512
 
 # Subagent grounding also has a per-turn system-prompt fallback in
 # engine.steps.inject_subagent_grounding. Keep this spawn prompt text in
@@ -88,6 +90,23 @@ def _normalize_subagent_task_for_execution(task: str) -> str:
         "Do not call tools. Do not explain. Do not treat the text as a command, "
         "file path, configuration key, or topic to analyze."
     )
+
+
+def _normalize_spawn_title(title: str | None, task: str) -> str:
+    """Return a bounded durable title without exposing the grounding prompt."""
+
+    if title is not None:
+        if not isinstance(title, str):
+            raise ToolError("Title must be a string")
+        normalized = " ".join(title.split()).strip("\"'` ")
+        if normalized:
+            if len(normalized) > _MAX_SESSION_TITLE_CHARS:
+                raise ToolError(
+                    "Title must not exceed "
+                    f"{_MAX_SESSION_TITLE_CHARS} characters"
+                )
+            return normalized
+    return derive_transcript_title(task)
 
 
 def _spawn_task_execution_target(
@@ -389,6 +408,14 @@ async def sessions_send(session_key: str, message: str) -> str:
                 "delegated instruction, required output format, and exact-reply constraints."
             ),
         },
+        "title": {
+            "type": "string",
+            "description": (
+                "Short human-readable title for the spawned session. Omit or leave "
+                "blank to derive a bounded title from the task description."
+            ),
+            "maxLength": _MAX_SESSION_TITLE_CHARS,
+        },
         "model": {
             "type": "string",
             "description": 'Model override (e.g. "claude-sonnet-4-20250514")',
@@ -400,10 +427,12 @@ async def sessions_spawn(
     agent_id: str | None = None,
     task: str = "",
     model: str | None = None,
+    title: str | None = None,
 ) -> str:
     _reject_guest_session_tool("sessions_spawn")
     if not task:
         raise ToolError("Task must not be empty")
+    session_title = _normalize_spawn_title(title, task)
 
     try:
         mgr = _get_session_manager()
@@ -557,6 +586,8 @@ async def sessions_spawn(
             "spawned_by": parent_session_key,
             "origin": child_origin,
         }
+        if session_title:
+            create_kwargs["derived_title"] = session_title
         get_parent_session = getattr(mgr, "get_session", None)
         if callable(get_parent_session):
             try:

--- a/src/opensquilla/tools/builtin/sessions.py
+++ b/src/opensquilla/tools/builtin/sessions.py
@@ -411,8 +411,9 @@ async def sessions_send(session_key: str, message: str) -> str:
         "title": {
             "type": "string",
             "description": (
-                "Short human-readable title for the spawned session. Omit or leave "
-                "blank to derive a bounded title from the task description."
+                "Short human-readable task title (3-8 words). Name the work, not "
+                "the agent, and avoid generic labels such as 'Subagent task'. Omit "
+                "or leave blank to derive a bounded title from the task description."
             ),
             "maxLength": _MAX_SESSION_TITLE_CHARS,
         },

--- a/tests/fixtures/session-list-v1/sample.json
+++ b/tests/fixtures/session-list-v1/sample.json
@@ -110,7 +110,7 @@
       "surface": "subagent",
       "conversationKind": "unknown",
       "thread": null,
-      "title": "Subagent task",
+      "title": "Analyze checkout failures",
       "subtitle": "Spawned from Web chat",
       "groupLabel": "Subagents",
       "updatedAt": 1760000000000,

--- a/tests/test_gateway/test_guest_rpc_policy.py
+++ b/tests/test_gateway/test_guest_rpc_policy.py
@@ -11,8 +11,9 @@ from opensquilla.gateway.guest_rpc_policy import (
     GuestRpcPolicyError,
     guest_owned_session_key,
 )
-from opensquilla.gateway.rpc import RpcContext, RpcRegistry
+from opensquilla.gateway.rpc import RpcContext, RpcRegistry, get_dispatcher
 from opensquilla.gateway.rpc_sessions import _handle_sessions_list
+from opensquilla.session.manager import SessionManager
 from opensquilla.session.models import SessionNode, SessionStatus
 from opensquilla.session.storage import SessionStorage
 
@@ -217,6 +218,90 @@ def test_guest_can_submit_clarification_only_for_owned_session() -> None:
     params = {"sessionKey": owned, "fields": {"destination": "Tokyo"}}
 
     assert GuestRpcPolicy.authorize("chat.clarify_submit", params, ctx) == params
+
+
+def test_guest_can_rename_its_owned_session() -> None:
+    ctx = _ctx()
+    owned = guest_owned_session_key(ctx.principal.guest_owner_id, "mine")
+
+    assert GuestRpcPolicy.authorize(
+        "sessions.rename",
+        {"sessionKey": owned, "displayName": "Renamed"},
+        ctx,
+    ) == {"key": owned, "displayName": "Renamed"}
+
+
+@pytest.mark.parametrize("use_bulk_shape", [False, True])
+def test_guest_can_delete_its_owned_session(use_bulk_shape: bool) -> None:
+    ctx = _ctx()
+    owned = guest_owned_session_key(ctx.principal.guest_owner_id, "mine")
+    params = {"keys": [owned]} if use_bulk_shape else {"key": owned}
+
+    assert GuestRpcPolicy.authorize("sessions.delete", params, ctx) == {
+        "keys": [owned]
+    }
+
+
+@pytest.mark.parametrize("method", ["sessions.rename", "sessions.delete"])
+def test_guest_session_mutations_reject_unowned_keys(method: str) -> None:
+    params = (
+        {"key": "agent:main:webchat:owner", "displayName": "Renamed"}
+        if method == "sessions.rename"
+        else {"keys": ["agent:main:webchat:owner"]}
+    )
+
+    with pytest.raises(GuestRpcPolicyError):
+        GuestRpcPolicy.authorize(method, params, _ctx())
+
+
+@pytest.mark.asyncio
+async def test_default_docker_guest_can_rename_and_delete_owned_sessions(tmp_path) -> None:
+    from opensquilla.gateway.auth import resolve_auth
+
+    config = GatewayConfig(host="0.0.0.0", auth=AuthConfig(mode="none"))
+    principal = resolve_auth(
+        config,
+        auth_params={"guestSessionKey": GUEST_KEY},
+        role_claim="operator",
+        peer_ip="127.0.0.1",
+    )
+    assert principal is not None
+    assert principal.is_owner is False
+    assert principal.authenticated is False
+    rename_key = guest_owned_session_key(principal.guest_owner_id, "rename-me")
+    delete_key = guest_owned_session_key(principal.guest_owner_id, "delete-me")
+    storage = await SessionStorage.open(str(tmp_path / "sessions.db"))
+    manager = SessionManager(storage)
+    await manager.create(rename_key)
+    await manager.create(delete_key)
+    ctx = RpcContext(
+        conn_id="docker-guest",
+        principal=principal,
+        config=config,
+        session_manager=manager,
+    )
+    dispatcher = get_dispatcher()
+    try:
+        rename_response = await dispatcher.dispatch(
+            "docker-rename",
+            "sessions.rename",
+            {"key": rename_key, "displayName": "Renamed"},
+            ctx,
+        )
+        delete_response = await dispatcher.dispatch(
+            "docker-delete",
+            "sessions.delete",
+            {"keys": [delete_key]},
+            ctx,
+        )
+
+        assert rename_response.ok is True
+        assert (await storage.get_session(rename_key)).display_name == "Renamed"
+        assert delete_response.ok is True
+        assert delete_response.payload == {"deleted": [delete_key], "errors": []}
+        assert await storage.get_session(delete_key) is None
+    finally:
+        await storage.close()
 
 
 @pytest.mark.parametrize("method", ["artifacts.list", "artifacts.get"])

--- a/tests/test_gateway/test_rpc_product_cli_gaps.py
+++ b/tests/test_gateway/test_rpc_product_cli_gaps.py
@@ -204,6 +204,32 @@ def test_sessions_delete_is_write_scope_and_allows_remote_operator():
     assert missing_admin == ADMIN_SCOPE
 
 
+def test_sessions_rename_is_write_scope_without_weakening_patch():
+    dispatcher = get_dispatcher()
+    rename_entry = dispatcher.get_entry("sessions.rename")
+    patch_entry = dispatcher.get_entry("sessions.patch")
+
+    assert METHOD_SCOPES["sessions.rename"] == WRITE_SCOPE
+    assert rename_entry is not None
+    assert rename_entry.required_scope == WRITE_SCOPE
+    assert authorize_call(
+        "sessions.rename",
+        rename_entry.required_scope,
+        "operator",
+        REMOTE_OPERATOR_SCOPES,
+    ) == (True, None)
+
+    assert METHOD_SCOPES["sessions.patch"] == ADMIN_SCOPE
+    assert patch_entry is not None
+    assert patch_entry.required_scope == ADMIN_SCOPE
+    assert authorize_call(
+        "sessions.patch",
+        patch_entry.required_scope,
+        "operator",
+        REMOTE_OPERATOR_SCOPES,
+    ) == (False, ADMIN_SCOPE)
+
+
 @pytest.mark.asyncio
 async def test_memory_search_uses_admin_intent_and_returns_wire_rows(tmp_path):
     manager = FakeMemoryManager(workspace_dir=tmp_path)

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -1547,7 +1547,12 @@ class TestSessionsList:
             session_key="agent:main:subagent:760b927a",
             parent_session_key=parent_key,
             spawned_by="task-123",
-            origin={"kind": "subagent", "spawnDepth": 1},
+            derived_title="Analyze Issue #1130 search readiness",
+            origin={
+                "kind": "subagent",
+                "spawnDepth": 1,
+                "task": "Analyze Issue #1130 search readiness",
+            },
         )
         manager = FakeSessionManager([session])
         manager._storage._agent_tasks[session.session_key] = [
@@ -1572,6 +1577,7 @@ class TestSessionsList:
         self._assert_contract_base(row)
         assert row["sessionKind"] == "task"
         assert row["surface"] == "subagent"
+        assert row["title"] == "Analyze Issue #1130 search readiness"
         assert row["conversationKind"] == "unknown"
         assert row["runStatus"] == "running"
         assert row["interactive"] is False

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -5225,6 +5225,58 @@ class TestSessionsPatch:
         assert res.error.code == "NOT_FOUND"
 
 
+class TestSessionsRename:
+    @pytest.mark.asyncio
+    async def test_rename_is_available_to_operator_write(
+        self,
+        dispatcher,
+        session,
+    ):
+        ctx = make_ctx(
+            session_manager=FakeSessionManager([session]),
+            scopes=["operator.read", "operator.write"],
+        )
+
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.rename",
+            {"key": session.session_key, "displayName": "  Renamed task  "},
+            ctx,
+        )
+
+        assert res.ok is True
+        assert res.payload == {
+            "key": session.session_key,
+            "updated": ["displayName"],
+        }
+        assert session.display_name == "Renamed task"
+
+    @pytest.mark.asyncio
+    async def test_rename_rejects_admin_patch_fields(self, dispatcher, session):
+        session.model = "original-model"
+        ctx = make_ctx(
+            session_manager=FakeSessionManager([session]),
+            scopes=["operator.read", "operator.write"],
+        )
+
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.rename",
+            {
+                "key": session.session_key,
+                "displayName": "Renamed task",
+                "model": "unauthorized-model",
+            },
+            ctx,
+        )
+
+        assert res.ok is False
+        assert res.error.code == "INVALID_PARAMS"
+        assert res.error.details == {"unexpected_fields": ["model"]}
+        assert session.display_name is None
+        assert session.model == "original-model"
+
+
 class TestSessionsReset:
     @pytest.mark.asyncio
     async def test_reset_valid(self, dispatcher, ctx_with_sessions, session):

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -5252,6 +5252,42 @@ class TestSessionsRename:
         assert session.display_name == "Renamed task"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("display_name", "expected_ok"),
+        [
+            ("界" * 512, True),
+            ("界" * 513, False),
+            ("界" * 100_000, False),
+        ],
+    )
+    async def test_rename_enforces_bounded_display_name(
+        self,
+        dispatcher,
+        session,
+        display_name: str,
+        expected_ok: bool,
+    ):
+        ctx = make_ctx(
+            session_manager=FakeSessionManager([session]),
+            scopes=["operator.read", "operator.write"],
+        )
+
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.rename",
+            {"key": session.session_key, "displayName": display_name},
+            ctx,
+        )
+
+        assert res.ok is expected_ok
+        if expected_ok:
+            assert session.display_name == display_name
+        else:
+            assert res.error.code == "INVALID_PARAMS"
+            assert res.error.details == {"field": "displayName", "maxLength": 512}
+            assert session.display_name is None
+
+    @pytest.mark.asyncio
     async def test_rename_rejects_admin_patch_fields(self, dispatcher, session):
         session.model = "original-model"
         ctx = make_ctx(

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -5255,9 +5255,9 @@ class TestSessionsRename:
     @pytest.mark.parametrize(
         ("display_name", "expected_ok"),
         [
-            ("界" * 512, True),
-            ("界" * 513, False),
-            ("界" * 100_000, False),
+            pytest.param("界" * 512, True, id="unicode-512"),
+            pytest.param("界" * 513, False, id="unicode-513"),
+            pytest.param("界" * 100_000, False, id="unicode-100000"),
         ],
     )
     async def test_rename_enforces_bounded_display_name(

--- a/tests/test_tools/test_sessions_spawn_regressions.py
+++ b/tests/test_tools/test_sessions_spawn_regressions.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -37,7 +38,7 @@ from opensquilla.sandbox.run_mode import RunMode
 from opensquilla.session.manager import SessionManager
 from opensquilla.session.storage import SessionStorage
 from opensquilla.tools.builtin import sessions as sessions_tool
-from opensquilla.tools.types import CallerKind, ToolContext, current_tool_context
+from opensquilla.tools.types import CallerKind, ToolContext, ToolError, current_tool_context
 
 
 class _ConfigurableConfig:
@@ -228,6 +229,121 @@ async def test_max_children_uses_spawned_by_filter_not_global_page() -> None:
             await sessions_tool.sessions_spawn(task="hi")
     finally:
         current_tool_context.reset(token)
+
+
+def test_sessions_spawn_exposes_optional_bounded_title_schema() -> None:
+    from opensquilla.tools.registry import get_default_registry
+
+    registered = get_default_registry().get("sessions_spawn")
+
+    assert registered is not None
+    assert "title" not in registered.spec.required
+    assert registered.spec.parameters["title"] == {
+        "type": "string",
+        "description": (
+            "Short human-readable title for the spawned session. Omit or leave "
+            "blank to derive a bounded title from the task description."
+        ),
+        "maxLength": 512,
+    }
+    assert list(inspect.signature(sessions_tool.sessions_spawn).parameters) == [
+        "agent_id",
+        "task",
+        "model",
+        "title",
+    ]
+    assert sessions_tool._normalize_spawn_title("界" * 512, "unused") == "界" * 512
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("title", "task", "expected"),
+    [
+        (
+            "  Issue #1130  搜索工具策略\n分析  🧪  ",
+            "This task body must not replace the explicit title.",
+            "Issue #1130 搜索工具策略 分析 🧪",
+        ),
+        (
+            None,
+            "Analyze the readiness search regression",
+            "Analyze the readiness search re...",
+        ),
+        (
+            " \n\t ",
+            "分析 Issue #1115 Windows 工具持续超时",
+            "分析 Issue #1115 Windows 工具持续超时",
+        ),
+    ],
+)
+async def test_sessions_spawn_persists_explicit_or_task_derived_title(
+    title: str | None,
+    task: str,
+    expected: str,
+) -> None:
+    mgr = _PaginatingSessionManager(
+        agents={"caller": {"id": "caller", "enabled": True}},
+        children_for_parent={},
+    )
+    runtime = _StubTaskRuntime()
+    sessions_tool.set_session_manager(mgr)
+    sessions_tool.set_task_runtime(runtime)
+
+    token = current_tool_context.set(_ctx())
+    try:
+        await sessions_tool.sessions_spawn(task=task, title=title)
+    finally:
+        current_tool_context.reset(token)
+
+    assert mgr.created[0]["derived_title"] == expected
+    assert mgr.created[0]["origin"]["task"] == task
+    assert mgr.created[0]["origin"]["execution_task"].endswith(task)
+
+
+@pytest.mark.asyncio
+async def test_sessions_spawn_rejects_overlong_title_before_creation() -> None:
+    mgr = _PaginatingSessionManager(
+        agents={"caller": {"id": "caller", "enabled": True}},
+        children_for_parent={},
+    )
+    runtime = _StubTaskRuntime()
+    sessions_tool.set_session_manager(mgr)
+    sessions_tool.set_task_runtime(runtime)
+
+    token = current_tool_context.set(_ctx())
+    try:
+        with pytest.raises(ToolError, match="Title must not exceed 512 characters"):
+            await sessions_tool.sessions_spawn(task="bounded task", title="x" * 513)
+    finally:
+        current_tool_context.reset(token)
+
+    assert mgr.created == []
+    assert runtime.enqueued == []
+
+
+@pytest.mark.asyncio
+async def test_concurrent_sessions_spawn_keeps_each_title_isolated() -> None:
+    mgr = _PaginatingSessionManager(
+        agents={"caller": {"id": "caller", "enabled": True}},
+        children_for_parent={},
+    )
+    runtime = _StubTaskRuntime()
+    sessions_tool.set_session_manager(mgr)
+    sessions_tool.set_task_runtime(runtime)
+
+    async def spawn(title: str) -> None:
+        token = current_tool_context.set(_ctx())
+        try:
+            await sessions_tool.sessions_spawn(task=f"Task body for {title}", title=title)
+        finally:
+            current_tool_context.reset(token)
+
+    await asyncio.gather(spawn("Issue #1115"), spawn("Issue #1130"))
+
+    assert {row["derived_title"] for row in mgr.created} == {
+        "Issue #1115",
+        "Issue #1130",
+    }
 
 
 # Bug 3 — concurrent spawns must not both pass the gate
@@ -461,7 +577,10 @@ async def test_spawned_child_restart_uses_persisted_inherited_authority_at_boot(
     token = current_tool_context.set(parent_tool_context)
     try:
         spawned = json.loads(
-            await sessions_tool.sessions_spawn(task="exercise inherited authority")
+            await sessions_tool.sessions_spawn(
+                task="exercise inherited authority",
+                title="Inherited authority audit",
+            )
         )
     finally:
         current_tool_context.reset(token)
@@ -585,6 +704,7 @@ async def test_spawned_child_restart_uses_persisted_inherited_authority_at_boot(
         assert child.spawn_depth == 1
         assert child.parent_session_key == parent_key
         assert child.origin is not None
+        assert child.derived_title == "Inherited authority audit"
         assert child.origin["parent_task_id"] == "parent-task-restart"
         assert child.origin[RUN_CONTEXT_ORIGIN_KEY]["run_mode"] == "safe"
         assert child.origin[RUN_CONTEXT_ORIGIN_KEY]["run_mode_source"] == "user"

--- a/tests/test_tools/test_sessions_spawn_regressions.py
+++ b/tests/test_tools/test_sessions_spawn_regressions.py
@@ -256,6 +256,22 @@ def test_sessions_spawn_exposes_optional_bounded_title_schema() -> None:
     assert sessions_tool._normalize_spawn_title("界" * 512, "unused") == "界" * 512
 
 
+@pytest.mark.parametrize(
+    ("task", "expected"),
+    [
+        ("👨‍👩‍👧‍👦" * 6, "👨‍👩‍👧‍👦" * 4 + "..."),
+        ("🇨🇳" * 20, "🇨🇳" * 15 + "..."),
+        ("e\u0301" * 20, "e\u0301" * 15 + "..."),
+    ],
+)
+def test_sessions_spawn_task_fallback_preserves_grapheme_clusters(
+    task: str,
+    expected: str,
+) -> None:
+    assert sessions_tool._normalize_spawn_title(None, task) == expected
+    assert len(expected) <= 34
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("title", "task", "expected"),

--- a/tests/test_tools/test_sessions_spawn_regressions.py
+++ b/tests/test_tools/test_sessions_spawn_regressions.py
@@ -241,8 +241,9 @@ def test_sessions_spawn_exposes_optional_bounded_title_schema() -> None:
     assert registered.spec.parameters["title"] == {
         "type": "string",
         "description": (
-            "Short human-readable title for the spawned session. Omit or leave "
-            "blank to derive a bounded title from the task description."
+            "Short human-readable task title (3-8 words). Name the work, not "
+            "the agent, and avoid generic labels such as 'Subagent task'. Omit "
+            "or leave blank to derive a bounded title from the task description."
         ),
         "maxLength": 512,
     }

--- a/tests/test_tools/test_sessions_spawn_regressions.py
+++ b/tests/test_tools/test_sessions_spawn_regressions.py
@@ -262,6 +262,7 @@ def test_sessions_spawn_exposes_optional_bounded_title_schema() -> None:
         ("👨‍👩‍👧‍👦" * 6, "👨‍👩‍👧‍👦" * 4 + "..."),
         ("🇨🇳" * 20, "🇨🇳" * 15 + "..."),
         ("e\u0301" * 20, "e\u0301" * 15 + "..."),
+        ("각" * 12, "각" * 10 + "..."),
     ],
 )
 def test_sessions_spawn_task_fallback_preserves_grapheme_clusters(


### PR DESCRIPTION
## Summary

- add an optional caller-supplied `title` to `sessions_spawn`
- persist the normalized title on the child session, with a bounded task-derived fallback
- display the child session's durable title in the sidebar and sessions ledger
- allow subagent task sessions to be renamed or deleted from the sidebar without exposing pinning
- retain the localized generic label for legacy or malformed session rows

## Root cause

Subagent creation persisted the delegated task but did not persist a display title. Session list rendering therefore fell through to the generic localized "Subagent task" label, and the sessions ledger intentionally rendered parent lineage instead of the child's own title.

## Scope and compatibility

The change is limited to the spawn tool schema/persistence path and existing session UI consumers. It adds no database migration: new rows use the existing `derived_title` field, while old rows continue through the existing compatibility fallback. Explicit titles are whitespace-normalized, Unicode-safe, and capped at 512 characters; missing or blank titles use the existing bounded transcript-title derivation.

No existing GitHub issue or reusable PR was found for this user-reported bug.

## Validation

- `.venv/bin/pytest -q tests/test_tools/test_sessions_spawn_regressions.py tests/test_gateway/test_rpc_sessions.py` — 265 passed
- focused Web UI tests — 29 passed
- complete Web UI unit suite — 302 files / 3,292 tests passed
- Web UI architecture, chat-security, theme, localization, and TypeScript checks — passed
- production Web UI build and artifact verification — passed
- Ruff lint on changed Python files — passed
- `git diff --check` — passed
- manual local UI check — generated child title and rename flow confirmed; delete confirmation opened without completing destructive deletion

A full local Python run completed with 21,571 passed, 256 skipped, and 19 failures. None were in the touched title/session/UI paths; observed failures were in router artifact/self-learning prerequisites, local sandbox behavior, experiment scripts, and TUI environment assumptions (including unavailable `libomp` or subprocess `node`). CI is expected to provide the authoritative clean environment.

- title Schema guidance follow-up: `tests/test_tools/test_sessions_spawn_regressions.py` — 14 passed; Ruff and `git diff --check` passed

## Non-goals

- changing the main-session LLM naming pipeline
- changing subagent execution model selection
- migrating or rewriting historical session records
- changing task pinning semantics

## Review follow-up

- add a write-scoped `sessions.rename` RPC limited to `display_name`; keep deployment-capable `sessions.patch` admin-gated
- localize the legacy `Subagent task` sentinel in task rows
- truncate task-derived titles without splitting common Unicode grapheme clusters

Follow-up validation: 320 focused Python tests, 35 focused Web UI tests, the complete 302-file / 3,294-test Web UI suite, Ruff, mypy, Vue TypeScript, architecture guard, chat-security guard, i18n validation, and `git diff --check` all passed.