### PR TITLE
Stabilize packaged first-send launch gate

### DIFF
--- a/desktop/electron/scripts/test-packaged-first-send-renderer.mjs
+++ b/desktop/electron/scripts/test-packaged-first-send-renderer.mjs
@@ -336,10 +336,19 @@ try {
   for (let iteration = 1; iteration <= iterations; iteration += 1) {
     await page.setViewportSize(iteration % 2 === 1 ? WIDE_VIEWPORT : TIGHT_VIEWPORT)
     const draftUrl = new URL(page.url())
+    const alreadyOnEmptyDraft = draftUrl.pathname === '/control/chat/new'
+      && draftUrl.search === ''
+      && draftUrl.hash === ''
     draftUrl.pathname = '/control/chat/new'
     draftUrl.search = ''
     draftUrl.hash = ''
-    await page.goto(draftUrl.toString(), { waitUntil: 'domcontentloaded' })
+    // Packaged macOS Electron can report ERR_ABORTED for a redundant
+    // same-document navigation immediately after launch. The first iteration
+    // already starts on the empty draft; later iterations still exercise the
+    // real transition back from a materialized session.
+    if (!alreadyOnEmptyDraft) {
+      await page.goto(draftUrl.toString(), { waitUntil: 'domcontentloaded' })
+    }
 
     const composer = page.locator('.chat-textarea')
     const header = page.locator('#app-route-header [data-testid="chat-header-actions"]')

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -82,6 +82,12 @@ def test_release_workflow_builds_desktop_installers() -> None:
     assert "--executable $candidate.Path `" in workflow
     assert "npm run test:packaged-first-send-renderer -- `" not in workflow
 
+    first_send_gate = Path(
+        "desktop/electron/scripts/test-packaged-first-send-renderer.mjs"
+    ).read_text(encoding="utf-8")
+    assert "const alreadyOnEmptyDraft" in first_send_gate
+    assert "if (!alreadyOnEmptyDraft)" in first_send_gate
+
 
 def test_release_workflow_runs_legacy_windows_upgrade_checks_on_server_2022() -> None:
     workflow = yaml.safe_load(


### PR DESCRIPTION
## Scope

- avoid a redundant first navigation when the packaged Desktop smoke already starts on the empty new-chat route
- keep all later transitions from materialized sessions back to the new-chat route under test
- lock the initial-route guard in release consistency tests

## Branch target

- Base: `main`
- Head: `fix/release-first-send-initial-route`

## Linked issue

None.

## Release note status

Not required. This stabilizes release validation only and does not change product behavior or release contents.

## Validation

- `PYTHONPATH=/tmp/opensquilla-053-metadata:src .venv/bin/pytest -q tests/test_release_consistency.py tests/test_public_release_hygiene.py` — 46 passed
- `.venv/bin/ruff check tests/test_release_consistency.py` — passed
- `node --check desktop/electron/scripts/test-packaged-first-send-renderer.mjs` — passed
- `actionlint .github/workflows/wheelhouse-release.yml` — passed
- `git diff --check` — passed

## Safety and compatibility

- No runtime, schema, installer-content, or public-interface behavior changes.
- The first iteration still validates the launched empty draft; later iterations still navigate from real materialized sessions.
- Windows and macOS use the same packaged smoke script after platform-specific packaging.

## Third-party origin

None.
