### PR TITLE
fix(webui): render created chat cards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,7 @@ jobs:
           npm run test:e2e --
           assistant-activity.spec.ts
           history-hydration.spec.ts
+          session-created-card.spec.ts
           goal-mode.spec.ts
           queue-steer.spec.ts
           share.spec.ts

--- a/opensquilla-webui/e2e/session-created-card.spec.ts
+++ b/opensquilla-webui/e2e/session-created-card.spec.ts
@@ -1,0 +1,275 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const CONTROL_URL = '/control/'
+const PARENT_KEY = 'agent:main:webchat:e2e-session-created-parent'
+const FIRST_CHILD_KEY = 'agent:main:subagent:first123'
+const SECOND_CHILD_KEY = 'agent:main:subagent:second45'
+
+function response(id: string | number | undefined, payload: unknown) {
+  return JSON.stringify({ type: 'res', id, ok: true, payload })
+}
+
+async function mockSessionCreatedHistory(
+  page: Page,
+  options: { liveHandoff?: boolean } = {},
+) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('opensquilla-locale', 'en')
+    window.localStorage.setItem('opensquilla.routerVisualEffects', '1')
+  })
+  await page.route('**/api/approvals', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ pending: [] }),
+  }))
+  await page.routeWebSocket(/\/ws$/, ws => {
+    ws.send(JSON.stringify({ type: 'event', event: 'connect.challenge', payload: {} }))
+    ws.onMessage(message => {
+      let frame: Record<string, unknown>
+      try {
+        frame = JSON.parse(String(message)) as Record<string, unknown>
+      } catch {
+        return
+      }
+      if (frame.type !== 'req') return
+      const method = String(frame.method || '')
+      const params = frame.params && typeof frame.params === 'object'
+        ? frame.params as Record<string, unknown>
+        : {}
+      if (method === 'connect') {
+        ws.send(JSON.stringify({ protocol: 3, policy: { tick_interval_ms: 30_000 } }))
+        return
+      }
+      if (method === 'chat.history') {
+        const sessionKey = String(params.sessionKey || '')
+        if (sessionKey === PARENT_KEY) {
+          if (options.liveHandoff) {
+            ws.send(response(frame.id as string | number | undefined, {
+              messages: [{
+                role: 'user',
+                text: 'Create a child chat',
+                id: 'live-session-created-user',
+                timestamp: Math.floor(Date.now() / 1000) - 3,
+                turn_context: { turn_id: 'creation-turn' },
+              }, {
+                role: 'router',
+                text: '',
+                id: 'live-resume-router',
+                timestamp: Math.floor(Date.now() / 1000) - 2,
+                turn_context: { turn_id: 'resume-turn' },
+                provenance_kind: 'router_decision',
+                router_decision: {
+                  tier: 'c1',
+                  model: 'deepseek-v4-pro',
+                  source: 'heuristic',
+                },
+              }, {
+                role: 'assistant',
+                text: '',
+                id: 'live-session-created-assistant',
+                timestamp: Math.floor(Date.now() / 1000) - 1,
+                turn_context: { turn_id: 'creation-turn' },
+                tool_calls: [{
+                  tool_use_id: 'spawn-first',
+                  name: 'sessions_spawn',
+                  result: JSON.stringify({ session_key: FIRST_CHILD_KEY, status: 'queued' }),
+                  execution_status: { status: 'success' },
+                }],
+              }],
+              has_more: false,
+              canonical_available: true,
+              canonical_complete: true,
+            }))
+            return
+          }
+          ws.send(response(frame.id as string | number | undefined, {
+            messages: [{
+              role: 'user',
+              text: 'Create two child chats',
+              id: 'session-created-user',
+              timestamp: Math.floor(Date.now() / 1000) - 2,
+              turn_context: { turn_id: 'creation-turn' },
+            }, {
+              role: 'assistant',
+              text: 'Child chats created; waiting for completion.',
+              id: 'session-created-assistant',
+              timestamp: Math.floor(Date.now() / 1000) - 1,
+              turn_context: { turn_id: 'creation-turn' },
+              usage: {
+                routed_tier: 'c0',
+                routed_model: 'deepseek-v4-flash',
+                routing_source: 'heuristic',
+                routing_applied: true,
+              },
+              tool_calls: [{
+                tool_use_id: 'spawn-first',
+                name: 'sessions_spawn',
+                result: JSON.stringify({ session_key: FIRST_CHILD_KEY, status: 'queued' }),
+                execution_status: { status: 'success' },
+              }, {
+                tool_use_id: 'spawn-second',
+                name: 'sessions_spawn',
+                result: JSON.stringify({ session_key: SECOND_CHILD_KEY, status: 'queued' }),
+                execution_status: { status: 'success' },
+              }],
+            }, {
+              role: 'system',
+              text: JSON.stringify({
+                type: 'subagent_completion',
+                child_session_key: FIRST_CHILD_KEY,
+                result: 'first child done',
+              }),
+              id: 'subagent-completion-first',
+              timestamp: Math.floor(Date.now() / 1000),
+              turn_context: { turn_id: 'creation-turn' },
+              provenance_kind: 'internal_system',
+              provenance_source_tool: 'subagent_completion',
+              provenance_source_session_key: FIRST_CHILD_KEY,
+            }, {
+              role: 'system',
+              text: JSON.stringify({
+                type: 'subagent_completion',
+                child_session_key: SECOND_CHILD_KEY,
+                result: 'second child done',
+              }),
+              id: 'subagent-completion-second',
+              timestamp: Math.floor(Date.now() / 1000),
+              turn_context: { turn_id: 'creation-turn' },
+              provenance_kind: 'internal_system',
+              provenance_source_tool: 'subagent_completion',
+              provenance_source_session_key: SECOND_CHILD_KEY,
+            }, {
+              role: 'assistant',
+              text: 'Parent final reply',
+              id: 'parent-final-assistant',
+              timestamp: Math.floor(Date.now() / 1000) + 1,
+              turn_context: { turn_id: 'resume-turn' },
+              usage: {
+                routed_tier: 'c1',
+                routed_model: 'deepseek-v4-pro',
+                routing_source: 'heuristic',
+                routing_applied: true,
+              },
+            }],
+            has_more: false,
+            canonical_available: true,
+            canonical_complete: true,
+          }))
+          return
+        }
+        ws.send(response(frame.id as string | number | undefined, {
+          messages: [{
+            role: 'assistant',
+            text: `Opened child session ${sessionKey}`,
+            id: 'child-session-assistant',
+            timestamp: Math.floor(Date.now() / 1000),
+            usage: {
+              model: 'deepseek-v4-pro',
+              routed_model: 'deepseek-v4-pro',
+              routing_source: 'none',
+              routing_applied: true,
+            },
+          }],
+          has_more: false,
+          canonical_available: true,
+          canonical_complete: true,
+        }))
+        return
+      }
+      if (method === 'sessions.messages.snapshot') {
+        ws.send(response(frame.id as string | number | undefined, {
+          key: String(params.key || ''),
+          events: [],
+          current_stream_seq: 0,
+        }))
+        return
+      }
+      const payloads: Record<string, unknown> = {
+        'agents.list': { agents: [] },
+        'commands.list_for_surface': { commands: [] },
+        'config.get': {
+          squilla_router: {
+            enabled: true,
+            rollout_phase: 'full',
+            tiers: {
+              c0: { model: 'deepseek-v4-flash' },
+              c1: { model: 'deepseek-v4-pro' },
+            },
+          },
+          permissions: {},
+          skills: {},
+        },
+        'models.routing.get': { mode: 'router' },
+        'onboarding.status': { audioConfigured: false },
+        'sessions.list': { sessions: [], has_more: false },
+        'sessions.messages.subscribe': {
+          subscribed: true,
+          replay_complete: true,
+          current_stream_seq: 0,
+          run_status: options.liveHandoff ? 'running' : 'idle',
+          active_task: options.liveHandoff
+            ? { task_id: 'resume-turn', status: 'running' }
+            : null,
+        },
+        'sessions.messages.hydrate': {
+          subscribed: true,
+          replay_complete: true,
+          current_stream_seq: 0,
+          run_status: options.liveHandoff ? 'running' : 'idle',
+          active_task: options.liveHandoff
+            ? { task_id: 'resume-turn', status: 'running' }
+            : null,
+        },
+        'usage.status': { sessions: [] },
+      }
+      ws.send(response(frame.id as string | number | undefined, payloads[method] ?? {}))
+    })
+  })
+}
+
+test('restores ordered created-chat cards and opens the selected child session', async ({ page }) => {
+  await mockSessionCreatedHistory(page)
+  await page.goto(CONTROL_URL + 'chat?session=' + encodeURIComponent(PARENT_KEY))
+
+  const cards = page.getByTestId('session-created-card')
+  await expect(cards).toHaveCount(2)
+  await expect(cards.nth(0)).toHaveAttribute('data-session-key', FIRST_CHILD_KEY)
+  await expect(cards.nth(1)).toHaveAttribute('data-session-key', SECOND_CHILD_KEY)
+  await expect(cards.nth(0)).toContainText('Chat created')
+  await expect(page.getByText('session_key')).toHaveCount(0)
+  await expect(page.getByText('Sub-agent', { exact: true })).toHaveCount(0)
+  await expect(page.getByText('subagent_completion')).toHaveCount(0)
+  await expect(page.getByRole('group', { name: 'Router selected deepseek-v4-flash' })).toHaveCount(1)
+  const finalReply = page.locator('.msg-ai').filter({ hasText: 'Parent final reply' })
+  await expect(finalReply.getByTestId('session-created-card')).toHaveCount(2)
+  await expect.poll(async () => {
+    const text = await finalReply.innerText()
+    return text.indexOf('Parent final reply') < text.indexOf('Chat created')
+  }).toBe(true)
+
+  await page.reload()
+  await expect(page.locator('.msg-ai').filter({ hasText: 'Parent final reply' })
+    .getByTestId('session-created-card')).toHaveCount(2)
+
+  await page.getByTestId('session-created-card').nth(1).getByRole('button', {
+    name: 'Open chat',
+  }).click()
+  await expect.poll(() => new URL(page.url()).searchParams.get('session')).toBe(SECOND_CHILD_KEY)
+  await expect(page.getByText(`Opened child session ${SECOND_CHILD_KEY}`)).toBeVisible()
+  await expect(page.getByRole('group', { name: 'Router selected deepseek-v4-pro' })).toBeVisible()
+})
+
+test('keeps only the router above a created-chat card during the parent handoff', async ({ page }) => {
+  await mockSessionCreatedHistory(page, { liveHandoff: true })
+  await page.goto(CONTROL_URL + 'chat?session=' + encodeURIComponent(PARENT_KEY))
+
+  await expect(page.getByTestId('session-created-card')).toHaveCount(1)
+  await expect(page.locator('.router-fx')).toHaveCount(1)
+  await expect(page.locator('.router-fx-reserve')).toHaveCount(0)
+  await expect(page.locator('.chat-message-surface .router-fx')).toHaveCount(1)
+  await expect.poll(async () => page.evaluate(() => {
+    const router = document.querySelector('.chat-message-surface .router-fx')
+    const card = document.querySelector('[data-testid="session-created-card"]')
+    return Boolean(router && card && router.getBoundingClientRect().top < card.getBoundingClientRect().top)
+  })).toBe(true)
+})

