### PR TITLE
Stabilize Windows desktop cleanup recovery CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1062,6 +1062,13 @@ jobs:
             fi
           }
 
+          is_retryable_windows_failure() {
+            local log_path="$1"
+            [[ "${RUNNER_OS}" == "Windows" ]] || return 1
+            grep -Fq 'Gateway did not become healthy' "${log_path}" \
+              || grep -Fq 'Timed out waiting for post-exit delete-all helper completion' "${log_path}"
+          }
+
           case "${{ matrix.shard }}" in
             all)
               entries=(
@@ -1119,8 +1126,7 @@ jobs:
 
             first_log="${CI_REPORT_DIR}/${name}-attempt-1.log"
             printf 'failed_case=%s\n' "${name}" > "${CI_REPORT_DIR}/first-failure.txt"
-            if [[ "${RUNNER_OS}" == "Windows" ]] \
-              && grep -Fq 'Gateway did not become healthy' "${first_log}"
+            if is_retryable_windows_failure "${first_log}"
             then
               printf 'retry_case=%s\n' "${name}" >> "${CI_REPORT_DIR}/first-failure.txt"
               if run_case "${name}" "${script}" 2; then

--- a/desktop/electron/scripts/test-desktop-cleanup-flow.mjs
+++ b/desktop/electron/scripts/test-desktop-cleanup-flow.mjs
@@ -98,7 +98,21 @@ const consolidationBackupMarker = join(
   'archived-recovery-data.txt',
 )
 const cleanupJournal = join(userData, '.opensquilla.profile-cleanup.json')
+const deleteAllHelperTimeoutMs = process.platform === 'win32' ? 90_000 : 30_000
 let desktopApp
+
+async function pendingDeleteAllTargets() {
+  const targets = [
+    ['primary-home', primaryHome],
+    ['consolidation-backup', consolidationBackupRoot],
+    ['desktop-logs', join(userData, 'logs')],
+  ]
+  const states = await Promise.all(targets.map(async ([name, path]) => ({
+    name,
+    exists: await exists(path),
+  })))
+  return states.filter((state) => state.exists).map((state) => state.name)
+}
 
 async function seedProfileContext(updatedAt) {
   await writeFile(join(userData, 'desktop-locale'), 'en', 'utf8')
@@ -263,11 +277,19 @@ try {
       throw new Error('Desktop did not exit before the delete-all helper handoff.')
     }),
   ])
-  await waitFor(async () => (
-    !await exists(primaryHome)
-    && !await exists(consolidationBackupRoot)
-    && !await exists(join(userData, 'logs'))
-  ), 'post-exit delete-all helper completion', 30_000)
+  try {
+    await waitFor(async () => (
+      !await exists(primaryHome)
+      && !await exists(consolidationBackupRoot)
+      && !await exists(join(userData, 'logs'))
+    ), 'post-exit delete-all helper completion', deleteAllHelperTimeoutMs)
+  } catch (error) {
+    const pendingTargets = await pendingDeleteAllTargets()
+    throw new Error(
+      `${error.message}; pending synthetic targets: ${pendingTargets.join(', ') || 'none'}`,
+      { cause: error },
+    )
+  }
 
   console.log(JSON.stringify({
     ok: true,

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -1404,8 +1404,14 @@ def test_desktop_recovery_e2e_runs_compiled_flows_on_all_release_platforms() -> 
     assert "test-unsafe-legacy-recovery-no-write.mjs" in run["run"]
     assert 'case "${{ matrix.shard }}" in' in run["run"]
     assert 'local log_path="${CI_REPORT_DIR}/${name}-attempt-${attempt}.log"' in run["run"]
-    assert '[[ "${RUNNER_OS}" == "Windows" ]]' in run["run"]
+    assert "is_retryable_windows_failure()" in run["run"]
+    assert '[[ "${RUNNER_OS}" == "Windows" ]] || return 1' in run["run"]
     assert "grep -Fq 'Gateway did not become healthy'" in run["run"]
+    assert (
+        "grep -Fq 'Timed out waiting for post-exit delete-all helper completion'"
+        in run["run"]
+    )
+    assert 'if is_retryable_windows_failure "${first_log}"' in run["run"]
     assert 'run_case "${name}" "${script}" 2' in run["run"]
     assert "exit 1" in run["run"]
     assert upload["if"] == "${{ always() }}"
@@ -1901,3 +1907,12 @@ def test_linux_desktop_recovery_e2e_scripts_preserve_x11_authority() -> None:
             "DISPLAY/XAUTHORITY, so the ubuntu Desktop recovery E2E job will fail with "
             "'Missing X server or $DISPLAY'"
         )
+
+
+def test_desktop_cleanup_flow_allows_windows_helper_release_latency() -> None:
+    source = Path(
+        "desktop/electron/scripts/test-desktop-cleanup-flow.mjs"
+    ).read_text(encoding="utf-8")
+
+    assert "process.platform === 'win32' ? 90_000 : 30_000" in source
+    assert "pending synthetic targets" in source


### PR DESCRIPTION
## Scope

- Give the detached delete-all helper a Windows-specific 90-second completion budget while retaining the existing 30-second budget elsewhere.
- Report which synthetic cleanup targets remain when the helper times out.
- Retry once on Windows only for the exact post-exit helper timeout, preserving fail-fast behavior for every other failure.
- Add workflow and harness contract coverage.

Scope boundary: CI and synthetic Desktop recovery E2E harness only.
Non-goals: production cleanup semantics, public APIs, persistence formats, or user preferences.

## Branch

Base branch: main
Target exception: N/A

## Issue

Linked issue: None
If None, reason: repeated Windows-only merge-queue flakes blocked otherwise-green PRs; the exact failure signature was reproduced in three CI runs.

## Release Note

Release note: NONE

## Tests

Ruff: `.venv/bin/ruff check tests/test_ci/test_workflows.py`
Pytest: `.venv/bin/pytest -q tests/test_ci/test_workflows.py` (91 passed)
Build: `npm run build` in `desktop/electron`; full WebUI typecheck/build
Regression tests: added
Notes: `test-desktop-cleanup-contract.mjs` passed, and the real macOS Electron cleanup flow completed all three phases. The default test path remains offline, deterministic, credential-free, and safe for forks. Windows behavior is covered by the required Desktop recovery CI matrix.

## Maintainer Live Check

Maintainer live check: no
Surface: N/A
Maintainer-only note: no credentials or live services are required.

## Safety

Only synthetic temporary paths are inspected. No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are included.

Platform impact: Windows CI only receives the longer helper budget and exact one-time retry; macOS and Linux retain the 30-second helper budget. Production runtime behavior is unchanged.
Upgrade compatibility: no persisted data, configuration, database, RPC, CLI, or public interface changes.

## Third-Party Origin

Third-party origin: none
Details if non-none: N/A

## Documentation Changes

- [x] No documentation changes required.