### PR TITLE
Restore WebUI connections after wake (#962)

### DIFF
--- a/opensquilla-webui/e2e/history-hydration.spec.ts
+++ b/opensquilla-webui/e2e/history-hydration.spec.ts
@@ -9,6 +9,15 @@ function successResponse(id: string, payload: unknown) {
   return JSON.stringify({ type: 'res', id, ok: true, payload })
 }
 
+function replyToPing(
+  ws: { send(message: string): void },
+  frame: { type?: unknown },
+): boolean {
+  if (frame?.type !== 'ping') return false
+  ws.send(JSON.stringify({ type: 'pong' }))
+  return true
+}
+
 function helloResponse(tickIntervalMs: number) {
   return JSON.stringify({
     protocol: 3,
@@ -90,6 +99,7 @@ test('keeps the conversation usable while startup and long history are delayed',
     ws.onMessage(message => {
       try {
         const frame = JSON.parse(String(message))
+        if (replyToPing(ws, frame)) return
         if (frame?.type !== 'req') return
         if (frame.method === 'connect') {
           ws.send(helloResponse(30000))
@@ -254,6 +264,7 @@ test('recovers from stuck automatic metadata before sending', async ({ page }) =
     ws.onMessage(message => {
       try {
         const frame = JSON.parse(String(message))
+        if (replyToPing(ws, frame)) return
         if (frame?.type !== 'req') return
         const method = String(frame.method || '')
         if (method === 'connect') {
@@ -346,6 +357,7 @@ test('shows a recoverable initial failure and retries it', async ({ page }) => {
     ws.onMessage(message => {
       try {
         const frame = JSON.parse(String(message))
+        if (replyToPing(ws, frame)) return
         if (frame?.type !== 'req') return
         if (frame.method === 'connect') {
           ws.send(helloResponse(30000))
@@ -458,6 +470,7 @@ test('terminates stalled history and live hydration despite ongoing ticks, then 
     ws.onMessage(message => {
       try {
         const frame = JSON.parse(String(message))
+        if (replyToPing(ws, frame)) return
         if (frame?.type !== 'req') return
         if (frame.method === 'connect') {
           ws.send(helloResponse(1000))
@@ -612,6 +625,7 @@ test('preserves a Sessions Hub auto-send draft when live recovery terminates', a
     ws.onMessage(message => {
       try {
         const frame = JSON.parse(String(message))
+        if (replyToPing(ws, frame)) return
         if (frame?.type !== 'req') return
         if (frame.method === 'connect') {
           ws.send(helloResponse(1000))
@@ -700,6 +714,7 @@ test('cancels delayed auto-send when the user edits the draft before live is rea
     ws.onMessage(message => {
       try {
         const frame = JSON.parse(String(message))
+        if (replyToPing(ws, frame)) return
         if (frame?.type !== 'req') return
         if (frame.method === 'connect') {
           ws.send(helloResponse(30000))
@@ -763,6 +778,7 @@ test('keeps loaded messages visible when an earlier page fails and retries inlin
     ws.onMessage(message => {
       try {
         const frame = JSON.parse(String(message))
+        if (replyToPing(ws, frame)) return
         if (frame?.type !== 'req') return
         if (frame.method === 'connect') {
           ws.send(helloResponse(30000))
@@ -851,6 +867,7 @@ test('ignores a late history response after navigating to another session', asyn
     ws.onMessage(message => {
       try {
         const frame = JSON.parse(String(message))
+        if (replyToPing(ws, frame)) return
         if (frame?.type !== 'req') return
         if (frame.method === 'connect') {
           ws.send(helloResponse(30000))

--- a/opensquilla-webui/src/lib/rpc.test.ts
+++ b/opensquilla-webui/src/lib/rpc.test.ts
@@ -47,9 +47,15 @@ function pendingCount(client: RpcClient): number {
   )._pending.size
 }
 
-function establishConnection(socket: MockWebSocket): void {
+function establishConnection(
+  socket: MockWebSocket,
+  policy: Record<string, unknown> = {},
+): void {
   socket.receive({ type: 'event', event: 'connect.challenge' })
-  socket.receive({ protocol: 3, policy: { tick_interval_ms: 30_000 } })
+  socket.receive({
+    protocol: 3,
+    policy: { tick_interval_ms: 30_000, ...policy },
+  })
 }
 
 describe('RpcClient', () => {
@@ -396,6 +402,48 @@ describe('RpcClient', () => {
     client.disconnect()
   })
 
+  it('keeps four session requests on the shared socket when an advertised optional read times out', async () => {
+    const client = new RpcClient()
+    client.connect('ws://rpc.test')
+    const socket = MockWebSocket.instances[0]
+    establishConnection(socket, {
+      concurrent_optional_read_methods: ['sessions.list'],
+    })
+
+    const sessionKeys = ['session-a', 'session-b', 'session-c', 'session-d']
+    const sessionRequests = sessionKeys.map(key => client.call(
+      'sessions.messages.snapshot',
+      { key },
+    ))
+    const optionalRead = client.call('sessions.list', {}, {
+      timeoutMs: 25,
+      timeoutAction: 'reconnect',
+    }).catch((error: unknown) => error)
+
+    await vi.advanceTimersByTimeAsync(25)
+
+    await expect(optionalRead).resolves.toBeInstanceOf(RpcTimeoutError)
+    expect(socket.readyState).toBe(MockWebSocket.OPEN)
+    expect(MockWebSocket.instances).toHaveLength(1)
+
+    const snapshotFrames = socket.sent
+      .map(frame => JSON.parse(frame) as { id?: string; method?: string; params?: { key?: string } })
+      .filter(frame => frame.method === 'sessions.messages.snapshot')
+    expect(snapshotFrames.map(frame => frame.params?.key)).toEqual(sessionKeys)
+    for (const frame of snapshotFrames) {
+      socket.receive({
+        type: 'res',
+        id: frame.id,
+        ok: true,
+        payload: { key: frame.params?.key },
+      })
+    }
+    await expect(Promise.all(sessionRequests)).resolves.toEqual(
+      sessionKeys.map(key => ({ key })),
+    )
+    client.disconnect()
+  })
+
   it('supports typed timeout and abort termination while waiting for a connection', async () => {
     const timeoutClient = new RpcClient()
     timeoutClient.connect('ws://rpc.test')
@@ -499,6 +547,98 @@ describe('RpcClient', () => {
     expect(MockWebSocket.instances).toHaveLength(delays.length + 1)
     await vi.advanceTimersByTimeAsync(1)
     expect(MockWebSocket.instances).toHaveLength(delays.length + 2)
+    client.disconnect()
+  })
+
+  it('interrupts a saturated reconnect backoff when the browser comes online', async () => {
+    const client = new RpcClient()
+    client.connect('ws://rpc.test')
+
+    const delays = [1_000, 2_000, 4_000, 8_000, 15_000]
+    for (const [index, delay] of delays.entries()) {
+      MockWebSocket.instances[index].close()
+      await vi.advanceTimersByTimeAsync(delay)
+    }
+    const saturated = MockWebSocket.instances[delays.length]
+    saturated.close()
+
+    window.dispatchEvent(new Event('online'))
+    await vi.advanceTimersByTimeAsync(99)
+    expect(MockWebSocket.instances).toHaveLength(delays.length + 1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(MockWebSocket.instances).toHaveLength(delays.length + 2)
+    client.disconnect()
+  })
+
+  it('coalesces browser wake signals and keeps a healthy pong connection', async () => {
+    const client = new RpcClient()
+    client.connect('ws://rpc.test')
+    const socket = MockWebSocket.instances[0]
+    establishConnection(socket)
+
+    window.dispatchEvent(new Event('online'))
+    window.dispatchEvent(new Event('pageshow'))
+    document.dispatchEvent(new Event('visibilitychange'))
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(socket.sent.filter(frame => frame === '{"type":"ping"}')).toHaveLength(1)
+    socket.receive({ type: 'pong' })
+    await vi.advanceTimersByTimeAsync(3_000)
+
+    expect(socket.readyState).toBe(MockWebSocket.OPEN)
+    expect(MockWebSocket.instances).toHaveLength(1)
+    client.disconnect()
+  })
+
+  it('probes the connection when a hidden page becomes visible', async () => {
+    const client = new RpcClient()
+    client.connect('ws://rpc.test')
+    const socket = MockWebSocket.instances[0]
+    establishConnection(socket)
+
+    document.dispatchEvent(new Event('visibilitychange'))
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(socket.sent).toContain('{"type":"ping"}')
+    socket.receive({ type: 'pong' })
+    client.disconnect()
+  })
+
+  it('replaces a half-open socket after a wake probe receives no pong', async () => {
+    const client = new RpcClient()
+    client.connect('ws://rpc.test')
+    const socket = MockWebSocket.instances[0]
+    establishConnection(socket)
+
+    window.dispatchEvent(new Event('pageshow'))
+    await vi.advanceTimersByTimeAsync(100)
+    expect(socket.sent).toContain('{"type":"ping"}')
+
+    await vi.advanceTimersByTimeAsync(3_000)
+    expect(socket.readyState).toBe(MockWebSocket.CLOSED)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(MockWebSocket.instances).toHaveLength(2)
+    client.disconnect()
+  })
+
+  it('does not let an old wake deadline retire the gateway replacement', async () => {
+    const client = new RpcClient()
+    client.connect('ws://rpc.test')
+    const firstSocket = MockWebSocket.instances[0]
+    establishConnection(firstSocket)
+
+    window.dispatchEvent(new Event('online'))
+    await vi.advanceTimersByTimeAsync(100)
+    firstSocket.close()
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    const replacement = MockWebSocket.instances[1]
+    establishConnection(replacement)
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(replacement.readyState).toBe(MockWebSocket.OPEN)
+    expect(client.state).toBe('connected')
+    expect(MockWebSocket.instances).toHaveLength(2)
     client.disconnect()
   })
 

--- a/opensquilla-webui/src/lib/rpc.test.ts
+++ b/opensquilla-webui/src/lib/rpc.test.ts
@@ -8,13 +8,15 @@ import {
 } from '@/lib/rpc'
 
 class MockWebSocket {
+  static readonly CONNECTING = 0
   static readonly OPEN = 1
   static readonly CLOSED = 3
   static instances: MockWebSocket[] = []
+  static initialReadyState = MockWebSocket.OPEN
 
   readonly sent: string[] = []
   throwOnSend = false
-  readyState = MockWebSocket.OPEN
+  readyState = MockWebSocket.initialReadyState
   onopen: (() => void) | null = null
   onmessage: ((event: MessageEvent) => void) | null = null
   onclose: (() => void) | null = null
@@ -61,6 +63,7 @@ function establishConnection(
 describe('RpcClient', () => {
   beforeEach(() => {
     MockWebSocket.instances = []
+    MockWebSocket.initialReadyState = MockWebSocket.OPEN
     localStorage.clear()
     vi.stubGlobal('WebSocket', MockWebSocket)
     vi.useFakeTimers()
@@ -590,6 +593,101 @@ describe('RpcClient', () => {
     client.disconnect()
   })
 
+  it('keeps a disconnected wake replacement alive after its matching hello', async () => {
+    const client = new RpcClient()
+    client.connect('ws://rpc.test')
+    const firstSocket = MockWebSocket.instances[0]
+    establishConnection(firstSocket)
+    firstSocket.close()
+
+    MockWebSocket.initialReadyState = MockWebSocket.CONNECTING
+    window.dispatchEvent(new Event('online'))
+    await vi.advanceTimersByTimeAsync(100)
+
+    const replacement = MockWebSocket.instances[1]
+    expect(replacement).toBeDefined()
+    expect(client.state).toBe('connecting')
+    replacement.readyState = MockWebSocket.OPEN
+    establishConnection(replacement)
+
+    await vi.advanceTimersByTimeAsync(3_001)
+
+    expect(replacement.readyState).toBe(MockWebSocket.OPEN)
+    expect(client.state).toBe('connected')
+    expect(MockWebSocket.instances).toHaveLength(2)
+    client.disconnect()
+  })
+
+  it('does not let an old generation hello clear the replacement wake deadline', async () => {
+    const client = new RpcClient()
+    client.connect('ws://rpc.test')
+    const firstSocket = MockWebSocket.instances[0]
+    establishConnection(firstSocket)
+    firstSocket.close()
+
+    MockWebSocket.initialReadyState = MockWebSocket.CONNECTING
+    window.dispatchEvent(new Event('pageshow'))
+    await vi.advanceTimersByTimeAsync(100)
+
+    const replacement = MockWebSocket.instances[1]
+    expect(replacement).toBeDefined()
+    firstSocket.receive({ protocol: 3, policy: { tick_interval_ms: 30_000 } })
+
+    await vi.advanceTimersByTimeAsync(3_000)
+
+    expect(replacement.readyState).toBe(MockWebSocket.CLOSED)
+    expect(client.state).not.toBe('connected')
+    client.disconnect()
+  })
+
+  it('handles a duplicate hello without rearming or repeating connection recovery', async () => {
+    const client = new RpcClient()
+    const helloHandler = vi.fn()
+    client.on('_hello', helloHandler)
+    client.connect('ws://rpc.test')
+    const firstSocket = MockWebSocket.instances[0]
+    establishConnection(firstSocket)
+    firstSocket.close()
+
+    MockWebSocket.initialReadyState = MockWebSocket.CONNECTING
+    window.dispatchEvent(new Event('online'))
+    await vi.advanceTimersByTimeAsync(100)
+
+    const replacement = MockWebSocket.instances[1]
+    replacement.readyState = MockWebSocket.OPEN
+    establishConnection(replacement)
+    replacement.receive({ protocol: 3, policy: { tick_interval_ms: 30_000 } })
+
+    await vi.advanceTimersByTimeAsync(3_001)
+
+    expect(replacement.readyState).toBe(MockWebSocket.OPEN)
+    expect(client.state).toBe('connected')
+    expect(helloHandler).toHaveBeenCalledTimes(2)
+    expect(MockWebSocket.instances).toHaveLength(2)
+    client.disconnect()
+  })
+
+  it('cleans a connecting wake deadline on explicit disconnect', async () => {
+    const client = new RpcClient()
+    client.connect('ws://rpc.test')
+    const firstSocket = MockWebSocket.instances[0]
+    establishConnection(firstSocket)
+    firstSocket.close()
+
+    MockWebSocket.initialReadyState = MockWebSocket.CONNECTING
+    window.dispatchEvent(new Event('online'))
+    await vi.advanceTimersByTimeAsync(100)
+
+    const replacement = MockWebSocket.instances[1]
+    expect(replacement.readyState).toBe(MockWebSocket.CONNECTING)
+    client.disconnect()
+    await vi.advanceTimersByTimeAsync(3_001)
+
+    expect(replacement.readyState).toBe(MockWebSocket.CLOSED)
+    expect(client.state).toBe('disconnected')
+    expect(MockWebSocket.instances).toHaveLength(2)
+  })
+
   it('probes the connection when a hidden page becomes visible', async () => {
     const client = new RpcClient()
     client.connect('ws://rpc.test')
@@ -618,6 +716,23 @@ describe('RpcClient', () => {
     expect(socket.readyState).toBe(MockWebSocket.CLOSED)
     await vi.advanceTimersByTimeAsync(1)
     expect(MockWebSocket.instances).toHaveLength(2)
+    client.disconnect()
+  })
+
+  it('does not treat a duplicate hello as the pong required by an open wake probe', async () => {
+    const client = new RpcClient()
+    client.connect('ws://rpc.test')
+    const socket = MockWebSocket.instances[0]
+    establishConnection(socket)
+
+    window.dispatchEvent(new Event('pageshow'))
+    await vi.advanceTimersByTimeAsync(100)
+    expect(socket.sent).toContain('{"type":"ping"}')
+
+    socket.receive({ protocol: 3, policy: { tick_interval_ms: 30_000 } })
+    await vi.advanceTimersByTimeAsync(3_000)
+
+    expect(socket.readyState).toBe(MockWebSocket.CLOSED)
     client.disconnect()
   })
 

--- a/opensquilla-webui/src/lib/rpc.ts
+++ b/opensquilla-webui/src/lib/rpc.ts
@@ -446,6 +446,10 @@ export class RpcClient {
 
       // Handshake: HelloOk frame
       if (data.protocol !== undefined && this._state === 'connecting') {
+        // The authenticated Hello is a liveness proof for this exact socket.
+        // onmessage is generation/socket fenced above, and _clearWakeProbe
+        // refuses to clear a deadline owned by any replacement generation.
+        this._clearWakeProbe(generation);
         this._policy = data.policy || null;
         const serverGuestSessionKey = data.auth?.guestSessionKey;
         if (

--- a/opensquilla-webui/src/lib/rpc.ts
+++ b/opensquilla-webui/src/lib/rpc.ts
@@ -80,6 +80,8 @@ export type RpcEventHandler = {
 }['bivarianceHack'];
 
 const RECONNECT_BACKOFF_MS = [1_000, 2_000, 4_000, 8_000, 15_000] as const;
+const WAKE_DEBOUNCE_MS = 100;
+const WAKE_PROBE_TIMEOUT_MS = 3_000;
 
 interface PendingRequest {
   resolve: (value: unknown) => void;
@@ -147,12 +149,28 @@ export class RpcClient {
   private _lastFrameAt = 0;
   private _tickWatchTimer: ReturnType<typeof setInterval> | null = null;
   private _tickTimeoutMs = 60000;
+  private _wakeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private _wakeProbeTimer: ReturnType<typeof setTimeout> | null = null;
+  private _wakeProbeGeneration: number | null = null;
+  private _lifecycleWatchStarted = false;
+
+  private readonly _handleWakeSignal = (event: Event): void => {
+    if (
+      event.type === 'visibilitychange'
+      && typeof document !== 'undefined'
+      && document.visibilityState === 'hidden'
+    ) {
+      return;
+    }
+    this._scheduleWakeProbe();
+  };
 
   connect(url: string, token?: string): void {
     this._url = url;
     this._token = token || null;
     this._guestSessionKey = this._guestSessionKey || loadGuestSessionKey();
     this._autoReconnect = true;
+    this._startLifecycleWatch();
     this._clearReconnectTimer();
     if (this._ws) {
       this._retireCurrentSocket(new Error('Connection replaced'), false);
@@ -162,6 +180,7 @@ export class RpcClient {
 
   disconnect(): void {
     this._autoReconnect = false;
+    this._stopLifecycleWatch();
     this._clearReconnectTimer();
     this._retireCurrentSocket(new Error('Disconnected'), false);
     this._rejectAllPending(new Error('Disconnected'));
@@ -199,7 +218,7 @@ export class RpcClient {
 
       const terminate = (error: Error, action: RpcTerminationAction): void => {
         if (!this._rejectPending(id, error, generation)) return;
-        if (action === 'reconnect') {
+        if (this._terminationAction(method, action) === 'reconnect') {
           this._recycleConnection(
             generation,
             new Error(`Connection recycled after ${method} terminated`)
@@ -485,6 +504,7 @@ export class RpcClient {
       if (!this._isCurrentSocket(socket, generation)) return;
       this._ws = null;
       ++this._socketGeneration;
+      this._clearWakeProbe(generation);
       this._stopPing();
       this._stopTickWatch();
       this._rejectPendingForGeneration(generation, new Error('Connection closed'));
@@ -497,6 +517,24 @@ export class RpcClient {
 
   private _isCurrentSocket(socket: WebSocket, generation: number): boolean {
     return this._ws === socket && this._socketGeneration === generation;
+  }
+
+  private _terminationAction(
+    method: string,
+    requested: RpcTerminationAction
+  ): RpcTerminationAction {
+    if (requested !== 'reconnect') return requested;
+    // A current Gateway advertises only reads that it dispatches outside the
+    // serialized request loop. Their local timeout can therefore reject in
+    // isolation; older Gateways retain the reconnect escape hatch.
+    const concurrentMethods = this._policy?.concurrent_optional_read_methods;
+    if (
+      Array.isArray(concurrentMethods)
+      && concurrentMethods.some((candidate) => candidate === method)
+    ) {
+      return 'reject';
+    }
+    return requested;
   }
 
   private _takePending(id: string, generation?: number): PendingRequest | undefined {
@@ -547,6 +585,7 @@ export class RpcClient {
   private _retireCurrentSocket(error: Error, reconnect: boolean): void {
     const socket = this._ws;
     const generation = this._socketGeneration;
+    this._clearWakeProbe(generation);
     if (!socket) {
       this._stopPing();
       this._stopTickWatch();
@@ -595,8 +634,110 @@ export class RpcClient {
     }
   }
 
+  private _startLifecycleWatch(): void {
+    if (
+      this._lifecycleWatchStarted
+      || typeof window === 'undefined'
+      || typeof document === 'undefined'
+    ) {
+      return;
+    }
+    this._lifecycleWatchStarted = true;
+    window.addEventListener('online', this._handleWakeSignal);
+    window.addEventListener('pageshow', this._handleWakeSignal);
+    document.addEventListener('visibilitychange', this._handleWakeSignal);
+  }
+
+  private _stopLifecycleWatch(): void {
+    if (
+      this._lifecycleWatchStarted
+      && typeof window !== 'undefined'
+      && typeof document !== 'undefined'
+    ) {
+      window.removeEventListener('online', this._handleWakeSignal);
+      window.removeEventListener('pageshow', this._handleWakeSignal);
+      document.removeEventListener('visibilitychange', this._handleWakeSignal);
+    }
+    this._lifecycleWatchStarted = false;
+    if (this._wakeDebounceTimer !== null) {
+      clearTimeout(this._wakeDebounceTimer);
+      this._wakeDebounceTimer = null;
+    }
+    this._clearWakeProbe();
+  }
+
+  private _scheduleWakeProbe(): void {
+    if (!this._autoReconnect) return;
+    if (this._wakeDebounceTimer !== null) {
+      clearTimeout(this._wakeDebounceTimer);
+    }
+    this._wakeDebounceTimer = setTimeout(() => {
+      this._wakeDebounceTimer = null;
+      this._runWakeProbe();
+    }, WAKE_DEBOUNCE_MS);
+  }
+
+  private _runWakeProbe(): void {
+    if (!this._autoReconnect) return;
+    this._reconnectAttempt = 0;
+
+    let socket = this._ws;
+    if (!socket) {
+      this._clearReconnectTimer();
+      this._doConnect();
+      socket = this._ws;
+      if (!socket) return;
+    }
+
+    const generation = this._socketGeneration;
+    if (this._wakeProbeGeneration === generation) return;
+    if (socket.readyState === WebSocket.OPEN) {
+      try {
+        socket.send('{"type":"ping"}');
+      } catch (error) {
+        this._recycleConnection(
+          generation,
+          error instanceof Error ? error : new Error('Wake probe send failed')
+        );
+        return;
+      }
+    } else if (socket.readyState !== WebSocket.CONNECTING) {
+      this._recycleConnection(generation, new Error('Connection stale after wake'));
+      return;
+    }
+    this._armWakeProbe(socket, generation);
+  }
+
+  private _armWakeProbe(socket: WebSocket, generation: number): void {
+    this._clearWakeProbe();
+    this._wakeProbeGeneration = generation;
+    this._wakeProbeTimer = setTimeout(() => {
+      if (!this._isCurrentSocket(socket, generation)) return;
+      this._clearWakeProbe(generation);
+      const handlers = this._listeners.get('_gap');
+      if (handlers) handlers.forEach((h) => h({ reason: 'wake_probe_timeout' }));
+      this._retireCurrentSocket(new Error('Wake probe timed out'), true);
+    }, WAKE_PROBE_TIMEOUT_MS);
+  }
+
+  private _clearWakeProbe(generation?: number): void {
+    if (
+      generation !== undefined
+      && this._wakeProbeGeneration !== null
+      && this._wakeProbeGeneration !== generation
+    ) {
+      return;
+    }
+    if (this._wakeProbeTimer !== null) {
+      clearTimeout(this._wakeProbeTimer);
+      this._wakeProbeTimer = null;
+    }
+    this._wakeProbeGeneration = null;
+  }
+
   private _noteIncomingFrame(data: RpcFrame): boolean {
     this._lastFrameAt = Date.now();
+    if (data?.type === 'pong') this._clearWakeProbe(this._socketGeneration);
     if (!data || data.type !== 'event' || typeof data.seq !== 'number') return true;
 
     const seq = data.seq;

--- a/src/opensquilla/gateway/protocol.py
+++ b/src/opensquilla/gateway/protocol.py
@@ -143,6 +143,7 @@ class PolicyInfo(BaseModel):
     max_buffered_bytes: int = MAX_BUFFERED_BYTES
     tick_interval_ms: int = TICK_INTERVAL_MS
     concurrent_history_reads: bool = False
+    concurrent_optional_read_methods: list[str] = []
     agent_stream_heartbeat_interval_ms: int = 15_000
     agent_stream_idle_timeout_ms: int = 600_000
     webui_stream_idle_grace_ms: int = 630_000

--- a/src/opensquilla/gateway/websocket.py
+++ b/src/opensquilla/gateway/websocket.py
@@ -71,7 +71,25 @@ _DIRECT_CLOSE_TIMEOUT_SECONDS = 1.0
 # Sentinel pushed into the outbox by ``_stop_writer`` to wake a writer
 # blocked in ``await self._outbox.get()`` and exit cleanly.
 _SENTINEL_STOP: Any = object()
-_DETACHED_RPC_METHODS: frozenset[str] = frozenset({"meta.drafts.list"})
+# Keep this list side-effect free: the Web UI uses the advertised methods to
+# turn a reconnect-on-timeout fallback into a request-local rejection.
+_CONCURRENT_OPTIONAL_READ_METHODS: frozenset[str] = frozenset(
+    {
+        "agents.list",
+        "artifacts.list",
+        "commands.list_for_surface",
+        "config.get",
+        "models.routing.get",
+        "onboarding.status",
+        "sandbox.run_mode.preference.get",
+        "sessions.list",
+        "usage.status",
+        "workspaces.list",
+    }
+)
+_DETACHED_RPC_METHODS: frozenset[str] = frozenset({"meta.drafts.list"}).union(
+    _CONCURRENT_OPTIONAL_READ_METHODS
+)
 _MAX_DETACHED_REQUESTS_PER_CONNECTION = 4
 _DETACHED_REQUEST_DRAIN_SECONDS = 0.25
 
@@ -1027,6 +1045,7 @@ async def handle_ws_connection(
         ),
         policy=PolicyInfo(
             concurrent_history_reads=True,
+            concurrent_optional_read_methods=sorted(_CONCURRENT_OPTIONAL_READ_METHODS),
             agent_stream_heartbeat_interval_ms=int(
                 max(0.0, float(getattr(config, "agent_stream_heartbeat_interval_seconds", 15.0)))
                 * 1000

--- a/tests/test_gateway/test_websocket_request_concurrency.py
+++ b/tests/test_gateway/test_websocket_request_concurrency.py
@@ -83,6 +83,32 @@ class _ConcurrentHistoryDispatcher:
             self.release_history[req_id].set()
 
 
+class _ConcurrentOptionalReadDispatcher:
+    def __init__(self, held_request_ids: set[str]) -> None:
+        self.held_request_ids = frozenset(held_request_ids)
+        self.request_started = {req_id: asyncio.Event() for req_id in self.held_request_ids}
+        self.release_request = {req_id: asyncio.Event() for req_id in self.held_request_ids}
+        self.quick_dispatched = asyncio.Event()
+
+    def list_methods(self) -> list[str]:
+        return ["sessions.list", "noop"]
+
+    async def dispatch(self, req_id: str, method: str, params: Any, ctx: Any) -> Any:
+        if method == "sessions.list":
+            self.request_started[req_id].set()
+            await self.release_request[req_id].wait()
+        elif method == "noop":
+            self.quick_dispatched.set()
+        return make_ok_res(req_id, {"method": method})
+
+    async def wait_for_requests(self, *req_ids: str) -> None:
+        await asyncio.gather(*(self.request_started[req_id].wait() for req_id in req_ids))
+
+    def release(self, *req_ids: str) -> None:
+        for req_id in req_ids:
+            self.release_request[req_id].set()
+
+
 class _HistoryWebSocket:
     client_state = WebSocketState.CONNECTED
     client = SimpleNamespace(host="127.0.0.1", port=12345)
@@ -253,6 +279,68 @@ async def test_slow_history_does_not_block_another_history_or_noop(
     assert observed["history_a_still_pending"]
     assert response_indexes["history-b"] < response_indexes["history-a"]
     assert response_indexes["quick"] < response_indexes["history-a"]
+    assert ws.close_codes == []
+
+
+@pytest.mark.parametrize("writer_queue_enabled", [False, True])
+async def test_four_slow_optional_reads_do_not_block_interactive_rpc(
+    writer_queue_enabled: bool,
+) -> None:
+    request_ids = tuple(f"session-{index}" for index in range(1, 5))
+    dispatcher = _ConcurrentOptionalReadDispatcher(set(request_ids))
+    observed: dict[str, bool] = {}
+
+    async def finish_after_quick_response(socket: _HistoryWebSocket) -> None:
+        await dispatcher.wait_for_requests(*request_ids)
+        await socket.wait_for_response("quick")
+        observed["reads_still_pending"] = all(
+            not socket.has_response(req_id) for req_id in request_ids
+        )
+        dispatcher.release(*request_ids)
+        await asyncio.gather(*(socket.wait_for_response(req_id) for req_id in request_ids))
+
+    frames = [_CONNECT_FRAME]
+    frames.extend(
+        json.dumps(
+            {
+                "type": "req",
+                "id": req_id,
+                "method": "sessions.list",
+                "params": {"sessionKey": req_id},
+            }
+        )
+        for req_id in request_ids
+    )
+    frames.append(json.dumps({"type": "req", "id": "quick", "method": "noop"}))
+    ws = _HistoryWebSocket(
+        frames,
+        dispatcher,
+        after_frames=finish_after_quick_response,
+    )
+
+    await asyncio.wait_for(
+        handle_ws_connection(
+            ws,
+            GatewayConfig(ws_writer_queue_enabled=writer_queue_enabled),
+            dispatcher=dispatcher,
+        ),
+        timeout=2,
+    )
+
+    assert observed["reads_still_pending"]
+    assert dispatcher.quick_dispatched.is_set()
+    assert ws.hello()["policy"]["concurrent_optional_read_methods"] == [
+        "agents.list",
+        "artifacts.list",
+        "commands.list_for_surface",
+        "config.get",
+        "models.routing.get",
+        "onboarding.status",
+        "sandbox.run_mode.preference.get",
+        "sessions.list",
+        "usage.status",
+        "workspaces.list",
+    ]
     assert ws.close_codes == []
 
 


### PR DESCRIPTION
## Problem and root cause

After browser/laptop sleep or a network transition, the Web UI can retain a half-open shared WebSocket or remain in reconnect backoff. Multiple active sessions then stop receiving task updates. In addition, an auxiliary read RPC configured with `timeoutAction=reconnect` could recycle that single shared transport and disconnect every session.

The transport had no browser lifecycle wake trigger with a bounded liveness check, and the client could not distinguish Gateway read methods that are safe to fail locally. A replacement socket opened during a wake probe also needs its authenticated Hello to count as liveness only for the exact current socket generation; otherwise its still-armed wake deadline can retire a healthy replacement.

## Changes

- Listen for `online`, `pageshow`, and visible `visibilitychange` events, debounce duplicate lifecycle signals, reset reconnect backoff, and probe the current transport generation.
- For an already OPEN socket, send a ping and require its matching pong before the wake deadline; another Hello does not satisfy this OPEN-socket probe.
- For a disconnected/CONNECTING replacement, treat the authenticated Hello as generation-bound liveness only after the existing current-socket/current-generation fence. Stale generations cannot clear a newer deadline, and disconnect cleanup retires owned timers.
- Advertise a bounded set of optional read RPCs that the Gateway can dispatch concurrently. When the capability is present, their client timeout is request-local instead of recycling the shared WebSocket, so unrelated sessions and long-running tasks remain connected.
- Add fake-timer state-machine coverage for wake/network black holes, reconnect backoff, gateway restart equivalents, duplicate lifecycle events, stale generations, repeated Hello, disconnect cleanup, and 2–4 concurrent shared-session requests. Add Gateway concurrency coverage for four slow reads alongside a quick request.

## Non-goals

- No rewrite of the connection architecture and no changes to authentication or capability negotiation semantics.
- Transport reconnection remains separate from session resume. Existing session bootstrap, re-subscription, streaming-event handling, and post-reconnect state reconciliation remain responsible for restoring session state.
- No new stream replay/persistence protocol and no browser-specific power-management integration.

## Validation

- `npm run test:unit` — 329 test files, 3,743 tests passed.
- `npm run build` — architecture/security/theme/i18n guards, Vue typecheck, production bundle, and artifact verification passed.
- `uv run pytest -q tests/test_gateway/test_websocket_request_concurrency.py` — 11 passed.
- `git diff --check origin/main..HEAD` — passed.

Platform limitation: sleep/wake behavior is covered with deterministic lifecycle events and fake timers, but this environment did not run a physical laptop sleep/wake E2E in a real browser. That remains a platform validation boundary.

## Commit Lineage

- Base: `38d1cf46fa4a33f791cba5a34888c4143a8d2247` (`origin/main`)
- `0e5b6ceb876a98f7bdb764bd89b6f97effd561a5` — base wake reconnect and shared-read isolation implementation.
- `c09d79e32b649739f6fb875c35c4cd413696b938` — follow-up generation-safe authenticated-Hello liveness fix.

The two original commits and their authorship were preserved; no amend, squash, rebase, or force-push was used.

## Existing PR relationship

No eligible linked or unlinked implementation PR for #962 was found. This Draft PR is the canonical candidate and does not replace or modify an existing PR.

Fixes #962
