### PR TITLE
Polish sidebar session interactions

### DIFF
--- a/opensquilla-webui/src/components/SidebarConversations.context-menu.test.ts
+++ b/opensquilla-webui/src/components/SidebarConversations.context-menu.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import i18n from '@/i18n'
+import SidebarConversations, { type SidebarSection } from './SidebarConversations.vue'
+
+const platformState = vi.hoisted(() => ({ isDesktop: false }))
+
+vi.mock('@/platform', () => ({
+  usePlatform: () => ({
+    capabilities: { isDesktop: platformState.isDesktop },
+  }),
+}))
+
+const mounted: App[] = []
+
+afterEach(() => {
+  mounted.splice(0).forEach(app => app.unmount())
+  document.body.innerHTML = ''
+  platformState.isDesktop = false
+})
+
+async function mountSidebar() {
+  i18n.global.locale.value = 'en'
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  const sections: SidebarSection[] = [{
+    family: 'chats',
+    label: 'Tasks',
+    rows: [{
+      rowKind: 'session',
+      key: 'session-1',
+      title: 'First task',
+      effectiveAgentId: 'main',
+      agentName: 'Main',
+      sessionKind: 'chat',
+      depth: 0,
+      runStatus: 'idle',
+      runLabel: 'Idle',
+      taskAttention: 'none',
+      updatedAt: Date.now(),
+      hasContractGaps: false,
+    }],
+  }]
+  const app = createApp(SidebarConversations, {
+    sections,
+    error: false,
+    loading: false,
+    currentKey: '',
+    contractDebugEnabled: false,
+    searchHint: '⌘K',
+  })
+  app.use(i18n)
+  app.mount(root)
+  mounted.push(app)
+  await nextTick()
+  return root
+}
+
+function dispatchContextMenu(target: Element): MouseEvent {
+  const event = new MouseEvent('contextmenu', {
+    bubbles: true,
+    cancelable: true,
+    clientX: 120,
+    clientY: 180,
+  })
+  target.dispatchEvent(event)
+  return event
+}
+
+describe('SidebarConversations session context menu', () => {
+  it('opens the existing row actions at the pointer in the desktop client', async () => {
+    platformState.isDesktop = true
+    const root = await mountSidebar()
+    const row = root.querySelector<HTMLElement>('.sidebar-history-item')
+    expect(row).not.toBeNull()
+
+    const event = dispatchContextMenu(row!)
+    await nextTick()
+
+    expect(event.defaultPrevented).toBe(true)
+    const menu = document.body.querySelector<HTMLElement>('.sidebar-row-menu')
+    expect(menu?.style.left).toBe('120px')
+    expect(menu?.style.top).toBe('180px')
+    const actions = Array.from(
+      menu?.querySelectorAll<HTMLElement>('.sidebar-row-menu__item') ?? [],
+    ).map(item => item.textContent?.trim())
+    expect(actions).toEqual(['Pin task', 'Rename', 'Delete'])
+  })
+
+  it('leaves the browser context menu untouched on the web build', async () => {
+    const root = await mountSidebar()
+    const row = root.querySelector<HTMLElement>('.sidebar-history-item')
+    expect(row).not.toBeNull()
+
+    const event = dispatchContextMenu(row!)
+    await nextTick()
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(document.body.querySelector('.sidebar-row-menu')).toBeNull()
+  })
+})

--- a/opensquilla-webui/src/components/SidebarConversations.vue
+++ b/opensquilla-webui/src/components/SidebarConversations.vue
@@ -56,6 +56,7 @@ import SidebarSessionHoverCard, {
 } from './SidebarSessionHoverCard.vue'
 import { useConfirm } from '@/composables/useConfirm'
 import { useDocumentEvent } from '@/composables/useDocumentEvent'
