### PR TITLE
Explain chat interruptions after Gateway restarts

### DIFF
--- a/opensquilla-webui/src/components/chat/AssistantMessage.activity-fold.test.ts
+++ b/opensquilla-webui/src/components/chat/AssistantMessage.activity-fold.test.ts
@@ -439,6 +439,43 @@ describe('AssistantMessage activity disclosure', () => {
     }
   })
 
+  it('keeps restart recovery guidance visible beside durable activity', async () => {
+    const el = mountMessage(baseMessage({
+      timelineItems: successfulTimeline(),
+      turnOutcome: {
+        turnId: 'turn-restart-activity',
+        status: 'abandoned',
+        kind: 'interrupted',
+        reason: 'process_restart',
+      },
+    }), true)
+    await nextTick()
+
+    expect(el.querySelector('.assistant-activity')).not.toBeNull()
+    expect(el.querySelector('.turn-outcome--process-restart')?.textContent)
+      .toContain("This task won't continue automatically")
+  })
+
+  it('keeps restart recovery guidance visible beside a Plan card', async () => {
+    const el = mountMessage(baseMessage({
+      text: '',
+      timelineItems: [],
+      parts: [planPart()],
+      statusHistory: [],
+      turnOutcome: {
+        turnId: 'turn-restart-plan',
+        status: 'abandoned',
+        kind: 'interrupted',
+        errorClass: 'process_restart',
+      },
+    }), true)
+    await nextTick()
+
+    expect(el.querySelector('.plan-card')).not.toBeNull()
+    expect(el.querySelector('.turn-outcome--process-restart')?.textContent)
+      .toContain('Review any existing results or tool activity')
+  })
+
   it('retains the legacy footer usage entry when history has no turn outcome', async () => {
     const el = mountMessage(baseMessage({
       timelineItems: [],

--- a/opensquilla-webui/src/components/chat/AssistantMessage.vue
+++ b/opensquilla-webui/src/components/chat/AssistantMessage.vue
@@ -28,8 +28,10 @@
         v-if="
           showTurnOutcome
           && message.turnOutcome
-          && !showActivityDisclosure
-          && !hasPlan
+          && (
+            processRestart
+            || (!showActivityDisclosure && !hasPlan)
+          )
         "
         :outcome="message.turnOutcome"
       />
@@ -448,6 +450,7 @@ import {
 } from '@/utils/chat/activityDisclosureState'
 import { absoluteTime, fullTime, isoTime, relativeTime } from '@/utils/messageTime'
 import {
+  isProcessRestartOutcome,
   turnOutcomeDurationSeconds,
   turnOutcomePresentation,
 } from '@/utils/chat/turnOutcome'
@@ -612,6 +615,7 @@ const standaloneInterruptParts = computed(() =>
   )),
 )
 const outcomePresentation = computed(() => turnOutcomePresentation(props.message.turnOutcome))
+const processRestart = computed(() => isProcessRestartOutcome(props.message.turnOutcome))
 
 function epochMilliseconds(value: string | number | null | undefined): number {
   if (value == null) return 0

--- a/opensquilla-webui/src/components/chat/ChatMessageList.fork.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatMessageList.fork.test.ts
@@ -200,6 +200,27 @@ describe('ChatMessageList fork targets', () => {
   })
 })
 
+describe('ChatMessageList restart outcome anchor', () => {
+  it('renders restart guidance once on the final visible message in the turn', () => {
+    const source = user('user-restart', 'turn:restart', 'turn-restart')
+    const partial = assistant('assistant-restart', 'turn:restart', 'turn-restart')
+    const outcome = {
+      turnId: 'turn-restart',
+      status: 'abandoned',
+      kind: 'interrupted',
+      reason: 'process_restart',
+    }
+    source.turnOutcome = outcome
+    partial.turnOutcome = outcome
+
+    const { host } = mountList([source, partial])
+    const notices = host.querySelectorAll('.turn-outcome--process-restart')
+
+    expect(notices).toHaveLength(1)
+    expect(notices[0]?.closest('.msg-ai')).not.toBeNull()
+  })
+})
+
 describe('ChatMessageList usage barrier retry anchor', () => {
   it('shows Retry when the durable same-turn user is loaded', () => {
     const { host } = mountList([

--- a/opensquilla-webui/src/components/chat/TurnOutcomeStatus.test.ts
+++ b/opensquilla-webui/src/components/chat/TurnOutcomeStatus.test.ts
@@ -92,4 +92,49 @@ describe('TurnOutcomeStatus', () => {
     expect(host.querySelector('.msg-ai')).toBeNull()
     app.unmount()
   })
+
+  it.each([
+    { reason: 'process_restart' },
+    { errorClass: 'process_restart' },
+  ])('shows restart-specific cause and recovery guidance for $reason$errorClass', async (proof) => {
+    const { app, host } = await renderOutcome({
+      turnId: 'turn-restart',
+      status: 'abandoned',
+      kind: 'interrupted',
+      ...proof,
+    })
+
+    expect(host.querySelector('.turn-outcome--process-restart')).not.toBeNull()
+    expect(host.querySelector('.turn-outcome__title')?.textContent)
+      .toContain('OpenSquilla restarted and interrupted this task.')
+    expect(host.querySelector('.turn-outcome__guidance')?.textContent)
+      .toContain("This task won't continue automatically.")
+    expect(host.textContent).toContain('Review any existing results or tool activity')
+    app.unmount()
+  })
+
+  it('does not treat a generic gateway cancellation as a process restart', async () => {
+    const { app, host } = await renderOutcome({
+      turnId: 'turn-disconnect',
+      status: 'cancelled',
+      cancellationSource: 'gateway_restart',
+    })
+
+    expect(host.querySelector('.turn-outcome--process-restart')).toBeNull()
+    expect(host.textContent).toContain('Interrupted')
+    expect(host.textContent).not.toContain("won't continue automatically")
+    app.unmount()
+  })
+
+  it('requires the exact process restart reason', async () => {
+    const { app, host } = await renderOutcome({
+      turnId: 'turn-lookalike',
+      status: 'interrupted',
+      reason: 'PROCESS_RESTART',
+    })
+
+    expect(host.querySelector('.turn-outcome--process-restart')).toBeNull()
+    expect(host.textContent).toContain('Interrupted')
+    app.unmount()
+  })
 })

--- a/opensquilla-webui/src/components/chat/TurnOutcomeStatus.vue
+++ b/opensquilla-webui/src/components/chat/TurnOutcomeStatus.vue
@@ -1,13 +1,25 @@
 <template>
   <div
     class="turn-outcome"
-    :class="`turn-outcome--${presentation}`"
+    :class="[
+      `turn-outcome--${presentation}`,
+      { 'turn-outcome--process-restart': processRestart },
+    ]"
     role="status"
     :data-testid="`turn-outcome-${presentation}`"
   >
     <span class="turn-outcome__dot" aria-hidden="true" />
-    <span>{{ label }}</span>
-    <span v-if="durationLabel" class="turn-outcome__duration">· {{ durationLabel }}</span>
+    <span v-if="processRestart" class="turn-outcome__content">
+      <span class="turn-outcome__title">
+        {{ t('chat.restartInterruptedTitle') }}
+        <span v-if="durationLabel" class="turn-outcome__duration">· {{ durationLabel }}</span>
+      </span>
+      <span class="turn-outcome__guidance">{{ t('chat.restartInterruptedGuidance') }}</span>
+    </span>
+    <template v-else>
+      <span>{{ label }}</span>
+      <span v-if="durationLabel" class="turn-outcome__duration">· {{ durationLabel }}</span>
+    </template>
   </div>
 </template>
 
@@ -16,6 +28,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { ChatTurnOutcome } from '@/types/chat'
 import {
+  isProcessRestartOutcome,
   turnOutcomeDurationSeconds,
   turnOutcomePresentation,
 } from '@/utils/chat/turnOutcome'
@@ -23,6 +36,7 @@ import {
 const props = defineProps<{ outcome: ChatTurnOutcome }>()
 const { t } = useI18n()
 const presentation = computed(() => turnOutcomePresentation(props.outcome))
+const processRestart = computed(() => isProcessRestartOutcome(props.outcome))
 const label = computed(() => t({
   completed: 'chat.activity.lifecycle.settled',
   stopped: 'sessions.status.cancelled',
@@ -55,6 +69,31 @@ const durationLabel = computed(() => {
   border-radius: var(--radius-full);
   background: currentColor;
   opacity: 0.65;
+}
+
+.turn-outcome--process-restart {
+  align-items: flex-start;
+  width: min(100%, 42rem);
+}
+
+.turn-outcome--process-restart .turn-outcome__dot {
+  margin-top: 0.5rem;
+}
+
+.turn-outcome__content {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.turn-outcome__title {
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.turn-outcome__guidance {
+  color: var(--text-dim);
 }
 
 .turn-outcome--failed,

--- a/opensquilla-webui/src/components/chat/UserMessage.turn-outcome.test.ts
+++ b/opensquilla-webui/src/components/chat/UserMessage.turn-outcome.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, nextTick } from 'vue'
+import i18n from '@/i18n'
+import type { ChatRenderedMessage } from '@/types/chat'
+import UserMessage from './UserMessage.vue'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  i18n.global.locale.value = 'en'
+})
+
+describe('UserMessage turn outcome', () => {
+  it('shows restart guidance when an interrupted turn has no assistant message', async () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const message: ChatRenderedMessage = {
+      id: 'user-restart',
+      role: 'user',
+      displayRole: 'user',
+      roleLabel: 'You',
+      text: 'Continue the task',
+      timeStr: '',
+      showHeader: false,
+      turnOutcome: {
+        turnId: 'turn-restart',
+        status: 'abandoned',
+        kind: 'interrupted',
+        reason: 'process_restart',
+      },
+    }
+    const app = createApp(UserMessage, {
+      message,
+      shareMode: false,
+      shareSelected: false,
+      shareMessageId: message.id,
+      stripTimePrefix: (value: string) => value,
+      copyMessage: async () => true,
+      downloadAttachment: async () => true,
+      showTurnOutcome: true,
+    })
+    app.use(i18n)
+    app.mount(host)
+    await nextTick()
+
+    expect(host.querySelector('.turn-outcome--process-restart')?.textContent)
+      .toContain("This task won't continue automatically")
+    app.unmount()
+  })
+})

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -3343,6 +3343,8 @@
     "subagentPrefix": "Subagent: ",
     "subagentCompletion": "Subagent-Abschluss",
     "turnFailed": "Durchlauf fehlgeschlagen",
+    "restartInterruptedTitle": "Ein Neustart von OpenSquilla hat diese Aufgabe unterbrochen.",
+    "restartInterruptedGuidance": "Diese Aufgabe wird nicht automatisch fortgesetzt. Prüfen Sie vorhandene Ergebnisse oder Werkzeugaktionen und bearbeiten Sie anschließend die ursprüngliche Anfrage oder setzen Sie die Unterhaltung fort.",
     "usageAccountingBlockedTitle": "Nutzungserfassung vorübergehend nicht verfügbar",
     "usageAccountingBlockedMessage": "Die Anfrage wurde nicht an den Modellanbieter gesendet und es wurden keine Kosten erfasst. Sie können diesen Durchlauf sicher erneut versuchen.",
     "usageAccountingBlockedUnsafeMessage": "Diese Modellanfrage wurde nicht gesendet. Frühere Arbeit in diesem Durchlauf könnte bereits ausgeführt oder abgerechnet worden sein. Prüfen Sie die Ergebnisse, bevor Sie es erneut versuchen.",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -3396,6 +3396,8 @@
     "subagentPrefix": "Subagent: ",
     "subagentCompletion": "Subagent completion",
     "turnFailed": "Turn failed",
+    "restartInterruptedTitle": "OpenSquilla restarted and interrupted this task.",
+    "restartInterruptedGuidance": "This task won't continue automatically. Review any existing results or tool activity, then edit the original request or continue the conversation.",
     "usageAccountingBlockedTitle": "Usage accounting temporarily unavailable",
     "usageAccountingBlockedMessage": "The provider request was not sent and no usage was billed. You can safely retry this turn.",
     "usageAccountingBlockedUnsafeMessage": "This provider request was not sent. Earlier work in this turn may already have run or been billed, so review it before trying again.",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -3343,6 +3343,8 @@
     "subagentPrefix": "Subagente: ",
     "subagentCompletion": "Finalización del subagente",
     "turnFailed": "El turno falló",
+    "restartInterruptedTitle": "El reinicio de OpenSquilla interrumpió esta tarea.",
+    "restartInterruptedGuidance": "Esta tarea no continuará automáticamente. Revisa los resultados existentes o las acciones de las herramientas y, después, edita la solicitud original o continúa la conversación.",
     "usageAccountingBlockedTitle": "La contabilidad de uso no está disponible temporalmente",
     "usageAccountingBlockedMessage": "La solicitud no se envió al proveedor del modelo y no se facturó ningún uso. Puedes reintentar este turno de forma segura.",
     "usageAccountingBlockedUnsafeMessage": "Esta solicitud al modelo no se envió. Es posible que el trabajo anterior de este turno ya se haya ejecutado o facturado; revísalo antes de volver a intentarlo.",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -3343,6 +3343,8 @@
     "subagentPrefix": "Sous-agent : ",
     "subagentCompletion": "Achèvement du sous-agent",
     "turnFailed": "Échec du tour",
+    "restartInterruptedTitle": "Le redémarrage d’OpenSquilla a interrompu cette tâche.",
+    "restartInterruptedGuidance": "Cette tâche ne reprendra pas automatiquement. Vérifiez les résultats existants ou les actions des outils, puis modifiez la demande d’origine ou poursuivez la conversation.",
     "usageAccountingBlockedTitle": "Comptabilisation de l’utilisation temporairement indisponible",
     "usageAccountingBlockedMessage": "La requête n’a pas été envoyée au fournisseur du modèle et aucune utilisation n’a été facturée. Vous pouvez réessayer ce tour en toute sécurité.",
     "usageAccountingBlockedUnsafeMessage": "Cette requête au modèle n’a pas été envoyée. Des opérations antérieures de ce tour ont peut-être déjà été exécutées ou facturées ; vérifiez-les avant de réessayer.",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -3343,6 +3343,8 @@
     "subagentPrefix": "サブエージェント: ",
     "subagentCompletion": "サブエージェントの完了",
     "turnFailed": "ターンが失敗しました",
+    "restartInterruptedTitle": "OpenSquilla の再起動によりタスクが中断されました。",
+    "restartInterruptedGuidance": "このタスクは自動的には続行されません。既存の結果やツール操作を確認してから、元のリクエストを編集するか、会話を続けてください。",
     "usageAccountingBlockedTitle": "使用量の記録を一時的に利用できません",
     "usageAccountingBlockedMessage": "モデルプロバイダーにはリクエストが送信されておらず、料金も発生していません。このターンは安全に再試行できます。",
     "usageAccountingBlockedUnsafeMessage": "このモデルリクエストは送信されませんでした。ただし、このターンの以前の処理が実行済みまたは課金済みの可能性があります。再試行する前に結果を確認してください。",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -3396,6 +3396,8 @@
     "subagentPrefix": "子智能体：",
     "subagentCompletion": "子智能体完成",
     "turnFailed": "本轮失败",
+    "restartInterruptedTitle": "OpenSquilla 重启导致任务中断。",
+    "restartInterruptedGuidance": "任务不会自动继续。请检查已有结果或工具操作，然后编辑原请求或继续对话。",
     "usageAccountingBlockedTitle": "用量记账暂时不可用",
     "usageAccountingBlockedMessage": "请求尚未发送给模型服务，也没有产生计费。你可以安全地重试本轮。",
     "usageAccountingBlockedUnsafeMessage": "本次模型请求尚未发送，但本轮更早的操作可能已经执行或产生计费。请检查已有结果后再决定是否重试。",

--- a/opensquilla-webui/src/utils/chat/turnOutcome.ts
+++ b/opensquilla-webui/src/utils/chat/turnOutcome.ts
@@ -260,6 +260,13 @@ export type TurnOutcomePresentation =
   | 'timeout'
   | 'failed'
 
+export function isProcessRestartOutcome(
+  outcome: ChatTurnOutcome | null | undefined,
+): boolean {
+  return outcome?.reason === 'process_restart'
+    || outcome?.errorClass === 'process_restart'
+}
+
 export function turnOutcomePresentation(
   outcome: ChatTurnOutcome | null | undefined,
 ): TurnOutcomePresentation {


### PR DESCRIPTION
## Scope

- show the durable process_restart reason in the chat timeline
- explain that interrupted work does not continue automatically
- keep the guidance visible for user-only, partial-answer, activity, and Plan turns
- preserve existing behavior for Stop, timeout, and generic interruptions
- add all six supported translations

## Branch target

main

## Linked issue

None

## Release note

Yes — WebUI now explains when a Gateway restart interrupted a task and gives conservative recovery guidance.

## Verification

- 73 focused Vitest tests passed
- npm run typecheck passed
- npm run build:artifact passed
- git diff --check passed
- real Vue + Gateway hard-kill/restart validation passed; history reload preserved exactly one notice

## Safety and compatibility

- no database, Gateway, RPC, or public protocol changes
- no automatic retry or resume; existing retryable metadata is not treated as replay-safe proof
- old clients continue to show their existing generic interruption status
- new clients connected to old Gateways fall back to the generic status when process_restart evidence is absent
- platform-neutral WebUI-only change

## Third-party origin

None