### PR TITLE
Avoid labeling ordinary history messages as Steer

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatHistory.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatHistory.test.ts
@@ -75,6 +75,8 @@ describe('useChatHistory canonical pagination', () => {
           timestamp: '2026-07-06T00:00:00Z',
           turn_context: {
             turn_id: 'turn-send',
+            target_turn_id: 'turn-send',
+            client_request_id: 'request-send',
             client_message_id: 'client-send',
             intent: 'send',
             disposition: 'applied',
@@ -94,7 +96,111 @@ describe('useChatHistory canonical pagination', () => {
     })
     expect(messages.value[0]?.inputDisposition).toBeUndefined()
     expect(messages.value[0]?.inputDispositionRevision).toBeUndefined()
+    expect(messages.value[0]?.steerClientRequestId).toBeUndefined()
     expect(messages.value[0]?.steerClientMessageId).toBeUndefined()
+  })
+
+  it('restores an explicit Steer intent without relying on shared transport IDs', async () => {
+    const { api, messages } = makeHistory(false, {
+      response: {
+        messages: [{
+          id: 'current-steer',
+          message_id: 'current-steer',
+          role: 'user',
+          text: 'current same-turn correction',
+          timestamp: '2026-07-06T00:00:00Z',
+          turn_context: {
+            turn_id: 'turn-steer',
+            client_request_id: 'request-steer',
+            client_message_id: 'client-steer',
+            intent: 'steer',
+            disposition: 'applied',
+            revision: 2,
+          },
+        }],
+        has_more: false,
+      },
+    })
+
+    await api.loadHistory()
+
+    expect(messages.value[0]).toMatchObject({
+      inputDisposition: 'applied',
+      inputDispositionRevision: 2,
+      steerClientRequestId: 'request-steer',
+      steerClientMessageId: 'client-steer',
+    })
+  })
+
+  it('does not infer legacy Steer UX from shared primary-input fields', async () => {
+    const { api, messages } = makeHistory(false, {
+      response: {
+        messages: (['applied', 'cancelled', 'rejected'] as const).map((disposition, index) => ({
+          id: `legacy-send-${disposition}`,
+          message_id: `legacy-send-${disposition}`,
+          role: 'user' as const,
+          text: `legacy primary ${disposition}`,
+          timestamp: `2026-07-06T00:00:0${index}Z`,
+          turn_context: {
+            turn_id: 'turn-send',
+            target_turn_id: 'turn-send',
+            client_request_id: `request-${disposition}`,
+            client_message_id: `client-${disposition}`,
+            disposition,
+            revision: 2,
+            applied_iteration: null,
+          },
+        })),
+        has_more: false,
+      },
+    })
+
+    await api.loadHistory()
+
+    for (const message of messages.value) {
+      expect(message.inputDisposition).toBeUndefined()
+      expect(message.inputDispositionRevision).toBeUndefined()
+      expect(message.steerClientRequestId).toBeUndefined()
+      expect(message.steerClientMessageId).toBeUndefined()
+    }
+  })
+
+  it('restores an applied legacy steer from model-call evidence when intent is absent', async () => {
+    const { api, messages } = makeHistory(false, {
+      response: {
+        messages: [{
+          id: 'legacy-steer',
+          message_id: 'legacy-steer',
+          role: 'user',
+          text: 'legacy same-turn correction',
+          timestamp: '2026-07-06T00:00:00Z',
+          turn_context: {
+            turn_id: 'turn-steer',
+            client_request_id: 'request-steer',
+            client_message_id: 'client-steer',
+            disposition: 'applied',
+            revision: 2,
+            model_call_id: '2.0',
+            applied_iteration: 2,
+          },
+        }],
+        has_more: false,
+      },
+    })
+
+    await api.loadHistory()
+
+    expect(messages.value[0]).toMatchObject({
+      role: 'user',
+      text: 'legacy same-turn correction',
+      turnId: 'turn-steer',
+      inputDisposition: 'applied',
+      inputDispositionRevision: 2,
+      steerClientRequestId: 'request-steer',
+      steerClientMessageId: 'client-steer',
+      steerModelCallId: '2.0',
+      steerAppliedIteration: 2,
+    })
   })
 
   it('requests canonical messages with durable compaction summaries', async () => {

--- a/opensquilla-webui/src/composables/chat/useChatHistory.ts
+++ b/opensquilla-webui/src/composables/chat/useChatHistory.ts
@@ -91,12 +91,17 @@ function historyContextText(value: unknown, key: string): string | undefined {
 function historyHasSteerEvidence(value: unknown): boolean {
   const disposition = historyContextText(value, 'disposition')
   const intent = historyContextText(value, 'intent')
-  return intent === 'steer'
-    || disposition === 'steering'
+  // Current gateways persist an intent for both primary sends and Steers.
+  // Treat that explicit value as authoritative: primary sends also carry a
+  // client_request_id, so transport identity alone cannot prove Steer UX.
+  if (intent) return intent === 'steer'
+  // Older gateways omitted intent. Preserve their Steer rows using fields
+  // that are specific to same-turn admission/application rather than IDs
+  // shared by every durable user input.
+  return disposition === 'steering'
     || disposition === 'promoted'
-    || disposition === 'cancelled'
-    || disposition === 'rejected'
-    || Boolean(historyContextText(value, 'client_request_id'))
+    || Boolean(historyContextText(value, 'promoted_turn_id'))
+    || Boolean(historyContextText(value, 'promoted_from_turn_id'))
     || Boolean(historyContextText(value, 'model_call_id'))
     || historyContextInteger(value, 'applied_iteration') !== undefined
 }
@@ -124,7 +129,10 @@ function historyDispositionRevision(value: unknown): number | undefined {
 
 function historyContextInteger(value: unknown, key: string): number | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
-  const number = Number((value as Record<string, unknown>)[key])
+  const raw = (value as Record<string, unknown>)[key]
+  if (typeof raw !== 'number' && typeof raw !== 'string') return undefined
+  if (typeof raw === 'string' && !raw.trim()) return undefined
+  const number = Number(raw)
   return Number.isInteger(number) && number >= 0 ? number : undefined
 }
 


### PR DESCRIPTION
## Scope

Scope boundary: Fix WebUI history hydration so ordinary user sends are not rendered with Steer status labels. Preserve recovery of current and legacy durable Steer rows using explicit or Steer-specific evidence.

Non-goals: Change Steer delivery, Gateway admission, database storage, RPC schemas, or routing behavior.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Follow-up display regression discovered while verifying the Steer delivery fix in #1143.

## Release Note

Release note: Fix ordinary chat messages being mislabeled as Steer after history refresh.

## Tests

Ruff: N/A (WebUI-only change)

Pytest: N/A (WebUI-only change)

Build: `cd opensquilla-webui && npm run build` (passed)

Regression tests: added

Notes:

- 144 focused WebUI unit tests passed across history, rendering, RPC event, Steer delivery, and status-label coverage.
- `queue-steer.spec.ts` passed 4/4 in Chromium with deterministic WebSocket scenarios.
- The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: No credentials or external providers are required for this fix.

## Safety

No secrets, local artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are included. The change is platform-neutral and does not alter persisted schemas, configuration, RPC contracts, or public interfaces.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
