### PR TITLE
Disable thinking for length-capped reasoning-only retries

### DIFF
--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -9710,6 +9710,15 @@ class Agent:
                             attempt_classification.kind,
                             input_tokens=iter_input_tokens,
                         )
+                        if (
+                            large_context_invalid
+                            and attempt_classification.kind
+                            == _ProviderAttemptKind.REASONING_ONLY
+                            and (attempt_classification.stop_reason or "").lower()
+                            == "length"
+                        ):
+                            _thinking_fallback_done = True
+                            _disable_thinking_for_next_provider_call = True
                         supports_reasoning_replay = supports_reasoning_prefill_replay(
                             model_capabilities=self.config.model_capabilities,
                             reasoning_content=iter_reasoning_content,
@@ -9920,14 +9929,6 @@ class Agent:
                                 )
                             ):
                                 _invalid_response_fallback_done = True
-                                if (
-                                    attempt_classification.kind
-                                    == _ProviderAttemptKind.REASONING_ONLY
-                                    and (attempt_classification.stop_reason or "").lower()
-                                    == "length"
-                                ):
-                                    _thinking_fallback_done = True
-                                    _disable_thinking_for_next_provider_call = True
                                 fallback_reason = _provider_activity_reason_for_attempt(
                                     attempt_classification.kind
                                 )

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -9944,7 +9944,11 @@ class Agent:
 
                             if (
                                 attempt_classification.kind == _ProviderAttemptKind.REASONING_ONLY
-                                and thinking_enabled
+                                and (
+                                    thinking_enabled
+                                    or (attempt_classification.stop_reason or "").lower()
+                                    == "length"
+                                )
                                 and _retry_policy.can_retry_attempt(
                                     _ProviderAttemptKind.REASONING_ONLY,
                                     _attempt_retries_used,

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -9951,11 +9951,15 @@ class Agent:
                                 )
                             ):
                                 _attempt_retries_used[_ProviderAttemptKind.REASONING_ONLY] += 1
-                                disable_thinking = bool(
-                                    getattr(
-                                        self.config,
-                                        "reasoning_only_thinking_fallback",
-                                        False,
+                                disable_thinking = (
+                                    (attempt_classification.stop_reason or "").lower()
+                                    == "length"
+                                    or bool(
+                                        getattr(
+                                            self.config,
+                                            "reasoning_only_thinking_fallback",
+                                            False,
+                                        )
                                     )
                                 )
                                 if disable_thinking:

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -9920,6 +9920,14 @@ class Agent:
                                 )
                             ):
                                 _invalid_response_fallback_done = True
+                                if (
+                                    attempt_classification.kind
+                                    == _ProviderAttemptKind.REASONING_ONLY
+                                    and (attempt_classification.stop_reason or "").lower()
+                                    == "length"
+                                ):
+                                    _thinking_fallback_done = True
+                                    _disable_thinking_for_next_provider_call = True
                                 fallback_reason = _provider_activity_reason_for_attempt(
                                     attempt_classification.kind
                                 )

--- a/tests/test_engine/test_agent_invalid_provider_response.py
+++ b/tests/test_engine/test_agent_invalid_provider_response.py
@@ -927,6 +927,64 @@ async def test_large_reasoning_only_without_fallback_keeps_thinking_by_default()
 
 
 @pytest.mark.asyncio
