### PR TITLE
Fix pasted composer state synchronization (#1017)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,7 @@ jobs:
         run: >-
           npm run test:e2e --
           assistant-activity.spec.ts
+          composer-paste.spec.ts
           history-hydration.spec.ts
           session-created-card.spec.ts
           goal-mode.spec.ts

--- a/opensquilla-webui/e2e/composer-paste.spec.ts
+++ b/opensquilla-webui/e2e/composer-paste.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test'
+
+const CONTROL_URL = '/control/chat/new'
+
+test('clipboard paste restores send readiness after stale IME composition', async ({ context, page }) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+  await page.goto(CONTROL_URL)
+  await expect(page.locator('.conn-pill.connected')).toBeVisible({ timeout: 10_000 })
+
+  const textarea = page.locator('.chat-textarea')
+  const sendButton = page.locator('.chat-send-btn[aria-label="Send"]')
+  await expect(textarea).toBeVisible()
+  await textarea.focus()
+
+  const pastedText = 'pasted from the Chromium clipboard'
+  await page.evaluate(async text => navigator.clipboard.writeText(text), pastedText)
+
+  // Leave Vue's element-level composing flag set, matching the Windows/IME
+  // state from #1017, then use the browser's real clipboard shortcut. The DOM
+  // receives the text even though vModelText ignores the input event.
+  await textarea.dispatchEvent('compositionstart')
+  await page.keyboard.press('ControlOrMeta+V')
+
+  await expect(textarea).toHaveValue(pastedText)
+  await expect(sendButton).toHaveClass(/is-ready/)
+})

