### PR TITLE
Validate merge queue candidates in required CI

### DIFF
--- a/.github/scripts/validate-pr-target-branch.sh
+++ b/.github/scripts/validate-pr-target-branch.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 base_ref="${PR_BASE_REF:-${BASE_REF:-${BASE:-}}}"
+base_ref="${base_ref#refs/heads/}"
 event_path="${GITHUB_EVENT_PATH:-}"
 
 if [[ -z "${base_ref}" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 "on":
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [main]
   workflow_dispatch:
@@ -54,6 +56,19 @@ jobs:
               git diff --name-only \
                 "${{ github.event.pull_request.base.sha }}" \
                 "${{ github.event.pull_request.head.sha }}" > "${changed_files}"
+              ;;
+            merge_group)
+              base="${{ github.event.merge_group.base_sha }}"
+              head="${{ github.event.merge_group.head_sha }}"
+              if [[ -n "${base}" && -n "${head}" ]] \
+                && git cat-file -e "${base}^{commit}" \
+                && git cat-file -e "${head}^{commit}" \
+                && git diff --name-only "${base}" "${head}" > "${changed_files}"; then
+                :
+              else
+                echo "Merge-group diff is unavailable; running the full CI matrix." >&2
+                printf '.ci/run-all\n' > "${changed_files}"
+              fi
               ;;
             push)
               before="${{ github.event.before }}"
@@ -733,7 +748,7 @@ jobs:
         run: |
           set -euo pipefail
           maxfail_args=()
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "merge_group" ]]; then
             maxfail_args+=(--maxfail=3)
           fi
 
@@ -767,7 +782,7 @@ jobs:
           set -euo pipefail
           markers="not llm and not live_search and not live_skill_hub and not live_channel and not webui_browser and not tui_real_terminal and not local_golden and not agent_context_boundary and not llm_router_acc"
           maxfail_args=()
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "merge_group" ]]; then
             maxfail_args+=(--maxfail=3)
           fi
 
@@ -869,7 +884,7 @@ jobs:
             --durations=50
             --junitxml="${CI_REPORT_DIR}/junit.xml"
           )
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "merge_group" ]]; then
             pytest_args+=(--maxfail=3)
           fi
 

--- a/.github/workflows/pr-target-branch.yml
+++ b/.github/workflows/pr-target-branch.yml
@@ -3,6 +3,8 @@ name: PR target branch
 "on":
   pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
@@ -20,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Check out bootstrap validator before first merge
-        if: ${{ hashFiles('.github/scripts/validate-pr-target-branch.sh') == '' }}
+        if: ${{ github.event_name == 'pull_request' && hashFiles('.github/scripts/validate-pr-target-branch.sh') == '' }}
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -28,8 +30,8 @@ jobs:
 
       - name: Validate target branch
         env:
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BASE_REF: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_ref || github.event.pull_request.base.ref }}
+          PR_HEAD_REF: ${{ github.event_name == 'merge_group' && github.event.merge_group.head_ref || github.event.pull_request.head.ref }}
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -183,7 +183,8 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     data = _workflow("ci.yml")
     text = ci_path.read_text(encoding="utf-8")
 
-    assert {"pull_request", "push", "workflow_dispatch"} <= _trigger_keys(data)
+    assert {"pull_request", "merge_group", "push", "workflow_dispatch"} <= _trigger_keys(data)
+    assert data["on"]["merge_group"]["types"] == ["checks_requested"]
     assert "branches: [main]" in text
     assert "PYTHONPATH: ${{ github.workspace }}" in text
     assert "Configure runtime directories" in text
@@ -199,6 +200,10 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     assert "Release packaging contracts" in text
     assert "CI result" in text
     assert 'push)\n              before="${{ github.event.before }}"' in text
