### PR TITLE
Hide flattened tool-call markers from compacted chat history

### DIFF
--- a/src/opensquilla/chat/flattened_tool_markers.py
+++ b/src/opensquilla/chat/flattened_tool_markers.py
@@ -1,0 +1,55 @@
+"""Recognition helpers for legacy flattened tool transcript projections."""
+
+from __future__ import annotations
+
+import re
+
+_USED_TOOL_LINE = re.compile(r"^\[Used tool: [^\]\r\n]*\]$")
+_TOOL_RESULT_PREFIX = re.compile(r"^\[Tool result \([^\)\r\n]+\): ")
+_SINGLE_LINE_TOOL_RESULT = re.compile(
+    r"^\[Tool result \([^\)\r\n]+\): [^\r\n]*\](?:\r?\n|$)"
+)
+
+
+def has_flattened_used_tool_line(content: str) -> bool:
+    """Return whether content carries an exact flattened tool-use line."""
+
+    return any(_USED_TOOL_LINE.fullmatch(line.strip()) for line in content.splitlines())
+
+
+def strip_flattened_used_tool_lines(content: str) -> str:
+    """Remove exact tool-use marker lines while preserving surrounding prose."""
+
+    kept = [
+        line
+        for line in content.split("\n")
+        if _USED_TOOL_LINE.fullmatch(line.strip()) is None
+    ]
+    return "\n".join(kept).strip()
+
+
+def is_flattened_tool_result_dump(content: str) -> bool:
+    """Recognize a complete legacy ``[Tool result (...): ...]`` projection."""
+
+    visible = content.lstrip()
+    return bool(_TOOL_RESULT_PREFIX.match(visible)) and visible.rstrip().endswith("]")
+
+
+def strip_confirmed_flattened_tool_result(content: str) -> str:
+    """Hide a confirmed result projection without discarding visible suffix text.
+
+    The historical serializer did not escape newlines or brackets inside result
+    snippets, so a multiline projection cannot be split safely from arbitrary
+    suffix prose. Pure result dumps are removable as a whole; the unambiguous
+    single-line form may also be removed while retaining the following text.
+    """
+
+    leading = len(content) - len(content.lstrip())
+    visible = content[leading:]
+    single_line = _SINGLE_LINE_TOOL_RESULT.match(visible)
+    if single_line is not None:
+        suffix = visible[single_line.end() :]
+        return suffix.strip()
+    if is_flattened_tool_result_dump(visible):
+        return ""
+    return content

