### PR TITLE
Harden Ensemble timeout fallback (#880, #1029)

### DIFF
--- a/docs/features/LLM-ensemble-design.md
+++ b/docs/features/LLM-ensemble-design.md
@@ -200,7 +200,10 @@ The two timeout fields have intentionally different streaming semantics.
 `aggregator_timeout_seconds` is an idle/stall budget between upstream stream
 events, so an active aggregation may run longer than that value while a silent
 provider is still bounded. Host-generated keep-alive heartbeats do not reset
-the aggregator budget.
+the aggregator budget. This field is not the turn's total wall-clock deadline:
+the outer Agent/TaskRuntime deadline remains authoritative for the complete
+turn. A completed aggregator idle budget is terminal for that attempt and is
+never retried as another full-budget aggregator request.
 
 `min_successful_proposers` is additionally clamped down to the actual proposer
 count. Both the configured and effective values (min-success, timeouts, shuffle)
@@ -228,13 +231,14 @@ usage accounting retain every started attempt, including zero-usage rows marked
 `usage_receipt_missing = true`.
 
 The aggregator already retries bounded transient upstream failures in place.
-It also retries a timeout or a stream that ends before `DoneEvent` when that
-attempt has emitted no text, reasoning, or tool delta, reusing the completed
-proposer drafts. Once any user-visible delta has been emitted, the attempt is
-terminal so a retry cannot duplicate text or tool activity downstream.
-After the retry budget is exhausted without user-visible output,
+It also retries a stream that ends before `DoneEvent` when that attempt has
+emitted no text, reasoning, or tool delta, reusing the completed proposer
+drafts. Once any user-visible delta has been emitted, the attempt is terminal
+so a retry cannot duplicate text or tool activity downstream.
+When an aggregator exhausts its idle budget without user-visible output,
 `fallback_single` makes exactly one request with the original conversation;
-the `error` policy remains terminal.
+it does not retry the timed-out aggregator or rerun proposers. The `error`
+policy remains terminal.
 
 Proposers never own an executable tool boundary. By default they receive no
 current tool schemas. Setting `proposer_tools = true` exposes those schemas only

--- a/docs/features/LLM-ensemble-design.md
+++ b/docs/features/LLM-ensemble-design.md
@@ -195,6 +195,13 @@ not a public configuration field:
 | `shuffle_candidates` | `True` | `False` |
 | `quorum_grace_seconds` | 0 (wait for every proposer) | 10 |
 
+The two timeout fields have intentionally different streaming semantics.
+`proposer_timeout_seconds` bounds each proposer's total execution time.
+`aggregator_timeout_seconds` is an idle/stall budget between upstream stream
+events, so an active aggregation may run longer than that value while a silent
+provider is still bounded. Host-generated keep-alive heartbeats do not reset
+the aggregator budget.
+
 `min_successful_proposers` is additionally clamped down to the actual proposer
 count. Both the configured and effective values (min-success, timeouts, shuffle)
 are recorded in the selection plan for debugging.
@@ -225,6 +232,9 @@ It also retries a timeout or a stream that ends before `DoneEvent` when that
 attempt has emitted no text, reasoning, or tool delta, reusing the completed
 proposer drafts. Once any user-visible delta has been emitted, the attempt is
 terminal so a retry cannot duplicate text or tool activity downstream.
+After the retry budget is exhausted without user-visible output,
+`fallback_single` makes exactly one request with the original conversation;
+the `error` policy remains terminal.
 
 Proposers never own an executable tool boundary. By default they receive no
 current tool schemas. Setting `proposer_tools = true` exposes those schemas only

--- a/opensquilla-webui/src/components/setup/SetupModelStrategyPanel.test.ts
+++ b/opensquilla-webui/src/components/setup/SetupModelStrategyPanel.test.ts
@@ -10,6 +10,7 @@ const FACTS = {
   quorum: 1,
   proposerCount: 2,
   proposerTimeoutSeconds: 300,
+  configuredAggregatorTimeoutSeconds: 3600,
   aggregatorTimeoutSeconds: 480,
   quorumGraceSeconds: 10,
 }
@@ -111,6 +112,7 @@ function panel(overrides: Record<string, unknown> = {}) {
         quorum: 3,
         proposerCount: 4,
         proposerTimeoutSeconds: 300,
+        configuredAggregatorTimeoutSeconds: 3600,
         aggregatorTimeoutSeconds: 480,
         quorumGraceSeconds: 10,
       },
@@ -943,6 +945,10 @@ describe('SetupModelStrategyPanel', () => {
     runtime.querySelector('summary')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     await nextTick()
     expect(runtime.open).toBe(true)
+    expect(runtime.textContent).toContain(
+      'aggregator 480s idle between provider events (configured 3600s)',
+    )
+    expect(runtime.textContent).toContain('outer turn deadline separate')
 
     const threshold = el.querySelector<HTMLSelectElement>('select[name="setup_model_strategy_min_successful"]')!
     threshold.value = '2'

--- a/opensquilla-webui/src/components/setup/SetupModelStrategyPanel.vue
+++ b/opensquilla-webui/src/components/setup/SetupModelStrategyPanel.vue
@@ -1374,6 +1374,7 @@ function credentialLabel(candidate: EnsembleCandidateView): string {
               <span>
                 {{ t('setup.modelStrategy.runtimeLimits', {
                   proposerTimeout: activeFacts.proposerTimeoutSeconds,
+                  configuredAggregatorTimeout: activeFacts.configuredAggregatorTimeoutSeconds,
                   aggregatorTimeout: activeFacts.aggregatorTimeoutSeconds,
                   grace: activeFacts.quorumGraceSeconds,
                 }) }}

--- a/opensquilla-webui/src/composables/setup/useSetupEnsembleForm.test.ts
+++ b/opensquilla-webui/src/composables/setup/useSetupEnsembleForm.test.ts
@@ -930,6 +930,7 @@ describe('useSetupEnsembleForm — panel contract', () => {
       quorum: 3,
       proposerCount: 4,
       proposerTimeoutSeconds: 300,
+      configuredAggregatorTimeoutSeconds: 3600,
       aggregatorTimeoutSeconds: 480,
       quorumGraceSeconds: 10,
     })
@@ -988,6 +989,7 @@ describe('useSetupEnsembleForm — effective timeout facts', () => {
     })
     const facts = makePanel(f, 'openrouter').value.presetFacts
     expect(facts.proposerTimeoutSeconds).toBe(600)
+    expect(facts.configuredAggregatorTimeoutSeconds).toBe(900)
     expect(facts.aggregatorTimeoutSeconds).toBe(900)
     expect(facts.quorumGraceSeconds).toBe(10)
     // The stored timeouts are read-only facts, never a pending edit.
@@ -1005,6 +1007,7 @@ describe('useSetupEnsembleForm — effective timeout facts', () => {
     })
     const legacyFacts = makePanel(explicitLegacy, 'openrouter').value.presetFacts
     expect(legacyFacts.proposerTimeoutSeconds).toBe(300)
+    expect(legacyFacts.configuredAggregatorTimeoutSeconds).toBe(3600)
     expect(legacyFacts.aggregatorTimeoutSeconds).toBe(480)
 
     // Older gateways may omit the keys from the config slice entirely.
@@ -1012,6 +1015,7 @@ describe('useSetupEnsembleForm — effective timeout facts', () => {
     absent.initFromConfig({ enabled: true, selection_mode: 'static_openrouter_b5' })
     const absentFacts = makePanel(absent, 'openrouter').value.presetFacts
     expect(absentFacts.proposerTimeoutSeconds).toBe(300)
+    expect(absentFacts.configuredAggregatorTimeoutSeconds).toBe(3600)
     expect(absentFacts.aggregatorTimeoutSeconds).toBe(480)
   })
 
@@ -1028,6 +1032,7 @@ describe('useSetupEnsembleForm — effective timeout facts', () => {
     })
     const facts = makePanel(f, 'deepseek').value.custom.facts
     expect(facts.proposerTimeoutSeconds).toBe(720)
+    expect(facts.configuredAggregatorTimeoutSeconds).toBe(3600)
     expect(facts.aggregatorTimeoutSeconds).toBe(480)
     expect(facts.quorumGraceSeconds).toBe(10)
   })
@@ -1041,6 +1046,7 @@ describe('useSetupEnsembleForm — effective timeout facts', () => {
     })
     const facts = makePanel(f, 'deepseek').value.custom.facts
     expect(facts.proposerTimeoutSeconds).toBe(3600)
+    expect(facts.configuredAggregatorTimeoutSeconds).toBe(3600)
     expect(facts.aggregatorTimeoutSeconds).toBe(3600)
     expect(facts.quorumGraceSeconds).toBe(0)
   })