+    assert 'merge_group)\n              base="${{ github.event.merge_group.base_sha }}"' in text
+    assert 'head="${{ github.event.merge_group.head_sha }}"' in text
+    assert 'git diff --name-only "${base}" "${head}" > "${changed_files}"' in text
+    assert "Merge-group diff is unavailable; running the full CI matrix." in text
     assert 'git diff --name-only "${before}" "${after}" > "${changed_files}"' in text
     assert 'printf \'.ci/run-all\\n\' > "${changed_files}"' in text
     assert "runtime_changed" in text
@@ -217,6 +222,10 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     assert ".github/scripts/check_ci_results.py" in text
     assert "code_changed" not in text
     assert "workflow_changed" not in text
+    assert text.count(
+        '"${{ github.event_name }}" == "pull_request" || '
+        '"${{ github.event_name }}" == "merge_group"'
+    ) == 3
 
 
 def test_default_ci_keeps_main_pushes_targeted_and_manual_runs_full() -> None:
@@ -595,16 +604,31 @@ def test_pr_target_branch_workflow_runs_trusted_base_validator() -> None:
     data = _workflow("pr-target-branch.yml")
     text = (WORKFLOW_DIR / "pr-target-branch.yml").read_text(encoding="utf-8")
 
-    assert _trigger_keys(data) == {"pull_request"}
+    assert _trigger_keys(data) == {"pull_request", "merge_group"}
+    assert data["on"]["merge_group"]["types"] == ["checks_requested"]
     assert "pull_request_target" not in text
     assert "Validate target branch" in text
     assert "github.event.repository.default_branch" in text
     assert "hashFiles('.github/scripts/validate-pr-target-branch.sh') == ''" in text
     assert "github.event.pull_request.head.sha" in text
+    assert "github.event.merge_group.base_ref" in text
+    assert "github.event.merge_group.head_ref" in text
     assert "pull-requests: read" in text
     assert "PR_LABELS" in text
     assert "PR_NUMBER" in text
     assert ".github/scripts/validate-pr-target-branch.sh" in text
+
+
+def test_pr_target_validator_accepts_merge_group_base_ref(tmp_path: Path) -> None:
+    result = _validate_pr_target(tmp_path, base="refs/heads/main")
+
+    assert result.returncode == 0
+    assert "targets main" in result.stdout
+
+    blocked = _validate_pr_target(tmp_path, base="refs/heads/feature/private-target")
+
+    assert blocked.returncode == 1
+    assert "Ordinary pull requests should target main" in blocked.stderr
 
 
 def test_pr_body_lint_workflow_warns_from_trusted_base() -> None:


### PR DESCRIPTION
## Scope

- Run the required `CI result` workflow for GitHub merge-group candidates.
- Classify the cumulative `base_sha..head_sha` queue diff, with a fail-closed full-matrix fallback.
- Report the required `Validate target branch` check on merge-group SHAs.
- Treat merge-group test runs as pre-merge checks for bounded failure reporting.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

Reason: repository governance and CI compatibility for a controlled Merge Queue pilot.

## Release Note

Release note: NONE

Reason: CI and repository merge governance only; no shipped runtime behavior changes.

## Tests

- `uv run pytest tests/test_ci/test_workflows.py tests/test_ci/test_ci_result_gate.py -q` — 107 passed
- `uv run pytest tests/test_ci -q` — passed, 1 skipped
- `uv run ruff check tests/test_ci/test_workflows.py tests/test_ci/test_ci_result_gate.py .github/scripts/check_ci_results.py`
- `bash -n` for both changed/relevant shell validators
- `actionlint -color=false .github/workflows/ci.yml .github/workflows/pr-target-branch.yml`
- `git diff --check`

Regression tests: added trigger, event-payload, fail-closed, and merge-group base-ref coverage.

## Safety

The merge-group diff path fails closed to the complete CI matrix when Git objects or event SHAs cannot be resolved. Required check names and their GitHub Actions provenance remain unchanged. Permissions remain read-only.

## Compatibility

No persisted state, public protocol, configuration, CLI, desktop client, or runtime behavior is affected. The workflow change covers Linux, macOS, and Windows through the existing conditional matrix.

## Third-Party Origin

Third-party origin: none
