### PR TITLE
Prevent pending-drain tests from exhausting recovery timers

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
@@ -6732,7 +6732,7 @@ describe('useChatSend Ensemble image guard', () => {
       pending.schedulePendingDrainAfterTerminal()
       stream.isStreaming.value = false
       await nextTick()
-      await vi.runAllTimersAsync()
+      await vi.advanceTimersByTimeAsync(50)
       await nextTick()
 
       expect(pending.pendingQueue.value).toEqual([])
@@ -7043,7 +7043,7 @@ describe('useChatSend slash-prefixed input fall-through', () => {
       expect(inputText.value).toBe('')
       stream.isStreaming.value = false
       pending.schedulePendingDrainAfterTerminal()
-      await vi.runAllTimersAsync()
+      await vi.advanceTimersByTimeAsync(50)
       await nextTick()
 
       expect(rpcCall).toHaveBeenCalledWith(
@@ -7169,7 +7169,7 @@ describe('useChatSend slash-prefixed input fall-through', () => {
       )
       stream.isStreaming.value = false
       pending.schedulePendingDrainAfterTerminal()
-      await vi.runAllTimersAsync()
+      await vi.advanceTimersByTimeAsync(50)
       await nextTick()
 
       expect(classifySlashCommand).not.toHaveBeenCalled()
@@ -7659,7 +7659,7 @@ describe('useChatSend slash-prefixed input fall-through', () => {
         })
 
         pending.schedulePendingDrainAfterTerminal()
-        await vi.runAllTimersAsync()
+        await vi.advanceTimersByTimeAsync(50)
         await nextTick()
 
         expect(classifySlashCommand).toHaveBeenCalledOnce()


### PR DESCRIPTION
## Scope

Scope boundary: stabilize WebUI pending-queue drain regressions by advancing only the queue's 50 ms drain timer instead of exhausting every fake timer in the worker.

- Update the four `useChatSend.attachments.test.ts` cases that exercise `schedulePendingDrainAfterTerminal()`.
- Preserve `runAllTimersAsync()` in the three tests that intentionally exercise acceptance recovery.

Non-goals: changing production retry behavior, bounding acceptance recovery, adding lifecycle disposal, or changing pending-queue timing.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: CI flake discovered in the merge-queue run for #1216; this PR is a focused test-stability follow-up.

## Release Note

Release note: NONE — test-only CI stability fix with no product behavior change.

## Tests

Ruff: N/A — TypeScript test-only change.

Pytest: N/A — TypeScript test-only change.

Build:

- `npm ci` — passed.
- Focused four pending-drain cases — 5 passed.
- `useChatSend.attachments.test.ts` — 224 passed; repeated 10 consecutive times (2,240 test executions).
- Related send/pending-queue suite — 3 files, 275 tests passed.
- `npm run typecheck` — passed, including architecture, chat-security, theme, i18n, channel-catalog, README-locale, and `vue-tsc` checks.
- `npm run build:artifact` — passed; 820 modules transformed and the 198-file artifact verified.
- `git diff --check` — passed.
- Independent final diff review — no findings.

Regression tests: strengthened existing pending-drain regressions.

Notes:

- The pre-fix full WebUI run reproduced fake-timer exhaustion in an acceptance-recovery test.
- A post-fix local full-suite attempt encountered existing unrelated 5-second `ChannelsView.test.ts` timeouts; the changed file did not fail. This PR will not enter the merge queue until GitHub's complete required CI matrix is green.
- The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: no live provider or browser credentials are required for this test-only change.

## Safety

Only fake-timer advancement in tests changes. Production code, runtime behavior, public interfaces, persisted state, configuration, RPC, generated assets, and dependencies are unchanged. The change is platform-neutral and upgrade-neutral. No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are included.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