--- a/src/opensquilla/chat/history.py
+++ b/src/opensquilla/chat/history.py
@@ -55,6 +55,38 @@ def _is_legacy_generated_plan_implementation(
     return _LEGACY_PLAN_IMPLEMENTATION_PROMPT.fullmatch(visible) is not None
 
 
+# Compaction collapses structured tool_use/tool_result content blocks into
+# plain-text markers so a summarized turn still names what ran; see
+# engine.agent._flatten_content_blocks ("[Used tool: <name>]" and
+# "[Tool result (<id>): <snippet>]"). Those markers are an internal transcript
+# representation, not conversation, so a compacted turn that is later loaded for
+# display must not render them as raw chat text.
+_FLATTENED_USED_TOOL_LINE = re.compile(r"^\[Used tool: [^\]]*\]$")
+
+
+def _strip_flattened_tool_markers(content: str) -> str:
+    """Drop flattened tool-call markers from a compacted turn's display text.
+
+    Returns the human-readable remainder. A turn whose content is a
+    ``[Tool result (...)]`` dump collapses to an empty string (the caller then
+    drops the entry, mirroring the ``[ContentBlock ...]`` handling); an
+    assistant turn keeps its narration with any ``[Used tool: ...]`` lines
+    removed. Content without these markers is returned unchanged.
+    """
+
+    text = content or ""
+    if text.lstrip().startswith("[Tool result ("):
+        return ""
+    if "[Used tool: " not in text:
+        return text
+    kept = [
+        line
+        for line in text.split("\n")
+        if not _FLATTENED_USED_TOOL_LINE.match(line.strip())
+    ]
+    return "\n".join(kept).strip()
+
+
 def transcript_entries_to_chat_messages(
     entries: list[object],
     *,
@@ -100,6 +132,16 @@ def transcript_entries_to_chat_messages(
             content = "\n".join(t.replace("\\n", "\n") for t in texts) if texts else ""
             if not content.strip():
                 continue
+        if content:
+            cleaned = _strip_flattened_tool_markers(content)
+            if cleaned != content:
+                # The entry carried OpenSquilla's flattened tool serialization.
+                # Drop it when nothing but internal tool transcript remains and
+                # there is no structured tool timeline to render instead;
+                # otherwise keep the narration that surrounded the markers.
+                if not cleaned.strip() and not silent_reply.segments:
+                    continue
+                content = cleaned
         if role == "user":
             display_text = display_text_from_preflight_confirmation(content)
             if display_text is not None:

--- a/src/opensquilla/chat/history.py
+++ b/src/opensquilla/chat/history.py
@@ -7,6 +7,12 @@ import re
 from typing import Any
 
 from opensquilla.artifacts import artifact_payload, strip_artifact_markers_from_text
+from opensquilla.chat.flattened_tool_markers import (
+    has_flattened_used_tool_line,
+    is_flattened_tool_result_dump,
+    strip_confirmed_flattened_tool_result,
+    strip_flattened_used_tool_lines,
+)
 from opensquilla.meta_preflight_protocol import (
     display_text_from_preflight_confirmation,
     strip_preflight_confirmation_protocol_text,
@@ -55,36 +61,31 @@ def _is_legacy_generated_plan_implementation(
     return _LEGACY_PLAN_IMPLEMENTATION_PROMPT.fullmatch(visible) is not None
 
 
-# Compaction collapses structured tool_use/tool_result content blocks into
-# plain-text markers so a summarized turn still names what ran; see
-# engine.agent._flatten_content_blocks ("[Used tool: <name>]" and
-# "[Tool result (<id>): <snippet>]"). Those markers are an internal transcript
-# representation, not conversation, so a compacted turn that is later loaded for
-# display must not render them as raw chat text.
-_FLATTENED_USED_TOOL_LINE = re.compile(r"^\[Used tool: [^\]]*\]$")
+def _legacy_flattened_tool_result_indexes(entries: list[object]) -> set[int]:
+    """Identify metadata-poor result rows from an adjacent flattened tool call.
 
-
-def _strip_flattened_tool_markers(content: str) -> str:
-    """Drop flattened tool-call markers from a compacted turn's display text.
-
-    Returns the human-readable remainder. A turn whose content is a
-    ``[Tool result (...)]`` dump collapses to an empty string (the caller then
-    drops the entry, mirroring the ``[ContentBlock ...]`` handling); an
-    assistant turn keeps its narration with any ``[Used tool: ...]`` lines
-    removed. Content without these markers is returned unchanged.
+    Modern rows carry ``tool_call_id`` or role ``tool``. Older compaction
+    projections sometimes persisted Anthropic-style tool results as role
+    ``user`` with no structured identity, so recognize only the adjacent
+    assistant-marker/result pair. An isolated user message that merely quotes
+    the legacy syntax must remain ordinary conversation text.
     """
 
-    text = content or ""
-    if text.lstrip().startswith("[Tool result ("):
-        return ""
-    if "[Used tool: " not in text:
-        return text
-    kept = [
-        line
-        for line in text.split("\n")
-        if not _FLATTENED_USED_TOOL_LINE.match(line.strip())
-    ]
-    return "\n".join(kept).strip()
+    indexes: set[int] = set()
+    previous_was_flattened_call = False
+    for index, entry in enumerate(entries):
+        role = str(getattr(entry, "role", "unknown") or "unknown").lower()
+        content = str(getattr(entry, "content", "") or "")
+        if (
+            previous_was_flattened_call
+            and role in {"tool", "user"}
+            and is_flattened_tool_result_dump(content)
+        ):
+            indexes.add(index)
+        previous_was_flattened_call = (
+            role == "assistant" and has_flattened_used_tool_line(content)
+        )
+    return indexes
 
 
 def transcript_entries_to_chat_messages(
@@ -93,8 +94,9 @@ def transcript_entries_to_chat_messages(
     limit: int | None = None,
 ) -> list[dict[str, Any]]:
     selected = entries[-limit:] if limit is not None else entries
+    legacy_tool_result_indexes = _legacy_flattened_tool_result_indexes(selected)
     messages: list[dict[str, Any]] = []
-    for entry in selected:
+    for entry_index, entry in enumerate(selected):
         role = getattr(entry, "role", "unknown")
         turn_context = getattr(entry, "turn_context", None)
         silent_reply = sanitize_historical_silent_reply(
@@ -133,7 +135,16 @@ def transcript_entries_to_chat_messages(
             if not content.strip():
                 continue
         if content:
-            cleaned = _strip_flattened_tool_markers(content)
+            cleaned = content
+            if role == "assistant" and has_flattened_used_tool_line(cleaned):
+                cleaned = strip_flattened_used_tool_lines(cleaned)
+            confirmed_tool_result = (
+                role == "tool"
+                or bool(getattr(entry, "tool_call_id", None))
+                or entry_index in legacy_tool_result_indexes
+            )
+            if confirmed_tool_result:
+                cleaned = strip_confirmed_flattened_tool_result(cleaned)
             if cleaned != content:
                 # The entry carried OpenSquilla's flattened tool serialization.
                 # Drop it when nothing but internal tool transcript remains and

--- a/src/opensquilla/gateway/session_view.py
+++ b/src/opensquilla/gateway/session_view.py
@@ -6,6 +6,7 @@ import json
 import re
 from typing import Any
 
+from opensquilla.chat.flattened_tool_markers import is_flattened_tool_result_dump
 from opensquilla.session.keys import derive_chat_type, parse_agent_id
 
 _CHANNEL_SURFACES = frozenset(
@@ -438,6 +439,8 @@ def derive_transcript_title(content: Any, *, max_chars: int = 34) -> str:
     if not text:
         return ""
     text = _TIME_PREFIX_RE.sub("", text, count=1)
+    if is_flattened_tool_result_dump(text):
+        return ""
     cleaned = re.sub(r"\s+", " ", text).strip()
     cleaned = cleaned.strip("\"'` ")
     if not cleaned:

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -1391,6 +1391,27 @@ class TestSessionsList:
         assert res.payload["sessions"][0]["title"] == "Agent PM面试清单"
 
     @pytest.mark.asyncio
+    async def test_list_webchat_title_skips_flattened_tool_result(self, dispatcher):
+        session = FakeSession(
+            session_key="agent:main:webchat:tool-result-title",
+            display_name="WebChat",
+        )
+        manager = FakeSessionManager([session])
+        manager._storage._transcripts[session.session_id] = [
+            SimpleNamespace(
+                role="user",
+                content="[Tool result (call-1): internal result projection]",
+            ),
+            SimpleNamespace(role="user", content="Keep the visible request as the title"),
+        ]
+        ctx = make_ctx(session_manager=manager)
+
+        res = await dispatcher.dispatch("r1", "sessions.list", None, ctx)
+
+        assert res.ok is True
+        assert res.payload["sessions"][0]["title"] == "Keep the visible request as the..."
+
+    @pytest.mark.asyncio
     async def test_list_contract_cli_current_tui_compatible_row(self, dispatcher):
         session = FakeSession(session_key="agent:main:cli:a1b2c3d4")
         ctx = make_ctx(session_manager=FakeSessionManager([session]))

--- a/tests/unit/chat/test_history.py
+++ b/tests/unit/chat/test_history.py
@@ -356,16 +356,47 @@ def test_transcript_entries_to_chat_messages_strips_flattened_used_tool_markers(
 def test_transcript_entries_to_chat_messages_drops_flattened_tool_result_dump() -> None:
     # A "[Tool result (...)]" dump is pure internal transcript; with no
     # structured segments to render it is dropped rather than shown as a bubble.
-    entry = _assistant_entry(
-        message_id="m-flat-toolresult",
-        role="user",
-        content=(
-            '[Tool result (call_00_TUIq7hPsIGaww7lcUiuc8669): 1  """Proposal '
-            'generation and management API routes."""\n2  \n3  import json]'
+    entries = [
+        _assistant_entry(
+            message_id="m-flat-tooluse",
+            content="[Used tool: read_file]",
         ),
+        _assistant_entry(
+            message_id="m-flat-toolresult",
+            role="user",
+            content=(
+                '[Tool result (call_00_TUIq7hPsIGaww7lcUiuc8669): 1  """Proposal '
+                'generation and management API routes."""\n2  \n3  import json]'
+            ),
+        ),
+    ]
+
+    assert transcript_entries_to_chat_messages(entries) == []
+
+
+def test_transcript_entries_to_chat_messages_keeps_unattributed_tool_result_text() -> None:
+    entry = _assistant_entry(
+        message_id="m-user-toolresult-doc",
+        role="user",
+        content="[Tool result (example): this is documentation, not a tool event]",
     )
 
-    assert transcript_entries_to_chat_messages([entry]) == []
+    messages = transcript_entries_to_chat_messages([entry])
+
+    assert messages[0]["text"] == entry.content
+
+
+def test_transcript_entries_to_chat_messages_keeps_text_after_confirmed_tool_result() -> None:
+    entry = _assistant_entry(
+        message_id="m-toolresult-with-request",
+        role="user",
+        tool_call_id="call-1",
+        content="[Tool result (call-1): ok]\nPlease also update README.md",
+    )
+
+    messages = transcript_entries_to_chat_messages([entry])
+
+    assert messages[0]["text"] == "Please also update README.md"
 
 
 def test_transcript_entries_to_chat_messages_drops_tool_only_flattened_turn() -> None:

--- a/tests/unit/chat/test_history.py
+++ b/tests/unit/chat/test_history.py
@@ -330,3 +330,94 @@ def test_transcript_entries_to_chat_messages_hides_exact_assistant_sentinel() ->
     entry = _assistant_entry(content="  NO_REPLY\n", tool_calls=None)
 
     assert transcript_entries_to_chat_messages([entry]) == []
+
+
+def test_transcript_entries_to_chat_messages_strips_flattened_used_tool_markers() -> None:
+    # A compacted assistant turn keeps its narration but drops the flattened
+    # "[Used tool: ...]" markers that engine.agent._flatten_content_blocks emits.
+    entry = _assistant_entry(
+        message_id="m-flat-narration",
+        content=(
+            "继续补齐上下文: 章节重新生成接口、前端 API client 与测试结构。\n"
+            "[Used tool: read_file]\n"
+            "[Used tool: read_file]\n"
+            "[Used tool: list_dir]"
+        ),
+    )
+
+    messages = transcript_entries_to_chat_messages([entry])
+
+    assert messages[0]["text"] == (
+        "继续补齐上下文: 章节重新生成接口、前端 API client 与测试结构。"
+    )
+    assert "[Used tool:" not in messages[0]["text"]
+
+
+def test_transcript_entries_to_chat_messages_drops_flattened_tool_result_dump() -> None:
+    # A "[Tool result (...)]" dump is pure internal transcript; with no
+    # structured segments to render it is dropped rather than shown as a bubble.
+    entry = _assistant_entry(
+        message_id="m-flat-toolresult",
+        role="user",
+        content=(
+            '[Tool result (call_00_TUIq7hPsIGaww7lcUiuc8669): 1  """Proposal '
+            'generation and management API routes."""\n2  \n3  import json]'
+        ),
+    )
+
+    assert transcript_entries_to_chat_messages([entry]) == []
+
+
+def test_transcript_entries_to_chat_messages_drops_tool_only_flattened_turn() -> None:
+    # An assistant turn whose entire content is "[Used tool: ...]" markers (no
+    # narration) collapses to nothing, matching a fully collapsed activity fold.
+    entry = _assistant_entry(
+        message_id="m-flat-toolonly",
+        content="[Used tool: read_file]\n[Used tool: list_dir]",
+    )
+
+    assert transcript_entries_to_chat_messages([entry]) == []
+
+
+def test_transcript_entries_to_chat_messages_keeps_ordinary_bracketed_text() -> None:
+    # Regression guard: bracketed prose that is not a tool marker is untouched.
+    entry = _assistant_entry(
+        message_id="m-brackets",
+        content="Here is the plan.\n[step 1] read the config\n[step 2] apply it",
+    )
+
+    messages = transcript_entries_to_chat_messages([entry])
+
+    assert messages[0]["text"] == (
+        "Here is the plan.\n[step 1] read the config\n[step 2] apply it"
+    )
+
+
+def test_transcript_entries_to_chat_messages_keeps_narration_when_segments_present() -> None:
+    # When structured tool segments exist, the folded timeline renders them, so
+    # the turn is kept even after its "[Used tool: ...]" narration marker is
+    # stripped from the display text.
+    entry = _assistant_entry(
+        message_id="m-flat-with-segments",
+        content="Reading the files now.\n[Used tool: read_file]",
+        tool_calls=[
+            {
+                "type": "tool_use",
+                "tool_use_id": "call-1",
+                "name": "read_file",
+                "input": {},
+            }
+        ],
+    )
+
+    messages = transcript_entries_to_chat_messages([entry])
+
+    assert messages[0]["text"] == "Reading the files now."
+    assert messages[0]["tool_calls"] == [
+        {
+            "type": "tool_use",
+            "tool_use_id": "call-1",
+            "name": "read_file",
+            "input": {},
+        }
+    ]


### PR DESCRIPTION
Refs #1151.

The structured "Used tools" activity fold in the chat view already does the right thing for live turns: it collapses each tool call into an expandable disclosure instead of dumping raw tool traffic into the conversation. This PR extends that intent to compacted history.

## Root cause

When a long turn is compacted, `engine.agent._flatten_content_blocks` can collapse `tool_use` and `tool_result` blocks into plain-text markers such as `[Used tool: <name>]` and `[Tool result (<id>): <snippet>]`. The history-to-chat conversion did not recognize those legacy projections, so they could render as ordinary chat text and seed the fallback session title.

## Resolution

- Remove exact flattened `[Used tool: ...]` lines from assistant display text while retaining surrounding narration.
- Hide tool-result projections only when the row has structured identity (`role == "tool"` or `tool_call_id`) or when a metadata-poor legacy row forms an adjacent assistant-marker/result pair.
- Preserve ordinary user text that merely resembles the legacy syntax.
- Preserve visible suffix text after an unambiguous single-line result projection.
- Skip complete flattened tool-result projections when deriving fallback session titles.
- Keep provider/model context unchanged; this is a display-path compatibility fix.

## Scope

This addresses the raw-tool-transcript and malformed-title parts of #1151. The separate "earlier messages were summarized" affordance remains out of scope, so this PR intentionally uses `Refs #1151` rather than closing the issue.

## Verification

- 307 related and adjacent tests pass, including the complete `tests/test_gateway/test_rpc_sessions.py` suite.
- Regression coverage includes narration-plus-markers, pure result dumps, isolated user-authored marker-shaped text, marker-plus-visible-suffix text, tool-only turns, ordinary bracketed prose, structured segments, and fallback-title selection.
- `ruff`, `mypy`, and `git diff --check` pass on the changed surface.

## Commit lineage

- Original contributor implementation: `a8e7ff679da4593db92b03da737c8d005a39df62` by `freeaccount-create`.
- Maintainer safety/title follow-up: `4d9d77465f203a2c822b86606150c3118883f5c9`.
