### PR TITLE
Keep TaskRuntime slots fully utilized

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,28 @@ OpenSquilla reads configuration in this order:
 Use `--config ./opensquilla.toml` when you want to write or inspect a
 project-local config file.
 
+## Task Runtime Concurrency
+
+Fresh installations allow up to eight cross-session turns to run at once:
+
+```toml
+[task_runtime]
+max_concurrency = 8
+max_pending_per_session = 64
+```
+
+Eight is the desktop default because it matches the built-in channel in-flight
+budget and leaves enough capacity for interactive tasks, Goal continuations,
+Cron runs, and subagents without bypassing TaskRuntime's global queue. Turns in
+the same session remain serialized. Provider pressure is still handled by the
+configured credential pool, provider health/fallback policy, and `Retry-After`
+cooldowns; this setting does not manufacture extra credentials or disable
+provider rate limiting.
+
+This is a default change, not a migration. An existing TOML value such as
+`max_concurrency = 4`, or an explicit
+`OPENSQUILLA_TASK_MAX_CONCURRENCY=4`, remains authoritative after upgrade.
+
 ## Secret Handling
 
 Prefer environment-variable references for secrets:

--- a/opensquilla-webui/e2e/ensemble-router-strip.spec.ts
+++ b/opensquilla-webui/e2e/ensemble-router-strip.spec.ts
@@ -182,6 +182,15 @@ async function mockStreamingEnsembleRun(page: Page) {
             stream_seq: 2,
             to_state: 'thinking',
           }))
