### PR TITLE
feat(audio): add Atlas Cloud TTS and music provider

### DIFF
--- a/docs/artifacts-and-media.md
+++ b/docs/artifacts-and-media.md
@@ -143,6 +143,27 @@ dependencies, and runtime policy.
 The media tool family includes image, PDF, and TTS helpers. Availability can
 depend on provider config, optional dependencies, and runtime policy.
 
+Atlas Cloud can back the `tts`, `music_generate`, and `song_generate` tools:
+
+```toml
+[audio]
+enabled = true
+provider = "atlascloud"
+
+[audio.providers.atlascloud]
+api_key_env = "ATLASCLOUD_API_KEY"
+tts_model = "elevenlabs/v3/text-to-speech"
+tts_voice = "hpp4J3VqNfWAUOO0d1Us"
+music_model = "minimax/music-2.6"
+```
+
+The Atlas adapter submits asynchronous audio predictions, polls them to a
+terminal state, and downloads generated audio without forwarding the API key
+to the media host. The Atlas music model does not expose exact duration
+control, so `duration_seconds` is not sent for Atlas requests. ElevenLabs
+remains the provider for transcription, voice search, voice cloning,
+conversion, and dubbing.
+
 Use media helpers when the requested output is naturally a file or asset rather
 than a plain text answer.
 

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -1569,10 +1569,21 @@ class AudioElevenLabsProviderConfig(BaseModel):
     music_output_format: str = "mp3_44100_128"
 
 
+class AudioAtlasCloudProviderConfig(BaseModel):
+    base_url: str = "https://api.atlascloud.ai"
+    api_key: str = ""
+    api_key_env: str = "ATLASCLOUD_API_KEY"
+    tts_model: str = "elevenlabs/v3/text-to-speech"
+    tts_voice: str = "hpp4J3VqNfWAUOO0d1Us"
+    music_model: str = "minimax/music-2.6"
+    music_output_format: str = "mp3_44100_256"
+
+
 class AudioProvidersConfig(BaseModel):
     elevenlabs: AudioElevenLabsProviderConfig = Field(
         default_factory=AudioElevenLabsProviderConfig
     )
+    atlascloud: AudioAtlasCloudProviderConfig = Field(default_factory=AudioAtlasCloudProviderConfig)
 
 
 class AudioTTSConfig(BaseModel):
@@ -1595,6 +1606,7 @@ class AudioConfig(BaseSettings):
     )
 
     enabled: bool = False
+    provider: Literal["elevenlabs", "atlascloud"] = "elevenlabs"
     tts: AudioTTSConfig = Field(default_factory=AudioTTSConfig)
     providers: AudioProvidersConfig = Field(default_factory=AudioProvidersConfig)
 
@@ -2932,14 +2944,19 @@ class GatewayConfig(BaseSettings):
         # operator explicitly entered the key (recorded by
         # ``clear_runtime_secret``) — an explicit entry must persist even
         # when it coincides with the env value.
-        if "audio.providers.elevenlabs.api_key" not in self._explicit_secret_paths:
-            _delete_env_sourced_secret(
-                data,
-                "audio.providers.elevenlabs.api_key",
-                "audio.providers.elevenlabs.api_key_env",
-                default_env="ELEVENLABS_API_KEY",
-                settings_env="OPENSQUILLA_AUDIO_PROVIDERS__ELEVENLABS__API_KEY",
-            )
+        for provider_id, default_env in (
+            ("elevenlabs", "ELEVENLABS_API_KEY"),
+            ("atlascloud", "ATLASCLOUD_API_KEY"),
+        ):
+            secret_path = f"audio.providers.{provider_id}.api_key"
+            if secret_path not in self._explicit_secret_paths:
+                _delete_env_sourced_secret(
+                    data,
+                    secret_path,
+                    f"audio.providers.{provider_id}.api_key_env",
+                    default_env=default_env,
+                    settings_env=(f"OPENSQUILLA_AUDIO_PROVIDERS__{provider_id.upper()}__API_KEY"),
+                )
         router = data.get("squilla_router")
         if isinstance(router, dict) and router.get("tier_profile"):
             profile = str(router["tier_profile"]).strip().lower()

--- a/src/opensquilla/onboarding/audio_specs.py
+++ b/src/opensquilla/onboarding/audio_specs.py
@@ -47,6 +47,37 @@ _AUDIO_PROVIDER_DATA: dict[str, dict[str, Any]] = {
         "default_tts_model": "eleven_multilingual_v2",
         "default_tts_voice": "21m00Tcm4TlvDq8ikWAM",
         "default_language_code": "",
+        "readme_scenarios": (
+            "text-to-speech",
+            "speech-to-text",
+            "voice cloning",
+            "voice conversion",
+            "dubbing",
+            "music and singing",
+        ),
+        "what_you_need": (
+            "API key via ELEVENLABS_API_KEY or a one-time paste.",
+            "A default TTS voice id for generated speech.",
+            "Optional language code to guide accent and pronunciation.",
+        ),
+    },
+    "atlascloud": {
+        "label": "Atlas Cloud Audio",
+        "env_key": "ATLASCLOUD_API_KEY",
+        "default_base_url": "https://api.atlascloud.ai",
+        "default_tts_model": "elevenlabs/v3/text-to-speech",
+        "default_tts_voice": "hpp4J3VqNfWAUOO0d1Us",
+        "default_language_code": "",
+        "readme_scenarios": (
+            "text-to-speech",
+            "instrumental music",
+            "music and singing",
+        ),
+        "what_you_need": (
+            "API key via ATLASCLOUD_API_KEY or a one-time paste.",
+            "An Atlas Cloud TTS voice id for generated speech.",
+            "Optional language code to guide pronunciation.",
+        ),
     },
 }
 
@@ -127,19 +158,8 @@ def list_audio_provider_setup_specs() -> list[AudioProviderSetupSpec]:
             deployment="cloud",
             blocking=False,
             can_probe=False,