--- a/opensquilla-webui/e2e/session-created-card.spec.ts
+++ b/opensquilla-webui/e2e/session-created-card.spec.ts
@@ -150,6 +150,18 @@ async function mockSessionCreatedHistory(
                 routing_source: 'heuristic',
                 routing_applied: true,
               },
+            }, {
+              role: 'user',
+              text: 'A later separate question',
+              id: 'later-user',
+              timestamp: Math.floor(Date.now() / 1000) + 2,
+              turn_context: { turn_id: 'later-turn' },
+            }, {
+              role: 'assistant',
+              text: 'A later separate answer',
+              id: 'later-assistant',
+              timestamp: Math.floor(Date.now() / 1000) + 3,
+              turn_context: { turn_id: 'later-turn' },
             }],
             has_more: false,
             canonical_available: true,
@@ -240,6 +252,7 @@ test('restores ordered created-chat cards and opens the selected child session',
   await expect(page.getByText('Sub-agent', { exact: true })).toHaveCount(0)
   await expect(page.getByText('subagent_completion')).toHaveCount(0)
   await expect(page.getByRole('group', { name: 'Router selected deepseek-v4-flash' })).toHaveCount(1)
+  await expect(page.locator('.chat-message-surface .router-fx')).toHaveCount(1)
   const finalReply = page.locator('.msg-ai').filter({ hasText: 'Parent final reply' })
   await expect(finalReply.getByTestId('session-created-card')).toHaveCount(2)
   await expect.poll(async () => {

--- a/opensquilla-webui/src/components/chat/AssistantMessage.session-created.test.ts
+++ b/opensquilla-webui/src/components/chat/AssistantMessage.session-created.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import i18n from '@/i18n'
+import type {
+  ChatRenderedMessage,
+  ChatStreamTimelineItem,
+  ChatToolCall,
+  ChatToolCallRenderItem,
+} from '@/types/chat'
+import AssistantMessage from './AssistantMessage.vue'
+
+const apps: App[] = []
+
+function spawnCall(overrides: Partial<ChatToolCall> = {}): ChatToolCall {
+  return {
+    toolId: 'spawn-1',
+    name: 'sessions_spawn',
+    displayName: 'sessions_spawn',
+    inputPreview: '',
+    isRunning: false,
+    status: 'success',
+    isError: false,
+    result: JSON.stringify({ session_key: 'agent:main:subagent:abc12345' }),
+    resultPreview: '',
+    isOpen: false,
+    ...overrides,
+  }
+}
+
+function timeline(call: ChatToolCall): ChatStreamTimelineItem[] {
+  return [{
+    type: 'tool-group',
+    key: 'spawn-group',
+    group: {
+      groupId: 'spawn-group',
+      operationKey: 'tool.sessions.spawn',
+      label: 'sessions_spawn',
+      iconName: 'chat',
+      calls: [{ ...call, renderKey: 'spawn-render' } as ChatToolCallRenderItem],
+      secondary: '',
+      isRunning: false,
+      isError: false,
+      status: 'success',
+    },
+  }]
+}
+
+async function mount(message: ChatRenderedMessage, onOpenSession = vi.fn()) {
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  const app = createApp(AssistantMessage, {
+    message,
+    index: 0,
+    shareMode: false,
+    shareSelected: false,
+    shareMessageId: 'assistant-0',
+    renderMarkdown: (text: string) => text,
+    fmtTok: (value: number) => String(value),
+    toolCallGroups: (calls: ChatToolCall[]) => timeline(calls[0]!).map(item => (
+      item.type === 'tool-group' ? item.group : null
+    )).filter(Boolean),
+    isToolGroupOpen: () => true,
+    isToolItemOpen: () => true,
+    toolGroupStatusText: () => '',
+    toolStatusText: () => '',
+    toolSecondaryText: () => '',
+    copyMessage: async () => true,
+    onOpenSession,
+  })
+  apps.push(app)
+  app.use(i18n)
+  app.mount(el)
+  await nextTick()
+  return { el, onOpenSession }
+}
+
+function message(overrides: Partial<ChatRenderedMessage> = {}): ChatRenderedMessage {
+  return {
+    role: 'assistant',
+    displayRole: 'assistant',
+    roleLabel: 'Assistant',
+    text: '',
+    timeStr: '',
+    showHeader: false,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  i18n.global.locale.value = 'en'
+})
+
+afterEach(() => {
+  apps.splice(0).forEach(app => app.unmount())
+  document.body.innerHTML = ''
+})
+
+describe('AssistantMessage created session cards', () => {
+  it('replaces a successful live spawn tool result with an openable card', async () => {
+    const call = spawnCall()
+    const { el, onOpenSession } = await mount(message({
+      toolCalls: [call],
+      timelineItems: timeline(call),
+    }))
+
+    expect(el.querySelectorAll('[data-testid="session-created-card"]')).toHaveLength(1)
+    expect(el.textContent).toContain('Chat created')
+    expect(el.textContent).not.toContain('session_key')
+    expect(el.querySelector('.tool-row')).toBeNull()
+
+    el.querySelector<HTMLButtonElement>('.session-created-card__open')?.click()
+    await nextTick()
+    expect(onOpenSession).toHaveBeenCalledWith('agent:main:subagent:abc12345')
+  })
+
+  it('renders ordered cards from restored tool calls without a timeline', async () => {
+    const first = spawnCall()
+    const second = spawnCall({
+      toolId: 'spawn-2',
+      result: JSON.stringify({ session_key: 'agent:main:subagent:def67890' }),
+    })
+    const { el } = await mount(message({ toolCalls: [first, second] }))
+
+    expect(Array.from(el.querySelectorAll('[data-session-key]')).map(node => (
+      node.getAttribute('data-session-key')
+    ))).toEqual([
+      'agent:main:subagent:abc12345',
+      'agent:main:subagent:def67890',
+    ])
+  })
+
+  it('keeps malformed and failed results out of the semantic card surface', async () => {
+    const { el } = await mount(message({
+      toolCalls: [
+        spawnCall({ result: '{}' }),
+        spawnCall({ toolId: 'spawn-2', status: 'error', isError: true }),
+      ],
+    }))
+    expect(el.querySelector('[data-testid="session-created-card"]')).toBeNull()
+  })
+
+  it('rehomes the card below the parent final reply without restoring raw tool output', async () => {
+    const call = spawnCall()
+    const source = await mount(message({
+      toolCalls: [call],
+      timelineItems: timeline(call),
+      createdSessionLinks: [],
+    }))
+    expect(source.el.querySelector('[data-testid="session-created-card"]')).toBeNull()
+    expect(source.el.querySelector('.tool-row')).toBeNull()
+
+    const target = await mount(message({
+      text: 'Parent final reply',
+      createdSessionLinks: [{
+        callId: 'spawn-1',
+        sessionKey: 'agent:main:subagent:abc12345',
+      }],
+    }))
+    const replyText = target.el.textContent || ''
+    expect(replyText.indexOf('Parent final reply')).toBeLessThan(replyText.indexOf('Chat created'))
+  })
+})

--- a/opensquilla-webui/src/components/chat/AssistantMessage.vue
+++ b/opensquilla-webui/src/components/chat/AssistantMessage.vue
@@ -182,6 +182,13 @@
         @replan="$emit('planReplan', $event)"
       />
 
+      <SessionCreatedCard
+        v-for="createdSession in createdSessions"
+        :key="createdSession.callId"
+        :session-key="createdSession.sessionKey"
+        @open="$emit('openSession', $event)"
+      />
+
       <div
         class="msg-ai-ending"
         :class="{ 'msg-ai-ending--done': showDoneBlock }"
@@ -396,6 +403,7 @@ import ToolCallTimeline from '@/components/chat/ToolCallTimeline.vue'
 import InterruptPart from '@/components/chat/parts/InterruptPart.vue'
 import PlanCard from '@/components/chat/PlanCard.vue'
 import ReasoningPart from '@/components/chat/parts/ReasoningPart.vue'
+import SessionCreatedCard from '@/components/chat/SessionCreatedCard.vue'
 import StatusHistoryPart from '@/components/chat/parts/StatusHistoryPart.vue'
 import TextPart from '@/components/chat/parts/TextPart.vue'
 import TurnOutcomeStatus from '@/components/chat/TurnOutcomeStatus.vue'
@@ -403,6 +411,7 @@ import TurnUsageDetails from '@/components/chat/TurnUsageDetails.vue'
 import { useChatRouteFeedback } from '@/composables/chat/useChatRouteFeedback'
 import { useCopyFeedback } from '@/composables/chat/useCopyFeedback'
 import { useRelativeNow } from '@/composables/useRelativeNow'
+import { createdSessionsFromMessage } from '@/utils/chat/createdSessions'
 import {
   hasIncompleteUsageCoverage,
   usageCoverageText,
@@ -481,6 +490,7 @@ const emit = defineEmits<{
   planImplementCurrent: [target: PlanCardActionTarget]
   planImplementNew: [target: PlanCardActionTarget]
   planReplan: [target: PlanCardActionTarget]
+  openSession: [sessionKey: string]
 }>()
 
 // Absolute label is static; only the relative label subscribes to the shared
@@ -709,6 +719,14 @@ const legacyTimelineItems = computed<ChatStreamTimelineItem[]>(() => {
   }))
 })
 
+const semanticCreatedSessions = computed(() => createdSessionsFromMessage(props.message))
+const createdSessions = computed(() => (
+  props.message.createdSessionLinks ?? semanticCreatedSessions.value
+))
+const createdSessionCallIds = computed(() => new Set(
+  semanticCreatedSessions.value.map(createdSession => createdSession.callId),
+))
+
 const activityLifecycle = computed<AssistantActivityLifecycle>(() => {
   if (outcomePresentation.value === 'stopped') return 'interrupted'
   if (outcomePresentation.value === 'interrupted') return 'interrupted'
@@ -758,7 +776,9 @@ function withoutFailedActivity(
       return []
     }
     const calls = item.group.calls.filter(
-      call => !call.isError && call.status !== 'error',
+      call => !call.isError
+        && call.status !== 'error'
+        && !createdSessionCallIds.value.has(call.toolId),
     )
     if (calls.length === 0) return []
     const isRunning = calls.some(call => call.isRunning)

--- a/opensquilla-webui/src/components/chat/ChatMessageList.vue
+++ b/opensquilla-webui/src/components/chat/ChatMessageList.vue
@@ -63,6 +63,7 @@
       @toggle-tool-group="$emit('toggleToolGroup', $event)"
       @toggle-tool-item="$emit('toggleToolItem', $event)"
       @show-tool-result="(content, title, context) => $emit('showToolResult', content, title, context)"
+      @open-session="$emit('openSession', $event)"
       @resolve-interrupt="(id, decision) => $emit('resolveInterrupt', id, decision)"
       @extend-interrupt="id => $emit('extendInterrupt', id)"
       @clarify-submit="(fields, request) => $emit('clarifySubmit', fields, request)"
@@ -140,6 +141,7 @@ defineEmits<{
   toggleToolGroup: [groupId: string]
   toggleToolItem: [renderKey: string]
   showToolResult: [content: string, title: string, context?: ToolResultContext]
+  openSession: [sessionKey: string]
   forkConversation: [throughTurnId?: string]
   resolveInterrupt: [id: string, decision: 'allow-once' | 'allow-always' | 'deny']
   extendInterrupt: [id: string]

--- a/opensquilla-webui/src/components/chat/SessionCreatedCard.vue
+++ b/opensquilla-webui/src/components/chat/SessionCreatedCard.vue
@@ -1,0 +1,100 @@
+<template>
+  <div
+    class="session-created-card"
+    data-testid="session-created-card"
+    :data-session-key="sessionKey"
+  >
+    <span class="session-created-card__identity">
+      <Icon name="chat" :size="17" />
+      <span>{{ t('chat.sessionCreated.title') }}</span>
+    </span>
+    <button
+      type="button"
+      class="session-created-card__open"
+      :aria-label="t('chat.sessionCreated.open')"
+      @click="$emit('open', sessionKey)"
+    >
+      {{ t('chat.sessionCreated.open') }}
+      <Icon name="chevronRight" :size="15" />
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import Icon from '@/components/Icon.vue'
+
+defineProps<{
+  sessionKey: string
+}>()
+
+defineEmits<{
+  open: [sessionKey: string]
+}>()
+
+const { t } = useI18n()
+</script>
+
+<style scoped>
+.session-created-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  gap: var(--sp-3);
+  margin: var(--sp-2) 0;
+  padding: var(--sp-3) var(--sp-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  color: var(--text);
+}
+
+.session-created-card__identity,
+.session-created-card__open {
+  display: inline-flex;
+  align-items: center;
+}
+
+.session-created-card__identity {
+  min-width: 0;
+  gap: var(--sp-2);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+}
+
+.session-created-card__identity :deep(.icon) {
+  color: var(--text-muted);
+}
+
+.session-created-card__open {
+  flex: 0 0 auto;
+  gap: var(--sp-1);
+  padding: var(--sp-1) var(--sp-2);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: var(--fs-sm);
+  cursor: pointer;
+}
+
+.session-created-card__open:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.session-created-card__open:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
+}
+
+@media (max-width: 540px) {
+  .session-created-card {
+    padding: var(--sp-3);
+  }
+}
+</style>

--- a/opensquilla-webui/src/composables/chat/useChatRenderedMessages.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRenderedMessages.test.ts
@@ -201,6 +201,253 @@ describe('useChatRenderedMessages internal control turns', () => {
     expect(api.renderedMessages.value).toHaveLength(1)
     expect(api.renderedMessages.value[0]?.hasAttachments).toBe(true)
   })
+
+  it('keeps subagent completion control rows out while retaining the parent creation route', () => {
+    const messages: ChatMessage[] = [
+      { role: 'user', text: 'Create a child chat', ts: 1, turnId: 'parent-turn' },
+      {
+        role: 'router',
+        text: '',
+        ts: 2,
+        turnId: 'parent-turn',
+        provenanceKind: 'router_decision',
+        routerDecision: {
+          tier: 'c0',
+          model: 'deepseek-v4-flash',
+          source: 'heuristic',
+        },
+      },
+      {
+        role: 'system',
+        text: '{"type":"subagent_completion","child_session_key":"agent:main:subagent:child1"}',
+        ts: 3,
+        provenanceKind: 'internal_system',
+        provenanceSourceTool: 'subagent_completion',
+        provenanceSourceSessionKey: 'agent:main:subagent:child1',
+      },
+      {
+        role: 'assistant',
+        text: '',
+        ts: 4,
+        turnId: 'parent-turn',
+        usage: {
+          routed_tier: 'c0',
+          routed_model: 'deepseek-v4-flash',
+          routing_source: 'heuristic',
+        },
+        tool_calls: [
+          {
+            type: 'tool_use',
+            tool_use_id: 'spawn-1',
+            name: 'sessions_spawn',
+            input: { task: 'Do the work' },
+          },
+          {
+            type: 'tool_result',
+            tool_use_id: 'spawn-1',
+            name: 'sessions_spawn',
+            result: '{"session_key":"agent:main:subagent:child1"}',
+            is_error: false,
+          },
+        ],
+      },
+      { role: 'assistant', text: 'Child completed', ts: 5, turnId: 'parent-resume' },
+    ]
+    const api = useChatRenderedMessages({
+      messages: ref(messages),
+      sessionKey: ref('agent:main:webchat:parent'),
+      routerSlots: ref(['c0', 'c1']),
+      routerModels: ref({ c0: 'deepseek-v4-flash', c1: 'deepseek-v4-pro' }),
+      routerTierConfigs: ref({
+        c0: { model: 'deepseek-v4-flash', supportsImage: false, imageOnly: false },
+        c1: { model: 'deepseek-v4-pro', supportsImage: false, imageOnly: false },
+      }),
+      routerVisualEffectsEnabled: ref(true),
+      routerVisualMode: ref('real_candidates'),
+      renderMarkdown: text => text,
+      stripGeneratedArtifactMarkers: text => text,
+      stripTimePrefix: text => text,
+      isSubagentCompletionMessage: (role, text, message) => (
+        role === 'system'
+        && (
+          message?.provenanceSourceTool === 'subagent_completion'
+          || text.includes('"type":"subagent_completion"')
+        )
+      ),
+    })
+
+    expect(api.renderedMessages.value.find(message => message.isRouterStrip)?.gridCells)
+      .toEqual(expect.arrayContaining([expect.objectContaining({ model: 'deepseek-v4-flash' })]))
+    expect(api.renderedMessages.value.some(message => message.displayRole === 'subagent')).toBe(false)
+    expect(api.renderedMessages.value.some(message => message.text.includes('subagent_completion'))).toBe(false)
+    expect(api.renderedMessages.value.find(message => (
+      message.sourceIndex === 3 && message.displayRole === 'assistant'
+    ))?.toolCalls)
+      .toEqual(expect.arrayContaining([expect.objectContaining({ name: 'sessions_spawn' })]))
+    expect(api.renderedMessages.value.find(message => (
+      message.sourceIndex === 3 && message.displayRole === 'assistant'
+    ))?.createdSessionLinks)
+      .toEqual([])
+    const parentReply = api.renderedMessages.value[api.renderedMessages.value.length - 1]
+    expect(parentReply?.text).toBe('Child completed')
+    expect(parentReply?.createdSessionLinks).toEqual([{
+      callId: 'spawn-1',
+      sessionKey: 'agent:main:subagent:child1',
+    }])
+  })
+
+  it('shows the actual inherited model route on the child session', () => {
+    const api = useChatRenderedMessages({
+      messages: ref<ChatMessage[]>([
+        { role: 'user', text: 'Do the work', ts: 1 },
+        {
+          role: 'assistant',
+          text: 'Done',
+          ts: 2,
+          restoredFromHistory: true,
+          usage: {
+            model: 'deepseek-v4-pro',
+            routed_model: 'deepseek-v4-pro',
+            routing_source: 'none',
+            routing_applied: true,
+          },
+        },
+      ]),
+      sessionKey: ref('agent:main:subagent:child1'),
+      routerSlots: ref(['c0', 'c1']),
+      routerModels: ref({ c0: 'deepseek-v4-flash', c1: 'deepseek-v4-pro' }),
+      routerTierConfigs: ref({
+        c0: { model: 'deepseek-v4-flash', supportsImage: false, imageOnly: false },
+        c1: { model: 'deepseek-v4-pro', supportsImage: false, imageOnly: false },
+      }),
+      routerVisualEffectsEnabled: ref(true),
+      routerVisualMode: ref('real_candidates'),
+      renderMarkdown: text => text,
+      stripGeneratedArtifactMarkers: text => text,
+      stripTimePrefix: text => text,
+      isSubagentCompletionMessage: () => false,
+    })
+
+    const strip = api.renderedMessages.value.find(message => message.isRouterStrip)
+    expect(strip?.routerSource).toBe('session_model')
+    expect(strip?.gridCells?.[strip.winnerIdx ?? -1]?.model).toBe('deepseek-v4-pro')
+    expect(api.renderedMessages.value[api.renderedMessages.value.length - 1]?.text).toBe('Done')
+  })
+
+  it('keeps the card at its source when completion identity is missing', () => {
+    const api = useChatRenderedMessages({
+      messages: ref<ChatMessage[]>([
+        {
+          role: 'assistant',
+          text: '',
+          ts: 1,
+          tool_calls: [{
+            type: 'tool_result',
+            tool_use_id: 'spawn-1',
+            name: 'sessions_spawn',
+            result: '{"session_key":"agent:main:subagent:child1"}',
+            is_error: false,
+          }],
+        },
+        {
+          role: 'system',
+          text: '{"type":"subagent_completion"}',
+          ts: 2,
+          provenanceSourceTool: 'subagent_completion',
+        },
+        { role: 'assistant', text: 'Unrelated parent reply', ts: 3 },
+      ]),
+      sessionKey: ref('agent:main:webchat:parent'),
+      routerSlots: ref([]),
+      routerModels: ref({}),
+      routerTierConfigs: ref({}),
+      routerVisualEffectsEnabled: ref(false),
+      routerVisualMode: ref('real_candidates'),
+      renderMarkdown: text => text,
+      stripGeneratedArtifactMarkers: text => text,
+      stripTimePrefix: text => text,
+      isSubagentCompletionMessage: (role, text, message) => (
+        role === 'system'
+        && (message?.provenanceSourceTool === 'subagent_completion'
+          || text.includes('"type":"subagent_completion"'))
+      ),
+    })
+
+    expect(api.renderedMessages.value.find(message => message.sourceIndex === 0)?.createdSessionLinks)
+      .toEqual([{ callId: 'spawn-1', sessionKey: 'agent:main:subagent:child1' }])
+    expect(api.renderedMessages.value.find(message => message.sourceIndex === 2)?.createdSessionLinks)
+      .toEqual([])
+  })
+
+  it('does not infer a fixed-model route for a regular parent session', () => {
+    const api = useChatRenderedMessages({
+      messages: ref<ChatMessage[]>([{
+        role: 'assistant',
+        text: 'Done',
+        ts: 1,
+        usage: {
+          routed_model: 'deepseek-v4-pro',
+          routing_source: 'none',
+        },
+      }]),
+      sessionKey: ref('agent:main:webchat:parent'),
+      routerSlots: ref(['c0', 'c1']),
+      routerModels: ref({ c0: 'deepseek-v4-flash', c1: 'deepseek-v4-pro' }),
+      routerTierConfigs: ref({
+        c0: { model: 'deepseek-v4-flash', supportsImage: false, imageOnly: false },
+        c1: { model: 'deepseek-v4-pro', supportsImage: false, imageOnly: false },
+      }),
+      routerVisualEffectsEnabled: ref(true),
+      routerVisualMode: ref('real_candidates'),
+      renderMarkdown: text => text,
+      stripGeneratedArtifactMarkers: text => text,
+      stripTimePrefix: text => text,
+      isSubagentCompletionMessage: () => false,
+    })
+
+    expect(api.renderedMessages.value.some(message => message.isRouterStrip)).toBe(false)
+  })
+
+  it('keeps parent routing visible when session creation fails or returns no child key', () => {
+    const api = useChatRenderedMessages({
+      messages: ref<ChatMessage[]>([
+        { role: 'user', text: 'Create a child chat', ts: 1 },
+        {
+          role: 'assistant',
+          text: '',
+          ts: 2,
+          usage: {
+            routed_tier: 'c0',
+            routed_model: 'deepseek-v4-flash',
+            routing_source: 'heuristic',
+          },
+          tool_calls: [{
+            type: 'tool_result',
+            tool_use_id: 'spawn-failed',
+            name: 'sessions_spawn',
+            result: '{"status":"error"}',
+            is_error: true,
+          }],
+        },
+      ]),
+      sessionKey: ref('agent:main:webchat:parent'),
+      routerSlots: ref(['c0', 'c1']),
+      routerModels: ref({ c0: 'deepseek-v4-flash', c1: 'deepseek-v4-pro' }),
+      routerTierConfigs: ref({
+        c0: { model: 'deepseek-v4-flash', supportsImage: false, imageOnly: false },
+        c1: { model: 'deepseek-v4-pro', supportsImage: false, imageOnly: false },
+      }),
+      routerVisualEffectsEnabled: ref(true),
+      routerVisualMode: ref('real_candidates'),
+      renderMarkdown: text => text,
+      stripGeneratedArtifactMarkers: text => text,
+      stripTimePrefix: text => text,
+      isSubagentCompletionMessage: () => false,
+    })
+
+    expect(api.renderedMessages.value.find(message => message.isRouterStrip)?.routerSource)
+      .toBe('heuristic')
+  })
 })
 
 describe('useChatRenderedMessages silent sentinel compatibility', () => {

--- a/opensquilla-webui/src/composables/chat/useChatRenderedMessages.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRenderedMessages.test.ts
@@ -379,6 +379,86 @@ describe('useChatRenderedMessages internal control turns', () => {
       .toEqual([])
   })
 
+  it('does not rehome a completed card across the next visible user turn', () => {
+    const api = useChatRenderedMessages({
+      messages: ref<ChatMessage[]>([
+        {
+          role: 'assistant',
+          text: '',
+          ts: 1,
+          tool_calls: [{
+            type: 'tool_result',
+            tool_use_id: 'spawn-1',
+            name: 'sessions_spawn',
+            result: '{"session_key":"agent:main:subagent:child1"}',
+            is_error: false,
+          }],
+        },
+        {
+          role: 'system',
+          text: '{"type":"subagent_completion","child_session_key":"agent:main:subagent:child1"}',
+          ts: 2,
+          provenanceSourceTool: 'subagent_completion',
+          provenanceSourceSessionKey: 'agent:main:subagent:child1',
+        },
+        { role: 'user', text: 'A separate question', ts: 3 },
+        { role: 'assistant', text: 'A separate answer', ts: 4 },
+      ]),
+      sessionKey: ref('agent:main:webchat:parent'),
+      routerSlots: ref([]),
+      routerModels: ref({}),
+      routerTierConfigs: ref({}),
+      routerVisualEffectsEnabled: ref(false),
+      routerVisualMode: ref('real_candidates'),
+      renderMarkdown: text => text,
+      stripGeneratedArtifactMarkers: text => text,
+      stripTimePrefix: text => text,
+      isSubagentCompletionMessage: (role, text, message) => (
+        role === 'system'
+        && (message?.provenanceSourceTool === 'subagent_completion'
+          || text.includes('"type":"subagent_completion"'))
+      ),
+    })
+
+    expect(api.renderedMessages.value.find(message => message.sourceIndex === 0)?.createdSessionLinks)
+      .toEqual([{ callId: 'spawn-1', sessionKey: 'agent:main:subagent:child1' }])
+    expect(api.renderedMessages.value.find(message => message.sourceIndex === 3)?.createdSessionLinks)
+      .toEqual([])
+  })
+
+  it.each([
+    ['agent:main:subagent:child1', 'none'],
+    ['subagent:agent:main:webchat:parent', 'session_model'],
+  ])('shows a fixed route for %s with a non-slot model', (childSessionKey, routingSource) => {
+    const api = useChatRenderedMessages({
+      messages: ref<ChatMessage[]>([{
+        role: 'assistant',
+        text: 'Done',
+        ts: 1,
+        usage: {
+          routed_model: 'provider/custom-child-model',
+          routing_source: routingSource,
+        },
+      }]),
+      sessionKey: ref(childSessionKey),
+      routerSlots: ref([]),
+      routerModels: ref({}),
+      routerTierConfigs: ref({}),
+      routerVisualEffectsEnabled: ref(true),
+      routerVisualMode: ref('real_candidates'),
+      renderMarkdown: text => text,
+      stripGeneratedArtifactMarkers: text => text,
+      stripTimePrefix: text => text,
+      isSubagentCompletionMessage: () => false,
+    })
+
+    const strip = api.renderedMessages.value.find(message => message.isRouterStrip)
+    expect(strip?.routerSource).toBe('session_model')
+    expect(strip?.gridCells).toHaveLength(1)
+    expect(strip?.gridCells?.[strip.winnerIdx ?? -1]?.model)
+      .toBe('provider/custom-child-model')
+  })
+
   it('does not infer a fixed-model route for a regular parent session', () => {
     const api = useChatRenderedMessages({
       messages: ref<ChatMessage[]>([{

--- a/opensquilla-webui/src/composables/chat/useChatRenderedMessages.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRenderedMessages.ts
@@ -4,6 +4,7 @@ import type {
   ChatEnsembleMetaModel,
   ChatEnsembleTrace,
   ChatEnsembleUsageRow,
+  ChatCreatedSessionLink,
   ChatMessage,
   ChatMessageMeta,
   ChatRenderedMessage,
@@ -39,6 +40,7 @@ import type { ModelRoutingMode } from '@/types/modelRouting'
 import type { InterruptViewState } from '@/types/parts'
 import { toParts, toolState, type ToPartsInterrupt } from '@/utils/chat/toParts'
 import { toSources } from '@/utils/chat/toSources'
+import { createdSessionFromToolCall } from '@/utils/chat/createdSessions'
 import { relativeTime, type TimeTranslator } from '@/utils/messageTime'
 import {
   isLegacySilentSentinelOnly,
@@ -183,6 +185,67 @@ function terminatesPriorAssistant(message: ChatMessage, priorAssistant?: ChatMes
     && message.turnId === priorAssistant.turnId
 }
 
+function createdSessionLinksFromCalls(calls: ChatToolCall[]): ChatCreatedSessionLink[] {
+  return calls.flatMap((call) => {
+    const link = createdSessionFromToolCall(call)
+    return link ? [link] : []
+  })
+}
+
+function completionChildSessionKey(message: ChatMessage): string {
+  const provenanceKey = String(message.provenanceSourceSessionKey || '').trim()
+  if (provenanceKey) return provenanceKey
+  try {
+    const payload = JSON.parse(message.text) as Record<string, unknown>
+    return typeof payload.child_session_key === 'string'
+      ? payload.child_session_key.trim()
+      : ''
+  } catch {
+    return ''
+  }
+}
+
+function rehomeCompletedSessionCards(
+  rawMessages: readonly ChatMessage[],
+  renderedMessages: ChatRenderedMessage[],
+  isCompletion: UseChatRenderedMessagesOptions['isSubagentCompletionMessage'],
+): void {
+  const completionIndices = new Map<string, number>()
+  rawMessages.forEach((message, index) => {
+    if (!isCompletion(message.role, message.text, message)) return
+    const childSessionKey = completionChildSessionKey(message)
+    if (childSessionKey && !completionIndices.has(childSessionKey)) {
+      completionIndices.set(childSessionKey, index)
+    }
+  })
+
+  for (const source of renderedMessages) {
+    const links = source.createdSessionLinks ?? []
+    if (!links.length || source.sourceIndex === undefined) continue
+    const sourceOwnsCards = (source.toolCalls ?? [])
+      .some(call => createdSessionFromToolCall(call) !== null)
+    if (!sourceOwnsCards) continue
+    const boundaries = links.map(link => completionIndices.get(link.sessionKey))
+    if (boundaries.some(index => index === undefined)) continue
+    const completionBoundary = Math.max(source.sourceIndex, ...boundaries as number[])
+    const target = renderedMessages.find(message => (
+      message.displayRole === 'assistant'
+      && message.sourceIndex !== undefined
+      && message.sourceIndex > completionBoundary
+      && message.text.trim().length > 0
+    ))
+    if (!target) continue
+
+    const existing = target.createdSessionLinks ?? []
+    const seen = new Set(existing.map(link => link.callId))
+    target.createdSessionLinks = [
+      ...existing,
+      ...links.filter(link => !seen.has(link.callId)),
+    ]
+    source.createdSessionLinks = []
+  }
+}
+
 export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions) {
   const renderedMessages = computed((): ChatRenderedMessage[] => {
     const result: ChatRenderedMessage[] = []
@@ -279,6 +342,15 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
         }
       }
 
+      // Subagent completion is a durable control-plane row used to wake the
+      // parent model. It belongs in the parent transcript, but it is not a
+      // parent-chat message and must never project its JSON (or any metadata
+      // attached by compatibility gateways) into the visible conversation.
+      if (options.isSubagentCompletionMessage(msg.role, msg.text, msg)) {
+        prevRole = ''
+        continue
+      }
+
       const routerDecision = normalizeRouterDecision(msg.routerDecision || (msg.provenanceKind === 'router_decision' ? msg : null))
       if (routerDecision) {
         const stripItem = renderedRouterStrip(
@@ -316,7 +388,7 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
         }
         prevRole = ''
       } else {
-        const usageRouterDecision = routerDecisionFromUsage(msg)
+        const usageRouterDecision = routerDecisionFromUsage(msg, inheritedSubagentRoute(msg))
         if (usageRouterDecision) {
           const stripItem = renderedRouterStrip(
             msg,
@@ -332,9 +404,8 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
         }
       }
 
-      const isSubagent = options.isSubagentCompletionMessage(msg.role, msg.text, msg)
-      const displayRole = isSubagent ? 'subagent' : msg.role
-      const roleLabel = displayRole === 'user' ? 'You' : displayRole === 'assistant' ? 'Assistant' : displayRole === 'subagent' ? 'Sub-agent' : displayRole.charAt(0).toUpperCase() + displayRole.slice(1)
+      const displayRole = msg.role
+      const roleLabel = displayRole === 'user' ? 'You' : displayRole === 'assistant' ? 'Assistant' : displayRole.charAt(0).toUpperCase() + displayRole.slice(1)
       const collapsible = displayRole === 'user' || displayRole === 'assistant'
       const sameGroup = collapsible && displayRole === prevRole && day === prevDay && day !== ''
       if (collapsible) prevRole = displayRole
@@ -385,6 +456,7 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
         turnOutcome: msg.turnOutcome,
         hasAttachments: !!msg.attachments?.length,
         attachments: msg.attachments,
+        createdSessionLinks: createdSessionLinksFromCalls(normalizedToolCalls),
         // submit_plan is a transport/control detail. Once a typed immutable
         // plan part exists, the plan card is the authoritative visible item;
         // do not also render the same payload as an expandable tool timeline.
@@ -444,6 +516,11 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
       }
     }
 
+    rehomeCompletedSessionCards(
+      options.messages.value,
+      result,
+      options.isSubagentCompletionMessage,
+    )
     return result
   })
 
@@ -493,6 +570,31 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
       winnerIdx: routerWinnerCellIndex(cells, decision.tier),
       messageId: messageId || `${index}-router`,
     }
+  }
+
+  function inheritedSubagentRoute(msg: ChatMessage): NormalizedRouterDecision | null {
+    if (!options.sessionKey.value.includes(':subagent:')) return null
+    const usage = msg.usage || msg.turn_usage
+    if (!usage || (usage.routing_source && usage.routing_source !== 'none')) return null
+    const model = String(usage.routed_model || usage.model || msg.model || '').trim()
+    if (!model) return null
+
+    const tier = options.routerSlots.value.find((slot) => {
+      const configured = String(
+        options.routerModels.value[slot]
+        || options.routerTierConfigs.value[slot]?.model
+        || '',
+      ).trim()
+      return configured === model
+    })
+    if (!tier) return null
+    return normalizeRouterDecision({
+      tier,
+      model,
+      source: 'session_model',
+      routing_applied: true,
+      rollout_phase: usage.rollout_phase || 'full',
+    })
   }
 
   function renderedEnsembleRouterStrip(
@@ -1143,9 +1245,13 @@ export function normalizeRouterDecision(raw: unknown): NormalizedRouterDecision 
   }
 }
 
-function routerDecisionFromUsage(msg: ChatMessage): NormalizedRouterDecision | null {
+function routerDecisionFromUsage(
+  msg: ChatMessage,
+  inheritedRoute: NormalizedRouterDecision | null = null,
+): NormalizedRouterDecision | null {
   const usage = msg.usage || msg.turn_usage
-  if (!usage || usage.routing_source === 'none') return null
+  if (!usage) return inheritedRoute
+  if (usage.routing_source === 'none') return inheritedRoute
   const routePlan = usage.route_plan
   const immutablePlan = (
     routePlan
@@ -1157,7 +1263,7 @@ function routerDecisionFromUsage(msg: ChatMessage): NormalizedRouterDecision | n
   const tier = typeof immutablePlan?.tier === 'string'
     ? immutablePlan.tier
     : typeof usage.routed_tier === 'string' ? usage.routed_tier : ''
-  if (!tier) return null
+  if (!tier) return inheritedRoute
   const source = typeof immutablePlan?.source === 'string'
     ? immutablePlan.source
     : usage.routing_source || 'none'

--- a/opensquilla-webui/src/composables/chat/useChatRenderedMessages.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRenderedMessages.ts
@@ -228,10 +228,16 @@ function rehomeCompletedSessionCards(
     const boundaries = links.map(link => completionIndices.get(link.sessionKey))
     if (boundaries.some(index => index === undefined)) continue
     const completionBoundary = Math.max(source.sourceIndex, ...boundaries as number[])
+    const nextVisibleUserIndex = rawMessages.findIndex((message, index) => (
+      index > source.sourceIndex!
+      && message.role === 'user'
+      && (message.text.trim().length > 0 || (message.attachments?.length ?? 0) > 0)
+    ))
     const target = renderedMessages.find(message => (
       message.displayRole === 'assistant'
       && message.sourceIndex !== undefined
       && message.sourceIndex > completionBoundary
+      && (nextVisibleUserIndex < 0 || message.sourceIndex < nextVisibleUserIndex)
       && message.text.trim().length > 0
     ))
     if (!target) continue
@@ -545,7 +551,8 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
       )
     }
     const cells = routerDecisionCellsForRequest(decision, requestKind)
-    if (cells.length <= 1) return null
+    const fixedSessionRoute = decision.source === 'session_model'
+    if (cells.length === 0 || (cells.length === 1 && !fixedSessionRoute)) return null
     return {
       id: `router-turn-${turnIdx}`,
       role: 'router',
@@ -573,13 +580,20 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
   }
 
   function inheritedSubagentRoute(msg: ChatMessage): NormalizedRouterDecision | null {
-    if (!options.sessionKey.value.includes(':subagent:')) return null
+    const currentSessionKey = options.sessionKey.value.trim().toLowerCase()
+    if (!(
+      currentSessionKey.startsWith('subagent:')
+      || /^agent:[^:]+:subagent:[^:]+$/.test(currentSessionKey)
+    )) return null
     const usage = msg.usage || msg.turn_usage
-    if (!usage || (usage.routing_source && usage.routing_source !== 'none')) return null
+    const routingSource = String(usage?.routing_source || '').trim().toLowerCase()
+    if (!usage || !['', 'none', 'session_model'].includes(routingSource)) {
+      return null
+    }
     const model = String(usage.routed_model || usage.model || msg.model || '').trim()
     if (!model) return null
 
-    const tier = options.routerSlots.value.find((slot) => {
+    const configuredTier = options.routerSlots.value.find((slot) => {
       const configured = String(
         options.routerModels.value[slot]
         || options.routerTierConfigs.value[slot]?.model
@@ -587,7 +601,10 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
       ).trim()
       return configured === model
     })
-    if (!tier) return null
+    // Explicit sessions_spawn models and older session histories need not match
+    // the current router configuration. A synthetic fixed tier preserves the
+    // durable model identity without pretending the router selected it now.
+    const tier = configuredTier || 'session_model'
     return normalizeRouterDecision({
       tier,
       model,

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -3174,6 +3174,10 @@
     }
   },
   "chat": {
+    "sessionCreated": {
+      "title": "Chat erstellt",
+      "open": "Chat öffnen"
+    },
     "promptCacheKeepalive": {
       "action": "Prompt-Cache aktiv halten",
       "title": "Prompt-Cache aktiv halten",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -3225,6 +3225,10 @@
     }
   },
   "chat": {
+    "sessionCreated": {
+      "title": "Chat created",
+      "open": "Open chat"
+    },
     "promptCacheKeepalive": {
       "action": "Prompt cache keepalive",
       "title": "Prompt cache keepalive",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -3174,6 +3174,10 @@
     }
   },
   "chat": {
+    "sessionCreated": {
+      "title": "Chat creado",
+      "open": "Abrir chat"
+    },
     "promptCacheKeepalive": {
       "action": "Mantener caché del prompt",
       "title": "Mantener caché del prompt",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -3174,6 +3174,10 @@
     }
   },
   "chat": {
+    "sessionCreated": {
+      "title": "Discussion créée",
+      "open": "Ouvrir la discussion"
+    },
     "promptCacheKeepalive": {
       "action": "Maintien du cache de prompt",
       "title": "Maintien du cache de prompt",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -3174,6 +3174,10 @@
     }
   },
   "chat": {
+    "sessionCreated": {
+      "title": "チャットを作成しました",
+      "open": "チャットを開く"
+    },
     "promptCacheKeepalive": {
       "action": "プロンプトキャッシュの維持",
       "title": "プロンプトキャッシュの維持",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -3225,6 +3225,10 @@
     }
   },
   "chat": {
+    "sessionCreated": {
+      "title": "聊天已创建",
+      "open": "打开聊天"
+    },
     "promptCacheKeepalive": {
       "action": "提示词缓存保活",
       "title": "提示词缓存保活",

--- a/opensquilla-webui/src/types/chat.ts
+++ b/opensquilla-webui/src/types/chat.ts
@@ -537,6 +537,11 @@ export interface ChatMessageMeta {
   decisionId?: string
 }
 
+export interface ChatCreatedSessionLink {
+  callId: string
+  sessionKey: string
+}
+
 export interface ChatRenderedMessage {
   id?: string
   clientId?: string
@@ -567,6 +572,9 @@ export interface ChatRenderedMessage {
   turnOutcome?: ChatTurnOutcome
   hasAttachments?: boolean
   attachments?: DisplayAttachment[]
+  /** Explicit placement for successful sessions_spawn cards. An empty array
+   *  suppresses the source card after it is rehomed below the parent reply. */
+  createdSessionLinks?: ChatCreatedSessionLink[]
   toolCalls?: ChatToolCall[]
   planRevisions?: import('./plans').PlanRevisionSnapshot[]
   timelineItems?: ChatStreamTimelineItem[]

--- a/opensquilla-webui/src/utils/chat/createdSessions.test.ts
+++ b/opensquilla-webui/src/utils/chat/createdSessions.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  ChatRenderedMessage,
+  ChatStreamTimelineItem,
+  ChatToolCall,
+  ChatToolCallRenderItem,
+} from '@/types/chat'
+import {
+  createdSessionFromToolCall,
+  createdSessionsFromMessage,
+} from './createdSessions'
+
+function call(overrides: Partial<ChatToolCall> = {}): ChatToolCall {
+  return {
+    toolId: 'spawn-1',
+    name: 'sessions_spawn',
+    displayName: 'sessions_spawn',
+    inputPreview: '',
+    isRunning: false,
+    status: 'success',
+    isError: false,
+    result: JSON.stringify({
+      session_key: 'agent:main:subagent:abc12345',
+      status: 'queued',
+    }),
+    resultPreview: '',
+    isOpen: false,
+    ...overrides,
+  }
+}
+
+function message(overrides: Partial<ChatRenderedMessage> = {}): ChatRenderedMessage {
+  return {
+    role: 'assistant',
+    displayRole: 'assistant',
+    roleLabel: 'Assistant',
+    text: '',
+    timeStr: '',
+    showHeader: false,
+    ...overrides,
+  }
+}
+
+function timeline(...calls: ChatToolCall[]): ChatStreamTimelineItem[] {
+  return [{
+    type: 'tool-group',
+    key: 'spawn-group',
+    group: {
+      groupId: 'spawn-group',
+      operationKey: 'tool.sessions.spawn',
+      label: 'sessions_spawn',
+      iconName: 'chat',
+      calls: calls.map((item, index) => ({
+        ...item,
+        renderKey: `spawn-${index}`,
+      }) as ChatToolCallRenderItem),
+      secondary: '',
+      isRunning: false,
+      isError: false,
+      status: 'success',
+    },
+  }]
+}
+
+describe('created session tool results', () => {
+  it('accepts only completed sessions_spawn results with a subagent session key', () => {
+    expect(createdSessionFromToolCall(call())).toEqual({
+      callId: 'spawn-1',
+      sessionKey: 'agent:main:subagent:abc12345',
+    })
+    expect(createdSessionFromToolCall(call({ name: 'sessions_send' }))).toBeNull()
+    expect(createdSessionFromToolCall(call({ isRunning: true, status: '' }))).toBeNull()
+    expect(createdSessionFromToolCall(call({ isError: true, status: 'error' }))).toBeNull()
+    expect(createdSessionFromToolCall(call({ result: '{broken' }))).toBeNull()
+    expect(createdSessionFromToolCall(call({ result: '{}' }))).toBeNull()
+    expect(createdSessionFromToolCall(call({
+      result: JSON.stringify({ session_key: 'agent:main:webchat:not-a-child' }),
+    }))).toBeNull()
+  })
+
+  it('keeps multiple creates ordered and deduplicates replayed call ids', () => {
+    const first = call()
+    const second = call({
+      toolId: 'spawn-2',
+      result: JSON.stringify({ session_key: 'agent:main:subagent:def67890' }),
+    })
+    expect(createdSessionsFromMessage(message({
+      timelineItems: timeline(first, second),
+      toolCalls: [first, second],
+    }))).toEqual([
+      { callId: 'spawn-1', sessionKey: 'agent:main:subagent:abc12345' },
+      { callId: 'spawn-2', sessionKey: 'agent:main:subagent:def67890' },
+    ])
+  })
+
+  it('restores links from legacy messages that only carry toolCalls', () => {
+    expect(createdSessionsFromMessage(message({ toolCalls: [call()] }))).toEqual([
+      { callId: 'spawn-1', sessionKey: 'agent:main:subagent:abc12345' },
+    ])
+  })
+
+  it('accepts a later completed replay when an earlier copy is still pending', () => {
+    expect(createdSessionsFromMessage(message({
+      timelineItems: timeline(call({ isRunning: true, status: '', result: '' })),
+      toolCalls: [call()],
+    }))).toEqual([
+      { callId: 'spawn-1', sessionKey: 'agent:main:subagent:abc12345' },
+    ])
+  })
+})

--- a/opensquilla-webui/src/utils/chat/createdSessions.ts
+++ b/opensquilla-webui/src/utils/chat/createdSessions.ts
@@ -1,0 +1,78 @@
+import type {
+  ChatCreatedSessionLink,
+  ChatRenderedMessage,
+  ChatStreamTimelineItem,
+  ChatToolCall,
+} from '@/types/chat'
+
+export type CreatedSessionLink = ChatCreatedSessionLink
+
+function resultRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value === 'string') {
+    const text = value.trim()
+    if (!text.startsWith('{')) return null
+    try {
+      const parsed = JSON.parse(text)
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? parsed as Record<string, unknown>
+        : null
+    } catch {
+      return null
+    }
+  }
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function spawnedSessionKey(value: unknown): string | null {
+  const record = resultRecord(value)
+  const key = typeof record?.session_key === 'string'
+    ? record.session_key.trim()
+    : ''
+  if (!/^agent:[^:\s]+:subagent:[^:\s]+$/.test(key)) return null
+  return key
+}
+
+export function createdSessionFromToolCall(
+  call: Pick<ChatToolCall, 'toolId' | 'name' | 'isRunning' | 'status' | 'isError' | 'result'>,
+): CreatedSessionLink | null {
+  if (
+    call.name !== 'sessions_spawn'
+    || call.isRunning
+    || call.isError
+    || call.status !== 'success'
+  ) return null
+  const sessionKey = spawnedSessionKey(call.result)
+  if (!sessionKey) return null
+  return {
+    callId: call.toolId,
+    sessionKey,
+  }
+}
+
+function timelineCalls(items: ChatStreamTimelineItem[] | undefined): ChatToolCall[] {
+  return (items ?? []).flatMap(item => (
+    item.type === 'tool-group' ? item.group.calls : []
+  ))
+}
+
+/**
+ * Derive ordered, durable session links from the same normalized tool calls
+ * used by both the live stream and restored history renderers.
+ */
+export function createdSessionsFromMessage(message: ChatRenderedMessage): CreatedSessionLink[] {
+  const calls = [
+    ...timelineCalls(message.timelineItems),
+    ...(message.toolCalls ?? []),
+  ]
+  const seenCalls = new Set<string>()
+  const links: CreatedSessionLink[] = []
+  for (const call of calls) {
+    const link = createdSessionFromToolCall(call)
+    if (!link || seenCalls.has(link.callId)) continue
+    seenCalls.add(link.callId)
+    links.push(link)
+  }
+  return links
+}

--- a/opensquilla-webui/src/utils/chat/sessionCreationRouterPresentation.test.ts
+++ b/opensquilla-webui/src/utils/chat/sessionCreationRouterPresentation.test.ts
@@ -112,6 +112,27 @@ describe('session creation router presentation', () => {
       .toEqual(['prior-route', 'current-creation-route'])
   })
 
+  it('keeps an earlier creation interaction deduplicated after a later user turn', () => {
+    const source = cardOwner('creation-source')
+    const finalReply = message('creation-final', 'assistant', {
+      text: 'Child completed.',
+      createdSessionLinks: source.createdSessionLinks,
+    })
+    source.createdSessionLinks = []
+    const projection = projectSessionCreationRouterPresentation([
+      message('creation-user', 'user'),
+      message('creation-route', 'router', { isRouterStrip: true }),
+      source,
+      message('resume-route', 'router', { isRouterStrip: true }),
+      finalReply,
+      message('later-user', 'user'),
+      message('later-reply', 'assistant', { text: 'A separate answer.' }),
+    ], false)
+
+    expect(projection.messages.filter(item => item.isRouterStrip).map(item => item.id))
+      .toEqual(['creation-route'])
+  })
+
   it('leaves settled history and rehomed cards unchanged', () => {
     const route = message('final-route', 'router', { isRouterStrip: true })
     const rehomedCard = message('final-reply', 'assistant', {

--- a/opensquilla-webui/src/utils/chat/sessionCreationRouterPresentation.test.ts
+++ b/opensquilla-webui/src/utils/chat/sessionCreationRouterPresentation.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+import type { ChatRenderedMessage, ChatToolCall } from '@/types/chat'
+import {
+  hasRouterAfterLatestUser,
+  projectSessionCreationRouterPresentation,
+} from './sessionCreationRouterPresentation'
+
+function message(
+  id: string,
+  displayRole: string,
+  extra: Partial<ChatRenderedMessage> = {},
+): ChatRenderedMessage {
+  return {
+    id,
+    role: displayRole,
+    displayRole,
+    roleLabel: displayRole,
+    text: '',
+    timeStr: '',
+    showHeader: false,
+    ...extra,
+  }
+}
+
+function successfulSpawn(callId: string): ChatToolCall {
+  return {
+    toolId: callId,
+    name: 'sessions_spawn',
+    displayName: 'Create chat',
+    inputPreview: '',
+    isRunning: false,
+    isError: false,
+    status: 'success',
+    result: '{"session_key":"agent:main:subagent:child"}',
+    resultPreview: '',
+    isOpen: false,
+  }
+}
+
+function cardOwner(id = 'card'): ChatRenderedMessage {
+  return message(id, 'assistant', {
+    createdSessionLinks: [{
+      callId: 'spawn-1',
+      sessionKey: 'agent:main:subagent:child',
+    }],
+    toolCalls: [successfulSpawn('spawn-1')],
+  })
+}
+
+describe('session creation router presentation', () => {
+  it('keeps the creation route above a live created-chat card', () => {
+    const user = message('user', 'user')
+    const route = message('creation-route', 'router', { isRouterStrip: true })
+    const card = cardOwner()
+
+    const projection = projectSessionCreationRouterPresentation(
+      [user, route, card],
+      true,
+    )
+
+    expect(projection.active).toBe(true)
+    expect(projection.messages).toEqual([user, route, card])
+    expect(hasRouterAfterLatestUser(projection.messages)).toBe(true)
+  })
+
+  it('hides the resumed parent route below the card', () => {
+    const projection = projectSessionCreationRouterPresentation([
+      message('user', 'user'),
+      message('creation-route', 'router', { isRouterStrip: true }),
+      cardOwner(),
+      message('resume-route', 'router', { isRouterStrip: true }),
+    ], true)
+
+    expect(projection.messages.filter(item => item.isRouterStrip).map(item => item.id))
+      .toEqual(['creation-route'])
+    expect(hasRouterAfterLatestUser(projection.messages)).toBe(true)
+  })
+
+  it('uses the last card boundary for multiple child sessions completing together', () => {
+    const firstCard = cardOwner('first-card')
+    const secondCard = message('second-card', 'assistant', {
+      createdSessionLinks: [{
+        callId: 'spawn-2',
+        sessionKey: 'agent:main:subagent:second',
+      }],
+      toolCalls: [successfulSpawn('spawn-2')],
+    })
+    const projection = projectSessionCreationRouterPresentation([
+      message('user', 'user'),
+      message('first-route', 'router', { isRouterStrip: true }),
+      firstCard,
+      message('between-cards-route', 'router', { isRouterStrip: true }),
+      secondCard,
+    ], true)
+
+    expect(projection.messages.filter(item => item.isRouterStrip).map(item => item.id))
+      .toEqual(['first-route'])
+    expect(projection.messages.filter(item => item.createdSessionLinks?.length)).toHaveLength(2)
+  })
+
+  it('does not remove routes from an earlier user interaction', () => {
+    const priorRoute = message('prior-route', 'router', { isRouterStrip: true })
+    const projection = projectSessionCreationRouterPresentation([
+      message('prior-user', 'user'),
+      priorRoute,
+      message('current-user', 'user'),
+      message('current-creation-route', 'router', { isRouterStrip: true }),
+      cardOwner(),
+    ], true)
+
+    expect(projection.messages.filter(item => item.isRouterStrip).map(item => item.id))
+      .toEqual(['prior-route', 'current-creation-route'])
+  })
+
+  it('leaves settled history and rehomed cards unchanged', () => {
+    const route = message('final-route', 'router', { isRouterStrip: true })
+    const rehomedCard = message('final-reply', 'assistant', {
+      text: 'Done',
+      createdSessionLinks: [{
+        callId: 'spawn-1',
+        sessionKey: 'agent:main:subagent:child',
+      }],
+    })
+    const messages = [message('user', 'user'), route, rehomedCard]
+
+    expect(projectSessionCreationRouterPresentation(messages, false)).toEqual({
+      messages,
+      active: false,
+    })
+    expect(projectSessionCreationRouterPresentation(messages, true)).toEqual({
+      messages,
+      active: false,
+    })
+  })
+
+  it('keeps only the creation route after a multi-turn session creation settles', () => {
+    const visibleCreationReply = cardOwner('first-spawn')
+    visibleCreationReply.text = 'Chat created, waiting for completion.'
+    const rehomedFinalReply = message('final-reply', 'assistant', {
+      text: 'Child completed.',
+      createdSessionLinks: visibleCreationReply.createdSessionLinks,
+    })
+    visibleCreationReply.createdSessionLinks = []
+    const projection = projectSessionCreationRouterPresentation([
+      message('user', 'user'),
+      message('creation-route', 'router', { isRouterStrip: true }),
+      visibleCreationReply,
+      message('resumed-route', 'router', { isRouterStrip: true }),
+      rehomedFinalReply,
+    ], false)
+
+    expect(projection.active).toBe(false)
+    expect(projection.messages.filter(item => item.isRouterStrip).map(item => item.id))
+      .toEqual(['creation-route'])
+    expect(projection.messages.filter(item => item.createdSessionLinks?.length)).toHaveLength(1)
+    expect(projection.messages.find(item => item.id === 'first-spawn')?.text)
+      .toBe('Chat created, waiting for completion.')
+  })
+
+  it('does not activate for failed or incomplete spawn results without a card link', () => {
+    const messages = [
+      message('user', 'user'),
+      message('route', 'router', { isRouterStrip: true }),
+      message('failed-spawn', 'assistant', {
+        toolCalls: [{
+          ...successfulSpawn('spawn-failed'),
+          isError: true,
+          status: 'error',
+        }],
+      }),
+    ]
+
+    expect(projectSessionCreationRouterPresentation(messages, true)).toEqual({
+      messages,
+      active: false,
+    })
+  })
+})

--- a/opensquilla-webui/src/utils/chat/sessionCreationRouterPresentation.ts
+++ b/opensquilla-webui/src/utils/chat/sessionCreationRouterPresentation.ts
@@ -25,57 +25,50 @@ export function projectSessionCreationRouterPresentation(
   messages: readonly ChatRenderedMessage[],
   isStreaming: boolean,
 ): SessionCreationRouterPresentation {
-  let latestUserIndex = -1
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    if (messages[index]?.displayRole === 'user') {
-      latestUserIndex = index
-      break
-    }
-  }
+  const suppressedRouters = new Set<number>()
+  let interactionStart = 0
+  let active = false
 
-  let cardIndex = -1
-  let hasCreationSource = false
-  for (let index = messages.length - 1; index > latestUserIndex; index -= 1) {
-    const message = messages[index]!
-    if (cardIndex < 0 && (message.createdSessionLinks?.length ?? 0) > 0) cardIndex = index
-    if (createsSession(message)) hasCreationSource = true
-  }
-  // Rehoming intentionally separates these signals: the source assistant keeps
-  // the successful sessions_spawn tool while the final parent reply owns the
-  // visible card. Requiring both signals prevents unrelated cards or malformed
-  // tool results from collapsing ordinary route history.
-  if (cardIndex < 0 || !hasCreationSource) {
-    return { messages: messages as ChatRenderedMessage[], active: false }
-  }
+  function projectInteraction(start: number, end: number): void {
+    const interaction = messages.slice(start, end)
+    // Rehoming intentionally separates these signals: the source assistant
+    // keeps the successful sessions_spawn tool while the final parent reply
+    // owns the visible card. Requiring both prevents unrelated cards or
+    // malformed tool results from collapsing ordinary route history.
+    const hasCard = interaction.some(message => (
+      (message.createdSessionLinks?.length ?? 0) > 0
+    ))
+    const hasCreationSource = interaction.some(createsSession)
+    if (!hasCard || !hasCreationSource) return
 
-  if (!isStreaming) {
-    const routerIndices = messages.flatMap((message, index) => (
-      message.isRouterStrip && index > latestUserIndex ? [index] : []
+    const routerIndices = interaction.flatMap((message, offset) => (
+      message.isRouterStrip ? [start + offset] : []
     ))
     if (routerIndices.length <= 1) {
-      return { messages: messages as ChatRenderedMessage[], active: false }
+      if (isStreaming && end === messages.length) active = true
+      return
     }
-    const firstRouterIndex = routerIndices[0]
-    return {
-      messages: messages.filter((message, index) => !(
-        message.isRouterStrip
-        && index > latestUserIndex
-        && index !== firstRouterIndex
-      )),
-      active: false,
-    }
+    routerIndices.slice(1).forEach(index => suppressedRouters.add(index))
+    if (isStreaming && end === messages.length) active = true
   }
 
-  let keptRouter = false
-  const projected = messages.filter((message, index) => {
-    if (!message.isRouterStrip || index <= latestUserIndex) return true
-    if (!keptRouter) {
-      keptRouter = true
-      return true
-    }
-    return false
-  })
-  return { messages: projected, active: true }
+  // Treat each visible user row as the start of one interaction. Project every
+  // completed history interaction as well as the live tail so a later user turn
+  // cannot make a previously suppressed resumed-parent router reappear.
+  for (let index = 1; index < messages.length; index += 1) {
+    if (messages[index]?.displayRole !== 'user') continue
+    projectInteraction(interactionStart, index)
+    interactionStart = index
+  }
+  projectInteraction(interactionStart, messages.length)
+
+  if (!suppressedRouters.size) {
+    return { messages: messages as ChatRenderedMessage[], active }
+  }
+  return {
+    messages: messages.filter((_, index) => !suppressedRouters.has(index)),
+    active,
+  }
 }
 
 export function hasRouterAfterLatestUser(messages: readonly ChatRenderedMessage[]): boolean {

--- a/opensquilla-webui/src/utils/chat/sessionCreationRouterPresentation.ts
+++ b/opensquilla-webui/src/utils/chat/sessionCreationRouterPresentation.ts
@@ -1,0 +1,88 @@
+import type { ChatRenderedMessage } from '@/types/chat'
+import { createdSessionFromToolCall } from '@/utils/chat/createdSessions'
+
+export interface SessionCreationRouterPresentation {
+  messages: ChatRenderedMessage[]
+  active: boolean
+}
+
+function createsSession(message: ChatRenderedMessage): boolean {
+  return (message.toolCalls ?? []).some(call => createdSessionFromToolCall(call) !== null)
+}
+
+/**
+ * During a sessions_spawn handoff, the durable router strip for the creation
+ * call can settle just before the created-chat card while the resumed parent
+ * call starts a second live router surface below it. Treat both engine turns as
+ * one visible interaction: once the card exists, keep the first parent router
+ * above the card and suppress every later router in that user interaction.
+ *
+ * This is deliberately a display-only projection. Rehomed cards, other user
+ * turns, and the underlying router records remain unchanged. Once the
+ * interaction settles, the same first-router rule remains stable across refresh.
+ */
+export function projectSessionCreationRouterPresentation(
+  messages: readonly ChatRenderedMessage[],
+  isStreaming: boolean,
+): SessionCreationRouterPresentation {
+  let latestUserIndex = -1
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index]?.displayRole === 'user') {
+      latestUserIndex = index
+      break
+    }
+  }
+
+  let cardIndex = -1
+  let hasCreationSource = false
+  for (let index = messages.length - 1; index > latestUserIndex; index -= 1) {
+    const message = messages[index]!
+    if (cardIndex < 0 && (message.createdSessionLinks?.length ?? 0) > 0) cardIndex = index
+    if (createsSession(message)) hasCreationSource = true
+  }
+  // Rehoming intentionally separates these signals: the source assistant keeps
+  // the successful sessions_spawn tool while the final parent reply owns the
+  // visible card. Requiring both signals prevents unrelated cards or malformed
+  // tool results from collapsing ordinary route history.
+  if (cardIndex < 0 || !hasCreationSource) {
+    return { messages: messages as ChatRenderedMessage[], active: false }
+  }
+
+  if (!isStreaming) {
+    const routerIndices = messages.flatMap((message, index) => (
+      message.isRouterStrip && index > latestUserIndex ? [index] : []
+    ))
+    if (routerIndices.length <= 1) {
+      return { messages: messages as ChatRenderedMessage[], active: false }
+    }
+    const firstRouterIndex = routerIndices[0]
+    return {
+      messages: messages.filter((message, index) => !(
+        message.isRouterStrip
+        && index > latestUserIndex
+        && index !== firstRouterIndex
+      )),
+      active: false,
+    }
+  }
+
+  let keptRouter = false
+  const projected = messages.filter((message, index) => {
+    if (!message.isRouterStrip || index <= latestUserIndex) return true
+    if (!keptRouter) {
+      keptRouter = true
+      return true
+    }
+    return false
+  })
+  return { messages: projected, active: true }
+}
+
+export function hasRouterAfterLatestUser(messages: readonly ChatRenderedMessage[]): boolean {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]!
+    if (message.isRouterStrip) return true
+    if (message.displayRole === 'user') return false
+  }
+  return false
+}

--- a/opensquilla-webui/src/views/ChatView.fork-transition.test.ts
+++ b/opensquilla-webui/src/views/ChatView.fork-transition.test.ts
@@ -31,7 +31,7 @@ describe('chat fork hand-off contract', () => {
   })
 
   it('keeps a read-only parent projection visible until child history is ready', () => {
-    expect(chatViewSource).toContain(':messages="forkTransition?.previewMessages || renderedMessages"')
+    expect(chatViewSource).toContain(':messages="forkTransition?.previewMessages || visibleRenderedMessages"')
     expect(chatViewSource).toContain(':session-key="forkTransition?.parentKey || sessionKey"')
     expect(chatViewSource).toContain(':inert="forkTransition ? true : undefined"')
     expect(chatViewSource).toContain('Render-only snapshot; never becomes the child session\'s canonical messages.')

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -183,7 +183,7 @@
           :data-preview-session="forkTransition?.parentKey"
         >
         <ChatMessageList
-          :messages="forkTransition?.previewMessages || renderedMessages"
+          :messages="forkTransition?.previewMessages || visibleRenderedMessages"
           :session-key="forkTransition?.parentKey || sessionKey"
           :auth-token="readAuthToken()"
           :artifact-navigation-items="sessionArtifacts"
@@ -218,6 +218,7 @@
           @toggle-tool-group="toggleToolGroup"
           @toggle-tool-item="toggleToolItem"
           @show-tool-result="showToolResultModal"
+          @open-session="switchToSession"
           @resolve-interrupt="resolveInterrupt"
           @extend-interrupt="extendInterrupt"
           @clarify-submit="submitClarify"
@@ -953,6 +954,10 @@ import {
   shouldCaptureFilePaste,
 } from '@/utils/chat/attachments'
 import { isShareableChatMessage } from '@/utils/chat/messageIdentity'
+import {
+  hasRouterAfterLatestUser,
+  projectSessionCreationRouterPresentation,
+} from '@/utils/chat/sessionCreationRouterPresentation'
 import { agentIdFromSessionKey } from '@/utils/chat/sessionKeys'
 import { shouldDisableLandingSuggestions } from '@/utils/chat/landingSuggestions'
 import { handoffPlanQuestionnaireWheel } from '@/utils/chat/planQuestionnaireWheel'
@@ -1758,6 +1763,10 @@ const chatRenderedMessages = useChatRenderedMessages({
   timeTranslator: t,
 })
 const { renderedMessages, routerDecisionCells } = chatRenderedMessages
+const sessionCreationRouterPresentation = computed(() => (
+  projectSessionCreationRouterPresentation(renderedMessages.value, isStreaming.value)
+))
+const visibleRenderedMessages = computed(() => sessionCreationRouterPresentation.value.messages)
 
 function shouldRenderRouterStrip(_message: ChatRenderedMessage): boolean {
   // Always surface the router strip — the live ensemble strip is the primary
@@ -1772,16 +1781,12 @@ function shouldRenderRouterStrip(_message: ChatRenderedMessage): boolean {
  */
 const routerStripReserve = computed<ChatRenderedMessage | null>(() => {
   if (!isStreaming.value || !routerEnabled.value || !routerVisualEffectsEnabled.value) return null
-  const rendered = renderedMessages.value
-  const liveTurnKey = [...rendered]
-    .reverse()
-    .find(message => message.displayRole === 'user')
-    ?.turnKey
-  for (let i = rendered.length - 1; i >= 0; i--) {
-    const msg = rendered[i]
-    if (msg.isRouterStrip && (!liveTurnKey || msg.turnKey === liveTurnKey)) return null
-    if (msg.displayRole === 'user' && msg.turnKey !== liveTurnKey) break
-  }
+  const rendered = visibleRenderedMessages.value
+  // A subagent handoff can resume the same visible user interaction under a
+  // different engine turn id. Any router already visible after that user owns
+  // the single route slot; comparing turnKey here would append a duplicate
+  // reserve below it during the handoff/reconnect window.
+  if (hasRouterAfterLatestUser(rendered)) return null
   if (modelRoutingMode.value === 'llm_ensemble') {
     return {
       id: 'router-strip-reserve',


### PR DESCRIPTION
## Scope

Scope boundary: Render successful `sessions_spawn` results as localized, openable child-chat cards; keep completion control rows and raw tool JSON out of the parent conversation; place completed cards below the parent final reply; preserve a single parent router strip above the handoff; show the inherited fixed model route inside child sessions.

Non-goals: Backend/RPC/schema changes, session lifecycle changes, unrelated sub-agent presentation, card folding, or other chat UI fixes.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: User-reported UI defect without a public GitHub issue.

## Release Note

Release note: Successful child-chat creation now renders an openable card instead of raw JSON, with stable parent and child routing presentation.

## Tests

Ruff: N/A (Web UI-only change)

Pytest: N/A (Web UI-only change)

Build: `vue-tsc --noEmit`; all Web UI architecture/security/theme/i18n checks; production Vite build and artifact verification.

Regression tests: added

Notes: Focused Vitest: 4 files / 62 tests. Full Vitest: 319 files / 3,539 tests. Playwright: 2 scenarios covering ordered multi-card history restoration, refresh, navigation, inherited child route, interaction-scoped router deduplication, and the single parent router during a live handoff. The browser spec is included in the Web UI recovery CI selection. The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: browser

Maintainer-only note: Deterministic mocked WebSocket browser coverage is included; no provider secret is required.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and `tests/_private/` contents are not committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No documentation files changed.
- [x] Examples and fixtures contain no real secrets, local private paths, or private transcripts.

## Root Cause

The renderer treated `sessions_spawn` like an ordinary tool result, so its structured result and the subsequent `subagent_completion` control row leaked into the visible parent transcript. Parent resumption could also project a second router surface for the same user interaction, while inherited child-session model usage with `routing_source: none` had no display route.

## User Impact

Parents now show concise “Chat created” cards after the final reply, each card opens the correct child session, multiple cards retain tool-call order, refresh/reconnect restores the same presentation, and only one parent route remains visible. Child sessions display their actual inherited model selection.