+          ws.send(wsEvent('session.event.ensemble_progress', {
+            key: STREAM_SESSION_KEY,
+            task_id: 'ensemble-stream-task',
+            stream_seq: 3,
+            event_type: 'proposer_start',
+            proposer_label: 'anchor',
+            proposer_provider: 'openrouter',
+            proposer_model: 'qwen/qwen3.7-plus',
+          }))
           return
         }
         const payloads: Record<string, unknown> = {
@@ -819,8 +828,8 @@ test('live ensemble routing shows the strip alongside flat activity', async ({ p
 
   // The flat activity surface runs its normal execution phase...
   await expect(page.locator('.assistant-activity--live')).toBeVisible({ timeout: 10000 })
-  // ...and the ensemble strip is surfaced independently — here as the pre-decision
-  // reserve, before any member arrives — instead of being hidden behind it.
+  // ...and the ensemble strip is surfaced independently after authoritative
+  // proposer activity arrives, instead of being inferred before Router work.
   await expect(page.locator('.router-fx[data-panel="llm-ensemble"]')).toHaveCount(1)
   // It is live, not settled.
   await expect(page.locator('.router-fx[data-panel="llm-ensemble"][data-settled="true"]')).toHaveCount(0)

--- a/opensquilla-webui/e2e/queued-runtime-phase.spec.ts
+++ b/opensquilla-webui/e2e/queued-runtime-phase.spec.ts
@@ -147,7 +147,7 @@ test('durable queued stays queued until running and an authoritative router deci
 
   lifecycle.markProviderActive()
   await expect(activity.locator('.assistant-activity__live-label')).toHaveText(
-    'Planning next step',
+    'Working',
   )
   await expect(activity).not.toContainText('Waiting for model')
   await expect(page.locator('.router-fx')).toHaveCount(0)

--- a/opensquilla-webui/e2e/queued-runtime-phase.spec.ts
+++ b/opensquilla-webui/e2e/queued-runtime-phase.spec.ts
@@ -1,0 +1,158 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const CONTROL_URL = '/control/'
+const SESSION_KEY = 'agent:main:webchat:e2e-queued-runtime-phase'
+const TASK_ID = 'queued-runtime-phase-task'
+
+function wsResponse(id: string | number | undefined, payload: unknown) {
+  return JSON.stringify({ type: 'res', id, ok: true, payload })
+}
+
+function wsEvent(event: string, payload: unknown) {
+  return JSON.stringify({ type: 'event', event, payload })
+}
+
+async function mockQueuedRouterLifecycle(page: Page) {
+  let sendFrame: ((frame: string) => void) | null = null
+  let streamSeq = 2
+
+  const emit = (event: string, payload: Record<string, unknown> = {}) => {
+    if (!sendFrame) throw new Error('queued lifecycle websocket is not connected')
+    sendFrame(wsEvent(event, {
+      key: SESSION_KEY,
+      session_key: SESSION_KEY,
+      task_id: TASK_ID,
+      stream_seq: streamSeq++,
+      ...payload,
+    }))
+  }
+
+  await page.addInitScript(() => {
+    window.localStorage.setItem('opensquilla-locale', 'en')
+    window.localStorage.setItem('opensquilla.routerVisualEffects', '1')
+  })
+  await page.route('**/api/approvals', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ pending: [] }),
+  }))
+  await page.routeWebSocket(/\/ws$/, ws => {
+    sendFrame = frame => ws.send(frame)
+    ws.send(wsEvent('connect.challenge', {}))
+    ws.onMessage(message => {
+      let frame: Record<string, unknown>
+      try {
+        frame = JSON.parse(String(message)) as Record<string, unknown>
+      } catch {
+        return
+      }
+      if (frame.type !== 'req') return
+      const method = String(frame.method || '')
+      if (method === 'connect') {
+        ws.send(JSON.stringify({ protocol: 3, policy: { tick_interval_ms: 30_000 } }))
+        return
+      }
+      if (method === 'chat.send') {
+        ws.send(wsResponse(frame.id as string | number | undefined, {
+          accepted: true,
+          session: SESSION_KEY,
+          sessionKey: SESSION_KEY,
+          task_id: TASK_ID,
+          stream_seq: 1,
+          user_message_id: 'queued-runtime-phase-user',
+        }))
+        ws.send(wsEvent('task.queued', {
+          key: SESSION_KEY,
+          session_key: SESSION_KEY,
+          task_id: TASK_ID,
+          stream_seq: 1,
+          queue_depth: 2,
+          queue_position: 2,
+        }))
+        return
+      }
+
+      const payloads: Record<string, unknown> = {
+        'agents.list': { agents: [] },
+        'chat.history': { messages: [], has_more: false },
+        'commands.list_for_surface': { commands: [] },
+        'config.get': {
+          squilla_router: {
+            enabled: true,
+            rollout_phase: 'full',
+            tiers: {
+              c0: { model: 'test/router-small' },
+              c1: { model: 'test/router-selected' },
+              c2: { model: 'test/router-large' },
+            },
+          },
+          llm_ensemble: { enabled: false },
+          permissions: {},
+          skills: {},
+        },
+        'onboarding.status': { audioConfigured: false },
+        'sessions.list': { sessions: [], has_more: false },
+        'sessions.messages.subscribe': {
+          subscribed: true,
+          replay_complete: true,
+          current_stream_seq: 0,
+          run_status: 'idle',
+        },
+        'usage.status': { sessions: [] },
+      }
+      ws.send(wsResponse(
+        frame.id as string | number | undefined,
+        payloads[method] ?? {},
+      ))
+    })
+  })
+
+  return {
+    markRunning() {
+      emit('task.running')
+    },
+    markProviderActive() {
+      emit('session.event.state_change', { to_state: 'thinking' })
+    },
+    decideRoute() {
+      emit('session.event.router_decision', {
+        tier: 'c1',
+        model: 'test/router-selected',
+        source: 'squilla_router',
+        routing_applied: true,
+      })
+    },
+  }
+}
+
+test('durable queued stays queued until running and an authoritative router decision', async ({
+  page,
+}) => {
+  const lifecycle = await mockQueuedRouterLifecycle(page)
+  await page.goto(CONTROL_URL + 'chat?session=' + encodeURIComponent(SESSION_KEY))
+  await expect(page.locator('.conn-pill.connected')).toBeVisible({ timeout: 10_000 })
+
+  await page.locator('.chat-textarea').fill('Wait for a real runtime slot.')
+  await page.locator('.chat-send-btn[aria-label="Send"]').click()
+
+  const activity = page.locator('.assistant-activity--live')
+  await expect(activity).toBeVisible({ timeout: 10_000 })
+  await expect(activity.locator('.assistant-activity__live-label')).toHaveText('Queued')
+  await expect(activity).not.toContainText('Waiting for model')
+  await expect(page.locator('.router-fx')).toHaveCount(0)
+
+  lifecycle.markRunning()
+  await expect(activity.locator('.assistant-activity__live-label')).toHaveText('Running')
+  await expect(page.locator('.router-fx')).toHaveCount(0)
+
+  lifecycle.markProviderActive()
+  await expect(activity.locator('.assistant-activity__live-label')).toHaveText(
+    'Planning next step',
+  )
+  await expect(activity).not.toContainText('Waiting for model')
+  await expect(page.locator('.router-fx')).toHaveCount(0)
+
+  lifecycle.decideRoute()
+  await expect(page.locator('.router-fx')).toHaveCount(1)
+  await expect(page.locator('.router-fx')).toContainText('router-selected')
+})

--- a/opensquilla-webui/src/components/chat/ActivityDisclosure.test.ts
+++ b/opensquilla-webui/src/components/chat/ActivityDisclosure.test.ts
@@ -62,6 +62,34 @@ afterEach(() => {
 })
 
 describe('ActivityDisclosure lifecycle transitions', () => {
+  it('renders queued then running as explicit live lifecycle phases', async () => {
+    const state = reactive({ phase: 'Queued' })
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const app = createApp({
+      render: () => h(ActivityDisclosure, {
+        lifecycle: 'working',
+        defaultOpen: true,
+        stepCount: 0,
+        failureCount: 0,
+        phaseLabel: state.phase,
+        elapsedLabel: '0s',
+      }),
+    })
+    mountedApps.push(app)
+    app.use(i18n)
+    app.mount(host)
+    await nextTick()
+
+    const label = host.querySelector('.assistant-activity__live-label')
+    expect(label?.textContent).toBe('Queued')
+    expect(host.textContent).not.toContain('Waiting for model')
+
+    state.phase = 'Running'
+    await nextTick()
+    expect(label?.textContent).toBe('Running')
+  })
+
   it('uses AA text tokens and no text shimmer for the live header', () => {
     const rule = cssRule('.assistant-activity__summary')
     expect(rule).toContain('color: var(--text-muted);')

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
@@ -1221,6 +1221,9 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
       activeStreamTaskId.value = taskId
     }
     options.applySessionRunState({ run_status: 'running', active_task: { ...(payload || {}), status: 'running' } })
+    if (stream.isStreaming.value && !stream.streamHasVisibleOutput.value) {
+      stream.setStreamActivity('Running')
+    }
   }
 
   function handleRpcTaskGroupWaiting(payload: SessionEventPayload) {

--- a/opensquilla-webui/src/composables/chat/useChatStream.render.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatStream.render.test.ts
@@ -83,6 +83,23 @@ describe('useChatStream render coalescing', () => {
     api.cleanup()
   })
 
+  it('keeps a durable queued task in the queue phase without model narration', () => {
+    const { api, runStatus } = makeStream()
+    api.startStreaming()
+    runStatus.value = {
+      status: 'queued',
+      label: 'Queued',
+      task: { task_id: 'queued-task', status: 'queued' },
+    }
+
+    expect(api.streamPhaseLabel.value).toBe('Queued')
+    expect(api.streamPhaseElapsed.value).toBe('')
+    vi.advanceTimersByTime(15_000)
+    expect(api.streamPhaseLabel.value).toBe('Queued')
+    expect(api.streamPhaseLabel.value).not.toContain('model')
+    api.cleanup()
+  })
+
   it('preserves the authoritative active-task steer capability when streaming starts late', () => {
     const { api, runStatus, applySessionRunState } = makeStream()
     runStatus.value = {

--- a/opensquilla-webui/src/composables/chat/useChatStream.ts
+++ b/opensquilla-webui/src/composables/chat/useChatStream.ts
@@ -46,7 +46,7 @@ const THINKING_TTL_MS = 60000
 // than this (longer than any realistic provider tool run) as skew/garbage.
 const SERVER_CLOCK_TOLERANCE_MS = 5000
 const MAX_TRUSTED_TOOL_AGE_MS = 60 * 60 * 1000
-const SQUILLA_VERBS = ['Planning next step', 'Reading context', 'Waiting for model', 'Preparing output']
+const SQUILLA_VERBS = ['Planning next step', 'Reading context', 'Preparing output']
 
 // Internal phase labels stay English (they double as stable keys for dedup,
 // matching, and the appended status-frame action). Localize only at the display
@@ -54,6 +54,7 @@ const SQUILLA_VERBS = ['Planning next step', 'Reading context', 'Waiting for mod
 // back to their English text.
 const STREAM_LABEL_KEYS: Record<string, string> = {
   Sending: 'chat.stream.sending',
+  Running: 'chat.status.running',
   'Planning next step': 'chat.stream.planningNextStep',
   'Reading context': 'chat.stream.readingContext',
   'Waiting for model': 'chat.stream.waitingForModel',
@@ -150,6 +151,12 @@ export function useChatStream(options: UseChatStreamOptions) {
   // the step chip render as separate elements rather than one packed string.
   const streamPhaseLabel = computed(() => {
     streamActivityTick.value
+    // A queued task is durable but has not acquired a TaskRuntime slot. Keep
+    // that boundary authoritative: local animation timers must not relabel it
+    // as model or router work that has not started.
+    if (options.runStatus?.value.status === 'queued') {
+      return i18n.global.t('chat.status.queued')
+    }
     const now = Date.now()
     if (lastSignalAt.value > 0 && now - lastSignalAt.value > STALE_SIGNAL_MS) {
       // Static on purpose: this feeds a polite live region, so a ticking
@@ -157,16 +164,15 @@ export function useChatStream(options: UseChatStreamOptions) {
       // stall. The aria-hidden elapsed chip carries the seconds instead.
       return i18n.global.t('chat.activity.stale')
     }
-    const startedAt = streamActivity.value.startedAt || now
-    const seconds = Math.max(0, Math.floor((now - startedAt) / 1000))
-    return seconds >= 10 && streamActivity.value.label === 'Planning next step'
-      ? i18n.global.t('chat.stream.stillWaiting')
-      : localizeStreamLabel(streamActivity.value.label)
+    return localizeStreamLabel(streamActivity.value.label)
   })
 
   // Elapsed seconds for the current phase, rendered as its own chip.
   const streamPhaseElapsed = computed(() => {
     streamActivityTick.value
+    // task.queued has no authoritative server timestamp. Do not present the
+    // optimistic browser send clock as durable queue wait time.
+    if (options.runStatus?.value.status === 'queued') return ''
     const now = Date.now()
     if (lastSignalAt.value > 0 && now - lastSignalAt.value > STALE_SIGNAL_MS) {
       // During a stall the phase label is static for screen readers, so the

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -2986,7 +2986,15 @@ const liveActivityPhaseLabel = computed(() => {
   if (runStatus.value.status === 'queued' || streamActivityStale.value) {
     return streamPhaseLabel.value
   }
-  if (!streamHasVisibleOutput.value) return streamPhaseLabel.value
+  // Keep the slot-acquired boundary explicit until a real provider/router
+  // signal replaces it. Once that activity exists, use the established
+  // timeline projection (for example Working during a tool turn).
+  if (
+    !streamHasVisibleOutput.value
+    && streamPhaseLabel.value === String(t('chat.status.running'))
+  ) {
+    return streamPhaseLabel.value
+  }
   const currentStatus = [...liveActivityProjection.value.statusSteps]
     .reverse()
     .find(step => step.isCurrent)

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -279,16 +279,6 @@
           @replan="beginPlanRevision"
         />
 
-        <!-- Pre-reveal router phase: shown only before the live activity owns
-             the turn. Once activity is visible, execution status becomes
-             the single primary progress surface. -->
-        <RouterFxStrip
-          v-if="routerStripReserve"
-          class="router-fx-reserve"
-          :message="routerStripReserve"
-          aria-hidden="true"
-        />
-
         <!-- MetaSkill run cards: preflight checkpoint + progress ribbon,
              grouped per run_id above the live activity area. -->
         <template v-for="runId in metaRuns.ribbonOrder.value" :key="`meta-${runId}`">
@@ -958,7 +948,6 @@ import {
 } from '@/utils/chat/attachments'
 import { isShareableChatMessage } from '@/utils/chat/messageIdentity'
 import {
-  hasRouterAfterLatestUser,
   projectSessionCreationRouterPresentation,
 } from '@/utils/chat/sessionCreationRouterPresentation'
 import { agentIdFromSessionKey } from '@/utils/chat/sessionKeys'
@@ -1768,7 +1757,7 @@ const chatRenderedMessages = useChatRenderedMessages({
   isSubagentCompletionMessage,
   timeTranslator: t,
 })
-const { renderedMessages, routerDecisionCells } = chatRenderedMessages
+const { renderedMessages } = chatRenderedMessages
 const sessionCreationRouterPresentation = computed(() => (
   projectSessionCreationRouterPresentation(renderedMessages.value, isStreaming.value)
 ))
@@ -1779,59 +1768,6 @@ function shouldRenderRouterStrip(_message: ChatRenderedMessage): boolean {
   // surface for the synthesizing process and no longer defers to activity.
   return true
 }
-
-/**
- * Pre-decision router-strip placeholder. It holds the strip's slot for the short
- * window before the first router_decision / ensemble_progress lands, so the live
- * ensemble strip appears from the very start of the turn rather than popping in.
- */
-const routerStripReserve = computed<ChatRenderedMessage | null>(() => {
-  if (!isStreaming.value || !routerEnabled.value || !routerVisualEffectsEnabled.value) return null
-  const rendered = visibleRenderedMessages.value
-  // A subagent handoff can resume the same visible user interaction under a
-  // different engine turn id. Any router already visible after that user owns
-  // the single route slot; comparing turnKey here would append a duplicate
-  // reserve below it during the handoff/reconnect window.
-  if (hasRouterAfterLatestUser(rendered)) return null
-  if (modelRoutingMode.value === 'llm_ensemble') {
-    return {
-      id: 'router-strip-reserve',
-      role: 'router',
-      displayRole: 'router',
-      roleLabel: 'Router',
-      text: '',
-      timeStr: '',
-      showHeader: false,
-      isRouterStrip: true,
-      routerState: 'pending',
-      routerSource: 'llm_ensemble',
-      routerStatic: false,
-      routerPanel: 'llm-ensemble',
-      routerMode: 'llm_ensemble',
-      gridCells: [],
-      winnerIdx: -1,
-    }
-  }
-
-  const cells = routerDecisionCells({ tier: '', model: '' })
-  if (cells.length <= 1) return null
-  return {
-    id: 'router-strip-reserve',
-    role: 'router',
-    displayRole: 'router',
-    roleLabel: 'Router',
-    text: '',
-    timeStr: '',
-    showHeader: false,
-    isRouterStrip: true,
-    routerState: 'pending',
-    routerSource: 'none',
-    routerStatic: false,
-    routerPanel: routerVisualMode.value === 'legacy_grid' ? 'legacy-grid' : 'real-candidates',
-    gridCells: cells,
-    winnerIdx: -1,
-  }
-})
 
 const aiGeneratedLabel = computed(() => t('chat.aiGeneratedLabel'))
 
@@ -3047,7 +2983,10 @@ const liveActivityProjection = computed(() =>
   }),
 )
 const liveActivityPhaseLabel = computed(() => {
-  if (streamActivityStale.value) return streamPhaseLabel.value
+  if (runStatus.value.status === 'queued' || streamActivityStale.value) {
+    return streamPhaseLabel.value
+  }
+  if (!streamHasVisibleOutput.value) return streamPhaseLabel.value
   const currentStatus = [...liveActivityProjection.value.statusSteps]
     .reverse()
     .find(step => step.isCurrent)

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -381,8 +381,9 @@ max_skills_prompt_chars = 8000
 
 [task_runtime]
 # Server-side agent turn queue. Same-session tasks are serialized;
-# different sessions can run concurrently up to this limit.
-max_concurrency = 4
+# different sessions can run concurrently up to this limit. Eight matches the
+# desktop channel budget while keeping provider pressure behind one global queue.
+max_concurrency = 8
 # Waiting tasks per session before new follow-up work is rejected.
 max_pending_per_session = 64
 

--- a/src/opensquilla/gateway/channel_dispatch.py
+++ b/src/opensquilla/gateway/channel_dispatch.py
@@ -356,7 +356,7 @@ def _compute_channel_cap(config: Any) -> int:
     """
     task_runtime_cfg = getattr(config, "task_runtime", None) if config is not None else None
     raw_cap: int = getattr(task_runtime_cfg, "channel_inflight_cap", 8)
-    max_concurrency: int = getattr(task_runtime_cfg, "max_concurrency", 4)
+    max_concurrency: int = getattr(task_runtime_cfg, "max_concurrency", 8)
     formula_cap = max(2 * max_concurrency, 1)
     return min(raw_cap, formula_cap)
 

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -316,7 +316,7 @@ class PermissionsConfig(BaseModel):
 class TaskRuntimeConfig(BaseModel):
     """Server-side task-runtime queue settings."""
 
-    max_concurrency: int = Field(default=4, ge=1)
+    max_concurrency: int = Field(default=8, ge=1)
     max_pending_per_session: int = Field(default=64, ge=1)
     # Per-channel-adapter in-flight semaphore (separate from
     # task_runtime._global_sem). Configured here so OPENSQUILLA_CHANNEL_INFLIGHT_CAP

--- a/src/opensquilla/gateway/task_runtime.py
+++ b/src/opensquilla/gateway/task_runtime.py
@@ -926,7 +926,7 @@ class TaskRuntime:
         event_emitter: EventEmitter | None = None,
         terminal_listener: TerminalListener | None = None,
         lifecycle_listener: TaskLifecycleListener | None = None,
-        max_concurrency: int = 4,
+        max_concurrency: int = 8,
         max_pending_per_session: int | None = 64,
         subagent_reserved_slots: int = 0,
         turn_hard_deadline_s: float | None = None,
@@ -1032,9 +1032,11 @@ class TaskRuntime:
         #
         # Design: true round-robin across sessions of the same agent_id.
         # ``_agent_session_rr[agent_id]`` is a deque of session_keys that have
-        # active (pending or running) tasks for that agent.  When a task needs a
-        # slot it must be at the front of its agent's deque; after acquiring the
-        # slot the deque entry rotates to the tail so the next session goes next.
+        # active (pending or running) tasks for that agent. ``_agent_slot_waiters``
+        # narrows that enrollment to sessions whose driver is genuinely waiting
+        # for a global slot; running sessions must never block idle capacity.
+        # After a waiter acquires, the RR deque rotates past that session so the
+        # next waiting session goes next.
         # When a session has no more pending/running tasks it is removed from the
         # deque in ``_mark_terminal``.
         #
@@ -1049,6 +1051,7 @@ class TaskRuntime:
         # Lazily initialised like _slot_cond.
         self._agent_session_rr: dict[str, deque[str]] = {}
         self._agent_active_sessions: dict[str, set[str]] = {}
+        self._agent_slot_waiters: dict[str, set[str]] = {}
         self._agent_in_flight: dict[str, int] = {}
         self._fair_cond: asyncio.Condition | None = None
 
@@ -4765,25 +4768,21 @@ class TaskRuntime:
         return self._fair_cond
 
     async def _acquire_fair_slot(self, task: _RuntimeTask) -> None:
-        """Acquire one global concurrency slot with per-agent_id round-robin enrollment.
+        """Acquire one global slot with round-robin among genuine slot waiters.
 
         A task must satisfy one predicate before it is granted a slot:
 
         1. A slot is available: ``_global_in_flight < _max_concurrency``.
 
-        The per-agent RR deque is rotated on each acquire so that the *next*
-        task to grab a free slot comes from the next session in enrollment
-        order.  Crucially, the deque is NOT used as a blocking gate — it only
-        controls which session goes first when multiple sessions are competing
-        for the same slot.  This means sessions of the same agent with
-        different session_keys can all run concurrently when idle slots exist,
-        preventing head-session blocking.
+        The active-session RR deque supplies stable ordering, but eligibility is
+        filtered through ``_agent_slot_waiters``. Existing running sessions and
+        sessions whose next task is still behind its execution lock therefore
+        cannot become a phantom head that leaves global capacity idle.
 
         When only one slot is left (``_global_in_flight == _max_concurrency - 1``),
-        the session at the front of the agent's RR deque is preferred: other
-        sessions of the same agent yield so the deque head gets the last slot.
-        This preserves starvation-free round-robin ordering without blocking
-        concurrent execution when multiple slots are free.
+        the first *waiting* session in RR order is preferred. Other waiters for
+        the same agent yield so the last slot remains starvation-free without
+        being blocked by a session that is already running.
 
         When a slot is released ``_fair_cond.notify_all()`` wakes all waiters
         so they re-check the predicate.
@@ -4793,29 +4792,46 @@ class TaskRuntime:
         session_key = task.envelope.session_key
 
         async with cond:
-            while True:
-                # Predicate 1: global slot available.
-                if self._global_in_flight >= self._max_concurrency:
-                    await cond.wait()
-                    continue
-                # Tie-break: when exactly one slot remains and this agent has
-                # multiple active sessions, only the deque-head session may
-                # take it.  All other sessions of this agent yield so that RR
-                # ordering is preserved without wasting the slot.
-                idle_slots = self._max_concurrency - self._global_in_flight
-                rr = self._agent_session_rr.get(agent_id)
-                if idle_slots == 1 and rr and len(rr) > 1 and rr[0] != session_key:
-                    await cond.wait()
-                    continue
-                # Predicate satisfied — rotate deque and claim the slot.
-                if rr and rr[0] == session_key:
-                    rr.rotate(-1)
-                self._global_in_flight += 1
-                if task.run_kind == "subagent":
-                    self._subagent_in_flight += 1
-                self._agent_in_flight[agent_id] = self._agent_in_flight.get(agent_id, 0) + 1
-                task.acquired_slot = True
-                break
+            waiters = self._agent_slot_waiters.setdefault(agent_id, set())
+            waiters.add(session_key)
+            try:
+                while True:
+                    # Predicate 1: global slot available.
+                    if self._global_in_flight >= self._max_concurrency:
+                        await cond.wait()
+                        continue
+                    # Tie-break only among sessions that are actually inside
+                    # this global-slot wait. Active/running RR entries are not
+                    # eligible and cannot strand the last idle slot.
+                    idle_slots = self._max_concurrency - self._global_in_flight
+                    rr = self._agent_session_rr.get(agent_id)
+                    fair_session = next(
+                        (candidate for candidate in (rr or ()) if candidate in waiters),
+                        None,
+                    )
+                    if idle_slots == 1 and fair_session != session_key:
+                        await cond.wait()
+                        continue
+                    # Predicate satisfied — rotate past the granted session and
+                    # claim the slot. Rotation works even when non-waiting RR
+                    # entries precede this session.
+                    if rr and session_key in rr:
+                        rr.rotate(-(rr.index(session_key) + 1))
+                    self._global_in_flight += 1
+                    if task.run_kind == "subagent":
+                        self._subagent_in_flight += 1
+                    self._agent_in_flight[agent_id] = (
+                        self._agent_in_flight.get(agent_id, 0) + 1
+                    )
+                    task.acquired_slot = True
+                    break
+            finally:
+                waiters.discard(session_key)
+                if not waiters:
+                    self._agent_slot_waiters.pop(agent_id, None)
+                # Cancellation or a successful grant changes the genuine RR
+                # head. Wake peers even when no global slot count changed.
+                cond.notify_all()
 
         # Update storage and emit running metric outside the condition lock. A
         # collect claim can keep this await open; if cancellation or persistence

--- a/tests/test_gateway/test_channel_concurrent_dispatch.py
+++ b/tests/test_gateway/test_channel_concurrent_dispatch.py
@@ -128,6 +128,13 @@ def test_compute_channel_cap_env_override(monkeypatch: pytest.MonkeyPatch) -> No
     assert _compute_channel_cap(cfg) == 1
 
 
+def test_compute_channel_cap_missing_runtime_value_uses_desktop_default() -> None:
+    config = MagicMock()
+    config.task_runtime = MagicMock(spec=["channel_inflight_cap"])
+    config.task_runtime.channel_inflight_cap = 16
+    assert _compute_channel_cap(config) == 16
+
+
 # ── _ChannelInFlightSet docstring must mention SEPARATE second-layer semaphore
 
 

--- a/tests/test_gateway/test_config_concurrency.py
+++ b/tests/test_gateway/test_config_concurrency.py
@@ -3,9 +3,22 @@ OPENSQUILLA_CHANNEL_INFLIGHT_CAP env overrides.
 """
 from __future__ import annotations
 
+import tomllib
+from pathlib import Path
+
 import pytest
 
 from opensquilla.gateway.config import GatewayConfig
+
+
+def test_fresh_install_task_concurrency_defaults_to_eight() -> None:
+    assert GatewayConfig().task_runtime.max_concurrency == 8
+
+
+def test_generated_config_example_uses_desktop_default_eight() -> None:
+    example = Path(__file__).resolve().parents[2] / "opensquilla.toml.example"
+    payload = tomllib.loads(example.read_text(encoding="utf-8"))
+    assert payload["task_runtime"]["max_concurrency"] == 8
 
 
 def test_task_max_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -18,14 +31,14 @@ def test_task_max_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_invalid_env_fallback(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Non-integer OPENSQUILLA_TASK_MAX_CONCURRENCY falls back to default 4 with a warning."""
+    """Invalid task concurrency falls back to the fresh-install default 8."""
     monkeypatch.setenv("OPENSQUILLA_TASK_MAX_CONCURRENCY", "abc")
     import logging
 
     with caplog.at_level(logging.WARNING):
         config = GatewayConfig()
 
-    assert config.task_runtime.max_concurrency == 4
+    assert config.task_runtime.max_concurrency == 8
     assert any(
         "OPENSQUILLA_TASK_MAX_CONCURRENCY" in record.message
         for record in caplog.records
@@ -67,14 +80,14 @@ def test_channel_inflight_cap_invalid_fallback(
 def test_zero_env_fallback(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """OPENSQUILLA_TASK_MAX_CONCURRENCY=0 falls back to default 4 with a warning."""
+    """OPENSQUILLA_TASK_MAX_CONCURRENCY=0 falls back to default 8 with a warning."""
     monkeypatch.setenv("OPENSQUILLA_TASK_MAX_CONCURRENCY", "0")
     import logging
 
     with caplog.at_level(logging.WARNING):
         config = GatewayConfig()
 
-    assert config.task_runtime.max_concurrency == 4
+    assert config.task_runtime.max_concurrency == 8
     assert any(
         "OPENSQUILLA_TASK_MAX_CONCURRENCY" in record.message
         for record in caplog.records
@@ -85,19 +98,35 @@ def test_zero_env_fallback(
 def test_negative_env_fallback(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """OPENSQUILLA_TASK_MAX_CONCURRENCY=-5 falls back to default 4 with a warning."""
+    """OPENSQUILLA_TASK_MAX_CONCURRENCY=-5 falls back to default 8 with a warning."""
     monkeypatch.setenv("OPENSQUILLA_TASK_MAX_CONCURRENCY", "-5")
     import logging
 
     with caplog.at_level(logging.WARNING):
         config = GatewayConfig()
 
-    assert config.task_runtime.max_concurrency == 4
+    assert config.task_runtime.max_concurrency == 8
     assert any(
         "OPENSQUILLA_TASK_MAX_CONCURRENCY" in record.message
         for record in caplog.records
         if record.levelno >= logging.WARNING
     )
+
+
+def test_explicit_legacy_task_concurrency_is_preserved() -> None:
+    """Existing users who explicitly pinned four slots are not migrated."""
+
+    config = GatewayConfig(task_runtime={"max_concurrency": 4})
+    assert config.task_runtime.max_concurrency == 4
+
+
+def test_explicit_legacy_task_concurrency_env_is_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The legacy four-slot environment override remains authoritative."""
+
+    monkeypatch.setenv("OPENSQUILLA_TASK_MAX_CONCURRENCY", "4")
+    assert GatewayConfig().task_runtime.max_concurrency == 4
 
 
 def test_channel_zero_env_fallback(

--- a/tests/test_gateway/test_fair_queuing.py
+++ b/tests/test_gateway/test_fair_queuing.py
@@ -413,3 +413,97 @@ async def test_no_underutilization() -> None:
     await asyncio.gather(*(runtime.wait(h.task_id, timeout=60.0) for h in handles))
 
     assert peak_in_flight == max_concurrency
+
+
+@pytest.mark.asyncio
+async def test_max_eight_staggered_waiters_preserve_capacity_fairness_and_cancel() -> None:
+    """Ten staggered sessions keep eight slots full around a cancelled waiter."""
+
+    max_concurrency = 8
+    agent_id = "agent-max-eight-stress"
+    release_by_label = {
+        label: asyncio.Event()
+        for label in [*(f"base-{index}" for index in range(max_concurrency)), "W1", "W3"]
+    }
+    started_by_label = {
+        label: asyncio.Event()
+        for label in [*(f"base-{index}" for index in range(max_concurrency)), "W1", "W2", "W3"]
+    }
+    start_order: list[str] = []
+    current_in_flight = 0
+    peak_in_flight = 0
+    counter_lock = asyncio.Lock()
+
+    async def turn_handler(run: Any) -> None:
+        nonlocal current_in_flight, peak_in_flight
+        label = run.message
+        async with counter_lock:
+            current_in_flight += 1
+            peak_in_flight = max(peak_in_flight, current_in_flight)
+            start_order.append(label)
+            started_by_label[label].set()
+        try:
+            await release_by_label[label].wait()
+        finally:
+            async with counter_lock:
+                current_in_flight -= 1
+
+    runtime = TaskRuntime(
+        storage=_make_storage(),
+        turn_handler=turn_handler,
+        max_concurrency=max_concurrency,
+        max_pending_per_session=None,
+    )
+    handles = []
+    try:
+        for index in range(max_concurrency):
+            label = f"base-{index}"
+            env = _make_envelope(agent_id, f"{agent_id}::session-{label}")
+            handles.append(await runtime.enqueue(env, label))
+            await asyncio.wait_for(started_by_label[label].wait(), timeout=1.0)
+
+        assert current_in_flight == max_concurrency
+
+        waiter_handles = {}
+        for label in ("W1", "W2", "W3"):
+            env = _make_envelope(agent_id, f"{agent_id}::session-{label}")
+            handle = await runtime.enqueue(env, label)
+            handles.append(handle)
+            waiter_handles[label] = handle
+
+        waiter_sessions = {
+            label: f"{agent_id}::session-{label}"
+            for label in ("W1", "W2", "W3")
+        }
+        async with asyncio.timeout(1.0):
+            while runtime._agent_slot_waiters.get(agent_id) != set(waiter_sessions.values()):
+                await asyncio.sleep(0)
+        assert not any(started_by_label[label].is_set() for label in ("W1", "W2", "W3"))
+
+        assert await runtime.cancel(task_id=waiter_handles["W2"].task_id) == 1
+        await runtime.wait(waiter_handles["W2"].task_id, timeout=2.0)
+        assert runtime._agent_slot_waiters.get(agent_id) == {
+            waiter_sessions["W1"],
+            waiter_sessions["W3"],
+        }
+
+        release_by_label["base-0"].set()
+        await asyncio.wait_for(started_by_label["W1"].wait(), timeout=1.0)
+        assert not started_by_label["W3"].is_set()
+        assert current_in_flight == max_concurrency
+
+        release_by_label["base-1"].set()
+        await asyncio.wait_for(started_by_label["W3"].wait(), timeout=1.0)
+        assert current_in_flight == max_concurrency
+        assert start_order[-2:] == ["W1", "W3"]
+    finally:
+        for event in release_by_label.values():
+            event.set()
+        await asyncio.gather(
+            *(runtime.wait(handle.task_id, timeout=10.0) for handle in handles),
+            return_exceptions=True,
+        )
+
+    assert peak_in_flight == max_concurrency
+    assert runtime._global_in_flight == 0
+    assert runtime._agent_slot_waiters == {}

--- a/tests/test_gateway/test_fair_queuing.py
+++ b/tests/test_gateway/test_fair_queuing.py
@@ -490,11 +490,11 @@ async def test_max_eight_staggered_waiters_preserve_capacity_fairness_and_cancel
         release_by_label["base-0"].set()
         await asyncio.wait_for(started_by_label["W1"].wait(), timeout=1.0)
         assert not started_by_label["W3"].is_set()
-        assert current_in_flight == max_concurrency
+        assert runtime._global_in_flight == max_concurrency
 
         release_by_label["base-1"].set()
         await asyncio.wait_for(started_by_label["W3"].wait(), timeout=1.0)
-        assert current_in_flight == max_concurrency
+        assert runtime._global_in_flight == max_concurrency
         assert start_order[-2:] == ["W1", "W3"]
     finally:
         for event in release_by_label.values():

--- a/tests/test_gateway/test_no_head_blocking.py
+++ b/tests/test_gateway/test_no_head_blocking.py
@@ -161,7 +161,6 @@ async def test_staggered_fourth_session_fills_last_idle_slot() -> None:
         max_pending_per_session=None,
     )
     handles = []
-    d_started_before_release = False
     try:
         for label in ("A", "B", "C"):
             env = _make_envelope(agent_id, f"{agent_id}::sess-{label}")
@@ -174,9 +173,10 @@ async def test_staggered_fourth_session_fills_last_idle_slot() -> None:
         handles.append(await runtime.enqueue(d_env, "start D later"))
         try:
             await asyncio.wait_for(started["D"].wait(), timeout=0.5)
-            d_started_before_release = True
         except TimeoutError:
-            pass
+            d_started_before_release = False
+        else:
+            d_started_before_release = True
     finally:
         release_handlers.set()
         await asyncio.gather(

--- a/tests/test_gateway/test_no_head_blocking.py
+++ b/tests/test_gateway/test_no_head_blocking.py
@@ -62,6 +62,14 @@ def _make_storage() -> Any:
     return storage
 
 
+def test_task_runtime_constructor_defaults_to_eight_slots() -> None:
+    async def turn_handler(_run: Any) -> None:
+        return None
+
+    runtime = TaskRuntime(storage=_make_storage(), turn_handler=turn_handler)
+    assert runtime._max_concurrency == 8
+
+
 # ---------------------------------------------------------------------------
 # no_head_blocking_with_idle_slots
 # ---------------------------------------------------------------------------
@@ -127,4 +135,55 @@ async def test_no_head_blocking_with_idle_slots() -> None:
     assert last_start <= start_deadline, (
         f"Last session started {last_start:.2f}s after enqueue — head-blocking "
         f"suspected (expected all 4 within {start_deadline}s): {started_at}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_staggered_fourth_session_fills_last_idle_slot() -> None:
+    """A/B/C already running must not leave D parked behind a running RR head."""
+
+    agent_id = "agent-staggered-slot"
+    release_handlers = asyncio.Event()
+    started = {
+        label: asyncio.Event()
+        for label in ("A", "B", "C", "D")
+    }
+
+    async def turn_handler(run: Any) -> None:
+        label = run.session_key.rsplit("-", 1)[-1]
+        started[label].set()
+        await release_handlers.wait()
+
+    runtime = TaskRuntime(
+        storage=_make_storage(),
+        turn_handler=turn_handler,
+        max_concurrency=4,
+        max_pending_per_session=None,
+    )
+    handles = []
+    d_started_before_release = False
+    try:
+        for label in ("A", "B", "C"):
+            env = _make_envelope(agent_id, f"{agent_id}::sess-{label}")
+            handles.append(await runtime.enqueue(env, f"start {label}"))
+            await asyncio.wait_for(started[label].wait(), timeout=1.0)
+
+        assert runtime._global_in_flight == 3
+
+        d_env = _make_envelope(agent_id, f"{agent_id}::sess-D")
+        handles.append(await runtime.enqueue(d_env, "start D later"))
+        try:
+            await asyncio.wait_for(started["D"].wait(), timeout=0.5)
+            d_started_before_release = True
+        except TimeoutError:
+            pass
+    finally:
+        release_handlers.set()
+        await asyncio.gather(
+            *(runtime.wait(handle.task_id, timeout=5.0) for handle in handles),
+            return_exceptions=True,
+        )
+
+    assert d_started_before_release, (
+        "D did not claim the fourth idle slot while A/B/C were already running"
     )


### PR DESCRIPTION
## Scope

- Limit TaskRuntime's last-slot round-robin gate to sessions that are genuinely waiting for a global slot, so running or otherwise ineligible RR entries cannot strand idle capacity.
- Raise the fresh-install `task_runtime.max_concurrency` default from 4 to 8 while preserving explicit TOML and environment overrides, including existing values of 4.
- Present durable queued turns as `Queued`, transition to `Running` only after slot acquisition, and render Router visuals only after authoritative router/provider activity.
- Add staggered-arrival characterization, max-8 fairness/cancellation/capacity stress, config compatibility coverage, component coverage, and synthetic Playwright lifecycle coverage.

Scope boundary: TaskRuntime global-slot admission, its default configuration contract, and the WebUI's queued/running/router lifecycle presentation.

Non-goals: provider-specific concurrency caps, credential-pool changes, forced migration of existing configs, changes to PR #1161, auto-merge, or merge-queue enrollment.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Refs #1161

This independent issue was found during real-client acceptance of #1161. It neither modifies nor depends on that PR.

## Release Note

Release note: FIX — keep TaskRuntime slots fully utilized, use eight slots for fresh desktop installs, and show durable queued work accurately in the WebUI.

## Tests

Ruff: `uv run ruff check src tests`

Mypy: `uv run mypy src/opensquilla --show-error-codes` (931 source files)

Pytest: 364 relevant tests passed across TaskRuntime fairness/capacity, cancellation, reservations, hard deadlines, terminal cleanup, recovery, same-session locking, graceful shutdown, Goal, Cron/router boot, channel dispatch, and subagent gates.

WebUI unit/type/build: `npm run test:unit` (3,576 tests), `npm run typecheck`, and `npm run build` including artifact verification.

Playwright: 3 focused Chromium regressions passed for queued→running→router decision, authoritative ensemble activity, and the existing tool-turn activity lifecycle.

Regression tests: added

Notes: The staggered A/B/C-then-D characterization failed before the scheduler fix because D could not claim the idle fourth slot. Tests use synthetic sessions and offline providers only.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: gateway | browser

Maintainer-only note: no secrets or credentialed checks are needed; the browser regression mocks the WebSocket lifecycle locally.

## Safety

No secrets, local-only artifacts, private prompts/transcripts, real session identifiers, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are included.

The concurrency implementation is platform-neutral asyncio/deque/set logic and does not change filesystem, subprocess, signal, or OS-specific behavior on Linux, macOS, or Windows. Existing explicit concurrency values are preserved. Provider load remains bounded by TaskRuntime's global queue, the configured credential pool, provider health/fallback handling, and Retry-After cooldowns; no additional provider-specific cap was needed or added.

## Third-Party Origin

Third-party origin: none

No third-party code, fixtures, identifiers, or wording were copied or adapted.

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
