### PR TITLE
Match Zhipu reasoning dialects to the official API root

### DIFF
--- a/scripts/live_provider_profile_smoke.py
+++ b/scripts/live_provider_profile_smoke.py
@@ -20,6 +20,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from opensquilla.engine.pricing import estimate_cost, resolve_model_price  # noqa: E402
+from opensquilla.provider.compat_policy import effective_reasoning_format  # noqa: E402
 from opensquilla.provider.model_catalog import ModelCatalog  # noqa: E402
 from opensquilla.provider.openai import _versioned_api_url  # noqa: E402
 from opensquilla.provider.reasoning_dialects import (  # noqa: E402
@@ -278,9 +279,14 @@ def _apply_direct_reasoning_off(
     if not caps.supports_reasoning:
         return
     spec = get_provider_spec(provider)
+    reasoning_format = effective_reasoning_format(
+        spec.compat,
+        caps.reasoning_format,
+        base_url,
+    )
     apply_reasoning_disable(
         payload,
-        caps.reasoning_format,
+        reasoning_format,
         ReasoningDisableArgs(
             model=model,
             disable_reasoning_by_default_models=(

--- a/scripts/live_provider_thinking_smoke.py
+++ b/scripts/live_provider_thinking_smoke.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import httpx
 
+from opensquilla.provider.compat_policy import effective_reasoning_format
 from opensquilla.provider.model_catalog import ModelCatalog
 from opensquilla.provider.registry import get_provider_spec
 from opensquilla.provider.selector import ProviderConfig, _build_provider
@@ -92,6 +93,8 @@ def _chat_url(base_url: str) -> str:
 def _provider_thinking_payload(
     provider: str,
     *,
+    model: str,
+    base_url: str,
     enabled: bool,
     budget: int,
 ) -> dict[str, Any]:
@@ -107,7 +110,21 @@ def _provider_thinking_payload(
         if enabled:
             payload["reasoning_effort"] = "high"
         return payload
-    if provider in {"moonshot", "volcengine", "zhipu"}:
+    if provider == "zhipu":
+        caps = ModelCatalog().get_capabilities(
+            model,
+            provider_name=provider,
+            base_url=base_url,
+        )
+        dialect = effective_reasoning_format(
+            get_provider_spec(provider).compat,
+            caps.reasoning_format,
+            base_url,
+        )
+        if dialect != "zai":
+            return {}
+        return {"thinking": {"type": "enabled" if enabled else "disabled"}}
+    if provider in {"moonshot", "volcengine"}:
         return {"thinking": {"type": "enabled" if enabled else "disabled"}}
     return {}
 
@@ -152,7 +169,13 @@ async def _direct_case(
             }
         ],
         "max_tokens": max_tokens,
-        **_provider_thinking_payload(provider, enabled=enabled, budget=thinking_budget),
+        **_provider_thinking_payload(
+            provider,
+            model=model,
+            base_url=base_url,
+            enabled=enabled,
+            budget=thinking_budget,
+        ),
     }
     start = time.perf_counter()
     try:

--- a/src/opensquilla/endpoint_identity.py
+++ b/src/opensquilla/endpoint_identity.py
@@ -59,6 +59,11 @@ def base_url_matches_official_api(
     candidate = str(candidate_base_url or "").strip() or official
     if not official or not candidate:
         return False
+    # ``urlsplit`` normalizes a present-but-empty query or fragment to an
+    # empty string. Preserve strict root identity by rejecting the raw URL
+    # delimiters themselves; percent-encoded path characters remain valid.
+    if "?" in official or "#" in official or "?" in candidate or "#" in candidate:
+        return False
     try:
         official_parts = urlsplit(official)
         candidate_parts = urlsplit(candidate)

--- a/src/opensquilla/provider/compat_policy.py
+++ b/src/opensquilla/provider/compat_policy.py
@@ -258,6 +258,11 @@ class OpenAICompatPolicy:
     # Reasoning format assumed when no model capabilities are available.
     default_reasoning_format: str = ""
 
+    # Whether the reasoning dialect's payload (e.g. a vendor-specific
+    # ``thinking`` object) is only valid on this provider's official_host;
+    # off-host requests omit it instead of sending an unrecognized field.
+    reasoning_dialect_requires_official_host: bool = False
+
     # Models that need an explicit thinking enable/disable payload even when
     # no capability profile is available (exact ids, lowercase).
     thinking_toggle_model_ids: frozenset[str] = frozenset()
@@ -477,7 +482,11 @@ _POLICIES_BY_KIND: dict[str, OpenAICompatPolicy] = {
     "mimo": OpenAICompatPolicy(display_name="MiMo"),
     "mistral": OpenAICompatPolicy(display_name="Mistral"),
     "groq": OpenAICompatPolicy(display_name="Groq"),
-    "zhipu": OpenAICompatPolicy(display_name="Zhipu"),
+    "zhipu": OpenAICompatPolicy(
+        display_name="Zhipu",
+        official_host="open.bigmodel.cn",
+        reasoning_dialect_requires_official_host=True,
+    ),
     "qianfan": OpenAICompatPolicy(display_name="Qianfan"),
     "siliconflow": OpenAICompatPolicy(display_name="SiliconFlow"),
     "aihubmix": OpenAICompatPolicy(display_name="AiHubMix"),

--- a/src/opensquilla/provider/compat_policy.py
+++ b/src/opensquilla/provider/compat_policy.py
@@ -21,6 +21,8 @@ from fnmatch import fnmatchcase
 from typing import Literal
 from urllib.parse import urlsplit
 
+from opensquilla.endpoint_identity import base_url_matches_official_api
+
 from .model_identity import DEEPSEEK_V4_MODEL_IDS
 from .qwen_token_plan import (
     QWEN_TOKEN_PLAN_DEEPSEEK_V4_MODEL_IDS,
@@ -338,6 +340,26 @@ class OpenAICompatPolicy:
         """
 
         return self.text_tool_profile.enabled
+
+
+def effective_reasoning_format(
+    policy: OpenAICompatPolicy,
+    reasoning_format: str,
+    base_url: str,
+) -> str:
+    """Suppress a provider-native dialect outside its exact official API root."""
+
+    restricted_dialect = policy.official_reasoning_dialect.strip().lower()
+    if (
+        restricted_dialect
+        and reasoning_format.strip().lower() == restricted_dialect
+        and not base_url_matches_official_api(
+            policy.official_reasoning_api_root,
+            base_url,
+        )
+    ):
+        return ""
+    return reasoning_format
 
 
 _ARK_UNSUPPORTED_TOOL_SCHEMA_KEYWORDS = frozenset(

--- a/src/opensquilla/provider/compat_policy.py
+++ b/src/opensquilla/provider/compat_policy.py
@@ -258,10 +258,11 @@ class OpenAICompatPolicy:
     # Reasoning format assumed when no model capabilities are available.
     default_reasoning_format: str = ""
 
-    # Whether the reasoning dialect's payload (e.g. a vendor-specific
-    # ``thinking`` object) is only valid on this provider's official_host;
-    # off-host requests omit it instead of sending an unrecognized field.
-    reasoning_dialect_requires_official_host: bool = False
+    # One provider-native reasoning dialect may be valid only at an exact API
+    # root. A custom endpoint using another explicitly configured dialect is
+    # unaffected, and an empty pair leaves compatible relays unrestricted.
+    official_reasoning_dialect: str = ""
+    official_reasoning_api_root: str = ""
 
     # Models that need an explicit thinking enable/disable payload even when
     # no capability profile is available (exact ids, lowercase).
@@ -485,7 +486,8 @@ _POLICIES_BY_KIND: dict[str, OpenAICompatPolicy] = {
     "zhipu": OpenAICompatPolicy(
         display_name="Zhipu",
         official_host="open.bigmodel.cn",
-        reasoning_dialect_requires_official_host=True,
+        official_reasoning_dialect="zai",
+        official_reasoning_api_root="https://open.bigmodel.cn/api/paas/v4",
     ),
     "qianfan": OpenAICompatPolicy(display_name="Qianfan"),
     "siliconflow": OpenAICompatPolicy(display_name="SiliconFlow"),

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -20,6 +20,7 @@ from uuid import uuid4
 import httpx
 import structlog
 
+from opensquilla.endpoint_identity import base_url_matches_official_api
 from opensquilla.env import trust_env as _trust_env
 from opensquilla.execution_status import compact_provider_status, derive_is_error
 from opensquilla.safety.secret_redaction import redact_secret_text
@@ -729,9 +730,15 @@ def _effective_reasoning_format(
     reasoning_format: str,
     base_url: str,
 ) -> str:
-    """Suppress a reasoning dialect that only the official host understands."""
-    if policy.reasoning_dialect_requires_official_host and not _on_official_host(
-        policy, base_url
+    """Suppress one provider-native dialect outside its exact official API root."""
+    restricted_dialect = policy.official_reasoning_dialect.strip().lower()
+    if (
+        restricted_dialect
+        and reasoning_format.strip().lower() == restricted_dialect
+        and not base_url_matches_official_api(
+            policy.official_reasoning_api_root,
+            base_url,
+        )
     ):
         return ""
     return reasoning_format
@@ -3447,18 +3454,19 @@ class OpenAIProvider:
         if (caps and caps.supports_reasoning and cfg.thinking) or (
             thinking_toggle_model and cfg.thinking
         ):
-            reasoning_format = (
+            resolved_reasoning_format = (
                 reasoning_rule.reasoning_format
                 if reasoning_rule and reasoning_rule.reasoning_format
-                else _effective_reasoning_format(
-                    self._compat,
-                    (
-                        caps.reasoning_format
-                        if caps is not None
-                        else self._compat.default_reasoning_format
-                    ),
-                    self._base_url,
+                else (
+                    caps.reasoning_format
+                    if caps is not None
+                    else self._compat.default_reasoning_format
                 )
+            )
+            reasoning_format = _effective_reasoning_format(
+                self._compat,
+                resolved_reasoning_format,
+                self._base_url,
             )
             reasoning_effort_override: str | None = None
             if reasoning_rule and reasoning_rule.reasoning_format:
@@ -3511,9 +3519,14 @@ class OpenAIProvider:
                     "none",
                     "off",
                 }:
+                    reasoning_format = _effective_reasoning_format(
+                        self._compat,
+                        reasoning_rule.reasoning_format,
+                        self._base_url,
+                    )
                     apply_reasoning_disable(
                         payload,
-                        reasoning_rule.reasoning_format,
+                        reasoning_format,
                         ReasoningDisableArgs(model=self._model),
                     )
             else:

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -724,6 +724,19 @@ def _on_official_host(policy: OpenAICompatPolicy, base_url: str) -> bool:
     return bool(policy.official_host) and policy.official_host in base_url.lower()
 
 
+def _effective_reasoning_format(
+    policy: OpenAICompatPolicy,
+    reasoning_format: str,
+    base_url: str,
+) -> str:
+    """Suppress a reasoning dialect that only the official host understands."""
+    if policy.reasoning_dialect_requires_official_host and not _on_official_host(
+        policy, base_url
+    ):
+        return ""
+    return reasoning_format
+
+
 def _uses_max_completion_tokens(
     policy: OpenAICompatPolicy,
     base_url: str,
@@ -3437,10 +3450,14 @@ class OpenAIProvider:
             reasoning_format = (
                 reasoning_rule.reasoning_format
                 if reasoning_rule and reasoning_rule.reasoning_format
-                else (
-                    caps.reasoning_format
-                    if caps is not None
-                    else self._compat.default_reasoning_format
+                else _effective_reasoning_format(
+                    self._compat,
+                    (
+                        caps.reasoning_format
+                        if caps is not None
+                        else self._compat.default_reasoning_format
+                    ),
+                    self._base_url,
                 )
             )
             reasoning_effort_override: str | None = None
@@ -3504,7 +3521,9 @@ class OpenAIProvider:
         elif caps and caps.supports_reasoning:
             apply_reasoning_disable(
                 payload,
-                caps.reasoning_format,
+                _effective_reasoning_format(
+                    self._compat, caps.reasoning_format, self._base_url
+                ),
                 ReasoningDisableArgs(
                     model=self._model,
                     disable_reasoning_by_default_models=(

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -20,7 +20,6 @@ from uuid import uuid4
 import httpx
 import structlog
 
-from opensquilla.endpoint_identity import base_url_matches_official_api
 from opensquilla.env import trust_env as _trust_env
 from opensquilla.execution_status import compact_provider_status, derive_is_error
 from opensquilla.safety.secret_redaction import redact_secret_text
@@ -41,6 +40,7 @@ from .compat_policy import (
     OpenAICompatPolicy,
     ReasoningModelRule,
     compat_policy_for_kind,
+    effective_reasoning_format,
 )
 from .context_capabilities import supports_openrouter_explicit_prompt_cache
 from .error_redaction import (
@@ -723,25 +723,6 @@ def _strip_think_tags(text: str) -> str:
 
 def _on_official_host(policy: OpenAICompatPolicy, base_url: str) -> bool:
     return bool(policy.official_host) and policy.official_host in base_url.lower()
-
-
-def _effective_reasoning_format(
-    policy: OpenAICompatPolicy,
-    reasoning_format: str,
-    base_url: str,
-) -> str:
-    """Suppress one provider-native dialect outside its exact official API root."""
-    restricted_dialect = policy.official_reasoning_dialect.strip().lower()
-    if (
-        restricted_dialect
-        and reasoning_format.strip().lower() == restricted_dialect
-        and not base_url_matches_official_api(
-            policy.official_reasoning_api_root,
-            base_url,
-        )
-    ):
-        return ""
-    return reasoning_format
 
 
 def _uses_max_completion_tokens(
@@ -3463,7 +3444,7 @@ class OpenAIProvider:
                     else self._compat.default_reasoning_format
                 )
             )
-            reasoning_format = _effective_reasoning_format(
+            reasoning_format = effective_reasoning_format(
                 self._compat,
                 resolved_reasoning_format,
                 self._base_url,
@@ -3519,7 +3500,7 @@ class OpenAIProvider:
                     "none",
                     "off",
                 }:
-                    reasoning_format = _effective_reasoning_format(
+                    reasoning_format = effective_reasoning_format(
                         self._compat,
                         reasoning_rule.reasoning_format,
                         self._base_url,
@@ -3534,7 +3515,7 @@ class OpenAIProvider:
         elif caps and caps.supports_reasoning:
             apply_reasoning_disable(
                 payload,
-                _effective_reasoning_format(
+                effective_reasoning_format(
                     self._compat, caps.reasoning_format, self._base_url
                 ),
                 ReasoningDisableArgs(

--- a/tests/test_live_provider_profile_smoke.py
+++ b/tests/test_live_provider_profile_smoke.py
@@ -27,6 +27,24 @@ def _load_smoke_module():
 smoke = _load_smoke_module()
 
 
+def _load_thinking_smoke_module():
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "scripts"
+        / "live_provider_thinking_smoke.py"
+    )
+    spec = importlib.util.spec_from_file_location("live_provider_thinking_smoke", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+thinking_smoke = _load_thinking_smoke_module()
+
+
 def test_live_smoke_env_maps_cover_openai_zhipu_kimi_and_minimax() -> None:
     assert smoke._MODEL_ENV["anthropic"] == "ANTHROPIC_MODEL"
     assert smoke._BASE_ENV["anthropic"] == "ANTHROPIC_BASE_URL"
@@ -257,10 +275,66 @@ def test_direct_smoke_explicitly_disables_supported_reasoning_dialects(
         payload,
         provider=provider,
         model=model,
-        base_url="https://provider.example/v1",
+        base_url=(
+            "https://open.bigmodel.cn/api/paas/v4"
+            if provider == "zhipu"
+            else "https://provider.example/v1"
+        ),
     )
 
     assert payload == expected
+
+
+@pytest.mark.parametrize("suffix", ["", "/"])
+def test_zhipu_direct_smokes_keep_native_controls_on_official_api(suffix: str) -> None:
+    base_url = f"https://open.bigmodel.cn/api/paas/v4{suffix}"
+    payload: dict[str, Any] = {}
+
+    smoke._apply_direct_reasoning_off(
+        payload,
+        provider="zhipu",
+        model="glm-5.2",
+        base_url=base_url,
+    )
+
+    assert payload == {"thinking": {"type": "disabled"}}
+    assert thinking_smoke._provider_thinking_payload(
+        "zhipu",
+        model="glm-5.2",
+        base_url=base_url,
+        enabled=True,
+        budget=1024,
+    ) == {"thinking": {"type": "enabled"}}
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://relay.example.test/v1",
+        "https://open.bigmodel.cn/api/paas/v4?",
+        "https://open.bigmodel.cn/api/paas/v4#",
+    ],
+)
+def test_zhipu_direct_smokes_omit_native_controls_on_nonofficial_api(
+    base_url: str,
+) -> None:
+    payload: dict[str, Any] = {}
+
+    smoke._apply_direct_reasoning_off(
+        payload,
+        provider="zhipu",
+        model="glm-5.2",
+        base_url=base_url,
+    )
+
+    assert payload == {}
+    assert thinking_smoke._provider_thinking_payload(
+        "zhipu",
+        model="glm-5.2",
+        base_url=base_url,
+        enabled=True,
+        budget=1024,
+    ) == {}
 
 
 def test_live_smoke_parses_csv_model_lists() -> None:

--- a/tests/test_provider_compat_policy.py
+++ b/tests/test_provider_compat_policy.py
@@ -45,6 +45,11 @@ def test_registry_attaches_kind_policy() -> None:
     assert specs["openrouter"].compat.post_terminal_metadata_keys == frozenset(
         {"provider"}
     )
+    assert specs["zhipu"].compat.official_reasoning_dialect == "zai"
+    assert (
+        specs["zhipu"].compat.official_reasoning_api_root
+        == specs["zhipu"].default_base_url
+    )
     assert specs["volcengine"].compat.tool_schema_unsupported_keywords
     assert specs["vllm"].compat.display_name == "OpenAI"  # kind-aliased to openai
 

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -2442,6 +2442,56 @@ def test_zai_non_thinking_sends_provider_disabled_for_default_thinking_model(
     assert captured["payload"]["thinking"] == {"type": "disabled"}
 
 
+def test_zai_thinking_omits_provider_thinking_object_off_official_host(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="glm-5.2",
+        base_url="https://openrouter.ai/api/v1",
+        provider_kind="zhipu",
+    )
+    cfg = ChatConfig(
+        thinking=True,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            supports_tools=True,
+            reasoning_format="zai",
+        ),
+    )
+
+    _collect(provider, cfg)
+
+    assert "thinking" not in captured["payload"]
+
+
+def test_zai_non_thinking_omits_provider_thinking_object_off_official_host(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="glm-5.2",
+        base_url="https://openrouter.ai/api/v1",
+        provider_kind="zhipu",
+    )
+    cfg = ChatConfig(
+        thinking=False,
+        model_capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            supports_tools=True,
+            reasoning_format="zai",
+        ),
+    )
+
+    _collect(provider, cfg)
+
+    assert "thinking" not in captured["payload"]
+
+
 def test_dashscope_cache_on_marks_system_and_latest_user(monkeypatch: Any) -> None:
     captured: dict[str, Any] = {}
     _patch_transport(monkeypatch, captured)

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -11,6 +11,7 @@ import structlog.testing
 
 from opensquilla.engine.types import ThinkingLevel
 from opensquilla.provider.compat_policy import compat_policy_for_kind
+from opensquilla.provider.model_catalog import ModelCatalog
 from opensquilla.provider.openai import (
     OpenAIProvider,
     _build_openai_tool,
@@ -2442,54 +2443,206 @@ def test_zai_non_thinking_sends_provider_disabled_for_default_thinking_model(
     assert captured["payload"]["thinking"] == {"type": "disabled"}
 
 
-def test_zai_thinking_omits_provider_thinking_object_off_official_host(
-    monkeypatch: Any,
-) -> None:
-    captured: dict[str, Any] = {}
-    _patch_transport(monkeypatch, captured)
+_ZHIPU_CATALOG_MODELS = (
+    ("glm-4.5", True),
+    ("glm-4.5-air", True),
+    ("glm-4.5-flash", True),
+    ("glm-4.5v", True),
+    ("glm-4.6", False),
+    ("glm-4.6v", False),
+    ("glm-4.7", True),
+    ("glm-4.7-flash", True),
+    ("glm-4.7-flashx", True),
+    ("glm-5", True),
+    ("glm-5-turbo", True),
+    ("glm-5.1", True),
+    ("glm-5.2", True),
+    ("glm-5v-turbo", True),
+)
+
+
+def _project_zhipu_payload(
+    *,
+    model: str = "glm-5.2",
+    base_url: str,
+    thinking: bool,
+    capabilities: ModelCapabilities,
+    provider_kind: str = "zhipu",
+) -> dict[str, Any]:
     provider = OpenAIProvider(
         api_key="test",
-        model="glm-5.2",
-        base_url="https://openrouter.ai/api/v1",
-        provider_kind="zhipu",
+        model=model,
+        base_url=base_url,
+        provider_kind=provider_kind,
     )
-    cfg = ChatConfig(
+    return provider.project_final_request(
+        [Message(role="user", content="hi")],
+        config=ChatConfig(
+            thinking=thinking,
+            thinking_level=ThinkingLevel.HIGH,
+            model_capabilities=capabilities,
+        ),
+    ).payload
+
+
+@pytest.mark.parametrize(("model", "supports_reasoning"), _ZHIPU_CATALOG_MODELS)
+@pytest.mark.parametrize("thinking", [True, False])
+@pytest.mark.parametrize(
+    ("base_url", "official"),
+    [
+        ("https://open.bigmodel.cn/api/paas/v4", True),
+        ("https://relay.example.test/v1", False),
+    ],
+)
+def test_all_zhipu_catalog_models_scope_zai_to_the_official_api_root(
+    model: str,
+    supports_reasoning: bool,
+    thinking: bool,
+    base_url: str,
+    official: bool,
+) -> None:
+    capabilities = ModelCatalog().get_capabilities(
+        model,
+        provider_name="zhipu",
+        base_url=base_url,
+    )
+    assert capabilities.supports_reasoning is supports_reasoning
+    assert capabilities.reasoning_format == ("zai" if supports_reasoning else "none")
+
+    payload = _project_zhipu_payload(
+        model=model,
+        base_url=base_url,
+        thinking=thinking,
+        capabilities=capabilities,
+    )
+
+    expected = {"type": "enabled" if thinking else "disabled"}
+    if official and supports_reasoning:
+        assert payload["thinking"] == expected
+    else:
+        assert "thinking" not in payload
+
+
+@pytest.mark.parametrize("thinking", [True, False])
+@pytest.mark.parametrize(
+    ("base_url", "official"),
+    [
+        ("https://open.bigmodel.cn/api/paas/v4", True),
+        ("HTTPS://OPEN.BIGMODEL.CN/api/paas/v4", True),
+        ("https://open.bigmodel.cn:443/api/paas/v4", True),
+        ("https://open.bigmodel.cn/api/paas/v4/", True),
+        ("http://open.bigmodel.cn/api/paas/v4", False),
+        ("http://open.bigmodel.cn:80/api/paas/v4", False),
+        ("https://open.bigmodel.cn:80/api/paas/v4", False),
+        ("https://open.bigmodel.cn:8443/api/paas/v4", False),
+        ("https://open.bigmodel.cn", False),
+        ("https://open.bigmodel.cn/api/paas", False),
+        ("https://open.bigmodel.cn/api/paas/v4/chat/completions", False),
+        ("https://user@open.bigmodel.cn/api/paas/v4", False),
+        ("https://user:pass@open.bigmodel.cn/api/paas/v4", False),
+        ("https://open.bigmodel.cn/api/paas/v4?relay=1", False),
+        ("https://open.bigmodel.cn/api/paas/v4#relay", False),
+        ("https://open.bigmodel.cn.evil.test/api/paas/v4", False),
+        ("https://evil-open.bigmodel.cn/api/paas/v4", False),
+        ("https://open.bigmodel.cn\\@evil.test/api/paas/v4", False),
+        ("https://open.bigmodel.cn:bad/api/paas/v4", False),
+        ("open.bigmodel.cn/api/paas/v4", False),
+    ],
+)
+def test_zhipu_zai_endpoint_identity_matrix(
+    base_url: str,
+    official: bool,
+    thinking: bool,
+) -> None:
+    payload = _project_zhipu_payload(
+        base_url=base_url,
+        thinking=thinking,
+        capabilities=ModelCapabilities(
+            supports_reasoning=True,
+            supports_tools=True,
+            reasoning_format="zai",
+        ),
+    )
+
+    if official:
+        assert payload["thinking"] == {
+            "type": "enabled" if thinking else "disabled"
+        }
+    else:
+        assert "thinking" not in payload
+
+
+@pytest.mark.parametrize("thinking", [True, False])
+def test_custom_provider_with_explicit_zai_format_remains_available(
+    thinking: bool,
+) -> None:
+    catalog = ModelCatalog()
+    catalog.set_user_overrides(
+        {
+            "custom/glm-5.2": {
+                "supports_reasoning": True,
+                "supports_tools": True,
+                "reasoning_format": "zai",
+            }
+        }
+    )
+    payload = _project_zhipu_payload(
+        base_url="https://trusted-zai-relay.example.test/v1",
+        thinking=thinking,
+        provider_kind="custom",
+        capabilities=catalog.get_capabilities(
+            "glm-5.2",
+            provider_name="custom",
+        ),
+    )
+
+    assert payload["thinking"] == {"type": "enabled" if thinking else "disabled"}
+
+
+@pytest.mark.parametrize("thinking", [True, False])
+def test_zhipu_model_override_with_non_zai_format_is_not_host_gated(
+    thinking: bool,
+) -> None:
+    catalog = ModelCatalog()
+    catalog.set_user_overrides(
+        {
+            "zhipu/glm-4.6": {
+                "supports_reasoning": True,
+                "supports_tools": True,
+                "reasoning_format": "deepseek",
+            }
+        }
+    )
+    payload = _project_zhipu_payload(
+        model="glm-4.6",
+        base_url="https://trusted-deepseek-relay.example.test/v1",
+        thinking=thinking,
+        capabilities=catalog.get_capabilities(
+            "glm-4.6",
+            provider_name="zhipu",
+        ),
+    )
+
+    assert payload["thinking"] == {"type": "enabled" if thinking else "disabled"}
+    if thinking:
+        assert payload["reasoning_effort"] == "high"
+    else:
+        assert "reasoning_effort" not in payload
+
+
+def test_other_provider_zai_format_is_not_gated_by_zhipu_endpoint_policy() -> None:
+    payload = _project_zhipu_payload(
+        base_url="https://another-provider.example.test/v1",
         thinking=True,
-        model_capabilities=ModelCapabilities(
+        provider_kind="openai",
+        capabilities=ModelCapabilities(
             supports_reasoning=True,
             supports_tools=True,
             reasoning_format="zai",
         ),
     )
 
-    _collect(provider, cfg)
-
-    assert "thinking" not in captured["payload"]
-
-
-def test_zai_non_thinking_omits_provider_thinking_object_off_official_host(
-    monkeypatch: Any,
-) -> None:
-    captured: dict[str, Any] = {}
-    _patch_transport(monkeypatch, captured)
-    provider = OpenAIProvider(
-        api_key="test",
-        model="glm-5.2",
-        base_url="https://openrouter.ai/api/v1",
-        provider_kind="zhipu",
-    )
-    cfg = ChatConfig(
-        thinking=False,
-        model_capabilities=ModelCapabilities(
-            supports_reasoning=True,
-            supports_tools=True,
-            reasoning_format="zai",
-        ),
-    )
-
-    _collect(provider, cfg)
-
-    assert "thinking" not in captured["payload"]
+    assert payload["thinking"] == {"type": "enabled"}
 
 
 def test_dashscope_cache_on_marks_system_and_latest_user(monkeypatch: Any) -> None:

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -2542,6 +2542,9 @@ def test_all_zhipu_catalog_models_scope_zai_to_the_official_api_root(
         ("https://user:pass@open.bigmodel.cn/api/paas/v4", False),
         ("https://open.bigmodel.cn/api/paas/v4?relay=1", False),
         ("https://open.bigmodel.cn/api/paas/v4#relay", False),
+        ("https://open.bigmodel.cn/api/paas/v4?", False),
+        ("https://open.bigmodel.cn/api/paas/v4#", False),
+        ("https://open.bigmodel.cn/api/paas/v4?#", False),
         ("https://open.bigmodel.cn.evil.test/api/paas/v4", False),
         ("https://evil-open.bigmodel.cn/api/paas/v4", False),
         ("https://open.bigmodel.cn\\@evil.test/api/paas/v4", False),
@@ -2573,7 +2576,16 @@ def test_zhipu_zai_endpoint_identity_matrix(
 
 
 @pytest.mark.parametrize("thinking", [True, False])
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://trusted-zai-relay.example.test/v1",
+        "https://trusted-zai-relay.example.test/v1/%3F",
+        "https://trusted-zai-relay.example.test/v1;mode=compat",
+    ],
+)
 def test_custom_provider_with_explicit_zai_format_remains_available(
+    base_url: str,
     thinking: bool,
 ) -> None:
     catalog = ModelCatalog()
@@ -2587,7 +2599,7 @@ def test_custom_provider_with_explicit_zai_format_remains_available(
         }
     )
     payload = _project_zhipu_payload(
-        base_url="https://trusted-zai-relay.example.test/v1",
+        base_url=base_url,
         thinking=thinking,
         provider_kind="custom",
         capabilities=catalog.get_capabilities(


### PR DESCRIPTION
## Scope

Gate Zhipu-native `zai` reasoning payloads by strict official API identity after the final model reasoning dialect is resolved.

- Official Zhipu API roots retain `thinking.enabled/disabled`.
- Ordinary relays omit the vendor field.
- `custom` providers with an explicit `zai` override retain the trusted-relay escape hatch.
- All current Zhipu catalog and preset models are covered.
- Empty query/fragment delimiters, userinfo, malformed URLs, non-default ports, and non-canonical paths fail closed.

Non-goals: changing DeepSeek, Moonshot, Volcengine, retrying schema 400 responses, or adding a public configuration switch.

## Target

`main`

## Linked issue

Fixes #961

## Release note

Zhipu-compatible models no longer send the vendor-specific `thinking` object to non-official relay endpoints unless an explicit custom `zai` dialect is configured.

## Tests

- Provider payload/compatibility: 295 passed
- Reasoning/catalog/preset/request golden: 185 passed
- Ruff: passed
- Mypy: 932 source files passed
- `git diff --check`: passed
- Offline URL identity and payload matrices only; no credentialed live relay call

## Safety and compatibility

No schema, database, RPC, permission, or persisted configuration changes. Existing trusted relays can use the existing `custom` provider plus explicit `zai` model override.

## Commit lineage

Builds on #1053 by replaying contributor commit `ac33132e584bc45f1a1d4d126cc4d394fd8df8f3` as `82e7c803124d825d85a8aad24e0b3b1ef4c397ef` with `cherry-pick -x`. Original author attribution is preserved. Strict endpoint and review corrections are separate commits.

## Third-party origin

No third-party code, fixtures, or documentation were copied.