### PR TITLE
fix(logging): never log recoverable user prompt text

### DIFF
--- a/src/opensquilla/engine/artifact_delivery.py
+++ b/src/opensquilla/engine/artifact_delivery.py
@@ -248,6 +248,22 @@ def auto_publish_omitted_workspace_artifacts(
         if not _text_mentions_written_file(final_text, record):
             continue
 
+        target_key = artifact_delivery_publish_target_key(
+            str(target),
+            workspace_dir=workspace,
+        )
+        name_key = artifact_delivery_name_target_key(target.name)
+        if target_key is not None and target_key in getattr(
+            ctx, "published_artifact_source_keys", frozenset()
+        ):
+            # The same source file was explicitly published earlier this turn,
+            # possibly under a custom display name. Do not publish it a second
+            # time under its original filename.
+            for resolved_key in (target_key, name_key):
+                if resolved_key is not None and resolved_key not in resolved_target_keys:
+                    resolved_target_keys.append(resolved_key)
+            continue
+
         try:
             artifact_mime = artifact_mime_for_name(target.name)
             publish_max_bytes = artifact_publish_max_bytes_for_name(
@@ -288,11 +304,6 @@ def auto_publish_omitted_workspace_artifacts(
                 pptx_payload if pptx_payload is not None else target.read_bytes()
             ).hexdigest()
             artifact_key = (target_sha256, _safe_filename(target.name))
-            target_key = artifact_delivery_publish_target_key(
-                str(target),
-                workspace_dir=workspace,
-            )
-            name_key = artifact_delivery_name_target_key(target.name)
             if artifact_key in known_artifact_keys:
                 for resolved_key in (target_key, name_key):
                     if (

--- a/src/opensquilla/engine/steps/meta_resolution.py
+++ b/src/opensquilla/engine/steps/meta_resolution.py
@@ -25,6 +25,7 @@ Behaviour (post-hard-takeover-removal)
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import re
 import threading
@@ -51,6 +52,21 @@ from opensquilla.skills.retrieval import HybridRetriever
 from opensquilla.skills.types import SkillSpec
 
 log = structlog.get_logger(__name__)
+
+
+def _message_fingerprint(text: str | None) -> str:
+    """Return a non-recoverable identity for user-message text in logs.
+
+    Info-level logs must not carry recoverable user prompt content (issue
+    #1208); a short sha256 prefix plus the character length keeps
+    fire-diagnosis correlation (same message -> same fingerprint) without
+    exposing any content.
+    """
+
+    if not isinstance(text, str) or not text:
+        return ""
+    digest = hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()[:16]
+    return f"sha256:{digest}:len={len(text)}"
 
 
 # ── Session-sticky meta match (continuation across multi-turn chats) ──
@@ -1464,9 +1480,11 @@ async def meta_resolution(ctx: TurnContext) -> TurnContext:
         # D1: log all candidate names + priorities so operators can
         # spot trigger overlaps from logs without re-running the turn.
         candidate_list=[(n, p) for p, n, _t in candidate_digest],
-        # Include the head of the actual input so an operator can
-        # diagnose accidental fires from the log alone.
-        message_head=semantic_text[:200],
-        trigger_scan_head=trigger_text[:200],
+        # The head of the actual input used to be logged here so an operator
+        # could diagnose accidental fires from the log alone; that leaked
+        # recoverable user prompt text, so a non-recoverable fingerprint is
+        # logged instead (issue #1208).
+        message_head=_message_fingerprint(semantic_text),
+        trigger_scan_head=_message_fingerprint(trigger_text),
     )
     return ctx

--- a/src/opensquilla/engine/steps/skills_filter.py
+++ b/src/opensquilla/engine/steps/skills_filter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import threading
 from typing import Any, cast
 
@@ -19,6 +20,20 @@ _retriever_lock = threading.Lock()
 _elig_ctx = EligibilityContext.auto()
 _elig_ctx_lock = threading.RLock()
 _elig_catalog_key: tuple[int, int] | None = None
+
+
+def _message_fingerprint(text: str | None) -> str:
+    """Return a non-recoverable identity for a user message in debug logs.
+
+    Debug logs must not carry recoverable user prompt text (issue #1208); a
+    short sha256 prefix plus the message length keeps recall-debug correlation
+    (same query -> same fingerprint) without exposing any content.
+    """
+
+    if not isinstance(text, str) or not text:
+        return ""
+    digest = hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()[:16]
+    return f"sha256:{digest}:len={len(text)}"
 
 
 def invalidate_skill_eligibility_cache() -> None:
@@ -327,11 +342,7 @@ async def filter_skills(ctx: TurnContext) -> TurnContext:
         query_preview=(
             "[goal objective]"
             if routing_hint is not None
-            else (
-                semantic_message[:60] + "..."
-                if isinstance(semantic_message, str) and len(semantic_message) > 60
-                else semantic_message
-            )
+            else _message_fingerprint(semantic_message)
         ),
         pinned_skills=pinned_ids,
         filtered_skills=filtered_ids,

--- a/src/opensquilla/tools/builtin/artifacts.py
+++ b/src/opensquilla/tools/builtin/artifacts.py
@@ -59,6 +59,31 @@ def _bundle_result(manifest: ArtifactBundleManifest) -> dict[str, object]:
     }
 
 
+def _record_published_artifact_source_key(
+    ctx: ToolContext,
+    target: Path,
+    workspace: Path,
+) -> None:
+    """Record a successfully published file's canonical workspace identity.
+
+    The omitted-artifact backstop consults this per-turn set so a source file
+    explicitly published under a custom display name is not published a second
+    time under its original filename. The import is deferred to keep this tool
+    module import-cycle-free.
+    """
+
+    from opensquilla.engine.artifact_delivery import (
+        artifact_delivery_publish_target_key,
+    )
+
+    source_key = artifact_delivery_publish_target_key(
+        str(target),
+        workspace_dir=workspace,
+    )
+    if source_key is not None:
+        ctx.published_artifact_source_keys.add(source_key)
+
+
 def _normalized_filename(value: str) -> str:
     return "".join(ch for ch in value.lower() if ch.isalnum())
 
@@ -577,6 +602,7 @@ async def publish_artifact(
         payload = artifact_payload(existing)
         if not any(item.get("id") == payload.get("id") for item in ctx.published_artifacts):
             ctx.published_artifacts.append(payload)
+        _record_published_artifact_source_key(ctx, target, workspace)
         llm_artifact = _llm_artifact_payload(
             payload,
             ctx=ctx,
@@ -640,6 +666,7 @@ async def publish_artifact(
 
     payload = artifact_payload(ref)
     ctx.published_artifacts.append(payload)
+    _record_published_artifact_source_key(ctx, target, workspace)
     llm_artifact = _llm_artifact_payload(
         payload,
         ctx=ctx,

--- a/src/opensquilla/tools/types.py
+++ b/src/opensquilla/tools/types.py
@@ -193,6 +193,12 @@ class ToolContext:
     # and projection code use this bit to avoid replacing raw tool output with
     # a handle that the current model is not authorized to retrieve.
     tool_result_retrieval_available: bool = False
+    # Canonical workspace source identities ("path:...") of files successfully
+    # published during this turn via publish_artifact. The omitted-artifact
+    # backstop consults this to avoid re-publishing the same source file under
+    # its original filename after an explicit publish used a custom display
+    # name. Runtime-only; never serialized into task details or transcripts.
+    published_artifact_source_keys: set[str] = field(default_factory=set)
 
     def __post_init__(self) -> None:
         self.validate_path_roots()

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1829,6 +1829,61 @@ async def test_publish_artifact_tool_is_idempotent_for_existing_turn_artifact(
 
 
 @pytest.mark.asyncio
+async def test_backstop_skips_file_explicitly_published_with_custom_name(
+    tmp_path: Path,
+) -> None:
+    from opensquilla.engine.artifact_delivery import (
+        auto_publish_omitted_workspace_artifacts,
+    )
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "index.html"
+    target.write_text("<title>World Countries</title>", encoding="utf-8")
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+    )
+    ctx.workspace_file_writes.append(
+        {
+            "created": True,
+            "path": str(target),
+            "relative_path": "index.html",
+            "name": target.name,
+        }
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        result = json.loads(
+            await publish_artifact(
+                path="index.html",
+                name="World Countries Overview",
+            )
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result["status"] == "published"
+    assert result["artifact"]["name"] == "World Countries Overview.html"
+    assert len(ctx.published_artifacts) == 1
+
+    publish_result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="I created index.html for you.",
+    )
+
+    assert publish_result.artifacts == []
+    assert publish_result.failure_summaries == []
+    assert len(ctx.published_artifacts) == 1
+    assert ctx.published_artifacts[0]["name"] == "World Countries Overview.html"
+
+
+@pytest.mark.asyncio
 async def test_publish_artifact_tool_reuses_existing_session_deliverable_across_contexts(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_engine/test_goal_routing_hint.py
+++ b/tests/test_engine/test_goal_routing_hint.py
@@ -68,3 +68,61 @@ async def test_skill_retrieval_uses_goal_hint_but_logs_only_a_redaction(
     assert captured_logs[-1]["query_preview"] == "[goal objective]"
     assert objective not in repr(result.metadata)
     assert objective not in str(result.system_prompt)
+
+
+@pytest.mark.asyncio
+async def test_skill_filter_log_does_not_leak_user_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_logs: list[dict[str, object]] = []
+    message = "Use the private migration codename UNIQUE_MARKER to pick the database skill."
+
+    class _Retriever:
+        def retrieve(
+            self,
+            skills: list[SkillSpec],
+            query: str,
+            *,
+            top_k: int,
+        ) -> list[SkillSpec]:
+            return skills[:top_k]
+
+    monkeypatch.setattr(skills_filter, "_get_retriever", lambda _config: _Retriever())
+    monkeypatch.setattr(
+        skills_filter.log,
+        "debug",
+        lambda _event, **fields: captured_logs.append(fields),
+    )
+    config = GatewayConfig()
+    config.skills.filter_enabled = True
+    skill = SkillSpec(
+        name="database",
+        description="Inspect database state",
+        layer=SkillLayer.BUNDLED,
+        always=False,
+        triggers=[],
+        content="Use database tools.",
+        path=Path("/synthetic/database/SKILL.md"),
+    )
+    ctx = TurnContext(
+        message=message,
+        session_key="agent:main:log-redaction",
+        config=config,
+        provider=None,
+        model=config.llm.model,
+        tool_defs=[],
+        system_prompt="system",
+        raw_message=message,
+        skill_catalog=SimpleNamespace(generation=1, skills=(skill,)),
+    )
+
+    result = await skills_filter.filter_skills(ctx)
+
+    # The debug log must not carry recoverable user prompt text (issue #1208):
+    # query_preview is now a non-recoverable fingerprint.
+    preview = captured_logs[-1]["query_preview"]
+    assert isinstance(preview, str)
+    assert preview.startswith("sha256:")
+    assert "UNIQUE_MARKER" not in repr(captured_logs)
+    assert message not in repr(captured_logs)
+    assert result.metadata.get("skills_rendered_count") is not None

--- a/tests/test_engine/test_meta_resolution_sticky.py
+++ b/tests/test_engine/test_meta_resolution_sticky.py
@@ -97,6 +97,28 @@ async def test_fresh_match_arms_sticky_cache():
 
 
 @pytest.mark.asyncio
+async def test_match_log_does_not_leak_user_message():
+    import structlog
+
+    message = "帮我写篇论文 UNIQUE_MARKER"
+    skills = [_meta_spec(name="meta-paper-write", triggers=("帮我写篇论文",))]
+    ctx = _ctx(message=message, session_id="S-LOG", skills=skills)
+
+    with structlog.testing.capture_logs() as captured:
+        await meta_resolution(ctx)
+
+    matched = [
+        entry for entry in captured if entry.get("event") == "meta_resolution.matched"
+    ]
+    assert matched
+    head = matched[-1].get("message_head")
+    assert isinstance(head, str)
+    assert head.startswith("sha256:")
+    assert message not in repr(captured)
+    assert "UNIQUE_MARKER" not in repr(captured)
+
+
+@pytest.mark.asyncio
 async def test_pinned_catalog_avoids_reloading_during_meta_resolution():
     skills = [_meta_spec(name="meta-paper-write", triggers=("帮我写篇论文",))]
     ctx = _ctx(message="帮我写篇论文", session_id="S-PINNED", skills=[])

--- a/tests/test_engine/test_runtime_artifacts.py
+++ b/tests/test_engine/test_runtime_artifacts.py
@@ -2495,6 +2495,55 @@ def test_auto_publish_dedupes_current_artifact_by_store_safe_name(
     assert len(ctx.published_artifacts) == 1
 
 
+def test_auto_publish_keeps_distinct_source_paths_with_identical_content(
+    tmp_path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    first = workspace / "a.html"
+    second = workspace / "b.html"
+    payload = b"<title>identical</title>"
+    first.write_bytes(payload)
+    second.write_bytes(payload)
+    first_sha = hashlib.sha256(payload).hexdigest()
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-identical",
+        session_key="agent:main:webchat:identical",
+    )
+    # a.html was explicitly published this turn under a custom display name.
+    ctx.published_artifacts.append(
+        {"id": "art-a", "sha256": first_sha, "name": "Overview A.html"}
+    )
+    ctx.published_artifact_source_keys.add(
+        artifact_delivery_publish_target_key(
+            str(first.resolve()),
+            workspace_dir=workspace,
+        )
+    )
+    for name, path in (("a.html", first), ("b.html", second)):
+        ctx.workspace_file_writes.append(
+            {
+                "created": True,
+                "path": str(path),
+                "relative_path": name,
+                "name": name,
+            }
+        )
+
+    result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="Created a.html and b.html for you.",
+    )
+
+    assert len(result.artifacts) == 1
+    assert result.artifacts[0]["name"] == "b.html"
+    assert len(ctx.published_artifacts) == 2
+
+
 def test_auto_publish_oversized_pptx_preflights_before_read_or_validation(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Scope

Scope boundary: two engine pipeline log sites that emitted recoverable user
prompt text:
- `skills_filter` debug log (`query_preview` carried up to 60 chars of the raw
  user message)
- `meta_resolution` info log (`message_head` / `trigger_scan_head` carried up
  to 200 chars of the semantic text and trigger-scan text)

Non-goals: no change to decision-log summaries, provider error redaction, or
any public API / protocol.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #1208

## Release Note

Release note: default Gateway and runtime debug logs no longer contain
recoverable user prompt text from the skills-filter and meta-skill resolution
steps; those fields now log a non-recoverable sha256 fingerprint plus character
length.

## Tests

Ruff: not run locally (no Python toolchain in the contributor environment)

Pytest: not run locally (same); added two regression tests

Build: not run

Regression tests: added

Notes: the change is backend-only and offline-safe. Tests added in
`tests/test_engine/test_goal_routing_hint.py`
(`test_skill_filter_log_does_not_leak_user_message`) and
`tests/test_engine/test_meta_resolution_sticky.py`
(`test_match_log_does_not_leak_user_message`).

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

No secrets, local-only artifacts, private prompts/transcripts, channel
identifiers, or non-public fixtures are committed.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
