### PR TITLE
Fix final-step artifact publication ordering

### DIFF
--- a/src/opensquilla/tools/builtin/artifacts.py
+++ b/src/opensquilla/tools/builtin/artifacts.py
@@ -220,6 +220,23 @@ def _plan_run_steps_ready_for_delivery(run: Any) -> bool:
     )
 
 
+def _plan_run_allows_delivery(ctx: ToolContext, run: Any) -> bool:
+    """Return whether the current task may deliver from this PlanRun state."""
+
+    status = str(getattr(run, "status", "") or "")
+    if status == "completed":
+        return True
+    if status != "running":
+        return False
+    task_id = str(getattr(ctx, "task_id", "") or "").strip()
+    active_task_id = str(getattr(run, "active_task_id", "") or "").strip()
+    return (
+        bool(task_id)
+        and active_task_id == task_id
+        and _plan_run_steps_ready_for_delivery(run)
+    )
+
+
 def _plan_run_final_step_ready_for_publish(run: Any) -> str | None:
     """Return the sole unfinished current step that publication can finalize."""
 
@@ -277,7 +294,7 @@ async def _checkpoint_final_plan_step_for_publish(
         )
     except PlanRunConflictError:
         refreshed = await storage.get_plan_run(run_id)
-        if refreshed is not None and _plan_run_steps_ready_for_delivery(refreshed):
+        if refreshed is not None and _plan_run_allows_delivery(ctx, refreshed):
             return refreshed
         raise RetryableToolInputError(
             "publish_artifact was not executed because the attached PlanRun "
@@ -302,7 +319,7 @@ async def _require_plan_run_ready_for_publish(ctx: ToolContext) -> Any | None:
     status = str(getattr(run, "status", "") or "")
     task_id = str(getattr(ctx, "task_id", "") or "").strip()
     active_task_id = str(getattr(run, "active_task_id", "") or "").strip()
-    if status == "completed":
+    if _plan_run_allows_delivery(ctx, run):
         return None
     if status == "running":
         if not task_id or active_task_id != task_id:

--- a/src/opensquilla/tools/builtin/artifacts.py
+++ b/src/opensquilla/tools/builtin/artifacts.py
@@ -30,6 +30,10 @@ from opensquilla.artifacts import (
     collect_artifact_bundle,
 )
 from opensquilla.sandbox.operation_runtime import SandboxToolDescriptor
+from opensquilla.session.plans import (
+    PLAN_STEP_TERMINAL_STATUSES,
+    PlanRunConflictError,
+)
 from opensquilla.tools.path_aliases import resolve_workspace_alias
 from opensquilla.tools.path_policy import reject_foreign_host_path
 from opensquilla.tools.registry import tool
@@ -216,12 +220,78 @@ def _plan_run_steps_ready_for_delivery(run: Any) -> bool:
     )
 
 
-async def _require_plan_run_ready_for_publish(ctx: ToolContext) -> None:
-    """Keep artifact delivery behind the authoritative final checkpoint."""
+def _plan_run_final_step_ready_for_publish(run: Any) -> str | None:
+    """Return the sole unfinished current step that publication can finalize."""
+
+    current_step_id = str(getattr(run, "current_step_id", "") or "")
+    if not current_step_id:
+        return None
+    step_states = list(getattr(run, "step_states", []) or [])
+    current_matches = [
+        state
+        for state in step_states
+        if isinstance(state, dict)
+        and str(state.get("step_id") or "") == current_step_id
+    ]
+    if len(current_matches) != 1:
+        return None
+    if str(current_matches[0].get("status") or "") != "in_progress":
+        return None
+    if any(
+        not isinstance(state, dict)
+        or (
+            str(state.get("step_id") or "") != current_step_id
+            and str(state.get("status") or "") not in PLAN_STEP_TERMINAL_STATUSES
+        )
+        for state in step_states
+    ):
+        return None
+    return current_step_id
+
+
+async def _checkpoint_final_plan_step_for_publish(
+    ctx: ToolContext,
+    run: Any,
+) -> Any:
+    """Atomically enter delivery when publish is the final step operation."""
+
+    step_id = _plan_run_final_step_ready_for_publish(run)
+    if step_id is None:
+        return run
+    storage = getattr(ctx, "plan_storage", None)
+    if storage is None:
+        return run
+    checkpoint_plan_run = getattr(storage, "checkpoint_plan_run", None)
+    if not callable(checkpoint_plan_run):
+        return run
+    run_id = str(getattr(ctx, "plan_run_id", "") or "").strip()
+    task_id = str(getattr(ctx, "task_id", "") or "").strip()
+    try:
+        return await checkpoint_plan_run(
+            run_id,
+            expected_state_revision=int(getattr(run, "state_revision", 0)),
+            step_id=step_id,
+            step_status="completed",
+            next_step_id=None,
+            expected_active_task_id=task_id,
+        )
+    except PlanRunConflictError:
+        refreshed = await storage.get_plan_run(run_id)
+        if refreshed is not None and _plan_run_steps_ready_for_delivery(refreshed):
+            return refreshed
+        raise RetryableToolInputError(
+            "publish_artifact was not executed because the attached PlanRun "
+            "changed while entering artifact delivery. Retry publish_artifact "
+            "with the current PlanRun state."
+        ) from None
+
+
+async def _require_plan_run_ready_for_publish(ctx: ToolContext) -> Any | None:
+    """Validate delivery state and return a final step to checkpoint if needed."""
 
     run_id = str(getattr(ctx, "plan_run_id", "") or "").strip()
     if not run_id:
