### PR TITLE
Preserve assistant activity roles and refine tool details

### DIFF
--- a/opensquilla-webui/src/components/chat/ActivityToolDetails.test.ts
+++ b/opensquilla-webui/src/components/chat/ActivityToolDetails.test.ts
@@ -63,6 +63,30 @@ describe('ActivityToolDetails interaction affordances', () => {
   })
 })
 
+describe('ActivityToolDetails bounded window treatment', () => {
+  it('uses one borderless shadow container instead of nested cards', () => {
+    const window = ruleBody('.activity-tool-details--bounded')
+    expect(window).toContain('max-height: min(20rem, 52vh);')
+    expect(window).toContain('border: 0;')
+    expect(window).toContain('box-shadow: var(--shadow-md);')
+    expect(window).toContain('overflow: hidden;')
+
+    const section = ruleBody('.activity-tool-details__section')
+    expect(section).toContain('border: 0;')
+    expect(section).toContain('background: transparent;')
+    const preview = ruleBody('.activity-tool-details__preview')
+    expect(preview).toContain('border: 0;')
+    expect(preview).toContain('background: transparent;')
+  })
+
+  it('keeps the duplicate category title out and provides a bottom fade', () => {
+    expect(activityToolDetailsSource).not.toContain('activity-tool-details__title')
+    expect(ruleBody('.activity-tool-details__fade')).toContain(
+      'background: linear-gradient(to bottom, transparent, var(--bg-elevated));',
+    )
+  })
+})
+
 describe('ActivityToolDetails byte units', () => {
   it('labels 1024-based sizes with binary units', () => {
     expect(activityToolDetailsSource).toContain("['KiB', 'MiB', 'GiB']")

--- a/opensquilla-webui/src/components/chat/ActivityToolDetails.vue
+++ b/opensquilla-webui/src/components/chat/ActivityToolDetails.vue
@@ -1,7 +1,56 @@
 <template>
-  <div class="activity-tool-details">
+  <div
+    class="activity-tool-details"
+    :class="{ 'activity-tool-details--bounded': isBoundedDetail }"
+  >
+    <template v-if="isBoundedDetail">
+      <button
+        type="button"
+        class="activity-tool-details__copy"
+        :class="{
+          'is-copied': copyState === 'copied',
+          'is-error': copyState === 'error',
+        }"
+        data-share-control
+        data-testid="activity-tool-detail-copy"
+        :aria-label="copyLabel"
+        :title="copyLabel"
+        @click.stop="copyDetails"
+      >
+        <Icon :name="copyIcon" :size="13" aria-hidden="true" />
+      </button>
+      <span
+        class="activity-tool-details__copy-status"
+        aria-live="polite"
+        aria-atomic="true"
+      >{{ copyState === 'idle' ? '' : copyLabel }}</span>
+      <div
+        class="activity-tool-details__window"
+        role="region"
+        tabindex="0"
+        :aria-label="detailActionLabel"
+      >
+        <section
+          v-for="section in detailSections"
+          :key="section.kind"
+          class="activity-tool-details__section"
+        >
+          <div class="activity-tool-details__section-label">{{ section.label }}</div>
+          <pre class="activity-tool-details__preview">{{ section.preview }}</pre>
+        </section>
+        <button
+          type="button"
+          class="activity-tool-details__view"
+          data-share-control
+          @click.stop="showRawDetails"
+        >
+          {{ t('shared.runTrace.viewFull') }}
+        </button>
+      </div>
+      <div class="activity-tool-details__fade" aria-hidden="true"></div>
+    </template>
     <div
-      v-if="projection.lines.length"
+      v-else-if="projection.lines.length"
       class="activity-tool-details__summary"
       :class="{ 'activity-tool-details__summary--interactive': projection.rawContent }"
     >
@@ -41,13 +90,28 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onBeforeUnmount, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import Icon from '@/components/Icon.vue'
 import type { ChatToolCallRenderItem, ToolResultContext } from '@/types/chat'
 import {
   projectActivityToolDetail,
+  redactActivityDetail,
   type ActivityToolDetailLine,
 } from '@/utils/chat/activityToolDetails'
+import { copyTextWithFallback } from '@/utils/browser'
+
+const DETAIL_WINDOW_CHAR_LIMIT = 360
+const DETAIL_WINDOW_LINE_LIMIT = 6
+const DETAIL_PREVIEW_CHAR_LIMIT = 6_000
+const DETAIL_PREVIEW_LINE_LIMIT = 80
+
+type ActivityDetailSection = {
+  kind: 'input' | 'result' | 'error'
+  label: string
+  content: string
+  preview: string
+}
 
 const props = defineProps<{
   call: ChatToolCallRenderItem
@@ -63,6 +127,155 @@ const { locale, t } = useI18n()
 const projection = computed(() =>
   projectActivityToolDetail(props.call, props.operationKey),
 )
+const copyState = ref<'idle' | 'copied' | 'error'>('idle')
+let copyResetId: number | null = null
+
+function asRecord(value: string): Record<string, unknown> | null {
+  const source = String(value || '').trim()
+  if (!source.startsWith('{')) return null
+  try {
+    const parsed = JSON.parse(source)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null
+  } catch {
+    return null
+  }
+}
+
+function recordString(
+  record: Record<string, unknown> | null,
+  keys: string[],
+): string {
+  if (!record) return ''
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return ''
+}
+
+function detailInputText(): string {
+  const raw = String(props.call.inputRaw || props.call.inputPreview || '').trim()
+  if (!raw) return ''
+  if (props.operationKey === 'command.run' || props.operationKey === 'code.python') {
+    const executable = recordString(asRecord(raw), [
+      'command',
+      'cmd',
+      'code',
+      'script',
+    ])
+    if (executable) return redactActivityDetail(executable)
+  }
+  return redactActivityDetail(raw)
+}
+
+function detailResultText(): string {
+  return redactActivityDetail(
+    String(props.call.result || props.call.resultPreview || '').trim(),
+  )
+}
+
+function detailLineCount(value: string): number {
+  return value ? value.split(/\r\n|\r|\n/).length : 0
+}
+
+function boundedPreview(value: string): string {
+  const lines = value.split(/\r\n|\r|\n/)
+  let preview = lines.slice(0, DETAIL_PREVIEW_LINE_LIMIT).join('\n')
+  let truncated = lines.length > DETAIL_PREVIEW_LINE_LIMIT
+  if (preview.length > DETAIL_PREVIEW_CHAR_LIMIT) {
+    preview = preview.slice(0, DETAIL_PREVIEW_CHAR_LIMIT).trimEnd()
+    truncated = true
+  }
+  return truncated ? `${preview}\n…` : preview
+}
+
+const detailSections = computed<ActivityDetailSection[]>(() => {
+  const sections: ActivityDetailSection[] = []
+  const input = detailInputText()
+  const result = detailResultText()
+  if (input) {
+    sections.push({
+      kind: 'input',
+      label: t('shared.runTrace.sectionInput'),
+      content: input,
+      preview: boundedPreview(input),
+    })
+  }
+  if (result) {
+    const kind = props.call.isError || props.call.status === 'error'
+      ? 'error'
+      : 'result'
+    sections.push({
+      kind,
+      label: t(
+        kind === 'error'
+          ? 'shared.runTrace.sectionError'
+          : 'shared.runTrace.sectionResult',
+      ),
+      content: result,
+      preview: boundedPreview(result),
+    })
+  }
+  return sections
+})
+
+const isBoundedDetail = computed(() => {
+  if (!projection.value.rawContent) return false
+  const sections = detailSections.value
+  const characters = sections.reduce(
+    (total, section) => total + section.content.length,
+    0,
+  )
+  const lines = sections.reduce(
+    (total, section) => total + detailLineCount(section.content),
+    0,
+  )
+  return characters > DETAIL_WINDOW_CHAR_LIMIT || lines > DETAIL_WINDOW_LINE_LIMIT
+})
+
+const copyLabel = computed(() => (
+  copyState.value === 'copied'
+    ? t('chat.copied')
+    : copyState.value === 'error'
+      ? t('chat.toast.copyFailed')
+      : t('chat.copy')
+))
+
+const copyIcon = computed(() => (
+  copyState.value === 'copied'
+    ? 'check'
+    : copyState.value === 'error'
+      ? 'x'
+      : 'copy'
+))
+
+function clearCopyReset() {
+  if (copyResetId === null) return
+  window.clearTimeout(copyResetId)
+  copyResetId = null
+}
+
+function scheduleCopyReset() {
+  clearCopyReset()
+  copyResetId = window.setTimeout(() => {
+    copyState.value = 'idle'
+    copyResetId = null
+  }, 1600)
+}
+
+async function copyDetails() {
+  try {
+    await copyTextWithFallback(redactActivityDetail(projection.value.rawContent))
+    copyState.value = 'copied'
+  } catch {
+    copyState.value = 'error'
+  }
+  scheduleCopyReset()
+}
+
+onBeforeUnmount(clearCopyReset)
 
 function formatNumber(value: number): string {
   return new Intl.NumberFormat(locale.value).format(value)
@@ -130,6 +343,147 @@ function showRawDetails() {
   padding: 0.0625rem 0 0.25rem;
   font-size: 0.75rem;
   line-height: 1.45;
+}
+
+.activity-tool-details--bounded {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  max-width: min(100%, 48rem);
+  max-height: min(20rem, 52vh);
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow-md);
+  overflow: hidden;
+}
+
+.activity-tool-details__window {
+  min-height: 0;
+  padding: 0.625rem 2.75rem 1.5rem 0.75rem;
+  overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+
+.activity-tool-details__window:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring-inset);
+}
+
+.activity-tool-details__section {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.activity-tool-details__section + .activity-tool-details__section {
+  margin-top: 0.75rem;
+}
+
+.activity-tool-details__section-label {
+  margin-bottom: 0.25rem;
+  color: var(--text-dim);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.activity-tool-details__preview {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-family: var(--font-mono);
+  font-variant-ligatures: none;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.activity-tool-details__copy {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.375rem;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+}
+
+.activity-tool-details__copy:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.activity-tool-details__copy:focus-visible,
+.activity-tool-details__view:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.activity-tool-details__copy.is-copied {
+  color: var(--ok);
+}
+
+.activity-tool-details__copy.is-error {
+  color: var(--danger);
+}
+
+.activity-tool-details__copy-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.activity-tool-details__view {
+  margin: 0.625rem 0 0;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.71875rem;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, currentColor 40%, transparent);
+  text-underline-offset: 0.15em;
+}
+
+.activity-tool-details__view:hover,
+.activity-tool-details__view:focus-visible {
+  color: var(--text);
+  text-decoration-color: currentColor;
+}
+
+.activity-tool-details__fade {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 1.5rem;
+  background: linear-gradient(to bottom, transparent, var(--bg-elevated));
+  pointer-events: none;
 }
 
 .activity-tool-details__summary {
@@ -261,6 +615,13 @@ function showRawDetails() {
 @media (prefers-reduced-motion: reduce) {
   .activity-tool-details__fallback {
     transition: none;
+  }
+}
+
+@media (pointer: coarse) {
+  .activity-tool-details__copy {
+    width: 2.75rem;
+    height: 2.75rem;
   }
 }
 </style>

--- a/opensquilla-webui/src/components/chat/ActivityToolDetails.window.test.ts
+++ b/opensquilla-webui/src/components/chat/ActivityToolDetails.window.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App } from 'vue'
+
+const mocks = vi.hoisted(() => ({
+  copy: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/utils/browser', () => ({
+  copyTextWithFallback: mocks.copy,
+}))
+
+import ActivityToolDetails from '@/components/chat/ActivityToolDetails.vue'
+import i18n from '@/i18n'
+import type { ChatToolCallRenderItem } from '@/types/chat'
+import { redactActivityDetail } from '@/utils/chat/activityToolDetails'
+
+const mountedApps: App[] = []
+
+function call(overrides: Partial<ChatToolCallRenderItem> = {}): ChatToolCallRenderItem {
+  return {
+    toolId: 'detail-call',
+    renderKey: 'detail-call',
+    name: 'custom_tool',
+    displayName: 'Custom tool',
+    inputRaw: '',
+    inputPreview: '',
+    isRunning: false,
+    status: 'success',
+    isError: false,
+    result: '',
+    resultPreview: '',
+    isOpen: true,
+    ...overrides,
+  }
+}
+
+async function mountDetails(
+  toolCall: ChatToolCallRenderItem,
+  operationKey = 'tool.custom',
+  onShowResult = vi.fn(),
+) {
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  const Host = defineComponent({
+    setup() {
+      return () => h(ActivityToolDetails, {
+        call: toolCall,
+        label: 'Run command',
+        operationKey,
+        onShowResult,
+      })
+    },
+  })
+  const app = createApp(Host)
+  mountedApps.push(app)
+  app.use(i18n)
+  app.mount(el)
+  await nextTick()
+  return { el, onShowResult }
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+  i18n.global.locale.value = 'en'
+  mocks.copy.mockReset()
+  mocks.copy.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  while (mountedApps.length) mountedApps.pop()?.unmount()
+  document.body.innerHTML = ''
+  vi.useRealTimers()
+})
+
+describe('ActivityToolDetails adaptive detail window', () => {
+  it.each([
+    ['360 characters', 'x'.repeat(360), false],
+    ['361 characters', 'x'.repeat(361), true],
+    ['6 lines', Array.from({ length: 6 }, (_, index) => `line ${index}`).join('\n'), false],
+    ['7 lines', Array.from({ length: 7 }, (_, index) => `line ${index}`).join('\n'), true],
+  ])('uses the bounded window beyond the %s threshold', async (_name, input, bounded) => {
+    const { el } = await mountDetails(call({
+      inputRaw: input,
+      inputPreview: input.slice(0, 200),
+    }))
+
+    expect(el.querySelector('.activity-tool-details--bounded') !== null).toBe(bounded)
+    expect(el.querySelector('.activity-tool-details__window') !== null).toBe(bounded)
+    expect(el.querySelector('[data-testid="activity-tool-detail-copy"]') !== null).toBe(bounded)
+  })
+
+  it('shows real redacted lines, copies safe full detail, and preserves View full', async () => {
+    const secret = 'sk-secretvalue123456789'
+    const command = [
+      'echo begin',
+      `OPENAI_API_KEY=${secret}`,
+      ...Array.from({ length: 7 }, (_, index) => `command line ${index + 3}`),
+    ].join('\n')
+    const inputRaw = JSON.stringify({ command })
+    const result = Array.from(
+      { length: 40 },
+      (_, index) => `output line ${index + 1}`,
+    ).join('\n')
+    const toolCall = call({
+      name: 'shell',
+      inputRaw,
+      inputPreview: inputRaw.slice(0, 200),
+      result,
+      resultPreview: result.slice(0, 200),
+    })
+    const { el, onShowResult } = await mountDetails(toolCall, 'command.run')
+
+    const window = el.querySelector('.activity-tool-details__window')
+    const copy = el.querySelector<HTMLButtonElement>(
+      '[data-testid="activity-tool-detail-copy"]',
+    )
+    const viewFull = el.querySelector<HTMLButtonElement>('.activity-tool-details__view')
+
+    expect(window?.textContent).toContain('echo begin')
+    expect(window?.textContent).toContain('command line 9')
+    expect(window?.textContent).toContain('output line 40')
+    expect(window?.textContent).toContain('[redacted]')
+    expect(window?.textContent).not.toContain(secret)
+    expect(window?.textContent).not.toContain('Run command')
+    expect(el.querySelector('.activity-tool-details__summary')).toBeNull()
+    expect(el.querySelector('.activity-tool-details__fade')).not.toBeNull()
+    expect(copy?.getAttribute('aria-label')).toBe('Copy')
+    expect(viewFull?.textContent?.trim()).toBe('view full')
+
+    copy?.click()
+
+    expect(mocks.copy).toHaveBeenCalledWith(redactActivityDetail(
+      `INPUT\n${inputRaw}\n\nRESULT\n${result}`,
+    ))
+    await vi.waitFor(() => {
+      expect(copy?.getAttribute('aria-label')).toBe('Copied')
+    })
+
+    viewFull?.click()
+    expect(onShowResult).toHaveBeenCalledWith(
+      `INPUT\n${inputRaw}\n\nRESULT\n${result}`,
+      'Run command · details',
+      {
+        toolName: 'shell',
+        inputRaw,
+        section: undefined,
+      },
+    )
+  })
+})

--- a/opensquilla-webui/src/components/run/RunTrace.activity-presentation.test.ts
+++ b/opensquilla-webui/src/components/run/RunTrace.activity-presentation.test.ts
@@ -196,6 +196,25 @@ describe('RunTrace activity presentation', () => {
     )
   })
 
+  it('fades only activity detail bodies and disables the motion when requested', () => {
+    expect(runTraceSource).toContain(
+      '<Transition name="activity-tool-detail" :css="presentation === \'activity\'">',
+    )
+    expect(ruleBody('.tool-timeline--activity .activity-tool-detail-enter-active')).toContain(
+      'opacity var(--dur-base) var(--ease-out)',
+    )
+    expect(ruleBody('.tool-timeline--activity .activity-tool-detail-enter-from,')).toContain(
+      'opacity: 0;',
+    )
+
+    const reducedMotionStart = runTraceSource.indexOf('@media (prefers-reduced-motion: reduce)')
+    const reducedMotion = runTraceSource.slice(reducedMotionStart)
+    expect(reducedMotion).toContain(
+      '.tool-timeline--activity .activity-tool-detail-enter-active',
+    )
+    expect(reducedMotion).toContain('transition: none;')
+  })
+
   const completedGroup = group('completed-group', [
     call('completed-one'),
     call('completed-two'),
@@ -346,7 +365,7 @@ describe('RunTrace activity presentation', () => {
     expect(el.querySelector('.activity-tool-details')).toBeNull()
   })
 
-  it('keeps compact semantic details and explicit raw forwarding available', async () => {
+  it('shows long activity details in one bounded preview and preserves raw forwarding', async () => {
     const result = 'file contents\n'.repeat(30)
     const onShowResult = vi.fn()
     // A read-shaped call: content-size summaries are reserved for read
@@ -366,22 +385,22 @@ describe('RunTrace activity presentation', () => {
     })
 
     const details = el.querySelector('.activity-tool-details')
-    const summary = el.querySelector('.activity-tool-details__summary')
-    const detailTrigger = el.querySelector<HTMLButtonElement>(
-      '.activity-tool-details__hit-target',
+    const window = el.querySelector('.activity-tool-details__window')
+    const viewFull = el.querySelector<HTMLButtonElement>(
+      '.activity-tool-details__view',
     )
     expect(details).not.toBeNull()
-    expect(summary).not.toBeNull()
-    expect(summary?.textContent).toContain('30 lines')
-    expect(summary?.textContent).not.toContain('view details')
-    expect(el.querySelectorAll('.activity-tool-details__summary')).toHaveLength(1)
-    expect(el.querySelector('.activity-tool-details__view')).toBeNull()
+    expect(details?.classList.contains('activity-tool-details--bounded')).toBe(true)
+    expect(window?.textContent).toContain('file contents')
+    expect(window?.textContent).toContain('view full')
+    expect(el.querySelector('.activity-tool-details__summary')).toBeNull()
+    expect(el.querySelectorAll('.activity-tool-details__window')).toHaveLength(1)
     expect(el.querySelector('.tool-row-section')).toBeNull()
-    expect(detailTrigger?.tagName).toBe('BUTTON')
-    expect(detailTrigger?.hasAttribute('data-share-control')).toBe(true)
-    expect(detailTrigger?.getAttribute('aria-label')?.toLowerCase()).toContain('view details')
+    expect(el.querySelector('.activity-tool-details__fade')).not.toBeNull()
+    expect(viewFull?.tagName).toBe('BUTTON')
+    expect(viewFull?.hasAttribute('data-share-control')).toBe(true)
 
-    detailTrigger?.click()
+    viewFull?.click()
 
     expect(onShowResult).toHaveBeenCalledWith(
       `INPUT\n{}\n\nRESULT\n${result.trim()}`,

--- a/opensquilla-webui/src/components/run/RunTrace.vue
+++ b/opensquilla-webui/src/components/run/RunTrace.vue
@@ -192,21 +192,23 @@
                   <Icon v-if="presentation !== 'activity'" class="step-chevron" name="chevronRight" :size="14" />
                 </span>
               </button>
-              <div v-if="callOpen(call)" class="tool-row-body">
-                <ActivityToolDetails
-                  v-if="presentation === 'activity'"
-                  :call="call"
-                  :label="call.displayName"
-                  :operation-key="operationKey(call)"
-                  @show-result="forwardShowResult"
-                />
-                <ToolRowSections
-                  v-else
-                  :call="call"
-                  :label="call.displayName"
-                  @show-result="forwardShowResult"
-                />
-              </div>
+              <Transition name="activity-tool-detail" :css="presentation === 'activity'">
+                <div v-if="callOpen(call)" class="tool-row-body">
+                  <ActivityToolDetails
+                    v-if="presentation === 'activity'"
+                    :call="call"
+                    :label="call.displayName"
+                    :operation-key="operationKey(call)"
+                    @show-result="forwardShowResult"
+                  />
+                  <ToolRowSections
+                    v-else
+                    :call="call"
+                    :label="call.displayName"
+                    @show-result="forwardShowResult"
+                  />
+                </div>
+              </Transition>
             </div>
           </TransitionGroup>
         </template>
@@ -250,21 +252,23 @@
                 <Icon v-if="presentation !== 'activity'" class="step-chevron" name="chevronRight" :size="14" />
               </span>
             </button>
-            <div v-if="callOpen(call)" class="tool-row-body">
-              <ActivityToolDetails
-                v-if="presentation === 'activity'"
-                :call="call"
-                :label="item.group.label"
-                :operation-key="operationKey(call)"
-                @show-result="forwardShowResult"
-              />
-              <ToolRowSections
-                v-else
-                :call="call"
-                :label="item.group.label"
-                @show-result="forwardShowResult"
-              />
-            </div>
+            <Transition name="activity-tool-detail" :css="presentation === 'activity'">
+              <div v-if="callOpen(call)" class="tool-row-body">
+                <ActivityToolDetails
+                  v-if="presentation === 'activity'"
+                  :call="call"
+                  :label="item.group.label"
+                  :operation-key="operationKey(call)"
+                  @show-result="forwardShowResult"
+                />
+                <ToolRowSections
+                  v-else
+                  :call="call"
+                  :label="item.group.label"
+                  @show-result="forwardShowResult"
+                />
+              </div>
+            </Transition>
           </div>
         </template>
       </div>
@@ -1880,6 +1884,28 @@ function fmtTok(n?: number | null): string {
   padding: 0 0 0.125rem 1.625rem;
 }
 
+.tool-timeline--activity .activity-tool-detail-enter-active {
+  transform-origin: top left;
+  transition:
+    opacity var(--dur-base) var(--ease-out),
+    transform var(--dur-base) var(--ease-out);
+  will-change: opacity, transform;
+}
+
+.tool-timeline--activity .activity-tool-detail-leave-active {
+  transform-origin: top left;
+  transition:
+    opacity var(--dur-fast) var(--ease-in),
+    transform var(--dur-fast) var(--ease-in);
+  will-change: opacity, transform;
+}
+
+.tool-timeline--activity .activity-tool-detail-enter-from,
+.tool-timeline--activity .activity-tool-detail-leave-to {
+  opacity: 0;
+  transform: translateY(-0.25rem);
+}
+
 .tool-timeline--activity .step-group-members {
   padding-left: 1.5rem;
 }
@@ -2010,6 +2036,17 @@ function fmtTok(n?: number | null): string {
   .tool-member-enter-active,
   .tool-member-move {
     transition: none;
+  }
+
+  .tool-timeline--activity .activity-tool-detail-enter-active,
+  .tool-timeline--activity .activity-tool-detail-leave-active {
+    transition: none;
+  }
+
+  .tool-timeline--activity .activity-tool-detail-enter-from,
+  .tool-timeline--activity .activity-tool-detail-leave-to {
+    opacity: 1;
+    transform: none;
   }
 
   .tool-timeline--checklist .tool-row--running,

--- a/opensquilla-webui/src/composables/chat/turnParity.test.ts
+++ b/opensquilla-webui/src/composables/chat/turnParity.test.ts
@@ -115,4 +115,24 @@ describe('diffFoldVsLegacy — terminal states and structure', () => {
     )
     expect(problems.some(p => p.includes('timeline length'))).toBe(true)
   })
+
+  it('flags a semantic text-presentation mismatch', () => {
+    const foldedTimeline = [{
+      type: 'text' as const,
+      key: 'text-0',
+      html: '',
+      rawText: 'Working note.',
+      presentation: 'intermediate' as const,
+    }]
+    const legacyTimeline = [{
+      ...foldedTimeline[0],
+      presentation: 'answer' as const,
+    }]
+    const problems = diffFoldVsLegacy(
+      makeFold([], { timelineItems: foldedTimeline }),
+      makeLegacy([], { timelineItems: legacyTimeline }),
+    )
+
+    expect(problems).toContain('timeline text 0 presentation diverges')
+  })
 })

--- a/opensquilla-webui/src/composables/chat/turnParity.ts
+++ b/opensquilla-webui/src/composables/chat/turnParity.ts
@@ -236,6 +236,9 @@ function compareTimeline(
     // folded html would spuriously diverge from the still-stale legacy html
     // during that window. Whole-turn rawText equality (above) plus type+key
     // parity here covers text correctness.
+    if (a.type === 'text' && b.type === 'text' && a.presentation !== b.presentation) {
+      problems.push(`timeline text ${i} presentation diverges`)
+    }
     if (a.type === 'tool-group' && b.type === 'tool-group') {
       if (a.group.groupId !== b.group.groupId) {
         problems.push(`timeline tool-group ${i} groupId diverges`)

--- a/opensquilla-webui/src/composables/chat/useChatHistory.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatHistory.test.ts
@@ -64,6 +64,32 @@ function historyMessage(id: string): NonNullable<ChatHistoryResponse['messages']
 }
 
 describe('useChatHistory canonical pagination', () => {
+  it('preserves semantic text presentation from canonical history', async () => {
+    const { api, messages } = makeHistory(false, {
+      response: {
+        messages: [{
+          id: 'assistant-1',
+          message_id: 'assistant-1',
+          role: 'assistant',
+          text: 'Working note.Final answer.',
+          timestamp: '2026-07-06T00:00:00Z',
+          timeline: [
+            { type: 'text', raw: 'Working note.', presentation: 'intermediate' },
+            { type: 'text', raw: 'Final answer.', presentation: 'answer' },
+          ],
+        }],
+        has_more: false,
+      },
+    })
+
+    await api.loadHistory()
+
+    expect(messages.value[0]?.timeline).toEqual([
+      { type: 'text', raw: 'Working note.', presentation: 'intermediate' },
+      { type: 'text', raw: 'Final answer.', presentation: 'answer' },
+    ])
+  })
+
   it('does not expose an ordinary send disposition as same-turn steer status', async () => {
     const { api, messages } = makeHistory(false, {
       response: {

--- a/opensquilla-webui/src/composables/chat/useChatMessageActions.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatMessageActions.test.ts
@@ -890,6 +890,34 @@ describe('useChatMessageActions protocol-shaped copy text', () => {
     )
   })
 
+  it('copies only the explicit final answer after intermediate commentary', async () => {
+    const { api } = makeOptions([], text => text, () => 'AI generated')
+
+    await api.copyMessage(renderedMessage({
+      role: 'assistant',
+      displayRole: 'assistant',
+      text: 'Working note.Final answer.',
+      timelineItems: [
+        {
+          type: 'text',
+          key: 'work',
+          html: 'Working note.',
+          rawText: 'Working note.',
+          presentation: 'intermediate',
+        },
+        {
+          type: 'text',
+          key: 'answer',
+          html: 'Final answer.',
+          rawText: 'Final answer.',
+          presentation: 'answer',
+        },
+      ],
+    }))
+
+    expect(copyTextWithFallback).toHaveBeenCalledWith('Final answer.\n\nAI generated')
+  })
+
   it('copies the complete terminal Markdown answer from an ordinary tool transcript', async () => {
     const { api } = makeOptions([], text => text, () => 'AI generated')
 

--- a/opensquilla-webui/src/composables/chat/useChatRenderedMessages.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRenderedMessages.test.ts
@@ -531,6 +531,34 @@ describe('useChatRenderedMessages internal control turns', () => {
 })
 
 describe('useChatRenderedMessages silent sentinel compatibility', () => {
+  it('preserves presentation from explicit and legacy persisted timelines', () => {
+    const explicit = renderedMessagesFor([{
+      role: 'assistant',
+      text: 'Working note.Final answer.',
+      ts: 1,
+      timeline: [
+        { type: 'text', raw: 'Working note.', presentation: 'intermediate' },
+        { type: 'text', raw: 'Final answer.', presentation: 'answer' },
+      ],
+    }]).renderedMessages.value[0]!
+    const legacy = renderedMessagesFor([{
+      role: 'assistant',
+      text: 'Working note.Final answer.',
+      ts: 1,
+      tool_calls: [
+        { type: 'text', text: 'Working note.', presentation: 'intermediate' },
+        { type: 'text', text: 'Final answer.', presentation: 'answer' },
+      ],
+    }]).renderedMessages.value[0]!
+
+    expect(explicit.timelineItems?.map(item => (
+      item.type === 'text' ? item.presentation : item.type
+    ))).toEqual(['intermediate', 'answer'])
+    expect(legacy.timelineItems?.map(item => (
+      item.type === 'text' ? item.presentation : item.type
+    ))).toEqual(['intermediate', 'answer'])
+  })
+
   it('projects mixed legacy text and explicit timeline markers without mutating history', () => {
     const source: ChatMessage = {
       role: 'assistant',

--- a/opensquilla-webui/src/composables/chat/useChatRenderedMessages.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRenderedMessages.ts
@@ -1091,7 +1091,17 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
     return segments.flatMap((seg, idx): ChatStreamTimelineItem[] => {
       if (seg?.type === 'text') {
         const raw = String(seg.raw ?? seg.text ?? '')
-        return raw ? [{ type: 'text', key: `${ownerKey}:timeline:text:${idx}`, html: options.renderMarkdown(raw), rawText: raw }] : []
+        const presentation = seg.presentation === 'intermediate'
+          || seg.presentation === 'answer'
+          ? seg.presentation
+          : undefined
+        return raw ? [{
+          type: 'text',
+          key: `${ownerKey}:timeline:text:${idx}`,
+          html: options.renderMarkdown(raw),
+          rawText: raw,
+          presentation,
+        }] : []
       }
       if (seg?.type === 'tool-group') {
         const groupId = String(seg.groupId || seg.group_id || '')
@@ -1170,7 +1180,17 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
       const type = String(segment?.type || '')
       if (type === 'text') {
         const raw = String(segment.text || segment.raw || '')
-        if (raw) items.push({ type: 'text', key: `${ownerKey}:timeline:text:${index}`, html: options.renderMarkdown(raw), rawText: raw })
+        const presentation = segment.presentation === 'intermediate'
+          || segment.presentation === 'answer'
+          ? segment.presentation
+          : undefined
+        if (raw) items.push({
+          type: 'text',
+          key: `${ownerKey}:timeline:text:${index}`,
+          html: options.renderMarkdown(raw),
+          rawText: raw,
+          presentation,
+        })
         return
       }
       if (type === 'tool_use') {

--- a/opensquilla-webui/src/composables/chat/useChatStream.render.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatStream.render.test.ts
@@ -537,9 +537,9 @@ describe('useChatStream render coalescing', () => {
 
     expect(messages.value[0]?.text).toBe(prefix + suffix)
     expect(messages.value[0]?.timeline).toEqual([
-      { type: 'text', raw: prefix },
+      { type: 'text', raw: prefix, presentation: 'answer' },
       { type: 'tool-group', groupId: 'stream:tool-group:web.search:0', operationKey: 'web.search' },
-      { type: 'text', raw: suffix },
+      { type: 'text', raw: suffix, presentation: 'answer' },
     ])
     api.cleanup()
   })
@@ -788,7 +788,7 @@ describe('useChatStream render coalescing', () => {
   })
 
   it('keeps intermediate and answer text in separate live segments', () => {
-    const { api } = makeStream()
+    const { api, messages } = makeStream()
 
     api.appendToolCall({ tool_use_id: 'tool-1', tool_name: 'web_search' })
     api.appendToolResult({ tool_use_id: 'tool-1', tool_name: 'web_search', result: 'ok' })
@@ -809,6 +809,14 @@ describe('useChatStream render coalescing', () => {
       presentation: item.type === 'text' ? item.presentation : undefined,
       rawText: item.type === 'text' ? item.rawText : undefined,
     })))
+
+    api.endStreaming()
+
+    expect(messages.value[0]?.timeline).toEqual([
+      expect.objectContaining({ type: 'tool-group' }),
+      { type: 'text', raw: 'Checking.', presentation: 'intermediate' },
+      { type: 'text', raw: 'Verified answer.', presentation: 'answer' },
+    ])
     api.cleanup()
   })
 
@@ -1014,7 +1022,7 @@ describe('useChatStream render coalescing', () => {
     expect(messages.value[0]?.text).toBe('Canonical answer')
     expect(messages.value[0]?.timeline).toEqual([
       { type: 'tool-group', groupId: 'stream:tool-group:web.search:0', operationKey: 'web.search' },
-      { type: 'text', raw: 'Canonical answer' },
+      { type: 'text', raw: 'Canonical answer', presentation: 'answer' },
     ])
     expect(messages.value[0]?.tool_calls?.[0]).toMatchObject({
       tool_use_id: 'tool-1',
@@ -1105,7 +1113,9 @@ describe('useChatStream render coalescing', () => {
     api.endStreaming()
 
     expect(messages.value[0]?.text).toBe('streamed fallback')
-    expect(messages.value[0]?.timeline).toEqual([{ type: 'text', raw: 'streamed fallback' }])
+    expect(messages.value[0]?.timeline).toEqual([
+      { type: 'text', raw: 'streamed fallback', presentation: 'answer' },
+    ])
     api.cleanup()
   })
 

--- a/opensquilla-webui/src/composables/chat/useChatStream.ts
+++ b/opensquilla-webui/src/composables/chat/useChatStream.ts
@@ -1281,7 +1281,7 @@ export function useChatStream(options: UseChatStreamOptions) {
       .flatMap((seg): ChatTimelineSegment[] => {
         if (seg.type === 'text') {
           const raw = String(seg.raw || '')
-          return raw ? [{ type: 'text', raw }] : []
+          return raw ? [{ type: 'text', raw, presentation: seg.presentation }] : []
         }
         if (seg.type === 'tool-group') {
           return [{
@@ -1292,7 +1292,9 @@ export function useChatStream(options: UseChatStreamOptions) {
         }
         return []
       })
-    if (segments.length === 0 && fallbackText) return [{ type: 'text', raw: fallbackText }]
+    if (segments.length === 0 && fallbackText) {
+      return [{ type: 'text', raw: fallbackText, presentation: 'answer' }]
+    }
     return segments
   }
 

--- a/opensquilla-webui/src/types/chat.ts
+++ b/opensquilla-webui/src/types/chat.ts
@@ -205,12 +205,14 @@ export interface ChatToolCallGroup {
   status: '' | 'success' | 'error'
 }
 
+export type ChatTextPresentation = 'intermediate' | 'answer'
+
 export interface ChatStreamSegment {
   type: 'text' | 'tool-group' | 'interrupt'
   raw?: string
   html?: string
   dirty?: boolean
-  presentation?: 'intermediate' | 'answer'
+  presentation?: ChatTextPresentation
   groupId?: string
   operationKey?: string
   approvalId?: string
@@ -222,7 +224,7 @@ export type ChatStreamTimelineItem =
       key: string
       html: string
       rawText?: string
-      presentation?: 'intermediate' | 'answer'
+      presentation?: ChatTextPresentation
     }
   | { type: 'tool-group'; key: string; group: ChatToolCallGroup }
   | {
@@ -332,12 +334,14 @@ export interface RawToolCallPayload extends Record<string, unknown> {
   execution_status?: { status?: string }
   groupId?: string
   group_id?: string
+  presentation?: ChatTextPresentation
 }
 
 export interface ChatTimelineSegment extends Record<string, unknown> {
   type?: string
   raw?: string
   text?: string
+  presentation?: ChatTextPresentation
   groupId?: string
   group_id?: string
   approvalId?: string

--- a/opensquilla-webui/src/utils/chat/assistantActivity.test.ts
+++ b/opensquilla-webui/src/utils/chat/assistantActivity.test.ts
@@ -221,6 +221,41 @@ describe('projectAssistantActivity', () => {
     ])
   })
 
+  it('keeps an explicit intermediate span out of the adjacent final answer', () => {
+    const projection = projectAssistantActivity(
+      message({
+        text: 'Inspecting.Working note.Final answer.',
+        timelineItems: [
+          { type: 'text', key: 'opening', html: 'Inspecting.', rawText: 'Inspecting.' },
+          toolGroup([call('inspect', { name: 'read_file' })], 'inspect'),
+          {
+            type: 'text',
+            key: 'work',
+            html: 'Working note.',
+            rawText: 'Working note.',
+            presentation: 'intermediate',
+          },
+          {
+            type: 'text',
+            key: 'answer',
+            html: 'Final answer.',
+            rawText: 'Final answer.',
+            presentation: 'answer',
+          },
+        ],
+      }),
+      text => text,
+    )
+
+    expect(projection.answerSource).toBe('terminal-timeline-boundary')
+    expect(projection.answerPart?.rawText).toBe('Final answer.')
+    expect(projection.activityItems.map(item => item.key)).toEqual([
+      'opening',
+      'inspect',
+      'work',
+    ])
+  })
+
   it.each([
     ['dash thematic break', 'Summary before.\n\n---\n\nSummary after.'],
     ['asterisk thematic break', 'Summary before.\n\n***\n\nSummary after.'],

--- a/opensquilla-webui/src/utils/chat/assistantActivity.ts
+++ b/opensquilla-webui/src/utils/chat/assistantActivity.ts
@@ -504,22 +504,40 @@ function terminalTimelineAnswerCandidate(
     break
   }
 
-  if (index < 0 || timeline[index]?.type !== 'text') return null
+  const terminalItem = timeline[index]
+  if (
+    index < 0
+    || !terminalItem
+    || terminalItem.type !== 'text'
+    || terminalItem.presentation === 'intermediate'
+  ) return null
 
   const indexes = new Set<number>()
   const chunks: string[] = []
   while (index >= 0) {
     const item = timeline[index]
-    if (!item || item.type !== 'text') break
+    if (!item || item.type !== 'text' || item.presentation === 'intermediate') break
     if (typeof item.rawText !== 'string') return null
     indexes.add(index)
     chunks.unshift(item.rawText)
     index -= 1
   }
+  // A gateway-owned intermediate marker is an explicit semantic boundary.
+  // It is stronger than the legacy adjacency heuristic and keeps immediately
+  // preceding work narration inside Activity even when no tool separates it
+  // from the final answer span.
+  const boundaryItem = timeline[index]
+  const crossedPresentationBoundary = index >= 0
+    && boundaryItem?.type === 'text'
+    && boundaryItem.presentation === 'intermediate'
   const crossedOrdinaryToolBoundary = index >= 0
     && timeline[index]?.type === 'tool-group'
     && !isSuccessfulAnswerTransparentControlGroup(timeline[index])
-  if (!crossedControlBoundary && !crossedOrdinaryToolBoundary) return null
+  if (
+    !crossedControlBoundary
+    && !crossedOrdinaryToolBoundary
+    && !crossedPresentationBoundary
+  ) return null
 
   const compact = chunks.join('')
   if (!compact.trim()) return null

--- a/opensquilla-webui/src/utils/chat/foldTurn.test.ts
+++ b/opensquilla-webui/src/utils/chat/foldTurn.test.ts
@@ -124,6 +124,32 @@ describe('foldTurn — text, thinking, status, artifacts', () => {
       expect.objectContaining({ type: 'text', rawText: 'Checking.', presentation: 'intermediate' }),
       expect.objectContaining({ type: 'text', rawText: 'Answer', presentation: 'answer' }),
     ])
+    expect(f.timelineSegments).toEqual([
+      expect.objectContaining({ type: 'tool-group' }),
+      { type: 'text', raw: 'Checking.', presentation: 'intermediate' },
+      { type: 'text', raw: 'Answer', presentation: 'answer' },
+    ])
+  })
+
+  it('does not merge an authoritative answer suffix into intermediate commentary', () => {
+    const f = fold([
+      { kind: 'tool-result', seq: 0, toolId: 't', name: 'bash', result: 'ok', isError: false, input: '{}', at: 1 },
+      { kind: 'text', seq: 1, text: 'Working note.', presentation: 'intermediate' },
+      { kind: 'final-text', seq: 2, text: 'Working note.Final answer.' },
+    ])
+
+    expect(f.rawText).toBe('Working note.Final answer.')
+    expect(f.timelineItems).toHaveLength(3)
+    expect(f.timelineItems[1]).toMatchObject({
+      type: 'text',
+      rawText: 'Working note.',
+      presentation: 'intermediate',
+    })
+    expect(f.timelineItems[2]).toMatchObject({
+      type: 'text',
+      rawText: 'Final answer.',
+      presentation: 'answer',
+    })
   })
 
   it('replaces stale text around tools with one canonical terminal segment', () => {

--- a/opensquilla-webui/src/utils/chat/foldTurn.ts
+++ b/opensquilla-webui/src/utils/chat/foldTurn.ts
@@ -62,11 +62,11 @@ export interface ReconciledTextSnapshot {
 /**
  * Apply an authoritative terminal text snapshot without losing tool history.
  *
- * A strict extension is still an ordinary suffix and therefore stays after the
- * last streamed segment. A conflicting snapshot supersedes every streamed text
- * segment, but keeps tool groups in arrival order and places the one canonical
- * text segment after them. An empty snapshot intentionally clears text while
- * retaining those tool groups.
+ * A strict extension is still an ordinary answer suffix and therefore stays
+ * after the last streamed answer segment. A conflicting snapshot supersedes
+ * streamed answer text, but keeps tool groups and intermediate commentary in
+ * arrival order before the canonical answer. An empty snapshot intentionally
+ * clears answer text while retaining that work history.
  */
 export function reconcileTextSnapshot(
   segments: ChatStreamSegment[],
@@ -81,7 +81,7 @@ export function reconcileTextSnapshot(
     const suffix = snapshot.slice(accumulatedText.length)
     const next = segments.slice()
     const last = next[next.length - 1]
-    if (last?.type === 'text') {
+    if (last?.type === 'text' && last.presentation !== 'intermediate') {
       next[next.length - 1] = {
         ...last,
         raw: `${last.raw || ''}${suffix}`,
@@ -93,7 +93,9 @@ export function reconcileTextSnapshot(
     return { rawText: snapshot, segments: next, changed: true }
   }
 
-  const next = segments.filter(segment => segment.type !== 'text')
+  const next = segments.filter(segment => (
+    segment.type !== 'text' || segment.presentation === 'intermediate'
+  ))
   if (snapshot) {
     next.push({ type: 'text', raw: snapshot, html: '', dirty: true, presentation: 'answer' })
   }
@@ -563,7 +565,7 @@ export class TurnAccumulator {
     const timelineSegments = segments.flatMap((segment): ChatTimelineSegment[] => {
       if (segment.type === 'text') {
         const raw = String(segment.raw || '')
-        return raw ? [{ type: 'text', raw }] : []
+        return raw ? [{ type: 'text', raw, presentation: segment.presentation }] : []
       }
       if (segment.type === 'interrupt') {
         const approvalId = String(segment.approvalId || '')
@@ -909,7 +911,7 @@ export function foldTurn(
   const timelineSegments = segments.flatMap((segment): ChatTimelineSegment[] => {
     if (segment.type === 'text') {
       const raw = String(segment.raw || '')
-      return raw ? [{ type: 'text', raw }] : []
+      return raw ? [{ type: 'text', raw, presentation: segment.presentation }] : []
     }
     if (segment.type === 'interrupt') {
       const approvalId = String(segment.approvalId || '')

--- a/opensquilla-webui/src/utils/chat/historyMerge.test.ts
+++ b/opensquilla-webui/src/utils/chat/historyMerge.test.ts
@@ -166,6 +166,28 @@ describe('mergeLiveOnlyFields', () => {
     expect(mergeLiveOnlyFields(msg({ interrupted: true }), msg({ interrupted: false })).interrupted).toBe(false)
   })
 
+  it('keeps the ordered local timeline and matching calls for an older server row', () => {
+    const timeline = [
+      { type: 'text', raw: 'Working note.', presentation: 'intermediate' as const },
+      { type: 'tool-group', groupId: 'stream:tool-group:file.read:0' },
+      { type: 'text', raw: 'Final answer.', presentation: 'answer' as const },
+    ]
+    const toolCalls = [{
+      id: 'tool-1',
+      name: 'read_file',
+      groupId: 'stream:tool-group:file.read:0',
+      result: 'ok',
+    }]
+
+    const merged = mergeLiveOnlyFields(
+      msg({ timeline, tool_calls: toolCalls }),
+      msg({ timeline: [], tool_calls: [{ id: 'server-tool', name: 'read_file' }] }),
+    )
+
+    expect(merged.timeline).toEqual(timeline)
+    expect(merged.tool_calls).toEqual(toolCalls)
+  })
+
   it('does not let stale history regress a terminal steer disposition', () => {
     const merged = mergeLiveOnlyFields(
       msg({

--- a/opensquilla-webui/src/utils/chat/historyMerge.ts
+++ b/opensquilla-webui/src/utils/chat/historyMerge.ts
@@ -175,6 +175,17 @@ export function mergeLiveOnlyFields(
   }
   if (prev.steerRestored) merged.steerRestored = true
 
+  // Older gateways may return the canonical answer without the ordered local
+  // timeline. Keep the just-finished snapshot so intermediate/answer roles and
+  // their grouped call ids survive the immediate history replacement. A
+  // non-empty server timeline remains authoritative.
+  if ((server.timeline?.length ?? 0) === 0 && (prev.timeline?.length ?? 0) > 0) {
+    merged.timeline = prev.timeline?.map(segment => ({ ...segment }))
+    if ((prev.tool_calls?.length ?? 0) > 0) {
+      merged.tool_calls = prev.tool_calls?.map(call => ({ ...call }))
+    }
+  }
+
   // Approval/clarify interrupts are live event metadata. Canonical transcript
   // rows currently persist the surrounding text/tools but not these decisions,
   // so carry the in-flow timeline snapshot across the immediate history sync.

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -182,6 +182,7 @@ from opensquilla.engine.turn_runner.harness import (
 )
 from opensquilla.engine.turn_runner.stream_consumer_stage import (
     _could_be_human_silent_reply_prefix,
+    _flush_current_text_segment,
     _StreamState,
 )
 from opensquilla.engine.types import (
@@ -4982,6 +4983,7 @@ class TurnRunner:
         # CancelledError handler can flush a trailing text segment the same way
         # the normal-completion path does.
         current_text_parts: list[str] = []
+        stream_state: _StreamState | None = None
         self._emit_turn_event(
             "turn_start",
             trace_context,
@@ -5947,9 +5949,7 @@ class TurnRunner:
             # Post-stage edge owned by the harness: flush remaining
             # text segment. The stage's post-stream notify already
             # fired (it is the last action of the stage body).
-            if current_text_parts:
-                turn_segments.append({"type": "text", "text": "".join(current_text_parts)})
-                current_text_parts.clear()
+            _flush_current_text_segment(stream_state)
 
             # 10. Persist assistant response (filter sentinel tokens).
             # TurnFinalizerStage owns the slice. The four side effects
@@ -6127,8 +6127,20 @@ class TurnRunner:
             # timeline) drops the visible partial answer.
             trailing = "".join(current_text_parts)
             if trailing:
-                turn_segments.append({"type": "text", "text": trailing})
-                current_text_parts.clear()
+                if stream_state is not None:
+                    _flush_current_text_segment(stream_state)
+                else:
+                    # Cancellation before the stream stage exists can only
+                    # observe legacy answer text. Keep the additive field
+                    # explicit for consistency with normal persistence.
+                    turn_segments.append(
+                        {
+                            "type": "text",
+                            "text": trailing,
+                            "presentation": "answer",
+                        }
+                    )
+                    current_text_parts.clear()
             from opensquilla.engine.silent_reply import (
                 is_silent_reply_prefix,
                 normalize_silent_reply,

--- a/src/opensquilla/engine/turn_runner/stream_consumer_stage.py
+++ b/src/opensquilla/engine/turn_runner/stream_consumer_stage.py
@@ -30,7 +30,7 @@ import asyncio
 import json
 from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Any, Final, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Final, Literal, Protocol, runtime_checkable
 
 import structlog
 
@@ -287,6 +287,11 @@ class _StreamState:
 
     # Moved INTO stage scope (declared inline before the stage extraction).
     current_text_parts: list[str] = field(default_factory=list)
+    # Presentation for ``current_text_parts``. Persisted text segments carry
+    # this additive field so history reloads can distinguish user-visible work
+    # narration from the terminal answer. ``answer`` is the compatibility
+    # default for legacy producers and rows that predate the field.
+    current_text_presentation: Literal["intermediate", "answer"] = "answer"
     error_message: str | None = None
     pending_error_event: ErrorEvent | None = None
     done_event: DoneEvent | None = None
@@ -480,6 +485,44 @@ def _normalize_cumulative_text_delta(text: str, state: _StreamState) -> str:
     return text
 
 
+def _normalize_text_presentation(value: object) -> Literal["intermediate", "answer"]:
+    """Normalize optional or legacy presentation values to the answer default."""
+
+    return "intermediate" if value == "intermediate" else "answer"
+
+
+def _flush_current_text_segment(state: _StreamState) -> None:
+    """Persist the current text run without losing its presentation metadata."""
+
+    if not state.current_text_parts:
+        return
+    state.turn_segments.append(
+        {
+            "type": "text",
+            "text": "".join(state.current_text_parts),
+            "presentation": state.current_text_presentation,
+        }
+    )
+    state.current_text_parts[:] = []
+
+
+def _append_current_text(
+    state: _StreamState,
+    text: str,
+    *,
+    presentation: object,
+) -> None:
+    """Append text while keeping unlike presentation runs as separate segments."""
+
+    if not text:
+        return
+    normalized = _normalize_text_presentation(presentation)
+    if state.current_text_parts and state.current_text_presentation != normalized:
+        _flush_current_text_segment(state)
+    state.current_text_presentation = normalized
+    state.current_text_parts.append(text)
+
+
 class _TextDeltaHandler:
     """Accumulate streamed text deltas into the final-text and current-text buffers."""
 
@@ -491,7 +534,11 @@ class _TextDeltaHandler:
         canonical_delta = _normalize_cumulative_text_delta(event.text, state)
         if canonical_delta:
             state.final_text_parts.append(canonical_delta)
-            state.current_text_parts.append(canonical_delta)
+            _append_current_text(
+                state,
+                canonical_delta,
+                presentation=event.presentation,
+            )
         return replace(event, text=canonical_delta)
 
 class _ToolUseStartHandler:
@@ -502,11 +549,7 @@ class _ToolUseStartHandler:
         event: ToolUseStartEvent,
         state: _StreamState,
     ) -> ToolUseStartEvent:
-        if state.current_text_parts:
-            state.turn_segments.append(
-                {"type": "text", "text": "".join(state.current_text_parts)}
-            )
-            state.current_text_parts[:] = []
+        _flush_current_text_segment(state)
         state.turn_segments.append(
             {
                 "type": "tool_use",
@@ -702,6 +745,7 @@ class _WarningHandler:
         if accumulated_text.endswith(current_text):
             state.final_text_parts[:] = [accumulated_text[: -len(current_text)]]
         state.current_text_parts[:] = []
+        state.current_text_presentation = "answer"
 
 @dataclass
 class _DonePrePublish:
@@ -1165,22 +1209,29 @@ def _reconcile_done_text_snapshot(
 
         suffix = done_text[len(accumulated_text) :]
         state.final_text_parts.append(suffix)
-        state.current_text_parts.append(suffix)
-        return done_text, _TextDeltaEvent(text=suffix)
+        _append_current_text(state, suffix, presentation="answer")
+        return done_text, _TextDeltaEvent(text=suffix, presentation="answer")
 
     # The terminal aggregate is a complete Agent-owned snapshot. A mismatch means
     # streamed text was intentionally superseded (retry, recovery, or a producer
     # that emitted a cumulative final value). Keep non-text segments so tool
     # execution history is never erased, but collapse text to one canonical value.
+    if state.current_text_parts and state.current_text_presentation == "intermediate":
+        _flush_current_text_segment(state)
     state.final_text_parts[:] = [done_text] if done_text else []
     state.turn_segments[:] = [
         segment
         for segment in state.turn_segments
-        if not (isinstance(segment, dict) and segment.get("type") == "text")
+        if not (
+            isinstance(segment, dict)
+            and segment.get("type") == "text"
+            and _normalize_text_presentation(segment.get("presentation")) == "answer"
+        )
     ]
     state.current_text_parts[:] = (
         [done_text] if done_text and state.turn_segments else []
     )
+    state.current_text_presentation = "answer"
     return done_text, None
 
 
@@ -1202,6 +1253,7 @@ def _silent_reply_state_projection(
             {
                 "type": "text",
                 "text": current_text,
+                "presentation": state.current_text_presentation,
                 _CURRENT_SILENT_REPLY_TEXT_MARKER: True,
             }
         )
@@ -1236,14 +1288,19 @@ def _apply_silent_reply_normalization_to_state(
 
     turn_segments: list[dict[str, Any]] = []
     normalized_current = ""
+    normalized_current_presentation: Literal["intermediate", "answer"] = "answer"
     for raw_segment in projection.normalization.segments:
         segment = dict(raw_segment)
         if segment.pop(_CURRENT_SILENT_REPLY_TEXT_MARKER, False):
             normalized_current += str(segment.get("text") or "")
+            normalized_current_presentation = _normalize_text_presentation(
+                segment.get("presentation")
+            )
             continue
         turn_segments.append(segment)
     state.turn_segments[:] = turn_segments
     state.current_text_parts[:] = [normalized_current] if normalized_current else []
+    state.current_text_presentation = normalized_current_presentation
     state.final_text_parts[:] = (
         [projection.canonical_text] if projection.canonical_text else []
     )
@@ -1276,7 +1333,7 @@ def _append_done_notice_delta(
     separator = "\n\n" if accumulated_text.strip() else ""
     notice_delta = separator + notice
     state.final_text_parts.append(notice_delta)
-    state.current_text_parts.append(notice_delta)
+    _append_current_text(state, notice_delta, presentation="answer")
     final_text = "".join(state.final_text_parts)
     event = replace(
         event,
@@ -1286,7 +1343,7 @@ def _append_done_notice_delta(
         suppression_reason=None,
     )
     state.done_event = event
-    return event, _TextDeltaEvent(text=notice_delta)
+    return event, _TextDeltaEvent(text=notice_delta, presentation="answer")
 
 
 def _is_completed_meta_invoke(event: ToolResultEvent) -> bool:

--- a/src/opensquilla/engine/turn_runner/turn_finalizer_stage.py
+++ b/src/opensquilla/engine/turn_runner/turn_finalizer_stage.py
@@ -750,7 +750,13 @@ class TurnFinalizerStage:
                     if not (isinstance(segment, dict) and segment.get("type") == "text")
                 ]
                 if final_text:
-                    turn_segments.append({"type": "text", "text": final_text})
+                    turn_segments.append(
+                        {
+                            "type": "text",
+                            "text": final_text,
+                            "presentation": "answer",
+                        }
+                    )
 
         final_text = with_unconfirmed_action_notice(final_text, turn_segments)
 

--- a/tests/test_engine/test_cancelled_turn_segments.py
+++ b/tests/test_engine/test_cancelled_turn_segments.py
@@ -26,6 +26,7 @@ from opensquilla.tools.registry import ToolRegistry, ToolSpec
 from opensquilla.tools.types import CallerKind, ToolContext
 
 PARTIAL_ANSWER = "Based on the lookup, the answer is 42 and the reasoning is as follows"
+PARTIAL_ACTIVITY = "I will inspect another source before answering."
 
 
 class _ToolThenHangingTextProvider:
@@ -65,6 +66,21 @@ class _ToolThenCompletedTextProvider(_ToolThenHangingTextProvider):
             return
         yield ProviderText(text=PARTIAL_ANSWER)
         yield ProviderDone(stop_reason="end_turn", input_tokens=1, output_tokens=1)
+
+
+class _HangingIntermediateTextProvider(_ToolThenHangingTextProvider):
+    """Start a tool and then stream work narration before cancellation."""
+
+    async def _stream(self, call_number: int) -> AsyncIterator[Any]:
+        del call_number
+        yield ProviderToolUseStart(tool_use_id="tool-1", tool_name="lookup")
+        yield ProviderToolUseEnd(
+            tool_use_id="tool-1",
+            tool_name="lookup",
+            arguments={},
+        )
+        yield ProviderText(text=PARTIAL_ACTIVITY)
+        await asyncio.Event().wait()
 
 
 class _HangingReasoningProvider:
@@ -260,6 +276,71 @@ async def test_cancelled_turn_persists_trailing_text_segment(tmp_path) -> None:
         assert session.output_tokens == 1
         assert session.total_tokens == 2
         assert session.missing_cost_entries == 1
+    finally:
+        if not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_turn_preserves_intermediate_text_presentation(tmp_path) -> None:
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    manager = SessionManager(storage)
+    session_key = "agent:main:webchat:cancel-intermediate-text"
+    await manager.create(session_key)
+    runner = TurnRunner(
+        provider_selector=_ProviderSelector(_HangingIntermediateTextProvider()),
+        tool_registry=_registry(),
+        session_manager=manager,
+        config=GatewayConfig(
+            attachments=AttachmentsConfig(media_root=str(tmp_path / "media")),
+            squilla_router=SquillaRouterConfig(enabled=False),
+        ),
+    )
+    tool_context = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(tmp_path),
+    )
+    partial_seen = asyncio.Event()
+
+    async def _consume() -> None:
+        async for event in runner.run(
+            "inspect it before answering",
+            session_key,
+            tool_context=tool_context,
+            history_has_persisted_user=False,
+            no_memory_capture=True,
+        ):
+            if isinstance(event, TextDeltaEvent) and PARTIAL_ACTIVITY in (event.text or ""):
+                assert event.presentation == "intermediate"
+                partial_seen.set()
+
+    task = asyncio.create_task(_consume())
+    try:
+        await asyncio.wait_for(partial_seen.wait(), timeout=5.0)
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        transcript = await manager.get_transcript(session_key)
+        assistant = [entry for entry in transcript if entry.role == "assistant"][-1]
+        text_segments = [
+            segment
+            for segment in (assistant.tool_calls or [])
+            if isinstance(segment, dict) and segment.get("type") == "text"
+        ]
+        assert text_segments == [
+            {
+                "type": "text",
+                "text": PARTIAL_ACTIVITY,
+                "presentation": "intermediate",
+            }
+        ]
     finally:
         if not task.done():
             task.cancel()

--- a/tests/test_engine/turn_runner/test_canonical_text_contract.py
+++ b/tests/test_engine/turn_runner/test_canonical_text_contract.py
@@ -10,6 +10,7 @@ import pytest
 from opensquilla.engine.turn_runner.stream_consumer_stage import (
     StreamConsumerStageInput,
     _DoneHandler,
+    _flush_current_text_segment,
     _StreamState,
     _TextDeltaHandler,
     _ToolUseStartHandler,
@@ -193,7 +194,11 @@ async def test_literal_protocol_like_text_is_canonical_across_stream_done_and_pe
     assert streamed_text == literal_text
     assert done_event.text == literal_text
     assert "".join(state.final_text_parts) == literal_text
-    assert state.turn_segments[0] == {"type": "text", "text": literal_text}
+    assert state.turn_segments[0] == {
+        "type": "text",
+        "text": literal_text,
+        "presentation": "answer",
+    }
 
     final_text, transcript = await _finalize(state, done_event)
 
@@ -202,7 +207,79 @@ async def test_literal_protocol_like_text_is_canonical_across_stream_done_and_pe
     assert transcript.calls[0]["tool_calls"][0] == {
         "type": "text",
         "text": literal_text,
+        "presentation": "answer",
     }
+
+
+@pytest.mark.asyncio
+async def test_text_presentation_survives_segment_flush_and_transcript_persistence() -> None:
+    state = _make_state()
+    text_handler = _TextDeltaHandler()
+
+    text_handler.handle(
+        TextDeltaEvent(text="I will inspect the source.", presentation="intermediate"),
+        state,
+    )
+    _ToolUseStartHandler().handle(
+        ToolUseStartEvent(tool_use_id="tool-1", tool_name="read_file"),
+        state,
+    )
+    state.turn_segments.append(
+        {
+            "type": "tool_result",
+            "tool_use_id": "tool-1",
+            "name": "read_file",
+            "content": "ok",
+        }
+    )
+    text_handler.handle(
+        TextDeltaEvent(text="The source is valid.", presentation="answer"),
+        state,
+    )
+    _flush_current_text_segment(state)
+
+    done = DoneEvent(text="I will inspect the source.The source is valid.")
+    final_text, transcript = await _finalize(state, done)
+
+    assert final_text == "I will inspect the source.\n\nThe source is valid."
+    persisted_text = [
+        segment
+        for segment in transcript.calls[0]["tool_calls"]
+        if segment.get("type") == "text"
+    ]
+    assert persisted_text == [
+        {
+            "type": "text",
+            "text": "I will inspect the source.",
+            "presentation": "intermediate",
+        },
+        {
+            "type": "text",
+            "text": "The source is valid.",
+            "presentation": "answer",
+        },
+    ]
+
+
+def test_presentation_change_splits_adjacent_text_runs_without_a_tool_boundary() -> None:
+    state = _make_state()
+    handler = _TextDeltaHandler()
+
+    handler.handle(TextDeltaEvent(text="answer-shaped prefix"), state)
+    handler.handle(
+        TextDeltaEvent(text="work narration", presentation="intermediate"),
+        state,
+    )
+
+    assert state.turn_segments == [
+        {
+            "type": "text",
+            "text": "answer-shaped prefix",
+            "presentation": "answer",
+        }
+    ]
+    assert state.current_text_parts == ["work narration"]
+    assert state.current_text_presentation == "intermediate"
 
 
 def test_partial_protocol_like_suffix_is_immediately_available_for_cancellation() -> None:
@@ -358,6 +435,65 @@ def test_conflicting_done_snapshot_preserves_tool_events_and_replaces_only_text(
         "tool_result",
     ]
     assert "".join(state.current_text_parts) == "canonical successful answer"
+
+
+def test_conflicting_done_snapshot_keeps_intermediate_activity_segments() -> None:
+    state = _make_state()
+    text_handler = _TextDeltaHandler()
+    text_handler.handle(
+        TextDeltaEvent(text="Inspecting the repository.", presentation="intermediate"),
+        state,
+    )
+    _ToolUseStartHandler().handle(
+        ToolUseStartEvent(tool_use_id="tool-1", tool_name="search"),
+        state,
+    )
+    state.turn_segments.append(
+        {
+            "type": "tool_result",
+            "tool_use_id": "tool-1",
+            "name": "search",
+            "content": "ok",
+        }
+    )
+    text_handler.handle(TextDeltaEvent(text="stale answer"), state)
+
+    done_event, extra = _DoneHandler().handle(
+        DoneEvent(text="canonical answer"),
+        _make_stream_input(state),
+        state,
+    )
+
+    assert extra == []
+    assert done_event.text == "canonical answer"
+    assert state.turn_segments[0] == {
+        "type": "text",
+        "text": "Inspecting the repository.",
+        "presentation": "intermediate",
+    }
+    assert [segment["type"] for segment in state.turn_segments] == [
+        "text",
+        "tool_use",
+        "tool_result",
+    ]
+    assert state.current_text_parts == ["canonical answer"]
+    assert state.current_text_presentation == "answer"
+
+
+def test_legacy_text_segment_without_presentation_defaults_to_answer() -> None:
+    state = _make_state()
+    state.final_text_parts = ["legacy streamed answer"]
+    state.turn_segments = [{"type": "text", "text": "legacy streamed answer"}]
+
+    done_event, extra = _DoneHandler().handle(
+        DoneEvent(text="canonical answer"),
+        _make_stream_input(state),
+        state,
+    )
+
+    assert extra == []
+    assert done_event.text == "canonical answer"
+    assert state.turn_segments == []
 
 
 def test_cumulative_meta_final_snapshot_does_not_duplicate_streamed_prefix() -> None:

--- a/tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py
@@ -755,6 +755,7 @@ def test_tool_use_start_handler_preserves_canonical_details_text_segment() -> No
     assert state.turn_segments[0] == {
         "type": "text",
         "text": expected,
+        "presentation": "answer",
     }
     assert "".join(state.final_text_parts) == expected
 
@@ -773,7 +774,7 @@ def test_tool_use_start_handler_flushes_text_and_appends_segment() -> None:
         state,
     )
     assert state.turn_segments == [
-        {"type": "text", "text": "pre"},
+        {"type": "text", "text": "pre", "presentation": "answer"},
         {"type": "tool_use", "tool_use_id": "t1", "name": "echo", "input": ""},
     ]
     assert state.current_text_parts == []
@@ -2050,7 +2051,11 @@ async def test_system_event_normalization_preserves_text_around_tool_boundary(
         "tool_use",
         "tool_result",
     ]
-    assert inp.state.turn_segments[0] == {"type": "text", "text": "Preparing."}
+    assert inp.state.turn_segments[0] == {
+        "type": "text",
+        "text": "Preparing.",
+        "presentation": "answer",
+    }
     assert inp.state.current_text_parts == ["Finished."]
     assert "NO_REPLY" not in str(inp.state.turn_segments)
 
@@ -2128,6 +2133,7 @@ async def test_system_event_removes_bare_marker_after_tool_without_newline() -> 
     assert inp.state.turn_segments[0] == {
         "type": "text",
         "text": "Visible body.",
+        "presentation": "answer",
     }
     assert inp.state.current_text_parts == []
     assert inp.state.final_text_parts == ["Visible body."]
@@ -2835,7 +2841,7 @@ async def test_outer_stage_persists_literal_text_before_native_tool_segment() ->
     await _drain(stage, _make_input(state=state))
 
     assert state.turn_segments[:2] == [
-        {"type": "text", "text": literal},
+        {"type": "text", "text": literal, "presentation": "answer"},
         {
             "type": "tool_use",
             "tool_use_id": "native-1",

--- a/tests/test_gateway/test_rpc_chat_history.py
+++ b/tests/test_gateway/test_rpc_chat_history.py
@@ -1395,6 +1395,53 @@ async def test_chat_history_exposes_stable_message_identity() -> None:
 
 
 @pytest.mark.asyncio
+async def test_chat_history_preserves_text_segment_presentation_and_order() -> None:
+    segments = [
+        {
+            "type": "text",
+            "text": "I will inspect the source.",
+            "presentation": "intermediate",
+        },
+        {
+            "type": "tool_use",
+            "tool_use_id": "tool-1",
+            "name": "read_file",
+            "input": {"path": "README.md"},
+        },
+        {
+            "type": "tool_result",
+            "tool_use_id": "tool-1",
+            "name": "read_file",
+            "content": "ok",
+        },
+        {
+            "type": "text",
+            "text": "The source is valid.",
+            "presentation": "answer",
+        },
+    ]
+    entry = TranscriptEntry(
+        id=124,
+        session_id="parent",
+        session_key="agent:main:webchat:test",
+        role="assistant",
+        content="The source is valid.",
+        tool_calls=segments,
+    )
+
+    result = await _handle_chat_history(
+        {"sessionKey": "agent:main:webchat:test"},
+        RpcContext(
+            conn_id="test",
+            principal=SimpleNamespace(role="operator"),
+            session_manager=_FakeSessionManager([entry]),
+        ),
+    )
+
+    assert result["messages"][0]["tool_calls"] == segments
+
+
+@pytest.mark.asyncio
 async def test_chat_history_returns_requested_compaction_summaries() -> None:
     summary = SessionSummary(
         id=7,


### PR DESCRIPTION
## Scope

- Persist assistant text presentation (`intermediate` versus `answer`) in durable turn segments across normal completion, cancellation, and final reconciliation.
- Restore presentation through streaming snapshots, history merge/reload, answer extraction, and copy behavior.
- Refine long activity details into one borderless, shadowed window with a non-repeated title, safe full-content copy, enter/leave motion, and reduced-motion support.

## Base

- Target: `main`
- Branch: `feature/chat-activity-timeline`

## Linked issue

None.

## Release note

User-visible Web UI refinement and history-correctness fix.

## Verification

- Focused Web UI unit tests: 342 passed.
- Focused Python tests: 220 passed.
- `npm run typecheck` passed, including architecture, security, theme, motion, accessibility-adjacent contract, i18n, and `vue-tsc` checks.
- Targeted Ruff and Mypy checks passed.
- `npm run build:artifact` passed.
- `git diff --check origin/main...HEAD` passed.

## Safety and compatibility

- `presentation` is additive inside the existing persisted `tool_calls` JSON; legacy, missing, or unknown values default to `answer`. No database migration is required.
- Existing clients may ignore the additive field. Non-activity `RunTrace` views are unchanged.
- Copy and viewer payloads continue to use redacted content. Reduced-motion preferences are honored.
- The implementation is platform-neutral.
- No provider credentials, real session transcripts, or local runtime artifacts are included.

## Third-party origin

None; the implementation and tests are repository-native.
