### PR TITLE
Make CI stages fast and fail closed

### DIFF
--- a/.github/CI_OPTIMIZATION.md
+++ b/.github/CI_OPTIMIZATION.md
@@ -6,7 +6,7 @@ the nightly run.
 
 | Stage | Target | Responsibility |
 | --- | --- | --- |
-| Pull request | 8–15 minutes for ordinary changes | Run always-on contracts plus tests selected from the changed product area. Unknown, dependency, CI-policy, release, and platform-sensitive paths fail closed to the full matrix. |
+| Pull request | 8–15 minutes for ordinary changes | Run always-on contracts plus tests selected from the changed product area. Shared Python core changes run every offline Python shard; unknown, dependency, CI-policy, release, and platform-sensitive paths fail closed to the full matrix. |
 | Merge queue | 1–3 minutes when evidence is reusable | Verify exact-tree, base, workflow-run, PR association, and policy attestations. Any mismatch runs the full queue matrix. |
 | `main` push | 3–8 minutes in `enforce` | Build the WebUI and wheel, install in a clean environment, import the gateway, run the CLI, and exercise an offline provider/gateway canary. |
 | Nightly | Full matrix | Exercise all supported test shards and platform contracts without change-based selection. |

--- a/.github/CI_OPTIMIZATION.md
+++ b/.github/CI_OPTIMIZATION.md
@@ -19,16 +19,16 @@ CI and retain their existing live markers.
 
 Set the Actions repository variable `CI_OPTIMIZATION_MODE` to one of:
 
-- `shadow` (default): compute and report whether merge-queue evidence is reusable, but run
+- `shadow`: compute and report whether merge-queue evidence is reusable, but run
   the normal queue matrix. Change-based PR selection is active so its coverage and duration
   are observable before queue reuse is enabled.
-- `enforce`: reuse an exact trusted PR result in the merge queue; otherwise fail closed to
+- `enforce` (default): reuse an exact trusted PR result in the merge queue; otherwise fail closed to
   the full queue matrix. Replace the normal `main` push matrix with the installation and
   offline gateway canary.
 - `legacy`: emergency rollback mode. It deliberately runs full PR and queue CI and keeps
   the pre-enforcement `main` behavior.
 
-An unset or empty variable resolves to `shadow`. Any non-empty unsupported value fails CI.
+An unset or empty variable resolves to `enforce`. Any non-empty unsupported value fails CI.
 Changing modes does not modify code or persisted OpenSquilla configuration.
 
 ## Trust boundary
@@ -45,11 +45,11 @@ Reusable evidence is accepted only when all of these facts match authoritative G
 Missing, expired, malformed, stale, or unverifiable evidence never bypasses tests; it causes
 the queue to run the full matrix. The required branch-protection context remains `CI result`.
 
-Before switching to `enforce`, confirm that the main ruleset requires `CI result` and
+Before merging this rollout, confirm that the main ruleset requires `CI result` and
 `Validate target branch`, requires conversation resolution, and enforces code-owner review
 for `.github/workflows/`, `.github/scripts/`, and `.github/CODEOWNERS`. Keep `enforce` as a
-separate post-merge operator action so a CI-policy pull request cannot enable its own fast
-path.
+reviewed repository default; a CI-policy pull request still cannot reuse its own evidence
+because its policy digest differs from the target branch.
 
 ## Shadow validation and rollback
 

--- a/.github/CI_OPTIMIZATION.md
+++ b/.github/CI_OPTIMIZATION.md
@@ -1,0 +1,63 @@
+# CI optimization operations
+
+The default `CI` workflow keeps the required check name `CI result` while assigning
+different responsibilities to pull requests, merge queue entries, `main` pushes, and
+the nightly run.
+
+| Stage | Target | Responsibility |
+| --- | --- | --- |
+| Pull request | 8–15 minutes for ordinary changes | Run always-on contracts plus tests selected from the changed product area. Unknown, dependency, CI-policy, release, and platform-sensitive paths fail closed to the full matrix. |
+| Merge queue | 1–3 minutes when evidence is reusable | Verify exact-tree, base, workflow-run, PR association, and policy attestations. Any mismatch runs the full queue matrix. |
+| `main` push | 3–8 minutes in `enforce` | Build the WebUI and wheel, install in a clean environment, import the gateway, run the CLI, and exercise an offline provider/gateway canary. |
+| Nightly | Full matrix | Exercise all supported test shards and platform contracts without change-based selection. |
+
+Times are operational targets, not timeouts. High-risk pull requests intentionally remain
+slower. Provider-live, credential, and external-network tests remain excluded from required
+CI and retain their existing live markers.
+
+## Modes
+
+Set the Actions repository variable `CI_OPTIMIZATION_MODE` to one of:
+
+- `shadow` (default): compute and report whether merge-queue evidence is reusable, but run
+  the normal queue matrix. Change-based PR selection is active so its coverage and duration
+  are observable before queue reuse is enabled.
+- `enforce`: reuse an exact trusted PR result in the merge queue; otherwise fail closed to
+  the full queue matrix. Replace the normal `main` push matrix with the installation and
+  offline gateway canary.
+- `legacy`: emergency rollback mode. It deliberately runs full PR and queue CI and keeps
+  the pre-enforcement `main` behavior.
+
+An unset or empty variable resolves to `shadow`. Any non-empty unsupported value fails CI.
+Changing modes does not modify code or persisted OpenSquilla configuration.
+
+## Trust boundary
+
+Reusable evidence is accepted only when all of these facts match authoritative GitHub data:
+
+1. The successful source run was a `pull_request` run of `.github/workflows/ci.yml` in this
+   repository and is associated with the attested PR head.
+2. The PR merge preview and queue entry have the same Git tree and base commit.
+3. The attested PR head is an ancestor of the queue commit.
+4. Every workflow, CI helper, dependency lock/manifest, and `CODEOWNERS` policy input has the
+   same digest as `main`.
+
+Missing, expired, malformed, stale, or unverifiable evidence never bypasses tests; it causes
+the queue to run the full matrix. The required branch-protection context remains `CI result`.
+
+Before switching to `enforce`, confirm that the main ruleset requires `CI result` and
+`Validate target branch`, requires conversation resolution, and enforces code-owner review
+for `.github/workflows/`, `.github/scripts/`, and `.github/CODEOWNERS`. Keep `enforce` as a
+separate post-merge operator action so a CI-policy pull request cannot enable its own fast
+path.
+
+## Shadow validation and rollback
+
+During shadow validation, inspect the `Verify reusable PR CI evidence` summary on merge-group
+runs. A stable candidate reports `Reusable: true` while the regular queue jobs still run.
+Exercise at least one ordinary Python change, frontend-only change, docs-only change,
+platform-sensitive change, cancellation/supersession, and a base update. The base-update and
+CI-policy-change cases must report non-reusable evidence and run the fallback matrix.
+
+If enforcement behaves unexpectedly, set `CI_OPTIMIZATION_MODE=legacy`. This immediately
+disables evidence reuse without reverting the workflow or changing branch protection.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CI policy is a merge-safety boundary. Changes require an accountable maintainer.
+/.github/CODEOWNERS @Open-Squilla
+/.github/CI_OPTIMIZATION.md @Open-Squilla
+/.github/workflows/ @Open-Squilla
+/.github/scripts/ @Open-Squilla

