### PR TITLE
Fix Plan questionnaire terminal state

### DIFF
--- a/opensquilla-webui/src/components/chat/AssistantMessage.activity-fold.test.ts
+++ b/opensquilla-webui/src/components/chat/AssistantMessage.activity-fold.test.ts
@@ -160,6 +160,34 @@ function planPart(): Extract<ChatPart, { type: 'plan' }> {
   }
 }
 
+function clarifyPart(
+  presentation?: string,
+): Extract<ChatPart, { type: 'interrupt' }> {
+  return {
+    type: 'interrupt',
+    key: presentation ? 'plan-clarify-1' : 'generic-clarify-1',
+    interruptKind: 'clarify',
+    clarify: {
+      intro: 'Confirm the scope.',
+      fields: [{
+        name: 'scope',
+        prompt: 'Which scope?',
+        type: 'enum',
+        required: true,
+        defaultValue: '',
+        choices: ['focused', 'complete'],
+      }],
+      ...(presentation ? { presentation } : {}),
+      requestId: presentation ? 'plan-input-1' : 'generic-input-1',
+      runId: 'plan-run-1',
+      step: 'confirm_scope',
+    },
+    resolution: 'replied',
+    busy: false,
+    error: '',
+  }
+}
+
 function usageMeta(overrides: Partial<ChatMessageMeta> = {}): ChatMessageMeta {
   return {
     model: 'tokenrhythm/kimi-k2.7-code',
@@ -597,6 +625,33 @@ describe('AssistantMessage activity disclosure', () => {
 
     expect(el.querySelector('.plan-card')).not.toBeNull()
     expect(el.querySelector('[data-testid="turn-outcome-completed"]')).toBeNull()
+  })
+
+  it('removes the standalone Plan questionnaire receipt once the Plan card exists', async () => {
+    const el = mountMessage(baseMessage({
+      text: '',
+      timelineItems: [],
+      parts: [clarifyPart('plan_questionnaire_v1'), planPart()],
+      statusHistory: [],
+    }))
+    await nextTick()
+
+    expect(el.querySelector('.plan-card')).not.toBeNull()
+    expect(el.querySelector('.clarify-outcome--plan')).toBeNull()
+  })
+
+  it('does not suppress a generic clarify receipt when a Plan card exists', async () => {
+    const el = mountMessage(baseMessage({
+      text: '',
+      timelineItems: [],
+      parts: [clarifyPart(), planPart()],
+      statusHistory: [],
+    }))
+    await nextTick()
+
+    expect(el.querySelector('.plan-card')).not.toBeNull()
+    expect(el.querySelector('.clarify-outcome')).not.toBeNull()
+    expect(el.querySelector('.clarify-outcome--plan')).toBeNull()
   })
 
   it('keeps intermediate candidate narration inside activity and the final answer outside once', async () => {

--- a/opensquilla-webui/src/components/chat/AssistantMessage.vue
+++ b/opensquilla-webui/src/components/chat/AssistantMessage.vue
@@ -560,9 +560,6 @@ const timelineResolvedInterruptKeys = computed(() => new Set(
     )
     .map(item => item.part.key) ?? [],
 ))
-const standaloneInterruptParts = computed(() =>
-  interruptParts.value.filter(part => !timelineResolvedInterruptKeys.value.has(part.key)),
-)
 const planParts = computed(
   () =>
     props.message.parts?.filter(
@@ -570,6 +567,17 @@ const planParts = computed(
     ) ?? [],
 )
 const hasPlan = computed(() => planParts.value.length > 0)
+const standaloneInterruptParts = computed(() =>
+  interruptParts.value.filter(part => (
+    !timelineResolvedInterruptKeys.value.has(part.key)
+    && !(
+      hasPlan.value
+      && part.interruptKind === 'clarify'
+      && part.clarify?.presentation === 'plan_questionnaire_v1'
+      && part.resolution === 'replied'
+    )
+  )),
+)
 // The persisted activity timeline for this finished turn. Empty (fold hidden)
 // for OFF-mode turns and reloaded threads, which carry no snapshot.
 const statusHistory = computed(() => props.message.statusHistory ?? [])

--- a/opensquilla-webui/src/components/chat/ClarifyCard.source.test.ts
+++ b/opensquilla-webui/src/components/chat/ClarifyCard.source.test.ts
@@ -75,6 +75,9 @@ describe('ClarifyCard submit feedback', () => {
     expect(chatViewStyles).toContain(
       '.chat--plan-questionnaire-open .chat-thread :deep(.clarify-card--plan)',
     )
+    expect(chatViewStyles).toContain(
+      '.chat--plan-questionnaire-open .chat-thread :deep(.clarify-outcome--plan)',
+    )
   })
 
   it('uses restrained Plan-only presentation without changing generic outcome feedback', () => {

--- a/opensquilla-webui/src/composables/chat/useChatApprovals.contracts.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatApprovals.contracts.test.ts
@@ -425,6 +425,63 @@ describe('clarify tool-result recovery', () => {
     }
   })
 
+  it('releases a failed submit when reconnect says that request is no longer pending', async () => {
+    installSnapshot()
+    const runtime = await harness()
+    try {
+      runtime.handlers.get('session.event.tool_result')?.({
+        session_key: 'agent:main:web',
+        tool_use_id: 'request-input-1',
+        name: 'request_user_input',
+        result: planClarifyResult,
+      })
+      runtime.rpcCall.mockRejectedValueOnce(new Error('connection lost after send'))
+      await runtime.approvals.submitClarify({ scope: 'focused' })
+
+      expect(runtime.approvals.pendingClarify.value?.requestId).toBe('input-request-1')
+      expect(runtime.approvals.clarifyError.value).toContain('connection lost after send')
+
+      runtime.approvals.applyUserInputBootstrap({ pendingUserInputs: [] })
+
+      expect(runtime.approvals.pendingClarify.value).toBeNull()
+      expect(runtime.approvals.clarifySubmitted.value).toBe(false)
+      expect(runtime.approvals.clarifyBusy.value).toBe(false)
+      expect(runtime.approvals.clarifyError.value).toBe('')
+      expect(runtime.interruptState.value.get('input-request-1')).toEqual({
+        resolution: 'replied',
+        busy: false,
+        error: '',
+      })
+    } finally {
+      runtime.unsubscribe()
+      runtime.scope.stop()
+    }
+  })
+
+  it('does not settle a failed submit from a partial snapshot without pending-input state', async () => {
+    installSnapshot()
+    const runtime = await harness()
+    try {
+      runtime.handlers.get('session.event.tool_result')?.({
+        session_key: 'agent:main:web',
+        tool_use_id: 'request-input-1',
+        name: 'request_user_input',
+        result: planClarifyResult,
+      })
+      runtime.rpcCall.mockRejectedValueOnce(new Error('gateway unavailable'))
+      await runtime.approvals.submitClarify({ scope: 'focused' })
+
+      runtime.approvals.applyUserInputBootstrap({})
+
+      expect(runtime.approvals.pendingClarify.value?.requestId).toBe('input-request-1')
+      expect(runtime.approvals.clarifyError.value).toContain('gateway unavailable')
+      expect(runtime.interruptState.value.get('input-request-1')?.resolution).toBeNull()
+    } finally {
+      runtime.unsubscribe()
+      runtime.scope.stop()
+    }
+  })
+
   it('settles the matching card when the same tool id returns answered', async () => {
     installSnapshot()
     const runtime = await harness()

--- a/opensquilla-webui/src/composables/chat/useChatApprovals.contracts.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatApprovals.contracts.test.ts
@@ -348,6 +348,13 @@ describe('clarify tool-result recovery', () => {
       }],
     },
   }
+  const planClarifyResult = {
+    ...clarifyResult,
+    clarify_schema: {
+      ...clarifyResult.clarify_schema,
+      presentation: 'plan_questionnaire_v1',
+    },
+  }
 
   it.each([
     ['object result', clarifyResult],
@@ -389,6 +396,9 @@ describe('clarify tool-result recovery', () => {
         request_id: 'input-request-1',
         run_id: 'plan-run-1',
       })
+      expect(runtime.approvals.pendingClarify.value).toBeNull()
+      expect(runtime.approvals.clarifySubmitted.value).toBe(false)
+      expect(runtime.approvals.clarifyBusy.value).toBe(false)
     } finally {
       runtime.unsubscribe()
       runtime.scope.stop()
@@ -444,7 +454,187 @@ describe('clarify tool-result recovery', () => {
         busy: false,
         error: '',
       })
+      expect(runtime.approvals.pendingClarify.value).toBeNull()
+      expect(runtime.approvals.clarifySubmitted.value).toBe(false)
+      expect(runtime.approvals.clarifyBusy.value).toBe(false)
+      expect(runtime.approvals.clarifyError.value).toBe('')
+    } finally {
+      runtime.unsubscribe()
+      runtime.scope.stop()
+    }
+  })
+
+  it('keeps a Plan questionnaire actionable when submission fails', async () => {
+    installSnapshot()
+    const runtime = await harness()
+    try {
+      runtime.handlers.get('session.event.tool_result')?.({
+        session_key: 'agent:main:web',
+        tool_use_id: 'request-input-1',
+        name: 'request_user_input',
+        result: planClarifyResult,
+      })
+      runtime.rpcCall.mockRejectedValueOnce(new Error('gateway unavailable'))
+
+      await runtime.approvals.submitClarify({ scope: 'focused' })
+
+      expect(runtime.approvals.pendingClarify.value).toEqual(expect.objectContaining({
+        requestId: 'input-request-1',
+        presentation: 'plan_questionnaire_v1',
+      }))
+      expect(runtime.approvals.clarifySubmitted.value).toBe(false)
+      expect(runtime.approvals.clarifyBusy.value).toBe(false)
+      expect(runtime.approvals.clarifyError.value).toContain('gateway unavailable')
+      expect(runtime.interruptState.value.get('input-request-1')).toEqual(expect.objectContaining({
+        resolution: null,
+        busy: false,
+      }))
+    } finally {
+      runtime.unsubscribe()
+      runtime.scope.stop()
+    }
+  })
+
+  it('does not let a delayed submit response dismiss a newer questionnaire', async () => {
+    installSnapshot()
+    const runtime = await harness()
+    const submitted = deferred<unknown>()
+    try {
+      const handler = runtime.handlers.get('session.event.tool_result')
+      handler?.({
+        session_key: 'agent:main:web',
+        tool_use_id: 'request-input-1',
+        name: 'request_user_input',
+        result: planClarifyResult,
+      })
+      runtime.rpcCall.mockImplementationOnce(async <T,>() => await submitted.promise as T)
+      const firstSubmit = runtime.approvals.submitClarify({ scope: 'focused' })
+      await vi.waitFor(() => expect(runtime.rpcCall).toHaveBeenCalledWith(
+        'chat.clarify_submit',
+        expect.objectContaining({ request_id: 'input-request-1' }),
+      ))
+
+      handler?.({
+        session_key: 'agent:main:web',
+        tool_use_id: 'request-input-2',
+        name: 'request_user_input',
+        result: {
+          ...planClarifyResult,
+          request_id: 'input-request-2',
+          run_id: 'plan-run-2',
+        },
+      })
+      submitted.resolve({ resolved: true, request_id: 'input-request-1' })
+      await firstSubmit
+
+      expect(runtime.approvals.pendingClarify.value).toEqual(expect.objectContaining({
+        requestId: 'input-request-2',
+        runId: 'plan-run-2',
+      }))
+      expect(runtime.approvals.clarifySubmitted.value).toBe(false)
+      expect(runtime.approvals.clarifyBusy.value).toBe(false)
+      expect(runtime.approvals.clarifyError.value).toBe('')
+    } finally {
+      runtime.unsubscribe()
+      runtime.scope.stop()
+    }
+  })
+
+  it('does not clear a newer request for a non-matching terminal outcome', async () => {
+    installSnapshot()
+    const runtime = await harness()
+    try {
+      const handler = runtime.handlers.get('session.event.tool_result')
+      handler?.({
+        session_key: 'agent:main:web',
+        tool_use_id: 'request-input-2',
+        name: 'request_user_input',
+        result: {
+          ...planClarifyResult,
+          request_id: 'input-request-2',
+          run_id: 'plan-run-2',
+        },
+      })
+      handler?.({
+        session_key: 'agent:main:web',
+        tool_use_id: 'request-input-1',
+        name: 'request_user_input',
+        result: {
+          kind: 'user_input',
+          status: 'answered',
+          paused: false,
+          request_id: 'input-request-1',
+          answers: { scope: 'focused' },
+        },
+      })
+
+      expect(runtime.approvals.pendingClarify.value?.requestId).toBe('input-request-2')
+      expect(runtime.interruptState.value.get('input-request-1')?.resolution).toBe('replied')
+    } finally {
+      runtime.unsubscribe()
+      runtime.scope.stop()
+    }
+  })
+
+  it('does not resurrect a settled request from a late paused-event replay', async () => {
+    installSnapshot()
+    const runtime = await harness()
+    try {
+      const handler = runtime.handlers.get('session.event.tool_result')
+      handler?.({
+        session_key: 'agent:main:web',
+        tool_use_id: 'request-input-1',
+        name: 'request_user_input',
+        result: {
+          kind: 'user_input',
+          status: 'answered',
+          paused: false,
+          request_id: 'input-request-1',
+          answers: { scope: 'focused' },
+        },
+      })
+      const appendCount = runtime.appendInterruptFrame.mock.calls.length
+
+      handler?.({
+        session_key: 'agent:main:web',
+        tool_use_id: 'request-input-1',
+        name: 'request_user_input',
+        result: planClarifyResult,
+      })
+
+      expect(runtime.approvals.pendingClarify.value).toBeNull()
+      expect(runtime.appendInterruptFrame).toHaveBeenCalledTimes(appendCount)
+      expect(runtime.interruptState.value.get('input-request-1')?.resolution).toBe('replied')
+    } finally {
+      runtime.unsubscribe()
+      runtime.scope.stop()
+    }
+  })
+
+  it('retains the legacy cross-turn clarify receipt after a successful send acknowledgement', async () => {
+    installSnapshot()
+    const runtime = await harness()
+    try {
+      runtime.handlers.get('session.event.tool_result')?.({
+        session_key: 'agent:main:web',
+        tool_use_id: 'legacy-clarify',
+        name: 'request_user_input',
+        result: {
+          ...clarifyResult,
+          request_id: undefined,
+        },
+      })
+
+      await runtime.approvals.submitClarify({ scope: 'focused' })
+
+      expect(runtime.rpcCall).toHaveBeenLastCalledWith('chat.clarify_submit', {
+        sessionKey: 'agent:main:web',
+        fields: { scope: 'focused' },
+        run_id: 'plan-run-1',
+      })
+      expect(runtime.approvals.pendingClarify.value?.requestId).toBeUndefined()
       expect(runtime.approvals.clarifySubmitted.value).toBe(true)
+      expect(runtime.approvals.clarifyBusy.value).toBe(false)
     } finally {
       runtime.unsubscribe()
       runtime.scope.stop()

--- a/opensquilla-webui/src/composables/chat/useChatApprovals.ts
+++ b/opensquilla-webui/src/composables/chat/useChatApprovals.ts
@@ -504,6 +504,11 @@ export function useChatApprovals(options: UseChatApprovalsOptions) {
   const clarifySubmitted = ref(false)
   const clarifyBusy = ref(false)
   const clarifyError = ref('')
+  // A request-scoped submit can cross the Gateway boundary even when its RPC
+  // acknowledgement is lost. Keep that uncertainty until either the submit
+  // response/tool outcome settles it or an authoritative reconnect snapshot
+  // confirms that the request is no longer pending.
+  const clarifySubmitAttempts = new Set<string>()
 
   // Resolution view-state for inline interrupt parts is the shared `interruptState`
   // ref (keyed by approval id, or the clarify composite key). The fold reads it to
@@ -863,6 +868,7 @@ export function useChatApprovals(options: UseChatApprovalsOptions) {
     if (!isCurrentSessionPayload(payload, sessionKey.value)) return
     const outcome = userInputOutcomeFromValue(payload.result)
     if (outcome) {
+      clarifySubmitAttempts.delete(outcome.requestId)
       setInterruptState(outcome.requestId, {
         resolution: 'replied',
         busy: false,
@@ -999,12 +1005,14 @@ export function useChatApprovals(options: UseChatApprovalsOptions) {
       clarifySubmitted.value = true
       clarifyError.value = ''
     }
+    if (request.requestId) clarifySubmitAttempts.add(key)
     setInterruptState(key, { resolution: 'replied', busy: true, error: '' })
     const params: Record<string, unknown> = { sessionKey: sessionKey.value, fields }
     if (request.requestId) params.request_id = request.requestId
     if (request.runId) params.run_id = request.runId
     try {
       await rpc.call('chat.clarify_submit', params)
+      clarifySubmitAttempts.delete(key)
       setInterruptState(key, { resolution: 'replied', busy: false })
       // request_id submissions resolve the exact paused tool call in the same
       // turn. A successful RPC is therefore authoritative and can release the
@@ -1013,11 +1021,21 @@ export function useChatApprovals(options: UseChatApprovalsOptions) {
       if (request.requestId) clearPendingClarify(key)
     } catch (err) {
       const message = 'Send failed — ' + (err instanceof Error ? err.message : String(err))
-      if (pendingClarifyMatches(key)) {
+      const stillPending = pendingClarifyMatches(key)
+      // A terminal tool result or authoritative empty snapshot can win the
+      // race with a rejected/lost RPC acknowledgement. Never reopen that
+      // already-settled request from the late rejection.
+      const terminalConfirmed = !stillPending
+        && interruptState.value.get(key)?.resolution === 'replied'
+      if (stillPending) {
         clarifySubmitted.value = false
         clarifyError.value = message
       }
-      setInterruptState(key, { resolution: null, busy: false, error: message })
+      if (terminalConfirmed) {
+        clarifySubmitAttempts.delete(key)
+      } else {
+        setInterruptState(key, { resolution: null, busy: false, error: message })
+      }
     } finally {
       if (pendingClarifyMatches(key)) clarifyBusy.value = false
     }
@@ -1032,13 +1050,35 @@ export function useChatApprovals(options: UseChatApprovalsOptions) {
     pendingUserInputs?: unknown[]
     pending_user_inputs?: unknown[]
   }) {
+    const hasAuthoritativePendingList = Object.prototype.hasOwnProperty.call(
+      snapshot,
+      'pendingUserInputs',
+    ) || Object.prototype.hasOwnProperty.call(snapshot, 'pending_user_inputs')
+    if (!hasAuthoritativePendingList) return
+
     const pending = snapshot.pendingUserInputs || snapshot.pending_user_inputs || []
-    for (const value of pending) {
-      const request = clarifyRequestFromValue(value)
-      if (!request) continue
-      pendingClarify.value = request
-      resetClarifyPresentation()
+    const requests = pending
+      .map(value => clarifyRequestFromValue(value))
+      .filter((request): request is ChatClarifyRequest => request != null)
+    const pendingKeys = new Set(requests.map(request => clarifyFrameKey(request)))
+    const current = pendingClarify.value
+    if (current?.requestId) {
+      const currentKey = clarifyFrameKey(current)
+      if (clarifySubmitAttempts.has(currentKey) && !pendingKeys.has(currentKey)) {
+        clarifySubmitAttempts.delete(currentKey)
+        setInterruptState(currentKey, { resolution: 'replied', busy: false, error: '' })
+        clearPendingClarify(currentKey)
+      }
+    }
+
+    for (const request of requests) {
       const key = clarifyFrameKey(request)
+      if (interruptState.value.get(key)?.resolution === 'replied') continue
+      const sameRequest = pendingClarifyMatches(key)
+      pendingClarify.value = request
+      // Do not make an in-flight submission actionable again just because a
+      // racing snapshot still contains its pre-submit pending record.
+      if (!sameRequest || !clarifyBusy.value) resetClarifyPresentation()
       if (!interruptState.value.has(key)) setInterruptState(key, {})
       if (!stream.isStreaming.value) stream.ensureInterruptBubble()
       stream.appendInterruptFrame({
@@ -1061,6 +1101,7 @@ export function useChatApprovals(options: UseChatApprovalsOptions) {
     interruptState.value = new Map()
     interruptNamespaces.clear()
     interruptApprovals.clear()
+    clarifySubmitAttempts.clear()
     legacyPushBackfills.clear()
     dismissClarify()
     if (key) hydrateApprovals()

--- a/opensquilla-webui/src/composables/chat/useChatApprovals.ts
+++ b/opensquilla-webui/src/composables/chat/useChatApprovals.ts
@@ -535,6 +535,28 @@ export function useChatApprovals(options: UseChatApprovalsOptions) {
     return composite === '|' ? `clarify:${sessionKey.value}` : composite
   }
 
+  function resetClarifyPresentation() {
+    clarifySubmitted.value = false
+    clarifyBusy.value = false
+    clarifyError.value = ''
+  }
+
+  function pendingClarifyMatches(key: string): boolean {
+    return pendingClarify.value != null && clarifyFrameKey(pendingClarify.value) === key
+  }
+
+  /**
+   * Remove only the request whose terminal state was just confirmed. This
+   * identity guard prevents a delayed submit response from dismissing a newer
+   * questionnaire that arrived while the earlier RPC was in flight.
+   */
+  function clearPendingClarify(key: string): boolean {
+    if (!pendingClarifyMatches(key)) return false
+    pendingClarify.value = null
+    resetClarifyPresentation()
+    return true
+  }
+
   let pollTimer: ReturnType<typeof setInterval> | null = null
   let fetchInFlight = false
   let refetchQueued = false
@@ -846,18 +868,18 @@ export function useChatApprovals(options: UseChatApprovalsOptions) {
         busy: false,
         error: '',
       })
-      if (pendingClarify.value?.requestId === outcome.requestId) {
-        clarifySubmitted.value = true
-        clarifyBusy.value = false
-        clarifyError.value = ''
-      }
+      clearPendingClarify(outcome.requestId)
       return
     }
     const request = parseClarifyRequest(payload)
     if (!request) return
+    const key = clarifyFrameKey(request)
+    // Tool-result replay and reconnect delivery can surface the paused half
+    // after its terminal outcome. Never resurrect an already-settled request or
+    // let a duplicate paused event undo optimistic submit feedback.
+    if (interruptState.value.get(key)?.resolution === 'replied') return
     pendingClarify.value = request
-    clarifySubmitted.value = false
-    clarifyError.value = ''
+    resetClarifyPresentation()
     // Mirror the clarify into the turn log so it folds into an inline interrupt
     // part. The clarify keeps no approval id, so the runId|step composite keys it.
     const clarifyData: InterruptClarifyData = {
@@ -868,7 +890,6 @@ export function useChatApprovals(options: UseChatApprovalsOptions) {
       runId: request.runId,
       step: request.step,
     }
-    const key = clarifyFrameKey(request)
     if (!interruptState.value.has(key)) setInterruptState(key, {})
     if (!stream.isStreaming.value) stream.ensureInterruptBubble()
     stream.appendInterruptFrame({
@@ -972,9 +993,12 @@ export function useChatApprovals(options: UseChatApprovalsOptions) {
     const key = clarifyFrameKey(request)
     if (interruptState.value.get(key)?.resolution === 'replied') return
     if (!requestOverride && clarifySubmitted.value) return
-    clarifyBusy.value = true
-    clarifySubmitted.value = true
-    clarifyError.value = ''
+    const controlsPendingPresentation = pendingClarifyMatches(key)
+    if (controlsPendingPresentation) {
+      clarifyBusy.value = true
+      clarifySubmitted.value = true
+      clarifyError.value = ''
+    }
     setInterruptState(key, { resolution: 'replied', busy: true, error: '' })
     const params: Record<string, unknown> = { sessionKey: sessionKey.value, fields }
     if (request.requestId) params.request_id = request.requestId
@@ -982,20 +1006,26 @@ export function useChatApprovals(options: UseChatApprovalsOptions) {
     try {
       await rpc.call('chat.clarify_submit', params)
       setInterruptState(key, { resolution: 'replied', busy: false })
+      // request_id submissions resolve the exact paused tool call in the same
+      // turn. A successful RPC is therefore authoritative and can release the
+      // dock/composer immediately. Legacy clarifications create a new chat turn
+      // and intentionally retain their existing submitted receipt.
+      if (request.requestId) clearPendingClarify(key)
     } catch (err) {
       const message = 'Send failed — ' + (err instanceof Error ? err.message : String(err))
-      clarifySubmitted.value = false
-      clarifyError.value = message
+      if (pendingClarifyMatches(key)) {
+        clarifySubmitted.value = false
+        clarifyError.value = message
+      }
       setInterruptState(key, { resolution: null, busy: false, error: message })
     } finally {
-      clarifyBusy.value = false
+      if (pendingClarifyMatches(key)) clarifyBusy.value = false
     }
   }
 
   function dismissClarify() {
     pendingClarify.value = null
-    clarifySubmitted.value = false
-    clarifyError.value = ''
+    resetClarifyPresentation()
   }
 
   function applyUserInputBootstrap(snapshot: {
@@ -1007,8 +1037,7 @@ export function useChatApprovals(options: UseChatApprovalsOptions) {
       const request = clarifyRequestFromValue(value)
       if (!request) continue
       pendingClarify.value = request
-      clarifySubmitted.value = false
-      clarifyError.value = ''
+      resetClarifyPresentation()
       const key = clarifyFrameKey(request)
       if (!interruptState.value.has(key)) setInterruptState(key, {})
       if (!stream.isStreaming.value) stream.ensureInterruptBubble()

--- a/opensquilla-webui/src/styles/chat-view.css
+++ b/opensquilla-webui/src/styles/chat-view.css
@@ -586,9 +586,10 @@
   pointer-events: auto;
 }
 
-/* The transcript retains the unresolved interrupt for chronological folding,
-   while the active Plan questionnaire is owned by the composer dock. */
-.chat--plan-questionnaire-open .chat-thread :deep(.clarify-card--plan) {
+/* The transcript retains the interrupt for chronological folding, while the
+   active Plan questionnaire (pending or submitting) has one owner: the dock. */
+.chat--plan-questionnaire-open .chat-thread :deep(.clarify-card--plan),
+.chat--plan-questionnaire-open .chat-thread :deep(.clarify-outcome--plan) {
   display: none;
 }
 


### PR DESCRIPTION
## Summary

- settle request-scoped Plan questionnaires as soon as their reply is confirmed
- prevent docked questionnaires and reply outcomes from rendering twice
- remove the stale reply outcome once the generated Plan card is available
- reconcile lost submit acknowledgements from authoritative reconnect snapshots

## Why

After a user answered a Plan-mode questionnaire, the local pending clarification could
remain active after the Gateway had resumed the turn. That stale state kept the composer
disabled and could render duplicate reply receipts. The same lock could survive a reconnect
when the Gateway had accepted the answer but the browser lost the RPC acknowledgement.

## User impact

- the composer unlocks after a request-scoped questionnaire reply is confirmed
- failed submissions remain actionable and show their retry error
- late replay cannot resurrect a settled questionnaire
- Plan output no longer leaves duplicate or stale questionnaire receipts below it

## Compatibility and safety

- no RPC, persisted-state, database, configuration, or public type contract changes
- legacy cross-turn clarifications retain their existing submitted receipt behavior
- reconnect reconciliation only treats an explicitly present pending-input snapshot as authoritative
- the change is platform-neutral and affects only WebUI presentation and client-side state
- no third-party code or user data is included

## Validation

- post-rebase WebUI unit suite: 321 files / 3,583 tests passed
- WebUI typecheck, architecture, chat security, theme, and i18n guards: passed
- focused Plan questionnaire browser flow: pending, submitted, and generated-Plan states passed in Chromium
- synthetic merge with PR #1161: 327 files / 3,673 tests passed
- synthetic merge with PR #1161 production WebUI build: passed

Required GitHub checks remain authoritative.

## Release notes

Required: fixes duplicate Plan questionnaire receipts and restores composer input after a reply.

## Linked issue

None.

## Third-party origin

None.
