### PR TITLE
fix: search existing sessions on first query

### DIFF
--- a/src/opensquilla/memory/sync_manager.py
+++ b/src/opensquilla/memory/sync_manager.py
@@ -157,6 +157,7 @@ class MemorySyncManager:
         if (
             is_search_reason
             and not self._dirty
+            and not force
             and not session_delta_pending
             and (self._session_indexer is None or self._session_search_synced)
         ):

--- a/src/opensquilla/memory/sync_manager.py
+++ b/src/opensquilla/memory/sync_manager.py
@@ -79,6 +79,7 @@ class MemorySyncManager:
         self._ttl_days = ttl_days
         self._ttl_sweep_interval_minutes = ttl_sweep_interval_minutes
         self._session_indexer = session_indexer
+        self._session_search_synced = False
 
         self._dirty = False
         self._warmed_sessions: set[str] = set()
@@ -153,7 +154,12 @@ class MemorySyncManager:
         """
         is_search_reason = reason == "search" or reason.startswith("search:")
         session_delta_pending = self._delta.has_pending()
-        if is_search_reason and not self._dirty and not force and not session_delta_pending:
+        if (
+            is_search_reason
+            and not self._dirty
+            and not session_delta_pending
+            and (self._session_indexer is None or self._session_search_synced)
+        ):
             return
         if reason == "session-delta" and not self._delta.should_sync() and not force:
             return
@@ -214,6 +220,7 @@ class MemorySyncManager:
     def notify_message(self, byte_count: int) -> None:
         """Trigger 5: accumulate session delta."""
         self._delta.record(byte_count=byte_count)
+        self._session_search_synced = False
 
     # --- Internal ---
 
@@ -311,6 +318,7 @@ class MemorySyncManager:
             return False
         try:
             result = await self._session_indexer.sync(force=force)
+            self._session_search_synced = True
             logger.info(
                 "sync_manager.sessions_synced",
                 reason=reason,

--- a/tests/test_memory_sessions_source.py
+++ b/tests/test_memory_sessions_source.py
@@ -228,6 +228,37 @@ async def test_sync_manager_search_indexes_pending_session_delta(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_sync_manager_searches_existing_sessions_without_pending_delta(tmp_path):
+    class NoopStore:
+        async def index_file(self, **_kwargs):
+            return 0
+
+        async def remove_file(self, _path):
+            return None
+
+    class FakeSessionIndexer:
+        def __init__(self) -> None:
+            self.calls: list[bool] = []
+
+        async def sync(self, *, force: bool = False):
+            self.calls.append(force)
+            return SimpleNamespace(indexed=1, removed=0)
+
+    indexer = FakeSessionIndexer()
+    manager = MemorySyncManager(
+        store=NoopStore(),  # type: ignore[arg-type]
+        workspace_dir=tmp_path,
+        memory_dir=tmp_path / "memory",
+        session_indexer=indexer,
+    )
+
+    await manager.sync(reason="search:tool")
+    await manager.sync(reason="search:tool")
+
+    assert indexer.calls == [False]
+
+
+@pytest.mark.asyncio
 async def test_memory_search_tool_outputs_sessions_source(tmp_path):
     registry = ToolRegistry()
 


### PR DESCRIPTION
Closes #1203

Search synchronization returned early when no session delta was pending, so existing persisted sessions were not indexed on the first search. The manager now performs one session sync on demand and avoids repeating it until a new message marks the index stale.

Tested with `pytest -q tests/test_memory_sessions_source.py` (8 passed), including a regression test that exercises the first search of an existing session without a pending delta. The regression failed on the unchanged code and passed with this fix.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.