### PR TITLE
Preserve compacted history continuity (#1151)

### DIFF
--- a/opensquilla-webui/src/components/chat/ChatMessageList.history-anchor.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatMessageList.history-anchor.test.ts
@@ -69,12 +69,24 @@ describe('ChatMessageList history anchors', () => {
         source: 'manual',
         state: 'completed',
         durability: 'durable',
+        historyArchived: true,
+        canonicalComplete: true,
+      },
+    }
+    const incompleteMessage: ChatRenderedMessage = {
+      ...maintenanceMessage,
+      id: 'maintenance-2',
+      messageId: 'maintenance:context-compaction:summary:8',
+      maintenance: {
+        ...maintenanceMessage.maintenance!,
+        compactionId: 'cmp-8',
+        canonicalComplete: false,
       },
     }
     const host = document.createElement('div')
     document.body.appendChild(host)
     const app = createApp(ChatMessageList, {
-      messages: [maintenanceMessage],
+      messages: [maintenanceMessage, incompleteMessage],
       shareMode: false,
       selectedMessageIds: new Set<string>(),
       stripTimePrefix: (value: string) => value,
@@ -103,7 +115,13 @@ describe('ChatMessageList history anchors', () => {
       durability: 'durable',
       placement: 'transcript',
     })
-    expect(event?.textContent).toContain('Context organized')
+    expect(event?.textContent).toContain(
+      'Earlier context summarized; original messages remain available in history',
+    )
+    const events = host.querySelectorAll<HTMLElement>('[data-testid="compaction-event"]')
+    expect(events[1]?.textContent).toContain(
+      'Earlier context summarized; some original messages are unavailable',
+    )
     expect(host.querySelector('.msg-system')).toBeNull()
     expect(host.querySelector('.msg-ai')).toBeNull()
   })

--- a/opensquilla-webui/src/components/chat/CompactionEvent.vue
+++ b/opensquilla-webui/src/components/chat/CompactionEvent.vue
@@ -53,6 +53,11 @@ const labelCode = computed(() => {
   if (maintenance.value?.state === 'stale' || maintenance.value?.state === 'cancelled') {
     return 'chat.compact.cancelled'
   }
+  if (maintenance.value?.historyArchived) {
+    if (maintenance.value.canonicalComplete === true) return 'chat.compact.historyPreserved'
+    if (maintenance.value.canonicalComplete === false) return 'chat.compact.historyIncomplete'
+    return 'chat.compact.historySummarized'
+  }
   return 'chat.compact.compacted'
 })
 const liveRole = computed(() => {

--- a/opensquilla-webui/src/composables/chat/useChatHistory.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatHistory.test.ts
@@ -347,6 +347,7 @@ describe('useChatHistory canonical pagination', () => {
           timestamp: baseTime + 3_000,
         },
       ],
+      canonical_complete: true,
       compaction_summaries: [
         {
           id: 9,
@@ -399,6 +400,7 @@ describe('useChatHistory canonical pagination', () => {
       'assistant-1',
       'maintenance:context-compaction:summary:7',
       'maintenance:context-compaction:summary:9',
+      'maintenance:context-compaction:summary:8',
       'user-2',
     ]
     expect(messages.value.map(message => message.messageId)).toEqual(expectedIds)
@@ -415,6 +417,16 @@ describe('useChatHistory canonical pagination', () => {
         durability: 'durable',
         removedCount: 5,
         keptCount: 1,
+        historyArchived: true,
+        canonicalComplete: true,
+      },
+    })
+    expect(messages.value[4]).toMatchObject({
+      maintenance: {
+        compactionId: 'cmp-auto',
+        source: 'automatic',
+        historyArchived: true,
+        canonicalComplete: true,
       },
     })
     expect(messages.value.filter(message =>
@@ -737,7 +749,7 @@ describe('useChatHistory canonical pagination', () => {
     expect(messages.value[0]?.turnId).toBe('turn-1')
   })
 
-  it('restores durable compaction activity from canonical history', async () => {
+  it('prefers a durable summary boundary over duplicate activity metadata', async () => {
     const { api, messages } = makeHistory(false, {
       response: {
         messages: [{
@@ -756,6 +768,7 @@ describe('useChatHistory canonical pagination', () => {
             }],
           },
         }],
+        canonical_complete: true,
         compaction_summaries: [{
           id: 12,
           compaction_id: 'cmp-history',
@@ -768,21 +781,19 @@ describe('useChatHistory canonical pagination', () => {
 
     await api.loadHistory()
 
-    expect(messages.value[0]).toMatchObject({
+    const assistant = messages.value.find(message => message.role === 'assistant')
+    expect(assistant).toMatchObject({
       restoredFromHistory: true,
-      statusHistory: [{
-        action: 'context_compaction',
-        label: '',
-        at: 1_720_000_000_000,
-        id: 'cmp-history',
-        category: 'maintenance',
-        state: 'completed',
-        source: 'automatic',
-        durability: 'durable',
-      }],
+      statusHistory: [],
     })
-    expect(messages.value).toHaveLength(1)
-    expect(messages.value.some(message => message.role === 'maintenance')).toBe(false)
+    expect(messages.value).toHaveLength(2)
+    expect(messages.value.find(message => message.role === 'maintenance')).toMatchObject({
+      maintenance: {
+        compactionId: 'cmp-history',
+        historyArchived: true,
+        canonicalComplete: true,
+      },
+    })
   })
 
   it('interleaves cold same-turn output when the steer crosses a page boundary', async () => {

--- a/opensquilla-webui/src/composables/chat/useChatHistory.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatHistory.test.ts
@@ -321,6 +321,90 @@ describe('useChatHistory canonical pagination', () => {
     })
   })
 
+  it('keeps one legacy activity row across prepend and canonical refresh', async () => {
+    const activity = {
+      id: 'legacy-tools',
+      message_id: 'legacy-tools',
+      role: 'assistant',
+      text: '',
+      timestamp: '2026-07-06T00:00:01Z',
+      tool_calls: [
+        { type: 'text', text: 'Inspect the source.' },
+        { type: 'tool_use', tool_use_id: 'call-read', name: 'read_file', input: {} },
+        { type: 'text', text: 'Compare the directory.' },
+        { type: 'tool_use', tool_use_id: 'call-list', name: 'list_dir', input: {} },
+        { type: 'tool_result', tool_use_id: 'call-read', name: 'read_file', result: 'source' },
+        { type: 'tool_result', tool_use_id: 'call-list', name: 'list_dir', result: 'directory' },
+      ],
+    }
+    const { api, rpc, messages } = makeHistory(false, {
+      response: {
+        messages: [activity],
+        canonical_complete: false,
+        has_more: true,
+        oldest_cursor: 'cursor-tools',
+        newest_cursor: 'cursor-tools',
+      },
+    })
+    rpc.call
+      .mockResolvedValueOnce({
+        messages: [activity],
+        canonical_complete: false,
+        has_more: true,
+        oldest_cursor: 'cursor-tools',
+        newest_cursor: 'cursor-tools',
+      })
+      .mockResolvedValueOnce({
+        messages: [{
+          id: 'older-user',
+          message_id: 'older-user',
+          role: 'user',
+          text: 'Earlier request',
+          timestamp: '2026-07-06T00:00:00Z',
+        }],
+        canonical_complete: false,
+        has_more: false,
+        oldest_cursor: 'cursor-older',
+        newest_cursor: 'cursor-older',
+      })
+      .mockResolvedValueOnce({
+        messages: [
+          activity,
+          {
+            id: 'later-user',
+            message_id: 'later-user',
+            role: 'user',
+            text: 'Continue',
+            timestamp: '2026-07-06T00:00:02Z',
+          },
+        ],
+        canonical_complete: true,
+        has_more: false,
+        oldest_cursor: 'cursor-tools',
+        newest_cursor: 'cursor-later',
+      })
+
+    await api.loadHistory()
+    await api.loadEarlierHistory()
+    await api.loadHistory()
+
+    expect(messages.value.map(message => message.messageId)).toEqual([
+      'older-user',
+      'legacy-tools',
+      'later-user',
+    ])
+    expect(messages.value.filter(message => message.messageId === 'legacy-tools')).toHaveLength(1)
+    expect(messages.value[1]?.tool_calls?.map(segment => segment.tool_use_id)).toEqual([
+      undefined,
+      'call-read',
+      undefined,
+      'call-list',
+      'call-read',
+      'call-list',
+    ])
+    expect(api.historyState.value.canonicalComplete).toBe(true)
+  })
+
   it('restores manual compaction summaries in stable transcript chronology', async () => {
     const baseTime = 1_720_000_000_000
     const response: ChatHistoryResponse = {

--- a/opensquilla-webui/src/composables/chat/useChatHistory.ts
+++ b/opensquilla-webui/src/composables/chat/useChatHistory.ts
@@ -153,7 +153,10 @@ function historyContextInteger(value: unknown, key: string): number | undefined 
   return Number.isInteger(number) && number >= 0 ? number : undefined
 }
 
-function historyActivityMarkers(value: unknown): StatusPart[] {
+function historyActivityMarkers(
+  value: unknown,
+  suppressedCompactionIds: ReadonlySet<string> = new Set(),
+): StatusPart[] {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return []
   const markers = (value as Record<string, unknown>).activity_markers
   if (!Array.isArray(markers)) return []
@@ -162,7 +165,7 @@ function historyActivityMarkers(value: unknown): StatusPart[] {
     const data = marker as Record<string, unknown>
     if (data.kind !== 'context_compaction') return []
     const id = String(data.id || '').trim()
-    if (!id) return []
+    if (!id || suppressedCompactionIds.has(id)) return []
     const rawStatus = String(data.status || 'completed').toLowerCase()
     const state = rawStatus === 'completed'
       ? 'completed'
@@ -193,9 +196,10 @@ function summaryCount(value: unknown): number | undefined {
   return Number.isInteger(count) && count >= 0 ? count : undefined
 }
 
-function manualCompactionMessage(summary: ChatCompactionSummary): ChatMessage | null {
-  if (String(summary.trigger_reason || '').trim().toLowerCase() !== 'manual') return null
-
+function compactionSummaryMessage(
+  summary: ChatCompactionSummary,
+  canonicalComplete: boolean | null,
+): ChatMessage | null {
   const summaryId = summaryStableValue(summary.id)
   const compactionId = summaryStableValue(summary.compaction_id)
   const compactionIndex = summaryStableValue(summary.compaction_index)
@@ -217,21 +221,33 @@ function manualCompactionMessage(summary: ChatCompactionSummary): ChatMessage | 
     maintenance: {
       kind: 'context_compaction',
       compactionId: compactionId || identity,
-      source: 'manual',
+      source: String(summary.trigger_reason || '').trim().toLowerCase() === 'manual'
+        ? 'manual'
+        : 'automatic',
       state: 'completed',
       durability: 'durable',
       removedCount: summaryCount(summary.removed_count),
       keptCount: summaryCount(summary.kept_count),
+      historyArchived: true,
+      canonicalComplete,
     },
   }
 }
 
-function manualCompactionMessages(data: ChatHistoryResponse): ChatMessage[] {
+function compactionSummaryMessages(data: ChatHistoryResponse): ChatMessage[] {
   const summaries = data.compaction_summaries ?? data.compactionSummaries ?? []
+  const completeness = data.canonical_complete ?? data.canonicalComplete
+  const canonicalComplete = typeof completeness === 'boolean' ? completeness : null
   return summaries.flatMap((summary) => {
-    const message = manualCompactionMessage(summary)
+    const message = compactionSummaryMessage(summary, canonicalComplete)
     return message ? [message] : []
   })
+}
+
+function summaryCompactionIds(data: ChatHistoryResponse): Set<string> {
+  return new Set(
+    compactionSummaryMessages(data).map(message => message.maintenance!.compactionId),
+  )
 }
 
 function isHistoryMaintenance(message: ChatMessage): boolean {
@@ -268,7 +284,29 @@ function mergeHistoryMaintenance(
   messages: ChatMessage[],
   maintenance: ChatMessage[],
 ): ChatMessage[] {
-  const canonical = messages.filter(message => !isHistoryMaintenance(message))
+  const candidates = [
+    ...messages.filter(isHistoryMaintenance),
+    ...maintenance,
+  ]
+  const archivedCompactionIds = new Set(
+    candidates.flatMap(message =>
+      message.maintenance?.historyArchived
+        ? [message.maintenance.compactionId.trim()]
+        : [],
+    ),
+  )
+  const canonical = messages
+    .filter(message => !isHistoryMaintenance(message))
+    .map((message) => {
+      const statusHistory = message.statusHistory?.filter(entry =>
+        !(entry.category === 'maintenance'
+          && entry.id
+          && archivedCompactionIds.has(entry.id)),
+      )
+      return statusHistory?.length === message.statusHistory?.length
+        ? message
+        : { ...message, statusHistory }
+    })
   const embeddedCompactionIds = new Set(
     canonical.flatMap(message =>
       (message.statusHistory ?? []).flatMap(entry =>
@@ -277,10 +315,6 @@ function mergeHistoryMaintenance(
     ),
   )
   const maintenanceByCompactionId = new Map<string, ChatMessage>()
-  const candidates = [
-    ...messages.filter(isHistoryMaintenance),
-    ...maintenance,
-  ]
   for (const message of candidates) {
     if (!isHistoryMaintenance(message)) continue
     const compactionId = message.maintenance!.compactionId.trim()
@@ -450,7 +484,10 @@ export function useChatHistory(options: UseChatHistoryOptions) {
     scheduleHistorySync()
   }
 
-  function mapHistoryMessage(msg: ChatHistoryMessage): ChatMessage {
+  function mapHistoryMessage(
+    msg: ChatHistoryMessage,
+    suppressedCompactionIds: ReadonlySet<string> = new Set(),
+  ): ChatMessage {
     // History rows carry the turn's reasoning text but not the measured
     // thinking duration; live turn records re-fill seconds after sync.
     const reasoningText = typeof msg.reasoning_content === 'string' ? msg.reasoning_content.trim() : ''
@@ -496,7 +533,7 @@ export function useChatHistory(options: UseChatHistoryOptions) {
       input: msg.input || msg.input_tokens || undefined,
       output: msg.output || msg.output_tokens || undefined,
       statusHistory: msg.role === 'assistant'
-        ? historyActivityMarkers(msg.turn_context)
+        ? historyActivityMarkers(msg.turn_context, suppressedCompactionIds)
         : undefined,
       messageId,
       restoredFromHistory: true,
@@ -684,11 +721,15 @@ export function useChatHistory(options: UseChatHistoryOptions) {
         }
       }
 
-      let mapped = attachHistoryTurnOutcomes(msgs.map(mapHistoryMessage), data)
+      const summaryIds = summaryCompactionIds(data)
+      let mapped = attachHistoryTurnOutcomes(
+        msgs.map(message => mapHistoryMessage(message, summaryIds)),
+        data,
+      )
       const previousMessages = crossedSession ? [] : options.messages.value
       const previousMaintenance = previousMessages.filter(isHistoryMaintenance)
       const previousTranscript = previousMessages.filter(message => !isHistoryMaintenance(message))
-      const maintenanceMessages = manualCompactionMessages(data)
+      const maintenanceMessages = compactionSummaryMessages(data)
       let historyData = data
       let bridgeContinuationNeeded = false
       const needsForwardBridge = canonicalAvailable !== false
@@ -756,10 +797,12 @@ export function useChatHistory(options: UseChatHistoryOptions) {
           }
 
           const page = attachHistoryTurnOutcomes(
-            (bridgeData.messages || []).map(mapHistoryMessage),
+            (bridgeData.messages || []).map(message =>
+              mapHistoryMessage(message, summaryCompactionIds(bridgeData)),
+            ),
             bridgeData,
           )
-          maintenanceMessages.push(...manualCompactionMessages(bridgeData))
+          maintenanceMessages.push(...compactionSummaryMessages(bridgeData))
           for (const message of page) {
             const keyValue = messageKey(message)
             if (bridgedKeys.has(keyValue)) continue

--- a/opensquilla-webui/src/composables/chat/useChatRenderedMessages.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRenderedMessages.test.ts
@@ -579,6 +579,41 @@ describe('useChatRenderedMessages silent sentinel compatibility', () => {
     expect(source.tool_calls?.[0]?.text).toBe('HEARTBEAT_OK')
   })
 
+  it('projects narration and parallel legacy calls into one ordered activity timeline', () => {
+    const source: ChatMessage = {
+      role: 'assistant',
+      text: '',
+      ts: 1,
+      tool_calls: [
+        { type: 'text', text: 'Inspect the source.' },
+        { type: 'tool_use', tool_use_id: 'call-read', name: 'read_file', input: {} },
+        { type: 'text', text: 'Compare the directory.' },
+        { type: 'tool_use', tool_use_id: 'call-list', name: 'list_dir', input: {} },
+        { type: 'tool_result', tool_use_id: 'call-read', name: 'read_file', result: 'source payload' },
+        { type: 'tool_result', tool_use_id: 'call-list', name: 'list_dir', result: 'directory payload' },
+      ],
+    }
+
+    const message = renderedMessagesFor([source]).renderedMessages.value[0]!
+
+    expect(message.timelineItems?.map(item => item.type === 'text' ? item.rawText : item.type))
+      .toEqual(['Inspect the source.', 'tool-group', 'Compare the directory.', 'tool-group'])
+    const calls = message.timelineItems?.flatMap(item =>
+      item.type === 'tool-group' ? item.group.calls : [],
+    ) ?? []
+    expect(calls.map(call => ({ id: call.toolId, result: call.result }))).toEqual([
+      { id: 'call-read', result: 'source payload' },
+      { id: 'call-list', result: 'directory payload' },
+    ])
+    expect(message.parts?.map(part => part.type)).toEqual([
+      'text',
+      'tool',
+      'text',
+      'tool',
+    ])
+    expect(source.tool_calls?.[0]?.text).toBe('Inspect the source.')
+  })
+
   it('preserves mixed sentinel-looking text on an ordinary direct-user turn', () => {
     const source: ChatMessage = {
       role: 'assistant',

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -3858,6 +3858,9 @@
     "compact": {
       "compacting": "Kontext wird verdichtet",
       "compacted": "Kontext verdichtet",
+      "historyPreserved": "Früherer Kontext zusammengefasst; Originalnachrichten bleiben im Verlauf verfügbar",
+      "historyIncomplete": "Früherer Kontext zusammengefasst; einige Originalnachrichten sind nicht verfügbar",
+      "historySummarized": "Früherer Kontext zusammengefasst",
       "failed": "Verdichtung fehlgeschlagen",
       "withinBudget": "Kontext innerhalb des Budgets.",
       "skipped": "Die Kontextverdichtung wurde nicht angewendet.",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -3911,6 +3911,9 @@
     "compact": {
       "compacting": "Organizing context…",
       "compacted": "Context organized",
+      "historyPreserved": "Earlier context summarized; original messages remain available in history",
+      "historyIncomplete": "Earlier context summarized; some original messages are unavailable",
+      "historySummarized": "Earlier context summarized",
       "failed": "Context organization failed",
       "withinBudget": "No organization needed; context has enough space",
       "skipped": "Context organization was not applied",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -3858,6 +3858,9 @@
     "compact": {
       "compacting": "Compactando el contexto",
       "compacted": "Contexto compactado",
+      "historyPreserved": "Contexto anterior resumido; los mensajes originales siguen disponibles en el historial",
+      "historyIncomplete": "Contexto anterior resumido; algunos mensajes originales no están disponibles",
+      "historySummarized": "Contexto anterior resumido",
       "failed": "Error al compactar",
       "withinBudget": "Contexto dentro del presupuesto.",
       "skipped": "No se aplicó la compactación del contexto.",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -3858,6 +3858,9 @@
     "compact": {
       "compacting": "Compactage du contexte",
       "compacted": "Contexte compacté",
+      "historyPreserved": "Contexte antérieur résumé ; les messages d’origine restent disponibles dans l’historique",
+      "historyIncomplete": "Contexte antérieur résumé ; certains messages d’origine ne sont pas disponibles",
+      "historySummarized": "Contexte antérieur résumé",
       "failed": "Échec du compactage",
       "withinBudget": "Contexte dans les limites du budget.",
       "skipped": "Le compactage du contexte n’a pas été appliqué.",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -3858,6 +3858,9 @@
     "compact": {
       "compacting": "コンテキストを圧縮中",
       "compacted": "コンテキストを圧縮しました",
+      "historyPreserved": "以前のコンテキストを要約しました。元のメッセージは履歴で引き続き確認できます",
+      "historyIncomplete": "以前のコンテキストを要約しました。一部の元のメッセージは利用できません",
+      "historySummarized": "以前のコンテキストを要約しました",
       "failed": "圧縮に失敗しました",
       "withinBudget": "コンテキストは予算内です。",
       "skipped": "コンテキストの圧縮は適用されませんでした。",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -3911,6 +3911,9 @@
     "compact": {
       "compacting": "正在整理上下文…",
       "compacted": "上下文已整理",
+      "historyPreserved": "更早的上下文已汇总；原始消息仍可在历史记录中查看",
+      "historyIncomplete": "更早的上下文已汇总；部分原始消息不可用",
+      "historySummarized": "更早的上下文已汇总",
       "failed": "上下文整理失败",
       "withinBudget": "无需整理，上下文空间充足",
       "skipped": "未能应用上下文整理",

--- a/opensquilla-webui/src/types/chat.ts
+++ b/opensquilla-webui/src/types/chat.ts
@@ -474,6 +474,10 @@ export interface ChatMaintenanceEvent {
   reason?: string
   removedCount?: number
   keptCount?: number
+  /** This event marks a durable summary/archive boundary in canonical history. */
+  historyArchived?: boolean
+  /** Whether every original row remains available across that boundary. */
+  canonicalComplete?: boolean | null
 }
 
 export interface ChatMessage {

--- a/src/opensquilla/chat/flattened_tool_markers.py
+++ b/src/opensquilla/chat/flattened_tool_markers.py
@@ -3,18 +3,44 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 
 _USED_TOOL_LINE = re.compile(r"^\[Used tool: [^\]\r\n]*\]$")
 _TOOL_RESULT_PREFIX = re.compile(r"^\[Tool result \([^\)\r\n]+\): ")
+_TOOL_RESULT_PREFIX_CAPTURE = re.compile(
+    r"^\[Tool result \((?P<tool_use_id>[^\)\r\n]+)\): "
+)
 _SINGLE_LINE_TOOL_RESULT = re.compile(
     r"^\[Tool result \([^\)\r\n]+\): [^\r\n]*\](?:\r?\n|$)"
 )
+
+
+@dataclass(frozen=True, slots=True)
+class FlattenedToolResult:
+    """Structured display projection recovered from one legacy result marker."""
+
+    tool_use_id: str
+    content: str
 
 
 def has_flattened_used_tool_line(content: str) -> bool:
     """Return whether content carries an exact flattened tool-use line."""
 
     return any(_USED_TOOL_LINE.fullmatch(line.strip()) for line in content.splitlines())
+
+
+def flattened_used_tool_names(content: str) -> list[str]:
+    """Return tool names from exact flattened tool-use lines, in source order."""
+
+    names: list[str] = []
+    for line in content.splitlines():
+        visible = line.strip()
+        if _USED_TOOL_LINE.fullmatch(visible) is None:
+            continue
+        name = visible[len("[Used tool: ") : -1].strip()
+        if name:
+            names.append(name)
+    return names
 
 
 def strip_flattened_used_tool_lines(content: str) -> str:
@@ -33,6 +59,29 @@ def is_flattened_tool_result_dump(content: str) -> bool:
 
     visible = content.lstrip()
     return bool(_TOOL_RESULT_PREFIX.match(visible)) and visible.rstrip().endswith("]")
+
+
+def parse_flattened_tool_result_dump(content: str) -> FlattenedToolResult | None:
+    """Recover the id and payload from one confirmed complete legacy projection.
+
+    This parser is intentionally not a classifier. Callers must first establish
+    structured identity or adjacency to an exact ``[Used tool: ...]`` line so a
+    user-authored example is never reinterpreted as internal activity.
+    """
+
+    visible = content.lstrip()
+    if not is_flattened_tool_result_dump(visible):
+        return None
+    match = _TOOL_RESULT_PREFIX_CAPTURE.match(visible)
+    if match is None:
+        return None
+    payload_with_closer = visible[match.end() :].rstrip()
+    if not payload_with_closer.endswith("]"):
+        return None
+    return FlattenedToolResult(
+        tool_use_id=match.group("tool_use_id"),
+        content=payload_with_closer[:-1],
+    )
 
 
 def strip_confirmed_flattened_tool_result(content: str) -> str:

--- a/src/opensquilla/chat/flattened_tool_markers.py
+++ b/src/opensquilla/chat/flattened_tool_markers.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 
 _USED_TOOL_LINE = re.compile(r"^\[Used tool: [^\]\r\n]*\]$")
 _TOOL_RESULT_PREFIX = re.compile(r"^\[Tool result \([^\)\r\n]+\): ")
-_TOOL_RESULT_PREFIX_CAPTURE = re.compile(
-    r"^\[Tool result \((?P<tool_use_id>[^\)\r\n]+)\): "
+_TOOL_RESULT_START = re.compile(
+    r"(?m)^\[Tool result \((?P<tool_use_id>[^\)\r\n]+)\): "
 )
 _SINGLE_LINE_TOOL_RESULT = re.compile(
     r"^\[Tool result \([^\)\r\n]+\): [^\r\n]*\](?:\r?\n|$)"
@@ -21,6 +21,14 @@ class FlattenedToolResult:
 
     tool_use_id: str
     content: str
+
+
+@dataclass(frozen=True, slots=True)
+class FlattenedToolResults:
+    """Ordered results recovered from one confirmed legacy transcript row."""
+
+    results: tuple[FlattenedToolResult, ...]
+    trailing_text: str = ""
 
 
 def has_flattened_used_tool_line(content: str) -> bool:
@@ -57,8 +65,55 @@ def strip_flattened_used_tool_lines(content: str) -> str:
 def is_flattened_tool_result_dump(content: str) -> bool:
     """Recognize a complete legacy ``[Tool result (...): ...]`` projection."""
 
+    parsed = parse_flattened_tool_result_dumps(content)
+    return parsed is not None and not parsed.trailing_text
+
+
+def parse_flattened_tool_result_dumps(
+    content: str,
+) -> FlattenedToolResults | None:
+    """Recover every ordered result marker from one legacy flattened row.
+
+    The historical serializer joined content blocks with newlines and did not
+    escape newlines inside a result payload. Marker starts are therefore the
+    only reliable internal boundary. A final single-line marker may have
+    ordinary narration after it; that suffix is returned verbatim for the
+    caller to keep in the activity timeline.
+    """
+
     visible = content.lstrip()
-    return bool(_TOOL_RESULT_PREFIX.match(visible)) and visible.rstrip().endswith("]")
+    if not _TOOL_RESULT_PREFIX.match(visible):
+        return None
+    matches = list(_TOOL_RESULT_START.finditer(visible))
+    if not matches or matches[0].start() != 0:
+        return None
+
+    results: list[FlattenedToolResult] = []
+    trailing_text = ""
+    for index, match in enumerate(matches):
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(visible)
+        payload_with_closer = visible[match.end() : end]
+        if index + 1 == len(matches):
+            first_line, separator, suffix = payload_with_closer.partition("\n")
+            if first_line.rstrip("\r").rstrip().endswith("]"):
+                payload_with_closer = first_line.rstrip("\r").rstrip()
+                trailing_text = suffix.strip() if separator else ""
+            else:
+                payload_with_closer = payload_with_closer.rstrip()
+        else:
+            payload_with_closer = payload_with_closer.rstrip()
+        if not payload_with_closer.endswith("]"):
+            return None
+        tool_use_id = match.group("tool_use_id").strip()
+        if not tool_use_id:
+            return None
+        results.append(
+            FlattenedToolResult(
+                tool_use_id=tool_use_id,
+                content=payload_with_closer[:-1],
+            )
+        )
+    return FlattenedToolResults(tuple(results), trailing_text)
 
 
 def parse_flattened_tool_result_dump(content: str) -> FlattenedToolResult | None:
@@ -69,19 +124,10 @@ def parse_flattened_tool_result_dump(content: str) -> FlattenedToolResult | None
     user-authored example is never reinterpreted as internal activity.
     """
 
-    visible = content.lstrip()
-    if not is_flattened_tool_result_dump(visible):
+    parsed = parse_flattened_tool_result_dumps(content)
+    if parsed is None or len(parsed.results) != 1 or parsed.trailing_text:
         return None
-    match = _TOOL_RESULT_PREFIX_CAPTURE.match(visible)
-    if match is None:
-        return None
-    payload_with_closer = visible[match.end() :].rstrip()
-    if not payload_with_closer.endswith("]"):
-        return None
-    return FlattenedToolResult(
-        tool_use_id=match.group("tool_use_id"),
-        content=payload_with_closer[:-1],
-    )
+    return parsed.results[0]
 
 
 def strip_confirmed_flattened_tool_result(content: str) -> str:
@@ -95,6 +141,9 @@ def strip_confirmed_flattened_tool_result(content: str) -> str:
 
     leading = len(content) - len(content.lstrip())
     visible = content[leading:]
+    parsed = parse_flattened_tool_result_dumps(visible)
+    if parsed is not None:
+        return parsed.trailing_text
     single_line = _SINGLE_LINE_TOOL_RESULT.match(visible)
     if single_line is not None:
         suffix = visible[single_line.end() :]

--- a/src/opensquilla/chat/flattened_tool_markers.py
+++ b/src/opensquilla/chat/flattened_tool_markers.py
@@ -10,9 +10,6 @@ _TOOL_RESULT_PREFIX = re.compile(r"^\[Tool result \([^\)\r\n]+\): ")
 _TOOL_RESULT_START = re.compile(
     r"(?m)^\[Tool result \((?P<tool_use_id>[^\)\r\n]+)\): "
 )
-_SINGLE_LINE_TOOL_RESULT = re.compile(
-    r"^\[Tool result \([^\)\r\n]+\): [^\r\n]*\](?:\r?\n|$)"
-)
 
 
 @dataclass(frozen=True, slots=True)
@@ -28,7 +25,6 @@ class FlattenedToolResults:
     """Ordered results recovered from one confirmed legacy transcript row."""
 
     results: tuple[FlattenedToolResult, ...]
-    trailing_text: str = ""
 
 
 def has_flattened_used_tool_line(content: str) -> bool:
@@ -65,8 +61,7 @@ def strip_flattened_used_tool_lines(content: str) -> str:
 def is_flattened_tool_result_dump(content: str) -> bool:
     """Recognize a complete legacy ``[Tool result (...): ...]`` projection."""
 
-    parsed = parse_flattened_tool_result_dumps(content)
-    return parsed is not None and not parsed.trailing_text
+    return parse_flattened_tool_result_dumps(content) is not None
 
 
 def parse_flattened_tool_result_dumps(
@@ -76,9 +71,12 @@ def parse_flattened_tool_result_dumps(
 
     The historical serializer joined content blocks with newlines and did not
     escape newlines inside a result payload. Marker starts are therefore the
-    only reliable internal boundary. A final single-line marker may have
-    ordinary narration after it; that suffix is returned verbatim for the
-    caller to keep in the activity timeline.
+    only reliable internal boundary. In particular, a closing bracket on the
+    first payload line cannot distinguish a single-line result followed by
+    narration from a multiline payload whose first line happens to end in
+    ``]``. The final marker therefore owns the complete remainder through its
+    last closing bracket as auditable tool output. If the complete row has no
+    final closer, parsing fails and callers preserve the original text.
     """
 
     visible = content.lstrip()
@@ -89,19 +87,9 @@ def parse_flattened_tool_result_dumps(
         return None
 
     results: list[FlattenedToolResult] = []
-    trailing_text = ""
     for index, match in enumerate(matches):
         end = matches[index + 1].start() if index + 1 < len(matches) else len(visible)
-        payload_with_closer = visible[match.end() : end]
-        if index + 1 == len(matches):
-            first_line, separator, suffix = payload_with_closer.partition("\n")
-            if first_line.rstrip("\r").rstrip().endswith("]"):
-                payload_with_closer = first_line.rstrip("\r").rstrip()
-                trailing_text = suffix.strip() if separator else ""
-            else:
-                payload_with_closer = payload_with_closer.rstrip()
-        else:
-            payload_with_closer = payload_with_closer.rstrip()
+        payload_with_closer = visible[match.end() : end].rstrip()
         if not payload_with_closer.endswith("]"):
             return None
         tool_use_id = match.group("tool_use_id").strip()
@@ -113,7 +101,7 @@ def parse_flattened_tool_result_dumps(
                 content=payload_with_closer[:-1],
             )
         )
-    return FlattenedToolResults(tuple(results), trailing_text)
+    return FlattenedToolResults(tuple(results))
 
 
 def parse_flattened_tool_result_dump(content: str) -> FlattenedToolResult | None:
@@ -125,29 +113,23 @@ def parse_flattened_tool_result_dump(content: str) -> FlattenedToolResult | None
     """
 
     parsed = parse_flattened_tool_result_dumps(content)
-    if parsed is None or len(parsed.results) != 1 or parsed.trailing_text:
+    if parsed is None or len(parsed.results) != 1:
         return None
     return parsed.results[0]
 
 
 def strip_confirmed_flattened_tool_result(content: str) -> str:
-    """Hide a confirmed result projection without discarding visible suffix text.
+    """Hide a complete confirmed legacy result projection.
 
     The historical serializer did not escape newlines or brackets inside result
     snippets, so a multiline projection cannot be split safely from arbitrary
-    suffix prose. Pure result dumps are removable as a whole; the unambiguous
-    single-line form may also be removed while retaining the following text.
+    suffix prose. A parsed row is hidden only when its complete remainder is
+    retained as tool output; otherwise the original row remains verbatim.
     """
 
     leading = len(content) - len(content.lstrip())
     visible = content[leading:]
     parsed = parse_flattened_tool_result_dumps(visible)
     if parsed is not None:
-        return parsed.trailing_text
-    single_line = _SINGLE_LINE_TOOL_RESULT.match(visible)
-    if single_line is not None:
-        suffix = visible[single_line.end() :]
-        return suffix.strip()
-    if is_flattened_tool_result_dump(visible):
         return ""
     return content

--- a/src/opensquilla/chat/history.py
+++ b/src/opensquilla/chat/history.py
@@ -8,8 +8,10 @@ from typing import Any
 
 from opensquilla.artifacts import artifact_payload, strip_artifact_markers_from_text
 from opensquilla.chat.flattened_tool_markers import (
+    flattened_used_tool_names,
     has_flattened_used_tool_line,
     is_flattened_tool_result_dump,
+    parse_flattened_tool_result_dump,
     strip_confirmed_flattened_tool_result,
     strip_flattened_used_tool_lines,
 )
@@ -61,8 +63,8 @@ def _is_legacy_generated_plan_implementation(
     return _LEGACY_PLAN_IMPLEMENTATION_PROMPT.fullmatch(visible) is not None
 
 
-def _legacy_flattened_tool_result_indexes(entries: list[object]) -> set[int]:
-    """Identify metadata-poor result rows from an adjacent flattened tool call.
+def _legacy_flattened_tool_result_pairs(entries: list[object]) -> dict[int, int]:
+    """Map legacy result rows to their adjacent flattened assistant call row.
 
     Modern rows carry ``tool_call_id`` or role ``tool``. Older compaction
     projections sometimes persisted Anthropic-style tool results as role
@@ -71,7 +73,7 @@ def _legacy_flattened_tool_result_indexes(entries: list[object]) -> set[int]:
     the legacy syntax must remain ordinary conversation text.
     """
 
-    indexes: set[int] = set()
+    pairs: dict[int, int] = {}
     previous_was_flattened_call = False
     for index, entry in enumerate(entries):
         role = str(getattr(entry, "role", "unknown") or "unknown").lower()
@@ -81,22 +83,82 @@ def _legacy_flattened_tool_result_indexes(entries: list[object]) -> set[int]:
             and role in {"tool", "user"}
             and is_flattened_tool_result_dump(content)
         ):
-            indexes.add(index)
+            pairs[index] = index - 1
         previous_was_flattened_call = (
             role == "assistant" and has_flattened_used_tool_line(content)
         )
-    return indexes
+    return pairs
+
+
+def _legacy_tool_activity_segments(
+    tool_entry: object,
+    result_entry: object | None = None,
+) -> list[dict[str, Any]]:
+    """Project confirmed legacy text into the existing auditable tool timeline."""
+
+    names = flattened_used_tool_names(str(getattr(tool_entry, "content", "") or ""))
+    if not names:
+        return []
+    result = (
+        parse_flattened_tool_result_dump(str(getattr(result_entry, "content", "") or ""))
+        if result_entry is not None
+        else None
+    )
+    stable_entry_id = str(
+        getattr(result_entry or tool_entry, "message_id", None)
+        or getattr(result_entry or tool_entry, "id", None)
+        or "history"
+    )
+    segments: list[dict[str, Any]] = []
+    for index, name in enumerate(names):
+        is_result_owner = result is not None and index == len(names) - 1
+        tool_use_id = f"legacy:{stable_entry_id}:{index + 1}"
+        if result is not None and is_result_owner:
+            tool_use_id = result.tool_use_id
+        segments.append(
+            {
+                "type": "tool_use",
+                "tool_use_id": tool_use_id,
+                "name": name,
+                "input": {},
+                "legacy_projection": True,
+            }
+        )
+        if result is not None and is_result_owner:
+            segments.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "name": name,
+                    "result": result.content,
+                    "legacy_projection": True,
+                }
+            )
+    return segments
 
 
 def transcript_entries_to_chat_messages(
     entries: list[object],
     *,
     limit: int | None = None,
+    previous_entry: object | None = None,
+    next_entry: object | None = None,
 ) -> list[dict[str, Any]]:
     selected = entries[-limit:] if limit is not None else entries
-    legacy_tool_result_indexes = _legacy_flattened_tool_result_indexes(selected)
+    context_entries = [
+        *([previous_entry] if previous_entry is not None else []),
+        *selected,
+        *([next_entry] if next_entry is not None else []),
+    ]
+    selected_offset = 1 if previous_entry is not None else 0
+    legacy_tool_result_pairs = _legacy_flattened_tool_result_pairs(context_entries)
+    legacy_tool_call_pairs = {
+        tool_index: result_index
+        for result_index, tool_index in legacy_tool_result_pairs.items()
+    }
     messages: list[dict[str, Any]] = []
     for entry_index, entry in enumerate(selected):
+        context_index = selected_offset + entry_index
         role = getattr(entry, "role", "unknown")
         turn_context = getattr(entry, "turn_context", None)
         silent_reply = sanitize_historical_silent_reply(
@@ -106,6 +168,26 @@ def transcript_entries_to_chat_messages(
             turn_context=turn_context if isinstance(turn_context, dict) else None,
         )
         content = silent_reply.content or ""
+        legacy_segments: list[dict[str, Any]] = []
+        projected_role = role
+        paired_tool_index = legacy_tool_result_pairs.get(context_index)
+        if paired_tool_index is not None:
+            tool_entry = context_entries[paired_tool_index]
+            # Structured persisted segments already retain the complete audit
+            # trail. Synthesize only for metadata-poor legacy projections.
+            if not getattr(tool_entry, "tool_calls", None):
+                legacy_segments = _legacy_tool_activity_segments(tool_entry, entry)
+                if legacy_segments:
+                    projected_role = "assistant"
+        elif (
+            role == "assistant"
+            and has_flattened_used_tool_line(content)
+            and context_index not in legacy_tool_call_pairs
+            and not silent_reply.segments
+        ):
+            # Preserve an orphaned legacy call as an expandable activity rather
+            # than discarding the only surviving tool identity.
+            legacy_segments = _legacy_tool_activity_segments(entry)
         attachments = None
         artifacts = None
         if content and content.startswith("{"):
@@ -141,7 +223,7 @@ def transcript_entries_to_chat_messages(
             confirmed_tool_result = (
                 role == "tool"
                 or bool(getattr(entry, "tool_call_id", None))
-                or entry_index in legacy_tool_result_indexes
+                or paired_tool_index is not None
             )
             if confirmed_tool_result:
                 cleaned = strip_confirmed_flattened_tool_result(cleaned)
@@ -150,10 +232,10 @@ def transcript_entries_to_chat_messages(
                 # Drop it when nothing but internal tool transcript remains and
                 # there is no structured tool timeline to render instead;
                 # otherwise keep the narration that surrounded the markers.
-                if not cleaned.strip() and not silent_reply.segments:
+                if not cleaned.strip() and not silent_reply.segments and not legacy_segments:
                     continue
                 content = cleaned
-        if role == "user":
+        if projected_role == "user":
             display_text = display_text_from_preflight_confirmation(content)
             if display_text is not None:
                 content = display_text
@@ -165,7 +247,7 @@ def transcript_entries_to_chat_messages(
         msg: dict[str, Any] = {
             "id": getattr(entry, "message_id", None),
             "message_id": getattr(entry, "message_id", None),
-            "role": role,
+            "role": projected_role,
             "text": content,
             "timestamp": getattr(entry, "created_at", None),
             "provenance_kind": getattr(entry, "provenance_kind", None),
@@ -199,7 +281,7 @@ def transcript_entries_to_chat_messages(
             msg["output_tokens"] = output_tokens
             if usage.get("cost_usd") is not None:
                 msg["cost_usd"] = float(usage.get("cost_usd") or 0.0)
-        tool_calls = silent_reply.segments
+        tool_calls = [*(silent_reply.segments or []), *legacy_segments]
         if tool_calls:
             msg["tool_calls"] = _sanitize_display_protocol_payload(tool_calls)
         if (

--- a/src/opensquilla/chat/history.py
+++ b/src/opensquilla/chat/history.py
@@ -161,8 +161,6 @@ def _legacy_tool_activity_segments(
                 "legacy_projection": True,
             }
         )
-    if parsed_results.trailing_text:
-        segments.append({"type": "text", "text": parsed_results.trailing_text})
     return segments
 
 

--- a/src/opensquilla/chat/history.py
+++ b/src/opensquilla/chat/history.py
@@ -10,8 +10,7 @@ from opensquilla.artifacts import artifact_payload, strip_artifact_markers_from_
 from opensquilla.chat.flattened_tool_markers import (
     flattened_used_tool_names,
     has_flattened_used_tool_line,
-    is_flattened_tool_result_dump,
-    parse_flattened_tool_result_dump,
+    parse_flattened_tool_result_dumps,
     strip_confirmed_flattened_tool_result,
     strip_flattened_used_tool_lines,
 )
@@ -74,18 +73,28 @@ def _legacy_flattened_tool_result_pairs(entries: list[object]) -> dict[int, int]
     """
 
     pairs: dict[int, int] = {}
-    previous_was_flattened_call = False
+    previous_flattened_call: int | None = None
     for index, entry in enumerate(entries):
         role = str(getattr(entry, "role", "unknown") or "unknown").lower()
         content = str(getattr(entry, "content", "") or "")
         if (
-            previous_was_flattened_call
+            previous_flattened_call is not None
             and role in {"tool", "user"}
-            and is_flattened_tool_result_dump(content)
+            and _legacy_tool_activity_segments(
+                entries[previous_flattened_call],
+                entry,
+            )
+            is not None
         ):
-            pairs[index] = index - 1
-        previous_was_flattened_call = (
-            role == "assistant" and has_flattened_used_tool_line(content)
+            pairs[index] = previous_flattened_call
+        previous_flattened_call = (
+            index
+            if (
+                role == "assistant"
+                and has_flattened_used_tool_line(content)
+                and not getattr(entry, "tool_calls", None)
+            )
+            else None
         )
     return pairs
 
@@ -93,28 +102,41 @@ def _legacy_flattened_tool_result_pairs(entries: list[object]) -> dict[int, int]
 def _legacy_tool_activity_segments(
     tool_entry: object,
     result_entry: object | None = None,
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | None:
     """Project confirmed legacy text into the existing auditable tool timeline."""
 
-    names = flattened_used_tool_names(str(getattr(tool_entry, "content", "") or ""))
+    tool_content = str(getattr(tool_entry, "content", "") or "")
+    names = flattened_used_tool_names(tool_content)
     if not names:
-        return []
-    result = (
-        parse_flattened_tool_result_dump(str(getattr(result_entry, "content", "") or ""))
+        return None
+    parsed_results = (
+        parse_flattened_tool_result_dumps(str(getattr(result_entry, "content", "") or ""))
         if result_entry is not None
         else None
     )
-    stable_entry_id = str(
-        getattr(result_entry or tool_entry, "message_id", None)
-        or getattr(result_entry or tool_entry, "id", None)
-        or "history"
-    )
+    if parsed_results is None or len(parsed_results.results) != len(names):
+        return None
+    result_ids = [result.tool_use_id for result in parsed_results.results]
+    if len(set(result_ids)) != len(result_ids):
+        return None
     segments: list[dict[str, Any]] = []
-    for index, name in enumerate(names):
-        is_result_owner = result is not None and index == len(names) - 1
-        tool_use_id = f"legacy:{stable_entry_id}:{index + 1}"
-        if result is not None and is_result_owner:
-            tool_use_id = result.tool_use_id
+    text_lines: list[str] = []
+    tool_index = 0
+
+    def flush_text() -> None:
+        text = "".join(text_lines).strip()
+        text_lines.clear()
+        if text:
+            segments.append({"type": "text", "text": text})
+
+    for line in tool_content.splitlines(keepends=True):
+        line_names = flattened_used_tool_names(line)
+        if len(line_names) != 1:
+            text_lines.append(line)
+            continue
+        flush_text()
+        name = names[tool_index]
+        tool_use_id = result_ids[tool_index]
         segments.append(
             {
                 "type": "tool_use",
@@ -124,16 +146,23 @@ def _legacy_tool_activity_segments(
                 "legacy_projection": True,
             }
         )
-        if result is not None and is_result_owner:
-            segments.append(
-                {
-                    "type": "tool_result",
-                    "tool_use_id": tool_use_id,
-                    "name": name,
-                    "result": result.content,
-                    "legacy_projection": True,
-                }
-            )
+        tool_index += 1
+    flush_text()
+    if tool_index != len(names):
+        return None
+
+    for name, result in zip(names, parsed_results.results, strict=True):
+        segments.append(
+            {
+                "type": "tool_result",
+                "tool_use_id": result.tool_use_id,
+                "name": name,
+                "result": result.content,
+                "legacy_projection": True,
+            }
+        )
+    if parsed_results.trailing_text:
+        segments.append({"type": "text", "text": parsed_results.trailing_text})
     return segments
 
 
@@ -152,42 +181,50 @@ def transcript_entries_to_chat_messages(
     ]
     selected_offset = 1 if previous_entry is not None else 0
     legacy_tool_result_pairs = _legacy_flattened_tool_result_pairs(context_entries)
-    legacy_tool_call_pairs = {
-        tool_index: result_index
-        for result_index, tool_index in legacy_tool_result_pairs.items()
-    }
+    selected_start = selected_offset
+    selected_end = selected_start + len(selected)
+    legacy_projection_by_owner: dict[int, tuple[object, list[dict[str, Any]]]] = {}
+    suppressed_legacy_indexes: set[int] = set()
+    for result_index, tool_index in legacy_tool_result_pairs.items():
+        tool_selected = selected_start <= tool_index < selected_end
+        result_selected = selected_start <= result_index < selected_end
+        if not result_selected:
+            if tool_selected:
+                # Defer the combined activity until the result-owning page is
+                # loaded, so refresh/prepend cannot render duplicate halves.
+                suppressed_legacy_indexes.add(tool_index)
+            continue
+        segments = _legacy_tool_activity_segments(
+            context_entries[tool_index],
+            context_entries[result_index],
+        )
+        if segments is None:
+            continue
+        owner_index = tool_index if tool_selected else result_index
+        legacy_projection_by_owner[owner_index] = (
+            context_entries[tool_index],
+            segments,
+        )
+        if tool_selected:
+            suppressed_legacy_indexes.add(result_index)
     messages: list[dict[str, Any]] = []
     for entry_index, entry in enumerate(selected):
         context_index = selected_offset + entry_index
-        role = getattr(entry, "role", "unknown")
-        turn_context = getattr(entry, "turn_context", None)
+        if context_index in suppressed_legacy_indexes:
+            continue
+        legacy_projection = legacy_projection_by_owner.get(context_index)
+        projected_entry = legacy_projection[0] if legacy_projection else entry
+        role = getattr(projected_entry, "role", "unknown")
+        turn_context = getattr(projected_entry, "turn_context", None)
         silent_reply = sanitize_historical_silent_reply(
-            getattr(entry, "content", "") or "",
-            getattr(entry, "tool_calls", None),
+            getattr(projected_entry, "content", "") or "",
+            getattr(projected_entry, "tool_calls", None),
             role=role,
             turn_context=turn_context if isinstance(turn_context, dict) else None,
         )
-        content = silent_reply.content or ""
-        legacy_segments: list[dict[str, Any]] = []
-        projected_role = role
-        paired_tool_index = legacy_tool_result_pairs.get(context_index)
-        if paired_tool_index is not None:
-            tool_entry = context_entries[paired_tool_index]
-            # Structured persisted segments already retain the complete audit
-            # trail. Synthesize only for metadata-poor legacy projections.
-            if not getattr(tool_entry, "tool_calls", None):
-                legacy_segments = _legacy_tool_activity_segments(tool_entry, entry)
-                if legacy_segments:
-                    projected_role = "assistant"
-        elif (
-            role == "assistant"
-            and has_flattened_used_tool_line(content)
-            and context_index not in legacy_tool_call_pairs
-            and not silent_reply.segments
-        ):
-            # Preserve an orphaned legacy call as an expandable activity rather
-            # than discarding the only surviving tool identity.
-            legacy_segments = _legacy_tool_activity_segments(entry)
+        content = "" if legacy_projection else (silent_reply.content or "")
+        legacy_segments = legacy_projection[1] if legacy_projection else []
+        projected_role = "assistant" if legacy_projection else role
         attachments = None
         artifacts = None
         if content and content.startswith("{"):
@@ -218,12 +255,16 @@ def transcript_entries_to_chat_messages(
                 continue
         if content:
             cleaned = content
-            if role == "assistant" and has_flattened_used_tool_line(cleaned):
+            if (
+                role == "assistant"
+                and has_flattened_used_tool_line(cleaned)
+                and (silent_reply.segments or legacy_segments)
+            ):
                 cleaned = strip_flattened_used_tool_lines(cleaned)
             confirmed_tool_result = (
                 role == "tool"
-                or bool(getattr(entry, "tool_call_id", None))
-                or paired_tool_index is not None
+                or bool(getattr(projected_entry, "tool_call_id", None))
+                or bool(legacy_projection)
             )
             if confirmed_tool_result:
                 cleaned = strip_confirmed_flattened_tool_result(cleaned)
@@ -241,23 +282,27 @@ def transcript_entries_to_chat_messages(
                 content = display_text
             elif _is_legacy_generated_plan_implementation(
                 content,
-                getattr(entry, "turn_context", None),
+                getattr(projected_entry, "turn_context", None),
             ):
                 content = ""
         msg: dict[str, Any] = {
-            "id": getattr(entry, "message_id", None),
-            "message_id": getattr(entry, "message_id", None),
+            "id": getattr(projected_entry, "message_id", None),
+            "message_id": getattr(projected_entry, "message_id", None),
             "role": projected_role,
             "text": content,
-            "timestamp": getattr(entry, "created_at", None),
-            "provenance_kind": getattr(entry, "provenance_kind", None),
-            "provenance_source_session_key": getattr(entry, "provenance_source_session_key", None),
-            "provenance_source_tool": getattr(entry, "provenance_source_tool", None),
+            "timestamp": getattr(projected_entry, "created_at", None),
+            "provenance_kind": getattr(projected_entry, "provenance_kind", None),
+            "provenance_source_session_key": getattr(
+                projected_entry,
+                "provenance_source_session_key",
+                None,
+            ),
+            "provenance_source_tool": getattr(projected_entry, "provenance_source_tool", None),
         }
-        transcript_id = getattr(entry, "id", None)
+        transcript_id = getattr(projected_entry, "id", None)
         if transcript_id is not None:
             msg["transcript_id"] = transcript_id
-        reasoning = getattr(entry, "reasoning_content", None)
+        reasoning = getattr(projected_entry, "reasoning_content", None)
         if isinstance(reasoning, str) and reasoning.strip():
             msg["reasoning_content"] = reasoning
         if isinstance(turn_context, dict):
@@ -267,7 +312,7 @@ def transcript_entries_to_chat_messages(
             msg["attachments"] = attachments
         if artifacts:
             msg["artifacts"] = artifacts
-        usage = getattr(entry, "turn_usage", None)
+        usage = getattr(projected_entry, "turn_usage", None)
         if isinstance(usage, dict):
             msg["usage"] = usage
             model = usage.get("model") or usage.get("routed_model")

--- a/src/opensquilla/gateway/rpc_chat.py
+++ b/src/opensquilla/gateway/rpc_chat.py
@@ -460,13 +460,23 @@ async def _load_legacy_tool_projection_context(
     oldest_cursor = _chat_history_cursor_key(_chat_history_cursor(entries[0]))
     newest_cursor = _chat_history_cursor_key(_chat_history_cursor(entries[-1]))
     if _needs_legacy_tool_lookbehind(entries[0]) and oldest_cursor is not None:
-        page = await page_getter(
-            session_key,
-            limit=1,
-            before=oldest_cursor,
-            after=None,
-        )
-        candidates, _has_more, _complete = _canonical_page_parts(page)
+        try:
+            page = await page_getter(
+                session_key,
+                limit=1,
+                before=oldest_cursor,
+                after=None,
+            )
+            candidates, _has_more, _complete = _canonical_page_parts(page)
+        except StorageBusyError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - optional read-time projection
+            log.warning(
+                "chat_history_legacy_projection_context_unavailable",
+                edge="before",
+                error_type=type(exc).__name__,
+            )
+            return None, None
         if candidates:
             candidate = candidates[-1]
             candidate_cursor = _chat_history_cursor_key(_chat_history_cursor(candidate))
@@ -474,13 +484,23 @@ async def _load_legacy_tool_projection_context(
                 previous_entry = candidate
 
     if _needs_legacy_tool_lookahead(entries[-1]) and newest_cursor is not None:
-        page = await page_getter(
-            session_key,
-            limit=1,
-            before=None,
-            after=newest_cursor,
-        )
-        candidates, _has_more, _complete = _canonical_page_parts(page)
+        try:
+            page = await page_getter(
+                session_key,
+                limit=1,
+                before=None,
+                after=newest_cursor,
+            )
+            candidates, _has_more, _complete = _canonical_page_parts(page)
+        except StorageBusyError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - optional read-time projection
+            log.warning(
+                "chat_history_legacy_projection_context_unavailable",
+                edge="after",
+                error_type=type(exc).__name__,
+            )
+            return None, None
         if candidates:
             candidate = candidates[0]
             candidate_cursor = _chat_history_cursor_key(_chat_history_cursor(candidate))

--- a/src/opensquilla/gateway/rpc_chat.py
+++ b/src/opensquilla/gateway/rpc_chat.py
@@ -12,6 +12,10 @@ from uuid import uuid4
 import structlog
 
 from opensquilla.chat.conversation import ChatSendRequest, sessions_send_params
+from opensquilla.chat.flattened_tool_markers import (
+    has_flattened_used_tool_line,
+    is_flattened_tool_result_dump,
+)
 from opensquilla.chat.history import transcript_entries_to_chat_messages
 from opensquilla.chat.source import chat_source_metadata
 from opensquilla.gateway.compaction_target import (
@@ -413,6 +417,76 @@ async def _load_chat_history_page(
         after=after,
     )
     return entries, has_more, False, False
+
+
+def _needs_legacy_tool_lookbehind(entry: object | None) -> bool:
+    if entry is None or getattr(entry, "tool_call_id", None):
+        return False
+    role = str(getattr(entry, "role", "") or "").lower()
+    content = str(getattr(entry, "content", "") or "")
+    return role in {"tool", "user"} and is_flattened_tool_result_dump(content)
+
+
+def _needs_legacy_tool_lookahead(entry: object | None) -> bool:
+    if entry is None or getattr(entry, "tool_calls", None):
+        return False
+    role = str(getattr(entry, "role", "") or "").lower()
+    content = str(getattr(entry, "content", "") or "")
+    return role == "assistant" and has_flattened_used_tool_line(content)
+
+
+async def _load_legacy_tool_projection_context(
+    mgr: object,
+    session_key: str,
+    entries: list[object],
+    *,
+    canonical_available: bool,
+) -> tuple[object | None, object | None]:
+    """Load at most one adjacent row per page edge for legacy projection.
+
+    The selected page remains the pagination/accounting unit. These bounded
+    reads only provide enough context to recognize a marker/result pair split
+    by a page boundary; neither row is added to the response page.
+    """
+
+    if not entries or not canonical_available:
+        return None, None
+    page_getter = getattr(mgr, "get_canonical_transcript_page", None)
+    if not callable(page_getter):
+        return None, None
+
+    previous_entry = None
+    next_entry = None
+    oldest_cursor = _chat_history_cursor_key(_chat_history_cursor(entries[0]))
+    newest_cursor = _chat_history_cursor_key(_chat_history_cursor(entries[-1]))
+    if _needs_legacy_tool_lookbehind(entries[0]) and oldest_cursor is not None:
+        page = await page_getter(
+            session_key,
+            limit=1,
+            before=oldest_cursor,
+            after=None,
+        )
+        candidates, _has_more, _complete = _canonical_page_parts(page)
+        if candidates:
+            candidate = candidates[-1]
+            candidate_cursor = _chat_history_cursor_key(_chat_history_cursor(candidate))
+            if candidate_cursor is not None and candidate_cursor < oldest_cursor:
+                previous_entry = candidate
+
+    if _needs_legacy_tool_lookahead(entries[-1]) and newest_cursor is not None:
+        page = await page_getter(
+            session_key,
+            limit=1,
+            before=None,
+            after=newest_cursor,
+        )
+        candidates, _has_more, _complete = _canonical_page_parts(page)
+        if candidates:
+            candidate = candidates[0]
+            candidate_cursor = _chat_history_cursor_key(_chat_history_cursor(candidate))
+            if candidate_cursor is not None and candidate_cursor > newest_cursor:
+                next_entry = candidate
+    return previous_entry, next_entry
 
 
 async def _project_missing_history_usage(
@@ -833,27 +907,52 @@ async def _handle_chat_history(params: dict | None, ctx: RpcContext) -> dict:
 
     mgr = _require_chat_session_manager(ctx)
 
-    async def _load_page() -> tuple[list[object], bool, bool, bool]:
+    async def _load_page() -> tuple[
+        list[object],
+        bool,
+        bool,
+        bool,
+        object | None,
+        object | None,
+    ]:
         entries, has_more, canonical_available, canonical_complete = (
             await _load_chat_history_page(
-            mgr,
-            session_key,
-            limit=limit,
-            before=before,
-            after=after,
-            include_canonical=include_canonical,
+                mgr,
+                session_key,
+                limit=limit,
+                before=before,
+                after=after,
+                include_canonical=include_canonical,
             )
         )
         entries = await _project_missing_history_usage(mgr, session_key, entries)
-        return entries, has_more, canonical_available, canonical_complete
+        previous_entry, next_entry = await _load_legacy_tool_projection_context(
+            mgr,
+            session_key,
+            entries,
+            canonical_available=canonical_available,
+        )
+        return (
+            entries,
+            has_more,
+            canonical_available,
+            canonical_complete,
+            previous_entry,
+            next_entry,
+        )
 
     try:
         with bounded_interactive_storage_reads():
             history_lock = get_session_lock(ctx.turn_runner, session_key)
             if history_lock is None:
-                page_entries, has_more, canonical_available, canonical_complete = (
-                    await _load_page()
-                )
+                (
+                    page_entries,
+                    has_more,
+                    canonical_available,
+                    canonical_complete,
+                    previous_entry,
+                    next_entry,
+                ) = await _load_page()
             else:
                 # Canonical reads and compaction rewrites share one aiosqlite
                 # connection.  SQLite statements are snapshots, but a statement on
@@ -876,9 +975,14 @@ async def _handle_chat_history(params: dict | None, ctx: RpcContext) -> dict:
                             resource="session_mutation_lock",
                         ) from exc
                     acquired = True
-                    page_entries, has_more, canonical_available, canonical_complete = (
-                        await _load_page()
-                    )
+                    (
+                        page_entries,
+                        has_more,
+                        canonical_available,
+                        canonical_complete,
+                        previous_entry,
+                        next_entry,
+                    ) = await _load_page()
                 finally:
                     if acquired:
                         history_lock.release()
@@ -898,7 +1002,12 @@ async def _handle_chat_history(params: dict | None, ctx: RpcContext) -> dict:
     else:
         history_scope = "complete"
 
-    messages = transcript_entries_to_chat_messages(page_entries, limit=None)
+    messages = transcript_entries_to_chat_messages(
+        page_entries,
+        limit=None,
+        previous_entry=previous_entry,
+        next_entry=next_entry,
+    )
     turn_outcomes = await _chat_history_turn_outcomes(
         ctx,
         session_key,

--- a/tests/test_gateway/test_rpc_chat_history.py
+++ b/tests/test_gateway/test_rpc_chat_history.py
@@ -196,6 +196,38 @@ async def test_chat_history_projects_legacy_tool_pair_split_by_page_boundary(
                 session_manager=manager,
             ),
         )
+        earlier = await _handle_chat_history(
+            {
+                "sessionKey": session_key,
+                "limit": 2,
+                "before": result["oldest_cursor"],
+            },
+            RpcContext(
+                conn_id="test",
+                principal=SimpleNamespace(role="operator"),
+                session_manager=manager,
+            ),
+        )
+        forward = await _handle_chat_history(
+            {
+                "sessionKey": session_key,
+                "limit": 2,
+                "after": earlier["newest_cursor"],
+            },
+            RpcContext(
+                conn_id="test",
+                principal=SimpleNamespace(role="operator"),
+                session_manager=manager,
+            ),
+        )
+        refreshed = await _handle_chat_history(
+            {"sessionKey": session_key, "limit": 2},
+            RpcContext(
+                conn_id="test",
+                principal=SimpleNamespace(role="operator"),
+                session_manager=manager,
+            ),
+        )
     finally:
         await storage.close()
 
@@ -223,6 +255,219 @@ async def test_chat_history_projects_legacy_tool_pair_split_by_page_boundary(
         },
     ]
     assert "[Tool result" not in str(result["messages"])
+    assert [message["text"] for message in earlier["messages"]] == ["earlier request"]
+    assert earlier["loaded_count"] == 2
+    assert forward["messages"] == result["messages"]
+    assert forward["loaded_count"] == 2
+    assert refreshed["messages"] == result["messages"]
+    assert refreshed["oldest_cursor"] == result["oldest_cursor"]
+    assert refreshed["newest_cursor"] == result["newest_cursor"]
+
+
+@pytest.mark.asyncio
+async def test_chat_history_preserves_ambiguous_result_suffix_same_page_and_cross_page(
+    tmp_path,
+) -> None:
+    storage = SessionStorage(str(tmp_path / "history-legacy-ambiguous.db"))
+    await storage.connect()
+    manager = SessionManager(storage, inject_time_prefix=False)
+    session_key = "agent:main:webchat:legacy-ambiguous"
+    await manager.create(session_key)
+    ambiguous = "[Tool result (call-boundary): [\"a\"]\nsecond payload line]"
+    try:
+        await manager.append_message(session_key, "assistant", "[Used tool: read_file]")
+        await manager.append_message(session_key, "user", ambiguous)
+        await manager.append_message(session_key, "user", "continue")
+
+        same_page = await _handle_chat_history(
+            {"sessionKey": session_key, "limit": 3},
+            RpcContext(
+                conn_id="test",
+                principal=SimpleNamespace(role="operator"),
+                session_manager=manager,
+            ),
+        )
+        cross_page = await _handle_chat_history(
+            {"sessionKey": session_key, "limit": 2},
+            RpcContext(
+                conn_id="test",
+                principal=SimpleNamespace(role="operator"),
+                session_manager=manager,
+            ),
+        )
+    finally:
+        await storage.close()
+
+    same_activity = same_page["messages"][0]
+    cross_activity = cross_page["messages"][0]
+    assert same_activity["message_id"] == cross_activity["message_id"]
+    assert same_activity["tool_calls"] == cross_activity["tool_calls"]
+    assert cross_activity["tool_calls"][1]["result"] == '["a"]\nsecond payload line'
+    assert cross_page["loaded_count"] == 2
+    assert cross_page["messages"][1]["text"] == "continue"
+
+
+@pytest.mark.asyncio
+async def test_chat_history_fails_safe_for_result_line_with_untrusted_trailing_text(
+    tmp_path,
+) -> None:
+    storage = SessionStorage(str(tmp_path / "history-legacy-trailing-text.db"))
+    await storage.connect()
+    manager = SessionManager(storage, inject_time_prefix=False)
+    session_key = "agent:main:webchat:legacy-trailing-text"
+    await manager.create(session_key)
+    ambiguous = "[Tool result (call-boundary): ok]\nPlease also update README.md"
+    try:
+        await manager.append_message(session_key, "assistant", "[Used tool: read_file]")
+        await manager.append_message(session_key, "user", ambiguous)
+        await manager.append_message(session_key, "user", "continue")
+        same_page = await _handle_chat_history(
+            {"sessionKey": session_key, "limit": 3},
+            RpcContext(
+                conn_id="test",
+                principal=SimpleNamespace(role="operator"),
+                session_manager=manager,
+            ),
+        )
+        cross_page = await _handle_chat_history(
+            {"sessionKey": session_key, "limit": 2},
+            RpcContext(
+                conn_id="test",
+                principal=SimpleNamespace(role="operator"),
+                session_manager=manager,
+            ),
+        )
+    finally:
+        await storage.close()
+
+    assert [message["text"] for message in same_page["messages"]] == [
+        "[Used tool: read_file]",
+        ambiguous,
+        "continue",
+    ]
+    assert [message["text"] for message in cross_page["messages"]] == [
+        ambiguous,
+        "continue",
+    ]
+    assert all("tool_calls" not in message for message in same_page["messages"])
+    assert all("tool_calls" not in message for message in cross_page["messages"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auxiliary_failure",
+    [OSError("transient lookbehind failure"), TypeError("legacy manager signature")],
+)
+async def test_chat_history_auxiliary_lookbehind_failure_preserves_main_page(
+    auxiliary_failure: Exception,
+) -> None:
+    result_entry = _entry(11)
+    result_entry.content = "[Tool result (call-1): payload]"
+
+    class _AuxiliaryFailureManager(_FakeSessionManager):
+        def __init__(self) -> None:
+            super().__init__([result_entry], canonical_entries=[result_entry])
+            self.page_calls = 0
+
+        async def get_canonical_transcript_page(self, session_key, **kwargs):
+            self.page_calls += 1
+            if self.page_calls == 1:
+                return {
+                    "entries": [result_entry],
+                    "has_more": True,
+                    "canonical_complete": False,
+                }
+            raise auxiliary_failure
+
+    manager = _AuxiliaryFailureManager()
+    result = await _handle_chat_history(
+        {"sessionKey": "agent:main:webchat:test", "limit": 1},
+        RpcContext(
+            conn_id="test",
+            principal=SimpleNamespace(role="operator"),
+            session_manager=manager,
+        ),
+    )
+
+    assert [message["text"] for message in result["messages"]] == [result_entry.content]
+    assert result["loaded_count"] == 1
+    assert result["oldest_cursor"] == "11|11"
+    assert result["newest_cursor"] == "11|11"
+    assert result["has_more"] is True
+    assert result["canonical_complete"] is False
+
+
+@pytest.mark.asyncio
+async def test_chat_history_malformed_auxiliary_lookahead_preserves_main_page() -> None:
+    tool_entry = _entry(12, role="assistant")
+    tool_entry.content = "[Used tool: read_file]"
+
+    class _MalformedLookaheadManager(_FakeSessionManager):
+        def __init__(self) -> None:
+            super().__init__([tool_entry], canonical_entries=[tool_entry])
+            self.page_calls = 0
+
+        async def get_canonical_transcript_page(self, session_key, **kwargs):
+            self.page_calls += 1
+            if self.page_calls == 1:
+                return {
+                    "entries": [tool_entry],
+                    "has_more": False,
+                    "canonical_complete": True,
+                }
+            return {"has_more": False, "canonical_complete": True}
+
+    result = await _handle_chat_history(
+        {"sessionKey": "agent:main:webchat:test", "limit": 1},
+        RpcContext(
+            conn_id="test",
+            principal=SimpleNamespace(role="operator"),
+            session_manager=_MalformedLookaheadManager(),
+        ),
+    )
+
+    assert [message["text"] for message in result["messages"]] == [tool_entry.content]
+    assert result["loaded_count"] == 1
+    assert result["oldest_cursor"] == "12|12"
+    assert result["newest_cursor"] == "12|12"
+
+
+@pytest.mark.asyncio
+async def test_chat_history_auxiliary_storage_busy_remains_retryable() -> None:
+    result_entry = _entry(13)
+    result_entry.content = "[Tool result (call-1): payload]"
+    busy = StorageBusyError(
+        "get_canonical_transcript_page",
+        waited_ms=50,
+        retry_after_ms=100,
+    )
+
+    class _BusyLookbehindManager(_FakeSessionManager):
+        def __init__(self) -> None:
+            super().__init__([result_entry], canonical_entries=[result_entry])
+            self.page_calls = 0
+
+        async def get_canonical_transcript_page(self, session_key, **kwargs):
+            self.page_calls += 1
+            if self.page_calls == 1:
+                return {
+                    "entries": [result_entry],
+                    "has_more": True,
+                    "canonical_complete": True,
+                }
+            raise busy
+
+    with pytest.raises(StorageBusyError) as caught:
+        await _handle_chat_history(
+            {"sessionKey": "agent:main:webchat:test", "limit": 1},
+            RpcContext(
+                conn_id="test",
+                principal=SimpleNamespace(role="operator"),
+                session_manager=_BusyLookbehindManager(),
+            ),
+        )
+
+    assert caught.value is busy
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway/test_rpc_chat_history.py
+++ b/tests/test_gateway/test_rpc_chat_history.py
@@ -104,6 +104,66 @@ async def test_chat_history_returns_pagination_metadata_with_legacy_messages() -
 
 
 @pytest.mark.asyncio
+async def test_chat_history_projects_legacy_tool_pair_split_by_page_boundary(
+    tmp_path,
+) -> None:
+    storage = SessionStorage(str(tmp_path / "history-legacy-boundary.db"))
+    await storage.connect()
+    manager = SessionManager(storage, inject_time_prefix=False)
+    session_key = "agent:main:webchat:legacy-boundary"
+    await manager.create(session_key)
+    try:
+        await manager.append_message(session_key, "user", "earlier request")
+        await manager.append_message(
+            session_key,
+            "assistant",
+            "[Used tool: read_file]",
+        )
+        await manager.append_message(
+            session_key,
+            "user",
+            "[Tool result (call-boundary): private payload]",
+        )
+        await manager.append_message(session_key, "user", "continue")
+
+        result = await _handle_chat_history(
+            {"sessionKey": session_key, "limit": 2},
+            RpcContext(
+                conn_id="test",
+                principal=SimpleNamespace(role="operator"),
+                session_manager=manager,
+            ),
+        )
+    finally:
+        await storage.close()
+
+    assert result["loaded_count"] == 2
+    assert result["has_more"] is True
+    assert [message["role"] for message in result["messages"]] == [
+        "assistant",
+        "user",
+    ]
+    assert [message["text"] for message in result["messages"]] == ["", "continue"]
+    assert result["messages"][0]["tool_calls"] == [
+        {
+            "type": "tool_use",
+            "tool_use_id": "call-boundary",
+            "name": "read_file",
+            "input": {},
+            "legacy_projection": True,
+        },
+        {
+            "type": "tool_result",
+            "tool_use_id": "call-boundary",
+            "name": "read_file",
+            "result": "private payload",
+            "legacy_projection": True,
+        },
+    ]
+    assert "[Tool result" not in str(result["messages"])
+
+
+@pytest.mark.asyncio
 async def test_chat_history_batch_projects_missing_turn_usage_from_ledger(tmp_path) -> None:
     storage = SessionStorage(str(tmp_path / "history-usage-projection.db"))
     await storage.connect()

--- a/tests/test_gateway/test_rpc_chat_history.py
+++ b/tests/test_gateway/test_rpc_chat_history.py
@@ -104,6 +104,68 @@ async def test_chat_history_returns_pagination_metadata_with_legacy_messages() -
 
 
 @pytest.mark.asyncio
+async def test_chat_history_projects_parallel_legacy_activity_on_incomplete_page() -> None:
+    tool_entry = TranscriptEntry(
+        id=10,
+        session_id="parent",
+        session_key="agent:main:webchat:test",
+        role="assistant",
+        content=(
+            "Inspect the source.\n"
+            "[Used tool: read_file]\n"
+            "Compare the directory.\n"
+            "[Used tool: list_dir]"
+        ),
+        created_at=10,
+        message_id="legacy-tools",
+    )
+    result_entry = TranscriptEntry(
+        id=11,
+        session_id="parent",
+        session_key="agent:main:webchat:test",
+        role="user",
+        content=(
+            "[Tool result (call-read): source payload]\n"
+            "[Tool result (call-list): directory payload]"
+        ),
+        created_at=11,
+        message_id="legacy-results",
+    )
+    manager = _FakePagedSessionManager(
+        [tool_entry, result_entry],
+        page={
+            "entries": [tool_entry, result_entry],
+            "has_more": False,
+            "canonical_complete": False,
+        },
+    )
+
+    result = await _handle_chat_history(
+        {"sessionKey": "agent:main:webchat:test", "limit": 2},
+        RpcContext(
+            conn_id="test",
+            principal=SimpleNamespace(role="operator"),
+            session_manager=manager,
+        ),
+    )
+
+    assert result["loaded_count"] == 2
+    assert result["canonical_complete"] is False
+    assert len(result["messages"]) == 1
+    assert result["messages"][0]["message_id"] == "legacy-tools"
+    assert [segment.get("tool_use_id") for segment in result["messages"][0]["tool_calls"]] == [
+        None,
+        "call-read",
+        None,
+        "call-list",
+        "call-read",
+        "call-list",
+    ]
+    assert "[Used tool:" not in str(result["messages"])
+    assert "[Tool result" not in str(result["messages"])
+
+
+@pytest.mark.asyncio
 async def test_chat_history_projects_legacy_tool_pair_split_by_page_boundary(
     tmp_path,
 ) -> None:

--- a/tests/unit/chat/test_history.py
+++ b/tests/unit/chat/test_history.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from opensquilla.chat.history import transcript_entries_to_chat_messages
 
 
@@ -523,7 +525,7 @@ def test_transcript_entries_to_chat_messages_keeps_unattributed_tool_result_text
     assert messages[0]["text"] == entry.content
 
 
-def test_transcript_entries_to_chat_messages_keeps_text_after_confirmed_tool_result() -> None:
+def test_transcript_entries_to_chat_messages_preserves_ambiguous_result_suffix() -> None:
     entry = _assistant_entry(
         message_id="m-toolresult-with-request",
         role="user",
@@ -533,7 +535,59 @@ def test_transcript_entries_to_chat_messages_keeps_text_after_confirmed_tool_res
 
     messages = transcript_entries_to_chat_messages([entry])
 
-    assert messages[0]["text"] == "Please also update README.md"
+    assert messages[0]["text"] == entry.content
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '["a"]\nsecond payload line',
+        '{"items": []}\nJSON diagnostic detail',
+        "values = [1, 2]\nprint(values)",
+        "ordinary output ]\ncontinuation from the tool",
+    ],
+)
+def test_transcript_entries_to_chat_messages_keeps_ambiguous_multiline_remainder_in_result(
+    payload: str,
+) -> None:
+    entries = [
+        _assistant_entry(content="[Used tool: read_file]"),
+        _assistant_entry(
+            role="user",
+            content=f"[Tool result (call-1): {payload}]",
+        ),
+    ]
+
+    messages = transcript_entries_to_chat_messages(entries)
+
+    assert len(messages) == 1
+    assert messages[0]["tool_calls"][1]["result"] == payload
+    assert all(segment.get("type") != "text" for segment in messages[0]["tool_calls"])
+
+
+def test_transcript_entries_to_chat_messages_keeps_trusted_call_narration_ordered() -> None:
+    entries = [
+        _assistant_entry(
+            content=(
+                "Before the tool.\n"
+                "[Used tool: read_file]\n"
+                "After the tool was requested."
+            ),
+        ),
+        _assistant_entry(
+            role="user",
+            content="[Tool result (call-1): source payload]",
+        ),
+    ]
+
+    messages = transcript_entries_to_chat_messages(entries)
+
+    assert [segment.get("text") for segment in messages[0]["tool_calls"]] == [
+        "Before the tool.",
+        None,
+        "After the tool was requested.",
+        None,
+    ]
 
 
 def test_transcript_entries_to_chat_messages_keeps_isolated_tool_only_turn() -> None:

--- a/tests/unit/chat/test_history.py
+++ b/tests/unit/chat/test_history.py
@@ -333,8 +333,8 @@ def test_transcript_entries_to_chat_messages_hides_exact_assistant_sentinel() ->
 
 
 def test_transcript_entries_to_chat_messages_strips_flattened_used_tool_markers() -> None:
-    # A compacted assistant turn keeps its narration but drops the flattened
-    # "[Used tool: ...]" markers that engine.agent._flatten_content_blocks emits.
+    # A compacted assistant turn keeps narration and restores legacy markers
+    # as auditable structured activity instead of exposing the raw protocol.
     entry = _assistant_entry(
         message_id="m-flat-narration",
         content=(
@@ -351,11 +351,20 @@ def test_transcript_entries_to_chat_messages_strips_flattened_used_tool_markers(
         "继续补齐上下文: 章节重新生成接口、前端 API client 与测试结构。"
     )
     assert "[Used tool:" not in messages[0]["text"]
+    assert [segment["name"] for segment in messages[0]["tool_calls"]] == [
+        "read_file",
+        "read_file",
+        "list_dir",
+    ]
+    assert all(
+        segment["type"] == "tool_use" and segment["legacy_projection"] is True
+        for segment in messages[0]["tool_calls"]
+    )
 
 
-def test_transcript_entries_to_chat_messages_drops_flattened_tool_result_dump() -> None:
-    # A "[Tool result (...)]" dump is pure internal transcript; with no
-    # structured segments to render it is dropped rather than shown as a bubble.
+def test_transcript_entries_to_chat_messages_folds_flattened_tool_result_dump() -> None:
+    # The raw wrapper is hidden, while the tool identity and payload remain
+    # available through the existing expandable tool timeline.
     entries = [
         _assistant_entry(
             message_id="m-flat-tooluse",
@@ -371,7 +380,29 @@ def test_transcript_entries_to_chat_messages_drops_flattened_tool_result_dump() 
         ),
     ]
 
-    assert transcript_entries_to_chat_messages(entries) == []
+    messages = transcript_entries_to_chat_messages(entries)
+
+    assert len(messages) == 1
+    assert messages[0]["role"] == "assistant"
+    assert messages[0]["text"] == ""
+    assert messages[0]["tool_calls"] == [
+        {
+            "type": "tool_use",
+            "tool_use_id": "call_00_TUIq7hPsIGaww7lcUiuc8669",
+            "name": "read_file",
+            "input": {},
+            "legacy_projection": True,
+        },
+        {
+            "type": "tool_result",
+            "tool_use_id": "call_00_TUIq7hPsIGaww7lcUiuc8669",
+            "name": "read_file",
+            "result": (
+                '1  """Proposal generation and management API routes."""\n2  \n3  import json'
+            ),
+            "legacy_projection": True,
+        },
+    ]
 
 
 def test_transcript_entries_to_chat_messages_keeps_unattributed_tool_result_text() -> None:
@@ -399,15 +430,67 @@ def test_transcript_entries_to_chat_messages_keeps_text_after_confirmed_tool_res
     assert messages[0]["text"] == "Please also update README.md"
 
 
-def test_transcript_entries_to_chat_messages_drops_tool_only_flattened_turn() -> None:
-    # An assistant turn whose entire content is "[Used tool: ...]" markers (no
-    # narration) collapses to nothing, matching a fully collapsed activity fold.
+def test_transcript_entries_to_chat_messages_folds_tool_only_flattened_turn() -> None:
+    # A marker-only turn remains as one collapsed, auditable activity row.
     entry = _assistant_entry(
         message_id="m-flat-toolonly",
         content="[Used tool: read_file]\n[Used tool: list_dir]",
     )
 
-    assert transcript_entries_to_chat_messages([entry]) == []
+    messages = transcript_entries_to_chat_messages([entry])
+
+    assert len(messages) == 1
+    assert messages[0]["text"] == ""
+    assert [segment["name"] for segment in messages[0]["tool_calls"]] == [
+        "read_file",
+        "list_dir",
+    ]
+
+
+def test_transcript_entries_to_chat_messages_recognizes_legacy_pair_across_page() -> None:
+    previous = _assistant_entry(
+        id=10,
+        message_id="m-boundary-tool",
+        content="[Used tool: read_file]",
+    )
+    result = _assistant_entry(
+        id=11,
+        message_id="m-boundary-result",
+        role="user",
+        content="[Tool result (call-boundary): private payload]",
+    )
+
+    messages = transcript_entries_to_chat_messages(
+        [result],
+        previous_entry=previous,
+    )
+
+    assert len(messages) == 1
+    assert messages[0]["role"] == "assistant"
+    assert messages[0]["text"] == ""
+    assert messages[0]["tool_calls"][1] == {
+        "type": "tool_result",
+        "tool_use_id": "call-boundary",
+        "name": "read_file",
+        "result": "private payload",
+        "legacy_projection": True,
+    }
+
+
+def test_transcript_entries_to_chat_messages_uses_lookahead_without_duplicate_fold() -> None:
+    tool = _assistant_entry(
+        id=12,
+        message_id="m-boundary-tool",
+        content="[Used tool: read_file]",
+    )
+    following = _assistant_entry(
+        id=13,
+        message_id="m-boundary-result",
+        role="user",
+        content="[Tool result (call-boundary): private payload]",
+    )
+
+    assert transcript_entries_to_chat_messages([tool], next_entry=following) == []
 
 
 def test_transcript_entries_to_chat_messages_keeps_ordinary_bracketed_text() -> None:

--- a/tests/unit/chat/test_history.py
+++ b/tests/unit/chat/test_history.py
@@ -332,9 +332,9 @@ def test_transcript_entries_to_chat_messages_hides_exact_assistant_sentinel() ->
     assert transcript_entries_to_chat_messages([entry]) == []
 
 
-def test_transcript_entries_to_chat_messages_strips_flattened_used_tool_markers() -> None:
-    # A compacted assistant turn keeps narration and restores legacy markers
-    # as auditable structured activity instead of exposing the raw protocol.
+def test_transcript_entries_to_chat_messages_keeps_isolated_tool_markers_as_text() -> None:
+    # Exact syntax without a confirmed adjacent result is still ordinary text.
+    # This avoids reinterpreting user-requested examples as internal activity.
     entry = _assistant_entry(
         message_id="m-flat-narration",
         content=(
@@ -348,18 +348,12 @@ def test_transcript_entries_to_chat_messages_strips_flattened_used_tool_markers(
     messages = transcript_entries_to_chat_messages([entry])
 
     assert messages[0]["text"] == (
-        "继续补齐上下文: 章节重新生成接口、前端 API client 与测试结构。"
+        "继续补齐上下文: 章节重新生成接口、前端 API client 与测试结构。\n"
+        "[Used tool: read_file]\n"
+        "[Used tool: read_file]\n"
+        "[Used tool: list_dir]"
     )
-    assert "[Used tool:" not in messages[0]["text"]
-    assert [segment["name"] for segment in messages[0]["tool_calls"]] == [
-        "read_file",
-        "read_file",
-        "list_dir",
-    ]
-    assert all(
-        segment["type"] == "tool_use" and segment["legacy_projection"] is True
-        for segment in messages[0]["tool_calls"]
-    )
+    assert "tool_calls" not in messages[0]
 
 
 def test_transcript_entries_to_chat_messages_folds_flattened_tool_result_dump() -> None:
@@ -405,6 +399,118 @@ def test_transcript_entries_to_chat_messages_folds_flattened_tool_result_dump() 
     ]
 
 
+def test_transcript_entries_to_chat_messages_projects_ordered_parallel_activity() -> None:
+    entries = [
+        _assistant_entry(
+            id=20,
+            message_id="m-parallel-tools",
+            content=(
+                "Inspect the source.\n"
+                "[Used tool: read_file]\n"
+                "Compare the directory.\n"
+                "[Used tool: list_dir]"
+            ),
+        ),
+        _assistant_entry(
+            id=21,
+            message_id="m-parallel-results",
+            role="user",
+            content=(
+                "[Tool result (call-read): source payload]\n"
+                "[Tool result (call-list): directory payload]"
+            ),
+        ),
+    ]
+
+    messages = transcript_entries_to_chat_messages(entries)
+
+    assert len(messages) == 1
+    assert messages[0]["message_id"] == "m-parallel-tools"
+    assert messages[0]["text"] == ""
+    assert messages[0]["tool_calls"] == [
+        {"type": "text", "text": "Inspect the source."},
+        {
+            "type": "tool_use",
+            "tool_use_id": "call-read",
+            "name": "read_file",
+            "input": {},
+            "legacy_projection": True,
+        },
+        {"type": "text", "text": "Compare the directory."},
+        {
+            "type": "tool_use",
+            "tool_use_id": "call-list",
+            "name": "list_dir",
+            "input": {},
+            "legacy_projection": True,
+        },
+        {
+            "type": "tool_result",
+            "tool_use_id": "call-read",
+            "name": "read_file",
+            "result": "source payload",
+            "legacy_projection": True,
+        },
+        {
+            "type": "tool_result",
+            "tool_use_id": "call-list",
+            "name": "list_dir",
+            "result": "directory payload",
+            "legacy_projection": True,
+        },
+    ]
+
+
+def test_transcript_entries_to_chat_messages_keeps_untrusted_mismatch_as_text() -> None:
+    entries = [
+        _assistant_entry(
+            message_id="m-mismatch-tools",
+            content="[Used tool: read_file]",
+        ),
+        _assistant_entry(
+            message_id="m-mismatch-results",
+            role="user",
+            content=(
+                "[Tool result (call-read): source payload]\n"
+                "[Tool result (call-extra): unmatched payload]"
+            ),
+        ),
+    ]
+
+    messages = transcript_entries_to_chat_messages(entries)
+
+    assert [message["text"] for message in messages] == [
+        "[Used tool: read_file]",
+        (
+            "[Tool result (call-read): source payload]\n"
+            "[Tool result (call-extra): unmatched payload]"
+        ),
+    ]
+    assert all("tool_calls" not in message for message in messages)
+
+
+def test_transcript_entries_to_chat_messages_keeps_duplicate_result_ids_as_text() -> None:
+    entries = [
+        _assistant_entry(
+            content="[Used tool: read_file]\n[Used tool: list_dir]",
+        ),
+        _assistant_entry(
+            role="user",
+            content=(
+                "[Tool result (call-duplicate): source payload]\n"
+                "[Tool result (call-duplicate): directory payload]"
+            ),
+        ),
+    ]
+
+    messages = transcript_entries_to_chat_messages(entries)
+
+    assert len(messages) == 2
+    assert all("tool_calls" not in message for message in messages)
+    assert "[Used tool:" in messages[0]["text"]
+    assert "[Tool result" in messages[1]["text"]
+
+
 def test_transcript_entries_to_chat_messages_keeps_unattributed_tool_result_text() -> None:
     entry = _assistant_entry(
         message_id="m-user-toolresult-doc",
@@ -430,8 +536,7 @@ def test_transcript_entries_to_chat_messages_keeps_text_after_confirmed_tool_res
     assert messages[0]["text"] == "Please also update README.md"
 
 
-def test_transcript_entries_to_chat_messages_folds_tool_only_flattened_turn() -> None:
-    # A marker-only turn remains as one collapsed, auditable activity row.
+def test_transcript_entries_to_chat_messages_keeps_isolated_tool_only_turn() -> None:
     entry = _assistant_entry(
         message_id="m-flat-toolonly",
         content="[Used tool: read_file]\n[Used tool: list_dir]",
@@ -440,11 +545,8 @@ def test_transcript_entries_to_chat_messages_folds_tool_only_flattened_turn() ->
     messages = transcript_entries_to_chat_messages([entry])
 
     assert len(messages) == 1
-    assert messages[0]["text"] == ""
-    assert [segment["name"] for segment in messages[0]["tool_calls"]] == [
-        "read_file",
-        "list_dir",
-    ]
+    assert messages[0]["text"] == "[Used tool: read_file]\n[Used tool: list_dir]"
+    assert "tool_calls" not in messages[0]
 
 
 def test_transcript_entries_to_chat_messages_recognizes_legacy_pair_across_page() -> None:


### PR DESCRIPTION
Fixes #1151.

Builds on #1153, which is already merged into `main` and addressed raw flattened marker/title leakage. That PR intentionally left the broader history-continuity and compaction-boundary work open. This PR contains only the follow-up projection, pagination, and auditability changes.

## Problem and root cause

After a long turn is compacted, the Web UI can make earlier user messages appear missing and can expose legacy flattened tool transcript markers. Several read-path gaps combine here:

- the client historically loaded only the latest canonical window and did not clearly distinguish a preserved archive from incomplete canonical coverage;
- legacy flattened rows can contain multiple ordered tool uses/results, narration, or a pair split across a pagination boundary, while the display projection previously treated them as independent text rows;
- the legacy serializer did not escape payload newlines or brackets, so a first payload line ending in `]` is not a trustworthy result/narration boundary;
- optional lookaround reads used for cross-page reconstruction could fail the entire history RPC after its main page had already loaded successfully.

## Changes

- Preserve loaded canonical pages across refresh/prepend and expose durable compaction summaries with explicit archived/complete state.
- Project confirmed legacy narration, ordered multi-tool calls, and results into the existing auditable activity timeline using stable call IDs.
- Use one bounded previous/next row of canonical context to reconstruct trusted legacy pairs split by a page boundary without changing page accounting or message identity.
- Treat the complete ambiguous final remainder as auditable tool output, or preserve the original row when it cannot be parsed; never guess that part of a payload is assistant narration.
- Degrade non-busy auxiliary lookaround failures to the original page while preserving the existing retry behavior for `StorageBusyError`.
- Add focused backend and Web UI regression coverage for same-page and cross-page pairs, parallel results, narration, bidirectional pagination, refresh/deduplication, complete/incomplete canonical coverage, ambiguous JSON/code/plain payloads, and auxiliary read failures.

## Non-goals

- No transcript, database, schema, migration, RPC wire-contract, or write-protocol changes.
- No deletion or mutation of raw transcript records; this is a read-time display projection.
- No provider replay or compaction algorithm changes.
- No title-generation changes beyond the behavior already landed in #1153.

## Validation

- Focused backend history suites: 67 passed.
- Related backend chat/history/compaction suites: 91 passed, 2 skipped.
- Web UI unit suite: 329 files / 3,734 tests passed.
- `ruff`, `mypy`, `vue-tsc`, and `git diff --check` passed.
- Architecture, chat security, theme, motion, radius, i18n, channel-catalog, and README locale guards passed.
- Production Web UI build and artifact verification passed (198 files).

Validation was performed locally on macOS using the repository Python environment and bundled Node runtime. No live provider call, packaged cross-platform smoke run, or manual browser session against a naturally compacted production transcript was performed; GitHub CI remains the authoritative cross-platform check.

## Commit Lineage

This branch is based on `main` after the merged #1153 commit `27538cacc0bce4b51a977e355855fcf4fce6de84`.

- #1153 original contributor implementation: `a8e7ff679da4593db92b03da737c8d005a39df62` by `freeaccount-create`.
- #1153 maintainer safety/title follow-up: `4d9d77465f203a2c822b86606150c3118883f5c9` by `lihongguang-0014`.
- `697a4ae9e9d006af989a47e0f6f781f0db874b62` — canonical history continuity and compaction boundary projection.
- `d805b075a440e97ced803678db600c51a404812b` — ordered legacy multi-result activity timeline and cross-page reconstruction.
- `78654f42097b882fd56dd6245deb9bb0072d2b89` — ambiguity-safe parsing and fail-safe auxiliary lookaround behavior.

All follow-up commits remain separate; no contributor commit was amended or force-pushed.
