### PR TITLE
Make session naming follow fixed models

### DIFF
--- a/opensquilla-webui/src/composables/usage/useUsageData.setRange.test.ts
+++ b/opensquilla-webui/src/composables/usage/useUsageData.setRange.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope } from 'vue'
 
+import i18n, { loadLocaleMessages, type LocaleCode } from '@/i18n'
 import { useUsageData } from './useUsageData'
 import { requestUsageSnapshot } from './useUsageQuery'
 import type { UsageSnapshot } from '@/types/usage'
@@ -96,6 +97,7 @@ async function flushMicrotasks() {
 let scopes: Array<ReturnType<typeof effectScope>> = []
 
 beforeEach(() => {
+  i18n.global.locale.value = 'en'
   localStorage.setItem(RANGE_KEY, '7')
   vi.mocked(requestUsageSnapshot).mockReset()
 })
@@ -103,6 +105,7 @@ beforeEach(() => {
 afterEach(() => {
   scopes.forEach(scope => scope.stop())
   scopes = []
+  i18n.global.locale.value = 'en'
   localStorage.clear()
 })
 
@@ -169,5 +172,48 @@ describe('useUsageData range selection under concurrent refreshes', () => {
     expect(localStorage.getItem(RANGE_KEY)).toBe('7')
     // The cached 7d snapshot is still rendered, so no page-level error.
     expect(api.usageError.value).toBeNull()
+  })
+})
+
+describe('useUsageData model labels', () => {
+  const localizedModelCounts: ReadonlyArray<{
+    locale: LocaleCode
+    expected: string
+  }> = [
+    { locale: 'en', expected: '2 models' },
+    { locale: 'zh-Hans', expected: '2 个模型' },
+    { locale: 'ja', expected: '2 モデル' },
+    { locale: 'fr', expected: '2 modèles' },
+    { locale: 'de', expected: '2 Modelle' },
+    { locale: 'es', expected: '2 modelos' },
+  ]
+
+  it.each(localizedModelCounts)(
+    'describes multiple models neutrally in $locale',
+    async ({ locale, expected }) => {
+      await loadLocaleMessages(locale)
+      i18n.global.locale.value = locale
+      const { api, scope } = mountUsageData()
+      scopes.push(scope)
+
+      const label = api.modelDisplayLabel({
+        modelBreakdown: [
+          { model: 'provider/primary-model' },
+          { model: 'provider/helper-model' },
+        ],
+      })
+
+      expect(label).toBe(expected)
+      expect(label).not.toMatch(/auto|自动|自動/i)
+    },
+  )
+
+  it('keeps the model name for a single-model breakdown', () => {
+    const { api, scope } = mountUsageData()
+    scopes.push(scope)
+
+    expect(api.modelDisplayLabel({
+      modelBreakdown: [{ model: 'provider/only-model' }],
+    })).toBe('provider/only-model')
   })
 })

--- a/opensquilla-webui/src/composables/usage/useUsageData.ts
+++ b/opensquilla-webui/src/composables/usage/useUsageData.ts
@@ -543,7 +543,7 @@ function modelDisplayLabel(row: SessionRow): string {
   const bd = row.modelBreakdown
   if (Array.isArray(bd) && bd.length > 0) {
     return bd.length > 1
-      ? t('usageLogs.sessions.autoModels', { count: bd.length })
+      ? t('usageLogs.breakdown.modelCount', { count: bd.length })
       : (bd[0].model || row.model || '—')
   }
   return row.model || '—'

--- a/opensquilla-webui/src/composables/usage/useUsageSessionRows.test.ts
+++ b/opensquilla-webui/src/composables/usage/useUsageSessionRows.test.ts
@@ -25,4 +25,27 @@ describe('useUsageSessionRows', () => {
     )
     expect(sortedRows.value[0].sessionKey).toBe('agent:main:webchat:private-id')
   })
+
+  it('keeps rows with multiple models expandable', () => {
+    const { sortedRows } = useUsageSessionRows({
+      visibleSessions: computed(() => [{
+        sessionKey: 'agent:main:webchat:multi-model',
+        modelBreakdown: [
+          { model: 'provider/primary-model' },
+          { model: 'provider/helper-model' },
+        ],
+      }]),
+      rangeHiddenHint: computed(() => ''),
+      sortCol: ref('updated_at'),
+      sortAsc: ref(false),
+      rowVal: (row, ...keys) => keys.map(key => row[key]).find(value => value != null),
+      numericRowVal: () => null,
+      sessionTimestamp: () => null,
+      relTime: () => '-',
+      sortVal: () => 0,
+      taskName: () => 'Multi-model task',
+    })
+
+    expect(sortedRows.value[0].hasModelBreakdown).toBe(true)
+  })
 })

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -3065,8 +3065,7 @@
       "count": "{count} Aufgaben",
       "emptyTitle": "Noch keine Nutzungsdaten",
       "emptyText": "Nach dem Ausführen einer Aufgabe erscheint ihre Token-Nutzung hier automatisch.",
