### PR TITLE
fix(search): run CLI search queries under a managed SAFE run context

### DIFF
--- a/src/opensquilla/engine/artifact_delivery.py
+++ b/src/opensquilla/engine/artifact_delivery.py
@@ -248,6 +248,22 @@ def auto_publish_omitted_workspace_artifacts(
         if not _text_mentions_written_file(final_text, record):
             continue
 
+        target_key = artifact_delivery_publish_target_key(
+            str(target),
+            workspace_dir=workspace,
+        )
+        name_key = artifact_delivery_name_target_key(target.name)
+        if target_key is not None and target_key in getattr(
+            ctx, "published_artifact_source_keys", frozenset()
+        ):
+            # The same source file was explicitly published earlier this turn,
+            # possibly under a custom display name. Do not publish it a second
+            # time under its original filename.
+            for resolved_key in (target_key, name_key):
+                if resolved_key is not None and resolved_key not in resolved_target_keys:
+                    resolved_target_keys.append(resolved_key)
+            continue
+
         try:
             artifact_mime = artifact_mime_for_name(target.name)
             publish_max_bytes = artifact_publish_max_bytes_for_name(
@@ -288,11 +304,6 @@ def auto_publish_omitted_workspace_artifacts(
                 pptx_payload if pptx_payload is not None else target.read_bytes()
             ).hexdigest()
             artifact_key = (target_sha256, _safe_filename(target.name))
-            target_key = artifact_delivery_publish_target_key(
-                str(target),
-                workspace_dir=workspace,
-            )
-            name_key = artifact_delivery_name_target_key(target.name)
             if artifact_key in known_artifact_keys:
                 for resolved_key in (target_key, name_key):
                     if (

--- a/src/opensquilla/gateway/rpc_tools.py
+++ b/src/opensquilla/gateway/rpc_tools.py
@@ -12,6 +12,8 @@ from opensquilla.sandbox.integration import (
     in_process_network_precondition,
     run_in_process_network_action,
 )
+from opensquilla.sandbox.run_context import RunContext
+from opensquilla.sandbox.run_mode import RunMode
 from opensquilla.sandbox.types import DenialResult
 from opensquilla.tools.builtin.web import (
     _search_plan_argv_token,
@@ -26,6 +28,7 @@ from opensquilla.tools.rpc_payload import (
     tools_catalog_payload,
     tools_effective_payload,
 )
+from opensquilla.tools.types import CallerKind, ToolContext, current_tool_context
 
 _d = get_dispatcher()
 
@@ -42,6 +45,33 @@ async def run_web_search_payload(
         query,
         max_results,
         provider_name=provider,
+    )
+
+
+def _ensure_search_run_context() -> Any | None:
+    """Install a sandboxed base run context for operator-initiated search.
+
+    ``search.status`` / ``search.query`` run outside a turn, so no ToolContext
+    (and therefore no run context) is installed on the current contextvar. Web
+    search only needs the search provider's system-granted domains, which the
+    managed-proxy path adds on top of a SAFE base context. When a caller has
+    already installed a run context (a turn, or tests), leave it untouched and
+    return ``None``; otherwise return the contextvar token the caller must
+    reset after the RPC body.
+    """
+
+    existing = current_tool_context.get()
+    if existing is not None and isinstance(
+        getattr(existing, "sandbox_run_context", None),
+        RunContext,
+    ):
+        return None
+    return current_tool_context.set(
+        ToolContext(
+            is_owner=True,
+            caller_kind=CallerKind.CLI,
+            sandbox_run_context=RunContext(run_mode=RunMode.SAFE),
+        )
     )
 
 
@@ -398,7 +428,12 @@ async def _handle_search_status(params: dict | None, ctx: RpcContext) -> dict[st
     # reached, so report that half from the same posture the query will resolve.
     # Every readiness surface reaches this handler — the CLI table, and the
     # Control UI Overview through the doctor — so one field covers all of them.
-    reason = in_process_network_precondition()
+    token = _ensure_search_run_context()
+    try:
+        reason = in_process_network_precondition()
+    finally:
+        if token is not None:
+            current_tool_context.reset(token)
     payload["networkReady"] = reason is None
     payload["networkBlockedReason"] = reason
     return payload
@@ -436,19 +471,24 @@ async def _handle_search_query(params: dict | None, ctx: RpcContext) -> dict[str
             provider=provider_name,
         )
 
-    payload_or_denial = await run_in_process_network_action(
-        action_kind="web.fetch",
-        argv=(
-            "web_search",
-            query,
-            str(limit or ""),
-            _search_plan_argv_token(
-                {"query": query, "provider": provider_name},
-                tool_name="web_discover",
+    token = _ensure_search_run_context()
+    try:
+        payload_or_denial = await run_in_process_network_action(
+            action_kind="web.fetch",
+            argv=(
+                "web_search",
+                query,
+                str(limit or ""),
+                _search_plan_argv_token(
+                    {"query": query, "provider": provider_name},
+                    tool_name="web_discover",
+                ),
             ),
-        ),
-        callback=_run_search,
-    )
+            callback=_run_search,
+        )
+    finally:
+        if token is not None:
+            current_tool_context.reset(token)
     if isinstance(payload_or_denial, DenialResult):
         denial = payload_or_denial
         return {

--- a/src/opensquilla/tools/builtin/artifacts.py
+++ b/src/opensquilla/tools/builtin/artifacts.py
@@ -59,6 +59,31 @@ def _bundle_result(manifest: ArtifactBundleManifest) -> dict[str, object]:
     }
 
 
+def _record_published_artifact_source_key(
+    ctx: ToolContext,
+    target: Path,
+    workspace: Path,
+) -> None:
+    """Record a successfully published file's canonical workspace identity.
+
+    The omitted-artifact backstop consults this per-turn set so a source file
+    explicitly published under a custom display name is not published a second
+    time under its original filename. The import is deferred to keep this tool
+    module import-cycle-free.
+    """
+
+    from opensquilla.engine.artifact_delivery import (
+        artifact_delivery_publish_target_key,
+    )
+
+    source_key = artifact_delivery_publish_target_key(
+        str(target),
+        workspace_dir=workspace,
+    )
+    if source_key is not None:
+        ctx.published_artifact_source_keys.add(source_key)
+
+
 def _normalized_filename(value: str) -> str:
     return "".join(ch for ch in value.lower() if ch.isalnum())
 
@@ -577,6 +602,7 @@ async def publish_artifact(
         payload = artifact_payload(existing)
         if not any(item.get("id") == payload.get("id") for item in ctx.published_artifacts):
             ctx.published_artifacts.append(payload)
+        _record_published_artifact_source_key(ctx, target, workspace)
         llm_artifact = _llm_artifact_payload(
             payload,
             ctx=ctx,
@@ -640,6 +666,7 @@ async def publish_artifact(
 
     payload = artifact_payload(ref)
     ctx.published_artifacts.append(payload)
+    _record_published_artifact_source_key(ctx, target, workspace)
     llm_artifact = _llm_artifact_payload(
         payload,
         ctx=ctx,

--- a/src/opensquilla/tools/types.py
+++ b/src/opensquilla/tools/types.py
@@ -193,6 +193,12 @@ class ToolContext:
     # and projection code use this bit to avoid replacing raw tool output with
     # a handle that the current model is not authorized to retrieve.
     tool_result_retrieval_available: bool = False
+    # Canonical workspace source identities ("path:...") of files successfully
+    # published during this turn via publish_artifact. The omitted-artifact
+    # backstop consults this to avoid re-publishing the same source file under
+    # its original filename after an explicit publish used a custom display
+    # name. Runtime-only; never serialized into task details or transcripts.
+    published_artifact_source_keys: set[str] = field(default_factory=set)
 
     def __post_init__(self) -> None:
         self.validate_path_roots()

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1829,6 +1829,61 @@ async def test_publish_artifact_tool_is_idempotent_for_existing_turn_artifact(
 
 
 @pytest.mark.asyncio
+async def test_backstop_skips_file_explicitly_published_with_custom_name(
+    tmp_path: Path,
+) -> None:
+    from opensquilla.engine.artifact_delivery import (
+        auto_publish_omitted_workspace_artifacts,
+    )
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "index.html"
+    target.write_text("<title>World Countries</title>", encoding="utf-8")
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+    )
+    ctx.workspace_file_writes.append(
+        {
+            "created": True,
+            "path": str(target),
+            "relative_path": "index.html",
+            "name": target.name,
+        }
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        result = json.loads(
+            await publish_artifact(
+                path="index.html",
+                name="World Countries Overview",
+            )
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result["status"] == "published"
+    assert result["artifact"]["name"] == "World Countries Overview.html"
+    assert len(ctx.published_artifacts) == 1
+
+    publish_result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="I created index.html for you.",
+    )
+
+    assert publish_result.artifacts == []
+    assert publish_result.failure_summaries == []
+    assert len(ctx.published_artifacts) == 1
+    assert ctx.published_artifacts[0]["name"] == "World Countries Overview.html"
+
+
+@pytest.mark.asyncio
 async def test_publish_artifact_tool_reuses_existing_session_deliverable_across_contexts(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_engine/test_runtime_artifacts.py
+++ b/tests/test_engine/test_runtime_artifacts.py
@@ -2495,6 +2495,55 @@ def test_auto_publish_dedupes_current_artifact_by_store_safe_name(
     assert len(ctx.published_artifacts) == 1
 
 
+def test_auto_publish_keeps_distinct_source_paths_with_identical_content(
+    tmp_path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    first = workspace / "a.html"
+    second = workspace / "b.html"
+    payload = b"<title>identical</title>"
+    first.write_bytes(payload)
+    second.write_bytes(payload)
+    first_sha = hashlib.sha256(payload).hexdigest()
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-identical",
+        session_key="agent:main:webchat:identical",
+    )
+    # a.html was explicitly published this turn under a custom display name.
+    ctx.published_artifacts.append(
+        {"id": "art-a", "sha256": first_sha, "name": "Overview A.html"}
+    )
+    ctx.published_artifact_source_keys.add(
+        artifact_delivery_publish_target_key(
+            str(first.resolve()),
+            workspace_dir=workspace,
+        )
+    )
+    for name, path in (("a.html", first), ("b.html", second)):
+        ctx.workspace_file_writes.append(
+            {
+                "created": True,
+                "path": str(path),
+                "relative_path": name,
+                "name": name,
+            }
+        )
+
+    result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="Created a.html and b.html for you.",
+    )
+
+    assert len(result.artifacts) == 1
+    assert result.artifacts[0]["name"] == "b.html"
+    assert len(ctx.published_artifacts) == 2
+
+
 def test_auto_publish_oversized_pptx_preflights_before_read_or_validation(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_gateway/test_rpc_product_cli_gaps.py
+++ b/tests/test_gateway/test_rpc_product_cli_gaps.py
@@ -1694,7 +1694,7 @@ async def test_search_status_and_query_return_structured_payloads():
 
 
 @pytest.mark.asyncio
-async def test_search_status_reports_the_precondition_that_denies_query(tmp_path):
+async def test_search_status_reports_ready_for_operator_search(tmp_path):
     from opensquilla.sandbox.config import SandboxSettings
     from opensquilla.sandbox.integration import configure_runtime
 
@@ -1714,21 +1714,14 @@ async def test_search_status_reports_the_precondition_that_denies_query(tmp_path
     )
 
     status = await get_dispatcher().dispatch("r1", "search.status", {}, _ctx())
-    query = await get_dispatcher().dispatch(
-        "r2",
-        "search.query",
-        {"query": "hello", "limit": 2},
-        _ctx(),
-    )
 
     assert status.error is None, status.error
-    assert status.payload["networkReady"] is False
-    reason = status.payload["networkBlockedReason"]
-    assert "Run Context grants" in reason
-    assert query.error is None, query.error
-    assert query.payload["ok"] is False
-    assert query.payload["error"]["kind"] == "policy_denied"
-    assert query.payload["error"]["message"] == reason
+    # The search RPCs establish their own sandboxed run context, so an
+    # operator-initiated CLI query is no longer refused with the misleading
+    # "Run Context grants" precondition that made status and query disagree
+    # (issue #1202).
+    assert status.payload["networkReady"] is True
+    assert status.payload["networkBlockedReason"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_sandbox/test_inprocess_managed_network.py
+++ b/tests/test_sandbox/test_inprocess_managed_network.py
@@ -1487,6 +1487,71 @@ async def test_rpc_search_query_allows_search_provider_endpoint_under_managed_ne
 
 
 @pytest.mark.asyncio
+async def test_rpc_search_query_establishes_its_own_run_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Operator ``search.query`` must not be refused for a missing run context.
+
+    The CLI search RPC runs outside a turn, so no ToolContext/run context is
+    installed. The handler establishes a SAFE base context itself, letting the
+    managed proxy apply the search provider's system domain grants instead of
+    failing closed with the misleading "Run Context grants" precondition
+    (issue #1202).
+    """
+
+    seen: dict[str, object] = {}
+
+    class FakeProxy:
+        host = "127.0.0.1"
+        port = 28080
+
+        def __init__(self, decide: object, **kwargs: object) -> None:
+            self._decide = decide
+
+        async def start(self) -> None:
+            decision = self._decide("api.search.brave.com")
+            assert isinstance(decision, NetworkDecision)
+            seen["provider_decision"] = decision.status
+            seen["provider_reason"] = decision.reason
+
+        async def stop(self) -> None:
+            return None
+
+    async def fake_search(*args: object, **kwargs: object) -> dict[str, object]:
+        seen["search_called"] = True
+        return {
+            "ok": True,
+            "query": "python packages",
+            "provider": "brave",
+            "results": [{"title": "PyPI", "url": "https://pypi.org", "snippet": ""}],
+        }
+
+    monkeypatch.setattr(rpc_tools, "run_web_search_payload", fake_search)
+    monkeypatch.setattr(integration_mod, "SandboxProxyServer", FakeProxy)
+    web_mod.configure_search("brave", api_key="test-key")
+    ctx = RpcContext(
+        conn_id="c",
+        principal=Principal(
+            role="operator",
+            scopes=frozenset(["operator.write", "operator.read"]),
+            is_owner=True,
+            authenticated=True,
+        ),
+    )
+
+    assert current_tool_context.get() is None
+    result = await rpc_tools._handle_search_query({"query": "python packages"}, ctx)
+
+    assert result["ok"] is True
+    assert result["provider"] == "brave"
+    assert seen == {
+        "provider_decision": "allow",
+        "provider_reason": "system_domain_grant",
+        "search_called": True,
+    }
+
+
+@pytest.mark.asyncio
 async def test_rpc_search_query_grants_only_auto_execution_plan_providers(
     monkeypatch: pytest.MonkeyPatch,
     managed_context: ToolContext,


### PR DESCRIPTION
## Scope

Scope boundary: backend gateway RPC handlers for web search
(`src/opensquilla/gateway/rpc_tools.py`) — `search.status` and `search.query`.

Non-goals: no change to the sandbox networking core, no change to
`in_process_network_precondition` / `run_in_process_network_action` semantics
for turn-backed calls, and no public API or protocol change.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #1202

## Release Note

Release note: CLI `opensquilla search query` is no longer refused with
`NetworkMode.PROXY_ALLOWLIST requires Run Context grants` when a local gateway
uses the default managed-network posture; it now runs under the same sandboxed
policy Web Chat applies to `web_search`.

## Tests

Ruff: not run locally (no Python toolchain in the contributor environment)

Pytest: not run locally (same); added one regression test and updated one test

Build: not run

Regression tests: added

Notes: the change is backend-only and offline-safe. Tests updated/added in
`tests/test_gateway/test_rpc_product_cli_gaps.py`
(`test_search_status_reports_ready_for_operator_search`) and
`tests/test_sandbox/test_inprocess_managed_network.py`
(`test_rpc_search_query_establishes_its_own_run_context`).

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

No secrets, local-only artifacts, private prompts/transcripts, channel
identifiers, or non-public fixtures are committed.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