-        return
+        return None
     storage = getattr(ctx, "plan_storage", None)
     get_plan_run = getattr(storage, "get_plan_run", None)
     if not callable(get_plan_run):
@@ -233,7 +303,7 @@ async def _require_plan_run_ready_for_publish(ctx: ToolContext) -> None:
     task_id = str(getattr(ctx, "task_id", "") or "").strip()
     active_task_id = str(getattr(run, "active_task_id", "") or "").strip()
     if status == "completed":
-        return
+        return None
     if status == "running":
         if not task_id or active_task_id != task_id:
             raise ToolError(
@@ -241,7 +311,9 @@ async def _require_plan_run_ready_for_publish(ctx: ToolContext) -> None:
                 "owns the attached PlanRun."
             )
         if _plan_run_steps_ready_for_delivery(run):
-            return
+            return None
+        if _plan_run_final_step_ready_for_publish(run) is not None:
+            return run
     current_step_id = str(getattr(run, "current_step_id", "") or "")
     current_detail = (
         f" The current step is {current_step_id}."
@@ -314,7 +386,7 @@ async def publish_artifact(
     ctx = current_tool_context.get()
     if ctx is None:
         raise ToolError("publish_artifact requires tool context")
-    await _require_plan_run_ready_for_publish(ctx)
+    final_step_to_checkpoint = await _require_plan_run_ready_for_publish(ctx)
     if not ctx.workspace_dir:
         raise ToolError("publish_artifact requires an active workspace")
     if not ctx.artifact_media_root:
@@ -425,6 +497,17 @@ async def publish_artifact(
             for item in bundle_manifest.files
             if item.path == bundle_manifest.entrypoint
         )
+    if final_step_to_checkpoint is not None:
+        checkpointed_run = await _checkpoint_final_plan_step_for_publish(
+            ctx,
+            final_step_to_checkpoint,
+        )
+        if not _plan_run_steps_ready_for_delivery(checkpointed_run):
+            raise RetryableToolInputError(
+                "publish_artifact was not executed because the attached PlanRun "
+                "could not enter artifact delivery. Retry after checkpointing the "
+                "current final step."
+            )
     store = ArtifactStore(ctx.artifact_media_root)
     for published in reversed(ctx.published_artifacts):
         if published.get("sha256") != target_sha256:

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -884,6 +884,169 @@ async def test_publish_artifact_requires_completed_attached_plan_run(
 
 
 @pytest.mark.asyncio
+async def test_publish_artifact_checkpoints_the_only_unfinished_final_step(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "report.txt").write_text("ready", encoding="utf-8")
+
+    class PlanStorage:
+        def __init__(self) -> None:
+            self.run = SimpleNamespace(
+                status="running",
+                current_step_id="publish",
+                active_task_id="task-1",
+                state_revision=7,
+                step_states=[
+                    {"step_id": "build", "status": "completed"},
+                    {"step_id": "publish", "status": "in_progress"},
+                ],
+            )
+            self.checkpoints: list[dict[str, object]] = []
+
+        async def get_plan_run(self, run_id: str) -> SimpleNamespace:
+            assert run_id == "run-1"
+            return self.run
+
+        async def checkpoint_plan_run(self, run_id: str, **kwargs: object) -> SimpleNamespace:
+            assert run_id == "run-1"
+            self.checkpoints.append(kwargs)
+            self.run = SimpleNamespace(
+                status="running",
+                current_step_id=None,
+                active_task_id="task-1",
+                state_revision=8,
+                step_states=[
+                    {"step_id": "build", "status": "completed"},
+                    {"step_id": "publish", "status": "completed"},
+                ],
+            )
+            return self.run
+
+    storage = PlanStorage()
+    ctx = ToolContext(
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+        task_id="task-1",
+        plan_run_id="run-1",
+        plan_storage=storage,
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        payload = json.loads(await publish_artifact(path="report.txt"))
+    finally:
+        current_tool_context.reset(token)
+
+    assert payload["status"] == "published"
+    assert storage.checkpoints == [
+        {
+            "expected_state_revision": 7,
+            "step_id": "publish",
+            "step_status": "completed",
+            "next_step_id": None,
+            "expected_active_task_id": "task-1",
+        }
+    ]
+    assert len(ctx.published_artifacts) == 1
+
+
+@pytest.mark.asyncio
+async def test_publish_artifact_does_not_checkpoint_before_the_final_step(
+    tmp_path: Path,
+) -> None:
+    class PlanStorage:
+        def __init__(self) -> None:
+            self.checkpointed = False
+
+        async def get_plan_run(self, run_id: str) -> SimpleNamespace:
+            assert run_id == "run-1"
+            return SimpleNamespace(
+                status="running",
+                current_step_id="build",
+                active_task_id="task-1",
+                state_revision=3,
+                step_states=[
+                    {"step_id": "build", "status": "in_progress"},
+                    {"step_id": "publish", "status": "pending"},
+                ],
+            )
+
+        async def checkpoint_plan_run(self, run_id: str, **kwargs: object) -> None:
+            self.checkpointed = True
+
+    storage = PlanStorage()
+    ctx = ToolContext(
+        workspace_dir=str(tmp_path),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+        task_id="task-1",
+        plan_run_id="run-1",
+        plan_storage=storage,
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        with pytest.raises(RetryableToolInputError):
+            await publish_artifact(path="report.txt")
+    finally:
+        current_tool_context.reset(token)
+
+    assert storage.checkpointed is False
+    assert ctx.published_artifacts == []
+
+
+@pytest.mark.asyncio
+async def test_publish_artifact_does_not_checkpoint_an_invalid_final_artifact(
+    tmp_path: Path,
+) -> None:
+    class PlanStorage:
+        def __init__(self) -> None:
+            self.checkpointed = False
+
+        async def get_plan_run(self, run_id: str) -> SimpleNamespace:
+            assert run_id == "run-1"
+            return SimpleNamespace(
+                status="running",
+                current_step_id="publish",
+                active_task_id="task-1",
+                state_revision=4,
+                step_states=[
+                    {"step_id": "build", "status": "completed"},
+                    {"step_id": "publish", "status": "in_progress"},
+                ],
+            )
+
+        async def checkpoint_plan_run(self, run_id: str, **kwargs: object) -> None:
+            self.checkpointed = True
+
+    storage = PlanStorage()
+    ctx = ToolContext(
+        workspace_dir=str(tmp_path),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+        task_id="task-1",
+        plan_run_id="run-1",
+        plan_storage=storage,
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        with pytest.raises(ToolError, match="artifact file not found"):
+            await publish_artifact(path="missing.txt")
+    finally:
+        current_tool_context.reset(token)
+
+    assert storage.checkpointed is False
+    assert ctx.published_artifacts == []
+
+
+@pytest.mark.asyncio
 async def test_publish_artifact_allows_completed_attached_plan_run(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -26,6 +26,7 @@ from opensquilla.artifacts import (
     strip_artifact_markers_from_text,
 )
 from opensquilla.engine.types import ToolCall
+from opensquilla.session.plans import PlanRunConflictError
 from opensquilla.tools.builtin.artifacts import publish_artifact
 from opensquilla.tools.dispatch import build_tool_handler
 from opensquilla.tools.registry import ToolRegistry
@@ -951,6 +952,137 @@ async def test_publish_artifact_checkpoints_the_only_unfinished_final_step(
             "expected_active_task_id": "task-1",
         }
     ]
+    assert len(ctx.published_artifacts) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("refreshed_status", "refreshed_active_task_id"),
+    [
+        ("cancelled", None),
+        ("running", "task-2"),
+    ],
+)
+async def test_publish_artifact_rejects_disallowed_state_after_checkpoint_conflict(
+    tmp_path: Path,
+    refreshed_status: str,
+    refreshed_active_task_id: str | None,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "report.txt").write_text("ready", encoding="utf-8")
+
+    class PlanStorage:
+        def __init__(self) -> None:
+            self.refreshed = False
+
+        async def get_plan_run(self, run_id: str) -> SimpleNamespace:
+            assert run_id == "run-1"
+            if not self.refreshed:
+                return SimpleNamespace(
+                    status="running",
+                    current_step_id="publish",
+                    active_task_id="task-1",
+                    state_revision=7,
+                    step_states=[
+                        {"step_id": "build", "status": "completed"},
+                        {"step_id": "publish", "status": "in_progress"},
+                    ],
+                )
+            return SimpleNamespace(
+                status=refreshed_status,
+                current_step_id=None,
+                active_task_id=refreshed_active_task_id,
+                state_revision=9,
+                step_states=[
+                    {"step_id": "build", "status": "completed"},
+                    {"step_id": "publish", "status": "completed"},
+                ],
+            )
+
+        async def checkpoint_plan_run(self, run_id: str, **kwargs: object) -> None:
+            assert run_id == "run-1"
+            self.refreshed = True
+            raise PlanRunConflictError("plan run changed")
+
+    ctx = ToolContext(
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+        task_id="task-1",
+        plan_run_id="run-1",
+        plan_storage=PlanStorage(),
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        with pytest.raises(RetryableToolInputError, match="changed"):
+            await publish_artifact(path="report.txt")
+    finally:
+        current_tool_context.reset(token)
+
+    assert ctx.published_artifacts == []
+
+
+@pytest.mark.asyncio
+async def test_publish_artifact_allows_owned_delivery_after_checkpoint_conflict(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "report.txt").write_text("ready", encoding="utf-8")
+
+    class PlanStorage:
+        def __init__(self) -> None:
+            self.refreshed = False
+
+        async def get_plan_run(self, run_id: str) -> SimpleNamespace:
+            assert run_id == "run-1"
+            if not self.refreshed:
+                return SimpleNamespace(
+                    status="running",
+                    current_step_id="publish",
+                    active_task_id="task-1",
+                    state_revision=7,
+                    step_states=[
+                        {"step_id": "build", "status": "completed"},
+                        {"step_id": "publish", "status": "in_progress"},
+                    ],
+                )
+            return SimpleNamespace(
+                status="running",
+                current_step_id=None,
+                active_task_id="task-1",
+                state_revision=8,
+                step_states=[
+                    {"step_id": "build", "status": "completed"},
+                    {"step_id": "publish", "status": "completed"},
+                ],
+            )
+
+        async def checkpoint_plan_run(self, run_id: str, **kwargs: object) -> None:
+            assert run_id == "run-1"
+            self.refreshed = True
+            raise PlanRunConflictError("plan run changed")
+
+    ctx = ToolContext(
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+        task_id="task-1",
+        plan_run_id="run-1",
+        plan_storage=PlanStorage(),
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        payload = json.loads(await publish_artifact(path="report.txt"))
+    finally:
+        current_tool_context.reset(token)
+
+    assert payload["status"] == "published"
     assert len(ctx.published_artifacts) == 1
 
 


### PR DESCRIPTION
## Scope

Scope boundary: Fix only Issue #1112's final-step publish/checkpoint ordering coupling. When the current owned PlanRun step is the sole unfinished final step, validate the artifact, atomically checkpoint that step, then continue the same publication attempt.

Non-goals: No cancelled-run recovery or finalization path; no change to `plans.cancelRun`; no new public RPC; do not close Issue #1112.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Refs #1112

If None, reason: N/A

## Release Note

Release note: Fix Plan final-step artifact publication ordering.

## Tests

Ruff: `uv run --extra dev ruff check src/opensquilla/tools/builtin/artifacts.py tests/test_artifacts.py` — passed

Pytest: `uv run --extra dev pytest tests/test_artifacts.py tests/test_engine/test_plan_run_reconciliation.py tests/test_session/test_plan_storage.py tests/test_tools/test_plan_access.py tests/test_gateway/test_task_runtime_terminal_cleanup.py tests/test_engine/test_runtime_artifacts.py -q` — 223 passed

Build: Not run; no build-affecting files changed.

Regression tests: added

Notes: Added coverage for successful final-step publication, rejection before the final step, invalid-artifact behavior before checkpoint, and CAS conflicts that refresh to cancelled, changed-owner, or valid owned delivery-ready states. Mypy and `git diff --check` also pass. The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: The pre-fix failure was reproduced in the local OpenSquilla Web UI; this PR's automated tests exercise the corrected state transition without external credentials.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents are not committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No documentation changes.