+async def test_large_length_capped_reasoning_only_retry_disables_thinking() -> None:
+    provider = _SequenceProvider(
+        [
+            [
+                ProviderDone(
+                    stop_reason="length",
+                    input_tokens=35_858,
+                    output_tokens=16_384,
+                    reasoning_tokens=16_384,
+                    reasoning_content="internal reasoning",
+                    model="deepseek-v4-flash-0731",
+                )
+            ],
+            [
+                ProviderText(text="visible answer"),
+                ProviderDone(
+                    stop_reason="stop",
+                    input_tokens=35_858,
+                    output_tokens=2,
+                    model="deepseek-v4-flash-0731",
+                ),
+            ],
+        ]
+    )
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            thinking=ThinkingLevel.MEDIUM,
+            model_id="deepseek-v4-flash-0731",
+            max_tokens=16_384,
+            max_provider_retries=1,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("hello")]
+
+    assert len(provider.calls) == 2
+    assert provider.calls[0]["config"].thinking is True
+    assert provider.calls[0]["config"].max_tokens == 16_384
+    assert provider.calls[1]["config"].thinking is False
+    assert provider.calls[1]["config"].thinking_level == ThinkingLevel.OFF
+    assert provider.calls[1]["config"].thinking_budget_tokens == 0
+    assert provider.calls[1]["config"].max_tokens == 16_384
+    visible_retry = next(
+        event
+        for event in events
+        if event.kind == "warning"
+        and event.code == "provider_large_context_visible_retry"
+    )
+    assert "thinking disabled" in visible_retry.message
+    assert not any(event.kind == "error" for event in events)
+    done = next(event for event in events if event.kind == "done")
+    assert done.text == "visible answer"
+
+
+@pytest.mark.asyncio
 async def test_large_dashscope_reasoning_only_nudges_before_hard_fail(tmp_path) -> None:
     provider = _SequenceProvider(
         [

--- a/tests/test_engine/test_agent_invalid_provider_response.py
+++ b/tests/test_engine/test_agent_invalid_provider_response.py
@@ -283,6 +283,62 @@ async def test_reasoning_only_prefill_recovery_cleans_synthetic_history(tmp_path
     assert recovery_event["injected_to_model"] is True
 
 
+@pytest.mark.parametrize(
+    ("reasoning_format", "warning_code"),
+    [
+        ("openrouter", "provider_reasoning_prefill_continue"),
+        ("dashscope", "provider_reasoning_continuation"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_length_capped_reasoning_recovery_disables_thinking_on_next_call(
+    tmp_path,
+    reasoning_format: str,
+    warning_code: str,
+) -> None:
+    provider = _SequenceProvider(
+        [
+            [
+                ProviderDone(
+                    stop_reason="length",
+                    input_tokens=35_858,
+                    output_tokens=16_384,
+                    reasoning_tokens=16_384,
+                    reasoning_content="internal reasoning",
+                    model="test-reasoning",
+                )
+            ],
+            [
+                ProviderText(text="ok"),
+                ProviderDone(stop_reason="stop", input_tokens=4, output_tokens=1),
+            ],
+        ]
+    )
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            model_capabilities=ModelCapabilities(
+                supports_reasoning=True,
+                supports_tools=True,
+                reasoning_format=reasoning_format,
+            ),
+            reasoning_prefill_recovery_mode="recover",
+            runtime_events_path=str(tmp_path / "runtime_events.jsonl"),
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("hello")]
+
+    assert len(provider.calls) == 2
+    assert provider.calls[1]["config"].thinking is False
+    assert provider.calls[1]["config"].thinking_level == ThinkingLevel.OFF
+    assert provider.calls[1]["config"].thinking_budget_tokens == 0
+    assert any(event.kind == "warning" and event.code == warning_code for event in events)
+    assert any(event.kind == "done" and event.text == "ok" for event in events)
+
+
 @pytest.mark.asyncio
 async def test_tool_loop_observer_logs_reasoning_only_runtime_event(tmp_path) -> None:
     provider = _SequenceProvider(

--- a/tests/test_engine/test_agent_invalid_provider_response.py
+++ b/tests/test_engine/test_agent_invalid_provider_response.py
@@ -871,6 +871,47 @@ async def test_large_reasoning_only_uses_fallback_before_same_model_retry() -> N
     assert any(event.kind == "done" and event.text == "ok" for event in events)
 
 
+@pytest.mark.parametrize("thinking", [False, ThinkingLevel.MEDIUM])
+@pytest.mark.asyncio
+async def test_large_length_capped_reasoning_only_fallback_disables_thinking(
+    thinking: bool | ThinkingLevel,
+) -> None:
+    provider = _FallbackSequenceProvider(
+        [
+            [
+                ProviderDone(
+                    stop_reason="length",
+                    input_tokens=35_858,
+                    output_tokens=16_384,
+                    reasoning_tokens=16_384,
+                    reasoning_content="internal reasoning",
+                )
+            ],
+            [
+                ProviderText(text="ok"),
+                ProviderDone(stop_reason="stop", input_tokens=4, output_tokens=1),
+            ],
+        ]
+    )
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            thinking=thinking,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("hello")]
+
+    assert provider.fallback_reasons == ["reasoning_only"]
+    assert len(provider.calls) == 2
+    assert provider.calls[1]["config"].thinking is False
+    assert provider.calls[1]["config"].thinking_level == ThinkingLevel.OFF
+    assert provider.calls[1]["config"].thinking_budget_tokens == 0
+    assert any(event.kind == "done" and event.text == "ok" for event in events)
+
+
 @pytest.mark.asyncio
 async def test_large_reasoning_only_without_fallback_keeps_thinking_by_default() -> None:
     provider = _SequenceProvider(

--- a/tests/test_engine/test_agent_invalid_provider_response.py
+++ b/tests/test_engine/test_agent_invalid_provider_response.py
@@ -954,7 +954,6 @@ async def test_large_length_capped_reasoning_only_retry_disables_thinking() -> N
     agent = Agent(
         provider=provider,
         config=AgentConfig(
-            thinking=ThinkingLevel.MEDIUM,
             model_id="deepseek-v4-flash-0731",
             max_tokens=16_384,
             max_provider_retries=1,
@@ -966,7 +965,8 @@ async def test_large_length_capped_reasoning_only_retry_disables_thinking() -> N
     events = [event async for event in agent.run_turn("hello")]
 
     assert len(provider.calls) == 2
-    assert provider.calls[0]["config"].thinking is True
+    assert provider.calls[0]["config"].thinking is False
+    assert provider.calls[0]["config"].thinking_level is None
     assert provider.calls[0]["config"].max_tokens == 16_384
     assert provider.calls[1]["config"].thinking is False
     assert provider.calls[1]["config"].thinking_level == ThinkingLevel.OFF


### PR DESCRIPTION
## Scope

When a large-context provider attempt ends with reasoning only and `stop_reason=length`, mark the next physical recovery request as explicitly thinking-off so its completion allowance can produce a visible answer.

This changes only the shared Agent recovery path. Non-length reasoning-only retries continue to follow the existing `reasoning_only_thinking_fallback` setting.

## Branch

Base branch: main

Target exception: N/A

## Issue

Fixes #1171

## Root Cause

The large-context recovery path could reach several early recovery branches before the thinking-off retry logic: reasoning prefill replay, DashScope continuation, selector fallback, and the ordinary same-provider retry. It also required OpenSquilla's local thinking setting to be enabled, even though providers such as TokenRhythm may produce reasoning by default. Consequently, the next physical request could retain explicit thinking or omit the field and inherit provider-default reasoning, consuming the completion budget again.

## Behavior After This Change

- As soon as a large-context attempt is classified as reasoning-only and length-capped, the existing one-shot override is armed for the next physical request.
- The override applies across prefill replay, DashScope continuation, selector fallback, and ordinary retry.
- It covers both locally explicit thinking and provider-default reasoning.
- The request keeps the configured `max_tokens`; retry budgets, recovery ordering, and terminal handling are unchanged.
- Non-length reasoning-only behavior is unchanged.

## Non-Goals

- Changing model catalog limits or completion budgets.
- Changing the public fallback configuration or its default.
- Adding provider-specific budget parameters.
- Changing context compaction, routing, recovery ordering, or the large-context threshold.

## Release Note

Release note: Recover visible answers when a long-context reasoning response consumes its completion allowance before emitting text.

## Tests

- Regression coverage includes provider-default reasoning, explicit thinking, selector fallback, OpenRouter-style reasoning prefill replay, and DashScope continuation; every next physical recovery request is asserted as `thinking=False`, `thinking_level=OFF`, and zero thinking budget.
- `uv run pytest tests/test_engine/test_agent_invalid_provider_response.py -q` — 47 passed on the latest head.
- Earlier related suite: `uv run --extra dev pytest tests/test_engine/test_agent_invalid_provider_response.py tests/test_engine/test_reasoning_retry_and_deadline_thinking_levers.py tests/test_provider_tokenrhythm_v4_wire_policy.py -q` — 146 passed on the initial head.
- `uv run ruff check src/opensquilla/engine/agent.py tests/test_engine/test_agent_invalid_provider_response.py` — passed.
- `uv run mypy src/opensquilla --show-error-codes` — passed, 932 source files in the implementation environment.
- `git diff --check` — passed.

## Live Check Limitations

No credentialed TokenRhythm request was performed. The regression is offline and provider-independent, using synthetic usage and provider events matching the reported input, output, reasoning, stop reason, and configured `max_tokens` values. A live check is still needed to determine why the upstream request stopped at 16,384 tokens and whether that provider always honors thinking disablement.

## Safety and Compatibility

The change is platform-neutral and does not affect persisted state, database schemas, public APIs, configuration formats, provider call counts, recovery ordering, or upgrade behavior. It reuses the existing one-shot thinking override and recovery budgets. If a provider ignores the override, existing bounded terminal handling remains in effect.

No secrets, real transcripts, local paths, or private fixtures are included.

## Third-Party Origin

Third-party origin: none

The implementation and synthetic regression tests were independently authored from OpenSquilla issue evidence and current repository behavior.