-      "openChat": "Aufgabe „{task}“ öffnen",
-      "autoModels": "auto · {count} Modelle"
+      "openChat": "Aufgabe „{task}“ öffnen"
     },
     "columns": {
       "session": "Aufgabe",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -3116,8 +3116,7 @@
       "count": "{count} tasks",
       "emptyTitle": "No usage data yet",
       "emptyText": "Run a task and its token usage will appear here automatically.",
-      "openChat": "Open task “{task}”",
-      "autoModels": "auto · {count} models"
+      "openChat": "Open task “{task}”"
     },
     "columns": {
       "session": "Task",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -3065,8 +3065,7 @@
       "count": "{count} tareas",
       "emptyTitle": "Aún no hay datos de uso",
       "emptyText": "Ejecuta una tarea y su uso de tokens aparecerá aquí automáticamente.",
-      "openChat": "Abrir la tarea «{task}»",
-      "autoModels": "auto · {count} modelos"
+      "openChat": "Abrir la tarea «{task}»"
     },
     "columns": {
       "session": "Tarea",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -3065,8 +3065,7 @@
       "count": "{count} tâches",
       "emptyTitle": "Aucune donnée d'utilisation pour l'instant",
       "emptyText": "Exécutez une tâche et son utilisation de jetons apparaîtra ici automatiquement.",
-      "openChat": "Ouvrir la tâche « {task} »",
-      "autoModels": "auto · {count} modèles"
+      "openChat": "Ouvrir la tâche « {task} »"
     },
     "columns": {
       "session": "Tâche",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -3065,8 +3065,7 @@
       "count": "{count} タスク",
       "emptyTitle": "使用量データはまだありません",
       "emptyText": "タスクを実行すると、トークン使用量がここに自動的に表示されます。",
-      "openChat": "タスク「{task}」を開く",
-      "autoModels": "自動 · {count} モデル"
+      "openChat": "タスク「{task}」を開く"
     },
     "columns": {
       "session": "タスク",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -3116,8 +3116,7 @@
       "count": "{count} 个任务",
       "emptyTitle": "暂无用量数据",
       "emptyText": "运行任务后，Token 用量会自动显示在这里。",
-      "openChat": "打开任务“{task}”",
-      "autoModels": "自动 · {count} 个模型"
+      "openChat": "打开任务“{task}”"
     },
     "columns": {
       "session": "任务",

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -1417,9 +1417,10 @@ class SessionNamingConfig(BaseSettings):
     """LLM-generated session titles (auto-naming).
 
     After the first user message, a one-shot LLM call summarizes it into a short
-    title written to SessionNode.derived_title. Model selection mirrors compaction
-    but defaults to the router's default text tier rather than the session model:
-    ``model`` (explicit) > ``tier`` model > squilla_router.default_tier model.
+    title written to SessionNode.derived_title. Explicit ``model`` and ``tier``
+    settings override the mode-specific default: direct routing follows the
+    resolved session/provider model, while Router and Ensemble use the router's
+    default text tier.
     """
 
     model_config = SettingsConfigDict(env_prefix="OPENSQUILLA_NAMING_")
@@ -1428,8 +1429,8 @@ class SessionNamingConfig(BaseSettings):
     # Surfaces eligible for auto-naming. webchat/cli are chat; channel covers
     # inbound channel conversations. cron/subagent intentionally excluded.
     surfaces: list[str] = Field(default_factory=lambda: ["webchat", "cli", "channel"])
-    tier: str | None = None  # None = use squilla_router.default_tier
-    model: str | None = None  # None = use the resolved tier's model
+    tier: str | None = None  # None = use the routing mode's default target
+    model: str | None = None  # None = use the explicit tier or mode default
     timeout_seconds: float = 30.0
     max_chars: int = Field(default=48, ge=8)
     language: str = "auto"  # follow the conversation language

--- a/src/opensquilla/session/naming.py
+++ b/src/opensquilla/session/naming.py
@@ -4,14 +4,14 @@ After the first user message of an eligible session, :func:`generate_session_tit
 runs a single one-shot LLM call (mirroring the compaction summarizer's direct
 ``/chat/completions`` POST) and writes the result to ``SessionNode.derived_title``.
 
-Model selection deliberately does NOT reuse the session model. It resolves, in
-order: ``naming.model`` (explicit) → ``naming.tier`` model → the router's
-``default_tier`` model → the session/provider model as a last resort. A tier
-model is only eligible when the tier targets the active provider — matched on
-the configured provider id, with the wire kind accepted as an alias — or names
-no provider at all: tier model ids are spelled per provider catalog and are
-not portable across connections. Connection credentials (api_key / base_url)
-come from the same provider the compaction path resolves, so an
+Explicit ``naming.model`` and ``naming.tier`` settings always win. Without an
+explicit naming target, direct routing reuses the resolved session/provider
+model, while Router and Ensemble modes use the router's ``default_tier`` model.
+A tier model is only eligible when the tier targets the active provider —
+matched on the configured provider id, with the wire kind accepted as an alias
+— or names no provider at all: tier model ids are spelled per provider catalog
+and are not portable across connections. Connection credentials (api_key /
+base_url) come from the same provider the compaction path resolves, so an
 OpenRouter-backed gateway stays self-consistent.
 
 The title is written to ``derived_title`` (not ``display_name``) so it sits below
@@ -60,6 +60,7 @@ _MAX_INPUT_CHARS = 4000  # cap the untrusted first message fed to the namer
 # that off — the budget must cover thinking plus the title or the response
 # ends at length with empty content.
 _TITLE_MAX_TOKENS = 512
+_TOKENRHYTHM_TITLE_MAX_TOKENS = 1024
 _OPENROUTER_REASONING_DEFAULT_MODELS = frozenset(
     {
         "deepseek/deepseek-v4",
@@ -184,6 +185,8 @@ def resolve_naming_target(
     router_cfg: Any | None,
     provider: Any | None,
     fallback_model: str | None,
+    *,
+    use_router_default_tier: bool = True,
 ) -> NamingTarget | None:
     """Resolve ``(model, api_key, base_url, timeout)`` for the naming call.
 
@@ -198,9 +201,9 @@ def resolve_naming_target(
         if identity and identity.strip()
     )
 
-    tier_name = getattr(naming_cfg, "tier", None) or getattr(
-        router_cfg, "default_tier", DEFAULT_TEXT_TIER
-    )
+    tier_name = getattr(naming_cfg, "tier", None)
+    if not tier_name and use_router_default_tier:
+        tier_name = getattr(router_cfg, "default_tier", DEFAULT_TEXT_TIER)
     model = (
         getattr(naming_cfg, "model", None)
         or _tier_model(router_cfg, tier_name, provider_identities=provider_identities)
@@ -333,11 +336,16 @@ async def call_naming_llm(
     budget_provider = provider or (
         "openrouter" if "openrouter.ai" in url.lower() else "openai_compat"
     )
+    title_max_tokens = (
+        _TOKENRHYTHM_TITLE_MAX_TOKENS
+        if str(provider or "").strip().lower() == "tokenrhythm"
+        else _TITLE_MAX_TOKENS
+    )
     request_budget = resolve_auxiliary_request_budget(
         None,
         provider_id=budget_provider,
         model=model,
-        max_output_tokens=_TITLE_MAX_TOKENS,
+        max_output_tokens=title_max_tokens,
     )
     user_content = _fit_naming_user_content(
         first_message,
@@ -472,6 +480,7 @@ async def generate_session_title(
             return
 
         # Local imports avoid a module-load cycle (rpc_sessions imports this module).
+        from opensquilla.gateway.model_routing import model_routing_snapshot
         from opensquilla.gateway.rpc_chat import (
             _effective_compaction_model,
             _resolve_compaction_provider,
@@ -495,6 +504,9 @@ async def generate_session_title(
             getattr(config, "squilla_router", None),
             provider,
             _effective_compaction_model(session),
+            use_router_default_tier=(
+                model_routing_snapshot(config)["mode"] != "direct"
+            ),
         )
         if target is None:
             return

--- a/tests/test_session/test_naming.py
+++ b/tests/test_session/test_naming.py
@@ -194,6 +194,47 @@ def test_resolve_target_follows_configured_default_tier():
     assert target.model == "deepseek/deepseek-v4-flash"
 
 
+def test_resolve_target_direct_mode_uses_provider_model_instead_of_default_tier():
+    cfg = SimpleNamespace(tier=None, model=None, timeout_seconds=30.0)
+    provider = _FakeProvider(provider_kind="tokenrhythm", model="mimo-v2.5-pro")
+
+    target = resolve_naming_target(
+        cfg,
+        _router("c1"),
+        provider,
+        None,
+        use_router_default_tier=False,
+    )
+
+    assert target.model == "mimo-v2.5-pro"
+
+
+@pytest.mark.parametrize(
+    ("tier", "model", "expected"),
+    [
+        ("c0", None, "deepseek/deepseek-v4-flash"),
+        ("c0", "explicit/model", "explicit/model"),
+    ],
+)
+def test_resolve_target_direct_mode_preserves_explicit_naming_overrides(
+    tier,
+    model,
+    expected,
+):
+    cfg = SimpleNamespace(tier=tier, model=model, timeout_seconds=30.0)
+    provider = _FakeProvider(provider_kind="tokenrhythm", model="mimo-v2.5-pro")
+
+    target = resolve_naming_target(
+        cfg,
+        _router("c1"),
+        provider,
+        None,
+        use_router_default_tier=False,
+    )
+
+    assert target.model == expected
+
+
 def test_resolve_target_falls_back_to_provider_model():
     cfg = SimpleNamespace(tier=None, model=None, timeout_seconds=30.0)
     empty_router = SimpleNamespace(tiers={}, default_tier="c1")
@@ -367,6 +408,63 @@ async def test_call_naming_llm_payload_and_sanitization(monkeypatch):
     assert captured["headers"]["Authorization"] == "Bearer test-key"
     assert captured["headers"]["HTTP-Referer"] == "https://opensquilla.ai"
     assert captured["headers"]["X-Title"] == "OpenSquilla"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "base_url", "expected_max_tokens"),
+    [
+        ("tokenrhythm", "https://custom-tokenrhythm.example/v1", 1024),
+        ("openrouter", "https://openrouter.ai/api/v1", 512),
+    ],
+)
+async def test_call_naming_llm_selects_output_budget_by_provider_kind(
+    monkeypatch,
+    provider,
+    base_url,
+    expected_max_tokens,
+):
+    captured: dict = {}
+    budget_calls: list[dict] = []
+    monkeypatch.setattr(
+        "opensquilla.session.naming.httpx.AsyncClient",
+        lambda **kwargs: _fake_client(captured),
+    )
+
+    def resolve_budget(*args, **kwargs):
+        budget_calls.append(kwargs)
+        return AuxiliaryRequestBudget(
+            provider_id=kwargs["provider_id"],
+            model=kwargs["model"],
+            context_window_tokens=32_000,
+            max_output_tokens=kwargs["max_output_tokens"],
+            max_input_tokens=16_000,
+            provider_request_max_chars=64_000,
+            context_window_source="test",
+        )
+
+    monkeypatch.setattr(
+        "opensquilla.session.naming.resolve_auxiliary_request_budget",
+        resolve_budget,
+    )
+
+    title = await call_naming_llm(
+        "Help me reset my password please",
+        model="deepseek-v4-pro",
+        api_key="test-key",
+        base_url=base_url,
+        provider=provider,
+    )
+
+    assert title == "Reset my password"
+    assert budget_calls == [
+        {
+            "provider_id": provider,
+            "model": "deepseek-v4-pro",
+            "max_output_tokens": expected_max_tokens,
+        }
+    ]
+    assert captured["json"]["max_tokens"] == expected_max_tokens
 
 
 @pytest.mark.asyncio
@@ -752,7 +850,12 @@ async def test_old_db_without_derived_title_migrates():
 # ── generate_session_title (orchestrator) ───────────────────────────────────
 
 
-def _patch_provider_and_emit(monkeypatch, *, title: str | None):
+def _patch_provider_and_emit(
+    monkeypatch,
+    *,
+    title: str | None,
+    provider_model: str = "deepseek-v4-pro",
+):
     """Patch provider resolution, the LLM call, and the broadcast; capture emits."""
     import opensquilla.gateway.rpc_chat as rpc_chat_mod
     import opensquilla.gateway.rpc_sessions as rpc_sessions_mod
@@ -766,7 +869,8 @@ def _patch_provider_and_emit(monkeypatch, *, title: str | None):
         # aimed at another provider. The explicit model keeps resolution alive
         # via the connection fallback if the default profile ever changes.
         lambda ctx, session: _FakeProvider(
-            provider_kind="tokenrhythm", model="deepseek-v4-pro"
+            provider_kind="tokenrhythm",
+            model=provider_model,
         ),
     )
 
@@ -819,6 +923,86 @@ async def test_generate_session_title_writes_and_broadcasts(storage, mgr, monkey
     assert emit_key == key
     assert event_name == "sessions.changed"
     assert payload["reason"] == "auto_titled"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("routing_mode", "expected_model"),
+    [
+        ("direct", "mimo-v2.5-pro"),
+        ("direct_observe", "mimo-v2.5-pro"),
+        ("router", "deepseek-v4-pro"),
+        ("ensemble", "deepseek-v4-pro"),
+    ],
+)
+async def test_generate_session_title_follows_model_routing_mode(
+    storage,
+    mgr,
+    monkeypatch,
+    routing_mode,
+    expected_model,
+):
+    calls, _emits = _patch_provider_and_emit(
+        monkeypatch,
+        title="Routing Mode",
+        provider_model="mimo-v2.5-pro",
+    )
+    key = f"agent:main:webchat:naming-{routing_mode}"
+    await storage.upsert_session(
+        SessionNode(
+            session_key=key,
+            session_id=f"sid-{routing_mode}",
+            display_name="WebChat",
+        )
+    )
+    config = GatewayConfig()
+    config.squilla_router.tiers = {
+        "c1": {"provider": "tokenrhythm", "model": "deepseek-v4-pro"}
+    }
+    config.squilla_router.default_tier = "c1"
+    config.squilla_router.enabled = routing_mode in {"direct_observe", "router"}
+    config.squilla_router.rollout_phase = (
+        "full" if routing_mode == "router" else "observe"
+    )
+    config.llm_ensemble.enabled = routing_mode == "ensemble"
+    ctx = SimpleNamespace(config=config, session_manager=mgr, provider_selector=None)
+
+    await generate_session_title(ctx, key, "Which model names this session?")
+
+    assert calls["llm"] == 1
+    assert calls["kwargs"]["model"] == expected_model
+
+
+@pytest.mark.asyncio
+async def test_generate_session_title_direct_inherits_session_model_override(
+    storage,
+    mgr,
+    monkeypatch,
+):
+    calls, _emits = _patch_provider_and_emit(
+        monkeypatch,
+        title="Pinned Session",
+        provider_model="",
+    )
+    key = "agent:main:webchat:naming-session-model-override"
+    await storage.upsert_session(
+        SessionNode(
+            session_key=key,
+            session_id="sid-session-model-override",
+            display_name="WebChat",
+            model_override="session-pinned-model",
+        )
+    )
+    config = GatewayConfig()
+    config.squilla_router.enabled = False
+    config.squilla_router.rollout_phase = "observe"
+    config.llm_ensemble.enabled = False
+    ctx = SimpleNamespace(config=config, session_manager=mgr, provider_selector=None)
+
+    await generate_session_title(ctx, key, "Use my pinned session model")
+
+    assert calls["llm"] == 1
+    assert calls["kwargs"]["model"] == "session-pinned-model"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope

Scope boundary: session auto-naming target selection and provider-specific title budgeting, plus the Usage UI summary shown when one session contains calls from multiple models.

- In canonical `direct` mode (including Router observe), automatic titles inherit the resolved provider/session model unless `naming.model` or `naming.tier` is explicit.
- Router and Ensemble keep the existing router default-tier naming target.
- TokenRhythm title calls use a 1024-token output ceiling; other providers remain at 512, and the shared auxiliary budget may still clamp lower.
- Usage now shows a neutral localized model count while preserving expandable per-model Token and cost details.

Non-goals: changing the Usage ledger/backend/API or `run_kind=session_naming`; rewriting existing titles; changing other auxiliary calls; solving the full scoped-strategy design in #1165; replacing the naming transport with the provider adapter tracked by #1137; or changing the existing live-config race boundary.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Refs #207; Refs #1165

If None, reason: N/A

## Release Note

Release note: Bugfix — Fixed Model mode now keeps future automatic session titles on the selected session model unless a dedicated naming model or tier is configured. Router and Ensemble behavior remains unchanged, and Usage shows a neutral model count for sessions with auxiliary calls. TokenRhythm title calls receive enough output budget for reasoning plus a title.

## Tests

Ruff: `uv run ruff check src/opensquilla/session/naming.py src/opensquilla/gateway/config.py tests/test_session/test_naming.py tests/test_gateway/test_rpc_model_routing.py` — passed.

Pytest: `uv run pytest -q tests/test_session/test_naming.py tests/test_gateway/test_rpc_model_routing.py` — 124 passed.

Build:

- Focused WebUI Vitest — 2 files, 12 tests passed.
- Six-locale i18n parity — passed.
- `npm --prefix opensquilla-webui run typecheck` — passed.
- `npm --prefix opensquilla-webui run build` — passed; production artifact verified (198 files).
- `uv build --wheel` — passed.
- `git diff --check` — passed.
- Independent final diff review — no findings.

Regression tests: added

Notes: tests are synthetic, offline, deterministic, credential-free, and safe for forks.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: yes

Surface: provider

A credentialed TokenRhythm smoke test in canonical direct mode used a fixed MiMo model while the router default was DeepSeek. It produced a title with exactly one finalized `session_naming` usage event on MiMo and did not call the router-default model. No credential or live transcript is included in this branch.

## Safety

No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are committed.

There is no database, persisted-state, config-schema, RPC, or Usage API migration. The new resolver parameter defaults to legacy behavior for callers; explicit `naming.model` and `naming.tier` remain authoritative. Existing titles are not regenerated. The change is platform-neutral, and generated WebUI static output is not tracked.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
