### PR TITLE
Fail human turns that return silent sentinels

### DIFF
--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -169,7 +169,10 @@ from opensquilla.engine.turn_runner.harness import (
     _TurnRunnerTurnMemoryCaptureAdapter,
     _TurnRunnerUsageTelemetryAdapter,
 )
-from opensquilla.engine.turn_runner.stream_consumer_stage import _StreamState
+from opensquilla.engine.turn_runner.stream_consumer_stage import (
+    _could_be_human_silent_reply_prefix,
+    _StreamState,
+)
 from opensquilla.engine.types import (
     AgentConfig,
     AgentEvent,
@@ -5736,7 +5739,8 @@ class TurnRunner:
                 sanitize_silent_reply_segments,
             )
 
-            raw_partial_text = "".join(final_text_parts).rstrip()
+            raw_partial_text_untrimmed = "".join(final_text_parts)
+            raw_partial_text = raw_partial_text_untrimmed.rstrip()
             partial_normalization = normalize_silent_reply(
                 raw_partial_text,
                 run_kind=run_kind,
@@ -5744,14 +5748,22 @@ class TurnRunner:
                 heartbeat_ack_max_chars=heartbeat_ack_max_chars,
             )
             partial_text = partial_normalization.text.rstrip()
+            human_prefix_was_withheld = (
+                input_mode != "system_event"
+                and bool(raw_partial_text_untrimmed)
+                and _could_be_human_silent_reply_prefix(raw_partial_text_untrimmed)
+            )
             if (
-                input_mode == "system_event"
-                and run_kind in {"goal", "heartbeat"}
-                and is_silent_reply_prefix(raw_partial_text)
+                (
+                    input_mode == "system_event"
+                    and run_kind in {"goal", "heartbeat"}
+                    and is_silent_reply_prefix(raw_partial_text)
+                )
+                or human_prefix_was_withheld
             ):
-                # The shared stream stage deliberately holds internal text.
-                # A Stop can therefore land between chunks of a control token;
-                # never persist that distinctive unfinished marker as prose.
+                # The shared stream stage deliberately holds control-token
+                # candidates. A Stop can land between chunks; never persist a
+                # fragment that was not presented to the user as prose.
                 partial_text = ""
 
             raw_segment_text = "".join(
@@ -5771,7 +5783,16 @@ class TurnRunner:
                 for segment in normalized_segments
                 if isinstance(segment, dict) and segment.get("type") == "text"
             ).rstrip()