--- a/.github/scripts/check_ci_results.py
+++ b/.github/scripts/check_ci_results.py
@@ -20,6 +20,7 @@ BOOLEAN_FLAGS: Final[tuple[str, ...]] = (
     "tui_changed",
     "desktop_changed",
     "python_changed",
+    "python_full_required",
     "platform_sensitive_changed",
     "build_wheel_required",
     "toolchain_artifact_changed",
@@ -96,7 +97,11 @@ def check_ci_results(env: Mapping[str, str]) -> list[str]:
         ("RESULT_TUI", "OpenTUI package tests", flags["tui_changed"] or full),
         ("RESULT_DESKTOP", "Desktop Electron unit tests", flags["desktop_changed"] or full),
         ("RESULT_UBUNTU", "Ubuntu quality gate", flags["python_changed"] or full),
-        ("RESULT_UBUNTU_FULL", "Ubuntu full test matrix", full),
+        (
+            "RESULT_UBUNTU_FULL",
+            "Ubuntu full test matrix",
+            flags["python_full_required"] or full,
+        ),
         (
             "RESULT_WINDOWS_SMOKE",
             "Windows compatibility smoke tests",
@@ -135,6 +140,9 @@ def check_ci_results(env: Mapping[str, str]) -> list[str]:
 
     if flags["platform_sensitive_changed"] and not flags["windows_full_required"]:
         errors.append("Platform-sensitive changes must require the Windows high-risk matrix.")
+
+    if flags["python_full_required"] and not flags["python_changed"]:
+        errors.append("Python full-matrix changes must also be classified as Python changes.")
 
     if full:
         if flags["docs_only"]:

--- a/.github/scripts/check_ci_results.py
+++ b/.github/scripts/check_ci_results.py
@@ -115,8 +115,7 @@ def check_ci_results(env: Mapping[str, str]) -> list[str]:
         (
             "RESULT_DESKTOP_RECOVERY_E2E",
             "Desktop recovery E2E matrix",
-            flags["frontend_changed"]
-            or flags["platform_sensitive_changed"]
+            flags["platform_sensitive_changed"]
             or flags["desktop_changed"]
             or full,
         ),

--- a/.github/scripts/ci_attestation.py
+++ b/.github/scripts/ci_attestation.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""Create and verify fail-closed CI attestations for merge-queue reuse."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.parse
+import urllib.request
+import zipfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+SCHEMA_VERSION: Final = 1
+VALIDATION_PROFILE: Final = "precise-v1"
+WORKFLOW_PATH: Final = ".github/workflows/ci.yml"
+MAX_ATTESTATION_ARCHIVE_BYTES: Final = 64 * 1024
+SHA_RE: Final = re.compile(r"^[0-9a-f]{40}$")
+POLICY_PREFIXES: Final = (
+    ".github/scripts/",
+    ".github/workflows/",
+)
+POLICY_FILES: Final = {
+    ".github/CODEOWNERS",
+    ".python-version",
+    "pyproject.toml",
+    "uv.lock",
+    "opensquilla-webui/.node-version",
+    "opensquilla-webui/package.json",
+    "opensquilla-webui/package-lock.json",
+    "desktop/electron/package.json",
+    "desktop/electron/package-lock.json",
+    "src/opensquilla/cli/tui/opentui/package/.bun-version",
+    "src/opensquilla/cli/tui/opentui/package/package.json",
+    "src/opensquilla/cli/tui/opentui/package/bun.lock",
+}
+
+
+class AttestationError(RuntimeError):
+    """A queue attestation could not be trusted."""
+
+
+def _git(*args: str, cwd: Path) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _require_sha(value: object, label: str) -> str:
+    if not isinstance(value, str) or SHA_RE.fullmatch(value) is None:
+        raise AttestationError(f"{label} must be a lowercase 40-character SHA")
+    return value
+
+
+def _policy_paths(repo: Path, ref: str) -> list[str]:
+    paths = _git("ls-tree", "-r", "--name-only", ref, cwd=repo).splitlines()
+    return sorted(
+        path
+        for path in paths
+        if path in POLICY_FILES or any(path.startswith(prefix) for prefix in POLICY_PREFIXES)
+    )
+
+
+def policy_digest(repo: Path, ref: str = "HEAD") -> str:
+    """Hash every workflow, CI helper, and dependency-policy input at *ref*."""
+
+    digest = hashlib.sha256()
+    paths = _policy_paths(repo, ref)
+    if not paths:
+        raise AttestationError(f"CI policy is empty at {ref}")
+    for path in paths:
+        content = subprocess.run(
+            ["git", "show", f"{ref}:{path}"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        ).stdout
+        encoded_path = path.encode("utf-8")
+        digest.update(len(encoded_path).to_bytes(4, "big"))
+        digest.update(encoded_path)
+        digest.update(len(content).to_bytes(8, "big"))
+        digest.update(content)
+    return digest.hexdigest()
+
+
+def _read_event(path: Path) -> Mapping[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise AttestationError("GitHub event payload must be a JSON object")
+    return value
+
+
+def _write_outputs(path: Path | None, values: Mapping[str, object]) -> None:
+    if path is None:
+        return
+    with path.open("a", encoding="utf-8") as handle:
+        for name, value in values.items():
+            rendered = str(value).replace("\r", " ").replace("\n", " ")
+            handle.write(f"{name}={rendered}\n")
+
+
+def create_attestation(
+    *,
+    repo: Path,
+    repository: str,
+    event: Mapping[str, Any],
+    workflow_run_id: int,
+    workflow_run_attempt: int,
+    workflow_ref: str,
+    optimization_mode: str,
+) -> dict[str, object]:
+    pull_request = event.get("pull_request")
+    if not isinstance(pull_request, dict):
+        raise AttestationError("attestations may only be created for pull_request events")
+
+    number = pull_request.get("number")
+    if not isinstance(number, int) or number <= 0:
+        raise AttestationError("pull request number is missing")
+    head = pull_request.get("head")
+    base = pull_request.get("base")
+    if not isinstance(head, dict) or not isinstance(base, dict):
+        raise AttestationError("pull request head/base metadata is missing")
+
+    head_sha = _require_sha(head.get("sha"), "pull request head SHA")
+    event_base_sha = _require_sha(base.get("sha"), "pull request base SHA")
+    merge_commit = _require_sha(_git("rev-parse", "HEAD", cwd=repo), "tested commit SHA")
+    merge_tree = _require_sha(
+        _git("rev-parse", "HEAD^{tree}", cwd=repo), "tested tree SHA"
+    )
+    parents = _git("rev-list", "--parents", "-n", "1", "HEAD", cwd=repo).split()
+    if len(parents) != 3:
+        raise AttestationError("pull request CI must test a two-parent merge preview")
+    tested_base_sha = _require_sha(parents[1], "tested base SHA")
+    tested_head_sha = _require_sha(parents[2], "tested head SHA")
+    if tested_base_sha != event_base_sha or tested_head_sha != head_sha:
+        raise AttestationError("tested merge parents do not match the pull request event")
+
+    head_repo = head.get("repo")
+    head_repository = head_repo.get("full_name") if isinstance(head_repo, dict) else None
+    if not isinstance(head_repository, str) or not head_repository:
+        raise AttestationError("pull request head repository is missing")
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "validation_profile": VALIDATION_PROFILE,
+        "repository": repository,
+        "pull_request_number": number,
+        "head_repository": head_repository,
+        "head_sha": head_sha,
+        "base_ref": base.get("ref"),
+        "base_sha": tested_base_sha,
+        "tested_merge_sha": merge_commit,
+        "tested_tree_sha": merge_tree,
+        "policy_digest": policy_digest(repo),
+        "workflow_path": WORKFLOW_PATH,
+        "workflow_ref": workflow_ref,
+        "workflow_run_id": workflow_run_id,
+        "workflow_run_attempt": workflow_run_attempt,
+        "optimization_mode": optimization_mode,
+    }
+
+
+def _request_json(url: str, token: str) -> Mapping[str, Any]:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "opensquilla-ci-attestation",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        value = json.load(response)
+    if not isinstance(value, dict):
+        raise AttestationError(f"GitHub API returned a non-object for {url}")
+    return value
+
+
+def _request_bytes(url: str, token: str) -> bytes:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "opensquilla-ci-attestation",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return response.read()
+
+
+def _artifact_attestation(archive: bytes) -> Mapping[str, Any]:
+    if len(archive) > MAX_ATTESTATION_ARCHIVE_BYTES:
+        raise AttestationError("attestation artifact archive is too large")
+    with zipfile.ZipFile(io.BytesIO(archive)) as bundle:
+        names = bundle.namelist()
+        if names != ["ci-attestation.json"]:
+            raise AttestationError("attestation artifact must contain only ci-attestation.json")
+        info = bundle.getinfo(names[0])
+        if info.file_size > MAX_ATTESTATION_ARCHIVE_BYTES:
+            raise AttestationError("attestation JSON is too large")
+        value = json.loads(bundle.read(info))
+    if not isinstance(value, dict):
+        raise AttestationError("attestation must be a JSON object")
+    return value
+
+
+def validate_candidate(
+    *,
+    attestation: Mapping[str, Any],
+    run: Mapping[str, Any],
+    repository: str,
+    queue_tree_sha: str,
+    queue_base_sha: str,
+    queue_policy_digest: str,
+    pull_request_head_is_ancestor: bool,
+) -> None:
+    """Validate one downloaded artifact and its authoritative workflow run."""
+
+    expected = {
+        "schema_version": SCHEMA_VERSION,
+        "validation_profile": VALIDATION_PROFILE,
+        "repository": repository,
+        "base_ref": "main",
+        "base_sha": queue_base_sha,
+        "tested_tree_sha": queue_tree_sha,
+        "policy_digest": queue_policy_digest,
+        "workflow_path": WORKFLOW_PATH,
+    }
+    for key, expected_value in expected.items():
+        if attestation.get(key) != expected_value:
+            raise AttestationError(f"attestation {key} does not match the queue")
+
+    run_id = attestation.get("workflow_run_id")
+    run_attempt = attestation.get("workflow_run_attempt")
+    pr_number = attestation.get("pull_request_number")
+    if not isinstance(run_id, int) or run_id <= 0:
+        raise AttestationError("attestation workflow_run_id is invalid")
+    if not isinstance(run_attempt, int) or run_attempt <= 0:
+        raise AttestationError("attestation workflow_run_attempt is invalid")
+    if not isinstance(pr_number, int) or pr_number <= 0:
+        raise AttestationError("attestation pull_request_number is invalid")
+    head_sha = _require_sha(attestation.get("head_sha"), "attested head SHA")
+    _require_sha(attestation.get("tested_merge_sha"), "attested merge SHA")
+
+    run_repository = run.get("repository")
+    run_repository_name = (
+        run_repository.get("full_name") if isinstance(run_repository, dict) else None
+    )
+    authoritative = {
+        "id": run_id,
+        "run_attempt": run_attempt,
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "head_sha": head_sha,
+        "path": WORKFLOW_PATH,
+    }
+    for key, expected_value in authoritative.items():
+        if run.get(key) != expected_value:
+            raise AttestationError(f"workflow run {key} is not authoritative")
+    if run_repository_name != repository:
+        raise AttestationError("workflow run belongs to another repository")
+
+    pull_requests = run.get("pull_requests")
+    if not isinstance(pull_requests, list):
+        raise AttestationError("workflow run pull request association is missing")
+    matching_pr = False
+    for item in pull_requests:
+        if not isinstance(item, dict) or item.get("number") != pr_number:
+            continue
+        item_head = item.get("head")
+        item_base = item.get("base")
+        if (
+            isinstance(item_head, dict)
+            and isinstance(item_base, dict)
+            and item_head.get("sha") == head_sha
+            and item_base.get("ref") == "main"
+            and item_base.get("sha") == queue_base_sha
+        ):
+            matching_pr = True
+            break
+    if not matching_pr:
+        raise AttestationError("workflow run is not associated with the attested pull request")
+    if not pull_request_head_is_ancestor:
+        raise AttestationError("attested pull request head is not in the queue commit")
+
+
+def verify_queue(
+    *,
+    repo: Path,
+    repository: str,
+    event: Mapping[str, Any],
+    token: str,
+    api_url: str,
+    current_run_id: int,
+) -> tuple[bool, str, int | None]:
+    merge_group = event.get("merge_group")
+    if not isinstance(merge_group, dict):
+        return False, "not a merge_group event", None
+    try:
+        queue_head_sha = _require_sha(merge_group.get("head_sha"), "queue head SHA")
+        queue_base_sha = _require_sha(merge_group.get("base_sha"), "queue base SHA")
+        checked_out_sha = _require_sha(_git("rev-parse", "HEAD", cwd=repo), "checkout SHA")
+        if checked_out_sha != queue_head_sha:
+            raise AttestationError("checked out commit is not the merge-group head")
+        queue_tree_sha = _require_sha(
+            _git("rev-parse", "HEAD^{tree}", cwd=repo), "queue tree SHA"
+        )
+        queue_policy = policy_digest(repo)
+        base_policy = policy_digest(repo, queue_base_sha)
+        if queue_policy != base_policy:
+            raise AttestationError("CI policy changed relative to the queue base")
+
+        name = f"ci-attestation-{queue_tree_sha}"
+        encoded_name = urllib.parse.quote(name, safe="")
+        listing = _request_json(
+            f"{api_url}/repos/{repository}/actions/artifacts?name={encoded_name}&per_page=100",
+            token,
+        )
+        artifacts = listing.get("artifacts")
+        if not isinstance(artifacts, list) or not artifacts:
+            raise AttestationError("no PR CI attestation exists for the queue tree")
+
+        reasons: list[str] = []
+        for artifact in sorted(
+            (item for item in artifacts if isinstance(item, dict)),
+            key=lambda item: str(item.get("created_at", "")),
+            reverse=True,
+        ):
+            try:
+                if artifact.get("expired") is not False:
+                    raise AttestationError("artifact is expired")
+                artifact_size = artifact.get("size_in_bytes")
+                if (
+                    not isinstance(artifact_size, int)
+                    or artifact_size <= 0
+                    or artifact_size > MAX_ATTESTATION_ARCHIVE_BYTES
+                ):
+                    raise AttestationError("artifact size is invalid")
+                workflow_run = artifact.get("workflow_run")
+                run_id = workflow_run.get("id") if isinstance(workflow_run, dict) else None
+                if not isinstance(run_id, int) or run_id <= 0 or run_id == current_run_id:
+                    raise AttestationError("artifact workflow run identity is invalid")
+                archive_url = artifact.get("archive_download_url")
+                if not isinstance(archive_url, str) or not archive_url.startswith(
+                    "https://api.github.com/"
+                ):
+                    raise AttestationError("artifact download URL is invalid")
+                attestation = _artifact_attestation(_request_bytes(archive_url, token))
+                if attestation.get("workflow_run_id") != run_id:
+                    raise AttestationError("artifact and attestation run IDs differ")
+                run = _request_json(
+                    f"{api_url}/repos/{repository}/actions/runs/{run_id}", token
+                )
+                head_sha = attestation.get("head_sha")
+                head_is_ancestor = False
+                if isinstance(head_sha, str) and SHA_RE.fullmatch(head_sha):
+                    head_is_ancestor = subprocess.run(
+                        ["git", "merge-base", "--is-ancestor", head_sha, "HEAD"],
+                        cwd=repo,
+                        check=False,
+                    ).returncode == 0
+                validate_candidate(
+                    attestation=attestation,
+                    run=run,
+                    repository=repository,
+                    queue_tree_sha=queue_tree_sha,
+                    queue_base_sha=queue_base_sha,
+                    queue_policy_digest=queue_policy,
+                    pull_request_head_is_ancestor=head_is_ancestor,
+                )
+                return True, "matching trusted PR CI attestation", run_id
+            except (AttestationError, OSError, ValueError, zipfile.BadZipFile) as exc:
+                reasons.append(str(exc))
+        detail = "; ".join(reasons[:3]) or "no usable attestation artifacts"
+        raise AttestationError(detail)
+    except (AttestationError, OSError, subprocess.CalledProcessError, ValueError) as exc:
+        return False, str(exc), None
+
+
+def _create_command(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve()
+    event = _read_event(Path(args.event_path))
+    value = create_attestation(
+        repo=repo,
+        repository=args.repository,
+        event=event,
+        workflow_run_id=args.run_id,
+        workflow_run_attempt=args.run_attempt,
+        workflow_ref=args.workflow_ref,
+        optimization_mode=args.optimization_mode,
+    )
+    output = Path(args.output)
+    output.write_text(json.dumps(value, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    _write_outputs(
+        Path(args.github_output) if args.github_output else None,
+        {
+            "tree_sha": value["tested_tree_sha"],
+            "policy_digest": value["policy_digest"],
+        },
+    )
+    print(f"Created attestation for tree {value['tested_tree_sha']}")
+    return 0
+
+
+def _verify_queue_command(args: argparse.Namespace) -> int:
+    token = os.environ.get("GH_TOKEN", "")
+    if not token:
+        print("GH_TOKEN is required", file=sys.stderr)
+        return 2
+    reusable, reason, source_run_id = verify_queue(
+        repo=Path(args.repo).resolve(),
+        repository=args.repository,
+        event=_read_event(Path(args.event_path)),
+        token=token,
+        api_url=args.api_url.rstrip("/"),
+        current_run_id=args.run_id,
+    )
+    _write_outputs(
+        Path(args.github_output) if args.github_output else None,
+        {
+            "reusable": str(reusable).lower(),
+            "reason": reason,
+            "source_run_id": source_run_id or "",
+        },
+    )
+    print(f"reusable={str(reusable).lower()} reason={reason}")
+    return 0
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create = subparsers.add_parser("create")
+    create.add_argument("--repo", default=".")
+    create.add_argument("--repository", required=True)
+    create.add_argument("--event-path", required=True)
+    create.add_argument("--run-id", type=int, required=True)
+    create.add_argument("--run-attempt", type=int, required=True)
+    create.add_argument("--workflow-ref", required=True)
+    create.add_argument("--optimization-mode", required=True)
+    create.add_argument("--output", required=True)
+    create.add_argument("--github-output")
+    create.set_defaults(func=_create_command)
+
+    verify = subparsers.add_parser("verify-queue")
+    verify.add_argument("--repo", default=".")
+    verify.add_argument("--repository", required=True)
+    verify.add_argument("--event-path", required=True)
+    verify.add_argument("--run-id", type=int, required=True)
+    verify.add_argument("--api-url", default="https://api.github.com")
+    verify.add_argument("--github-output")
+    verify.set_defaults(func=_verify_queue_command)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        return int(args.func(args))
+    except (AttestationError, OSError, subprocess.CalledProcessError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/ci_attestation.py
+++ b/.github/scripts/ci_attestation.py
@@ -134,7 +134,7 @@ def create_attestation(
         raise AttestationError("pull request head/base metadata is missing")
 
     head_sha = _require_sha(head.get("sha"), "pull request head SHA")
-    event_base_sha = _require_sha(base.get("sha"), "pull request base SHA")
+    _require_sha(base.get("sha"), "pull request base SHA")
     merge_commit = _require_sha(_git("rev-parse", "HEAD", cwd=repo), "tested commit SHA")
     merge_tree = _require_sha(
         _git("rev-parse", "HEAD^{tree}", cwd=repo), "tested tree SHA"
@@ -144,8 +144,11 @@ def create_attestation(
         raise AttestationError("pull request CI must test a two-parent merge preview")
     tested_base_sha = _require_sha(parents[1], "tested base SHA")
     tested_head_sha = _require_sha(parents[2], "tested head SHA")
-    if tested_base_sha != event_base_sha or tested_head_sha != head_sha:
-        raise AttestationError("tested merge parents do not match the pull request event")
+    # GitHub's pull_request base SHA can predate the merge preview when main advances. The
+    # preview's first parent is the base that CI actually tested; queue validation still requires
+    # that exact base, tree, and policy before reusing this attestation.
+    if tested_head_sha != head_sha:
+        raise AttestationError("tested merge head does not match the pull request event")
 
     head_repo = head.get("repo")
     head_repository = head_repo.get("full_name") if isinstance(head_repo, dict) else None

--- a/.github/scripts/classify-ci-changes.sh
+++ b/.github/scripts/classify-ci-changes.sh
@@ -15,6 +15,7 @@ frontend_changed=false
 tui_changed=false
 desktop_changed=false
 python_changed=false
+python_full_required=false
 platform_sensitive_changed=false
 build_wheel_required=false
 toolchain_artifact_changed=false
@@ -44,6 +45,11 @@ mark_runtime_changed() {
   runtime_changed=true
   python_changed=true
   build_wheel_required=true
+}
+
+mark_python_full_required() {
+  mark_runtime_changed
+  python_full_required=true
 }
 
 mark_test_changed() {
@@ -114,6 +120,7 @@ mark_full_required() {
   tui_changed=true
   desktop_changed=true
   python_changed=true
+  python_full_required=true
   platform_sensitive_changed=true
   build_wheel_required=true
   toolchain_artifact_changed=true
@@ -295,10 +302,11 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       add_pytest_target "tests/test_gateway*.py"
       add_pytest_target "tests/functional/test_gateway_*_e2e.py"
       ;;
-    src/opensquilla/engine/*)
-      mark_runtime_changed
-      add_pytest_target "tests/test_engine"
-      add_pytest_target "tests/test_engine*.py"
+    src/opensquilla/engine/* | src/opensquilla/agents/* | src/opensquilla/agent/* | src/opensquilla/application/* | src/opensquilla/safety/*)
+      # These shared-core surfaces fan out across gateway, channel, session,
+      # CLI, and tool contracts. Run every offline Python shard without waking
+      # unrelated frontend, Desktop, release, or toolchain matrices.
+      mark_python_full_required
       ;;
     src/opensquilla/channels/*)
       mark_runtime_changed
@@ -324,14 +332,6 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       add_pytest_target "tests/test_cli"
       add_pytest_target "tests/integration/cli"
       ;;
-    src/opensquilla/agents/* | src/opensquilla/agent/*)
-      mark_runtime_changed
-      add_pytest_target "tests/test_agents"
-      ;;
-    src/opensquilla/application/*)
-      mark_runtime_changed
-      add_pytest_target "tests/test_application"
-      ;;
     src/opensquilla/identity/templates/*)
       mark_runtime_changed
       mark_platform_sensitive_changed
@@ -356,10 +356,6 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
     src/opensquilla/search/*)
       mark_runtime_changed
       add_pytest_target "tests/test_search"
-      ;;
-    src/opensquilla/safety/*)
-      mark_runtime_changed
-      add_pytest_target "tests/test_safety"
       ;;
     migrations/*)
       mark_runtime_changed
@@ -404,6 +400,7 @@ fi
   printf 'tui_changed=%s\n' "${tui_changed}"
   printf 'desktop_changed=%s\n' "${desktop_changed}"
   printf 'python_changed=%s\n' "${python_changed}"
+  printf 'python_full_required=%s\n' "${python_full_required}"
   printf 'platform_sensitive_changed=%s\n' "${platform_sensitive_changed}"
   printf 'build_wheel_required=%s\n' "${build_wheel_required}"
   printf 'toolchain_artifact_changed=%s\n' "${toolchain_artifact_changed}"

--- a/.github/scripts/classify-ci-changes.sh
+++ b/.github/scripts/classify-ci-changes.sh
@@ -19,7 +19,21 @@ platform_sensitive_changed=false
 build_wheel_required=false
 toolchain_artifact_changed=false
 full_required=false
+pytest_targets=""
 seen_file=false
+
+add_pytest_target() {
+  local target="${1:?pytest target is required}"
+  case ",${pytest_targets}," in
+    *",${target},"*) ;;
+    *)
+      if [[ -n "${pytest_targets}" ]]; then
+        pytest_targets+=","
+      fi
+      pytest_targets+="${target}"
+      ;;
+  esac
+}
 
 mark_non_docs_changed() {
   docs_only=false
@@ -104,6 +118,7 @@ mark_full_required() {
   build_wheel_required=true
   toolchain_artifact_changed=true
   full_required=true
+  pytest_targets="tests"
 }
 
 while IFS= read -r path || [[ -n "${path}" ]]; do
@@ -177,13 +192,50 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       mark_test_changed
       mark_platform_sensitive_changed
       ;;
-    tests/test_onboarding/* | tests/test_provider/* | tests/test_provider*.py)
+    tests/test_onboarding/*)
       mark_test_changed
-      mark_platform_sensitive_changed
+      add_pytest_target "tests/test_onboarding"
+      ;;
+    tests/test_provider/* | tests/test_provider*.py)
+      mark_test_changed
+      add_pytest_target "tests/test_provider"
+      add_pytest_target "tests/test_provider*.py"
+      ;;
+    tests/test_gateway/*)
+      mark_test_changed
+      add_pytest_target "tests/test_gateway"
+      add_pytest_target "tests/test_gateway*.py"
+      add_pytest_target "tests/functional/test_gateway_*_e2e.py"
+      ;;
+    tests/test_engine/* | tests/test_engine*.py)
+      mark_test_changed
+      add_pytest_target "tests/test_engine"
+      add_pytest_target "tests/test_engine*.py"
+      ;;
+    tests/test_channels/*)
+      mark_test_changed
+      add_pytest_target "tests/test_channels"
+      ;;
+    tests/test_memory/* | tests/test_memory*.py)
+      mark_test_changed
+      add_pytest_target "tests/test_memory"
+      add_pytest_target "tests/test_memory*.py"
+      ;;
+    tests/test_skills/* | tests/test_skills*.py)
+      mark_test_changed
+      add_pytest_target "tests/test_skills"
+      add_pytest_target "tests/test_skills*.py"
+      add_pytest_target "tests/test_meta_skill*.py"
+      ;;
+    tests/test_cli/* | tests/integration/cli/*)
+      mark_test_changed
+      add_pytest_target "tests/test_cli"
+      add_pytest_target "tests/integration/cli"
       ;;
     tests/functional/test_gateway_*_e2e.py)
       mark_test_changed
       mark_platform_sensitive_changed
+      add_pytest_target "tests/functional"
       ;;
     tests/*)
       # New or unclassified tests fail closed to the Windows high-risk suite.
@@ -210,13 +262,104 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       mark_runtime_changed
       mark_release_changed
       ;;
-    src/opensquilla/recovery/* | src/opensquilla/migration/* | src/opensquilla/persistence/* | src/opensquilla/memory/* | src/opensquilla/session/* | src/opensquilla/scheduler/* | src/opensquilla/sandbox/* | src/opensquilla/tools/boundary.py | src/opensquilla/tools/builtin/code_exec.py | src/opensquilla/tools/builtin/filesystem.py | src/opensquilla/tools/builtin/git.py | src/opensquilla/tools/builtin/shell.py | src/opensquilla/tools/builtin/shell_policy.py | src/opensquilla/tools/path_* | src/opensquilla/tools/policy* | src/opensquilla/tools/write_*)
+    src/opensquilla/recovery/* | src/opensquilla/migration/* | src/opensquilla/persistence/* | src/opensquilla/session/* | src/opensquilla/sandbox/* | src/opensquilla/tools/boundary.py | src/opensquilla/tools/builtin/code_exec.py | src/opensquilla/tools/builtin/filesystem.py | src/opensquilla/tools/builtin/git.py | src/opensquilla/tools/builtin/shell.py | src/opensquilla/tools/builtin/shell_policy.py | src/opensquilla/tools/path_* | src/opensquilla/tools/policy* | src/opensquilla/tools/write_*)
+      mark_runtime_changed
+      mark_platform_sensitive_changed
+      add_pytest_target "tests/test_recovery"
+      add_pytest_target "tests/test_migration"
+      add_pytest_target "tests/test_migrations"
+      add_pytest_target "tests/test_persistence"
+      add_pytest_target "tests/test_session"
+      add_pytest_target "tests/test_sandbox"
+      add_pytest_target "tests/test_tools"
+      ;;
+    src/opensquilla/onboarding/*)
+      mark_runtime_changed
+      mark_platform_sensitive_changed
+      add_pytest_target "tests/test_onboarding"
+      ;;
+    src/opensquilla/provider/* | src/opensquilla/router_tiers.py)
+      mark_runtime_changed
+      add_pytest_target "tests/test_provider"
+      add_pytest_target "tests/test_provider*.py"
+      add_pytest_target "tests/test_*router*.py"
+      add_pytest_target "tests/test_cross_provider_tiers.py"
+      ;;
+    src/opensquilla/squilla_router/*)
       mark_runtime_changed
       mark_platform_sensitive_changed
       ;;
-    src/opensquilla/onboarding/* | src/opensquilla/provider/*)
+    src/opensquilla/gateway/*)
+      mark_runtime_changed
+      add_pytest_target "tests/test_gateway"
+      add_pytest_target "tests/test_gateway*.py"
+      add_pytest_target "tests/functional/test_gateway_*_e2e.py"
+      ;;
+    src/opensquilla/engine/*)
+      mark_runtime_changed
+      add_pytest_target "tests/test_engine"
+      add_pytest_target "tests/test_engine*.py"
+      ;;
+    src/opensquilla/channels/*)
+      mark_runtime_changed
+      add_pytest_target "tests/test_channels"
+      ;;
+    src/opensquilla/memory/*)
+      mark_runtime_changed
+      add_pytest_target "tests/test_memory"
+      add_pytest_target "tests/test_memory*.py"
+      ;;
+    src/opensquilla/scheduler/*)
+      mark_runtime_changed
+      add_pytest_target "tests/test_scheduler"
+      ;;
+    src/opensquilla/skills/*)
+      mark_runtime_changed
+      add_pytest_target "tests/test_skills"
+      add_pytest_target "tests/test_skills*.py"
+      add_pytest_target "tests/test_meta_skill*.py"
+      ;;
+    src/opensquilla/cli/*)
+      mark_runtime_changed
+      add_pytest_target "tests/test_cli"
+      add_pytest_target "tests/integration/cli"
+      ;;
+    src/opensquilla/agents/* | src/opensquilla/agent/*)
+      mark_runtime_changed
+      add_pytest_target "tests/test_agents"
+      ;;
+    src/opensquilla/application/*)
+      mark_runtime_changed
+      add_pytest_target "tests/test_application"
+      ;;
+    src/opensquilla/identity/templates/*)
       mark_runtime_changed
       mark_platform_sensitive_changed
+      ;;
+    src/opensquilla/identity/*)
+      mark_runtime_changed
+      add_pytest_target "tests/test_identity"
+      ;;
+    src/opensquilla/mcp/* | src/opensquilla/mcp_server/*)
+      mark_runtime_changed
+      add_pytest_target "tests/test_mcp"
+      add_pytest_target "tests/test_mcp_server"
+      ;;
+    src/opensquilla/health/*)
+      mark_runtime_changed
+      add_pytest_target "tests/test_health"
+      ;;
+    src/opensquilla/observability/*)
+      mark_runtime_changed
+      add_pytest_target "tests/test_observability"
+      ;;
+    src/opensquilla/search/*)
+      mark_runtime_changed
+      add_pytest_target "tests/test_search"
+      ;;
+    src/opensquilla/safety/*)
+      mark_runtime_changed
+      add_pytest_target "tests/test_safety"
       ;;
     migrations/*)
       mark_runtime_changed
@@ -241,6 +384,14 @@ if [[ "${seen_file}" == "false" ]]; then
   mark_full_required
 fi
 
+# High-risk changes already run the exhaustive Windows matrix. Keep the targeted
+# Ubuntu lane compact; full CI still owns the complete cross-platform suite.
+if [[ "${full_required}" == "true" ]]; then
+  pytest_targets="tests"
+elif [[ "${platform_sensitive_changed}" == "true" ]]; then
+  pytest_targets=""
+fi
+
 {
   printf 'docs_only=%s\n' "${docs_only}"
   printf 'runtime_changed=%s\n' "${runtime_changed}"
@@ -257,4 +408,5 @@ fi
   printf 'build_wheel_required=%s\n' "${build_wheel_required}"
   printf 'toolchain_artifact_changed=%s\n' "${toolchain_artifact_changed}"
   printf 'full_required=%s\n' "${full_required}"
+  printf 'pytest_targets=%s\n' "${pytest_targets}"
 } >> "${output_file}"

--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -25,6 +25,7 @@
       "tests/test_channels/test_send_error_classification.py",
       "tests/test_channels/test_telegram_send_chunking.py",
       "tests/test_channels/test_wecom_websocket.py",
+      "tests/test_ci/test_ci_attestation.py",
       "tests/test_ci/test_dockerignore_context.py",
       "tests/test_ci/test_migrations_packaged.py",
       "tests/test_ci/test_pr_body_lint.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -82,6 +82,7 @@
     "tests/test_channels/test_wecom_websocket.py": 0.127,
     "tests/test_ci/test_architecture_import_contracts.py": 11.504,
     "tests/test_ci/test_bgm_asset_hygiene.py": 0.515,
+    "tests/test_ci/test_ci_attestation.py": 1.5,
     "tests/test_ci/test_ci_result_gate.py": 0.01,
     "tests/test_ci/test_decision_log_aggregate.py": 0.01,
     "tests/test_ci/test_dockerignore_context.py": 0.01,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,21 +6,100 @@ name: CI
     types: [checks_requested]
   push:
     branches: [main]
+  schedule:
+    - cron: "23 18 * * *"
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
+  CI_OPTIMIZATION_MODE: ${{ vars.CI_OPTIMIZATION_MODE || 'shadow' }}
   OPENSQUILLA_TESTING: "true"
 
 jobs:
+  queue-attestation:
+    name: Verify reusable PR CI evidence
+    if: ${{ github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      reusable: ${{ steps.verify.outputs.reusable || 'false' }}
+      reason: ${{ steps.verify.outputs.reason || steps.mode.outputs.reason }}
+      source_run_id: ${{ steps.verify.outputs.source_run_id }}
+    steps:
+      - name: Validate optimization mode
+        id: mode
+        shell: bash
+        run: |
+          case "${CI_OPTIMIZATION_MODE}" in
+            legacy | shadow | enforce) ;;
+            *)
+              echo "ERROR: CI_OPTIMIZATION_MODE must be legacy, shadow, or enforce." >&2
+              exit 2
+              ;;
+          esac
+          if [[ "${CI_OPTIMIZATION_MODE}" == "legacy" ]]; then
+            echo "reason=legacy mode always runs queue CI" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Check out merge-group commit
+        if: ${{ env.CI_OPTIMIZATION_MODE != 'legacy' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify matching trusted PR CI attestation
+        id: verify
+        if: ${{ env.CI_OPTIMIZATION_MODE != 'legacy' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python3 .github/scripts/ci_attestation.py verify-queue
+          --repository "${GITHUB_REPOSITORY}"
+          --event-path "${GITHUB_EVENT_PATH}"
+          --run-id "${GITHUB_RUN_ID}"
+          --api-url "${GITHUB_API_URL}"
+          --github-output "${GITHUB_OUTPUT}"
+
+      - name: Summarize queue decision
+        env:
+          REUSABLE: ${{ steps.verify.outputs.reusable || 'false' }}
+          REASON: ${{ steps.verify.outputs.reason || steps.mode.outputs.reason }}
+          SOURCE_RUN_ID: ${{ steps.verify.outputs.source_run_id }}
+        shell: bash
+        run: |
+          {
+            echo "## Merge queue CI evidence"
+            echo
+            echo "- Mode: \`${CI_OPTIMIZATION_MODE}\`"
+            echo "- Reusable: \`${REUSABLE}\`"
+            echo "- Reason: ${REASON}"
+            if [[ -n "${SOURCE_RUN_ID}" ]]; then
+              echo "- Source run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}"
+            fi
+            if [[ "${CI_OPTIMIZATION_MODE}" == "shadow" && "${REUSABLE}" == "true" ]]; then
+              echo "- Shadow decision: evidence matched, but the normal queue matrix still runs."
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
   classify-changes:
     name: Classify changed files
+    needs: queue-attestation
+    if: >-
+      ${{ always()
+          && (github.event_name != 'merge_group'
+              || (vars.CI_OPTIMIZATION_MODE || 'shadow') != 'enforce'
+              || needs.queue-attestation.outputs.reusable != 'true')
+          && (github.event_name != 'push'
+              || (vars.CI_OPTIMIZATION_MODE || 'shadow') != 'enforce') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -39,6 +118,7 @@ jobs:
       build_wheel_required: ${{ steps.classify.outputs.build_wheel_required }}
       toolchain_artifact_changed: ${{ steps.classify.outputs.toolchain_artifact_changed }}
       full_required: ${{ steps.classify.outputs.full_required }}
+      pytest_targets: ${{ steps.classify.outputs.pytest_targets }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -51,16 +131,32 @@ jobs:
           set -euo pipefail
           changed_files="${RUNNER_TEMP}/changed-files.txt"
 
+          case "${CI_OPTIMIZATION_MODE}" in
+            legacy | shadow | enforce) ;;
+            *)
+              echo "ERROR: CI_OPTIMIZATION_MODE must be legacy, shadow, or enforce." >&2
+              exit 2
+              ;;
+          esac
+
           case "${{ github.event_name }}" in
             pull_request)
-              git diff --name-only \
-                "${{ github.event.pull_request.base.sha }}" \
-                "${{ github.event.pull_request.head.sha }}" > "${changed_files}"
+              if [[ "${CI_OPTIMIZATION_MODE}" == "legacy" ]]; then
+                printf '.ci/run-all\n' > "${changed_files}"
+              else
+                git diff --name-only \
+                  "${{ github.event.pull_request.base.sha }}" \
+                  "${{ github.event.pull_request.head.sha }}" > "${changed_files}"
+              fi
               ;;
             merge_group)
               base="${{ github.event.merge_group.base_sha }}"
               head="${{ github.event.merge_group.head_sha }}"
-              if [[ -n "${base}" && -n "${head}" ]] \
+              if [[ "${CI_OPTIMIZATION_MODE}" == "legacy" \
+                || "${CI_OPTIMIZATION_MODE}" == "enforce" ]]; then
+                echo "Queue evidence was unavailable; running the full fail-closed matrix." >&2
+                printf '.ci/run-all\n' > "${changed_files}"
+              elif [[ -n "${base}" && -n "${head}" ]] \
                 && git cat-file -e "${base}^{commit}" \
                 && git cat-file -e "${head}^{commit}" \
                 && git diff --name-only "${base}" "${head}" > "${changed_files}"; then
@@ -95,6 +191,7 @@ jobs:
 
   workflow-lint:
     name: Validate GitHub Actions workflows
+    needs: classify-changes
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -440,29 +537,53 @@ jobs:
       - name: Test targeted PR suite
         if: ${{ needs.classify-changes.outputs.full_required != 'true' }}
         shell: bash
+        env:
+          TARGETED_PYTEST_TARGETS: ${{ needs.classify-changes.outputs.pytest_targets }}
         run: |
           set -euo pipefail
           markers="not llm and not live_search and not live_skill_hub and not live_channel and not webui_browser and not tui_real_terminal and not local_golden and not agent_context_boundary and not llm_router_acc"
 
+          pytest_targets=(
+            tests/unit
+            tests/test_ci
+            tests/test_desktop/test_electron_startup_contract.py
+            tests/test_recovery
+            tests/test_migration/test_opensquilla_home_migration.py
+            tests/test_engine/test_coding_mode.py
+            tests/test_engine/test_cancelled_turn_segments.py
+            tests/test_engine/test_history_silent_reply.py
+            tests/test_engine/test_silent_reply.py
+            tests/test_engine/test_silent_reply_runtime.py
+            tests/test_engine/test_stream_wrappers.py
+            tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py
+            tests/test_engine/turn_runner/test_turn_finalizer_stage_unit.py
+            tests/test_gateway/test_rpc_chat_history.py
+            tests/test_persistence/test_usage_ledger.py
+            tests/functional/test_gateway_silent_reply_process_e2e.py
+            tests/test_tools/test_shell_process_isolation.py
+          )
+          if [[ -n "${TARGETED_PYTEST_TARGETS}" ]]; then
+            IFS=',' read -r -a affected_targets <<< "${TARGETED_PYTEST_TARGETS}"
+            for target in "${affected_targets[@]}"; do
+              if [[ "${target}" == *'*'* || "${target}" == *'?'* || "${target}" == *'['* ]]; then
+                mapfile -t matched_targets < <(compgen -G "${target}" || true)
+                if [[ "${#matched_targets[@]}" -eq 0 ]]; then
+                  echo "ERROR: classifier pattern matched no pytest targets: ${target}" >&2
+                  exit 2
+                fi
+                pytest_targets+=("${matched_targets[@]}")
+              elif [[ ! -e "${target}" ]]; then
+                echo "ERROR: classifier selected a missing pytest target: ${target}" >&2
+                exit 2
+              else
+                pytest_targets+=("${target}")
+              fi
+            done
+          fi
+
           uv run pytest \
-            tests/unit \
-            tests/test_ci \
             --ignore=tests/test_ci/test_router_artifact_manifest.py \
-            tests/test_desktop/test_electron_startup_contract.py \
-            tests/test_recovery \
-            tests/test_migration/test_opensquilla_home_migration.py \
-            tests/test_engine/test_coding_mode.py \
-            tests/test_engine/test_cancelled_turn_segments.py \
-            tests/test_engine/test_history_silent_reply.py \
-            tests/test_engine/test_silent_reply.py \
-            tests/test_engine/test_silent_reply_runtime.py \
-            tests/test_engine/test_stream_wrappers.py \
-            tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py \
-            tests/test_engine/turn_runner/test_turn_finalizer_stage_unit.py \
-            tests/test_gateway/test_rpc_chat_history.py \
-            tests/test_persistence/test_usage_ledger.py \
-            tests/functional/test_gateway_silent_reply_process_e2e.py \
-            tests/test_tools/test_shell_process_isolation.py \
+            "${pytest_targets[@]}" \
             -q -m "${markers}" --durations=50
 
       - name: Test Docker build-context exclusions in full CI
@@ -914,7 +1035,7 @@ jobs:
     # contract, which is useful for their native recovery coverage.
     name: Desktop recovery E2E (${{ matrix.os }}, ${{ matrix.shard }})
     needs: [classify-changes, frontend-check]
-    if: ${{ needs.classify-changes.outputs.frontend_changed == 'true' || needs.classify-changes.outputs.platform_sensitive_changed == 'true' || needs.classify-changes.outputs.desktop_changed == 'true' || needs.classify-changes.outputs.full_required == 'true' }}
+    if: ${{ needs.classify-changes.outputs.platform_sensitive_changed == 'true' || needs.classify-changes.outputs.desktop_changed == 'true' || needs.classify-changes.outputs.full_required == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -1185,6 +1306,7 @@ jobs:
 
   readme-locale-check:
     name: README locale parity
+    needs: classify-changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -1206,9 +1328,81 @@ jobs:
     if: ${{ needs.classify-changes.outputs.toolchain_artifact_changed == 'true' || needs.classify-changes.outputs.full_required == 'true' }}
     uses: ./.github/workflows/managed-toolchain-artifacts.yml
 
+  main-canary:
+    name: Main installation and offline gateway canary
+    if: ${{ github.event_name == 'push' && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      UV_PYTHON: "3.12"
+      PYTHONPATH: ${{ github.workspace }}
+      OPENSQUILLA_TURN_CALL_LOG: "0"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Configure isolated runtime directories
+        shell: bash
+        run: |
+          printf 'OPENSQUILLA_STATE_DIR=%s/opensquilla-state\n' "${RUNNER_TEMP}" >> "${GITHUB_ENV}"
+          printf 'OPENSQUILLA_LOG_DIR=%s/opensquilla-logs\n' "${RUNNER_TEMP}" >> "${GITHUB_ENV}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: opensquilla-webui/.node-version
+          cache: npm
+          cache-dependency-path: opensquilla-webui/package-lock.json
+
+      - name: Install locked development dependencies
+        run: uv sync --extra dev --extra recommended --extra mcp --frozen
+
+      - name: Build production WebUI artifact
+        working-directory: opensquilla-webui
+        run: |
+          npm ci
+          npm run build:artifact
+          npm run verify:release-dist
+
+      - name: Build and install wheel in a clean environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          wheel_dir="${RUNNER_TEMP}/canary-wheel"
+          venv_dir="${RUNNER_TEMP}/canary-venv"
+          uv build --wheel --out-dir "${wheel_dir}"
+          wheels=("${wheel_dir}"/opensquilla-*.whl)
+          if [[ "${#wheels[@]}" -ne 1 || ! -f "${wheels[0]}" ]]; then
+            echo "ERROR: expected exactly one canary wheel" >&2
+            exit 1
+          fi
+          uv venv "${venv_dir}" --python 3.12
+          uv pip install --python "${venv_dir}/bin/python" "${wheels[0]}"
+          "${venv_dir}/bin/python" -c "import opensquilla; import opensquilla.gateway.app"
+          "${venv_dir}/bin/opensquilla" --help >/dev/null
+
+      - name: Run offline gateway and provider canary
+        run: >-
+          uv run pytest
+          tests/functional/test_gateway_silent_reply_process_e2e.py
+          -q --durations=10
+
   ci-result:
     name: CI result
     needs:
+      - queue-attestation
       - classify-changes
       - workflow-lint
       - readme-locale-check
@@ -1224,19 +1418,69 @@ jobs:
       - desktop-recovery-e2e
       - release-packaging
       - managed-toolchain-artifacts
+      - main-canary
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Accept verified queue or main fast path
+        if: >-
+          ${{ (github.event_name == 'merge_group'
+               && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce'
+               && needs.queue-attestation.outputs.reusable == 'true')
+              || (github.event_name == 'push'
+                  && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce') }}
+        env:
+          QUEUE_RESULT: ${{ needs.queue-attestation.result }}
+          QUEUE_REUSABLE: ${{ needs.queue-attestation.outputs.reusable }}
+          QUEUE_REASON: ${{ needs.queue-attestation.outputs.reason }}
+          MAIN_CANARY_RESULT: ${{ needs.main-canary.result }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "merge_group" ]]; then
+            if [[ "${QUEUE_RESULT}" != "success" || "${QUEUE_REUSABLE}" != "true" ]]; then
+              echo "ERROR: merge queue fast path lacks trusted green evidence: ${QUEUE_REASON}" >&2
+              exit 1
+            fi
+            echo "Merge queue reused trusted PR CI evidence: ${QUEUE_REASON}"
+          elif [[ "${MAIN_CANARY_RESULT}" != "success" ]]; then
+            echo "ERROR: main canary must succeed; got ${MAIN_CANARY_RESULT:-missing}." >&2
+            exit 1
+          else
+            echo "Main installation and offline gateway canary succeeded."
+          fi
+
       - name: Check out repository
+        if: >-
+          ${{ !((github.event_name == 'merge_group'
+                 && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce'
+                 && needs.queue-attestation.outputs.reusable == 'true')
+                || (github.event_name == 'push'
+                    && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce')) }}
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          persist-credentials: false
 
       - name: Set up Python
+        if: >-
+          ${{ !((github.event_name == 'merge_group'
+                 && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce'
+                 && needs.queue-attestation.outputs.reusable == 'true')
+                || (github.event_name == 'push'
+                    && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce')) }}
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
       - name: Check WebUI chat recovery result
+        if: >-
+          ${{ !((github.event_name == 'merge_group'
+                 && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce'
+                 && needs.queue-attestation.outputs.reusable == 'true')
+                || (github.event_name == 'push'
+                    && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce')) }}
         env:
           RESULT_WEBUI_CHAT_RECOVERY: ${{ needs.webui-chat-recovery.result }}
           FLAG_FRONTEND_CHANGED: ${{ needs.classify-changes.outputs.frontend_changed }}
@@ -1255,6 +1499,12 @@ jobs:
           fi
 
       - name: Check required CI results
+        if: >-
+          ${{ !((github.event_name == 'merge_group'
+                 && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce'
+                 && needs.queue-attestation.outputs.reusable == 'true')
+                || (github.event_name == 'push'
+                    && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce')) }}
         env:
           RESULT_CLASSIFY: ${{ needs.classify-changes.result }}
           RESULT_WORKFLOW_LINT: ${{ needs.workflow-lint.result }}
@@ -1286,3 +1536,26 @@ jobs:
           FLAG_TOOLCHAIN_ARTIFACT_CHANGED: ${{ needs.classify-changes.outputs.toolchain_artifact_changed }}
           FLAG_FULL_REQUIRED: ${{ needs.classify-changes.outputs.full_required }}
         run: python .github/scripts/check_ci_results.py
+
+      - name: Create trusted PR CI attestation
+        id: attestation
+        if: ${{ github.event_name == 'pull_request' && env.CI_OPTIMIZATION_MODE != 'legacy' }}
+        run: >-
+          python .github/scripts/ci_attestation.py create
+          --repository "${GITHUB_REPOSITORY}"
+          --event-path "${GITHUB_EVENT_PATH}"
+          --run-id "${GITHUB_RUN_ID}"
+          --run-attempt "${GITHUB_RUN_ATTEMPT}"
+          --workflow-ref "${GITHUB_WORKFLOW_REF}"
+          --optimization-mode "${CI_OPTIMIZATION_MODE}"
+          --output "${RUNNER_TEMP}/ci-attestation.json"
+          --github-output "${GITHUB_OUTPUT}"
+
+      - name: Upload trusted PR CI attestation
+        if: ${{ github.event_name == 'pull_request' && env.CI_OPTIMIZATION_MODE != 'legacy' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-attestation-${{ steps.attestation.outputs.tree_sha }}
+          path: ${{ runner.temp }}/ci-attestation.json
+          if-no-files-found: error
+          retention-days: 31

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CI_OPTIMIZATION_MODE: ${{ vars.CI_OPTIMIZATION_MODE || 'shadow' }}
+  CI_OPTIMIZATION_MODE: ${{ vars.CI_OPTIMIZATION_MODE || 'enforce' }}
   OPENSQUILLA_TESTING: "true"
 
 jobs:
@@ -101,10 +101,10 @@ jobs:
     if: >-
       ${{ always()
           && (github.event_name != 'merge_group'
-              || (vars.CI_OPTIMIZATION_MODE || 'shadow') != 'enforce'
+              || (vars.CI_OPTIMIZATION_MODE || 'enforce') != 'enforce'
               || needs.queue-attestation.outputs.reusable != 'true')
           && (github.event_name != 'push'
-              || (vars.CI_OPTIMIZATION_MODE || 'shadow') != 'enforce') }}
+              || (vars.CI_OPTIMIZATION_MODE || 'enforce') != 'enforce') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -1335,7 +1335,7 @@ jobs:
 
   main-canary:
     name: Main installation and offline gateway canary
-    if: ${{ github.event_name == 'push' && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce' }}
+    if: ${{ github.event_name == 'push' && (vars.CI_OPTIMIZATION_MODE || 'enforce') == 'enforce' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -1431,10 +1431,10 @@ jobs:
       - name: Accept verified queue or main fast path
         if: >-
           ${{ (github.event_name == 'merge_group'
-               && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce'
+               && (vars.CI_OPTIMIZATION_MODE || 'enforce') == 'enforce'
                && needs.queue-attestation.outputs.reusable == 'true')
               || (github.event_name == 'push'
-                  && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce') }}
+                  && (vars.CI_OPTIMIZATION_MODE || 'enforce') == 'enforce') }}
         env:
           QUEUE_RESULT: ${{ needs.queue-attestation.result }}
           QUEUE_REUSABLE: ${{ needs.queue-attestation.outputs.reusable }}
@@ -1459,10 +1459,10 @@ jobs:
       - name: Check out repository
         if: >-
           ${{ !((github.event_name == 'merge_group'
-                 && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce'
+                 && (vars.CI_OPTIMIZATION_MODE || 'enforce') == 'enforce'
                  && needs.queue-attestation.outputs.reusable == 'true')
                 || (github.event_name == 'push'
-                    && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce')) }}
+                    && (vars.CI_OPTIMIZATION_MODE || 'enforce') == 'enforce')) }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
@@ -1471,10 +1471,10 @@ jobs:
       - name: Set up Python
         if: >-
           ${{ !((github.event_name == 'merge_group'
-                 && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce'
+                 && (vars.CI_OPTIMIZATION_MODE || 'enforce') == 'enforce'
                  && needs.queue-attestation.outputs.reusable == 'true')
                 || (github.event_name == 'push'
-                    && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce')) }}
+                    && (vars.CI_OPTIMIZATION_MODE || 'enforce') == 'enforce')) }}
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -1482,10 +1482,10 @@ jobs:
       - name: Check WebUI chat recovery result
         if: >-
           ${{ !((github.event_name == 'merge_group'
-                 && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce'
+                 && (vars.CI_OPTIMIZATION_MODE || 'enforce') == 'enforce'
                  && needs.queue-attestation.outputs.reusable == 'true')
                 || (github.event_name == 'push'
-                    && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce')) }}
+                    && (vars.CI_OPTIMIZATION_MODE || 'enforce') == 'enforce')) }}
         env:
           RESULT_WEBUI_CHAT_RECOVERY: ${{ needs.webui-chat-recovery.result }}
           FLAG_FRONTEND_CHANGED: ${{ needs.classify-changes.outputs.frontend_changed }}
@@ -1506,10 +1506,10 @@ jobs:
       - name: Check required CI results
         if: >-
           ${{ !((github.event_name == 'merge_group'
-                 && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce'
+                 && (vars.CI_OPTIMIZATION_MODE || 'enforce') == 'enforce'
                  && needs.queue-attestation.outputs.reusable == 'true')
                 || (github.event_name == 'push'
-                    && (vars.CI_OPTIMIZATION_MODE || 'shadow') == 'enforce')) }}
+                    && (vars.CI_OPTIMIZATION_MODE || 'enforce') == 'enforce')) }}
         env:
           RESULT_CLASSIFY: ${{ needs.classify-changes.result }}
           RESULT_WORKFLOW_LINT: ${{ needs.workflow-lint.result }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,11 @@ env:
 jobs:
   queue-attestation:
     name: Verify reusable PR CI evidence
-    if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       reusable: ${{ steps.verify.outputs.reusable || 'false' }}
-      reason: ${{ steps.verify.outputs.reason || steps.mode.outputs.reason }}
+      reason: ${{ steps.verify.outputs.reason || steps.context.outputs.reason || steps.mode.outputs.reason }}
       source_run_id: ${{ steps.verify.outputs.source_run_id }}
     steps:
       - name: Validate optimization mode
@@ -49,8 +48,13 @@ jobs:
             echo "reason=legacy mode always runs queue CI" >> "${GITHUB_OUTPUT}"
           fi
 
+      - name: Record non-queue context
+        id: context
+        if: ${{ github.event_name != 'merge_group' }}
+        run: echo "reason=not a merge-group event" >> "${GITHUB_OUTPUT}"
+
       - name: Check out merge-group commit
-        if: ${{ env.CI_OPTIMIZATION_MODE != 'legacy' }}
+        if: ${{ github.event_name == 'merge_group' && env.CI_OPTIMIZATION_MODE != 'legacy' }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -58,7 +62,7 @@ jobs:
 
       - name: Verify matching trusted PR CI attestation
         id: verify
-        if: ${{ env.CI_OPTIMIZATION_MODE != 'legacy' }}
+        if: ${{ github.event_name == 'merge_group' && env.CI_OPTIMIZATION_MODE != 'legacy' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: >-
@@ -70,6 +74,7 @@ jobs:
           --github-output "${GITHUB_OUTPUT}"
 
       - name: Summarize queue decision
+        if: ${{ github.event_name == 'merge_group' }}
         env:
           REUSABLE: ${{ steps.verify.outputs.reusable || 'false' }}
           REASON: ${{ steps.verify.outputs.reason || steps.mode.outputs.reason }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
       tui_changed: ${{ steps.classify.outputs.tui_changed }}
       desktop_changed: ${{ steps.classify.outputs.desktop_changed }}
       python_changed: ${{ steps.classify.outputs.python_changed }}
+      python_full_required: ${{ steps.classify.outputs.python_full_required }}
       platform_sensitive_changed: ${{ steps.classify.outputs.platform_sensitive_changed }}
       build_wheel_required: ${{ steps.classify.outputs.build_wheel_required }}
       toolchain_artifact_changed: ${{ steps.classify.outputs.toolchain_artifact_changed }}
@@ -540,7 +541,7 @@ jobs:
         run: uv run mypy src/opensquilla --show-error-codes
 
       - name: Test targeted PR suite
-        if: ${{ needs.classify-changes.outputs.full_required != 'true' }}
+        if: ${{ needs.classify-changes.outputs.full_required != 'true' && needs.classify-changes.outputs.python_full_required != 'true' }}
         shell: bash
         env:
           TARGETED_PYTEST_TARGETS: ${{ needs.classify-changes.outputs.pytest_targets }}
@@ -617,7 +618,7 @@ jobs:
   ubuntu-full:
     name: Full offline tests (ubuntu-latest, ${{ matrix.shard }})
     needs: classify-changes
-    if: ${{ needs.classify-changes.outputs.full_required == 'true' }}
+    if: ${{ needs.classify-changes.outputs.full_required == 'true' || needs.classify-changes.outputs.python_full_required == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -1536,6 +1537,7 @@ jobs:
           FLAG_TUI_CHANGED: ${{ needs.classify-changes.outputs.tui_changed }}
           FLAG_DESKTOP_CHANGED: ${{ needs.classify-changes.outputs.desktop_changed }}
           FLAG_PYTHON_CHANGED: ${{ needs.classify-changes.outputs.python_changed }}
+          FLAG_PYTHON_FULL_REQUIRED: ${{ needs.classify-changes.outputs.python_full_required }}
           FLAG_PLATFORM_SENSITIVE_CHANGED: ${{ needs.classify-changes.outputs.platform_sensitive_changed }}
           FLAG_BUILD_WHEEL_REQUIRED: ${{ needs.classify-changes.outputs.build_wheel_required }}
           FLAG_TOOLCHAIN_ARTIFACT_CHANGED: ${{ needs.classify-changes.outputs.toolchain_artifact_changed }}

--- a/tests/test_ci/test_ci_attestation.py
+++ b/tests/test_ci/test_ci_attestation.py
@@ -37,7 +37,9 @@ def _write(repo: Path, relative: str, value: str) -> None:
     path.write_text(value, encoding="utf-8")
 
 
-def _merge_preview_repo(tmp_path: Path) -> tuple[Path, str, str, str]:
+def _merge_preview_repo(
+    tmp_path: Path, *, advance_base: bool = False
+) -> tuple[Path, str, str, str]:
     repo = tmp_path / "repo"
     repo.mkdir()
     _git(repo, "init", "-b", "main")
@@ -58,6 +60,11 @@ def _merge_preview_repo(tmp_path: Path) -> tuple[Path, str, str, str]:
     head_sha = _git(repo, "rev-parse", "HEAD")
 
     _git(repo, "switch", "main")
+    if advance_base:
+        _write(repo, "src/base_update.py", "UPDATED_BASE = True\n")
+        _git(repo, "add", "src/base_update.py")
+        _git(repo, "commit", "-m", "advance base")
+    base_sha = _git(repo, "rev-parse", "HEAD")
     _git(repo, "merge", "--no-ff", "feature", "-m", "merge preview")
     merge_sha = _git(repo, "rev-parse", "HEAD")
     return repo, base_sha, head_sha, merge_sha
@@ -127,6 +134,43 @@ def test_create_attestation_pins_merge_parents_tree_and_policy(tmp_path: Path) -
     assert attestation["tested_tree_sha"] == _git(repo, "rev-parse", "HEAD^{tree}")
     assert attestation["policy_digest"] == policy_digest(repo)
     assert attestation["validation_profile"] == "precise-v1"
+
+
+def test_create_attestation_uses_tested_base_when_event_base_is_stale(
+    tmp_path: Path,
+) -> None:
+    repo, tested_base_sha, head_sha, merge_sha = _merge_preview_repo(
+        tmp_path, advance_base=True
+    )
+    event_base_sha = _git(repo, "rev-parse", f"{head_sha}^")
+
+    assert event_base_sha != tested_base_sha
+    attestation = create_attestation(
+        repo=repo,
+        repository="opensquilla/opensquilla",
+        event=_event(event_base_sha, head_sha, merge_sha),
+        workflow_run_id=123,
+        workflow_run_attempt=1,
+        workflow_ref="opensquilla/opensquilla/.github/workflows/ci.yml@refs/pull/42/merge",
+        optimization_mode="enforce",
+    )
+
+    assert attestation["base_sha"] == tested_base_sha
+
+
+def test_create_attestation_rejects_merge_for_another_head(tmp_path: Path) -> None:
+    repo, base_sha, head_sha, merge_sha = _merge_preview_repo(tmp_path)
+
+    with pytest.raises(AttestationError, match="tested merge head"):
+        create_attestation(
+            repo=repo,
+            repository="opensquilla/opensquilla",
+            event=_event(base_sha, "0" * 40, merge_sha),
+            workflow_run_id=123,
+            workflow_run_attempt=1,
+            workflow_ref="workflow-ref",
+            optimization_mode="enforce",
+        )
 
 
 def test_validate_candidate_rejects_non_green_or_mismatched_runs(tmp_path: Path) -> None:

--- a/tests/test_ci/test_ci_attestation.py
+++ b/tests/test_ci/test_ci_attestation.py
@@ -51,7 +51,6 @@ def _merge_preview_repo(
     _write(repo, "src/example.py", "BASE = True\n")
     _git(repo, "add", ".")
     _git(repo, "commit", "-m", "base")
-    base_sha = _git(repo, "rev-parse", "HEAD")
 
     _git(repo, "switch", "-c", "feature")
     _write(repo, "src/example.py", "BASE = True\nFEATURE = True\n")

--- a/tests/test_ci/test_ci_attestation.py
+++ b/tests/test_ci/test_ci_attestation.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import io
+import json
+import runpy
+import subprocess
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+MODULE: dict[str, Any] = runpy.run_path(
+    ".github/scripts/ci_attestation.py", run_name="ci_attestation"
+)
+AttestationError = MODULE["AttestationError"]
+create_attestation = MODULE["create_attestation"]
+policy_digest = MODULE["policy_digest"]
+validate_candidate = MODULE["validate_candidate"]
+verify_queue = MODULE["verify_queue"]
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _write(repo: Path, relative: str, value: str) -> None:
+    path = repo / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(value, encoding="utf-8")
+
+
+def _merge_preview_repo(tmp_path: Path) -> tuple[Path, str, str, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "CI Test")
+    _git(repo, "config", "user.email", "ci@example.invalid")
+    _write(repo, ".github/workflows/ci.yml", "name: CI\n")
+    _write(repo, ".github/scripts/classify-ci-changes.sh", "#!/bin/sh\n")
+    _write(repo, "pyproject.toml", "[project]\nname='fixture'\nversion='0'\n")
+    _write(repo, "src/example.py", "BASE = True\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+    base_sha = _git(repo, "rev-parse", "HEAD")
+
+    _git(repo, "switch", "-c", "feature")
+    _write(repo, "src/example.py", "BASE = True\nFEATURE = True\n")
+    _git(repo, "add", "src/example.py")
+    _git(repo, "commit", "-m", "feature")
+    head_sha = _git(repo, "rev-parse", "HEAD")
+
+    _git(repo, "switch", "main")
+    _git(repo, "merge", "--no-ff", "feature", "-m", "merge preview")
+    merge_sha = _git(repo, "rev-parse", "HEAD")
+    return repo, base_sha, head_sha, merge_sha
+
+
+def _event(base_sha: str, head_sha: str, merge_sha: str) -> dict[str, Any]:
+    return {
+        "pull_request": {
+            "number": 42,
+            "base": {"ref": "main", "sha": base_sha},
+            "head": {
+                "ref": "feature",
+                "sha": head_sha,
+                "repo": {"full_name": "opensquilla/opensquilla"},
+            },
+        },
+        "merge_group": {
+            "base_sha": base_sha,
+            "head_sha": merge_sha,
+            "base_ref": "refs/heads/main",
+        },
+    }
+
+
+def _run(attestation: dict[str, object]) -> dict[str, Any]:
+    return {
+        "id": attestation["workflow_run_id"],
+        "run_attempt": attestation["workflow_run_attempt"],
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": "success",
+        "head_sha": attestation["head_sha"],
+        "path": ".github/workflows/ci.yml",
+        "repository": {"full_name": "opensquilla/opensquilla"},
+        "pull_requests": [
+            {
+                "number": 42,
+                "head": {"sha": attestation["head_sha"]},
+                "base": {"ref": "main", "sha": attestation["base_sha"]},
+            }
+        ],
+    }
+
+
+def _archive(attestation: dict[str, object]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as bundle:
+        bundle.writestr("ci-attestation.json", json.dumps(attestation))
+    return buffer.getvalue()
+
+
+def test_create_attestation_pins_merge_parents_tree_and_policy(tmp_path: Path) -> None:
+    repo, base_sha, head_sha, merge_sha = _merge_preview_repo(tmp_path)
+    attestation = create_attestation(
+        repo=repo,
+        repository="opensquilla/opensquilla",
+        event=_event(base_sha, head_sha, merge_sha),
+        workflow_run_id=123,
+        workflow_run_attempt=2,
+        workflow_ref="opensquilla/opensquilla/.github/workflows/ci.yml@refs/pull/42/merge",
+        optimization_mode="shadow",
+    )
+
+    assert attestation["base_sha"] == base_sha
+    assert attestation["head_sha"] == head_sha
+    assert attestation["tested_merge_sha"] == merge_sha
+    assert attestation["tested_tree_sha"] == _git(repo, "rev-parse", "HEAD^{tree}")
+    assert attestation["policy_digest"] == policy_digest(repo)
+    assert attestation["validation_profile"] == "precise-v1"
+
+
+def test_validate_candidate_rejects_non_green_or_mismatched_runs(tmp_path: Path) -> None:
+    repo, base_sha, head_sha, merge_sha = _merge_preview_repo(tmp_path)
+    attestation = create_attestation(
+        repo=repo,
+        repository="opensquilla/opensquilla",
+        event=_event(base_sha, head_sha, merge_sha),
+        workflow_run_id=123,
+        workflow_run_attempt=1,
+        workflow_ref="workflow-ref",
+        optimization_mode="enforce",
+    )
+    run = _run(attestation)
+
+    validate_candidate(
+        attestation=attestation,
+        run=run,
+        repository="opensquilla/opensquilla",
+        queue_tree_sha=str(attestation["tested_tree_sha"]),
+        queue_base_sha=base_sha,
+        queue_policy_digest=str(attestation["policy_digest"]),
+        pull_request_head_is_ancestor=True,
+    )
+
+    for field, value in (
+        ("conclusion", "failure"),
+        ("event", "workflow_dispatch"),
+        ("path", ".github/workflows/untrusted.yml"),
+    ):
+        tampered = dict(run)
+        tampered[field] = value
+        with pytest.raises(AttestationError):
+            validate_candidate(
+                attestation=attestation,
+                run=tampered,
+                repository="opensquilla/opensquilla",
+                queue_tree_sha=str(attestation["tested_tree_sha"]),
+                queue_base_sha=base_sha,
+                queue_policy_digest=str(attestation["policy_digest"]),
+                pull_request_head_is_ancestor=True,
+            )
+
+    wrong_base = dict(run)
+    wrong_base["pull_requests"] = [
+        {
+            "number": 42,
+            "head": {"sha": attestation["head_sha"]},
+            "base": {"ref": "main", "sha": "0" * 40},
+        }
+    ]
+    with pytest.raises(AttestationError):
+        validate_candidate(
+            attestation=attestation,
+            run=wrong_base,
+            repository="opensquilla/opensquilla",
+            queue_tree_sha=str(attestation["tested_tree_sha"]),
+            queue_base_sha=base_sha,
+            queue_policy_digest=str(attestation["policy_digest"]),
+            pull_request_head_is_ancestor=True,
+        )
+
+
+def test_verify_queue_reuses_only_exact_trusted_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo, base_sha, head_sha, merge_sha = _merge_preview_repo(tmp_path)
+    event = _event(base_sha, head_sha, merge_sha)
+    attestation = create_attestation(
+        repo=repo,
+        repository="opensquilla/opensquilla",
+        event=event,
+        workflow_run_id=123,
+        workflow_run_attempt=1,
+        workflow_ref="workflow-ref",
+        optimization_mode="shadow",
+    )
+    run = _run(attestation)
+
+    def fake_json(url: str, _token: str) -> dict[str, Any]:
+        if "actions/artifacts" in url:
+            return {
+                "artifacts": [
+                    {
+                        "expired": False,
+                        "size_in_bytes": len(_archive(attestation)),
+                        "created_at": "2026-08-13T00:00:00Z",
+                        "archive_download_url": "https://api.github.com/artifact.zip",
+                        "workflow_run": {"id": 123},
+                    }
+                ]
+            }
+        return run
+
+    monkeypatch.setitem(verify_queue.__globals__, "_request_json", fake_json)
+    monkeypatch.setitem(
+        verify_queue.__globals__, "_request_bytes", lambda _url, _token: _archive(attestation)
+    )
+
+    reusable, reason, source_run = verify_queue(
+        repo=repo,
+        repository="opensquilla/opensquilla",
+        event=event,
+        token="synthetic-token",
+        api_url="https://api.github.com",
+        current_run_id=999,
+    )
+
+    assert reusable is True
+    assert reason == "matching trusted PR CI attestation"
+    assert source_run == 123
+
+    _write(repo, ".github/workflows/ci.yml", "name: Changed CI\n")
+    _git(repo, "add", ".github/workflows/ci.yml")
+    _git(repo, "commit", "-m", "change policy")
+    changed_event = _event(base_sha, head_sha, _git(repo, "rev-parse", "HEAD"))
+    reusable, reason, source_run = verify_queue(
+        repo=repo,
+        repository="opensquilla/opensquilla",
+        event=changed_event,
+        token="synthetic-token",
+        api_url="https://api.github.com",
+        current_run_id=1000,
+    )
+
+    assert reusable is False
+    assert "CI policy changed" in reason
+    assert source_run is None

--- a/tests/test_ci/test_ci_result_gate.py
+++ b/tests/test_ci/test_ci_result_gate.py
@@ -90,6 +90,17 @@ def test_ci_result_gate_rejects_required_windows_matrix_skip() -> None:
     assert any("Windows high-risk matrix" in error and "skipped" in error for error in errors)
 
 
+def test_ci_result_gate_rejects_python_full_without_python_change() -> None:
+    env = _base_env()
+    env[_flag_env("docs_only")] = "false"
+    env[_flag_env("python_full_required")] = "true"
+    env["RESULT_UBUNTU_FULL"] = "success"
+
+    errors = check_ci_results(env)
+
+    assert any("must also be classified as Python changes" in error for error in errors)
+
+
 def test_ci_result_gate_accepts_windows_full_in_place_of_duplicate_smoke() -> None:
     env = _base_env()
     env[_flag_env("docs_only")] = "false"
@@ -121,7 +132,7 @@ def test_ci_result_gate_requires_smoke_for_targeted_python_without_full_matrix()
     assert any("Windows compatibility smoke tests" in error for error in errors)
 
 
-def test_ci_result_gate_requires_ubuntu_full_matrix_only_for_full_ci() -> None:
+def test_ci_result_gate_requires_ubuntu_full_matrix_for_shared_core_or_full_ci() -> None:
     targeted = _base_env()
     targeted[_flag_env("docs_only")] = "false"
     targeted[_flag_env("runtime_changed")] = "true"
@@ -131,6 +142,20 @@ def test_ci_result_gate_requires_ubuntu_full_matrix_only_for_full_ci() -> None:
     targeted["RESULT_UBUNTU"] = "success"
     targeted["RESULT_WINDOWS_SMOKE"] = "success"
     assert check_ci_results(targeted) == []
+
+    for result in ("skipped", "failure", "cancelled", ""):
+        env = dict(targeted)
+        env[_flag_env("python_full_required")] = "true"
+        env["RESULT_UBUNTU_FULL"] = result
+
+        errors = check_ci_results(env)
+
+        assert any("Ubuntu full test matrix" in error for error in errors)
+
+    python_full = dict(targeted)
+    python_full[_flag_env("python_full_required")] = "true"
+    python_full["RESULT_UBUNTU_FULL"] = "success"
+    assert check_ci_results(python_full) == []
 
     for result in ("skipped", "failure", "cancelled", ""):
         env = _full_env()

--- a/tests/test_ci/test_ci_result_gate.py
+++ b/tests/test_ci/test_ci_result_gate.py
@@ -253,7 +253,7 @@ def test_ci_result_gate_requires_desktop_recovery_e2e_for_desktop_changes() -> N
     assert any("Desktop recovery E2E matrix" in error and "skipped" in error for error in errors)
 
 
-def test_ci_result_gate_requires_desktop_recovery_e2e_for_frontend_changes() -> None:
+def test_ci_result_gate_uses_focused_browser_checks_for_frontend_changes() -> None:
     env = _base_env()
     env[_flag_env("docs_only")] = "false"
     env[_flag_env("runtime_changed")] = "true"
@@ -264,9 +264,7 @@ def test_ci_result_gate_requires_desktop_recovery_e2e_for_frontend_changes() -> 
     env["RESULT_UBUNTU"] = "success"
     env["RESULT_WINDOWS_SMOKE"] = "success"
 
-    errors = check_ci_results(env)
-
-    assert any("Desktop recovery E2E matrix" in error and "skipped" in error for error in errors)
+    assert check_ci_results(env) == []
 
 
 def test_ci_result_gate_rejects_failed_or_missing_desktop_recovery_e2e() -> None:

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -242,7 +242,7 @@ def test_ci_fast_paths_keep_the_required_check_and_fail_closed() -> None:
     jobs = workflow["jobs"]
 
     assert workflow["env"]["CI_OPTIMIZATION_MODE"] == (
-        "${{ vars.CI_OPTIMIZATION_MODE || 'shadow' }}"
+        "${{ vars.CI_OPTIMIZATION_MODE || 'enforce' }}"
     )
     assert jobs["queue-attestation"]["name"] == "Verify reusable PR CI evidence"
     assert "if" not in jobs["queue-attestation"]

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -117,14 +117,17 @@ def _expected_classifier_outputs(**overrides: str) -> dict[str, str]:
         "tui_changed": "false",
         "desktop_changed": "false",
         "python_changed": "false",
+        "python_full_required": "false",
         "platform_sensitive_changed": "false",
         "build_wheel_required": "false",
         "toolchain_artifact_changed": "false",
         "full_required": "false",
         "pytest_targets": "",
     }
-    if overrides.get("full_required") == "true" and "pytest_targets" not in overrides:
-        outputs["pytest_targets"] = "tests"
+    if overrides.get("full_required") == "true":
+        outputs["python_full_required"] = "true"
+        if "pytest_targets" not in overrides:
+            outputs["pytest_targets"] = "tests"
     outputs.update(overrides)
     return outputs
 
@@ -225,6 +228,7 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     assert "tui_changed" in text
     assert "desktop_changed" in text
     assert "python_changed" in text
+    assert "python_full_required" in text
     assert "platform_sensitive_changed" in text
     assert "build_wheel_required" in text
     assert "full_required" in text
@@ -297,6 +301,29 @@ def test_ci_change_classifier_routes_platform_neutral_provider_changes(
             "tests/test_provider,tests/test_provider*.py,tests/test_*router*.py,"
             "tests/test_cross_provider_tiers.py"
         ),
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "src/opensquilla/engine/runtime.py",
+        "src/opensquilla/application/approval_rpc.py",
+        "src/opensquilla/agents/registry.py",
+        "src/opensquilla/safety/injection_guard.py",
+    ],
+)
+def test_ci_change_classifier_runs_all_python_shards_for_shared_core(
+    tmp_path: Path,
+    path: str,
+) -> None:
+    outputs = _classify_changed_files(tmp_path, [path])
+
+    assert outputs == _expected_classifier_outputs(
+        runtime_changed="true",
+        python_changed="true",
+        python_full_required="true",
+        build_wheel_required="true",
     )
 
 
@@ -1350,6 +1377,7 @@ def test_default_ci_uses_layered_job_conditions() -> None:
     assert "desktop_changed == 'true'" in jobs["desktop-check"]["if"]
     assert "python_changed == 'true'" in jobs["ubuntu-quality"]["if"]
     assert "full_required == 'true'" in jobs["ubuntu-full"]["if"]
+    assert "python_full_required == 'true'" in jobs["ubuntu-full"]["if"]
     assert jobs["windows-compat"]["if"] == (
         "${{ (needs.classify-changes.outputs.python_changed == 'true' || "
         "needs.classify-changes.outputs.platform_sensitive_changed == 'true' || "
@@ -1432,6 +1460,7 @@ def test_ci_result_gate_covers_every_conditional_job_and_classifier_flag() -> No
         "FLAG_TUI_CHANGED",
         "FLAG_DESKTOP_CHANGED",
         "FLAG_PYTHON_CHANGED",
+        "FLAG_PYTHON_FULL_REQUIRED",
         "FLAG_PLATFORM_SENSITIVE_CHANGED",
         "FLAG_BUILD_WHEEL_REQUIRED",
         "FLAG_TOOLCHAIN_ARTIFACT_CHANGED",
@@ -1708,8 +1737,11 @@ def test_ubuntu_quality_keeps_targeted_pr_tests_and_full_ci_uses_balanced_matrix
         "${{ needs.classify-changes.outputs.full_required == 'true' }}"
     )
     assert test_step["if"] == (
-        "${{ needs.classify-changes.outputs.full_required != 'true' }}"
+        "${{ needs.classify-changes.outputs.full_required != 'true' && "
+        "needs.classify-changes.outputs.python_full_required != 'true' }}"
     )
+    assert "full_required == 'true'" in ubuntu_full["if"]
+    assert "python_full_required == 'true'" in ubuntu_full["if"]
     assert "uv run pytest" in test_step["run"]
     assert "tests/test_artifacts.py" not in test_step["run"]
     assert "--ignore=tests/test_ci/test_router_artifact_manifest.py" in test_step["run"]

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -245,6 +245,8 @@ def test_ci_fast_paths_keep_the_required_check_and_fail_closed() -> None:
         "${{ vars.CI_OPTIMIZATION_MODE || 'shadow' }}"
     )
     assert jobs["queue-attestation"]["name"] == "Verify reusable PR CI evidence"
+    assert "if" not in jobs["queue-attestation"]
+    assert "not a merge-group event" in str(jobs["queue-attestation"])
     assert "fetch-depth" in str(jobs["queue-attestation"])
     assert "verify-queue" in str(jobs["queue-attestation"])
     assert "full fail-closed matrix" in str(jobs["classify-changes"])

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -121,7 +121,10 @@ def _expected_classifier_outputs(**overrides: str) -> dict[str, str]:
         "build_wheel_required": "false",
         "toolchain_artifact_changed": "false",
         "full_required": "false",
+        "pytest_targets": "",
     }
+    if overrides.get("full_required") == "true" and "pytest_targets" not in overrides:
+        outputs["pytest_targets"] = "tests"
     outputs.update(overrides)
     return outputs
 
@@ -183,7 +186,13 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     data = _workflow("ci.yml")
     text = ci_path.read_text(encoding="utf-8")
 
-    assert {"pull_request", "merge_group", "push", "workflow_dispatch"} <= _trigger_keys(data)
+    assert {
+        "pull_request",
+        "merge_group",
+        "push",
+        "schedule",
+        "workflow_dispatch",
+    } <= _trigger_keys(data)
     assert data["on"]["merge_group"]["types"] == ["checks_requested"]
     assert "branches: [main]" in text
     assert "PYTHONPATH: ${{ github.workspace }}" in text
@@ -227,6 +236,83 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
         '"${{ github.event_name }}" == "merge_group"'
     ) == 3
 
+
+def test_ci_fast_paths_keep_the_required_check_and_fail_closed() -> None:
+    workflow = _workflow("ci.yml")
+    jobs = workflow["jobs"]
+
+    assert workflow["env"]["CI_OPTIMIZATION_MODE"] == (
+        "${{ vars.CI_OPTIMIZATION_MODE || 'shadow' }}"
+    )
+    assert jobs["queue-attestation"]["name"] == "Verify reusable PR CI evidence"
+    assert "fetch-depth" in str(jobs["queue-attestation"])
+    assert "verify-queue" in str(jobs["queue-attestation"])
+    assert "full fail-closed matrix" in str(jobs["classify-changes"])
+    assert 'CI_OPTIMIZATION_MODE}" == "legacy"' in str(jobs["classify-changes"])
+    assert jobs["main-canary"]["name"] == "Main installation and offline gateway canary"
+    assert "test_gateway_silent_reply_process_e2e.py" in str(jobs["main-canary"])
+    assert jobs["ci-result"]["name"] == "CI result"
+    assert "ci-attestation-${{ steps.attestation.outputs.tree_sha }}" in str(
+        jobs["ci-result"]
+    )
+
+
+def test_ci_change_classifier_routes_platform_neutral_gateway_changes(
+    tmp_path: Path,
+) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        [
+            "src/opensquilla/gateway/task_runtime.py",
+            "tests/test_gateway/test_task_runtime.py",
+        ],
+    )
+
+    assert outputs == _expected_classifier_outputs(
+        runtime_changed="true",
+        test_changed="true",
+        python_changed="true",
+        build_wheel_required="true",
+        pytest_targets=(
+            "tests/test_gateway,tests/test_gateway*.py,tests/functional/test_gateway_*_e2e.py"
+        ),
+    )
+
+
+def test_ci_change_classifier_routes_platform_neutral_provider_changes(
+    tmp_path: Path,
+) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        ["src/opensquilla/provider/registry.py"],
+    )
+
+    assert outputs == _expected_classifier_outputs(
+        runtime_changed="true",
+        python_changed="true",
+        build_wheel_required="true",
+        pytest_targets=(
+            "tests/test_provider,tests/test_provider*.py,tests/test_*router*.py,"
+            "tests/test_cross_provider_tiers.py"
+        ),
+    )
+
+
+def test_ci_change_classifier_keeps_native_router_changes_platform_sensitive(
+    tmp_path: Path,
+) -> None:
+    outputs = _classify_changed_files(
+        tmp_path,
+        ["src/opensquilla/squilla_router/inference.py"],
+    )
+
+    assert outputs == _expected_classifier_outputs(
+        runtime_changed="true",
+        windows_full_required="true",
+        python_changed="true",
+        platform_sensitive_changed="true",
+        build_wheel_required="true",
+    )
 
 def test_default_ci_keeps_main_pushes_targeted_and_manual_runs_full() -> None:
     ci_path = WORKFLOW_DIR / "ci.yml"
@@ -1273,7 +1359,8 @@ def test_default_ci_uses_layered_job_conditions() -> None:
     assert "windows_full_required == 'true'" in jobs["windows-full"]["if"]
     assert "platform_sensitive_changed == 'true'" in jobs["macos-recovery"]["if"]
     assert "desktop_changed == 'true'" in jobs["macos-recovery"]["if"]
-    assert "frontend_changed == 'true'" in jobs["desktop-recovery-e2e"]["if"]
+    assert "frontend_changed == 'true'" not in jobs["desktop-recovery-e2e"]["if"]
+    assert "frontend_changed == 'true'" in jobs["webui-chat-recovery"]["if"]
     assert "platform_sensitive_changed == 'true'" in jobs["desktop-recovery-e2e"]["if"]
     assert "desktop_changed == 'true'" in jobs["desktop-recovery-e2e"]["if"]
     assert "platform_sensitive_changed == 'true'" in jobs["webui-chat-recovery"]["if"]
@@ -1317,6 +1404,8 @@ def test_ci_result_gate_covers_every_conditional_job_and_classifier_flag() -> No
         "desktop-recovery-e2e",
         "release-packaging",
         "managed-toolchain-artifacts",
+        "queue-attestation",
+        "main-canary",
     }
     assert gate_step["run"] == "python .github/scripts/check_ci_results.py"
     assert gate_step["env"]["RESULT_UBUNTU_FULL"] == "${{ needs.ubuntu-full.result }}"


### PR DESCRIPTION
## Scope

Scope boundary: Make ordinary pull-request CI change-aware, add exact-tree PR evidence verification for merge queue entries, replace enforced `main` push CI with an install/offline gateway canary, and schedule the complete matrix nightly. Preserve the required `CI result` context and fail closed whenever evidence or classification is uncertain.

Non-goals: This PR does not change the main ruleset, join the merge queue, auto-merge itself, or relax platform-sensitive/full-matrix thresholds. The code default is `enforce`, but this PR remains open for maintainer validation and cannot activate before it is merged.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Maintainer-requested CI throughput and merge-queue governance improvement.

## Release Note

Release note: NONE

## Tests

Ruff: `ruff check src tests`; focused new CI helpers/tests also pass.

Pytest: 182 CI contract tests pass (2 existing skips); 129 focused workflow/attestation/shard tests pass; wheel packaging contracts 2/2; offline gateway canary 1/1.

Build: actionlint v1.7.12 passes; full mypy passes for 931 source files; WebUI production artifact and release-dist verification pass; wheel builds, installs into a clean Python 3.12 environment, imports the gateway, and runs CLI help.

Regression tests: added

Notes: Synthetic Git repositories and offline fixtures exercise exact merge parents/tree/policy, authoritative green-run validation, stale-policy rejection, Windows shard governance, change routing, and fail-closed paths.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: This PR must reach green and receive explicit manual maintainer validation before merge. With no repository-variable override, `enforce` becomes active only after merge.

## Safety

No secrets, API keys, real sessions/prompts/logs, channel identifiers, or machine-specific paths are committed. Reusable evidence must match the exact Git tree and base, a successful authoritative PR workflow run, PR association, head ancestry, and the current trusted CI-policy digest; otherwise the queue runs the full matrix. `CODEOWNERS` defines CI-policy ownership; ruleset enforcement is an explicit maintainer governance step.

Platform behavior: The workflow implementation is platform-neutral. Existing Windows/macOS high-risk coverage remains fail closed, while platform-neutral product areas route to affected offline suites plus Windows compatibility smoke.

Upgrade compatibility: No runtime configuration, persisted state, client protocol, or generated product asset contract changes. The CI mode is an Actions repository variable with `enforce` default and `legacy` rollback.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