-            readme_scenarios=(
-                "text-to-speech",
-                "speech-to-text",
-                "voice cloning",
-                "voice conversion",
-                "dubbing",
-                "music and singing",
-            ),
-            what_you_need=(
-                f"API key via {data['env_key']} or a one-time paste.",
-                "A default TTS voice id for generated speech.",
-                "Optional language code to guide accent and pronunciation.",
-            ),
+            readme_scenarios=tuple(data["readme_scenarios"]),
+            what_you_need=tuple(data["what_you_need"]),
             fields=_fields_for(data),
         )
         for provider_id, data in _AUDIO_PROVIDER_DATA.items()

--- a/src/opensquilla/onboarding/mutations.py
+++ b/src/opensquilla/onboarding/mutations.py
@@ -1880,7 +1880,7 @@ def upsert_audio_provider(
         raise ValueError(
             f"audio provider {provider_id!r} is not runtime-supported and cannot be configured"
         )
-    if provider_id != "elevenlabs":
+    if provider_id not in {"elevenlabs", "atlascloud"}:
         raise ValueError(f"audio provider {provider_id!r} is not supported")
 
     current_provider_cfg = _audio_provider_config(config, provider_id)
@@ -1937,12 +1937,20 @@ def upsert_audio_provider(
             f"audio provider {provider_id!r} requires an api_key or {spec.env_key}"
         )
 
-    effective_tts_voice = tts_voice or config.audio.tts.voice or spec.default_tts_voice
-    effective_tts_model = tts_model or config.audio.tts.model or spec.default_tts_model
-    effective_language_code = language_code or config.audio.tts.language_code
+    same_provider = config.audio.provider == provider_id
+    effective_tts_voice = (
+        tts_voice or (config.audio.tts.voice if same_provider else "") or spec.default_tts_voice
+    )
+    effective_tts_model = (
+        tts_model or (config.audio.tts.model if same_provider else "") or spec.default_tts_model
+    )
+    effective_language_code = language_code or (
+        config.audio.tts.language_code if same_provider else spec.default_language_code
+    )
 
     new_cfg = _clone(config)
     new_cfg.audio.enabled = bool(enabled)
+    new_cfg.audio.provider = cast(Literal["elevenlabs", "atlascloud"], provider_id)
     # Preserve an explicit legacy-client disabled decision even though false
     # equals the schema default and sparse persistence would otherwise omit it.
     new_cfg.mark_force_persist("audio.enabled")
@@ -1950,6 +1958,10 @@ def upsert_audio_provider(
     next_provider_cfg.api_key = effective_api_key
     next_provider_cfg.api_key_env = env_key
     next_provider_cfg.base_url = effective_base_url
+    if hasattr(next_provider_cfg, "tts_voice"):
+        next_provider_cfg.tts_voice = effective_tts_voice
+    if hasattr(next_provider_cfg, "tts_model"):
+        next_provider_cfg.tts_model = effective_tts_model
     if explicit_env_key == spec.env_key and not base_url_allows_credential_reuse(
         spec.default_base_url,
         effective_base_url,

--- a/src/opensquilla/provider/audio.py
+++ b/src/opensquilla/provider/audio.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 from dataclasses import dataclass, field
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
@@ -15,6 +17,16 @@ from opensquilla.secrets import clean_header_secret
 
 _ELEVENLABS_DEFAULT_API_KEY_ENV = "ELEVENLABS_API_KEY"
 _ELEVENLABS_DEFAULT_BASE_URL = "https://api.elevenlabs.io"
+_ATLASCLOUD_DEFAULT_API_KEY_ENV = "ATLASCLOUD_API_KEY"
+_ATLASCLOUD_DEFAULT_BASE_URL = "https://api.atlascloud.ai"
+_ATLASCLOUD_AUDIO_OUTPUT_HOSTS = frozenset(
+    {
+        "api.atlascloud.ai",
+        "atlas-media.oss-us-west-1.aliyuncs.com",
+        "static.atlascloud.ai",
+    }
+)
+_ATLASCLOUD_MAX_AUDIO_BYTES = 64 * 1024 * 1024
 
 
 def resolve_elevenlabs_api_key_env(provider_config: object | None) -> str:
@@ -38,11 +50,31 @@ def resolve_elevenlabs_api_key_env(provider_config: object | None) -> str:
     )
 
 
+def resolve_atlascloud_api_key_env(provider_config: object | None) -> str:
+    """Resolve Atlas credentials without moving the default across origins."""
+
+    fields_set = getattr(provider_config, "model_fields_set", None)
+    return credential_env_for_endpoint(
+        configured_env=str(
+            getattr(provider_config, "api_key_env", _ATLASCLOUD_DEFAULT_API_KEY_ENV) or ""
+        ),
+        configured_explicitly=(isinstance(fields_set, set) and "api_key_env" in fields_set),
+        default_env=_ATLASCLOUD_DEFAULT_API_KEY_ENV,
+        default_base_url=_ATLASCLOUD_DEFAULT_BASE_URL,
+        effective_base_url=str(
+            getattr(provider_config, "base_url", _ATLASCLOUD_DEFAULT_BASE_URL)
+            or _ATLASCLOUD_DEFAULT_BASE_URL
+        ),
+    )
+
+
 def _normalize_base_url(base_url: str) -> str:
     return base_url.rstrip("/")
 
 
 def _api_url(base_url: str, path: str) -> str:
+    if base_url.endswith("/api/v1") and path.startswith("/api/v1/"):
+        return f"{base_url}{path[7:]}"
     if base_url.endswith("/v1") and path.startswith("/v1/"):
         return f"{base_url}{path[3:]}"
     return f"{base_url}{path}"
@@ -70,6 +102,16 @@ def _audio_mime_type(content_type: str | None, response_format: str) -> str:
         return _FORMAT_MIME_TYPES[normalized_format]
     prefix = normalized_format.split("_", 1)[0]
     return _FORMAT_MIME_TYPES.get(prefix, "application/octet-stream")
+
+
+def _response_format_for_mime(mime_type: str, fallback: str) -> str:
+    return {
+        "audio/flac": "flac",
+        "audio/mpeg": "mp3",
+        "audio/opus": "opus",
+        "audio/wav": "wav",
+        "audio/x-wav": "wav",
+    }.get(mime_type, fallback)
 
 
 def _response_error_body(response: httpx.Response) -> str:
@@ -301,6 +343,204 @@ class ElevenLabsSharedVoicesResult:
     raw: dict[str, Any] = field(default_factory=dict)
 
 
+def _atlas_prediction_data(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise RuntimeError("Atlas Cloud audio provider returned an invalid payload")
+    data = payload.get("data")
+    if isinstance(data, dict):
+        return data
+    return payload
+
+
+def _atlas_output_format_parts(output_format: str) -> tuple[str, int, int]:
+    parts = output_format.lower().split("_")
+    audio_format = parts[0] if parts[0] in {"mp3", "wav", "pcm"} else "mp3"
+    sample_rate = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else 44100
+    bitrate_kbps = int(parts[2]) if len(parts) > 2 and parts[2].isdigit() else 256
+    if sample_rate not in {16000, 24000, 32000, 44100}:
+        sample_rate = 44100
+    if bitrate_kbps not in {32, 64, 128, 256}:
+        bitrate_kbps = 256
+    return audio_format, sample_rate, bitrate_kbps * 1000
+
+
+class AtlasCloudAudioProductionProvider:
+    """Atlas Cloud asynchronous audio generation adapter."""
+
+    provider_id = "atlascloud"
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_key_env: str = _ATLASCLOUD_DEFAULT_API_KEY_ENV,
+        base_url: str = _ATLASCLOUD_DEFAULT_BASE_URL,
+        poll_interval_seconds: float = 1.0,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._api_key_env = api_key_env
+        self._base_url = _normalize_base_url(base_url)
+        self._poll_interval_seconds = max(float(poll_interval_seconds), 0.0)
+        self._transport = transport
+
+    def _resolve_api_key(self) -> str:
+        return clean_header_secret(
+            self._api_key or os.environ.get(self._api_key_env, ""),
+            label="Atlas Cloud API key",
+        )
+
+    def _headers(self, api_key: str) -> dict[str, str]:
+        return {"Authorization": f"Bearer {api_key}"}
+
+    def _api_url(self, path: str) -> str:
+        return _api_url(self._base_url, path)
+
+    @staticmethod
+    def _validated_output_url(raw_url: Any) -> str:
+        if not isinstance(raw_url, str) or not raw_url.strip():
+            raise RuntimeError("Atlas Cloud audio provider returned no output URL")
+        parsed = urlparse(raw_url.strip())
+        if parsed.scheme != "https" or parsed.hostname not in _ATLASCLOUD_AUDIO_OUTPUT_HOSTS:
+            raise RuntimeError("Atlas Cloud audio provider returned an unsafe output URL")
+        if parsed.username or parsed.password:
+            raise RuntimeError("Atlas Cloud audio provider returned an unsafe output URL")
+        return raw_url.strip()
+
+    async def _generate(
+        self,
+        *,
+        payload: dict[str, Any],
+        timeout_seconds: float,
+    ) -> tuple[bytes, str, str | None]:
+        api_key = self._resolve_api_key()
+        if not api_key:
+            raise RuntimeError(f"{self._api_key_env} is not set")
+
+        deadline = asyncio.get_running_loop().time() + max(timeout_seconds, 0.1)
+        async with httpx.AsyncClient(
+            timeout=timeout_seconds,
+            trust_env=_trust_env(),
+            transport=self._transport,
+        ) as client:
+            response = await client.post(
+                self._api_url("/api/v1/model/generateAudio"),
+                headers=self._headers(api_key),
+                json=payload,
+            )
+            _raise_provider_http_error(response, "Atlas Cloud audio generation")
+            try:
+                prediction = _atlas_prediction_data(response.json())
+            except ValueError as exc:
+                raise RuntimeError("Atlas Cloud audio provider returned invalid JSON") from exc
+
+            generation_id = prediction.get("id")
+            status = str(prediction.get("status") or "").lower()
+            while status not in {"completed", "failed", "timeout"}:
+                if not isinstance(generation_id, str) or not generation_id.strip():
+                    raise RuntimeError("Atlas Cloud audio provider returned no prediction id")
+                if asyncio.get_running_loop().time() >= deadline:
+                    raise RuntimeError("Atlas Cloud audio generation timed out")
+                await asyncio.sleep(self._poll_interval_seconds)
+                response = await client.get(
+                    self._api_url(f"/api/v1/model/prediction/{generation_id.strip()}"),
+                    headers=self._headers(api_key),
+                )
+                _raise_provider_http_error(response, "Atlas Cloud audio prediction")
+                try:
+                    prediction = _atlas_prediction_data(response.json())
+                except ValueError as exc:
+                    raise RuntimeError(
+                        "Atlas Cloud audio provider returned invalid prediction JSON"
+                    ) from exc
+                status = str(prediction.get("status") or "").lower()
+
+            if status != "completed":
+                note = prediction.get("error") or prediction.get("message") or status
+                raise RuntimeError(f"Atlas Cloud audio generation failed: {note}")
+            outputs = prediction.get("outputs")
+            output_url = self._validated_output_url(
+                outputs[0] if isinstance(outputs, list) and outputs else None
+            )
+
+        async with httpx.AsyncClient(
+            timeout=timeout_seconds,
+            trust_env=_trust_env(),
+            transport=self._transport,
+            follow_redirects=False,
+        ) as download_client:
+            response = await download_client.get(output_url)
+            _raise_provider_http_error(response, "Atlas Cloud audio download")
+            declared_size = response.headers.get("Content-Length")
+            if declared_size:
+                try:
+                    if int(declared_size) > _ATLASCLOUD_MAX_AUDIO_BYTES:
+                        raise RuntimeError("Atlas Cloud audio output exceeds the 64 MiB limit")
+                except ValueError:
+                    pass
+            audio_bytes = response.content
+            if not audio_bytes:
+                raise RuntimeError("Atlas Cloud audio provider returned empty audio")
+            if len(audio_bytes) > _ATLASCLOUD_MAX_AUDIO_BYTES:
+                raise RuntimeError("Atlas Cloud audio output exceeds the 64 MiB limit")
+            mime_type = _audio_mime_type(response.headers.get("Content-Type"), "mp3")
+        return audio_bytes, mime_type, generation_id if isinstance(generation_id, str) else None
+
+    async def text_to_speech(
+        self, request: ElevenLabsTextToSpeechRequest
+    ) -> AudioGenerationResult:
+        payload: dict[str, Any] = {
+            "model": request.model_id,
+            "text": request.text,
+            "voice": request.voice,
+        }
+        if request.language_code:
+            payload["language_code"] = request.language_code.split("-", 1)[0]
+        stability = (request.voice_settings or {}).get("stability")
+        if isinstance(stability, (int, float)):
+            payload["stability"] = float(stability)
+        audio_bytes, mime_type, generation_id = await self._generate(
+            payload=payload,
+            timeout_seconds=request.timeout_seconds,
+        )
+        return AudioGenerationResult(
+            audio_bytes=audio_bytes,
+            provider=self.provider_id,
+            model=request.model_id,
+            voice=request.voice,
+            response_format=_response_format_for_mime(mime_type, request.output_format),
+            mime_type=mime_type,
+            generation_id=generation_id,
+        )
+
+    async def generate_music(
+        self, request: MusicGenerationRequest
+    ) -> MusicGenerationResult:
+        audio_format, sample_rate, bitrate = _atlas_output_format_parts(request.output_format)
+        payload: dict[str, Any] = {
+            "model": request.model_id,
+            "prompt": request.prompt,
+            "is_instrumental": bool(request.force_instrumental),
+            "format": audio_format,
+            "sample_rate": sample_rate,
+            "bitrate": bitrate,
+        }
+        if request.lyrics:
+            payload["lyrics"] = request.lyrics
+        audio_bytes, mime_type, generation_id = await self._generate(
+            payload=payload,
+            timeout_seconds=request.timeout_seconds,
+        )
+        return MusicGenerationResult(
+            audio_bytes=audio_bytes,
+            provider=self.provider_id,
+            model=request.model_id,
+            response_format=request.output_format,
+            mime_type=mime_type,
+            generation_id=generation_id,
+        )
+
+
 class ElevenLabsAudioProductionProvider:
     provider_id = "elevenlabs"
 
@@ -329,9 +569,7 @@ class ElevenLabsAudioProductionProvider:
     def _headers(self, api_key: str) -> dict[str, str]:
         return {"xi-api-key": api_key}
 
-    async def text_to_speech(
-        self, request: ElevenLabsTextToSpeechRequest
-    ) -> AudioGenerationResult:
+    async def text_to_speech(self, request: ElevenLabsTextToSpeechRequest) -> AudioGenerationResult:
         api_key = self._resolve_api_key()
         if not api_key:
             raise RuntimeError(f"{self._api_key_env} is not set")
@@ -623,9 +861,7 @@ class ElevenLabsAudioProductionProvider:
             mime_type=_audio_mime_type(response.headers.get("Content-Type"), "mp3"),
         )
 
-    async def generate_music(
-        self, request: MusicGenerationRequest
-    ) -> MusicGenerationResult:
+    async def generate_music(self, request: MusicGenerationRequest) -> MusicGenerationResult:
         api_key = self._resolve_api_key()
         if not api_key:
             raise RuntimeError(f"{self._api_key_env} is not set")

--- a/src/opensquilla/tools/builtin/admin.py
+++ b/src/opensquilla/tools/builtin/admin.py
@@ -757,7 +757,7 @@ async def gateway(
     params={
         "provider": {
             "type": "string",
-            "description": "Audio provider id (currently supported: elevenlabs)",
+            "description": "Audio provider id (supported: elevenlabs, atlascloud)",
         },
         "api_key": {
             "type": "string",

--- a/src/opensquilla/tools/builtin/media.py
+++ b/src/opensquilla/tools/builtin/media.py
@@ -27,6 +27,7 @@ from opensquilla.engine.usage_accounting import (
 )
 from opensquilla.env import trust_env as _trust_env
 from opensquilla.provider.audio import (
+    AtlasCloudAudioProductionProvider,
     AudioGenerationResult,
     DubbingDownloadRequest,
     DubbingRequest,
@@ -41,6 +42,7 @@ from opensquilla.provider.audio import (
     VoiceCloneRequest,
     VoiceConversionRequest,
     VoiceConversionResult,
+    resolve_atlascloud_api_key_env,
     resolve_elevenlabs_api_key_env,
 )
 from opensquilla.provider.auxiliary_budget import (
@@ -1125,24 +1127,33 @@ def _resolve_audio_config() -> Any:
     return AudioConfig()
 
 
-def _audio_provider_config(config: Any) -> Any:
+def _audio_provider_id(config: Any) -> str:
+    return str(getattr(config, "provider", "elevenlabs") or "elevenlabs")
+
+
+def _audio_provider_config(config: Any, provider_id: str | None = None) -> Any:
     providers = getattr(config, "providers", None)
-    return getattr(providers, "elevenlabs", None)
+    return getattr(providers, provider_id or _audio_provider_id(config), None)
 
 
-def _audio_configured(config: Any) -> bool:
+def _audio_configured(config: Any, provider_id: str | None = None) -> bool:
     if not getattr(config, "enabled", False):
         return False
-    provider_config = _audio_provider_config(config)
+    resolved_provider_id = provider_id or _audio_provider_id(config)
+    provider_config = _audio_provider_config(config, resolved_provider_id)
     if provider_config is None:
         return False
     api_key = str(getattr(provider_config, "api_key", "") or "")
-    api_key_env = resolve_elevenlabs_api_key_env(provider_config)
+    api_key_env = (
+        resolve_atlascloud_api_key_env(provider_config)
+        if resolved_provider_id == "atlascloud"
+        else resolve_elevenlabs_api_key_env(provider_config)
+    )
     return bool(api_key or os.environ.get(api_key_env))
 
 
 def _elevenlabs_provider(config: Any) -> ElevenLabsAudioProductionProvider:
-    provider_config = _audio_provider_config(config)
+    provider_config = _audio_provider_config(config, "elevenlabs")
     api_key_env = resolve_elevenlabs_api_key_env(provider_config)
     return ElevenLabsAudioProductionProvider(
         api_key=str(getattr(provider_config, "api_key", "") or "") or None,
@@ -1151,17 +1162,32 @@ def _elevenlabs_provider(config: Any) -> ElevenLabsAudioProductionProvider:
     )
 
 
+def _audio_production_provider(
+    config: Any,
+) -> ElevenLabsAudioProductionProvider | AtlasCloudAudioProductionProvider:
+    if _audio_provider_id(config) != "atlascloud":
+        return _elevenlabs_provider(config)
+    provider_config = _audio_provider_config(config, "atlascloud")
+    api_key_env = resolve_atlascloud_api_key_env(provider_config)
+    return AtlasCloudAudioProductionProvider(
+        api_key=str(getattr(provider_config, "api_key", "") or "") or None,
+        api_key_env=api_key_env,
+        base_url=str(getattr(provider_config, "base_url", "") or "https://api.atlascloud.ai"),
+    )
+
+
 def _audio_not_available_payload(
     *,
     tool_name: str,
     missing_capability: str,
     note: str,
+    provider: str = "elevenlabs",
 ) -> str:
     return json.dumps(
         {
             "status": "not_available",
             "tool": tool_name,
-            "provider": "elevenlabs",
+            "provider": provider,
             "missing_capability": missing_capability,
             "note": note,
         }
@@ -1487,7 +1513,7 @@ async def voice_clone(
             note="Voice cloning requires explicit consent metadata for the target voice.",
         )
     config = _resolve_audio_config()
-    if not _audio_configured(config):
+    if not _audio_configured(config, "elevenlabs"):
         return _audio_not_available_payload(
             tool_name="voice_clone",
             missing_capability="voice_cloning",
@@ -1558,13 +1584,13 @@ async def voice_convert(
             note="Voice conversion requires explicit consent metadata for the source voice.",
         )
     config = _resolve_audio_config()
-    if not _audio_configured(config):
+    if not _audio_configured(config, "elevenlabs"):
         return _audio_not_available_payload(
             tool_name="voice_convert",
             missing_capability="voice_conversion",
             note="ElevenLabs voice-conversion provider is disabled or not configured.",
         )
-    provider_config = _audio_provider_config(config)
+    provider_config = _audio_provider_config(config, "elevenlabs")
     model_id = str(
         getattr(provider_config, "voice_conversion_model", "")
         or "eleven_multilingual_sts_v2"
@@ -1625,7 +1651,7 @@ async def dubbing_generate(
     if not target_language or not target_language.strip():
         raise ToolError("Target language must not be empty")
     config = _resolve_audio_config()
-    if not _audio_configured(config):
+    if not _audio_configured(config, "elevenlabs"):
         return _audio_not_available_payload(
             tool_name="dubbing_generate",
             missing_capability="advanced_dubbing",
@@ -1682,7 +1708,7 @@ async def dubbing_status(dubbing_id: str) -> str:
     if not dubbing_id or not dubbing_id.strip():
         raise ToolError("Dubbing id must not be empty")
     config = _resolve_audio_config()
-    if not _audio_configured(config):
+    if not _audio_configured(config, "elevenlabs"):
         return _audio_not_available_payload(
             tool_name="dubbing_status",
             missing_capability="advanced_dubbing",
@@ -1740,7 +1766,7 @@ async def dubbing_download(
     if not language_code or not language_code.strip():
         raise ToolError("Language code must not be empty")
     config = _resolve_audio_config()
-    if not _audio_configured(config):
+    if not _audio_configured(config, "elevenlabs"):
         return _audio_not_available_payload(
             tool_name="dubbing_download",
             missing_capability="advanced_dubbing",
@@ -1802,7 +1828,7 @@ async def dubbing_download(
 
 @tool(
     name="music_generate",
-    description="Generate instrumental music through ElevenLabs.",
+    description="Generate instrumental music through the configured audio provider.",
     params={
         "prompt": {"type": "string", "description": "Music prompt."},
         "style": {"type": "string", "description": "Optional style hint."},
@@ -1822,17 +1848,19 @@ async def music_generate(
         raise ToolError("Prompt must not be empty")
     config = _resolve_audio_config()
     if not _audio_configured(config):
+        provider_id = _audio_provider_id(config)
         return _audio_not_available_payload(
             tool_name="music_generate",
             missing_capability="music_generation",
-            note="ElevenLabs music provider is disabled or not configured.",
+            note=f"{provider_id} music provider is disabled or not configured.",
+            provider=provider_id,
         )
     provider_config = _audio_provider_config(config)
     final_prompt = prompt.strip()
     if style and style.strip():
         final_prompt = f"{final_prompt}\nStyle: {style.strip()}"
     try:
-        result = await _elevenlabs_provider(config).generate_music(
+        result = await _audio_production_provider(config).generate_music(
             MusicGenerationRequest(
                 prompt=final_prompt,
                 model_id=str(getattr(provider_config, "music_model", "") or "music_v1"),
@@ -1849,6 +1877,7 @@ async def music_generate(
             tool_name="music_generate",
             missing_capability="music_generation",
             note=str(exc),
+            provider=_audio_provider_id(config),
         )
     return _write_generated_audio_payload(
         result,
@@ -1860,7 +1889,7 @@ async def music_generate(
 
 @tool(
     name="song_generate",
-    description="Generate a song with sung vocals through ElevenLabs music generation.",
+    description="Generate a song with sung vocals through the configured audio provider.",
     params={
         "lyrics": {"type": "string", "description": "Original lyrics to sing."},
         "vocal_style": {"type": "string", "description": "Optional vocal style."},
@@ -1882,10 +1911,12 @@ async def song_generate(
         raise ToolError("Lyrics must not be empty")
     config = _resolve_audio_config()
     if not _audio_configured(config):
+        provider_id = _audio_provider_id(config)
         return _audio_not_available_payload(
             tool_name="song_generate",
             missing_capability="singing_generation",
-            note="ElevenLabs music provider is disabled or not configured.",
+            note=f"{provider_id} music provider is disabled or not configured.",
+            provider=provider_id,
         )
     provider_config = _audio_provider_config(config)
     prompt_parts = ["Generate a complete song with sung vocals."]
@@ -1893,7 +1924,7 @@ async def song_generate(
         prompt_parts.append(f"Vocal style: {vocal_style.strip()}")
     if backing_style and backing_style.strip():
         prompt_parts.append(f"Backing style: {backing_style.strip()}")
-    provider = _elevenlabs_provider(config)
+    provider = _audio_production_provider(config)
     lyrics_text = lyrics.strip()
     model_id = str(getattr(provider_config, "music_model", "") or "music_v1")
     output_format = str(
@@ -1930,6 +1961,7 @@ async def song_generate(
                     tool_name="song_generate",
                     missing_capability="singing_generation",
                     note=str(retry_exc),
+                    provider=_audio_provider_id(config),
                 )
             return _write_generated_audio_payload(
                 result,
@@ -1949,6 +1981,7 @@ async def song_generate(
             tool_name="song_generate",
             missing_capability="singing_generation",
             note=str(exc),
+            provider=_audio_provider_id(config),
         )
     return _write_generated_audio_payload(
         result,
@@ -1960,7 +1993,7 @@ async def song_generate(
 
 @tool(
     name="audio_provider_capabilities",
-    description="Report configured ElevenLabs audio provider capabilities.",
+    description="Report configured audio provider capabilities.",
     params={
         "probe_live": {
             "type": "boolean",
@@ -1972,7 +2005,27 @@ async def song_generate(
 )
 async def audio_provider_capabilities(probe_live: bool = False) -> str:
     config = _resolve_audio_config()
+    provider_id = _audio_provider_id(config)
     configured = _audio_configured(config)
+    if provider_id == "atlascloud":
+        status = "available" if configured else "unavailable"
+        return json.dumps(
+            {
+                "status": "ok",
+                "provider": provider_id,
+                "configured": configured,
+                "capabilities": {
+                    "text_to_speech": {"status": status},
+                    "music_generation": {"status": status},
+                    "singing_generation": {"status": status},
+                    "voice_search": {"status": "unavailable"},
+                    "voice_conversion": {"status": "unavailable"},
+                    "advanced_dubbing": {"status": "unavailable"},
+                    "dubbing_download": {"status": "unavailable"},
+                    "voice_cloning": {"status": "unavailable"},
+                },
+            }
+        )
     payload: dict[str, Any] = {
         "status": "ok",
         "provider": "elevenlabs",
@@ -2060,7 +2113,7 @@ async def voice_search(
     page_size: int = 10,
 ) -> str:
     config = _resolve_audio_config()
-    if not _audio_configured(config):
+    if not _audio_configured(config, "elevenlabs"):
         return _audio_not_available_payload(
             tool_name="voice_search",
             missing_capability="voice_search",
@@ -2180,14 +2233,26 @@ async def tts(
 
     config = _resolve_audio_config()
     if not _audio_configured(config):
+        provider_id = _audio_provider_id(config)
         return _audio_not_available_payload(
             tool_name="tts",
             missing_capability="text_to_speech",
-            note="ElevenLabs audio provider is disabled or not configured.",
+            note=f"{provider_id} audio provider is disabled or not configured.",
+            provider=provider_id,
         )
     tts_config = getattr(config, "tts", None)
-    model_id = str(getattr(tts_config, "model", "") or "eleven_multilingual_v2")
-    resolved_voice = str(voice or getattr(tts_config, "voice", "") or "").strip()
+    provider_config = _audio_provider_config(config)
+    default_model = str(getattr(provider_config, "tts_model", "") or "eleven_multilingual_v2")
+    default_voice = str(getattr(provider_config, "tts_voice", "") or "")
+    model_id = str(getattr(tts_config, "model", "") or default_model)
+    if _audio_provider_id(config) == "atlascloud":
+        model_id = default_model
+    resolved_voice = str(
+        voice
+        or (default_voice if _audio_provider_id(config) == "atlascloud" else "")
+        or getattr(tts_config, "voice", "")
+        or ""
+    ).strip()
     if not resolved_voice:
         raise ToolError("Voice must not be empty")
     resolved_language_code = str(
@@ -2203,7 +2268,7 @@ async def tts(
     )
     output_format = str(getattr(tts_config, "output_format", "") or "mp3_44100_128")
     timeout_seconds = float(getattr(tts_config, "timeout_seconds", 120.0) or 120.0)
-    provider = _elevenlabs_provider(config)
+    provider = _audio_production_provider(config)
     try:
         result = await provider.text_to_speech(
             ElevenLabsTextToSpeechRequest(
@@ -2221,6 +2286,7 @@ async def tts(
             tool_name="tts",
             missing_capability="text_to_speech",
             note=str(exc),
+            provider=_audio_provider_id(config),
         )
     return _write_generated_audio_payload(
         result,

--- a/tests/test_gateway/test_config_audio.py
+++ b/tests/test_gateway/test_config_audio.py
@@ -7,6 +7,7 @@ def test_audio_config_defaults_are_disabled_and_elevenlabs_ready() -> None:
     cfg = GatewayConfig()
 
     assert cfg.audio.enabled is False
+    assert cfg.audio.provider == "elevenlabs"
     assert cfg.audio.tts.model == "eleven_multilingual_v2"
     assert cfg.audio.tts.voice == "21m00Tcm4TlvDq8ikWAM"
     assert cfg.audio.tts.output_format == "mp3_44100_128"
@@ -17,6 +18,10 @@ def test_audio_config_defaults_are_disabled_and_elevenlabs_ready() -> None:
     )
     assert cfg.audio.providers.elevenlabs.music_model == "music_v1"
     assert cfg.audio.providers.elevenlabs.music_output_format == "mp3_44100_128"
+    assert cfg.audio.providers.atlascloud.base_url == "https://api.atlascloud.ai"
+    assert cfg.audio.providers.atlascloud.api_key_env == "ATLASCLOUD_API_KEY"
+    assert cfg.audio.providers.atlascloud.tts_model == "elevenlabs/v3/text-to-speech"
+    assert cfg.audio.providers.atlascloud.music_model == "minimax/music-2.6"
 
 
 def test_audio_config_accepts_nested_elevenlabs_overrides() -> None:
@@ -62,3 +67,16 @@ def test_audio_config_to_toml_dict_omits_env_sourced_elevenlabs_api_key(
     assert cfg.audio.providers.elevenlabs.api_key == "el-env"
     assert "api_key" not in audio["providers"]["elevenlabs"]
     assert audio["providers"]["elevenlabs"]["api_key_env"] == "ELEVENLABS_API_KEY"
+
+
+def test_audio_config_to_toml_dict_omits_env_sourced_atlascloud_api_key(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_AUDIO_PROVIDERS__ATLASCLOUD__API_KEY", "atlas-env")
+
+    cfg = GatewayConfig()
+    audio = cfg.to_toml_dict()["audio"]
+
+    assert cfg.audio.providers.atlascloud.api_key == "atlas-env"
+    assert "api_key" not in audio["providers"]["atlascloud"]
+    assert audio["providers"]["atlascloud"]["api_key_env"] == "ATLASCLOUD_API_KEY"

--- a/tests/test_gateway/test_rpc_onboarding.py
+++ b/tests/test_gateway/test_rpc_onboarding.py
@@ -75,7 +75,7 @@ async def test_onboarding_catalog_returns_providers_and_channels(tmp_path, monke
     image_provider_ids = {p["providerId"] for p in payload["imageGenerationProviders"]}
     assert {"openai", "openrouter"} <= image_provider_ids
     audio_provider_ids = {p["providerId"] for p in payload["audioProviders"]}
-    assert {"elevenlabs"} <= audio_provider_ids
+    assert {"elevenlabs", "atlascloud"} <= audio_provider_ids
     assert all("whatYouNeed" in p for p in payload["audioProviders"])
     memory_provider_ids = {p["providerId"] for p in payload["memoryEmbeddingProviders"]}
     assert {

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -3023,6 +3023,21 @@ def test_audio_explicit_enabled_decision_is_force_persisted(tmp_path):
     assert data["audio"]["enabled"] is False
 
 
+def test_upsert_atlascloud_audio_selects_provider_defaults() -> None:
+    res = upsert_audio_provider(
+        GatewayConfig(),
+        provider_id="atlascloud",
+        api_key_env="MY_ATLAS_KEY",
+    )
+
+    assert res.config.audio.enabled is True
+    assert res.config.audio.provider == "atlascloud"
+    assert res.config.audio.providers.atlascloud.api_key_env == "MY_ATLAS_KEY"
+    assert res.config.audio.tts.model == "elevenlabs/v3/text-to-speech"
+    assert res.config.audio.tts.voice == "hpp4J3VqNfWAUOO0d1Us"
+    assert res.public_payload["api_key"] == ""
+
+
 def test_upsert_channel_blank_secret_keeps_stored_value():
     cfg = GatewayConfig()
     res1 = upsert_channel(

--- a/tests/test_provider/test_audio_provider.py
+++ b/tests/test_provider/test_audio_provider.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 
 from opensquilla.provider.audio import (
+    AtlasCloudAudioProductionProvider,
     ElevenLabsAudioProductionProvider,
     ElevenLabsSharedVoicesRequest,
     ElevenLabsSpeechToTextRequest,
@@ -13,6 +14,108 @@ from opensquilla.provider.audio import (
     MusicGenerationRequest,
     VoiceCloneRequest,
 )
+
+
+@pytest.mark.anyio
+async def test_atlascloud_text_to_speech_polls_and_downloads_without_key() -> None:
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/api/v1/model/generateAudio":
+            assert request.headers["Authorization"] == "Bearer atlas-test"
+            assert json.loads(request.content) == {
+                "model": "elevenlabs/v3/text-to-speech",
+                "text": "你好，OpenSquilla",
+                "voice": "IKne3meq5aSn9XLyUdCD",
+                "language_code": "zh",
+                "stability": 0.6,
+            }
+            return httpx.Response(
+                200,
+                json={"code": 200, "data": {"id": "audio_123", "status": "created"}},
+            )
+        if request.url.path == "/api/v1/model/prediction/audio_123":
+            assert request.headers["Authorization"] == "Bearer atlas-test"
+            return httpx.Response(
+                200,
+                json={
+                    "code": 200,
+                    "data": {
+                        "id": "audio_123",
+                        "status": "completed",
+                        "outputs": ["https://static.atlascloud.ai/media/speech.wav"],
+                    },
+                },
+            )
+        assert request.url == "https://static.atlascloud.ai/media/speech.wav"
+        assert "Authorization" not in request.headers
+        return httpx.Response(200, content=b"RIFFspeech", headers={"Content-Type": "audio/wav"})
+
+    provider = AtlasCloudAudioProductionProvider(
+        api_key="atlas-test",
+        poll_interval_seconds=0,
+        transport=httpx.MockTransport(handler),
+    )
+    result = await provider.text_to_speech(
+        ElevenLabsTextToSpeechRequest(
+            text="你好，OpenSquilla",
+            voice="IKne3meq5aSn9XLyUdCD",
+            model_id="elevenlabs/v3/text-to-speech",
+            output_format="wav",
+            language_code="zh-CN",
+            voice_settings={"stability": 0.6, "speed": 1.0},
+        )
+    )
+
+    assert len(requests) == 3
+    assert result.audio_bytes == b"RIFFspeech"
+    assert result.provider == "atlascloud"
+    assert result.generation_id == "audio_123"
+    assert result.mime_type == "audio/wav"
+    assert result.response_format == "wav"
+
+
+@pytest.mark.anyio
+async def test_atlascloud_music_maps_output_format_and_downloads_audio() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v1/model/generateAudio":
+            assert json.loads(request.content) == {
+                "model": "minimax/music-2.6",
+                "prompt": "cinematic product intro",
+                "is_instrumental": True,
+                "format": "mp3",
+                "sample_rate": 44100,
+                "bitrate": 256000,
+            }
+            return httpx.Response(
+                200,
+                json={
+                    "id": "music_123",
+                    "status": "completed",
+                    "outputs": ["https://static.atlascloud.ai/media/music.mp3"],
+                },
+            )
+        assert request.url == "https://static.atlascloud.ai/media/music.mp3"
+        assert "Authorization" not in request.headers
+        return httpx.Response(200, content=b"ID3music", headers={"Content-Type": "audio/mpeg"})
+
+    provider = AtlasCloudAudioProductionProvider(
+        api_key="atlas-test",
+        poll_interval_seconds=0,
+        transport=httpx.MockTransport(handler),
+    )
+    result = await provider.generate_music(
+        MusicGenerationRequest(
+            prompt="cinematic product intro",
+            model_id="minimax/music-2.6",
+            output_format="mp3_44100_256",
+        )
+    )
+
+    assert result.audio_bytes == b"ID3music"
+    assert result.provider == "atlascloud"
+    assert result.generation_id == "music_123"
 
 
 @pytest.mark.anyio

--- a/tests/test_provider_audio_media.py
+++ b/tests/test_provider_audio_media.py
@@ -26,11 +26,69 @@ def _audio_config(*, enabled: bool = True, api_key: str = "el-test") -> AudioCon
     return config
 
 
+def _atlas_audio_config() -> AudioConfig:
+    config = AudioConfig(enabled=True, provider="atlascloud")
+    config.providers.atlascloud.api_key = "atlas-test"
+    config.providers.atlascloud.api_key_env = "ATLASCLOUD_API_KEY"
+    config.tts.model = "elevenlabs/v3/text-to-speech"
+    config.tts.voice = "IKne3meq5aSn9XLyUdCD"
+    return config
+
+
 def _tool_context(tmp_path: Path) -> ToolContext:
     return ToolContext(
         caller_kind=CallerKind.AGENT,
         workspace_dir=str(tmp_path / "workspace"),
     )
+
+
+@pytest.mark.anyio
+async def test_atlascloud_routes_tts_and_music_tools(monkeypatch, tmp_path: Path) -> None:
+    from opensquilla.tools.builtin import media
+
+    captured: dict[str, object] = {}
+
+    class FakeProvider:
+        def __init__(self, **_kwargs):
+            return None
+
+        async def text_to_speech(self, request):
+            captured["tts"] = request
+            return AudioGenerationResult(
+                audio_bytes=b"atlas-speech",
+                provider="atlascloud",
+                model=request.model_id,
+                voice=request.voice,
+                response_format=request.output_format,
+                mime_type="audio/mpeg",
+            )
+
+        async def generate_music(self, request):
+            captured["music"] = request
+            return MusicGenerationResult(
+                audio_bytes=b"atlas-music",
+                provider="atlascloud",
+                model=request.model_id,
+                response_format=request.output_format,
+                mime_type="audio/mpeg",
+            )
+
+    monkeypatch.setattr(media, "AtlasCloudAudioProductionProvider", FakeProvider)
+    media.configure_audio(_atlas_audio_config())
+    token = current_tool_context.set(_tool_context(tmp_path))
+    try:
+        speech = json.loads(await media.tts(text="你好", output_path="speech.mp3"))
+        music = json.loads(
+            await media.music_generate(prompt="cinematic intro", output_path="music.mp3")
+        )
+    finally:
+        current_tool_context.reset(token)
+        media.configure_audio(None)
+
+    assert speech["provider"] == "atlascloud"
+    assert music["provider"] == "atlascloud"
+    assert getattr(captured["tts"], "model_id") == "elevenlabs/v3/text-to-speech"
+    assert getattr(captured["music"], "model_id") == "minimax/music-2.6"
 
 
 def test_audio_default_env_does_not_cross_endpoint_origin(monkeypatch) -> None:


### PR DESCRIPTION
## Scope

Scope boundary: Add Atlas Cloud as a first-class audio provider for the existing `tts`, `music_generate`, and `song_generate` tools, including onboarding, configuration, async prediction polling, safe media downloads, capabilities, documentation, and offline contract tests.

Non-goals: Voice search, voice cloning, voice conversion, dubbing, transcription, WebUI redesign, or changes to the existing ElevenLabs behavior.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: This is a focused provider addition with offline regression coverage; no matching public issue exists.

## Release Note

Release note: Add Atlas Cloud TTS and music generation support.

## Tests

Ruff: `uv run ruff check src tests` (passed)

Pytest: focused audio/config/onboarding coverage: 272 passed. Full suite: 21,794 passed, 249 skipped, 20 failed; representative failures reproduce on an unmodified `origin/main` worktree and are limited to existing local environment issues (isolated pip timeout, stale generated manifest, loopback WebSocket proxy/python-socks, missing macOS libomp, shell profile/seatbelt stderr, and BSD `sed -i` behavior).

Build: target mypy passed; WebUI typecheck and production build passed; wheel build passed.

Regression tests: added

Notes: Real Atlas Cloud smoke checks completed for `elevenlabs/v3/text-to-speech` and `minimax/music-2.6`; both returned valid MP3 data. Downloads use an HTTPS host allowlist and never forward the API key. No credentials or generated media are committed. The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: provider

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