-            if (
+            if human_prefix_was_withheld:
+                # These text carriers were never emitted. Remove them while
+                # retaining any tool, artifact, or activity records that were
+                # already presented before cancellation.
+                normalized_segments = [
+                    segment
+                    for segment in normalized_segments
+                    if segment.get("type") != "text"
+                ]
+            elif (
                 raw_segment_text == raw_partial_text
                 and segment_normalization.changed
                 and (

--- a/src/opensquilla/engine/silent_reply.py
+++ b/src/opensquilla/engine/silent_reply.py
@@ -3,6 +3,8 @@
 from opensquilla.silent_reply import (
     HEARTBEAT_ACK_TOKEN,
     NO_REPLY_TOKEN,
+    SILENT_REPLY_NOT_ALLOWED_CODE,
+    SILENT_REPLY_NOT_ALLOWED_MESSAGE,
     SILENT_REPLY_SENTINELS,
     HistoricalSilentReplySanitization,
     SilentReplyDelivery,
@@ -20,6 +22,8 @@ __all__ = [
     "HistoricalSilentReplySanitization",
     "NO_REPLY_TOKEN",
     "SILENT_REPLY_SENTINELS",
+    "SILENT_REPLY_NOT_ALLOWED_CODE",
+    "SILENT_REPLY_NOT_ALLOWED_MESSAGE",
     "SilentReplyDelivery",
     "SilentReplyNormalization",
     "SilentReplySegmentsNormalization",

--- a/src/opensquilla/engine/turn_runner/stream_consumer_stage.py
+++ b/src/opensquilla/engine/turn_runner/stream_consumer_stage.py
@@ -38,6 +38,11 @@ from opensquilla.engine.hooks.types import CompactionState
 from opensquilla.engine.route_plan import route_plan_snapshot
 from opensquilla.observability.decision_log import build_vision_followup_gate_reason_code
 from opensquilla.session.compaction_lifecycle import CompactionTimeoutError
+from opensquilla.silent_reply import (
+    SILENT_REPLY_NOT_ALLOWED_CODE,
+    SILENT_REPLY_NOT_ALLOWED_MESSAGE,
+    SILENT_REPLY_SENTINELS,
+)
 
 if TYPE_CHECKING:
     from opensquilla.engine.agent import Agent
@@ -66,6 +71,65 @@ _SUPPRESS: Final = object()
 _CURRENT_SILENT_REPLY_TEXT_MARKER: Final = (
     "_opensquilla_current_silent_reply_text"
 )
+_HUMAN_SILENT_REPLY_PREFIX_MAX_CHARS: Final = 64
+
+
+def _could_be_human_silent_reply_prefix(text: str) -> bool:
+    """Hold only a short initial payload that can still be a silent sentinel.
+
+    The character bound limits how much ordinary response text can be withheld.
+    """
+
+    if len(text) > _HUMAN_SILENT_REPLY_PREFIX_MAX_CHARS:
+        return False
+    candidate = text.strip()
+    if not candidate:
+        return True
+    return any(sentinel.startswith(candidate) for sentinel in SILENT_REPLY_SENTINELS)
+
+
+def _move_held_human_text_to_current_tail(
+    state: _StreamState,
+    held_text: str,
+) -> bool:
+    """Move withheld text after public non-text events in the durable timeline.
+
+    Tool and activity events remain live while the short prefix is withheld. If
+    the prefix later proves to be ordinary text, the client necessarily sees it
+    after those events. Reposition the matching text carriers so a history reload
+    preserves that same order. The rewrite is all-or-nothing and never changes
+    non-text segments.
+    """
+
+    remaining = held_text
+    rewritten_segments: list[dict[str, Any]] = []
+    for raw_segment in state.turn_segments:
+        segment = dict(raw_segment)
+        if segment.get("type") != "text" or not remaining:
+            rewritten_segments.append(segment)
+            continue
+        text = str(segment.get("text") or "")
+        if remaining.startswith(text):
+            remaining = remaining[len(text) :]
+            continue
+        if text.startswith(remaining):
+            suffix = text[len(remaining) :]
+            remaining = ""
+            if suffix:
+                segment["text"] = suffix
+                rewritten_segments.append(segment)
+            continue
+        return False
+
+    current_text = "".join(state.current_text_parts)
+    if remaining:
+        if not current_text.startswith(remaining):
+            return False
+        current_text = current_text[len(remaining) :]
+
+    state.turn_segments[:] = rewritten_segments
+    state.current_text_parts[:] = [held_text + current_text]
+    return True
 
 # ---------------------------------------------------------------------------
 # Ports -- five narrow Protocols + one callable
@@ -1549,6 +1613,10 @@ class StreamConsumerStage:
             inp.input_mode == "system_event"
             and inp.run_kind in {"goal", "heartbeat"}
         )
+        gate_human_silent_reply_prefix = inp.input_mode != "system_event"
+        human_silent_reply_prefix_open = gate_human_silent_reply_prefix
+        held_human_silent_reply_text = ""
+        human_prefix_crossed_public_boundary = False
         buffered_text_observed = False
         released_system_event_text: str | None = None
         released_system_event_source_text: str | None = None
@@ -1574,6 +1642,25 @@ class StreamConsumerStage:
                         )
                         buffered_text_observed = True
                     transformed = _SUPPRESS
+                elif human_silent_reply_prefix_open:
+                    held_human_silent_reply_text += transformed.text
+                    if _could_be_human_silent_reply_prefix(
+                        held_human_silent_reply_text
+                    ):
+                        transformed = _SUPPRESS
+                    else:
+                        if human_prefix_crossed_public_boundary:
+                            _move_held_human_text_to_current_tail(
+                                state,
+                                held_human_silent_reply_text,
+                            )
+                        transformed = replace(
+                            transformed,
+                            text=held_human_silent_reply_text,
+                        )
+                        held_human_silent_reply_text = ""
+                        human_silent_reply_prefix_open = False
+                        human_prefix_crossed_public_boundary = False
             elif isinstance(event, ThinkingEvent):
                 if event.text:
                     state.reasoning_parts.append(event.text)
@@ -1592,6 +1679,22 @@ class StreamConsumerStage:
                 transformed = self._artifact_handler.handle(event, state)
             elif isinstance(event, ErrorEvent):
                 transformed = self._error_handler.handle(event, state)
+                if (
+                    human_silent_reply_prefix_open
+                    and held_human_silent_reply_text
+                ):
+                    # A provider failure can terminate while a sentinel is only
+                    # partially streamed. Do not persist or reveal that control
+                    # prefix as a user-visible partial answer.
+                    _reconcile_done_text_snapshot(
+                        "",
+                        state,
+                        accumulated_text="".join(state.final_text_parts),
+                        authoritative=True,
+                    )
+                    held_human_silent_reply_text = ""
+                    human_silent_reply_prefix_open = False
+                    human_prefix_crossed_public_boundary = False
                 if buffer_system_event_text:
                     from opensquilla.engine.silent_reply import (
                         is_silent_reply_prefix,
@@ -1797,6 +1900,59 @@ class StreamConsumerStage:
                     if release_delta:
                         extra_yields.insert(0, TextDeltaEvent(text=release_delta))
                     released_system_event_text = canonical_text
+                elif (
+                    human_silent_reply_prefix_open
+                    and held_human_silent_reply_text
+                ):
+                    # A short initial candidate was withheld while it could
+                    # still be a control token. Once Done proves the payload is
+                    # visible, release one canonical delta and discard any
+                    # notice/reconciliation deltas that would duplicate it.
+                    extra_yields = [
+                        extra_event
+                        for extra_event in extra_yields
+                        if not isinstance(extra_event, TextDeltaEvent)
+                    ]
+                    snapshot_present, canonical_text = done_text_snapshot(transformed)
+                    if not snapshot_present:
+                        canonical_text = transformed.text
+                    if canonical_text and human_prefix_crossed_public_boundary:
+                        _move_held_human_text_to_current_tail(
+                            state,
+                            held_human_silent_reply_text,
+                        )
+                    if canonical_text:
+                        extra_yields.insert(0, TextDeltaEvent(text=canonical_text))
+                    held_human_silent_reply_text = ""
+                    human_silent_reply_prefix_open = False
+                    human_prefix_crossed_public_boundary = False
+
+                human_silent_reply_disallowed = (
+                    inp.input_mode != "system_event"
+                    and transformed.delivery == "suppressed"
+                    and transformed.suppression_reason
+                    in {"no_reply", "heartbeat_ack"}
+                    and not transformed.text.strip()
+                )
+                if human_silent_reply_disallowed:
+                    # Keep the usage-bearing DoneEvent in state for transcript
+                    # usage/session totals, but replace the public success
+                    # terminal with the existing error path. The outer runner
+                    # emits pending_error_event only after finalization.
+                    extra_yields = [
+                        extra_event
+                        for extra_event in extra_yields
+                        if not isinstance(extra_event, TextDeltaEvent)
+                    ]
+                    if state.pending_error_event is None:
+                        self._error_handler.handle(
+                            ErrorEvent(
+                                message=SILENT_REPLY_NOT_ALLOWED_MESSAGE,
+                                code=SILENT_REPLY_NOT_ALLOWED_CODE,
+                            ),
+                            state,
+                        )
+                    transformed = _SUPPRESS
             elif isinstance(event, CompactionEvent):
                 await self._compaction_handler.handle(event, inp)
                 transformed = _SUPPRESS
@@ -1816,6 +1972,14 @@ class StreamConsumerStage:
                 )
             else:
                 transformed = event
+
+            if (
+                human_silent_reply_prefix_open
+                and bool(held_human_silent_reply_text)
+                and not isinstance(event, (TextDeltaEvent, ErrorEvent, DoneEvent))
+                and (bool(extra_yields) or transformed is not _SUPPRESS)
+            ):
+                human_prefix_crossed_public_boundary = True
 
             for extra_event in extra_yields:
                 yield extra_event

--- a/src/opensquilla/session/terminal_reply.py
+++ b/src/opensquilla/session/terminal_reply.py
@@ -6,6 +6,10 @@ from collections.abc import Mapping
 from typing import Any
 
 from opensquilla.session.models import AgentTaskStatus
+from opensquilla.silent_reply import (
+    SILENT_REPLY_NOT_ALLOWED_CODE,
+    SILENT_REPLY_NOT_ALLOWED_MESSAGE,
+)
 
 CONTEXT_PAYLOAD_TOO_LARGE_CODE = "provider_request_too_large"
 ENSEMBLE_MULTIMODAL_UNSUPPORTED_CODE = "ensemble_multimodal_unsupported"
@@ -191,6 +195,11 @@ def build_terminal_reply(
             "The task was blocked because a tool it needed is not permitted by the "
             "current policy."
         )
+    if (
+        error_class == SILENT_REPLY_NOT_ALLOWED_CODE
+        or reason == SILENT_REPLY_NOT_ALLOWED_CODE
+    ):
+        return SILENT_REPLY_NOT_ALLOWED_MESSAGE
     if error_class in {
         "usage_accounting_busy",
         "usage_accounting_unavailable",

--- a/src/opensquilla/silent_reply.py
+++ b/src/opensquilla/silent_reply.py
@@ -15,6 +15,10 @@ type SilentReplySuppressionReason = Literal["no_reply", "heartbeat_ack"]
 NO_REPLY_TOKEN = "NO_REPLY"
 HEARTBEAT_ACK_TOKEN = "HEARTBEAT_OK"
 SILENT_REPLY_SENTINELS = frozenset({NO_REPLY_TOKEN, HEARTBEAT_ACK_TOKEN})
+SILENT_REPLY_NOT_ALLOWED_CODE = "silent_reply_not_allowed"
+SILENT_REPLY_NOT_ALLOWED_MESSAGE = (
+    "The model did not produce a usable reply. Review the request and try again."
+)
 
 _HEARTBEAT_THINK_BLOCK_RE = re.compile(r"<think>.*?</think>", re.DOTALL)
 _HEARTBEAT_UNCLOSED_THINK_RE = re.compile(r"<think>.*\Z", re.DOTALL)
@@ -644,6 +648,8 @@ __all__ = [
     "HistoricalSilentReplySanitization",
     "NO_REPLY_TOKEN",
     "SILENT_REPLY_SENTINELS",
+    "SILENT_REPLY_NOT_ALLOWED_CODE",
+    "SILENT_REPLY_NOT_ALLOWED_MESSAGE",
     "SilentReplyDelivery",
     "SilentReplyNormalization",
     "SilentReplySegmentsNormalization",

--- a/tests/test_engine/test_cancelled_turn_segments.py
+++ b/tests/test_engine/test_cancelled_turn_segments.py
@@ -506,8 +506,9 @@ async def test_cancelled_human_turn_does_not_persist_withheld_sentinel_prefix(
     try:
         await asyncio.wait_for(provider.text_consumed.wait(), timeout=5.0)
         task.cancel()
-        with pytest.raises(asyncio.CancelledError):
+        with contextlib.suppress(asyncio.CancelledError):
             await task
+        assert task.cancelled()
 
         transcript = await manager.get_transcript(session_key)
         assert [entry for entry in transcript if entry.role == "assistant"] == []
@@ -516,6 +517,7 @@ async def test_cancelled_human_turn_does_not_persist_withheld_sentinel_prefix(
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await task
+            assert task.cancelled()
         await storage.close()
 
 
@@ -562,8 +564,9 @@ async def test_cancelled_human_turn_preserves_released_over_bound_prefix(tmp_pat
         assert "".join(visible_text) == released_text
 
         task.cancel()
-        with pytest.raises(asyncio.CancelledError):
+        with contextlib.suppress(asyncio.CancelledError):
             await task
+        assert task.cancelled()
 
         transcript = await manager.get_transcript(session_key)
         assistants = [entry for entry in transcript if entry.role == "assistant"]
@@ -574,6 +577,7 @@ async def test_cancelled_human_turn_preserves_released_over_bound_prefix(tmp_pat
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await task
+            assert task.cancelled()
         await storage.close()
 
 

--- a/tests/test_engine/test_cancelled_turn_segments.py
+++ b/tests/test_engine/test_cancelled_turn_segments.py
@@ -507,7 +507,7 @@ async def test_cancelled_human_turn_does_not_persist_withheld_sentinel_prefix(
         await asyncio.wait_for(provider.text_consumed.wait(), timeout=5.0)
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
-            await task
+            _ = await task
         assert task.cancelled()
 
         transcript = await manager.get_transcript(session_key)
@@ -516,7 +516,7 @@ async def test_cancelled_human_turn_does_not_persist_withheld_sentinel_prefix(
         if not task.done():
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await task
+                _ = await task
             assert task.cancelled()
         await storage.close()
 
@@ -565,7 +565,7 @@ async def test_cancelled_human_turn_preserves_released_over_bound_prefix(tmp_pat
 
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
-            await task
+            _ = await task
         assert task.cancelled()
 
         transcript = await manager.get_transcript(session_key)
@@ -576,7 +576,7 @@ async def test_cancelled_human_turn_preserves_released_over_bound_prefix(tmp_pat
         if not task.done():
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await task
+                _ = await task
             assert task.cancelled()
         await storage.close()
 

--- a/tests/test_engine/test_cancelled_turn_segments.py
+++ b/tests/test_engine/test_cancelled_turn_segments.py
@@ -462,6 +462,122 @@ async def test_cancelled_system_event_does_not_persist_partial_sentinel(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "partial_marker",
+    ["N", "NO_REP", "HEART", pytest.param("   ", id="whitespace-only")],
+)
+async def test_cancelled_human_turn_does_not_persist_withheld_sentinel_prefix(
+    tmp_path,
+    partial_marker: str,
+) -> None:
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    manager = SessionManager(storage)
+    session_key = f"agent:main:webchat:cancel-human-prefix-{partial_marker}"
+    await manager.create(session_key)
+    provider = _HangingSystemEventProvider(partial_marker)
+    runner = TurnRunner(
+        provider_selector=_ProviderSelector(provider),
+        tool_registry=_registry(),
+        session_manager=manager,
+        config=GatewayConfig(
+            attachments=AttachmentsConfig(media_root=str(tmp_path / "media")),
+            squilla_router=SquillaRouterConfig(enabled=False),
+        ),
+    )
+    tool_context = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(tmp_path),
+    )
+
+    async def _consume() -> None:
+        async for _event in runner.run(
+            "ordinary human request",
+            session_key,
+            tool_context=tool_context,
+            history_has_persisted_user=False,
+            input_mode="user",
+            no_memory_capture=True,
+        ):
+            pass
+
+    task = asyncio.create_task(_consume())
+    try:
+        await asyncio.wait_for(provider.text_consumed.wait(), timeout=5.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        transcript = await manager.get_transcript(session_key)
+        assert [entry for entry in transcript if entry.role == "assistant"] == []
+    finally:
+        if not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_human_turn_preserves_released_over_bound_prefix(tmp_path) -> None:
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    manager = SessionManager(storage)
+    session_key = "agent:main:webchat:cancel-human-released-prefix"
+    await manager.create(session_key)
+    released_text = "N" + (" " * 64)
+    provider = _HangingSystemEventProvider(released_text)
+    runner = TurnRunner(
+        provider_selector=_ProviderSelector(provider),
+        tool_registry=_registry(),
+        session_manager=manager,
+        config=GatewayConfig(
+            attachments=AttachmentsConfig(media_root=str(tmp_path / "media")),
+            squilla_router=SquillaRouterConfig(enabled=False),
+        ),
+    )
+    tool_context = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(tmp_path),
+    )
+    visible_text: list[str] = []
+
+    async def _consume() -> None:
+        async for event in runner.run(
+            "ordinary human request",
+            session_key,
+            tool_context=tool_context,
+            history_has_persisted_user=False,
+            input_mode="user",
+            no_memory_capture=True,
+        ):
+            if isinstance(event, TextDeltaEvent):
+                visible_text.append(event.text)
+
+    task = asyncio.create_task(_consume())
+    try:
+        await asyncio.wait_for(provider.text_consumed.wait(), timeout=5.0)
+        assert "".join(visible_text) == released_text
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        transcript = await manager.get_transcript(session_key)
+        assistants = [entry for entry in transcript if entry.role == "assistant"]
+        assert len(assistants) == 1
+        assert assistants[0].content == "N"
+    finally:
+        if not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        await storage.close()
+
+
+@pytest.mark.asyncio
 async def test_cancelled_system_event_persists_body_without_sentinel(tmp_path) -> None:
     storage = SessionStorage(":memory:")
     await storage.connect()

--- a/tests/test_engine/test_silent_reply_runtime.py
+++ b/tests/test_engine/test_silent_reply_runtime.py
@@ -9,7 +9,7 @@ from typing import Any
 import pytest
 
 from opensquilla.engine.runtime import TurnRunner
-from opensquilla.engine.types import DoneEvent, TextDeltaEvent
+from opensquilla.engine.types import DoneEvent, ErrorEvent, TextDeltaEvent
 from opensquilla.gateway.config import AttachmentsConfig, GatewayConfig, SquillaRouterConfig
 from opensquilla.provider import ContentBlockText, Message, ModelInfo
 from opensquilla.provider import DoneEvent as ProviderDone
@@ -19,6 +19,10 @@ from opensquilla.provider import ToolUseEndEvent as ProviderToolUseEnd
 from opensquilla.provider import ToolUseStartEvent as ProviderToolUseStart
 from opensquilla.session.manager import SessionManager
 from opensquilla.session.storage import SessionStorage
+from opensquilla.silent_reply import (
+    SILENT_REPLY_NOT_ALLOWED_CODE,
+    SILENT_REPLY_NOT_ALLOWED_MESSAGE,
+)
 from opensquilla.tools.registry import ToolRegistry
 from opensquilla.tools.types import CallerKind, ToolContext, ToolSpec
 
@@ -215,6 +219,88 @@ async def test_system_event_runtime_emits_only_canonical_terminal_text(
             assert [entry.content for entry in assistants] == [expected_text]
         else:
             assert assistants == []
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "chunks",
+    [
+        list("NO_REPLY"),
+        ["HEARTBEAT_", "OK"],
+    ],
+)
+async def test_human_sentinel_runtime_emits_error_and_retains_usage(
+    tmp_path,
+    chunks: list[str],
+) -> None:
+    storage, manager, _provider, runner, context, session_key = await _runtime_stack(
+        tmp_path,
+        [chunks],
+    )
+    try:
+        events = [
+            event
+            async for event in runner.run(
+                "human request",
+                session_key,
+                tool_context=context,
+                history_has_persisted_user=False,
+                input_mode="user",
+                no_memory_capture=True,
+            )
+        ]
+
+        assert not any(isinstance(event, TextDeltaEvent) for event in events)
+        assert not any(isinstance(event, DoneEvent) for event in events)
+        errors = [event for event in events if isinstance(event, ErrorEvent)]
+        assert len(errors) == 1
+        assert errors[0].code == SILENT_REPLY_NOT_ALLOWED_CODE
+        assert errors[0].message == SILENT_REPLY_NOT_ALLOWED_MESSAGE
+
+        session = await manager.get_session(session_key)
+        assert session is not None
+        assert session.input_tokens == 3
+        assert session.output_tokens == 2
+        assert session.total_tokens == 5
+        transcript = await manager.get_transcript(session_key)
+        assert [entry for entry in transcript if entry.role == "assistant"] == []
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_human_mixed_sentinel_runtime_remains_visible(tmp_path) -> None:
+    body = "A normal human-facing reply."
+    source = f"NO_REPLY\n{body}"
+    storage, manager, _provider, runner, context, session_key = await _runtime_stack(
+        tmp_path,
+        [["NO_", "REPLY\n", body]],
+    )
+    try:
+        events = [
+            event
+            async for event in runner.run(
+                "human request",
+                session_key,
+                tool_context=context,
+                history_has_persisted_user=False,
+                input_mode="user",
+                no_memory_capture=True,
+            )
+        ]
+
+        assert [event.text for event in events if isinstance(event, TextDeltaEvent)] == [
+            source
+        ]
+        done = next(event for event in events if isinstance(event, DoneEvent))
+        assert done.text_snapshot == source
+        assert done.delivery == "visible"
+        assert not any(isinstance(event, ErrorEvent) for event in events)
+        transcript = await manager.get_transcript(session_key)
+        assistants = [entry for entry in transcript if entry.role == "assistant"]
+        assert [entry.content for entry in assistants] == [source]
     finally:
         await storage.close()
 

--- a/tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py
@@ -49,6 +49,10 @@ from opensquilla.engine.types import (
     WarningEvent,
 )
 from opensquilla.provider.types import EnsembleProgressEvent as ProviderEnsembleProgressEvent
+from opensquilla.silent_reply import (
+    SILENT_REPLY_NOT_ALLOWED_CODE,
+    SILENT_REPLY_NOT_ALLOWED_MESSAGE,
+)
 from opensquilla.tools.types import ToolContext
 
 # ---------------------------------------------------------------------------
@@ -1430,6 +1434,272 @@ async def test_outer_stage_yields_text_then_done_and_notifies_post_stream() -> N
     assert len(recs["memory_sync_notify"].calls) == 1
     assert recs["memory_sync_notify"].calls[0]["runtime_message"] == "hello there"
     assert recs["memory_sync_notify"].calls[0]["sync_manager_present"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("sentinel", "chunks"),
+    [
+        ("NO_REPLY", ["NO_REPLY"]),
+        ("NO_REPLY", list("NO_REPLY")),
+        ("HEARTBEAT_OK", ["HEARTBEAT_OK"]),
+        ("HEARTBEAT_OK", list("HEARTBEAT_OK")),
+        ("  NO_REPLY\n", ["  ", "NO_", "REPLY\n"]),
+        ("\tHEARTBEAT_OK  ", ["\tHEART", "BEAT_OK  "]),
+    ],
+)
+async def test_human_sentinel_only_done_becomes_pending_error_without_text_flash(
+    sentinel: str,
+    chunks: list[str],
+) -> None:
+    agent_run = _RecordingAgentRun(
+        events=[
+            *(TextDeltaEvent(text=chunk) for chunk in chunks),
+            DoneEvent(
+                text=sentinel,
+                text_snapshot=sentinel,
+                input_tokens=13,
+                output_tokens=2,
+            ),
+        ]
+    )
+    stage, _ = _make_stage(agent_run=agent_run)
+    inp = _make_input(input_mode="user")
+
+    yielded = await _drain(stage, inp)
+
+    assert yielded == []
+    assert inp.state.final_text_parts == []
+    assert inp.state.current_text_parts == []
+    assert inp.state.pending_error_event == ErrorEvent(
+        message=SILENT_REPLY_NOT_ALLOWED_MESSAGE,
+        code=SILENT_REPLY_NOT_ALLOWED_CODE,
+    )
+    assert inp.state.error_message == SILENT_REPLY_NOT_ALLOWED_MESSAGE
+    assert inp.state.done_event is not None
+    assert inp.state.done_event.input_tokens == 13
+    assert inp.state.done_event.output_tokens == 2
+    assert inp.state.done_event.delivery == "suppressed"
+
+
+@pytest.mark.asyncio
+async def test_human_done_only_sentinel_becomes_pending_error() -> None:
+    stage, _ = _make_stage(
+        agent_run=_RecordingAgentRun(
+            events=[
+                DoneEvent(
+                    text="NO_REPLY",
+                    text_snapshot="NO_REPLY",
+                    input_tokens=5,
+                    output_tokens=1,
+                )
+            ]
+        )
+    )
+    inp = _make_input(input_mode="user")
+
+    yielded = await _drain(stage, inp)
+
+    assert yielded == []
+    assert inp.state.pending_error_event is not None
+    assert inp.state.pending_error_event.code == SILENT_REPLY_NOT_ALLOWED_CODE
+    assert inp.state.done_event is not None
+    assert inp.state.done_event.input_tokens == 5
+
+
+@pytest.mark.asyncio
+async def test_human_short_normal_prefix_releases_at_done() -> None:
+    stage, _ = _make_stage(
+        agent_run=_RecordingAgentRun(
+            events=[
+                TextDeltaEvent(text="NO"),
+                DoneEvent(text="NO", text_snapshot="NO"),
+            ]
+        )
+    )
+    inp = _make_input(input_mode="user")
+
+    yielded = await _drain(stage, inp)
+
+    assert [type(event).__name__ for event in yielded] == [
+        "TextDeltaEvent",
+        "DoneEvent",
+    ]
+    assert yielded[0].text == "NO"
+    assert yielded[1].text_snapshot == "NO"
+    assert inp.state.pending_error_event is None
+
+
+@pytest.mark.asyncio
+async def test_human_prefix_crossing_tool_boundary_keeps_live_and_history_order() -> None:
+    stage, _ = _make_stage(
+        agent_run=_RecordingAgentRun(
+            events=[
+                TextDeltaEvent(text="NO"),
+                ToolUseStartEvent(tool_use_id="tool-1", tool_name="lookup"),
+                ToolResultEvent(
+                    tool_use_id="tool-1",
+                    tool_name="lookup",
+                    result="ok",
+                ),
+                TextDeltaEvent(text=" results"),
+                DoneEvent(text="NO results", text_snapshot="NO results"),
+            ]
+        )
+    )
+    inp = _make_input(input_mode="user")
+
+    yielded = await _drain(stage, inp)
+
+    assert [type(event).__name__ for event in yielded] == [
+        "ToolUseStartEvent",
+        "ToolResultEvent",
+        "TextDeltaEvent",
+        "DoneEvent",
+    ]
+    assert yielded[2].text == "NO results"
+    assert [segment["type"] for segment in inp.state.turn_segments] == [
+        "tool_use",
+        "tool_result",
+    ]
+    assert inp.state.current_text_parts == ["NO results"]
+
+
+@pytest.mark.asyncio
+async def test_human_short_prefix_done_after_tool_moves_text_to_history_tail() -> None:
+    stage, _ = _make_stage(
+        agent_run=_RecordingAgentRun(
+            events=[
+                TextDeltaEvent(text="NO"),
+                ToolUseStartEvent(tool_use_id="tool-1", tool_name="lookup"),
+                ToolResultEvent(
+                    tool_use_id="tool-1",
+                    tool_name="lookup",
+                    result="ok",
+                ),
+                DoneEvent(text="NO", text_snapshot="NO"),
+            ]
+        )
+    )
+    inp = _make_input(input_mode="user")
+
+    yielded = await _drain(stage, inp)
+
+    assert [type(event).__name__ for event in yielded] == [
+        "ToolUseStartEvent",
+        "ToolResultEvent",
+        "TextDeltaEvent",
+        "DoneEvent",
+    ]
+    assert yielded[2].text == "NO"
+    assert [segment["type"] for segment in inp.state.turn_segments] == [
+        "tool_use",
+        "tool_result",
+    ]
+    assert inp.state.current_text_parts == ["NO"]
+
+
+@pytest.mark.asyncio
+async def test_human_usage_done_after_provider_error_keeps_original_error() -> None:
+    provider_error = ErrorEvent(message="provider failed", code="provider_error")
+    stage, _ = _make_stage(
+        agent_run=_RecordingAgentRun(
+            events=[
+                TextDeltaEvent(text="NO_REP"),
+                provider_error,
+                DoneEvent(
+                    text="NO_REPLY",
+                    text_snapshot="NO_REPLY",
+                    input_tokens=8,
+                    output_tokens=1,
+                ),
+            ]
+        )
+    )
+    inp = _make_input(input_mode="user")
+
+    yielded = await _drain(stage, inp)
+
+    assert yielded == []
+    assert inp.state.pending_error_event is provider_error
+    assert inp.state.error_message == "provider failed"
+    assert inp.state.final_text_parts == []
+    assert inp.state.done_event is not None
+    assert inp.state.done_event.input_tokens == 8
+    assert inp.state.done_event.delivery == "suppressed"
+
+
+@pytest.mark.asyncio
+async def test_human_mixed_sentinel_prose_releases_once_and_completes() -> None:
+    body = "This is a normal human-facing reply."
+    source = f"NO_REPLY\n{body}"
+    stage, _ = _make_stage(
+        agent_run=_RecordingAgentRun(
+            events=[
+                TextDeltaEvent(text="NO_"),
+                TextDeltaEvent(text="REPLY\n"),
+                TextDeltaEvent(text=body),
+                DoneEvent(text=source, text_snapshot=source),
+            ]
+        )
+    )
+    inp = _make_input(input_mode="user")
+
+    yielded = await _drain(stage, inp)
+
+    assert [type(event).__name__ for event in yielded] == [
+        "TextDeltaEvent",
+        "DoneEvent",
+    ]
+    assert yielded[0].text == source
+    assert yielded[1].text_snapshot == source
+    assert inp.state.pending_error_event is None
+
+
+@pytest.mark.asyncio
+async def test_human_sentinel_failure_keeps_tool_and_artifact_activity() -> None:
+    artifact = ArtifactEvent(name="report.txt", mime="text/plain", size=4)
+    stage, _ = _make_stage(
+        agent_run=_RecordingAgentRun(
+            events=[
+                TextDeltaEvent(text="NO_REPLY"),
+                ToolUseStartEvent(tool_use_id="tool-1", tool_name="lookup"),
+                ToolResultEvent(
+                    tool_use_id="tool-1",
+                    tool_name="lookup",
+                    result="ok",
+                ),
+                artifact,
+                DoneEvent(
+                    text="NO_REPLY",
+                    text_snapshot="NO_REPLY",
+                    input_tokens=7,
+                    output_tokens=1,
+                ),
+            ]
+        )
+    )
+    inp = _make_input(input_mode="user")
+
+    yielded = await _drain(stage, inp)
+
+    assert [type(event).__name__ for event in yielded] == [
+        "ToolUseStartEvent",
+        "ToolResultEvent",
+        "ArtifactEvent",
+    ]
+    assert [segment["type"] for segment in inp.state.turn_segments] == [
+        "tool_use",
+        "tool_result",
+    ]
+    assert len(inp.state.turn_artifacts) == 1
+    assert inp.state.turn_artifacts[0]["name"] == "report.txt"
+    assert inp.state.turn_artifacts[0]["mime"] == "text/plain"
+    assert inp.state.turn_artifacts[0]["size"] == 4
+    assert inp.state.pending_error_event is not None
+    assert inp.state.pending_error_event.code == SILENT_REPLY_NOT_ALLOWED_CODE
+    assert inp.state.done_event is not None
+    assert inp.state.done_event.input_tokens == 7
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/turn_runner/test_turn_finalizer_stage_snapshot.py
+++ b/tests/test_engine/turn_runner/test_turn_finalizer_stage_snapshot.py
@@ -134,7 +134,7 @@ class _Case:
     expected_memory_capture_calls: int = 0
     expected_persist_error_calls: int = 0
     expected_update_calls: int = 0
-    expected_done_present: bool = False
+    expected_done_present: bool | None = None
     expected_pending_error_code: str | None = None
     private_memory_allowed: bool = True
     memory_capture_raises: type[BaseException] | None = None
@@ -196,7 +196,7 @@ _CORPUS: list[_Case] = [
         expected_persist_error_calls=1,
         expected_pending_error_code="agent_error",
     ),
-    # 5. Heartbeat-only sentinel -> NO transcript, NO memory
+    # 5. Human sentinel-only reply -> explicit error, but Done usage still rolls up.
     _Case(
         case_id="heartbeat_sentinel_empty",
         events=[
@@ -205,8 +205,10 @@ _CORPUS: list[_Case] = [
         ],
         expected_transcript_append_count=0,
         expected_memory_capture_calls=0,
+        expected_persist_error_calls=1,
         expected_update_calls=1,
-        expected_done_present=True,
+        expected_done_present=False,
+        expected_pending_error_code="silent_reply_not_allowed",
     ),
     # 6. DeepSeek reasoning_content included
     _Case(
@@ -541,9 +543,9 @@ async def test_turn_finalizer_stage_snapshot(
         tail = next(e for e in reversed(yielded) if isinstance(e, ErrorEvent))
         assert tail.code == case.expected_pending_error_code
 
-    if case.expected_done_present:
-        assert any(isinstance(e, DoneEvent) for e in yielded), (
-            f"{case_id}: expected DoneEvent in yielded stream"
+    if case.expected_done_present is not None:
+        assert any(isinstance(e, DoneEvent) for e in yielded) is case.expected_done_present, (
+            f"{case_id}: DoneEvent presence diverged"
         )
 
     if session_manager is None:
@@ -575,7 +577,10 @@ async def test_turn_finalizer_stage_snapshot(
     # Pin the cost rollup arguments per-case when an update was made.
     if case.expected_update_calls == 1:
         upd = session_manager.update_calls[0]
-        done = next(e for e in yielded if isinstance(e, DoneEvent))
+        done = next(
+            (event for event in yielded if isinstance(event, DoneEvent)),
+            next(event for event in case.events if isinstance(event, DoneEvent)),
+        )
         # input_tokens / output_tokens / cache totals come straight from
         # the DoneEvent additive over the zero-baseline session row.
         assert upd["input_tokens"] == done.input_tokens

--- a/tests/test_gateway/test_task_runtime_terminal_message.py
+++ b/tests/test_gateway/test_task_runtime_terminal_message.py
@@ -20,6 +20,10 @@ from opensquilla.gateway.routing import RouteEnvelope, SourceKind
 from opensquilla.gateway.task_runtime import SubagentCompletionEvent, TaskRuntime
 from opensquilla.session.models import AgentTaskRecord, AgentTaskStatus
 from opensquilla.session.storage import SessionStorage
+from opensquilla.silent_reply import (
+    SILENT_REPLY_NOT_ALLOWED_CODE,
+    SILENT_REPLY_NOT_ALLOWED_MESSAGE,
+)
 
 
 def _make_envelope(
@@ -145,6 +149,63 @@ async def test_typed_provider_exception_is_sanitized_in_task_record_and_wire_eve
     assert terminal_event[2]["terminal_message"] == "The task failed before it could finish."
     assert record.details is not None
     assert record.details["turn_outcome"]["retryable"] is True
+
+
+@pytest.mark.asyncio
+async def test_human_silent_reply_error_marks_task_failed_without_retry_hint(
+    tmp_path: Any,
+) -> None:
+    emitted: list[tuple[str, str, dict[str, Any]]] = []
+    db_path = tmp_path / "silent-reply-task.sqlite"
+
+    async def _emitter(
+        session_key: str,
+        event_name: str,
+        payload: dict[str, Any],
+    ) -> None:
+        emitted.append((session_key, event_name, payload))
+
+    async def _silent_reply_handler(_run: Any) -> None:
+        raise TaskRuntimeStreamError(
+            SILENT_REPLY_NOT_ALLOWED_MESSAGE,
+            code=SILENT_REPLY_NOT_ALLOWED_CODE,
+            terminal_reason="error",
+        )
+
+    storage = await SessionStorage.open(str(db_path))
+    try:
+        runtime = _make_runtime(
+            _silent_reply_handler,
+            event_emitter=_emitter,
+            storage=storage,
+        )
+        handle = await runtime.enqueue(_make_envelope(), "hello")
+
+        record = await runtime.wait(handle.task_id, timeout=2.0)
+
+        assert record.status == AgentTaskStatus.FAILED
+        assert record.error_class == SILENT_REPLY_NOT_ALLOWED_CODE
+        assert record.error_message == SILENT_REPLY_NOT_ALLOWED_MESSAGE
+        assert record.details is not None
+        assert record.details["turn_outcome"]["retryable"] is False
+        terminal_event = next(event for event in emitted if event[1] == "task.failed")
+        assert terminal_event[2]["terminal_message"] == SILENT_REPLY_NOT_ALLOWED_MESSAGE
+        assert "retryable" not in terminal_event[2]
+        task_id = handle.task_id
+    finally:
+        await storage.close()
+
+    restarted = await SessionStorage.open(str(db_path))
+    try:
+        recovered = await restarted.get_agent_task(task_id)
+        assert recovered is not None
+        assert recovered.status == AgentTaskStatus.FAILED
+        assert recovered.error_class == SILENT_REPLY_NOT_ALLOWED_CODE
+        assert recovered.error_message == SILENT_REPLY_NOT_ALLOWED_MESSAGE
+        assert recovered.details is not None
+        assert recovered.details["turn_outcome"]["retryable"] is False
+    finally:
+        await restarted.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway/test_terminal_reply.py
+++ b/tests/test_gateway/test_terminal_reply.py
@@ -12,6 +12,10 @@ from opensquilla.session.terminal_reply import (
     safe_provider_failure_message,
     sanitize_agent_error,
 )
+from opensquilla.silent_reply import (
+    SILENT_REPLY_NOT_ALLOWED_CODE,
+    SILENT_REPLY_NOT_ALLOWED_MESSAGE,
+)
 
 RAW_INTERNAL_STRINGS = (
     "Gateway task timeout",
@@ -186,6 +190,18 @@ def test_ensemble_multimodal_reply_is_actionable_and_stable() -> None:
         "Ensemble does not support image input yet. "
         "Switch to a single-model routing mode and try again."
     )
+
+
+def test_human_silent_reply_failure_has_actionable_terminal_message() -> None:
+    reply = build_terminal_reply(
+        {
+            "status": "failed",
+            "terminal_reason": "error",
+            "error_class": SILENT_REPLY_NOT_ALLOWED_CODE,
+        }
+    )
+
+    assert reply == SILENT_REPLY_NOT_ALLOWED_MESSAGE
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Scope

- convert sentinel-only NO_REPLY and HEARTBEAT_OK results on human turns from an empty success into a stable silent_reply_not_allowed ErrorEvent
- retain the internal DoneEvent so usage, cost, artifacts, tool results, and session totals are finalized normally
- gate only the bounded initial sentinel prefix so control fragments never flash in streaming clients
- preserve existing system_event Goal and heartbeat suppression behavior
- add a fixed terminal reply for Gateway and channel surfaces

## Branch target

main

## Linked issue

None

## Release note

Yes: Human chat turns that return only an internal silent sentinel now fail visibly instead of completing without an answer.

## Verification

- uv run ruff check on all 11 changed files
- uv run mypy on runtime, stream consumer, and terminal reply modules
- 317 focused engine, Gateway, CLI, channel, and TUI tests passed
- 123 stream and cancellation boundary tests passed after final review fixes
- deterministic real Gateway + Vue WebUI + SQLite acceptance: one failed terminal after reload, no sentinel transcript row, and usage totals preserved
- independent final code review: no findings

## Safety and compatibility

- no database migration, wire-schema change, new retry action, or automatic replay
- existing historical suppressed replies remain unchanged
- existing system_event Goal and heartbeat behavior remains unchanged
- provider and tool activity can already have occurred, so this failure is deliberately not replay-safe and TaskRuntime reports retryable=false
- the external CLI stream no longer receives Done for this rare failure, so its immediate per-turn usage summary may be empty; durable server usage remains accurate
- platform-neutral logic with no filesystem, process, signal, or OS-specific behavior

## Third-party origin

None. The implementation and tests are original OpenSquilla changes.

## Merge order

Review and merge after #1211 to keep the two user-facing fixes separate. There is no code dependency between the branches.