### PR TITLE
fix(recovery): surface the underlying OS error in state-database diagnostics

### DIFF
--- a/src/opensquilla/recovery/engine.py
+++ b/src/opensquilla/recovery/engine.py
@@ -588,6 +588,14 @@ class _DatabaseSourceChangedError(Exception):
     """The source bundle did not remain stable during offline inspection."""
 
 
+def _os_error_detail(path: Path, exc: OSError) -> str:
+    reason = exc.strerror or str(exc)
+    winerror = getattr(exc, "winerror", None)
+    if winerror is not None:
+        return f"{path.name}: {reason} (errno {exc.errno}, winerror {winerror})"
+    return f"{path.name}: {reason} (errno {exc.errno})"
+
+
 def _regular_source_stat(path: Path) -> os.stat_result | None:
     try:
         value = os.lstat(_native_io_path(path))
@@ -595,7 +603,7 @@ def _regular_source_stat(path: Path) -> os.stat_result | None:
         return None
     except OSError as exc:
         raise RecoveryError(
-            "runtime database bundle cannot be inspected",
+            f"runtime database bundle cannot be inspected: {_os_error_detail(path, exc)}",
             stable_code="state_database_unreadable",
         ) from exc
     if (
@@ -643,7 +651,8 @@ def _copy_source_file_no_follow(source: Path, destination: Path) -> _DatabaseSou
         raise _DatabaseSourceChangedError from exc
     except OSError as exc:
         raise RecoveryError(
-            "runtime database bundle cannot be opened without following links",
+            "runtime database bundle cannot be opened without following links: "
+            f"{_os_error_detail(source, exc)}",
             stable_code="state_database_unreadable",
         ) from exc
     try:
@@ -734,18 +743,18 @@ def _bundle_names(path: Path) -> tuple[Path, ...]:
     return (path, path.with_name(f"{path.name}-wal"), path.with_name(f"{path.name}-journal"))
 
 
-def _database_safety_code(path: Path) -> str | None:
+def _database_safety_code(path: Path) -> tuple[str, str | None] | None:
     """Validate a stable private SQLite snapshot without opening the source."""
 
     bundle = _bundle_names(path)
     try:
         present_before = tuple(_regular_source_stat(entry) is not None for entry in bundle)
     except RecoveryError as exc:
-        return exc.stable_code
+        return exc.stable_code, str(exc)
     if not present_before[0]:
         # A durable sidecar without its database is ambiguous and must never be
         # treated as a fresh state root.
-        return "state_database_unsafe_path" if any(present_before[1:]) else None
+        return ("state_database_unsafe_path", None) if any(present_before[1:]) else None
 
     snapshots: list[_DatabaseSourceSnapshot] = []
     try:
@@ -771,7 +780,8 @@ def _database_safety_code(path: Path) -> str | None:
                 try:
                     check = connection.execute("PRAGMA quick_check").fetchone()
                     if not check or str(check[0]).lower() != "ok":
-                        return "state_database_invalid"
+                        finding = str(check[0]) if check else "no quick_check result"
+                        return "state_database_invalid", f"{path.name}: {finding}"
                     tables = connection.execute(
                         "SELECT name FROM sqlite_master WHERE type='table' "
                         "AND name LIKE '%yoyo_migration'"
@@ -793,37 +803,37 @@ def _database_safety_code(path: Path) -> str | None:
                         ).fetchall()
                 finally:
                     connection.close()
-            except sqlite3.Error:
-                return "state_database_invalid"
+            except sqlite3.Error as exc:
+                return "state_database_invalid", f"{path.name}: {exc}"
             try:
                 present_after = tuple(_regular_source_stat(entry) is not None for entry in bundle)
             except RecoveryError as exc:
-                return exc.stable_code
+                return exc.stable_code, str(exc)
             if present_after != present_before or not all(
                 _source_snapshot_is_current(snapshot) for snapshot in snapshots
             ):
                 raise _DatabaseSourceChangedError
     except _DatabaseSourceChangedError:
-        return "state_database_changed"
+        return "state_database_changed", None
     except RecoveryError as exc:
-        return exc.stable_code
+        return exc.stable_code, str(exc)
 
     applied = {str(migration_id) for (migration_id,) in rows if migration_id}
     if not applied:
         return None
     known = _known_migration_ids()
     if not known:
-        return "state_migration_set_unavailable"
+        return "state_migration_set_unavailable", None
     if applied - known:
-        return "state_schema_too_new"
+        return "state_schema_too_new", None
     return None
 
 
-def _state_safety_code(state_dir: Path) -> str | None:
+def _state_safety_code(state_dir: Path) -> tuple[str, str | None] | None:
     try:
         state_before = PathIdentity.from_stat(_native_stat(state_dir))
-    except OSError:
-        return "effective_state_unreadable"
+    except OSError as exc:
+        return "effective_state_unreadable", _os_error_detail(state_dir, exc)
     for database_name in ("sessions.db", "scheduler.db"):
         code = _database_safety_code(state_dir / database_name)
         if code is not None:
@@ -831,9 +841,9 @@ def _state_safety_code(state_dir: Path) -> str | None:
     try:
         state_after = PathIdentity.from_stat(_native_stat(state_dir))
     except OSError:
-        return "state_database_changed"
+        return "state_database_changed", None
     if state_before.metadata_tuple() != state_after.metadata_tuple():
-        return "state_database_changed"
+        return "state_database_changed", None
     return None
 
 
@@ -2130,14 +2140,16 @@ def inspect_profile(
         )
     state_code = _state_safety_code(state_candidate.path)
     if state_code is not None:
+        code, state_detail = state_code
         return _report(
             home=home_path,
             config=config,
             candidates=candidates,
             outcome="attention",
-            stable_code=state_code,
+            stable_code=code,
             effective_workspace=effective,
             allowed_actions=_RECOVERY_ACTIONS,
+            detail=state_detail,
         )
 
     effective_candidate = next(

--- a/tests/test_recovery/test_engine.py
+++ b/tests/test_recovery/test_engine.py
@@ -848,6 +848,38 @@ def test_unsafe_session_database_blocks_before_gateway_migrations(
 
     assert report.outcome == "attention"
     assert report.stable_code == stable_code
+    if stable_code == "state_database_invalid":
+        assert report.detail is not None
+        assert "sessions.db" in report.detail
+
+
+def test_locked_session_database_reports_unreadable_with_os_detail(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "opensquilla"
+    _workspace(home / "workspace")
+    _desktop_config(home)
+    database = home / "state" / "sessions.db"
+    with sqlite3.connect(database) as connection:
+        connection.execute("CREATE TABLE user_data (id INTEGER PRIMARY KEY)")
+
+    real_open = os.open
+
+    def _denied_open(path: object, flags: int, *args: object, **kwargs: object) -> int:
+        if str(path).endswith("sessions.db"):
+            raise PermissionError(13, "Permission denied", str(path))
+        return real_open(path, flags, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(os, "open", _denied_open)
+
+    report = inspect_profile(home, profile_kind="desktop-primary")
+
+    assert report.outcome == "attention"
+    assert report.stable_code == "state_database_unreadable"
+    assert report.detail is not None
+    assert "sessions.db" in report.detail
+    assert "errno 13" in report.detail
 
 
 def test_wal_database_without_shm_is_validated_from_private_read_only_source_snapshot(


### PR DESCRIPTION
## What

`state_database_unreadable` / `state_database_invalid` recovery reports previously showed a bare stable code: the underlying `OSError` from `lstat`/`open` (and the `PRAGMA quick_check` finding) was dropped when `_database_safety_code` / `_state_safety_code` returned only the code string, so neither the boot screen nor "copy diagnostics" carried any cause. Support (and users) could not tell a sharing violation from a permission denial from actual corruption — three situations with completely different fixes.

Fixes #1159.

## How

- `_regular_source_stat` / `_copy_source_file_no_follow`: include the failing file *name* plus `strerror`, `errno` (and `winerror` on Windows) in the raised `RecoveryError` message via a new `_os_error_detail` helper.
- `_database_safety_code` / `_state_safety_code`: return `(stable_code, detail)` so the cause survives the exception boundary; `state_database_invalid` now carries the `quick_check` finding or `sqlite3.Error` text.
- The `inspect_profile` report site passes `detail` through to `_report(...)`, which applies the existing `<HOME>` sanitization. `RecoveryReport.detail` is an existing additive schema-1 field and the desktop boot screen already renders it (`boot.html` `recoveryDetail`) — no protocol or UI change needed.

Example rendered detail for the motivating case:

```
runtime database bundle cannot be opened without following links: sessions.db: Permission denied (errno 13, winerror 5)
```

## Tests

- New: `test_locked_session_database_reports_unreadable_with_os_detail` — denies `os.open` on `sessions.db` and asserts the report carries `state_database_unreadable` with file name + errno in `detail`.
- Extended: the corrupt-database parametrization now asserts `detail` names the failing file.
- `tests/test_recovery/test_engine.py`: 72 passed, 2 skipped (Windows). The 3 pre-existing failures in `test_session_merge.py` reproduce identically on clean `main` (43dea9b) and are unrelated.

Only file names (sessions.db / scheduler.db) are added to diagnostics; full paths remain redacted by the existing sanitizer.