--- a/opensquilla-webui/src/composables/setup/useSetupEnsembleForm.ts
+++ b/opensquilla-webui/src/composables/setup/useSetupEnsembleForm.ts
@@ -159,6 +159,7 @@ export interface EnsembleEffectiveFacts {
   quorum: number
   proposerCount: number
   proposerTimeoutSeconds: number
+  configuredAggregatorTimeoutSeconds: number
   aggregatorTimeoutSeconds: number
   quorumGraceSeconds: number
 }
@@ -899,6 +900,7 @@ export function useSetupEnsembleForm() {
         storedProposerTimeoutSeconds.value,
         STATIC_B5_PROPOSER_TIMEOUT_SECONDS,
       ),
+      configuredAggregatorTimeoutSeconds: storedAggregatorTimeoutSeconds.value,
       aggregatorTimeoutSeconds: substituteLegacy(
         storedAggregatorTimeoutSeconds.value,
         STATIC_B5_AGGREGATOR_TIMEOUT_SECONDS,

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -1043,7 +1043,7 @@
       "capacityWarn": "{calls} Modellaufrufe pro Runde — Kosten wachsen linear, der Fusionsgewinn nimmt ab 4 Entwürfen deutlich ab.",
       "capacityFull": "Limit von {max} Entwurfsmodellen erreicht — mehr Entwürfe verbessern die Fusion nicht; erst eines entfernen.",
       "diversityHint": "Mehrere Entwurfsmodelle stammen aus derselben Modellfamilie — ein anderer Anbieter verbessert die Fusion meist.",
-      "effectiveFacts": "Pro Runde: {calls} Modellaufrufe · Fusion ab {quorum}/{proposers} erfolgreichen Entwürfen · Entwurfs-Timeout {proposerTimeout}s · Aggregator-Timeout {aggregatorTimeout}s · {grace}s Nachfrist",
+      "effectiveFacts": "Pro Runde: {calls} Modellaufrufe · Fusion ab {quorum}/{proposers} erfolgreichen Entwürfen · Gesamt-Timeout je Entwurf {proposerTimeout}s · Aggregator-Leerlauf-Timeout {aggregatorTimeout}s · {grace}s Nachfrist",
       "effectiveSummary": "{proposers} Entwürfe parallel + 1 Aggregator · etwa {calls} Modellaufrufe pro Runde",
       "runtimeStrategyTitle": "Laufzeitstrategie",
       "runtimeStrategyDesc": "Erfolgsschwelle, Ausweichverhalten und Zeitlimits",
@@ -1052,7 +1052,7 @@
       "successThresholdExact": "{quorum} von {proposers}",
       "failurePolicyLabel": "Wenn die Aggregation nicht abgeschlossen werden kann",
       "runtimeLimitsLabel": "Zeitlimits",
-      "runtimeLimits": "Entwürfe {proposerTimeout}s · Aggregator {aggregatorTimeout}s · {grace}s Nachfrist nach Erreichen der Schwelle",
+      "runtimeLimits": "Entwürfe insgesamt {proposerTimeout}s · Aggregator-Leerlauf zwischen Anbieterereignissen {aggregatorTimeout}s (konfiguriert {configuredAggregatorTimeout}s) · separates Gesamtlimit der Runde · {grace}s Nachfrist",
       "quorumFailureLabel": "Wenn weniger als {quorum} Entwürfe gelingen"
     },
     "behavior": {

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -1094,7 +1094,7 @@
       "capacityWarn": "{calls} model calls per turn — cost grows linearly and fusion gains taper past 4 proposers.",
       "capacityFull": "Limit of {max} proposers reached — more drafts stop improving fusion; remove one before adding another.",
       "diversityHint": "Several proposers share a model family — adding a different vendor usually improves fusion.",
-      "effectiveFacts": "Per turn: {calls} model calls · fuses once {quorum}/{proposers} proposers succeed · proposer timeout {proposerTimeout}s · aggregator timeout {aggregatorTimeout}s · {grace}s grace after quorum",
+      "effectiveFacts": "Per turn: {calls} model calls · fuses once {quorum}/{proposers} proposers succeed · proposer total timeout {proposerTimeout}s · aggregator idle timeout {aggregatorTimeout}s · {grace}s grace after quorum",
       "effectiveSummary": "{proposers} proposers in parallel + 1 aggregator · about {calls} model calls per turn",
       "runtimeStrategyTitle": "Runtime strategy",
       "runtimeStrategyDesc": "Success threshold, fallback, and time limits",
@@ -1103,7 +1103,7 @@
       "successThresholdExact": "At least {quorum} of {proposers} return normally",
       "failurePolicyLabel": "If aggregation cannot complete",
       "runtimeLimitsLabel": "Time limits",
-      "runtimeLimits": "Proposers {proposerTimeout}s · aggregator {aggregatorTimeout}s · {grace}s grace after the threshold",
+      "runtimeLimits": "Proposers {proposerTimeout}s total · aggregator {aggregatorTimeout}s idle between provider events (configured {configuredAggregatorTimeout}s) · outer turn deadline separate · {grace}s grace after the threshold",
       "quorumFailureLabel": "If fewer than {quorum} proposers succeed"
     },
     "behavior": {

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -1043,7 +1043,7 @@
       "capacityWarn": "{calls} llamadas de modelo por turno — el coste crece linealmente y la mejora de fusión decae pasados 4 proponentes.",
       "capacityFull": "Límite de {max} proponentes alcanzado — más borradores no mejoran la fusión; quita uno antes de añadir otro.",
       "diversityHint": "Varios proponentes comparten familia de modelos — añadir otro proveedor suele mejorar la fusión.",
-      "effectiveFacts": "Por turno: {calls} llamadas de modelo · fusiona al lograr {quorum}/{proposers} proponentes · timeout de proponente {proposerTimeout}s · timeout de agregador {aggregatorTimeout}s · {grace}s de gracia tras el quórum",
+      "effectiveFacts": "Por turno: {calls} llamadas de modelo · fusiona al lograr {quorum}/{proposers} proponentes · timeout total de proponente {proposerTimeout}s · timeout de inactividad del agregador {aggregatorTimeout}s · {grace}s de gracia tras el quórum",
       "effectiveSummary": "{proposers} proponentes en paralelo + 1 agregador · unas {calls} llamadas por turno",
       "runtimeStrategyTitle": "Estrategia de ejecución",
       "runtimeStrategyDesc": "Umbral de éxito, alternativa y límites de tiempo",
@@ -1052,7 +1052,7 @@
       "successThresholdExact": "{quorum} de {proposers}",
       "failurePolicyLabel": "Si no se puede completar la agregación",
       "runtimeLimitsLabel": "Límites de tiempo",
-      "runtimeLimits": "Proponentes {proposerTimeout}s · agregador {aggregatorTimeout}s · {grace}s de gracia tras alcanzar el umbral",
+      "runtimeLimits": "Proponentes {proposerTimeout}s en total · inactividad del agregador entre eventos {aggregatorTimeout}s (configurado {configuredAggregatorTimeout}s) · límite total del turno separado · {grace}s de gracia tras el umbral",
       "quorumFailureLabel": "Si menos de {quorum} proponentes tienen éxito"
     },
     "behavior": {

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -1043,7 +1043,7 @@
       "capacityWarn": "{calls} appels de modèle par tour — le coût croît linéairement et le gain de fusion s'estompe au-delà de 4 proposants.",
       "capacityFull": "Limite de {max} proposants atteinte — davantage de brouillons n'améliore plus la fusion ; retirez-en un d'abord.",
       "diversityHint": "Plusieurs proposants partagent la même famille de modèles — ajouter un autre fournisseur améliore généralement la fusion.",
-      "effectiveFacts": "Par tour : {calls} appels de modèle · fusion dès {quorum}/{proposers} proposants réussis · timeout proposant {proposerTimeout}s · timeout agrégateur {aggregatorTimeout}s · {grace}s de grâce après quorum",
+      "effectiveFacts": "Par tour : {calls} appels de modèle · fusion dès {quorum}/{proposers} proposants réussis · délai total proposant {proposerTimeout}s · délai d'inactivité agrégateur {aggregatorTimeout}s · {grace}s de grâce après quorum",
       "effectiveSummary": "{proposers} proposants en parallèle + 1 agrégateur · environ {calls} appels par tour",
       "runtimeStrategyTitle": "Stratégie d'exécution",
       "runtimeStrategyDesc": "Seuil de réussite, repli et limites de temps",
@@ -1052,7 +1052,7 @@
       "successThresholdExact": "{quorum} sur {proposers}",
       "failurePolicyLabel": "Si l'agrégation ne peut pas aboutir",
       "runtimeLimitsLabel": "Limites de temps",
-      "runtimeLimits": "Proposants {proposerTimeout}s · agrégateur {aggregatorTimeout}s · {grace}s de grâce après le seuil",
+      "runtimeLimits": "Proposants {proposerTimeout}s au total · inactivité de l'agrégateur entre événements {aggregatorTimeout}s (configurée {configuredAggregatorTimeout}s) · délai total du tour séparé · {grace}s de grâce après le seuil",
       "quorumFailureLabel": "Si moins de {quorum} proposants réussissent"
     },
     "behavior": {

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -1043,7 +1043,7 @@
       "capacityWarn": "1 ターンあたり {calls} 回のモデル呼び出し — コストは線形に増え、候補 4 つを超えると集約の効果は逓減します。",
       "capacityFull": "候補の上限 {max} に達しました — これ以上追加しても集約は改善しません。先に 1 つ削除してください。",
       "diversityHint": "複数の候補が同じモデルファミリーです — 別ベンダーのモデルを追加すると集約が改善されることが多いです。",
-      "effectiveFacts": "1 ターンあたり {calls} 回のモデル呼び出し · {quorum}/{proposers} 件の成功で集約開始 · 候補タイムアウト {proposerTimeout} 秒 · 集約タイムアウト {aggregatorTimeout} 秒 · 充足後 {grace} 秒の猶予",
+      "effectiveFacts": "1 ターンあたり {calls} 回のモデル呼び出し · {quorum}/{proposers} 件の成功で集約開始 · 候補の合計タイムアウト {proposerTimeout} 秒 · 集約のアイドルタイムアウト {aggregatorTimeout} 秒 · 充足後 {grace} 秒の猶予",
       "effectiveSummary": "{proposers} 個の提案モデルを並列実行 + 1 個の集約モデル · 1 ターン約 {calls} 回呼び出し",
       "runtimeStrategyTitle": "実行戦略",
       "runtimeStrategyDesc": "成功条件、失敗時の動作、制限時間",
@@ -1052,7 +1052,7 @@
       "successThresholdExact": "{quorum}/{proposers}",
       "failurePolicyLabel": "集約を完了できない場合",
       "runtimeLimitsLabel": "制限時間",
-      "runtimeLimits": "提案モデル {proposerTimeout} 秒 · 集約モデル {aggregatorTimeout} 秒 · 条件達成後の猶予 {grace} 秒",
+      "runtimeLimits": "提案モデルは合計 {proposerTimeout} 秒 · 集約モデルはプロバイダーイベント間のアイドル {aggregatorTimeout} 秒（設定値 {configuredAggregatorTimeout} 秒）· ターン全体の期限は別管理 · 条件達成後の猶予 {grace} 秒",
       "quorumFailureLabel": "成功した候補が {quorum} 件未満の場合"
     },
     "behavior": {

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -1094,7 +1094,7 @@
       "capacityWarn": "每轮 {calls} 次模型调用——费用线性增长，超过 4 个提案模型后融合收益明显递减。",
       "capacityFull": "已达上限 {max} 个提案模型——更多草稿不会带来更好的融合结果，请先移除一个再添加。",
       "diversityHint": "多个提案来自同一模型家族——添加不同厂商的模型通常能提升融合质量。",
-      "effectiveFacts": "每轮 {calls} 次模型调用 · {quorum}/{proposers} 个候选正常返回即可融合 · 候选超时 {proposerTimeout} 秒 · 融合超时 {aggregatorTimeout} 秒 · 达标后宽限 {grace} 秒",
+      "effectiveFacts": "每轮 {calls} 次模型调用 · {quorum}/{proposers} 个候选正常返回即可融合 · 候选总超时 {proposerTimeout} 秒 · 融合空闲超时 {aggregatorTimeout} 秒 · 达标后宽限 {grace} 秒",
       "effectiveSummary": "{proposers} 个提案模型并行 + 1 个融合模型 · 预计每轮 {calls} 次调用",
       "runtimeStrategyTitle": "运行策略",
       "runtimeStrategyDesc": "正常返回阈值、失败处理与时限",
@@ -1103,7 +1103,7 @@
       "successThresholdExact": "至少 {quorum}/{proposers} 正常返回",
       "failurePolicyLabel": "无法完成融合时",
       "runtimeLimitsLabel": "运行时限",
-      "runtimeLimits": "每个提案最长 {proposerTimeout} 秒 · 达到阈值后再等待最多 {grace} 秒 · 融合最长 {aggregatorTimeout} 秒",
+      "runtimeLimits": "每个提案总时限 {proposerTimeout} 秒 · 融合模型事件间空闲时限 {aggregatorTimeout} 秒（配置值 {configuredAggregatorTimeout} 秒）· 整轮总时限另行控制 · 达标后宽限 {grace} 秒",
       "quorumFailureLabel": "正常返回的提案不足 {quorum} 个时"
     },
     "behavior": {

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -259,7 +259,7 @@ all_failed_policy = "fallback_single"
 # proposer_tools = false              # expose tool schemas as non-executable advice
 # candidate_max_chars = 24000         # per-candidate transcript budget (0 = unlimited)
 # proposer_timeout_seconds = 3600.0
-# aggregator_timeout_seconds = 3600.0
+# aggregator_timeout_seconds = 3600.0 # idle/stall budget between stream events
 # shuffle_candidates = true           # shuffle candidate order before aggregation
 # record_candidates = false           # persist per-proposer candidates for replay/debug
 

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -259,7 +259,7 @@ all_failed_policy = "fallback_single"
 # proposer_tools = false              # expose tool schemas as non-executable advice
 # candidate_max_chars = 24000         # per-candidate transcript budget (0 = unlimited)
 # proposer_timeout_seconds = 3600.0
-# aggregator_timeout_seconds = 3600.0 # idle/stall budget between stream events
+# aggregator_timeout_seconds = 3600.0 # idle/stall budget; outer turn deadline is separate
 # shuffle_candidates = true           # shuffle candidate order before aggregation
 # record_candidates = false           # persist per-proposer candidates for replay/debug
 

--- a/src/opensquilla/provider/ensemble.py
+++ b/src/opensquilla/provider/ensemble.py
@@ -2371,6 +2371,7 @@ class EnsembleProvider:
             "proposer_timeout_seconds": self.proposer_timeout_seconds,
             "aggregator_timeout_seconds": self.aggregator_timeout_seconds,
             "aggregator_timeout_mode": "idle",
+            "aggregator_total_deadline_source": "outer_turn_runtime",
             "quorum_grace_seconds": self.quorum_grace_seconds,
             "content_max_chars": TRACE_CONTENT_MAX_CHARS,
             "final_request_role": final_request_role,
@@ -2703,37 +2704,36 @@ class EnsembleProvider:
                     ),
                     code="ensemble_aggregator_timeout",
                 )
