### PR TITLE
Fix Windows release smoke arguments

### DIFF
--- a/.github/workflows/wheelhouse-release.yml
+++ b/.github/workflows/wheelhouse-release.yml
@@ -501,9 +501,12 @@ jobs:
           }
           $userData = Join-Path $env:RUNNER_TEMP "p1-5-first-send-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
           New-Item -ItemType Directory -Path $userData | Out-Null
-          npm run test:packaged-first-send-renderer -- `
-            --executable $candidate `
+          & node scripts/test-packaged-first-send-renderer.mjs `
+            --executable $candidate.Path `
             --user-data-dir $userData
+          if ($LASTEXITCODE -ne 0) {
+            throw "Packaged first-send renderer gate failed with exit code $LASTEXITCODE"
+          }
 
       - name: Verify RC3-to-candidate Windows upgrade and uninstall preserve profile data
         shell: pwsh

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -78,6 +78,9 @@ def test_release_workflow_builds_desktop_installers() -> None:
     assert 'NOTES_FILE="docs/releases/${TAG#v}.md"' in workflow
     assert '--notes-file "${NOTES_FILE}"' in workflow
     assert 'gh release upload "${TAG}" dist/* --clobber' in workflow
+    assert "& node scripts/test-packaged-first-send-renderer.mjs `" in workflow
+    assert "--executable $candidate.Path `" in workflow
+    assert "npm run test:packaged-first-send-renderer -- `" not in workflow
 
 
 def test_release_workflow_runs_legacy_windows_upgrade_checks_on_server_2022() -> None:


### PR DESCRIPTION
## Scope

- invoke the packaged first-send renderer gate directly with Node on Windows so PowerShell passes the required paths unchanged
- fail explicitly when the external smoke process exits non-zero
- lock the Windows release invocation shape in release consistency tests

## Branch target

- Base: `main`
- Head: `fix/release-windows-first-send-smoke`

## Linked issue

None.

## Release note status

Not required. This repairs release automation only and does not change product behavior or release contents.

## Validation

- `PYTHONPATH=/tmp/opensquilla-053-metadata:src .venv/bin/pytest -q tests/test_release_consistency.py tests/test_public_release_hygiene.py` — 46 passed
- `.venv/bin/ruff check tests/test_release_consistency.py` — passed
- `actionlint .github/workflows/wheelhouse-release.yml` — passed
- `git diff --check` — passed

## Safety and compatibility

- No runtime, schema, installer-content, or public-interface behavior changes.
- The change is isolated to the Windows release job's command invocation.
- Existing macOS and Python release paths are unchanged.

## Third-party origin

None.