--- a/opensquilla-webui/src/components/chat/ChatComposer.paste.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatComposer.paste.test.ts
@@ -38,6 +38,8 @@ const BASE_PROPS = {
   sendButtonTitle: 'Send',
   runMode: 'trusted',
   allowedRunModes: ['standard', 'trusted', 'full'],
+  runModeLocked: false,
+  runModeLockMessage: '',
   modelRoutingMode: 'llm_ensemble',
   modelRoutingSettingsBusy: false,
   routerVisualEffectsEnabled: true,
@@ -84,6 +86,8 @@ const ComposerWrapper = defineComponent({
       send-button-title="Send"
       :run-mode="'trusted'"
       :allowed-run-modes="['standard', 'trusted', 'full']"
+      :run-mode-locked="false"
+      run-mode-lock-message=""
       :model-routing-mode="'llm_ensemble'"
       :model-routing-settings-busy="false"
       :router-visual-effects-enabled="true"
@@ -92,11 +96,14 @@ const ComposerWrapper = defineComponent({
       :voice-busy="false"
       :voice-recording="false"
       :voice-ready="true"
-      @send="() => {}"
+      @input="observedAtInput.push(text)"
+      @send="sent.push(text)"
     />`,
   setup() {
     const text = ref('')
-    return { text }
+    const observedAtInput = ref<string[]>([])
+    const sent = ref<string[]>([])
+    return { observedAtInput, sent, text }
   },
 })
 
@@ -105,7 +112,11 @@ function mountWrapper() {
   document.body.appendChild(el)
   const app = createApp(ComposerWrapper)
   app.use(i18n)
-  const instance = app.mount(el) as unknown as { text: string }
+  const instance = app.mount(el) as unknown as {
+    observedAtInput: string[]
+    sent: string[]
+    text: string
+  }
   const textarea = el.querySelector<HTMLTextAreaElement>('.chat-textarea')
   if (!textarea) throw new Error('textarea not rendered')
   return { textarea, el, instance }
@@ -126,6 +137,12 @@ function sendButtonReady(el: HTMLElement): boolean {
   const button = el.querySelector<HTMLButtonElement>('.chat-send-btn')
   if (!button) throw new Error('send button not rendered')
   return button.classList.contains('is-ready')
+}
+
+function clickSend(el: HTMLElement) {
+  const button = el.querySelector<HTMLButtonElement>('.chat-send-btn')
+  if (!button) throw new Error('send button not rendered')
+  button.click()
 }
 
 afterEach(() => {
@@ -152,7 +169,26 @@ describe('ChatComposer paste → model sync', () => {
 
     // User-visible contract: the pasted text reached the parent model…
     expect(instance.text).toBe('pasted during stale composition')
+    // …parent input consumers observed the reconciled value…
+    expect(instance.observedAtInput).toEqual(['pasted during stale composition'])
     // …and the send button is ready.
     expect(sendButtonReady(el)).toBe(true)
+
+    clickSend(el)
+    expect(instance.sent).toEqual(['pasted during stale composition'])
+  })
+
+  it('preserves the normal IME composition lifecycle', async () => {
+    const { textarea, instance } = mountWrapper()
+
+    textarea.dispatchEvent(new Event('compositionstart'))
+    textarea.value = '输入'
+    textarea.dispatchEvent(new InputEvent('input', { inputType: 'insertCompositionText' }))
+    await nextTick()
+    expect(instance.text).toBe('')
+
+    textarea.dispatchEvent(new Event('compositionend'))
+    await nextTick()
+    expect(instance.text).toBe('输入')
   })
 })

--- a/opensquilla-webui/src/components/chat/ChatComposer.paste.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatComposer.paste.test.ts
@@ -8,13 +8,22 @@
 // @vue/runtime-dom — `if (e.target.composing) return`). On Windows, a paste
 // can land while that flag is stale after a composition round-trip, so the
 // v-model never observes the pasted text and `hasSendContent` (the send
-// button's readiness) stays false. The next composed keystroke's
-// compositionend clears the flag and re-dispatches an input event, which is
-// why typing one character "fixed" it. The fix force-syncs the model to the
-// textarea's real DOM value on every paste.
+// button's readiness) stays false.
+//
+// Timing matters: in real browsers the paste event fires BEFORE the default
+// insertion mutates the DOM, so a paste-handler (or nextTick scheduled from
+// it) reads an empty value. The input event with inputType "insertFromPaste"
+// fires AFTER the browser has written the pasted text; the composer syncs
+// the model from the DOM at that stage, restoring readiness even when
+// vModelText skipped the update.
+//
+// The tests model the real Chromium order (paste → beforeinput → input, with
+// textarea.value mutated between beforeinput and input) and assert the
+// user-visible contract: the pasted text reaches the parent model and the
+// send button becomes ready.
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { createApp, nextTick } from 'vue'
+import { createApp, defineComponent, nextTick, ref } from 'vue'
 import i18n from '@/i18n'
 import ChatComposer from './ChatComposer.vue'
 
@@ -58,13 +67,65 @@ function mountComposer() {
   return { updates, textarea, el }
 }
 
-async function simulatePaste(textarea: HTMLTextAreaElement, text: string) {
-  // Real browser paste order: paste → beforeinput → input.
-  textarea.value = text
+/** Parent wrapper mirroring ChatView's usage: send readiness derives from
+ * the model, so a model sync must visibly enable the send path. */
+const ComposerWrapper = defineComponent({
+  components: { ChatComposer },
+  template: `
+    <ChatComposer
+      v-model="text"
+      :attachments="[]"
+      :busy-send-mode="'queue'"
+      :has-send-content="text.trim().length > 0"
+      :is-streaming="false"
+      :can-stop="false"
+      :is-new-landing="false"
+      placeholder="Send a message"
+      send-button-title="Send"
+      :run-mode="'trusted'"
+      :allowed-run-modes="['standard', 'trusted', 'full']"
+      :model-routing-mode="'llm_ensemble'"
+      :model-routing-settings-busy="false"
+      :router-visual-effects-enabled="true"
+      :coding-mode-enabled="false"
+      :coding-mode-settings-busy="false"
+      :voice-busy="false"
+      :voice-recording="false"
+      :voice-ready="true"
+      @send="() => {}"
+    />`,
+  setup() {
+    const text = ref('')
+    return { text }
+  },
+})
+
+function mountWrapper() {
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  const app = createApp(ComposerWrapper)
+  app.use(i18n)
+  const instance = app.mount(el) as unknown as { text: string }
+  const textarea = el.querySelector<HTMLTextAreaElement>('.chat-textarea')
+  if (!textarea) throw new Error('textarea not rendered')
+  return { textarea, el, instance }
+}
+
+/** Model the real Chromium paste order: paste → beforeinput → input. The
+ * browser's default insertion mutates textarea.value between beforeinput
+ * and input — the DOM value only exists at the input stage. */
+async function simulateRealPaste(textarea: HTMLTextAreaElement, text: string) {
   textarea.dispatchEvent(new Event('paste'))
+  textarea.dispatchEvent(new InputEvent('beforeinput', { inputType: 'insertFromPaste' }))
+  textarea.value = text // browser default insertion (between beforeinput and input)
   textarea.dispatchEvent(new InputEvent('input', { inputType: 'insertFromPaste' }))
   await nextTick()
-  await nextTick()
+}
+
+function sendButtonReady(el: HTMLElement): boolean {
+  const button = el.querySelector<HTMLButtonElement>('.chat-send-btn')
+  if (!button) throw new Error('send button not rendered')
+  return button.classList.contains('is-ready')
 }
 
 afterEach(() => {
@@ -73,22 +134,25 @@ afterEach(() => {
 })
 
 describe('ChatComposer paste → model sync', () => {
-  it('updates the model on a plain paste', async () => {
+  it('updates the parent model on a plain paste', async () => {
     const { updates, textarea } = mountComposer()
-    await simulatePaste(textarea, 'hello from clipboard')
+    await simulateRealPaste(textarea, 'hello from clipboard')
     expect(updates[updates.length - 1]).toBe('hello from clipboard')
   })
 
-  it('updates the model when pasting while the IME composition flag is stale', async () => {
-    const { updates, textarea } = mountComposer()
+  it('restores send readiness on paste during stale composition', async () => {
+    const { textarea, el, instance } = mountWrapper()
 
     // Stale-composition simulation: Vue's compositionstart listener sets the
     // element's internal `composing` flag, which makes vModelText skip the
     // following input event — the exact state that stranded pasted text on
-    // Windows. The paste handler must sync the model regardless.
+    // Windows.
     textarea.dispatchEvent(new Event('compositionstart'))
-    await simulatePaste(textarea, 'pasted during stale composition')
+    await simulateRealPaste(textarea, 'pasted during stale composition')
 
-    expect(updates[updates.length - 1]).toBe('pasted during stale composition')
+    // User-visible contract: the pasted text reached the parent model…
+    expect(instance.text).toBe('pasted during stale composition')
+    // …and the send button is ready.
+    expect(sendButtonReady(el)).toBe(true)
   })
 })

--- a/opensquilla-webui/src/components/chat/ChatComposer.paste.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatComposer.paste.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+//
+// Regression: pasting text into the composer could leave the send button
+// disabled until the next composed keystroke (issue #1017).
+//
+// Mechanism: Vue's vModelText input listener skips model updates while the
+// element's internal IME-composition flag is set (see vModelText in
+// @vue/runtime-dom — `if (e.target.composing) return`). On Windows, a paste
+// can land while that flag is stale after a composition round-trip, so the
+// v-model never observes the pasted text and `hasSendContent` (the send
+// button's readiness) stays false. The next composed keystroke's
+// compositionend clears the flag and re-dispatches an input event, which is
+// why typing one character "fixed" it. The fix force-syncs the model to the
+// textarea's real DOM value on every paste.
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick } from 'vue'
+import i18n from '@/i18n'
+import ChatComposer from './ChatComposer.vue'
+
+const BASE_PROPS = {
+  attachments: [],
+  busySendMode: 'queue',
+  hasSendContent: false,
+  isStreaming: false,
+  canStop: false,
+  isNewLanding: false,
+  placeholder: 'Send a message',
+  sendButtonTitle: 'Send',
+  runMode: 'trusted',
+  allowedRunModes: ['standard', 'trusted', 'full'],
+  modelRoutingMode: 'llm_ensemble',
+  modelRoutingSettingsBusy: false,
+  routerVisualEffectsEnabled: true,
+  codingModeEnabled: false,
+  codingModeSettingsBusy: false,
+  voiceBusy: false,
+  voiceRecording: false,
+  voiceReady: true,
+}
+
+function mountComposer() {
+  const updates: string[] = []
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  const app = createApp(ChatComposer, {
+    ...BASE_PROPS,
+    modelValue: '',
+    'onUpdate:modelValue': (value: string) => {
+      updates.push(value)
+    },
+    onSend: vi.fn(),
+  })
+  app.use(i18n)
+  app.mount(el)
+  const textarea = el.querySelector<HTMLTextAreaElement>('.chat-textarea')
+  if (!textarea) throw new Error('textarea not rendered')
+  return { updates, textarea, el }
+}
+
+async function simulatePaste(textarea: HTMLTextAreaElement, text: string) {
+  // Real browser paste order: paste → beforeinput → input.
+  textarea.value = text
+  textarea.dispatchEvent(new Event('paste'))
+  textarea.dispatchEvent(new InputEvent('input', { inputType: 'insertFromPaste' }))
+  await nextTick()
+  await nextTick()
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  i18n.global.locale.value = 'en'
+})
+
+describe('ChatComposer paste → model sync', () => {
+  it('updates the model on a plain paste', async () => {
+    const { updates, textarea } = mountComposer()
+    await simulatePaste(textarea, 'hello from clipboard')
+    expect(updates[updates.length - 1]).toBe('hello from clipboard')
+  })
+
+  it('updates the model when pasting while the IME composition flag is stale', async () => {
+    const { updates, textarea } = mountComposer()
+
+    // Stale-composition simulation: Vue's compositionstart listener sets the
+    // element's internal `composing` flag, which makes vModelText skip the
+    // following input event — the exact state that stranded pasted text on
+    // Windows. The paste handler must sync the model regardless.
+    textarea.dispatchEvent(new Event('compositionstart'))
+    await simulatePaste(textarea, 'pasted during stale composition')
+
+    expect(updates[updates.length - 1]).toBe('pasted during stale composition')
+  })
+})

--- a/opensquilla-webui/src/components/chat/ChatComposer.vue
+++ b/opensquilla-webui/src/components/chat/ChatComposer.vue
@@ -72,8 +72,7 @@
             :aria-label="t('chat.messageToSend')"
             :aria-describedby="sendBlockedMessage ? 'chat-composer-send-status' : undefined"
             @beforeinput="emit('expand'); emit('beforeinput', $event)"
-            @paste="onTextareaPaste"
-            @input="emit('input', $event)"
+            @input="onTextareaInput"
             @keydown="emit('keydown', $event)"
             @compositionstart="emit('compositionChange', true)"
             @compositionend="emit('compositionChange', false)"
@@ -476,20 +475,28 @@ const inputText = defineModel<string>({ required: true })
 const composerEl = ref<HTMLElement | null>(null)
 const textareaEl = ref<HTMLTextAreaElement | null>(null)
 
-function onTextareaPaste() {
+function onTextareaInput(event: Event) {
+  emit('input', event)
   // vModelText skips model updates while the element's internal IME
   // composition flag is set (`if (e.target.composing) return` in
-  // @vue/runtime-dom). On Windows a paste can land while that flag is stale
-  // after a composition round-trip, leaving the model — and the send
-  // button's readiness — out of sync with what the textarea displays.
-  // Force the model to follow the DOM value after every paste; this is a
-  // no-op whenever v-model already picked up the change.
-  nextTick(() => {
-    const field = textareaEl.value
+  // @vue/runtime-dom). On Windows a paste can land while that flag is
+  // stale after a composition round-trip, leaving the model — and the
+  // send button's readiness — out of sync with what the textarea shows.
+  //
+  // A paste handler cannot repair this: in real browsers the paste event
+  // fires BEFORE the default insertion mutates the DOM, so any handler
+  // (or nextTick scheduled from it) still reads the empty value. The
+  // input event with inputType "insertFromPaste" fires AFTER the browser
+  // has written the pasted text, so syncing the model from the DOM at
+  // that stage restores readiness even when vModelText skipped the
+  // update. This is a no-op whenever v-model already picked up the
+  // change.
+  if (event instanceof InputEvent && event.inputType === 'insertFromPaste') {
+    const field = event.target as HTMLTextAreaElement | null
     if (field && inputText.value !== field.value) {
       inputText.value = field.value
     }
-  })
+  }
 }
 
 const fileInputEl = ref<HTMLInputElement | null>(null)

--- a/opensquilla-webui/src/components/chat/ChatComposer.vue
+++ b/opensquilla-webui/src/components/chat/ChatComposer.vue
@@ -72,6 +72,7 @@
             :aria-label="t('chat.messageToSend')"
             :aria-describedby="sendBlockedMessage ? 'chat-composer-send-status' : undefined"
             @beforeinput="emit('expand'); emit('beforeinput', $event)"
+            @paste="onTextareaPaste"
             @input="emit('input', $event)"
             @keydown="emit('keydown', $event)"
             @compositionstart="emit('compositionChange', true)"
@@ -474,6 +475,23 @@ const { t } = useI18n()
 const inputText = defineModel<string>({ required: true })
 const composerEl = ref<HTMLElement | null>(null)
 const textareaEl = ref<HTMLTextAreaElement | null>(null)
+
+function onTextareaPaste() {
+  // vModelText skips model updates while the element's internal IME
+  // composition flag is set (`if (e.target.composing) return` in
+  // @vue/runtime-dom). On Windows a paste can land while that flag is stale
+  // after a composition round-trip, leaving the model — and the send
+  // button's readiness — out of sync with what the textarea displays.
+  // Force the model to follow the DOM value after every paste; this is a
+  // no-op whenever v-model already picked up the change.
+  nextTick(() => {
+    const field = textareaEl.value
+    if (field && inputText.value !== field.value) {
+      inputText.value = field.value
+    }
+  })
+}
+
 const fileInputEl = ref<HTMLInputElement | null>(null)
 const addMenuOpen = ref(false)
 const modelRoutingOpen = ref(false)

--- a/opensquilla-webui/src/components/chat/ChatComposer.vue
+++ b/opensquilla-webui/src/components/chat/ChatComposer.vue
@@ -476,7 +476,6 @@ const composerEl = ref<HTMLElement | null>(null)
 const textareaEl = ref<HTMLTextAreaElement | null>(null)
 
 function onTextareaInput(event: Event) {
-  emit('input', event)
   // vModelText skips model updates while the element's internal IME
   // composition flag is set (`if (e.target.composing) return` in
   // @vue/runtime-dom). On Windows a paste can land while that flag is
@@ -492,11 +491,16 @@ function onTextareaInput(event: Event) {
   // update. This is a no-op whenever v-model already picked up the
   // change.
   if (event instanceof InputEvent && event.inputType === 'insertFromPaste') {
-    const field = event.target as HTMLTextAreaElement | null
-    if (field && inputText.value !== field.value) {
+    const field = event.currentTarget
+    if (field instanceof HTMLTextAreaElement
+      && field === textareaEl.value
+      && inputText.value !== field.value) {
       inputText.value = field.value
     }
   }
+  // Keep parent input consumers (auto-resize, slash commands, draft state)
+  // downstream of the reconciliation so they observe the pasted model.
+  emit('input', event)
 }
 
 const fileInputEl = ref<HTMLInputElement | null>(null)

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -1438,8 +1438,23 @@ def test_webui_chat_recovery_runs_the_verified_dist_through_gateway() -> None:
     assert install_gateway["run"] == "uv sync --frozen"
     assert job["env"]["OPENSQUILLA_PLAYWRIGHT_MANAGE_WEBUI"] == "gateway"
     assert job["env"]["OPENSQUILLA_WEBUI_BASE_URL"].endswith(":18791")
-    assert "history-hydration.spec.ts" in run["run"]
-    assert "goal-mode.spec.ts" in run["run"]
+    selected_specs = {
+        argument
+        for argument in run["run"].split()
+        if argument.endswith(".spec.ts")
+    }
+    required_specs = {
+        "assistant-activity.spec.ts",
+        "composer-paste.spec.ts",
+        "goal-mode.spec.ts",
+        "history-hydration.spec.ts",
+        "queue-steer.spec.ts",
+        "session-created-card.spec.ts",
+        "share.spec.ts",
+    }
+    assert selected_specs == required_specs
+    for spec in required_specs:
+        assert (Path("opensquilla-webui/e2e") / spec).is_file()
 
 
 def test_windows_smoke_does_not_install_bun_by_default() -> None:


### PR DESCRIPTION
## Problem and root cause

Issue #1017 reports that pasted text can appear in the composer while the Send button remains disabled. When an IME leaves the textarea's composing state stale, Vue's `v-model` input handling can ignore the browser's paste input even though the DOM value has changed. The parent model and send-readiness state then remain stale.

## Changes

- Synchronize the composer model from the actual textarea value for `insertFromPaste` before notifying parent input consumers.
- Preserve normal IME composition behavior and validate the input event belongs to the composer textarea.
- Add focused unit regressions for stale composition, parent-observer ordering, sending pasted text, and normal IME lifecycle.
- Add a real Chromium clipboard regression against the managed production gateway.
- Register the browser spec in the existing CI browser job and add a mechanical workflow inventory check so hard-coded browser specs cannot silently drift.

## Non-goals

- No changes for #1048 (sending after long-task completion).
- No changes for #1031 (steer/follow-up behavior).
- No broader composer/task state-machine refactor and no backend or RPC behavior changes.

## Tests

- `uv run pytest -q tests/test_ci/test_workflows.py` — 90 passed.
- Focused Vitest run for `ChatComposer.paste.test.ts` — 3 passed.
- `npm run typecheck` — passed.
- `npm run build` — passed (existing Vite large-chunk advisory only).
- Managed-gateway Chromium run of `composer-paste.spec.ts` — 1 passed.
- `git diff --check origin/main..HEAD` — passed.

## Platform limitations

The real clipboard regression was run in Chromium on macOS using `ControlOrMeta+V`, with a real managed OpenSquilla gateway. It deterministically recreates the stale-composition condition, but no manual physical Windows IME session was available locally. CI exercises Chromium on Linux.

## Commit Lineage

This branch preserves the reusable implementation and authorship from source PR #1020 by Kiuyor:

- `fb6d83a7c8eab361b3b375b6bc94a43c2938f610` — Kiuyor; adapted from source commit `c2bc8e57392539f5cf35a9d13de463792f383e07` with cherry-pick provenance.
- `1836b11b0bca753c1c589c844ddc1e8590a53008` — Kiuyor; adapted from source/head commit `1c308c1b61865d1b7005d6df6af6e2165235e79c` with cherry-pick provenance.
- `5499cd5dd352684c6fc72dc9a9a3141b75e764fb` — follow-up fixing observer ordering and extending regressions.
- `bbb50619024030ba811d8b2b455a5ca05eded259` — follow-up adding real-browser CI coverage and workflow inventory enforcement.

Range-diff paired both Kiuyor commits with their local adaptations. The focused test blob is identical at the imported boundary; the composer template adaptation preserves current-main behavior, and the later local commits address review and CI findings.

## Existing PR relationship

Source PR #1020 remains open and untouched. Its current head is `1c308c1b61865d1b7005d6df6af6e2165235e79c`; it has requested changes and conflicts with current `main`. This PR carries its effective implementation onto current `main`, preserves Kiuyor's authorship/source SHAs, and adds the review and CI follow-ups above.

Fixes #1017