+import { usePlatform } from '@/platform'
 import { shouldShowAgentFilterBadge } from '@/utils/sidebarConversations'
 import {
   buildSidebarDisplayProjection,
@@ -86,6 +87,8 @@ const props = withDefaults(defineProps<{
   canManageProjects: false,
   canCreateProjects: false,
 })
+
+const isDesktop = usePlatform().capabilities.isDesktop
 
 const emit = defineEmits<{
   (e: 'select', key: string): void
@@ -561,6 +564,26 @@ function setRenameInput(el: Element | ComponentPublicInstance | null) {
 // duplicate save through the input's blur handler.
 let renameCommitting = false
 
+function canOpenSessionMenu(row: SidebarDisplayRow): boolean {
+  return row.rowKind === 'session'
+    && (
+      row.sessionKind === 'chat'
+      || row.sessionKind === 'cron'
+      || row.sessionKind === 'channel'
+      || row.sessionKind === 'task'
+    )
+    && !row.provisional
+    && renamingKey.value !== row.key
+    && !selectionMode.value
+}
+
+function focusOpenMenu() {
+  nextTick(() => {
+    const items = openMenuEl.value?.querySelectorAll<HTMLElement>('.sidebar-row-menu__item')
+    items?.[0]?.focus()
+  })
+}
+
 function toggleMenu(key: string, event?: Event) {
   if (openMenuKey.value === key) {
     closeMenu()
@@ -588,10 +611,30 @@ function toggleMenu(key: string, event?: Event) {
     }
   }
   // Move focus into the menu so keyboard users land on an actionable item.
-  nextTick(() => {
-    const items = openMenuEl.value?.querySelectorAll<HTMLElement>('.sidebar-row-menu__item')
-    items?.[0]?.focus()
-  })
+  focusOpenMenu()
+}
+
+function openSessionContextMenu(row: SidebarDisplayRow, event: MouseEvent) {
+  // Keep the browser's native context menu on the web build. The desktop shell
+  // owns right-click behavior and reuses the same actions as the row's ⋯ menu.
+  if (!isDesktop || !canOpenSessionMenu(row)) return
+  event.preventDefault()
+  event.stopPropagation()
+  closeSessionPreview()
+  openMenuKey.value = row.key
+  const trigger = event.currentTarget
+  menuTriggerEl.value = trigger instanceof HTMLElement ? trigger : null
+  const openLeft = event.clientX + 160 > window.innerWidth
+  const openUp = event.clientY + 220 > window.innerHeight
+  menuStyle.value = {
+    position: 'fixed',
+    left: `${event.clientX}px`,
+    top: `${event.clientY}px`,
+    transform: openLeft
+      ? (openUp ? 'translate(-100%, -100%)' : 'translateX(-100%)')
+      : (openUp ? 'translateY(-100%)' : 'none'),
+  }
+  focusOpenMenu()
 }
 
 function closeMenu() {
@@ -1125,6 +1168,7 @@ function onSelectRow(row: SidebarConversationItem) {
               :aria-pressed="selectionMode && !row.provisional ? isRowSelected(row.key) : undefined"
               :aria-describedby="sessionPreview?.row.key === row.key ? 'sidebar-session-preview' : undefined"
               @click="onSelectRow(row)"
+              @contextmenu="openSessionContextMenu(row, $event)"
             >
               <span
                 v-if="selectionMode && !row.provisional"
@@ -1219,18 +1263,7 @@ function onSelectRow(row: SidebarConversationItem) {
             </Teleport>
 
             <div
-              v-if="
-                row.rowKind === 'session'
-                && (
-                  row.sessionKind === 'chat'
-                  || row.sessionKind === 'cron'
-                  || row.sessionKind === 'channel'
-                  || row.sessionKind === 'task'
-                )
-                && !row.provisional
-                && renamingKey !== row.key
-                && !selectionMode
-              "
+              v-if="canOpenSessionMenu(row)"
               class="sidebar-row-menu-wrap"
             >
               <button

--- a/opensquilla-webui/src/components/setup/SetupProviderPanel.vue
+++ b/opensquilla-webui/src/components/setup/SetupProviderPanel.vue
@@ -1373,7 +1373,7 @@ const tokenRhythmCredentialReplacementRequired = computed(() => (
   gap: var(--sp-3);
   margin: var(--sp-3) 0 0;
   justify-items: center;
-  padding: var(--sp-7) var(--sp-4);
+  padding: var(--sp-5) var(--sp-4);
   text-align: center;
 }
 

--- a/opensquilla-webui/src/styles/apple-modern.css
+++ b/opensquilla-webui/src/styles/apple-modern.css
@@ -422,6 +422,10 @@ body > .settings-overlay .settings-modal .settings-rail__item:not(:disabled):act
   position: relative;
 }
 
+.sidebar-history-row .sidebar-history-item {
+  margin-right: calc(-1 * var(--sp-1));
+}
+
 .sidebar-history-item.is-current {
   background:
     linear-gradient(


### PR DESCRIPTION
## Summary

- align hover and selected session surfaces with the row action control
- add a desktop-only session context menu that reuses the existing pin, rename, and delete actions while preserving the browser context menu on web
- add vertical breathing room to the configured-provider empty state
- cover the desktop and web context-menu boundaries with regression tests

## Validation

- `npm run typecheck`
- `npm run test:unit` — 338 test files, 4037 tests passed