### PR TITLE
fix(cli): preserve routed model cost breakdown

### DIFF
--- a/src/opensquilla/cli/cost_cmd.py
+++ b/src/opensquilla/cli/cost_cmd.py
@@ -33,12 +33,18 @@ def cost(
             lambda: {"input": 0, "output": 0, "cost": 0.0}
         )
         for row in rows:
-            model = row.get("model") or "unknown"
-            grouped[model]["input"] += int(row.get("input_tokens") or row.get("inputTokens") or 0)
-            grouped[model]["output"] += int(
-                row.get("output_tokens") or row.get("outputTokens") or 0
-            )
-            grouped[model]["cost"] += float(row.get("cost_usd") or row.get("costUsd") or 0.0)
+            model_rows = row.get("modelBreakdown") or row.get("model_breakdown") or [row]
+            for model_row in model_rows:
+                model = model_row.get("model") or "unknown"
+                grouped[model]["input"] += int(
+                    model_row.get("input_tokens") or model_row.get("inputTokens") or 0
+                )
+                grouped[model]["output"] += int(
+                    model_row.get("output_tokens") or model_row.get("outputTokens") or 0
+                )
+                grouped[model]["cost"] += float(
+                    model_row.get("cost_usd") or model_row.get("costUsd") or 0.0
+                )
         if json_output:
             print_json(
                 {

--- a/src/opensquilla/cli/cost_cmd.py
+++ b/src/opensquilla/cli/cost_cmd.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import math
 from collections import defaultdict
+from collections.abc import Mapping
 from typing import Any, cast
 
 import typer
@@ -13,6 +15,66 @@ from opensquilla.cli.output import print_json
 from opensquilla.cli.ui import ACCENT_HEADER, console
 
 app = typer.Typer(help="Inspect usage and estimated cost.")
+
+
+def _usage_values(row: Mapping[str, Any]) -> tuple[int, int, float]:
+    return (
+        int(row.get("input_tokens") or row.get("inputTokens") or 0),
+        int(row.get("output_tokens") or row.get("outputTokens") or 0),
+        float(row.get("cost_usd") or row.get("costUsd") or 0.0),
+    )
+
+
+def _model_rows_for_aggregation(row: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    breakdown = (
+        row.get("deploymentBreakdown")
+        or row.get("deployment_breakdown")
+        or row.get("modelBreakdown")
+        or row.get("model_breakdown")
+    )
+    if breakdown is None or breakdown == []:
+        return [row]
+
+    parent_input, parent_output, parent_cost = _usage_values(row)
+    if not isinstance(breakdown, list) or not all(
+        isinstance(item, Mapping) for item in breakdown
+    ):
+        return [
+            {
+                "model": "unknown",
+                "inputTokens": parent_input,
+                "outputTokens": parent_output,
+                "costUsd": parent_cost,
+            }
+        ]
+
+    model_rows = cast(list[Mapping[str, Any]], breakdown)
+    child_values = [_usage_values(model_row) for model_row in model_rows]
+    breakdown_input = sum(values[0] for values in child_values)
+    breakdown_output = sum(values[1] for values in child_values)
+    breakdown_cost = sum(values[2] for values in child_values)
+    cost_tolerance = 1e-6 * max(1, len(model_rows))
+    is_complete = (
+        breakdown_input == parent_input
+        and breakdown_output == parent_output
+        and math.isclose(
+            breakdown_cost,
+            parent_cost,
+            rel_tol=1e-9,
+            abs_tol=cost_tolerance,
+        )
+    )
+    if is_complete:
+        return model_rows
+
+    return [
+        {
+            "model": "unknown",
+            "inputTokens": parent_input,
+            "outputTokens": parent_output,
+            "costUsd": parent_cost,
+        }
+    ]
 
 
 @app.callback(invoke_without_command=True)
@@ -33,18 +95,12 @@ def cost(
             lambda: {"input": 0, "output": 0, "cost": 0.0}
         )
         for row in rows:
-            model_rows = row.get("modelBreakdown") or row.get("model_breakdown") or [row]
-            for model_row in model_rows:
+            for model_row in _model_rows_for_aggregation(row):
                 model = model_row.get("model") or "unknown"
-                grouped[model]["input"] += int(
-                    model_row.get("input_tokens") or model_row.get("inputTokens") or 0
-                )
-                grouped[model]["output"] += int(
-                    model_row.get("output_tokens") or model_row.get("outputTokens") or 0
-                )
-                grouped[model]["cost"] += float(
-                    model_row.get("cost_usd") or model_row.get("costUsd") or 0.0
-                )
+                input_tokens, output_tokens, cost_usd = _usage_values(model_row)
+                grouped[model]["input"] += input_tokens
+                grouped[model]["output"] += output_tokens
+                grouped[model]["cost"] += cost_usd
         if json_output:
             print_json(
                 {

--- a/tests/test_cli/test_cli_product_completeness.py
+++ b/tests/test_cli/test_cli_product_completeness.py
@@ -1577,6 +1577,54 @@ def test_cost_json_returns_gateway_payload(monkeypatch):
     assert ("usage.cost", {}) in fake.calls
 
 
+def test_cost_by_model_uses_routed_model_breakdown(monkeypatch):
+    fake = _install_fake_gateway(monkeypatch)
+    fake.cost_payload = {
+        "breakdown": [
+            {
+                "session": "agent:webchat:routed",
+                "model": "unknown",
+                "inputTokens": 30,
+                "outputTokens": 3,
+                "costUsd": 0.03,
+                "modelBreakdown": [
+                    {
+                        "model": "deepseek-v4-flash",
+                        "inputTokens": 10,
+                        "outputTokens": 1,
+                        "costUsd": 0.01,
+                    },
+                    {
+                        "model": "deepseek-v4-pro",
+                        "inputTokens": 20,
+                        "outputTokens": 2,
+                        "costUsd": 0.02,
+                    },
+                ],
+            }
+        ],
+        "totalCostUsd": 0.03,
+    }
+
+    result = runner.invoke(app, ["cost", "--by-model", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    assert json.loads(result.stdout)["byModel"] == [
+        {
+            "model": "deepseek-v4-flash",
+            "inputTokens": 10,
+            "outputTokens": 1,
+            "costUsd": 0.01,
+        },
+        {
+            "model": "deepseek-v4-pro",
+            "inputTokens": 20,
+            "outputTokens": 2,
+            "costUsd": 0.02,
+        },
+    ]
+
+
 def test_provider_and_search_diagnostics_use_gateway_rpcs(monkeypatch):
     fake = _install_fake_gateway(monkeypatch)
     fake.rpc_payloads = {

--- a/tests/test_cli/test_cli_product_completeness.py
+++ b/tests/test_cli/test_cli_product_completeness.py
@@ -1625,6 +1625,126 @@ def test_cost_by_model_uses_routed_model_breakdown(monkeypatch):
     ]
 
 
+def test_cost_by_model_prefers_deployment_breakdown(monkeypatch):
+    fake = _install_fake_gateway(monkeypatch)
+    fake.cost_payload = {
+        "breakdown": [
+            {
+                "session": "agent:webchat:multi-provider",
+                "model": "gpt-4o",
+                "inputTokens": 2_000_000,
+                "outputTokens": 0,
+                "costUsd": 2.5,
+                "modelBreakdown": [
+                    {
+                        "model": "gpt-4o",
+                        "inputTokens": 2_000_000,
+                        "outputTokens": 0,
+                        "costUsd": 0.0,
+                    }
+                ],
+                "deploymentBreakdown": [
+                    {
+                        "provider": "openai",
+                        "model": "gpt-4o",
+                        "inputTokens": 1_000_000,
+                        "outputTokens": 0,
+                        "costUsd": 2.5,
+                    },
+                    {
+                        "provider": "ollama",
+                        "model": "gpt-4o",
+                        "inputTokens": 1_000_000,
+                        "outputTokens": 0,
+                        "costUsd": 0.0,
+                    },
+                ],
+            }
+        ],
+        "totalCostUsd": 2.5,
+    }
+
+    result = runner.invoke(app, ["cost", "--by-model", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    assert json.loads(result.stdout)["byModel"] == [
+        {
+            "model": "gpt-4o",
+            "inputTokens": 2_000_000,
+            "outputTokens": 0,
+            "costUsd": 2.5,
+        }
+    ]
+
+
+def test_cost_by_model_falls_back_when_breakdown_is_partial(monkeypatch):
+    fake = _install_fake_gateway(monkeypatch)
+    fake.cost_payload = {
+        "breakdown": [
+            {
+                "session": "agent:webchat:resumed",
+                "model": "post-restart-model",
+                "inputTokens": 1_010,
+                "outputTokens": 101,
+                "costUsd": 0.11,
+                "deploymentBreakdown": [
+                    {
+                        "provider": "openai",
+                        "model": "post-restart-model",
+                        "inputTokens": 10,
+                        "outputTokens": 1,
+                        "costUsd": 0.01,
+                    }
+                ],
+            }
+        ],
+        "totalCostUsd": 0.11,
+    }
+
+    result = runner.invoke(app, ["cost", "--by-model", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    assert json.loads(result.stdout) == {
+        "byModel": [
+            {
+                "model": "unknown",
+                "inputTokens": 1_010,
+                "outputTokens": 101,
+                "costUsd": 0.11,
+            }
+        ],
+        "totalCostUsd": 0.11,
+    }
+
+
+def test_cost_by_model_preserves_legacy_row_fallback(monkeypatch):
+    fake = _install_fake_gateway(monkeypatch)
+    fake.cost_payload = {
+        "breakdown": [
+            {
+                "session": "agent:webchat:legacy",
+                "model": "legacy-model",
+                "input_tokens": 10,
+                "output_tokens": 2,
+                "cost_usd": 0.1,
+            }
+        ],
+        "totalCostUsd": 0.1,
+    }
+
+    result = runner.invoke(app, ["cost", "--by-model", "--json"])
+
+    assert result.exit_code == 0, result.stdout
+    assert json.loads(result.stdout)["byModel"] == [
+        {
+            "model": "legacy-model",
+            "inputTokens": 10,
+            "outputTokens": 2,
+            "costUsd": 0.1,
+        }
+    ]
+
+
 def test_provider_and_search_diagnostics_use_gateway_rpcs(monkeypatch):
     fake = _install_fake_gateway(monkeypatch)
     fake.rpc_payloads = {


### PR DESCRIPTION
Fixes #1204

Scope boundary: CLI `cost --by-model` aggregation and its regression coverage only.
Base branch: `main`
Target exception: None.
Linked issue: Fixes #1204.
Release note: Fix by-model usage and cost attribution for routed sessions, cross-provider same-model traffic, and sessions resumed after a gateway restart.
Maintainer live check: Not required; the changed path is deterministic, offline, and credential-free.
Third-party origin: None.

## Summary

- aggregate `cost --by-model` from exact `(provider, model)` deployment rows before collapsing them by model
- use nested breakdowns only when their input, output, and cost totals reconcile with the authoritative persisted session row
- conservatively attribute an incomplete post-restart breakdown to `unknown`, preserving the full session totals instead of undercounting
- preserve the legacy row-level fallback when no nested breakdown is available

## Tests

- `.venv/bin/pytest -q tests/test_cli/test_cli_product_completeness.py` — 57 passed
- `.venv/bin/pytest -q tests/test_engine/test_usage_tracker.py tests/test_gateway/test_rpc_usage.py` — 58 passed
- `.venv/bin/ruff check src tests` — passed
- `.venv/bin/mypy src/opensquilla --show-error-codes` — passed (934 source files)

## Safety and compatibility

- platform-neutral CLI-only change; no filesystem, process, or platform-specific behavior changed
- no database, persisted-state, provider, RPC, WebUI, or public protocol schema changes
- existing gateway payloads without nested breakdowns retain the previous row-level model fallback