+                # A completed idle budget is not a cheap transient failure:
+                # replaying the aggregator can repeat the same billed stall for
+                # another full budget. Preserve any earlier retry receipts, but
+                # do not retry this timed-out attempt. A fallback is safe only
+                # before any text, reasoning, or tool delta reached consumers.
+                yield aggregator_progress("aggregator_finish", error=error.message)
                 if (
                     not content_streamed
-                    and attempt < _ENSEMBLE_AGGREGATOR_MAX_RETRIES
+                    and self.all_failed_policy == "fallback_single"
+                    and self.fallback_provider is not None
                 ):
-                    retry_error = error
-                else:
-                    yield aggregator_progress("aggregator_finish", error=error.message)
-                    if (
-                        not content_streamed
-                        and self.all_failed_policy == "fallback_single"
-                        and self.fallback_provider is not None
+                    # Reuse the original conversation, not the synthetic
+                    # candidate bundle sent to the aggregator. Preserve
+                    # billed retry rows and count only attempts that ended
+                    # without a usage receipt as missing.
+                    async for fallback_event in self._fallback_or_error(
+                        original_messages,
+                        tools=tools,
+                        config=original_config,
+                        reason=error.message,
+                        code=error.code,
+                        candidates=candidates,
+                        prior_trace=trace,
+                        prior_usage_rows=retry_rows,
+                        extra_usage_missing_count=retry_missing_count + 1,
                     ):
-                        # Reuse the original conversation, not the synthetic
-                        # candidate bundle sent to the aggregator. Preserve
-                        # billed retry rows and count only attempts that ended
-                        # without a usage receipt as missing.
-                        async for fallback_event in self._fallback_or_error(
-                            original_messages,
-                            tools=tools,
-                            config=original_config,
-                            reason=error.message,
-                            code=error.code,
-                            candidates=candidates,
-                            prior_trace=trace,
-                            prior_usage_rows=retry_rows,
-                            extra_usage_missing_count=retry_missing_count + 1,
-                        ):
-                            yield fallback_event
-                        return
-                    yield partial_error(error)
+                        yield fallback_event
                     return
+                yield partial_error(error)
+                return
             except Exception as exc:  # noqa: BLE001 - provider boundary returns ErrorEvent
                 safe_message = redact_upstream_error_text(
                     f"ensemble aggregator failed: {exc}",

--- a/src/opensquilla/provider/ensemble.py
+++ b/src/opensquilla/provider/ensemble.py
@@ -207,10 +207,13 @@ async def _stream_with_heartbeats(
                         event = pending.result()
                     except StopAsyncIteration:
                         return
+                    yield event
                     pending = asyncio.ensure_future(stream_iter.__anext__())
                     if reset_deadline_on_event and timeout_budget is not None:
+                        # Consumer-side processing is not provider idle time.
+                        # Start the next idle budget only once the next provider
+                        # read is actually pending.
                         deadline = time.monotonic() + timeout_budget
-                    yield event
                     continue
                 wait_seconds = min(wait_seconds, remaining)
             done, _ = await asyncio.wait({pending}, timeout=wait_seconds)
@@ -221,12 +224,13 @@ async def _stream_with_heartbeats(
                 event = pending.result()
             except StopAsyncIteration:
                 return
-            if reset_deadline_on_event and timeout_budget is not None:
-                # Idle budget: a healthy stream that keeps producing events may
-                # run arbitrarily long; only a silent stall expires the wait.
-                deadline = time.monotonic() + timeout_budget
             yield event
             pending = asyncio.ensure_future(stream_iter.__anext__())
+            if reset_deadline_on_event and timeout_budget is not None:
+                # Idle budget: a healthy stream that keeps producing events may
+                # run arbitrarily long; only a silent provider read expires it.
+                # Exclude time spent by downstream consumers handling ``event``.
+                deadline = time.monotonic() + timeout_budget
     finally:
         cleanup_deadline = time.monotonic() + max(
             0.0,
@@ -1800,6 +1804,9 @@ class EnsembleProvider:
             prior_rows=proposer_rows,
             prior_missing_count=_candidate_missing_usage_count(candidates),
             trace=trace,
+            original_messages=messages,
+            original_config=config,
+            candidates=candidates,
         ):
             yield event
 
@@ -2363,6 +2370,7 @@ class EnsembleProvider:
             "proposer_max_retries": self.proposer_max_retries,
             "proposer_timeout_seconds": self.proposer_timeout_seconds,
             "aggregator_timeout_seconds": self.aggregator_timeout_seconds,
+            "aggregator_timeout_mode": "idle",
             "quorum_grace_seconds": self.quorum_grace_seconds,
             "content_max_chars": TRACE_CONTENT_MAX_CHARS,
             "final_request_role": final_request_role,
@@ -2421,6 +2429,9 @@ class EnsembleProvider:
         prior_rows: list[dict[str, Any]],
         prior_missing_count: int,
         trace: dict[str, Any],
+        original_messages: list[Message],
+        original_config: ChatConfig | None,
+        candidates: Sequence[_CandidateResult],
     ) -> AsyncIterator[StreamEvent]:
         final_text_parts: list[str] = []
         aggregator_started = time.monotonic()
@@ -2557,6 +2568,10 @@ class EnsembleProvider:
                     phase="ensemble_aggregator_wait",
                     message="Still waiting for ensemble aggregator response",
                     timeout_seconds=timeout_seconds,
+                    # Match provider read-timeout semantics: healthy aggregator
+                    # streams may run past this budget, but a silent stream may
+                    # not stall the turn indefinitely.
+                    reset_deadline_on_event=True,
                 )
                 async for event in heartbeat_stream:
                     if isinstance(event, DoneEvent):
@@ -2683,7 +2698,7 @@ class EnsembleProvider:
             except TimeoutError:
                 error = ErrorEvent(
                     message=(
-                        "ensemble aggregator timed out after "
+                        "ensemble aggregator stalled: no stream events for "
                         f"{self.aggregator_timeout_seconds:g}s"
                     ),
                     code="ensemble_aggregator_timeout",
@@ -2695,6 +2710,28 @@ class EnsembleProvider:
                     retry_error = error
                 else:
                     yield aggregator_progress("aggregator_finish", error=error.message)
+                    if (
+                        not content_streamed
+                        and self.all_failed_policy == "fallback_single"
+                        and self.fallback_provider is not None
+                    ):
+                        # Reuse the original conversation, not the synthetic
+                        # candidate bundle sent to the aggregator. Preserve
+                        # billed retry rows and count only attempts that ended
+                        # without a usage receipt as missing.
+                        async for fallback_event in self._fallback_or_error(
+                            original_messages,
+                            tools=tools,
+                            config=original_config,
+                            reason=error.message,
+                            code=error.code,
+                            candidates=candidates,
+                            prior_trace=trace,
+                            prior_usage_rows=retry_rows,
+                            extra_usage_missing_count=retry_missing_count + 1,
+                        ):
+                            yield fallback_event
+                        return
                     yield partial_error(error)
                     return
             except Exception as exc:  # noqa: BLE001 - provider boundary returns ErrorEvent
@@ -2776,15 +2813,26 @@ class EnsembleProvider:
         reason: str,
         code: str,
         candidates: Sequence[_CandidateResult],
+        prior_trace: Mapping[str, Any] | None = None,
+        prior_usage_rows: Sequence[Mapping[str, Any]] = (),
+        extra_usage_missing_count: int = 0,
     ) -> AsyncIterator[StreamEvent]:
         proposer_rows = _candidate_usage_rows(candidates, profile=self.profile_name)
+        final_path_rows = [
+            *proposer_rows,
+            *(dict(row) for row in prior_usage_rows),
+        ]
         proposer_missing_count = _candidate_missing_usage_count(candidates)
+        usage_missing_count = proposer_missing_count + max(
+            0,
+            int(extra_usage_missing_count),
+        )
 
         def proposer_error(event: ErrorEvent) -> ErrorEvent:
             return replace(
                 event,
-                model_usage_breakdown=list(proposer_rows),
-                usage_missing_count=proposer_missing_count,
+                model_usage_breakdown=list(final_path_rows),
+                usage_missing_count=usage_missing_count,
             )
 
         request_budget_error = _uniform_request_budget_error(candidates)
@@ -2857,17 +2905,31 @@ class EnsembleProvider:
             if request_budget_error is not None
             else code
         )
+        if prior_trace is not None:
+            trace["llm_request_count"] = max(
+                int(trace.get("llm_request_count") or 0),
+                int(prior_trace.get("llm_request_count") or 0),
+            )
+            prior_final_request = prior_trace.get("final_request")
+            if isinstance(prior_final_request, Mapping):
+                archived_request = _json_safe(dict(prior_final_request))
+                if isinstance(archived_request, dict):
+                    archived_request["terminal_code"] = code
+                    archived_request["terminal_reason"] = reason
+                    trace["prior_final_request"] = archived_request
+
         def partial_error(event: ErrorEvent) -> ErrorEvent:
             return replace(
                 event,
-                model_usage_breakdown=list(proposer_rows),
-                usage_missing_count=proposer_missing_count + 1,
+                model_usage_breakdown=list(final_path_rows),
+                usage_missing_count=usage_missing_count + 1,
             )
+
         final_text_parts: list[str] = []
         _mark_final_request_started(trace)
         yield ProviderHeartbeatEvent(
             phase="ensemble_fallback",
-            message="Ensemble quorum unavailable; waiting for fallback model",
+            message="Ensemble final path unavailable; waiting for fallback model",
         )
         try:
             async for event in _stream_with_heartbeats(
@@ -2910,7 +2972,7 @@ class EnsembleProvider:
                         provider=executed_provider,
                         model=executed_model,
                     )
-                    rows = [*proposer_rows, fallback_row]
+                    rows = [*final_path_rows, fallback_row]
                     yield replace(
                         event,
                         input_tokens=_summed_int(rows, "input_tokens"),
@@ -2923,7 +2985,7 @@ class EnsembleProvider:
                         cost_source=_rollup_cost_source(rows),
                         model_usage_breakdown=rows,
                         ensemble_trace=trace,
-                        usage_missing_count=proposer_missing_count,
+                        usage_missing_count=usage_missing_count,
                         billing_receipt=None,
                     )
                     return

--- a/tests/test_engine/turn_runner/test_turn_finalizer_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_turn_finalizer_stage_unit.py
@@ -476,6 +476,83 @@ async def test_turn_usage_persists_ensemble_breakdown_and_trace() -> None:
 
 
 @pytest.mark.asyncio
+async def test_timeout_fallback_persists_one_completed_turn_without_error_record() -> None:
+    stage, recs = _make_stage()
+    done = DoneEvent(
+        text="fallback answer",
+        input_tokens=18,
+        output_tokens=8,
+        model="fallback-model",
+        model_usage_breakdown=[
+            {
+                "role": "proposer",
+                "provider": "openrouter",
+                "model": "draft-model",
+                "input_tokens": 7,
+                "output_tokens": 3,
+            },
+            {
+                "role": "fallback_single",
+                "provider": "openrouter",
+                "model": "fallback-model",
+                "input_tokens": 11,
+                "output_tokens": 5,
+            },
+        ],
+        ensemble_trace={
+            "profile": "static_openrouter_b5",
+            "fallback_used": True,
+            "fallback_code": "ensemble_aggregator_timeout",
+            "aggregator_timeout_mode": "idle",
+            "aggregator_total_deadline_source": "outer_turn_runtime",
+            "llm_request_count": 3,
+            "prior_final_request": {
+                "role": "aggregator",
+                "terminal_code": "ensemble_aggregator_timeout",
+            },
+        },
+    )
+
+    await stage.run(
+        _make_input(final_text_parts=["fallback answer"], done_event=done)
+    )
+
+    assert len(recs["transcript_append"].calls) == 1
+    assert len(recs["session_totals"].calls) == 1
+    assert recs["turn_error_persist"].calls == []
+    usage = recs["transcript_append"].calls[0]["turn_usage"]
+    assert [row["role"] for row in usage["model_usage_breakdown"]] == [
+        "proposer",
+        "fallback_single",
+    ]
+    assert usage["ensemble_trace"]["fallback_code"] == "ensemble_aggregator_timeout"
+    assert usage["ensemble_trace"]["llm_request_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_partial_aggregator_timeout_persists_output_and_error_once() -> None:
+    stage, recs = _make_stage()
+    error = ErrorEvent(
+        message="ensemble aggregator stalled: no stream events for 480s",
+        code="ensemble_aggregator_timeout",
+    )
+
+    await stage.run(
+        _make_input(
+            final_text_parts=["partial answer"],
+            error_message=error.message,
+            pending_error_event=error,
+        )
+    )
+
+    assert len(recs["transcript_append"].calls) == 1
+    assert recs["transcript_append"].calls[0]["content"] == "partial answer"
+    assert len(recs["turn_error_persist"].calls) == 1
+    assert recs["turn_error_persist"].calls[0]["event"] is error
+    assert recs["session_totals"].calls == []
+
+
+@pytest.mark.asyncio
 async def test_turn_usage_persists_vision_followup_metadata() -> None:
     stage, recs = _make_stage()
     done = DoneEvent(text="ok", input_tokens=5, output_tokens=3)

--- a/tests/test_provider_ensemble.py
+++ b/tests/test_provider_ensemble.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass, field, replace
 from types import SimpleNamespace
 from typing import Any, Literal
@@ -503,6 +503,28 @@ async def test_heartbeat_wrapper_still_times_out_when_no_event_completed(
         async for _ in wrapped:
             pass
     release.set()
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_wrapper_idle_timeout_excludes_consumer_processing() -> None:
+    async def _source() -> AsyncIterator[StreamEvent]:
+        yield TextDeltaEvent(text="first")
+        yield DoneEvent(model="m")
+
+    wrapped = _stream_with_heartbeats(
+        _source(),
+        phase="unit",
+        message="waiting",
+        timeout_seconds=0.02,
+        reset_deadline_on_event=True,
+    )
+    events: list[StreamEvent] = []
+    async for event in wrapped:
+        events.append(event)
+        if isinstance(event, TextDeltaEvent):
+            await asyncio.sleep(0.05)
+
+    assert [type(event) for event in events] == [TextDeltaEvent, DoneEvent]
 
 
 def _tool() -> ToolDefinition:
@@ -4123,13 +4145,537 @@ async def test_ensemble_emits_proposer_progress_events(
     assert next(row for row in rows if row["role"] == "aggregator")["elapsed_ms"] >= 0
 
 
+class _ScriptedProvider(_ExactProjectionMixin):
+    def __init__(
+        self,
+        stream_factory: Callable[[], AsyncIterator[StreamEvent]],
+        *,
+        provider_name: str,
+    ) -> None:
+        self._stream_factory = stream_factory
+        self.provider_name = provider_name
+        self.calls: list[dict[str, Any]] = []
+
+    def chat(
+        self,
+        messages: list[Message],
+        tools: list[ToolDefinition] | None = None,
+        config: ChatConfig | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        self.calls.append(
+            {
+                "messages": list(messages),
+                "tools": tools,
+                "config": config,
+            }
+        )
+        return self._stream_factory()
+
+    async def list_models(self) -> list[Any]:
+        return []
+
+
+def _aggregator_timeout_harness(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    aggregator_stream: Callable[[], AsyncIterator[StreamEvent]],
+    fallback_stream: Callable[[], AsyncIterator[StreamEvent]] | None,
+    proposer_done: DoneEvent | None = None,
+    timeout_seconds: float = 0.01,
+    all_failed_policy: Literal["fallback_single", "error"] = "fallback_single",
+    selection_plan: dict[str, Any] | None = None,
+) -> tuple[
+    EnsembleProvider,
+    _FakeRegistry,
+    _ScriptedProvider,
+    _ScriptedProvider | None,
+]:
+    monkeypatch.setattr(
+        "opensquilla.provider.ensemble._ENSEMBLE_AGGREGATOR_RETRY_BACKOFF_SECONDS",
+        (0.0,),
+    )
+    registry = _FakeRegistry(
+        {
+            "p1": _FakePlan(
+                [
+                    TextDeltaEvent(text="draft"),
+                    proposer_done or DoneEvent(model="p1"),
+                ]
+            )
+        }
+    )
+    aggregator = _ScriptedProvider(aggregator_stream, provider_name="fake")
+    fallback = (
+        _ScriptedProvider(fallback_stream, provider_name="fallback")
+        if fallback_stream is not None
+        else None
+    )
+
+    def build_provider(cfg: ProviderConfig) -> Any:
+        if cfg.model == "agg":
+            return aggregator
+        return registry.provider_for(cfg)
+
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", build_provider)
+    provider = EnsembleProvider(
+        profile_name="default",
+        proposers=[_member("p1")],
+        aggregator=_member("agg"),
+        fallback_provider=fallback,
+        fallback_provider_name="fallback",
+        fallback_model="fallback",
+        all_failed_policy=all_failed_policy,
+        proposer_timeout_seconds=1,
+        aggregator_timeout_seconds=timeout_seconds,
+        shuffle_candidates=False,
+        selection_plan=selection_plan,
+    )
+    return provider, registry, aggregator, fallback
+
+
+@pytest.mark.asyncio
+async def test_aggregator_no_output_timeout_uses_single_fallback_and_preserves_usage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    proposer_receipt = ProviderBillingReceipt(
+        currency="USD",
+        status="confirmed",
+        amount_nanos=1_000,
+        usd_equivalent_nanos=1_000,
+        fx_native_per_usd_nanos=1_000_000_000,
+    )
+    fallback_receipt = replace(
+        proposer_receipt,
+        amount_nanos=2_000,
+        usd_equivalent_nanos=2_000,
+    )
+
+    async def stalled_aggregator() -> AsyncIterator[StreamEvent]:
+        await asyncio.sleep(0.05)
+        yield DoneEvent(model="agg")
+
+    async def successful_fallback() -> AsyncIterator[StreamEvent]:
+        yield TextDeltaEvent(text="fallback")
+        yield DoneEvent(
+            input_tokens=11,
+            output_tokens=5,
+            billed_cost=0.000002,
+            cost_source="provider_billed",
+            model="fallback",
+            billing_receipt=fallback_receipt,
+        )
+
+    selection_plan = {
+        "configured_aggregator_timeout_seconds": 3600.0,
+        "effective_aggregator_timeout_seconds": 0.01,
+    }
+    provider, registry, aggregator, fallback = _aggregator_timeout_harness(
+        monkeypatch,
+        aggregator_stream=stalled_aggregator,
+        fallback_stream=successful_fallback,
+        proposer_done=DoneEvent(
+            input_tokens=7,
+            output_tokens=3,
+            billed_cost=0.000001,
+            cost_source="provider_billed",
+            model="p1",
+            billing_receipt=proposer_receipt,
+        ),
+        selection_plan=selection_plan,
+    )
+
+    events = await _collect(provider)
+
+    assert [call["model"] for call in registry.calls] == ["p1"]
+    assert len(aggregator.calls) == 3
+    assert fallback is not None and len(fallback.calls) == 1
+    fallback_messages = fallback.calls[0]["messages"]
+    assert [(message.role, message.content) for message in fallback_messages] == [
+        ("user", "answer this")
+    ]
+    assert "<CANDIDATE" not in str(fallback_messages)
+    assert not any(isinstance(event, ErrorEvent) for event in events)
+    assert [
+        event.text for event in events if isinstance(event, TextDeltaEvent)
+    ] == ["fallback"]
+
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert (done.input_tokens, done.output_tokens) == (18, 8)
+    assert [row["role"] for row in done.model_usage_breakdown] == [
+        "proposer",
+        "fallback_single",
+    ]
+    assert [row["billing_receipt"] for row in done.model_usage_breakdown] == [
+        proposer_receipt,
+        fallback_receipt,
+    ]
+    assert done.billing_receipt is None
+    assert done.usage_missing_count == 3
+
+    trace = done.ensemble_trace
+    assert trace is not None
+    assert trace["fallback_used"] is True
+    assert trace["fallback_code"] == "ensemble_aggregator_timeout"
+    assert "no stream events" in trace["fallback_reason"]
+    assert trace["aggregator_timeout_mode"] == "idle"
+    assert trace["selection_plan"] == selection_plan
+    assert trace["llm_request_count"] == 5
+    assert trace["final_request"]["role"] == "fallback_single"
+    assert trace["final_request"]["output"]["text"] == "fallback"
+    prior_request = trace["prior_final_request"]
+    assert prior_request["request_started"] is True
+    assert prior_request["execution"]["model"] == "agg"
+    assert prior_request["retry_count"] == 2
+    assert prior_request["terminal_code"] == "ensemble_aggregator_timeout"
+
+    aggregator_finish = next(
+        event
+        for event in events
+        if isinstance(event, EnsembleProgressEvent) and event.event_type == "aggregator_finish"
+    )
+    fallback_heartbeat = next(
+        event
+        for event in events
+        if isinstance(event, ProviderHeartbeatEvent) and event.phase == "ensemble_fallback"
+    )
+    fallback_delta = next(
+        event
+        for event in events
+        if isinstance(event, TextDeltaEvent) and event.text == "fallback"
+    )
+    assert (
+        events.index(aggregator_finish)
+        < events.index(fallback_heartbeat)
+        < events.index(fallback_delta)
+        < events.index(done)
+    )
+    usage = normalize_provider_usage(
+        done,
+        default_provider="ensemble",
+        default_model="fallback",
+        completed_at_ms=1234,
+    )
+    assert len(usage.items) == 2
+    assert usage.missing_usage_entries == 3
+
+
+@pytest.mark.asyncio
+async def test_aggregator_stream_survives_past_timeout_while_events_flow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def slow_steady_aggregator() -> AsyncIterator[StreamEvent]:
+        for index in range(6):
+            await asyncio.sleep(0.02)
+            yield TextDeltaEvent(text=f"chunk{index}")
+        yield DoneEvent(input_tokens=11, output_tokens=5, model="agg")
+
+    async def unused_fallback() -> AsyncIterator[StreamEvent]:
+        yield DoneEvent(model="fallback")
+
+    provider, _, _, fallback = _aggregator_timeout_harness(
+        monkeypatch,
+        aggregator_stream=slow_steady_aggregator,
+        fallback_stream=unused_fallback,
+        proposer_done=DoneEvent(input_tokens=7, output_tokens=3, model="p1"),
+        timeout_seconds=0.05,
+    )
+
+    events = await _collect(provider)
+
+    assert fallback is not None and fallback.calls == []
+    assert not any(isinstance(event, ErrorEvent) for event in events)
+    assert [event.text for event in events if isinstance(event, TextDeltaEvent)] == [
+        f"chunk{index}" for index in range(6)
+    ]
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert [row["role"] for row in done.model_usage_breakdown] == [
+        "proposer",
+        "aggregator",
+    ]
+    assert done.usage_missing_count == 0
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["llm_request_count"] == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "partial_event",
+    [
+        TextDeltaEvent(text="partial"),
+        ReasoningDeltaEvent(text="thinking"),
+        ToolUseStartEvent(tool_use_id="call-1", tool_name="lookup"),
+    ],
+    ids=["text", "reasoning", "tool"],
+)
+async def test_aggregator_partial_output_idle_timeout_is_terminal_without_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    partial_event: StreamEvent,
+) -> None:
+    async def partial_aggregator() -> AsyncIterator[StreamEvent]:
+        yield partial_event
+        await asyncio.sleep(0.05)
+        yield DoneEvent(model="agg")
+
+    async def duplicate_fallback() -> AsyncIterator[StreamEvent]:
+        yield TextDeltaEvent(text="duplicate")
+        yield DoneEvent(model="fallback")
+
+    provider, _, _, fallback = _aggregator_timeout_harness(
+        monkeypatch,
+        aggregator_stream=partial_aggregator,
+        fallback_stream=duplicate_fallback,
+        proposer_done=DoneEvent(input_tokens=7, output_tokens=3, model="p1"),
+    )
+
+    events = await _collect(provider)
+
+    assert fallback is not None and fallback.calls == []
+    assert partial_event in events
+    assert not any(
+        isinstance(event, TextDeltaEvent) and event.text == "duplicate" for event in events
+    )
+    progress = [
+        event
+        for event in events
+        if isinstance(event, EnsembleProgressEvent) and event.event_type.startswith("aggregator_")
+    ]
+    error = next(event for event in events if isinstance(event, ErrorEvent))
+    assert [event.event_type for event in progress] == [
+        "aggregator_start",
+        "aggregator_finish",
+    ]
+    assert error.code == "ensemble_aggregator_timeout"
+    assert error.usage_missing_count == 1
+    assert events.index(progress[-1]) < events.index(error)
+
+
+@pytest.mark.asyncio
+async def test_aggregator_timeout_respects_error_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def stalled_aggregator() -> AsyncIterator[StreamEvent]:
+        await asyncio.sleep(0.05)
+        yield DoneEvent(model="agg")
+
+    async def unused_fallback() -> AsyncIterator[StreamEvent]:
+        yield DoneEvent(model="fallback")
+
+    provider, _, _, fallback = _aggregator_timeout_harness(
+        monkeypatch,
+        aggregator_stream=stalled_aggregator,
+        fallback_stream=unused_fallback,
+        all_failed_policy="error",
+    )
+
+    events = await _collect(provider)
+
+    assert fallback is not None and fallback.calls == []
+    error = next(event for event in events if isinstance(event, ErrorEvent))
+    assert error.code == "ensemble_aggregator_timeout"
+    assert error.usage_missing_count == 3
+
+
+@pytest.mark.asyncio
+async def test_aggregator_timeout_then_fallback_error_counts_both_missing_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def stalled_aggregator() -> AsyncIterator[StreamEvent]:
+        await asyncio.sleep(0.05)
+        yield DoneEvent(model="agg")
+
+    async def failing_fallback() -> AsyncIterator[StreamEvent]:
+        yield ErrorEvent(message="fallback failed", code="fallback_failed")
+
+    provider, _, _, fallback = _aggregator_timeout_harness(
+        monkeypatch,
+        aggregator_stream=stalled_aggregator,
+        fallback_stream=failing_fallback,
+        proposer_done=DoneEvent(input_tokens=7, output_tokens=3, model="p1"),
+    )
+
+    events = await _collect(provider)
+
+    assert fallback is not None and len(fallback.calls) == 1
+    errors = [event for event in events if isinstance(event, ErrorEvent)]
+    assert len(errors) == 1
+    assert errors[0].code == "fallback_failed"
+    assert [row["model"] for row in errors[0].model_usage_breakdown] == ["p1"]
+    assert errors[0].usage_missing_count == 4
+
+
+@pytest.mark.asyncio
+async def test_aggregator_retries_then_timeout_preserves_request_counts_in_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    aggregator_attempts = 0
+
+    def retry_then_stall() -> AsyncIterator[StreamEvent]:
+        nonlocal aggregator_attempts
+        aggregator_attempts += 1
+        attempt = aggregator_attempts
+
+        async def stream() -> AsyncIterator[StreamEvent]:
+            if attempt <= 2:
+                yield ErrorEvent(message="upstream rate limit", code="429")
+                return
+            await asyncio.sleep(0.05)
+            yield DoneEvent(model="agg")
+
+        return stream()
+
+    async def successful_fallback() -> AsyncIterator[StreamEvent]:
+        yield DoneEvent(input_tokens=11, output_tokens=5, model="fallback")
+
+    monkeypatch.setattr(
+        "opensquilla.provider.ensemble._ENSEMBLE_AGGREGATOR_RETRY_BACKOFF_SECONDS",
+        (0.0,),
+    )
+    provider, _, _, fallback = _aggregator_timeout_harness(
+        monkeypatch,
+        aggregator_stream=retry_then_stall,
+        fallback_stream=successful_fallback,
+        proposer_done=DoneEvent(input_tokens=7, output_tokens=3, model="p1"),
+    )
+
+    events = await _collect(provider)
+
+    assert aggregator_attempts == 3
+    assert fallback is not None and len(fallback.calls) == 1
+    assert (
+        len(
+            [
+                event
+                for event in events
+                if isinstance(event, EnsembleProgressEvent)
+                and event.event_type == "aggregator_finish"
+            ]
+        )
+        == 1
+    )
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.usage_missing_count == 3
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["llm_request_count"] == 5
+    assert done.ensemble_trace["prior_final_request"]["retry_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_aggregator_timeout_fallback_retains_reported_retry_usage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    aggregator_attempts = 0
+
+    def reported_error_then_stall() -> AsyncIterator[StreamEvent]:
+        nonlocal aggregator_attempts
+        aggregator_attempts += 1
+        attempt = aggregator_attempts
+
+        async def stream() -> AsyncIterator[StreamEvent]:
+            if attempt == 1:
+                yield DoneEvent(
+                    input_tokens=13,
+                    output_tokens=1,
+                    model="agg",
+                    stop_reason="error",
+                )
+                return
+            await asyncio.sleep(0.05)
+            yield DoneEvent(model="agg")
+
+        return stream()
+
+    async def successful_fallback() -> AsyncIterator[StreamEvent]:
+        yield DoneEvent(input_tokens=11, output_tokens=5, model="fallback")
+
+    provider, _, aggregator, fallback = _aggregator_timeout_harness(
+        monkeypatch,
+        aggregator_stream=reported_error_then_stall,
+        fallback_stream=successful_fallback,
+        proposer_done=DoneEvent(input_tokens=7, output_tokens=3, model="p1"),
+    )
+
+    events = await _collect(provider)
+
+    assert aggregator_attempts == 3
+    assert len(aggregator.calls) == 3
+    assert fallback is not None and len(fallback.calls) == 1
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert (done.input_tokens, done.output_tokens) == (31, 9)
+    assert [row["role"] for row in done.model_usage_breakdown] == [
+        "proposer",
+        "aggregator",
+        "fallback_single",
+    ]
+    retry_row = done.model_usage_breakdown[1]
+    assert retry_row["attempt_index"] == 1
+    assert retry_row["attempt_ok"] is False
+    assert retry_row["usage_reported"] is True
+    assert done.usage_missing_count == 2
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["llm_request_count"] == 5
+    assert done.ensemble_trace["prior_final_request"]["retry_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_aggregator_timeout_cleanup_is_bounded_before_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release = asyncio.Event()
+    cancellation_seen = asyncio.Event()
+    closed = asyncio.Event()
+
+    async def cancellation_resistant_aggregator() -> AsyncIterator[StreamEvent]:
+        try:
+            while not release.is_set():
+                try:
+                    await release.wait()
+                except asyncio.CancelledError:
+                    cancellation_seen.set()
+            yield TextDeltaEvent(text="late-after-timeout")
+            await asyncio.Event().wait()
+        finally:
+            closed.set()
+
+    async def successful_fallback() -> AsyncIterator[StreamEvent]:
+        yield TextDeltaEvent(text="fallback")
+        yield DoneEvent(model="fallback")
+
+    monkeypatch.setattr(
+        "opensquilla.provider.ensemble._ENSEMBLE_HEARTBEAT_INTERVAL_SECONDS",
+        0.005,
+    )
+    monkeypatch.setattr(
+        "opensquilla.provider.ensemble._ENSEMBLE_CANCEL_CLEANUP_TIMEOUT_SECONDS",
+        0.01,
+    )
+    provider, _, _, fallback = _aggregator_timeout_harness(
+        monkeypatch,
+        aggregator_stream=cancellation_resistant_aggregator,
+        fallback_stream=successful_fallback,
+        timeout_seconds=0.02,
+    )
+
+    started = time.monotonic()
+    events = await asyncio.wait_for(_collect(provider), timeout=0.5)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.3
+    assert cancellation_seen.is_set() is True
+    assert fallback is not None and len(fallback.calls) == 1
+    assert [
+        event.text for event in events if isinstance(event, TextDeltaEvent)
+    ] == ["fallback"]
+    release.set()
+    await asyncio.wait_for(closed.wait(), timeout=0.5)
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("mode", "expected_code", "expected_error"),
     [
         ("error", "agg_failed", "aggregator rejected request"),
         ("incomplete", "ensemble_aggregator_incomplete", "ended before DoneEvent"),
-        ("timeout", "ensemble_aggregator_timeout", "timed out after"),
+        ("timeout", "ensemble_aggregator_timeout", "no stream events for"),
     ],
 )
 async def test_ensemble_emits_aggregator_finish_before_terminal_error(

--- a/tests/test_provider_ensemble.py
+++ b/tests/test_provider_ensemble.py
@@ -3756,7 +3756,7 @@ async def test_aggregator_empty_incomplete_stream_is_retried_in_place(
 
 
 @pytest.mark.asyncio
-async def test_aggregator_timeout_before_content_is_retried_in_place(
+async def test_aggregator_timeout_before_content_is_terminal_without_retry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     registry = _FakeRegistry(
@@ -3800,12 +3800,11 @@ async def test_aggregator_timeout_before_content_is_retried_in_place(
 
     events = await _collect(provider)
 
-    assert call_count[0] == 2
-    assert not any(isinstance(event, ErrorEvent) for event in events)
-    done = next(event for event in events if isinstance(event, DoneEvent))
-    assert done.usage_missing_count == 1
-    assert done.ensemble_trace is not None
-    assert done.ensemble_trace["final_request"]["retry_count"] == 1
+    assert call_count[0] == 1
+    error = next(event for event in events if isinstance(event, ErrorEvent))
+    assert error.code == "ensemble_aggregator_timeout"
+    assert error.usage_missing_count == 1
+    assert not any(isinstance(event, DoneEvent) for event in events)
 
 
 @pytest.mark.asyncio
@@ -4287,7 +4286,9 @@ async def test_aggregator_no_output_timeout_uses_single_fallback_and_preserves_u
     events = await _collect(provider)
 
     assert [call["model"] for call in registry.calls] == ["p1"]
-    assert len(aggregator.calls) == 3
+    # A completed idle budget immediately selects the safe fallback path;
+    # retrying the aggregator would repeat a full, potentially billed stall.
+    assert len(aggregator.calls) == 1
     assert fallback is not None and len(fallback.calls) == 1
     fallback_messages = fallback.calls[0]["messages"]
     assert [(message.role, message.content) for message in fallback_messages] == [
@@ -4310,7 +4311,7 @@ async def test_aggregator_no_output_timeout_uses_single_fallback_and_preserves_u
         fallback_receipt,
     ]
     assert done.billing_receipt is None
-    assert done.usage_missing_count == 3
+    assert done.usage_missing_count == 1
 
     trace = done.ensemble_trace
     assert trace is not None
@@ -4318,14 +4319,15 @@ async def test_aggregator_no_output_timeout_uses_single_fallback_and_preserves_u
     assert trace["fallback_code"] == "ensemble_aggregator_timeout"
     assert "no stream events" in trace["fallback_reason"]
     assert trace["aggregator_timeout_mode"] == "idle"
+    assert trace["aggregator_total_deadline_source"] == "outer_turn_runtime"
     assert trace["selection_plan"] == selection_plan
-    assert trace["llm_request_count"] == 5
+    assert trace["llm_request_count"] == 3
     assert trace["final_request"]["role"] == "fallback_single"
     assert trace["final_request"]["output"]["text"] == "fallback"
     prior_request = trace["prior_final_request"]
     assert prior_request["request_started"] is True
     assert prior_request["execution"]["model"] == "agg"
-    assert prior_request["retry_count"] == 2
+    assert prior_request.get("retry_count", 0) == 0
     assert prior_request["terminal_code"] == "ensemble_aggregator_timeout"
 
     aggregator_finish = next(
@@ -4356,7 +4358,7 @@ async def test_aggregator_no_output_timeout_uses_single_fallback_and_preserves_u
         completed_at_ms=1234,
     )
     assert len(usage.items) == 2
-    assert usage.missing_usage_entries == 3
+    assert usage.missing_usage_entries == 1
 
 
 @pytest.mark.asyncio
@@ -4472,7 +4474,7 @@ async def test_aggregator_timeout_respects_error_policy(
     assert fallback is not None and fallback.calls == []
     error = next(event for event in events if isinstance(event, ErrorEvent))
     assert error.code == "ensemble_aggregator_timeout"
-    assert error.usage_missing_count == 3
+    assert error.usage_missing_count == 1
 
 
 @pytest.mark.asyncio
@@ -4500,7 +4502,7 @@ async def test_aggregator_timeout_then_fallback_error_counts_both_missing_reques
     assert len(errors) == 1
     assert errors[0].code == "fallback_failed"
     assert [row["model"] for row in errors[0].model_usage_breakdown] == ["p1"]
-    assert errors[0].usage_missing_count == 4
+    assert errors[0].usage_missing_count == 2
 
 
 @pytest.mark.asyncio
@@ -4596,8 +4598,8 @@ async def test_aggregator_timeout_fallback_retains_reported_retry_usage(
 
     events = await _collect(provider)
 
-    assert aggregator_attempts == 3
-    assert len(aggregator.calls) == 3
+    assert aggregator_attempts == 2
+    assert len(aggregator.calls) == 2
     assert fallback is not None and len(fallback.calls) == 1
     done = next(event for event in events if isinstance(event, DoneEvent))
     assert (done.input_tokens, done.output_tokens) == (31, 9)
@@ -4610,10 +4612,10 @@ async def test_aggregator_timeout_fallback_retains_reported_retry_usage(
     assert retry_row["attempt_index"] == 1
     assert retry_row["attempt_ok"] is False
     assert retry_row["usage_reported"] is True
-    assert done.usage_missing_count == 2
+    assert done.usage_missing_count == 1
     assert done.ensemble_trace is not None
-    assert done.ensemble_trace["llm_request_count"] == 5
-    assert done.ensemble_trace["prior_final_request"]["retry_count"] == 2
+    assert done.ensemble_trace["llm_request_count"] == 4
+    assert done.ensemble_trace["prior_final_request"]["retry_count"] == 1
 
 
 @pytest.mark.asyncio
@@ -4729,8 +4731,7 @@ async def test_ensemble_emits_aggregator_finish_before_terminal_error(
     assert expected_error in aggregator_progress[-1].error
     assert terminal_error.code == expected_code
     assert [row["model"] for row in terminal_error.model_usage_breakdown] == ["p1"]
-    expected_missing_count = 3 if mode == "timeout" else 1
-    assert terminal_error.usage_missing_count == expected_missing_count
+    assert terminal_error.usage_missing_count == 1
     assert events.index(aggregator_progress[-1]) < events.index(terminal_error)
 
 


### PR DESCRIPTION
## Problem and root cause

Issues #880 and #1029 report that an Ensemble turn can terminate after the aggregator reaches the effective 480-second timeout instead of honoring `fallback_single`.

The aggregator timeout was treated as a total attempt budget and then followed the generic aggregator retry/error path. A zero-output stall could therefore consume repeated full timeout windows and still bypass the configured fallback. The timeout path also needed an explicit boundary between safe zero-output recovery and unsafe replay after text, reasoning, or tool output had already become visible.

## Scope

Scope boundary: harden Ensemble aggregator timeout handling from stream deadline semantics through fallback selection, usage aggregation, trace data, persistence coverage, and the setup UI's effective-timeout explanation.

Changes:

- Treat `aggregator_timeout_seconds` as an idle budget between provider stream events; the outer turn runtime remains the total deadline.
- Never retry an aggregator attempt after that idle budget expires.
- On a zero-visible-output timeout, invoke `fallback_single` exactly once with the original conversation and retain completed proposer results.
- After any visible text, reasoning, or tool delta, terminate with the timeout error instead of transparently retrying or falling back.
- Carry retry usage receipts, unknown-usage counts, request counts, and the prior final-request trace into the fallback result without double-accounting.
- Document configured versus effective timeout values in the setup UI and Ensemble design documentation.

Non-goals:

- No proposer rerun and no retry of a timed-out aggregator.
- No fallback after partial visible aggregator output.
- No change to bounded retry behavior for other transient 429/5xx/transport failures.
- No provider protocol, persistence schema, or RPC contract change.

## Branch

Base branch: `main`

Target exception: N/A

## Issue

Fixes #880

Fixes #1029

## Existing PR relationship

PR #934 is the original open contribution by Shixi Li. Its current head (`7cc106093a2e9f24ccb2da977bbdcb1f64160e6e`) is preserved verbatim in this branch through the lineage commit below: stable patch IDs are identical. This PR is the latest-`main` canonical refinement, adding the zero-output/partial-output safety boundary, no-timeout-retry rule, idle-versus-total deadline semantics, accounting/persistence coverage, and UI/docs clarification. PR #934 is intentionally left unchanged.

## Commit Lineage

- `1a1a9412ee088d1d2d77fc1f8224fc55fee1e072` — authored by Shixi Li; cherry-picked from PR #934 commit `7cc106093a2e9f24ccb2da977bbdcb1f64160e6e`; identical stable patch ID `940162cbc65b7f0575e79dd9bbc550be9c695534`.
- `f3ada6e89b5dba33e5e39965d1cac047bbef5e91` — canonical refinement on current `main` covering timeout semantics, safe fallback boundaries, accounting/persistence, tests, UI, and documentation.

## Release Note

Ensemble aggregators now use an idle/stall timeout. A silent aggregator falls back once when `fallback_single` is configured, while partial visible output remains terminal to prevent duplicated output, tool activity, or billing.

## Tests

- `uv run --extra dev pytest -q tests/test_provider_ensemble.py tests/test_engine/test_usage_event_accounting.py tests/test_engine/test_agent_usage_tracker_billed_propagation.py tests/test_llm_ensemble_config.py tests/test_engine/turn_runner/test_turn_finalizer_stage_unit.py` — 245 passed.
- `uv run --extra dev ruff check src tests` — passed.
- `uv run --extra dev mypy src/opensquilla --show-error-codes --ignore-missing-imports` — passed across 931 source files.
- WebUI `vue-tsc --noEmit` — passed.
- Full WebUI Vitest suite — 329 files / 3,732 tests passed.
- WebUI architecture, security, design-token, theme, i18n, and locale guard suites — passed.
- Vite production build and static-dist verification — passed (815 modules; 198 output files).
- `uv build --wheel` after the required WebUI static build — passed (`opensquilla-0.5.3-py3-none-any.whl`).
- `git diff --check origin/main..HEAD` — passed.
- Regression tests added: zero-output timeout fallback, active streaming beyond the idle budget, partial text/reasoning/tool output timeout, error policy, fallback failure, retained retry usage, request counts, bounded cleanup, configured/effective UI facts, and single persistence finalization.

Platform limitations:

- Validation was run locally on macOS without live provider credentials; timeout/provider behavior is exercised with deterministic async fakes.
- The bundled pnpm dependency setup reported its ignored-builds policy for `vue-demi`; type checking, the complete Vitest suite, Vite build, dist verification, and wheel build all completed successfully afterward.
- GitHub CI for this refined branch is not yet available at PR creation time; PR #934's inherited patch currently has green checks.

## Maintainer Live Check

Maintainer live check required: no

Surface: Ensemble provider runtime and setup UI

Instructions: N/A; automated coverage exercises all new timeout/fallback branches without external credentials.

## Safety

- Prevents duplicate visible output and tool activity by forbidding transparent recovery after any visible aggregator delta.
- Prevents repeated full-budget aggregator stalls and duplicate billing attempts on timeout.
- Preserves proposer and prior-attempt usage evidence; missing upstream receipts remain explicitly unknown rather than guessed.
- Keeps fallback on the original user conversation, never on the synthetic candidate envelope.

## Third-Party Origin

Third-party origin: none

Details: N/A. Commit authorship and source SHA from the existing repository PR are retained in Commit Lineage.

## Documentation Changes

- [x] User-facing documentation updated
- [x] Configuration example updated
- [x] Setup UI copy updated

