### PR TITLE
Stop repeated model output safely (#949)

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -1134,6 +1134,7 @@
       "tests/test_engine/test_runtime_meta_invoke_surfacing.py",
       "tests/test_engine/test_runtime_tool_run_budget.py",
       "tests/test_engine/test_spawn_depth_unified.py",
+      "tests/test_engine/test_stream_repetition_guard.py",
       "tests/test_engine/test_stream_wrappers.py",
       "tests/test_engine/test_tokenjuice_tool_result_projection.py",
       "tests/test_engine/test_tool_concurrency.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -295,6 +295,7 @@
     "tests/test_engine/test_session_sanitize.py": 0.239,
     "tests/test_engine/test_slash_command_registry.py": 0.011,
     "tests/test_engine/test_spawn_depth_unified.py": 0.01,
+    "tests/test_engine/test_stream_repetition_guard.py": 0.01,
     "tests/test_engine/test_stream_wrappers.py": 0.357,
     "tests/test_engine/test_subagent_run_mode_inheritance.py": 0.01,
     "tests/test_engine/test_subagent_usage_rollup.py": 0.03,

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -75,6 +75,7 @@ from opensquilla.engine.repetition_guard import (
     MODEL_REPETITION_LOOP_CODE,
     MODEL_REPETITION_LOOP_MESSAGE,
     ModelRepetitionLoopError,
+    close_async_iterator_bounded,
     guard_provider_text_stream,
 )
 from opensquilla.engine.runtime_diagnostics import RuntimeDiagnosticsObserver
@@ -16920,6 +16921,25 @@ class Agent:
             raise
         except Exception:  # noqa: BLE001 - provider boundary
             raise _RaisedProviderBoundaryError from None
+        try:
+            async for event in self._stream_provider_events_with_deadline_unclosed(
+                stream_iter,
+                loop=loop,
+                total_deadline=total_deadline,
+                deadline_provider=deadline_provider,
+            ):
+                yield event
+        finally:
+            await self._close_provider_stream(stream_iter)
+
+    async def _stream_provider_events_with_deadline_unclosed(
+        self,
+        stream_iter: AsyncIterator[Any],
+        *,
+        loop: asyncio.AbstractEventLoop,
+        total_deadline: float | None,
+        deadline_provider: Callable[[], float | None] | None = None,
+    ) -> AsyncIterator[Any]:
         while True:
             dynamic_deadline = (
                 deadline_provider()
@@ -16938,7 +16958,6 @@ class Agent:
             if active_deadline is not None:
                 remaining_total = active_deadline - loop.time()
                 if remaining_total <= 0:
-                    await self._close_provider_stream(stream_iter)
                     raise _provider_stream_deadline_timeout(
                         timeout_seconds=self.config.timeout,
                         deadline_at_monotonic=active_deadline,
@@ -16988,16 +17007,11 @@ class Agent:
 
     @staticmethod
     async def _close_provider_stream(stream_iter: AsyncIterator[Any]) -> None:
-        aclose = getattr(stream_iter, "aclose", None)
-        if not callable(aclose):
-            return
-        try:
-            await aclose()
-        except Exception as exc:  # noqa: BLE001 - cleanup must not mask timeout
-            logger.debug(
-                "provider_stream.close_failed",
-                error_type=type(exc).__name__,
-            )
+        await close_async_iterator_bounded(
+            stream_iter,
+            timeout=0.25,
+            event_prefix="provider_stream",
+        )
 
     def _provider_request_messages(
         self,

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -71,6 +71,12 @@ from opensquilla.engine.post_write_convergence import (
 )
 from opensquilla.engine.progress_watchdog import ProgressObservation, ProgressWatchdog
 from opensquilla.engine.prompt_cache_keepalive import PromptCacheKeepaliveCandidate
+from opensquilla.engine.repetition_guard import (
+    MODEL_REPETITION_LOOP_CODE,
+    MODEL_REPETITION_LOOP_MESSAGE,
+    ModelRepetitionLoopError,
+    guard_provider_text_stream,
+)
 from opensquilla.engine.runtime_diagnostics import RuntimeDiagnosticsObserver
 from opensquilla.engine.runtime_events import append_runtime_event
 from opensquilla.engine.runtime_recovery import (
@@ -8369,6 +8375,7 @@ class Agent:
                             # exception is deliberately not chained because SDK
                             # messages may contain response bodies or secrets.
                             raise _RaisedProviderBoundaryError from None
+                        raw_stream = guard_provider_text_stream(raw_stream)
                         pending_install_deadline: float | None = (
                             self._pending_durable_compaction_event
                             .compaction_deadline_at_monotonic
@@ -9371,6 +9378,26 @@ class Agent:
                             yield TextDeltaEvent(text=response_text)
                             break
                         raise
+                    except ModelRepetitionLoopError as exc:
+                        usage_unknown_reason = MODEL_REPETITION_LOOP_CODE
+                        _notify_call_outcome(
+                            ok=False,
+                            failure_kind=MODEL_REPETITION_LOOP_CODE,
+                        )
+                        self._write_turn_call_log(
+                            "turn_policy_decision",
+                            action="stop",
+                            reason=MODEL_REPETITION_LOOP_CODE,
+                            code=MODEL_REPETITION_LOOP_CODE,
+                            **exc.detection.log_fields(),
+                        )
+                        yield self._transition(AgentState.ERROR)
+                        terminal_error = ErrorEvent(
+                            message=MODEL_REPETITION_LOOP_MESSAGE,
+                            code=MODEL_REPETITION_LOOP_CODE,
+                        )
+                        yield terminal_error
+                        break
                     except UsageAccountingUnavailableError as exc:
                         # Usage-ledger admission is an engine control-plane
                         # failure, not an upstream provider exception. Preserve
@@ -16946,7 +16973,11 @@ class Agent:
                 event = next_event.result()
             except StopAsyncIteration:
                 return
-            except (asyncio.CancelledError, UsageAccountingUnavailableError):
+            except (
+                asyncio.CancelledError,
+                UsageAccountingUnavailableError,
+                ModelRepetitionLoopError,
+            ):
                 raise
             except Exception:  # noqa: BLE001 - provider boundary
                 # TimeoutError raised *by the provider* is different from the

--- a/src/opensquilla/engine/repetition_guard.py
+++ b/src/opensquilla/engine/repetition_guard.py
@@ -40,6 +40,18 @@ _CONTAINER_LOG_LINE_RE = re.compile(
     r"(?:trace|debug|info|warn(?:ing)?|error|fatal)\b)",
     re.IGNORECASE,
 )
+_CRI_LOG_LINE_RE = re.compile(
+    r"^(?:[A-Za-z0-9_.-]{1,128}\s+)?(?:stdout|stderr)\s+[FP]\s+"
+    r"(?:\[?\d{4}-\d{2}-\d{2}[T ]|\d{2}:\d{2}:\d{2}|"
+    r"(?:trace|debug|info|warn(?:ing)?|error|fatal)\b)",
+    re.IGNORECASE,
+)
+_KUBECTL_PREFIX_LOG_LINE_RE = re.compile(
+    r"^\[pod/[A-Za-z0-9_.-]{1,253}(?:/container)?/[A-Za-z0-9_.-]{1,253}\]\s+"
+    r"(?:\[?\d{4}-\d{2}-\d{2}[T ]|\d{2}:\d{2}:\d{2}|"
+    r"(?:trace|debug|info|warn(?:ing)?|error|fatal)\b)",
+    re.IGNORECASE,
+)
 _QUERY_BORDER_RE = re.compile(r"^(?:\+-{2,}(?:\+-{2,})+\+?|[-=]{2,}(?:\+[-=]{2,})+)$")
 _QUERY_FOOTER_RE = re.compile(r"^\(\d+\s+rows?\)$", re.IGNORECASE)
 _CODE_PREFIX_RE = re.compile(
@@ -300,7 +312,12 @@ def _looks_structured(text: str, period: int) -> bool:
     structured_lines = 0
     for line in lines:
         is_table = line.count("|") >= 2
-        is_log = bool(_LOG_LINE_RE.match(line) or _CONTAINER_LOG_LINE_RE.match(line))
+        is_log = bool(
+            _LOG_LINE_RE.match(line)
+            or _CONTAINER_LOG_LINE_RE.match(line)
+            or _CRI_LOG_LINE_RE.match(line)
+            or _KUBECTL_PREFIX_LOG_LINE_RE.match(line)
+        )
         is_code = bool(
             _CODE_PREFIX_RE.match(line)
             or _CODE_CALL_RE.match(line)
@@ -363,6 +380,8 @@ async def close_async_iterator_bounded(
     timeout: float,
     event_prefix: str = "provider_stream",
 ) -> None:
+    caller = asyncio.current_task()
+    caller_cancelling_before = caller.cancelling() if caller is not None else 0
     aclose = getattr(stream_iter, "aclose", None)
     if not callable(aclose):
         return
@@ -388,9 +407,22 @@ async def close_async_iterator_bounded(
         )
         return
     except asyncio.CancelledError:
-        close_task.cancel()
-        close_task.add_done_callback(_consume_close_result)
-        raise
+        caller_cancelling_now = caller.cancelling() if caller is not None else 0
+        caller_is_cancelling = caller_cancelling_now > caller_cancelling_before or (
+            caller_cancelling_now > 0 and not close_task.cancelled()
+        )
+        if caller_is_cancelling:
+            close_task.cancel()
+            close_task.add_done_callback(_consume_close_result)
+            raise
+        # The provider's aclose() may cancel itself.  That is a cleanup
+        # failure, not evidence that the task driving the provider stream was
+        # cancelled, so it must not replace the stream's terminal outcome.
+        _consume_close_result(close_task)
+        log.warning(
+            f"{event_prefix}.close_failed",
+            error_type=asyncio.CancelledError.__name__,
+        )
     except Exception as exc:  # noqa: BLE001 - cleanup must not mask terminal outcome
         log.warning(
             f"{event_prefix}.close_failed",

--- a/src/opensquilla/engine/repetition_guard.py
+++ b/src/opensquilla/engine/repetition_guard.py
@@ -1,0 +1,371 @@
+"""Bounded detection for provider text streams stuck in repetition loops.
+
+The detector consumes normalized characters at fixed checkpoints instead of
+provider event boundaries.  A provider therefore cannot change the decision
+by splitting the same text into different delta sizes.  Detection is kept at
+the Provider -> Agent boundary so every UI/channel benefits and the upstream
+request can be closed before a terminal error is emitted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import re
+from collections import deque
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, replace
+from typing import Any
+
+import structlog
+
+from opensquilla.provider import TextDeltaEvent as ProviderTextDelta
+
+log = structlog.get_logger(__name__)
+
+MODEL_REPETITION_LOOP_CODE = "model_repetition_loop_detected"
+MODEL_REPETITION_LOOP_MESSAGE = (
+    "The model began repeating the same output, so OpenSquilla stopped the task."
+)
+
+_LOG_LINE_RE = re.compile(
+    r"^(?:\[?\d{4}-\d{2}-\d{2}[T ]|\d{2}:\d{2}:\d{2}|"
+    r"(?:trace|debug|info|warn(?:ing)?|error|fatal)\b)",
+    re.IGNORECASE,
+)
+_CODE_PREFIX_RE = re.compile(
+    r"^(?:async\s+def|def|class|function|const|let|var|if|else|elif|for|while|"
+    r"try|except|catch|return|import|from|package|public|private|protected|"
+    r"select|insert|update|delete|create|alter|drop)\b",
+    re.IGNORECASE,
+)
+_CODE_CALL_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*\(")
+
+
+@dataclass(frozen=True, slots=True)
+class RepetitionGuardPolicy:
+    """Conservative fixed policy for one provider attempt."""
+
+    max_buffer_chars: int = 65_536
+    check_stride_chars: int = 256
+    required_consecutive_checks: int = 3
+    min_period_chars: int = 48
+    max_period_chars: int = 2_048
+    min_repeated_chars: int = 4_096
+    min_repetitions: int = 8
+    min_similarity: float = 0.985
+    structured_min_repeated_chars: int = 32_768
+    structured_min_repetitions: int = 32
+    structured_min_similarity: float = 0.995
+    close_timeout_seconds: float = 0.25
+
+
+@dataclass(frozen=True, slots=True)
+class RepetitionDetection:
+    period_chars: int
+    repeated_chars: int
+    repetitions: int
+    similarity: float
+    structured: bool
+
+    def log_fields(self) -> dict[str, int | float | bool]:
+        """Return content-free diagnostics safe for durable logs."""
+
+        return {
+            "period_chars": self.period_chars,
+            "repeated_chars": self.repeated_chars,
+            "repetitions": self.repetitions,
+            "similarity": round(self.similarity, 5),
+            "structured": self.structured,
+        }
+
+
+class ModelRepetitionLoopError(RuntimeError):
+    """Internal control-flow signal after the provider stream is closed."""
+
+    code = MODEL_REPETITION_LOOP_CODE
+
+    def __init__(self, detection: RepetitionDetection) -> None:
+        super().__init__(MODEL_REPETITION_LOOP_MESSAGE)
+        self.detection = detection
+
+
+class StreamingRepetitionGuard:
+    """Detect a highly periodic suffix using bounded memory.
+
+    Whitespace is collapsed incrementally, including across chunk boundaries.
+    Checks happen every ``check_stride_chars`` normalized characters.  ``feed``
+    returns only the raw prefix up to the deterministic triggering checkpoint;
+    callers must stop feeding after a non-None detection.
+    """
+
+    def __init__(self, policy: RepetitionGuardPolicy | None = None) -> None:
+        self.policy = policy or RepetitionGuardPolicy()
+        self._buffer_chunks: deque[str] = deque()
+        self._buffer_chars = 0
+        self._normalized_chars = 0
+        self._next_check = self.policy.check_stride_chars
+        self._last_whitespace: str | None = None
+        self._repeat_evidence_streak = 0
+
+    @property
+    def buffered_chars(self) -> int:
+        return self._buffer_chars
+
+    def reset(self) -> None:
+        """Start a fresh text segment at a tool boundary."""
+
+        self._buffer_chunks.clear()
+        self._buffer_chars = 0
+        self._normalized_chars = 0
+        self._next_check = self.policy.check_stride_chars
+        self._last_whitespace = None
+        self._repeat_evidence_streak = 0
+
+    def feed(self, text: str) -> tuple[str, RepetitionDetection | None]:
+        if not text:
+            return text, None
+
+        pending: list[str] = []
+        for raw_index, char in enumerate(text):
+            if char.isspace():
+                normalized = "\n" if char in "\r\n" else " "
+                if self._last_whitespace == "\n":
+                    continue
+                if self._last_whitespace == normalized:
+                    continue
+                if normalized == " " and self._last_whitespace is not None:
+                    continue
+                self._last_whitespace = normalized
+            else:
+                normalized = char
+                self._last_whitespace = None
+
+            pending.append(normalized)
+            self._normalized_chars += 1
+            if self._normalized_chars < self._next_check:
+                continue
+
+            self._append("".join(pending))
+            pending.clear()
+            candidate = self._detect()
+            self._next_check += self.policy.check_stride_chars
+            if candidate is None:
+                self._repeat_evidence_streak = 0
+                continue
+            self._repeat_evidence_streak += 1
+            if self._repeat_evidence_streak >= self.policy.required_consecutive_checks:
+                return text[: raw_index + 1], candidate
+
+        if pending:
+            self._append("".join(pending))
+        return text, None
+
+    def _append(self, text: str) -> None:
+        if not text:
+            return
+        self._buffer_chunks.append(text)
+        self._buffer_chars += len(text)
+        overflow = self._buffer_chars - self.policy.max_buffer_chars
+        while overflow > 0:
+            oldest = self._buffer_chunks[0]
+            if len(oldest) <= overflow:
+                self._buffer_chunks.popleft()
+                self._buffer_chars -= len(oldest)
+                overflow -= len(oldest)
+                continue
+            self._buffer_chunks[0] = oldest[overflow:]
+            self._buffer_chars -= overflow
+            overflow = 0
+
+    def _buffer_text(self) -> str:
+        if not self._buffer_chunks:
+            return ""
+        if len(self._buffer_chunks) == 1:
+            return self._buffer_chunks[0]
+        text = "".join(self._buffer_chunks)
+        self._buffer_chunks.clear()
+        self._buffer_chunks.append(text)
+        return text
+
+    def _detect(self) -> RepetitionDetection | None:
+        policy = self.policy
+        if self._buffer_chars < policy.min_repeated_chars + policy.min_period_chars:
+            return None
+
+        text = self._buffer_text()
+        candidates = self._candidate_periods(text)
+        for period in candidates:
+            structured = _looks_structured(text[-max(8_192, period * 2) :], period)
+            min_repeated = (
+                policy.structured_min_repeated_chars if structured else policy.min_repeated_chars
+            )
+            min_repetitions = (
+                policy.structured_min_repetitions if structured else policy.min_repetitions
+            )
+            min_similarity = (
+                policy.structured_min_similarity if structured else policy.min_similarity
+            )
+            repeated_chars = max(min_repeated, period * min_repetitions)
+            if repeated_chars + period > len(text):
+                continue
+
+            comparison = text[-(repeated_chars + period) :]
+            previous = comparison[:-period]
+            current = comparison[period:]
+            matches = sum(left == right for left, right in zip(previous, current, strict=True))
+            similarity = matches / repeated_chars
+            if similarity < min_similarity:
+                continue
+            return RepetitionDetection(
+                period_chars=period,
+                repeated_chars=repeated_chars,
+                repetitions=repeated_chars // period,
+                similarity=similarity,
+                structured=structured,
+            )
+        return None
+
+    def _candidate_periods(self, text: str) -> list[int]:
+        """Find likely periods from several exact anchors near the suffix.
+
+        A near-repeating stream normally preserves most 24-character anchors;
+        gathering anchors at four phases lets a small changing field avoid one
+        anchor without defeating detection.  Candidate count is capped so each
+        fixed checkpoint has bounded CPU cost.
+        """
+
+        policy = self.policy
+        candidates: set[int] = set()
+        anchor_chars = 24
+        for end_offset in (0, 61, 137, 251):
+            anchor_end = len(text) - end_offset
+            anchor_start = anchor_end - anchor_chars
+            if anchor_start <= 0:
+                continue
+            anchor = text[anchor_start:anchor_end]
+            search_start = max(0, anchor_start - policy.max_period_chars)
+            search_end = anchor_start
+            occurrences = 0
+            while search_end > search_start and occurrences < policy.min_period_chars + 16:
+                previous = text.rfind(anchor, search_start, search_end)
+                if previous < 0:
+                    break
+                period = anchor_start - previous
+                if policy.min_period_chars <= period <= policy.max_period_chars:
+                    candidates.add(period)
+                search_end = previous
+                occurrences += 1
+        return sorted(candidates)
+
+
+def _looks_structured(text: str, period: int) -> bool:
+    """Recognize code/table/log shapes that need the slower threshold."""
+
+    unit = text[-period:]
+    if "```" in text:
+        return True
+    lines = [line.strip() for line in text.splitlines()[-128:] if line.strip()]
+    if not lines:
+        lines = [unit.strip()] if unit.strip() else []
+    if not lines:
+        return False
+
+    structured_lines = 0
+    for line in lines:
+        is_table = line.count("|") >= 2
+        is_log = _LOG_LINE_RE.match(line) is not None
+        is_code = bool(
+            _CODE_PREFIX_RE.match(line)
+            or _CODE_CALL_RE.match(line)
+            or line.startswith(("//", "# ", "/*", "* ", "@"))
+            or line.endswith((";", "{", "}"))
+            or (line.startswith("<") and line.endswith(">"))
+            or any(marker in line for marker in ("()", "=>", " = ", " := ", " == "))
+        )
+        structured_lines += int(is_table or is_log or is_code)
+    # A checkpoint may bisect the first/last line, so a two-line code unit can
+    # contribute just under half recognized lines in the sampled suffix.
+    return structured_lines / len(lines) >= 0.4
+
+
+def _consume_close_result(task: asyncio.Future[Any]) -> None:
+    if task.cancelled():
+        return
+    with contextlib.suppress(BaseException):
+        task.result()
+
+
+async def _close_stream_bounded(
+    stream_iter: AsyncIterator[Any],
+    *,
+    timeout: float,
+) -> None:
+    aclose = getattr(stream_iter, "aclose", None)
+    if not callable(aclose):
+        return
+    try:
+        close_task = asyncio.ensure_future(aclose())
+    except Exception as exc:  # noqa: BLE001 - cleanup must not mask detection
+        log.warning(
+            "provider_repetition_guard.close_failed",
+            error_type=type(exc).__name__,
+        )
+        return
+    done, _ = await asyncio.wait({close_task}, timeout=max(0.001, timeout))
+    if close_task in done:
+        _consume_close_result(close_task)
+        return
+    close_task.cancel()
+    close_task.add_done_callback(_consume_close_result)
+    log.warning(
+        "provider_repetition_guard.close_timeout",
+        timeout_seconds=timeout,
+    )
+
+
+async def guard_provider_text_stream(
+    stream: AsyncIterator[Any],
+    *,
+    policy: RepetitionGuardPolicy | None = None,
+) -> AsyncIterator[Any]:
+    """Pass through provider events until repeated text crosses the policy."""
+
+    active_policy = policy or RepetitionGuardPolicy()
+    guard = StreamingRepetitionGuard(active_policy)
+    stream_iter = stream.__aiter__()
+    async for event in stream_iter:
+        kind = str(getattr(event, "kind", "") or "")
+        if kind in {"tool_use_start", "tool_use_end"}:
+            guard.reset()
+            yield event
+            continue
+        if not isinstance(event, ProviderTextDelta):
+            yield event
+            continue
+
+        accepted_text, detection = guard.feed(event.text)
+        if accepted_text:
+            yield replace(event, text=accepted_text)
+        elif detection is None:
+            # Preserve existing empty-delta behavior.
+            yield event
+        if detection is None:
+            continue
+
+        await _close_stream_bounded(
+            stream_iter,
+            timeout=active_policy.close_timeout_seconds,
+        )
+        raise ModelRepetitionLoopError(detection)
+
+
+__all__ = [
+    "MODEL_REPETITION_LOOP_CODE",
+    "MODEL_REPETITION_LOOP_MESSAGE",
+    "ModelRepetitionLoopError",
+    "RepetitionDetection",
+    "RepetitionGuardPolicy",
+    "StreamingRepetitionGuard",
+    "guard_provider_text_stream",
+]

--- a/src/opensquilla/engine/repetition_guard.py
+++ b/src/opensquilla/engine/repetition_guard.py
@@ -33,6 +33,15 @@ _LOG_LINE_RE = re.compile(
     r"(?:trace|debug|info|warn(?:ing)?|error|fatal)\b)",
     re.IGNORECASE,
 )
+_CONTAINER_LOG_LINE_RE = re.compile(
+    r"^(?:\[[^\]\n]{1,80}\]\s*)?"
+    r"(?:[A-Za-z0-9_.-]{1,80}(?:/[A-Za-z0-9_.-]{1,80})?\s+\|\s+)"
+    r"(?:\[?\d{4}-\d{2}-\d{2}[T ]|\d{2}:\d{2}:\d{2}|"
+    r"(?:trace|debug|info|warn(?:ing)?|error|fatal)\b)",
+    re.IGNORECASE,
+)
+_QUERY_BORDER_RE = re.compile(r"^(?:\+-{2,}(?:\+-{2,})+\+?|[-=]{2,}(?:\+[-=]{2,})+)$")
+_QUERY_FOOTER_RE = re.compile(r"^\(\d+\s+rows?\)$", re.IGNORECASE)
 _CODE_PREFIX_RE = re.compile(
     r"^(?:async\s+def|def|class|function|const|let|var|if|else|elif|for|while|"
     r"try|except|catch|return|import|from|package|public|private|protected|"
@@ -50,13 +59,17 @@ class RepetitionGuardPolicy:
     check_stride_chars: int = 256
     required_consecutive_checks: int = 3
     min_period_chars: int = 48
-    max_period_chars: int = 2_048
+    max_period_chars: int = 8_192
     min_repeated_chars: int = 4_096
     min_repetitions: int = 8
     min_similarity: float = 0.985
-    structured_min_repeated_chars: int = 32_768
-    structured_min_repetitions: int = 32
-    structured_min_similarity: float = 0.995
+    large_period_threshold_chars: int = 2_048
+    large_period_min_repeated_chars: int = 16_384
+    large_period_min_repetitions: int = 4
+    structured_min_repeated_chars: int = 57_344
+    structured_min_repetitions: int = 7
+    structured_min_similarity: float = 0.9995
+    max_candidate_periods: int = 64
     close_timeout_seconds: float = 0.25
 
 
@@ -129,7 +142,7 @@ class StreamingRepetitionGuard:
         pending: list[str] = []
         for raw_index, char in enumerate(text):
             if char.isspace():
-                normalized = "\n" if char in "\r\n" else " "
+                normalized = "\n" if char in "\r\n" else "\t" if char == "\t" else " "
                 if self._last_whitespace == "\n":
                     continue
                 if self._last_whitespace == normalized:
@@ -206,6 +219,12 @@ class StreamingRepetitionGuard:
             min_similarity = (
                 policy.structured_min_similarity if structured else policy.min_similarity
             )
+            if not structured and period > policy.large_period_threshold_chars:
+                min_repeated = max(min_repeated, policy.large_period_min_repeated_chars)
+                min_repetitions = min(
+                    min_repetitions,
+                    policy.large_period_min_repetitions,
+                )
             repeated_chars = max(min_repeated, period * min_repetitions)
             if repeated_chars + period > len(text):
                 continue
@@ -236,27 +255,32 @@ class StreamingRepetitionGuard:
         """
 
         policy = self.policy
-        candidates: set[int] = set()
-        anchor_chars = 24
-        for end_offset in (0, 61, 137, 251):
-            anchor_end = len(text) - end_offset
-            anchor_start = anchor_end - anchor_chars
-            if anchor_start <= 0:
-                continue
-            anchor = text[anchor_start:anchor_end]
-            search_start = max(0, anchor_start - policy.max_period_chars)
-            search_end = anchor_start
-            occurrences = 0
-            while search_end > search_start and occurrences < policy.min_period_chars + 16:
-                previous = text.rfind(anchor, search_start, search_end)
-                if previous < 0:
-                    break
-                period = anchor_start - previous
-                if policy.min_period_chars <= period <= policy.max_period_chars:
-                    candidates.add(period)
-                search_end = previous
-                occurrences += 1
-        return sorted(candidates)
+        votes: dict[int, int] = {}
+        # Multiple anchor widths make the discovery resilient to a changing
+        # field landing inside one anchor, while the phase offsets keep the
+        # result independent of provider chunk boundaries.  Each rfind scans
+        # at most max_period_chars and both anchors and candidates are capped.
+        for anchor_chars in (24, 48, 96):
+            for end_offset in (0, 61, 137, 251, 509):
+                anchor_end = len(text) - end_offset
+                anchor_start = anchor_end - anchor_chars
+                if anchor_start <= 0:
+                    continue
+                anchor = text[anchor_start:anchor_end]
+                search_start = max(0, anchor_start - policy.max_period_chars)
+                search_end = anchor_start
+                occurrences = 0
+                while search_end > search_start and occurrences < 16:
+                    previous = text.rfind(anchor, search_start, search_end)
+                    if previous < 0:
+                        break
+                    period = anchor_start - previous
+                    if policy.min_period_chars <= period <= policy.max_period_chars:
+                        votes[period] = votes.get(period, 0) + 1
+                    search_end = previous
+                    occurrences += 1
+        ranked = sorted(votes, key=lambda period: (-votes[period], period))
+        return sorted(ranked[: policy.max_candidate_periods])
 
 
 def _looks_structured(text: str, period: int) -> bool:
@@ -270,11 +294,13 @@ def _looks_structured(text: str, period: int) -> bool:
         lines = [unit.strip()] if unit.strip() else []
     if not lines:
         return False
+    if _looks_delimited_rows(lines) or _looks_query_result(lines):
+        return True
 
     structured_lines = 0
     for line in lines:
         is_table = line.count("|") >= 2
-        is_log = _LOG_LINE_RE.match(line) is not None
+        is_log = bool(_LOG_LINE_RE.match(line) or _CONTAINER_LOG_LINE_RE.match(line))
         is_code = bool(
             _CODE_PREFIX_RE.match(line)
             or _CODE_CALL_RE.match(line)
@@ -289,6 +315,41 @@ def _looks_structured(text: str, period: int) -> bool:
     return structured_lines / len(lines) >= 0.4
 
 
+def _looks_delimited_rows(lines: list[str]) -> bool:
+    """Recognize CSV/TSV-shaped output without parsing or retaining fields."""
+
+    if len(lines) < 4:
+        return False
+    for delimiter in ("\t", ","):
+        counts = [line.count(delimiter) for line in lines]
+        eligible = [count for count in counts if count >= 1]
+        if len(eligible) < max(4, int(len(lines) * 0.75)):
+            continue
+        frequencies: dict[int, int] = {}
+        for count in eligible:
+            frequencies[count] = frequencies.get(count, 0) + 1
+        if max(frequencies.values(), default=0) >= max(3, int(len(lines) * 0.5)):
+            return True
+    return False
+
+
+def _looks_query_result(lines: list[str]) -> bool:
+    """Recognize common psql/sqlite/MySQL-style tabular query output."""
+
+    if len(lines) < 3:
+        return False
+    table_rows = sum(
+        1
+        for line in lines
+        if (
+            line.count("|") >= 1
+            or _QUERY_BORDER_RE.match(line) is not None
+            or _QUERY_FOOTER_RE.match(line) is not None
+        )
+    )
+    return table_rows >= max(3, int(len(lines) * 0.5))
+
+
 def _consume_close_result(task: asyncio.Future[Any]) -> None:
     if task.cancelled():
         return
@@ -296,10 +357,11 @@ def _consume_close_result(task: asyncio.Future[Any]) -> None:
         task.result()
 
 
-async def _close_stream_bounded(
+async def close_async_iterator_bounded(
     stream_iter: AsyncIterator[Any],
     *,
     timeout: float,
+    event_prefix: str = "provider_stream",
 ) -> None:
     aclose = getattr(stream_iter, "aclose", None)
     if not callable(aclose):
@@ -308,20 +370,54 @@ async def _close_stream_bounded(
         close_task = asyncio.ensure_future(aclose())
     except Exception as exc:  # noqa: BLE001 - cleanup must not mask detection
         log.warning(
-            "provider_repetition_guard.close_failed",
+            f"{event_prefix}.close_failed",
             error_type=type(exc).__name__,
         )
         return
-    done, _ = await asyncio.wait({close_task}, timeout=max(0.001, timeout))
-    if close_task in done:
-        _consume_close_result(close_task)
+    try:
+        await asyncio.wait_for(
+            asyncio.shield(close_task),
+            timeout=max(0.001, timeout),
+        )
+    except TimeoutError:
+        close_task.cancel()
+        close_task.add_done_callback(_consume_close_result)
+        log.warning(
+            f"{event_prefix}.close_timeout",
+            timeout_seconds=timeout,
+        )
         return
-    close_task.cancel()
-    close_task.add_done_callback(_consume_close_result)
-    log.warning(
-        "provider_repetition_guard.close_timeout",
-        timeout_seconds=timeout,
-    )
+    except asyncio.CancelledError:
+        close_task.cancel()
+        close_task.add_done_callback(_consume_close_result)
+        raise
+    except Exception as exc:  # noqa: BLE001 - cleanup must not mask terminal outcome
+        log.warning(
+            f"{event_prefix}.close_failed",
+            error_type=type(exc).__name__,
+        )
+    else:
+        _consume_close_result(close_task)
+
+
+class _IdempotentStreamCloser:
+    """Start at most one bounded close even when exit paths converge."""
+
+    def __init__(self, stream_iter: AsyncIterator[Any], *, timeout: float) -> None:
+        self._stream_iter = stream_iter
+        self._timeout = timeout
+        self._close_task: asyncio.Task[None] | None = None
+
+    async def close(self) -> None:
+        if self._close_task is None:
+            self._close_task = asyncio.create_task(
+                close_async_iterator_bounded(
+                    self._stream_iter,
+                    timeout=self._timeout,
+                    event_prefix="provider_repetition_guard",
+                )
+            )
+        await asyncio.shield(self._close_task)
 
 
 async def guard_provider_text_stream(
@@ -334,30 +430,34 @@ async def guard_provider_text_stream(
     active_policy = policy or RepetitionGuardPolicy()
     guard = StreamingRepetitionGuard(active_policy)
     stream_iter = stream.__aiter__()
-    async for event in stream_iter:
-        kind = str(getattr(event, "kind", "") or "")
-        if kind in {"tool_use_start", "tool_use_end"}:
-            guard.reset()
-            yield event
-            continue
-        if not isinstance(event, ProviderTextDelta):
-            yield event
-            continue
+    closer = _IdempotentStreamCloser(
+        stream_iter,
+        timeout=active_policy.close_timeout_seconds,
+    )
+    try:
+        async for event in stream_iter:
+            kind = str(getattr(event, "kind", "") or "")
+            if kind in {"tool_use_start", "tool_use_end"}:
+                guard.reset()
+                yield event
+                continue
+            if not isinstance(event, ProviderTextDelta):
+                yield event
+                continue
 
-        accepted_text, detection = guard.feed(event.text)
-        if accepted_text:
-            yield replace(event, text=accepted_text)
-        elif detection is None:
-            # Preserve existing empty-delta behavior.
-            yield event
-        if detection is None:
-            continue
+            accepted_text, detection = guard.feed(event.text)
+            if accepted_text:
+                yield replace(event, text=accepted_text)
+            elif detection is None:
+                # Preserve existing empty-delta behavior.
+                yield event
+            if detection is None:
+                continue
 
-        await _close_stream_bounded(
-            stream_iter,
-            timeout=active_policy.close_timeout_seconds,
-        )
-        raise ModelRepetitionLoopError(detection)
+            await closer.close()
+            raise ModelRepetitionLoopError(detection)
+    finally:
+        await closer.close()
 
 
 __all__ = [
@@ -367,5 +467,6 @@ __all__ = [
     "RepetitionDetection",
     "RepetitionGuardPolicy",
     "StreamingRepetitionGuard",
+    "close_async_iterator_bounded",
     "guard_provider_text_stream",
 ]

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -1796,9 +1796,14 @@ async def _emit_task_runtime_stream_events(
             code_text = str(code or "").lower()
             is_timeout = "timeout" in code_text or "stream idle" in error_message.lower()
             is_output_truncated = code_text == "provider_output_truncated"
-            terminal_reason = (
-                "timeout" if is_timeout else "output_truncated" if is_output_truncated else "error"
-            )
+            if is_timeout:
+                terminal_reason = "timeout"
+            elif is_output_truncated:
+                terminal_reason = "output_truncated"
+            elif code_text == "model_repetition_loop_detected":
+                terminal_reason = "model_repetition_loop_detected"
+            else:
+                terminal_reason = "error"
             terminal_payload = {
                 "status": "timeout" if is_timeout else "failed",
                 "terminal_reason": terminal_reason,

--- a/src/opensquilla/session/terminal_reply.py
+++ b/src/opensquilla/session/terminal_reply.py
@@ -61,6 +61,7 @@ _SAFE_PROVIDER_TERMINAL_CODES = frozenset(
         "invalid_response_status",
         "invalid_stream_frame",
         "invalid_stream_order",
+        "model_repetition_loop_detected",
         "provider_protocol_error",
         "provider_output_truncated",
         "provider_pretext_buffer_exhausted",
@@ -154,6 +155,11 @@ def build_terminal_reply(
         )
     if reason == "output_truncated" or error_class == "provider_output_truncated":
         return "The provider stopped because the output limit was reached before the task finished."
+    if (
+        reason == "model_repetition_loop_detected"
+        or error_class == "model_repetition_loop_detected"
+    ):
+        return "The model began repeating the same output, so OpenSquilla stopped the task."
     if status == AgentTaskStatus.CANCELLED.value or reason.startswith("cancelled"):
         return "The task was cancelled before it finished."
     if status == AgentTaskStatus.ABANDONED.value or reason == "shutdown_timeout":

--- a/src/opensquilla/usage_reasons.py
+++ b/src/opensquilla/usage_reasons.py
@@ -16,6 +16,7 @@ _INTERNAL_USAGE_UNKNOWN_REASONS = frozenset(
         "direct_request_failed",
         "iteration_timeout",
         "missing_or_invalid_usage_receipt",
+        "model_repetition_loop_detected",
         "process_restarted",
         "provider_error",
         "provider_exception",

--- a/tests/test_ci/test_windows_test_shards.py
+++ b/tests/test_ci/test_windows_test_shards.py
@@ -98,6 +98,7 @@ RECENTLY_ADDED_ACTIVE_TESTS = {
     "tests/test_engine/test_provider_activity.py",
     "tests/test_engine/test_long_task_backend_boundaries.py",
     "tests/test_engine/test_route_plan.py",
+    "tests/test_engine/test_stream_repetition_guard.py",
     "tests/test_engine/turn_runner/test_canonical_text_contract.py",
     "tests/test_gateway/test_api_chat.py",
     "tests/test_gateway/test_channel_turn_ingress.py",

--- a/tests/test_engine/test_runtime_agent_iteration_timeout.py
+++ b/tests/test_engine/test_runtime_agent_iteration_timeout.py
@@ -225,7 +225,7 @@ async def test_stream_iteration_timeout_does_not_double_close_provider_stream(
         ):
             pass
 
-    assert close_calls == 0
+    assert close_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/test_stream_repetition_guard.py
+++ b/tests/test_engine/test_stream_repetition_guard.py
@@ -462,7 +462,7 @@ async def test_bounded_close_propagates_real_caller_cancellation() -> None:
 
     close.cancel()
     with pytest.raises(asyncio.CancelledError):
-        await close
+        _ = await close
 
     assert close.cancelled()
     assert upstream.close_calls == 1
@@ -519,7 +519,7 @@ async def test_outer_wrapper_cancellation_propagates_once_to_provider() -> None:
     await upstream.blocked.wait()
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
-        await task
+        _ = await task
 
     assert upstream.close_calls == 1
 

--- a/tests/test_engine/test_stream_repetition_guard.py
+++ b/tests/test_engine/test_stream_repetition_guard.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
 from opensquilla.engine import Agent, AgentConfig
+from opensquilla.engine.agent import _IterationStreamTimeoutError
 from opensquilla.engine.repetition_guard import (
     MODEL_REPETITION_LOOP_CODE,
     ModelRepetitionLoopError,
@@ -45,6 +47,20 @@ def _feed_in_chunks(
         if detection is not None:
             break
     return "".join(emitted), detection, guard
+
+
+def _aperiodic_unit(length: int) -> str:
+    """Return deterministic text with no exact proper period."""
+
+    state = 0x12345678
+    alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    chars: list[str] = []
+    for _ in range(length):
+        state = (1_664_525 * state + 1_013_904_223) & 0xFFFFFFFF
+        chars.append(alphabet[state % len(alphabet)])
+    unit = "".join(chars)
+    assert all(unit[period:] != unit[:-period] for period in range(1, min(length, 2_049)))
+    return unit
 
 
 def test_repetition_detection_is_chunk_invariant() -> None:
@@ -89,6 +105,23 @@ def test_short_repeated_unit_is_detected_via_a_larger_period() -> None:
     assert detection.period_chars >= 48
 
 
+@pytest.mark.parametrize("period", [3_000, 4_096, 8_192])
+def test_large_aperiodic_loops_are_detected_chunk_invariant(period: int) -> None:
+    payload = _aperiodic_unit(period) * 12
+
+    results = [
+        _feed_in_chunks(payload, chunk_size)[:2] for chunk_size in (1, 257, 4_093, len(payload))
+    ]
+
+    assert len({len(emitted) for emitted, _ in results}) == 1
+    assert len({detection for _, detection in results}) == 1
+    [detection] = list({detection for _, detection in results})
+    assert detection is not None
+    assert detection.period_chars == period
+    assert detection.repeated_chars >= max(16_384, period * 4)
+    assert detection.structured is False
+
+
 @pytest.mark.parametrize(
     "unit",
     [
@@ -98,6 +131,16 @@ def test_short_repeated_unit_is_detected_via_a_larger_period() -> None:
         pytest.param(
             "2026-08-13T12:00:00 INFO provider stream remains active\n",
             id="log",
+        ),
+        pytest.param(
+            "api-1 | 2026-08-13T12:00:00 INFO request completed\n",
+            id="container-log",
+        ),
+        pytest.param("region,status,count\nus-east,ready,10\n", id="csv"),
+        pytest.param("region\tstatus\tcount\nus-east\tready\t10\n", id="tsv"),
+        pytest.param(
+            " id | status\n----+--------\n 1  | ready\n(1 row)\n",
+            id="query-result",
         ),
     ],
 )
@@ -112,14 +155,65 @@ def test_structured_repetition_uses_slow_threshold(unit: str) -> None:
 
 def test_long_structured_loop_is_not_permanently_exempt() -> None:
     unit = "for item in items:\n    print(item)\n"
-    payload = (unit * (50_000 // len(unit) + 1))[:50_000]
+    payload = (unit * (80_000 // len(unit) + 1))[:80_000]
 
     _, detection, _ = _feed_in_chunks(payload, 211)
 
     assert detection is not None
     assert detection.structured is True
-    assert detection.repeated_chars >= 32_768
-    assert detection.repetitions >= 32
+    assert detection.repeated_chars >= 57_344
+    assert detection.repetitions >= 7
+
+
+@pytest.mark.parametrize(
+    "row_factory",
+    [
+        pytest.param(
+            lambda index: (
+                f"api-{index % 7} | 2026-08-13T12:{index // 60:02d}:"
+                f"{index % 60:02d} INFO request={index} latency_ms={index * 17}\n"
+            ),
+            id="container-log",
+        ),
+        pytest.param(
+            lambda index: f"region-{index % 11},ready,{index},{index * 17}\n",
+            id="csv",
+        ),
+        pytest.param(
+            lambda index: f"region-{index % 11}\tready\t{index}\t{index * 17}\n",
+            id="tsv",
+        ),
+        pytest.param(
+            lambda index: f" {index:05d} | ready | value_{index * 17}\n",
+            id="query-result",
+        ),
+    ],
+)
+def test_long_progressing_structured_output_is_not_flagged(row_factory: Any) -> None:
+    payload = "".join(row_factory(index) for index in range(4_000))
+
+    emitted, detection, guard = _feed_in_chunks(payload, 173)
+
+    assert detection is None
+    assert emitted == payload
+    assert guard.buffered_chars <= 65_536
+
+
+def test_large_structured_loop_requires_full_conservative_budget() -> None:
+    period = 8_192
+    rows = [f"{index:04d},value_{_aperiodic_unit(32)}_{index:04d}\n" for index in range(160)]
+    unit = "column,value,index\n" + "".join(rows)
+    unit = (unit + _aperiodic_unit(period))[:period]
+    assert len(unit) == period
+    payload = unit * 10
+
+    _, detection, guard = _feed_in_chunks(payload, 251)
+
+    assert detection is not None
+    assert detection.period_chars == period
+    assert detection.structured is True
+    assert detection.repeated_chars >= 57_344
+    assert guard.buffered_chars <= 65_536
 
 
 def test_nonperiodic_code_table_and_log_output_does_not_trigger() -> None:
@@ -137,9 +231,10 @@ def test_nonperiodic_code_table_and_log_output_does_not_trigger() -> None:
 
 
 class _RepeatingIterator:
-    def __init__(self, *, block_close: bool = False) -> None:
+    def __init__(self, *, block_close: bool = False, fail_close: bool = False) -> None:
         self.close_calls = 0
         self.block_close = block_close
+        self.fail_close = fail_close
         self.close_started = asyncio.Event()
 
     def __aiter__(self) -> _RepeatingIterator:
@@ -154,8 +249,41 @@ class _RepeatingIterator:
     async def aclose(self) -> None:
         self.close_calls += 1
         self.close_started.set()
+        if self.fail_close:
+            raise RuntimeError("synthetic close failure")
         if self.block_close:
             await asyncio.Event().wait()
+
+
+class _LifecycleIterator:
+    def __init__(self, *, emit_first: bool = True) -> None:
+        self.close_calls = 0
+        self.emit_first = emit_first
+        self.emitted = False
+        self.blocked = asyncio.Event()
+
+    def __aiter__(self) -> _LifecycleIterator:
+        return self
+
+    async def __anext__(self) -> ProviderText:
+        if self.emit_first and not self.emitted:
+            self.emitted = True
+            return ProviderText(text="first event")
+        self.blocked.set()
+        await asyncio.Event().wait()
+        raise StopAsyncIteration
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+
+
+def _deadline_agent(iteration_timeout: float = 1.0) -> Agent:
+    agent = Agent.__new__(Agent)
+    agent.config = SimpleNamespace(
+        iteration_timeout=iteration_timeout,
+        timeout=iteration_timeout,
+    )
+    return agent
 
 
 @pytest.mark.asyncio
@@ -184,6 +312,73 @@ async def test_guard_close_is_bounded_when_upstream_ignores_close() -> None:
         await asyncio.wait_for(consume(), timeout=0.25)
 
     assert upstream.close_started.is_set()
+    assert upstream.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_guard_close_failure_does_not_mask_repetition_outcome() -> None:
+    upstream = _RepeatingIterator(fail_close=True)
+
+    with pytest.raises(ModelRepetitionLoopError) as exc_info:
+        async for _ in guard_provider_text_stream(upstream):
+            pass
+
+    assert exc_info.value.code == MODEL_REPETITION_LOOP_CODE
+    assert upstream.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_outer_wrapper_aclose_propagates_once_to_provider() -> None:
+    upstream = _LifecycleIterator()
+    guarded = guard_provider_text_stream(upstream)
+    wrapped = _deadline_agent()._stream_provider_events_with_deadline(
+        guarded,
+        loop=asyncio.get_running_loop(),
+        total_deadline=None,
+    )
+
+    assert (await anext(wrapped)).text == "first event"
+    await wrapped.aclose()
+
+    assert upstream.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_outer_wrapper_cancellation_propagates_once_to_provider() -> None:
+    upstream = _LifecycleIterator()
+    guarded = guard_provider_text_stream(upstream)
+
+    async def consume() -> None:
+        async for _ in _deadline_agent()._stream_provider_events_with_deadline(
+            guarded,
+            loop=asyncio.get_running_loop(),
+            total_deadline=None,
+        ):
+            pass
+
+    task = asyncio.create_task(consume())
+    await upstream.blocked.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert upstream.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_outer_wrapper_iteration_timeout_propagates_once_to_provider() -> None:
+    upstream = _LifecycleIterator(emit_first=False)
+    guarded = guard_provider_text_stream(upstream)
+    agent = _deadline_agent(iteration_timeout=0.01)
+
+    with pytest.raises(_IterationStreamTimeoutError):
+        async for _ in agent._stream_provider_events_with_deadline(
+            guarded,
+            loop=asyncio.get_running_loop(),
+            total_deadline=None,
+        ):
+            pass
+
     assert upstream.close_calls == 1
 
 

--- a/tests/test_engine/test_stream_repetition_guard.py
+++ b/tests/test_engine/test_stream_repetition_guard.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from opensquilla.engine import Agent, AgentConfig
+from opensquilla.engine.repetition_guard import (
+    MODEL_REPETITION_LOOP_CODE,
+    ModelRepetitionLoopError,
+    RepetitionDetection,
+    RepetitionGuardPolicy,
+    StreamingRepetitionGuard,
+    guard_provider_text_stream,
+)
+from opensquilla.engine.usage_accounting import (
+    UsageAccountingScope,
+    UsageCallResult,
+    UsageCallStart,
+    UsageExecutionContext,
+    account_provider_stream,
+    bind_usage_accounting_scope,
+)
+from opensquilla.provider import ChatConfig, Message
+from opensquilla.provider import DoneEvent as ProviderDone
+from opensquilla.provider import TextDeltaEvent as ProviderText
+from opensquilla.provider import ToolUseEndEvent as ProviderToolUseEnd
+from opensquilla.provider import ToolUseStartEvent as ProviderToolUseStart
+
+
+def _feed_in_chunks(
+    text: str,
+    chunk_size: int,
+    *,
+    policy: RepetitionGuardPolicy | None = None,
+) -> tuple[str, RepetitionDetection | None, StreamingRepetitionGuard]:
+    guard = StreamingRepetitionGuard(policy)
+    emitted: list[str] = []
+    detection: RepetitionDetection | None = None
+    for start in range(0, len(text), chunk_size):
+        accepted, detection = guard.feed(text[start : start + chunk_size])
+        emitted.append(accepted)
+        if detection is not None:
+            break
+    return "".join(emitted), detection, guard
+
+
+def test_repetition_detection_is_chunk_invariant() -> None:
+    phrase = "I am reading the file while checking the next section carefully. "
+    payload = phrase * 300
+
+    results = [_feed_in_chunks(payload, size)[:2] for size in (1, 7, 257, len(payload))]
+
+    emitted_lengths = {len(emitted) for emitted, _ in results}
+    detections = {detection for _, detection in results}
+    assert len(emitted_lengths) == 1
+    assert len(detections) == 1
+    [detection] = list(detections)
+    assert detection is not None
+    assert detection.repeated_chars >= 4_096
+    assert detection.repetitions >= 8
+    assert detection.similarity >= 0.985
+    assert detection.structured is False
+
+
+def test_highly_similar_repetition_with_small_changing_field_is_detected() -> None:
+    rows = [
+        (
+            f"Progress marker {chr(65 + index % 26)}: I am reading the file and "
+            "checking the same section before continuing carefully. "
+        )
+        for index in range(240)
+    ]
+
+    _, detection, _ = _feed_in_chunks("".join(rows), 113)
+
+    assert detection is not None
+    assert detection.similarity >= 0.985
+
+
+def test_short_repeated_unit_is_detected_via_a_larger_period() -> None:
+    payload = "yes " * 3_000
+
+    _, detection, _ = _feed_in_chunks(payload, 1)
+
+    assert detection is not None
+    assert detection.period_chars >= 48
+
+
+@pytest.mark.parametrize(
+    "unit",
+    [
+        pytest.param("for item in items:\n    print(item)\n", id="code"),
+        pytest.param("print(item)\n", id="code-call"),
+        pytest.param("| model | status |\n| --- | --- |\n", id="markdown-table"),
+        pytest.param(
+            "2026-08-13T12:00:00 INFO provider stream remains active\n",
+            id="log",
+        ),
+    ],
+)
+def test_structured_repetition_uses_slow_threshold(unit: str) -> None:
+    payload = (unit * (16_000 // len(unit) + 1))[:16_000]
+
+    emitted, detection, _ = _feed_in_chunks(payload, 97)
+
+    assert detection is None
+    assert emitted == payload
+
+
+def test_long_structured_loop_is_not_permanently_exempt() -> None:
+    unit = "for item in items:\n    print(item)\n"
+    payload = (unit * (50_000 // len(unit) + 1))[:50_000]
+
+    _, detection, _ = _feed_in_chunks(payload, 211)
+
+    assert detection is not None
+    assert detection.structured is True
+    assert detection.repeated_chars >= 32_768
+    assert detection.repetitions >= 32
+
+
+def test_nonperiodic_code_table_and_log_output_does_not_trigger() -> None:
+    payload = "".join(
+        f"2026-08-13T12:{index // 60:02d}:{index % 60:02d} INFO row | {index} | "
+        f"value_{index * 17}\n"
+        for index in range(2_000)
+    )
+
+    emitted, detection, guard = _feed_in_chunks(payload, 173)
+
+    assert detection is None
+    assert emitted == payload
+    assert guard.buffered_chars <= 65_536
+
+
+class _RepeatingIterator:
+    def __init__(self, *, block_close: bool = False) -> None:
+        self.close_calls = 0
+        self.block_close = block_close
+        self.close_started = asyncio.Event()
+
+    def __aiter__(self) -> _RepeatingIterator:
+        return self
+
+    async def __anext__(self) -> ProviderText:
+        await asyncio.sleep(0)
+        return ProviderText(
+            text="I am reading the file while checking the next section carefully. "
+        )
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+        self.close_started.set()
+        if self.block_close:
+            await asyncio.Event().wait()
+
+
+@pytest.mark.asyncio
+async def test_guard_closes_upstream_once_before_raising() -> None:
+    upstream = _RepeatingIterator()
+    emitted: list[str] = []
+
+    with pytest.raises(ModelRepetitionLoopError):
+        async for event in guard_provider_text_stream(upstream):
+            emitted.append(event.text)
+
+    assert upstream.close_calls == 1
+    assert 4_096 <= len("".join(emitted)) <= 5_120
+
+
+@pytest.mark.asyncio
+async def test_guard_close_is_bounded_when_upstream_ignores_close() -> None:
+    upstream = _RepeatingIterator(block_close=True)
+    policy = RepetitionGuardPolicy(close_timeout_seconds=0.01)
+
+    async def consume() -> None:
+        async for _ in guard_provider_text_stream(upstream, policy=policy):
+            pass
+
+    with pytest.raises(ModelRepetitionLoopError):
+        await asyncio.wait_for(consume(), timeout=0.25)
+
+    assert upstream.close_started.is_set()
+    assert upstream.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_tool_boundary_resets_repetition_budget() -> None:
+    phrase = "I am reading the file while checking the next section carefully. "
+
+    async def stream() -> AsyncIterator[Any]:
+        yield ProviderText(text=(phrase * 60)[:3_000])
+        yield ProviderToolUseStart(tool_use_id="tool-1", tool_name="read")
+        yield ProviderToolUseEnd(
+            tool_use_id="tool-1",
+            tool_name="read",
+            arguments={},
+        )
+        yield ProviderText(text=(phrase * 60)[:3_000])
+        yield ProviderDone()
+
+    events = [event async for event in guard_provider_text_stream(stream())]
+
+    assert [event.kind for event in events] == [
+        "text_delta",
+        "tool_use_start",
+        "tool_use_end",
+        "text_delta",
+        "done",
+    ]
+
+
+class _RecordingSink:
+    def __init__(self) -> None:
+        self.started: list[UsageCallStart] = []
+        self.finalized: list[tuple[UsageCallStart, UsageCallResult]] = []
+        self.unknown: list[tuple[UsageCallStart, str]] = []
+
+    async def start(self, call: UsageCallStart) -> None:
+        self.started.append(call)
+
+    async def finalize(self, call: UsageCallStart, result: UsageCallResult) -> None:
+        self.finalized.append((call, result))
+
+    async def mark_unknown(self, call: UsageCallStart, reason: str) -> None:
+        self.unknown.append((call, reason))
+
+
+class _RepeatingProvider:
+    provider_name = "synthetic"
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.streams: list[_RepeatingIterator] = []
+
+    def chat(
+        self,
+        messages: list[Message],
+        tools: list[Any] | None = None,
+        config: ChatConfig | None = None,
+    ) -> AsyncIterator[Any]:
+        del messages, tools, config
+        self.calls += 1
+        stream = _RepeatingIterator()
+        self.streams.append(stream)
+        return stream
+
+    async def list_models(self) -> list[Any]:
+        return []
+
+
+@pytest.mark.asyncio
+async def test_agent_stops_without_retry_and_marks_usage_unknown_once() -> None:
+    sink = _RecordingSink()
+    provider = _RepeatingProvider()
+    observer_calls: list[dict[str, Any]] = []
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            max_iterations=1,
+            max_provider_retries=3,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+            provider_id="synthetic",
+            model_id="looping-model",
+            provider_call_observer=lambda **kwargs: observer_calls.append(kwargs),
+        ),
+        usage_event_sink=sink,
+        usage_execution_context=UsageExecutionContext(
+            execution_id="execution-949",
+            agent_run_id="run-949",
+            turn_id="turn-949",
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("read the file")]
+
+    errors = [event for event in events if event.kind == "error"]
+    assert [event.code for event in errors] == [MODEL_REPETITION_LOOP_CODE]
+    assert not any(event.kind == "done" for event in events)
+    assert provider.calls == 1
+    assert provider.streams[0].close_calls == 1
+    assert len(sink.started) == 1
+    assert sink.finalized == []
+    assert [(call.event_id, reason) for call, reason in sink.unknown] == [
+        (sink.started[0].event_id, MODEL_REPETITION_LOOP_CODE)
+    ]
+    assert len(observer_calls) == 1
+    assert observer_calls[0]["ok"] is False
+    assert observer_calls[0]["failure_kind"] == MODEL_REPETITION_LOOP_CODE
+
+
+@pytest.mark.asyncio
+async def test_physical_usage_wrapper_closes_as_unknown_exactly_once() -> None:
+    sink = _RecordingSink()
+    upstream = _RepeatingIterator()
+    scope = UsageAccountingScope(
+        sink=sink,
+        context=UsageExecutionContext(
+            execution_id="execution-physical-949",
+            agent_run_id="run-physical-949",
+        ),
+    )
+
+    async def close_propagating_stream() -> AsyncIterator[Any]:
+        try:
+            async for event in upstream:
+                yield event
+        finally:
+            await upstream.aclose()
+
+    with bind_usage_accounting_scope(scope):
+        accounted = account_provider_stream(
+            close_propagating_stream,
+            provider="synthetic",
+            model="looping-model",
+        )
+        with pytest.raises(ModelRepetitionLoopError):
+            async for _ in guard_provider_text_stream(accounted):
+                pass
+
+    assert upstream.close_calls == 1
+    assert len(sink.started) == 1
+    assert sink.finalized == []
+    assert [(call.event_id, reason) for call, reason in sink.unknown] == [
+        (sink.started[0].event_id, "provider_stream_ended_without_usage")
+    ]

--- a/tests/test_engine/test_stream_repetition_guard.py
+++ b/tests/test_engine/test_stream_repetition_guard.py
@@ -15,6 +15,7 @@ from opensquilla.engine.repetition_guard import (
     RepetitionDetection,
     RepetitionGuardPolicy,
     StreamingRepetitionGuard,
+    close_async_iterator_bounded,
     guard_provider_text_stream,
 )
 from opensquilla.engine.usage_accounting import (
@@ -136,6 +137,14 @@ def test_large_aperiodic_loops_are_detected_chunk_invariant(period: int) -> None
             "api-1 | 2026-08-13T12:00:00 INFO request completed\n",
             id="container-log",
         ),
+        pytest.param(
+            "pod-a stdout F 2026-08-13T12:00:00Z request completed\n",
+            id="cri-log",
+        ),
+        pytest.param(
+            "[pod/api-1/container/app] 2026-08-13T12:00:00Z request completed\n",
+            id="kubectl-prefix-log",
+        ),
         pytest.param("region,status,count\nus-east,ready,10\n", id="csv"),
         pytest.param("region\tstatus\tcount\nus-east\tready\t10\n", id="tsv"),
         pytest.param(
@@ -163,6 +172,85 @@ def test_long_structured_loop_is_not_permanently_exempt() -> None:
     assert detection.structured is True
     assert detection.repeated_chars >= 57_344
     assert detection.repetitions >= 7
+
+
+@pytest.mark.parametrize(
+    "unit",
+    [
+        pytest.param(
+            "pod-a stdout F 2026-08-13T12:00:00Z request completed\n",
+            id="cri-log",
+        ),
+        pytest.param(
+            "[pod/api-1/container/app] 2026-08-13T12:00:00Z request completed\n",
+            id="kubectl-prefix-log",
+        ),
+    ],
+)
+def test_prefixed_log_loop_uses_structured_threshold_chunk_invariant(unit: str) -> None:
+    payload = (unit * (80_000 // len(unit) + 1))[:80_000]
+
+    results = [_feed_in_chunks(payload, chunk_size) for chunk_size in (1, 257, 4_093)]
+
+    assert len({len(emitted) for emitted, _, _ in results}) == 1
+    assert len({detection for _, detection, _ in results}) == 1
+    [detection] = list({detection for _, detection, _ in results})
+    assert detection is not None
+    assert detection.structured is True
+    assert detection.repeated_chars >= 57_344
+    assert all(guard.buffered_chars <= 65_536 for _, _, guard in results)
+
+
+@pytest.mark.parametrize(
+    "row_factory",
+    [
+        pytest.param(
+            lambda index: (
+                f"pod-{index % 7} stdout F 2026-08-13T12:{index // 60:02d}:"
+                f"{index % 60:02d}Z request={index} latency_ms={index * 17}\n"
+            ),
+            id="cri-log",
+        ),
+        pytest.param(
+            lambda index: (
+                f"[pod/api-{index % 7}/container/app] 2026-08-13T12:{index // 60:02d}:"
+                f"{index % 60:02d}Z request={index} latency_ms={index * 17}\n"
+            ),
+            id="kubectl-prefix-log",
+        ),
+    ],
+)
+def test_progressing_prefixed_logs_are_not_flagged_chunk_invariant(row_factory: Any) -> None:
+    # Stay well beyond the historical ~4.8 KiB false-positive point without
+    # multiplying a full 64 KiB scan by every chunk partition in this matrix.
+    payload = "".join(row_factory(index) for index in range(320))
+
+    for chunk_size in (1, 257, 4_093):
+        emitted, detection, guard = _feed_in_chunks(payload, chunk_size)
+        assert detection is None
+        assert emitted == payload
+        assert guard.buffered_chars <= 65_536
+
+
+@pytest.mark.parametrize(
+    "unit",
+    [
+        pytest.param(
+            "A report says pod-a stdout F 2026-08-13 is prose, not a runtime record. ",
+            id="cri-words-in-prose",
+        ),
+        pytest.param(
+            "A report quotes [pod/api-1/container/app] 2026-08-13 in ordinary prose. ",
+            id="kubectl-prefix-in-prose",
+        ),
+    ],
+)
+def test_prefixed_log_words_do_not_exempt_prose(unit: str) -> None:
+    _, detection, _ = _feed_in_chunks(unit * 300, 173)
+
+    assert detection is not None
+    assert detection.structured is False
+    assert detection.repeated_chars < 16_000
 
 
 @pytest.mark.parametrize(
@@ -207,13 +295,16 @@ def test_large_structured_loop_requires_full_conservative_budget() -> None:
     assert len(unit) == period
     payload = unit * 10
 
-    _, detection, guard = _feed_in_chunks(payload, 251)
+    results = [_feed_in_chunks(payload, chunk_size) for chunk_size in (1, 251, 4_093)]
 
+    assert len({len(emitted) for emitted, _, _ in results}) == 1
+    assert len({detection for _, detection, _ in results}) == 1
+    [detection] = list({detection for _, detection, _ in results})
     assert detection is not None
     assert detection.period_chars == period
     assert detection.structured is True
     assert detection.repeated_chars >= 57_344
-    assert guard.buffered_chars <= 65_536
+    assert all(guard.buffered_chars <= 65_536 for _, _, guard in results)
 
 
 def test_nonperiodic_code_table_and_log_output_does_not_trigger() -> None:
@@ -231,10 +322,19 @@ def test_nonperiodic_code_table_and_log_output_does_not_trigger() -> None:
 
 
 class _RepeatingIterator:
-    def __init__(self, *, block_close: bool = False, fail_close: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        block_close: bool = False,
+        cancel_close: bool = False,
+        fail_close: bool = False,
+        fail_iteration: bool = False,
+    ) -> None:
         self.close_calls = 0
         self.block_close = block_close
+        self.cancel_close = cancel_close
         self.fail_close = fail_close
+        self.fail_iteration = fail_iteration
         self.close_started = asyncio.Event()
 
     def __aiter__(self) -> _RepeatingIterator:
@@ -242,6 +342,8 @@ class _RepeatingIterator:
 
     async def __anext__(self) -> ProviderText:
         await asyncio.sleep(0)
+        if self.fail_iteration:
+            raise RuntimeError("synthetic provider failure")
         return ProviderText(
             text="I am reading the file while checking the next section carefully. "
         )
@@ -249,6 +351,8 @@ class _RepeatingIterator:
     async def aclose(self) -> None:
         self.close_calls += 1
         self.close_started.set()
+        if self.cancel_close:
+            raise asyncio.CancelledError
         if self.fail_close:
             raise RuntimeError("synthetic close failure")
         if self.block_close:
@@ -324,6 +428,61 @@ async def test_guard_close_failure_does_not_mask_repetition_outcome() -> None:
             pass
 
     assert exc_info.value.code == MODEL_REPETITION_LOOP_CODE
+    assert upstream.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_guard_close_cancelled_error_does_not_mask_repetition_outcome() -> None:
+    upstream = _RepeatingIterator(cancel_close=True)
+
+    with pytest.raises(ModelRepetitionLoopError) as exc_info:
+        async for _ in guard_provider_text_stream(upstream):
+            pass
+
+    assert exc_info.value.code == MODEL_REPETITION_LOOP_CODE
+    assert upstream.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_guard_close_cancelled_error_does_not_mask_provider_failure() -> None:
+    upstream = _RepeatingIterator(cancel_close=True, fail_iteration=True)
+
+    with pytest.raises(RuntimeError, match="synthetic provider failure"):
+        async for _ in guard_provider_text_stream(upstream):
+            pass
+
+    assert upstream.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_bounded_close_propagates_real_caller_cancellation() -> None:
+    upstream = _RepeatingIterator(block_close=True)
+    close = asyncio.create_task(close_async_iterator_bounded(upstream, timeout=1.0))
+    await upstream.close_started.wait()
+
+    close.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await close
+
+    assert close.cancelled()
+    assert upstream.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_provider_close_cancellation_ignores_stale_caller_cancel_count() -> None:
+    upstream = _RepeatingIterator(cancel_close=True)
+    caller = asyncio.current_task()
+    assert caller is not None
+    caller.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.sleep(0)
+    assert caller.cancelling() > 0
+
+    try:
+        await close_async_iterator_bounded(upstream, timeout=1.0)
+    finally:
+        caller.uncancel()
+
     assert upstream.close_calls == 1
 
 

--- a/tests/test_gateway/test_task_runtime_terminal_message.py
+++ b/tests/test_gateway/test_task_runtime_terminal_message.py
@@ -547,6 +547,64 @@ async def test_task_runtime_stream_output_truncation_is_terminal_state() -> None
 
 
 @pytest.mark.asyncio
+async def test_task_runtime_stream_repetition_is_stable_failed_terminal() -> None:
+    emitted: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def _stream():
+        yield ErrorEvent(
+            message="The model began repeating the same output.",
+            code="model_repetition_loop_detected",
+        )
+
+    async def _emitter(session_key: str, event_name: str, payload: dict[str, Any]) -> None:
+        emitted.append((session_key, event_name, payload))
+
+    with pytest.raises(TaskRuntimeStreamError) as exc_info:
+        await _emit_task_runtime_stream_events(
+            _stream(),
+            "agent:main:test",
+            _emitter,
+            stream_event_sink=None,
+            idle_timeout=1.0,
+            heartbeat_interval=0.0,
+        )
+
+    assert exc_info.value.code == "model_repetition_loop_detected"
+    assert exc_info.value.terminal_reason == "model_repetition_loop_detected"
+    payload = emitted[-1][2]
+    assert payload["code"] == "model_repetition_loop_detected"
+    assert payload["terminal_reason"] == "model_repetition_loop_detected"
+    assert "repeating" in payload["terminal_message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_task_runtime_records_repetition_as_failed_not_succeeded() -> None:
+    async def _repetition_handler(_run: Any) -> None:
+        raise TaskRuntimeStreamError(
+            "The model began repeating the same output.",
+            code="model_repetition_loop_detected",
+            terminal_reason="model_repetition_loop_detected",
+        )
+
+    runtime = _make_runtime(_repetition_handler)
+    handle = await runtime.enqueue(_make_envelope(), "read a file")
+
+    record = await runtime.wait(handle.task_id, timeout=2.0)
+
+    assert record.status == AgentTaskStatus.FAILED
+    assert record.terminal_reason == "model_repetition_loop_detected"
+    assert record.error_class == "model_repetition_loop_detected"
+    assert "repeating" in str(record.error_message).lower()
+    assert record.details["turn_outcome"] == {
+        "kind": "failed",
+        "reason": "model_repetition_loop_detected",
+        "error_class": "model_repetition_loop_detected",
+        "error_message": "The model began repeating the same output.",
+        "retryable": False,
+    }
+
+
+@pytest.mark.asyncio
 async def test_task_runtime_records_output_truncation_as_failed_not_succeeded() -> None:
     async def _truncated_handler(_run: Any) -> None:
         raise TaskRuntimeStreamError(

--- a/tests/test_gateway/test_terminal_reply.py
+++ b/tests/test_gateway/test_terminal_reply.py
@@ -203,6 +203,24 @@ def test_build_terminal_reply_accepts_agent_task_record_like_objects() -> None:
         assert raw not in message
 
 
+def test_repetition_loop_has_stable_code_and_specific_terminal_reply() -> None:
+    code = safe_provider_failure_code(
+        "model_repetition_loop_detected",
+        "unknown",
+    )
+    message = build_terminal_reply(
+        {
+            "status": "failed",
+            "terminal_reason": code,
+            "error_class": code,
+        }
+    )
+
+    assert code == "model_repetition_loop_detected"
+    assert "repeating" in message.lower()
+    assert "stopped" in message.lower()
+
+
 def test_sanitize_agent_error_rewrites_raw_provider_output_limit_message() -> None:
     error_class, message = sanitize_agent_error(
         "Provider output limit reached before completion",


### PR DESCRIPTION
## Problem and root cause

When a provider text stream falls into a repeated-output loop, OpenSquilla can continue rendering tokens and consuming provider usage instead of ending the task with a stable failure. The provider boundary previously had idle/deadline handling but no bounded, chunk-invariant content-loop detector, and not every wrapper exit path reliably closed the upstream async iterator. A cleanup-time `CancelledError` could also replace the real repetition or provider terminal outcome.

## What changed

- Detect highly periodic provider text deltas at the shared Provider → Agent boundary so all UI and channel consumers receive the same behavior.
- Keep detection bounded to a 64 KiB normalized window, with deterministic 256-character checkpoints, capped candidate work, and periods up to 8 KiB. Detection is invariant to provider chunk splitting.
- Close the upstream iterator exactly once and within 250 ms on repetition, wrapper close, caller cancellation, iteration timeout, total timeout, provider failure, and normal exit.
- Preserve the real terminal outcome when provider `aclose()` raises its own `CancelledError`; propagate cancellation only when the caller is actually being cancelled.
- Emit the stable, non-retryable `model_repetition_loop_detected` terminal outcome. After visible output, no transparent provider retry is attempted; usage is finalized once when known or marked unknown once.
- Apply more conservative thresholds to legitimate structured repetition. Code, Markdown tables, ordinary/container/CRI/kubectl logs, CSV, TSV, and query-result shapes require about 56 KiB at 99.95% similarity before stopping. This reduces false positives while still stopping a true structured loop.
- Keep diagnostics content-safe: logs contain thresholds, counts, similarity, timeout, and error type, never model output text.

## Non-goals and tradeoffs

- This does not guarantee that a provider stops billing immediately after socket/request cancellation; it bounds OpenSquilla's close attempt and returns a truthful terminal state.
- It does not detect periods larger than 8 KiB or every near-loop whose anchor text changes continuously.
- Legitimate byte-for-byte structured output that continues beyond the conservative threshold can still be stopped. This is an intentional safety tradeoff rather than a permanent exemption.
- No provider protocol, persistence schema, public RPC schema, or retry policy was broadly redesigned.

## Validation

- Focused repetition guard regression suite: **42 passed**.
- Complete engine suite: **2936 passed**.
- Complete Gateway suite: **3121 passed, 12 skipped**.
- Ruff over `src` and `tests`: passed.
- mypy over 932 source files: passed.
- Production wheel build: passed (`opensquilla-0.5.3-py3-none-any.whl`).
- WebUI artifact/wheel byte verification: passed (199 artifact entries).
- `git diff --check` and complete `origin/main..HEAD` diff review: passed.

Coverage includes 3 KiB/4 KiB/8 KiB aperiodic loops across multiple chunk partitions; normal code/table/log/CSV/TSV/query output; CRI and `kubectl --prefix` logs; repetition/provider failures whose close raises `CancelledError`; real caller cancellation; bounded close; stable terminal projection; no transparent retry; and single/unknown usage settlement.

## Platform limitations

The complete local suites ran on macOS with Python 3.12. Synthetic async iterators and Chromium-independent unit contracts cover cancellation and chunk boundaries, but this was not exercised against every live provider, a real Windows IME/provider socket, or provider billing telemetry. Linux/Windows CI remains the authoritative cross-platform validation.

## Commit Lineage

The branch preserves three independent commits without amend or history rewriting:

1. `4742bba9325e936d0dd83c314735d9e7e021ab30` — `fix(engine): stop repeated model streams`
2. `16b0907466df853bba00c2bf5e62799d5ae86126` — `fix(engine): harden repetition stream cleanup`
3. `8346f738b9ee70d2143e0458e5e036b2d705794b` — `fix(engine): preserve repetition cleanup outcomes`

All three retain author and committer `lihongguang-0014 <hongguang.li@tokenrhythm.ai>`.

## Existing PR relationship

No eligible linked or unlinked PR for #949 was found before publication, so this Draft PR is the canonical implementation candidate. No older PR or Issue was modified or closed.

Fixes #949
