### PR TITLE
Stabilize packaged release smoke checks

### DIFF
--- a/desktop/electron/scripts/test-packaged-first-send-renderer.mjs
+++ b/desktop/electron/scripts/test-packaged-first-send-renderer.mjs
@@ -261,6 +261,9 @@ async function assertSettledMessageReceipt(page) {
     0,
     'usage details must not be embedded in the activity disclosure',
   )
+  // Keep the pointer outside the hover target so Escape exercises the pinned
+  // popover state consistently across Electron's Windows and macOS builds.
+  await page.mouse.move(1, 1)
   await page.keyboard.press('Escape')
   await usagePopover.waitFor({ state: 'hidden', timeout: SEND_TIMEOUT_MS })
 }
@@ -357,6 +360,10 @@ try {
       timeout: SEND_TIMEOUT_MS,
     })
     await composer.waitFor({ state: 'visible', timeout: SEND_TIMEOUT_MS })
+    // The packaged app can expose its initial draft URL before Vue has mounted
+    // the permanent route header. Establish the landing-route baseline before
+    // asserting that session materialization preserves the same DOM node.
+    await header.waitFor({ state: 'attached', timeout: SEND_TIMEOUT_MS })
     assert.equal(
       await header.count(),
       1,

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -87,6 +87,8 @@ def test_release_workflow_builds_desktop_installers() -> None:
     ).read_text(encoding="utf-8")
     assert "const alreadyOnEmptyDraft" in first_send_gate
     assert "if (!alreadyOnEmptyDraft)" in first_send_gate
+    assert "await header.waitFor({ state: 'attached'" in first_send_gate
+    assert "await page.mouse.move(1, 1)" in first_send_gate
 
 
 def test_release_workflow_runs_legacy_windows_upgrade_checks_on_server_2022() -> None:


### PR DESCRIPTION
## Scope

- wait for the packaged landing header to mount before asserting route-node continuity
- move the pointer outside the usage trigger before validating Escape dismissal

## Release

- Target: main
- Linked issue: None
- Release note: None; release-validation-only change for v0.5.3

## Verification

- 48 release consistency and public release hygiene tests passed
- Ruff passed
- Node syntax check passed
- git diff --check passed

## Safety and compatibility

No runtime product behavior, persisted state, public interface, or platform packaging contract changes. The test stabilization applies to packaged Windows and macOS validation only.

## Third-party origin

None.