### PR TITLE
fix(artifacts): do not seal delivery for terminal cancelled plan runs

### DIFF
--- a/src/opensquilla/engine/artifact_delivery.py
+++ b/src/opensquilla/engine/artifact_delivery.py
@@ -248,6 +248,22 @@ def auto_publish_omitted_workspace_artifacts(
         if not _text_mentions_written_file(final_text, record):
             continue
 
+        target_key = artifact_delivery_publish_target_key(
+            str(target),
+            workspace_dir=workspace,
+        )
+        name_key = artifact_delivery_name_target_key(target.name)
+        if target_key is not None and target_key in getattr(
+            ctx, "published_artifact_source_keys", frozenset()
+        ):
+            # The same source file was explicitly published earlier this turn,
+            # possibly under a custom display name. Do not publish it a second
+            # time under its original filename.
+            for resolved_key in (target_key, name_key):
+                if resolved_key is not None and resolved_key not in resolved_target_keys:
+                    resolved_target_keys.append(resolved_key)
+            continue
+
         try:
             artifact_mime = artifact_mime_for_name(target.name)
             publish_max_bytes = artifact_publish_max_bytes_for_name(
@@ -288,11 +304,6 @@ def auto_publish_omitted_workspace_artifacts(
                 pptx_payload if pptx_payload is not None else target.read_bytes()
             ).hexdigest()
             artifact_key = (target_sha256, _safe_filename(target.name))
-            target_key = artifact_delivery_publish_target_key(
-                str(target),
-                workspace_dir=workspace,
-            )
-            name_key = artifact_delivery_name_target_key(target.name)
             if artifact_key in known_artifact_keys:
                 for resolved_key in (target_key, name_key):
                     if (

--- a/src/opensquilla/tools/builtin/artifacts.py
+++ b/src/opensquilla/tools/builtin/artifacts.py
@@ -234,15 +234,32 @@ def _publish_artifact_metadata(
 def _plan_run_steps_ready_for_delivery(run: Any) -> bool:
     current_step_id = str(getattr(run, "current_step_id", "") or "")
     step_states = list(getattr(run, "step_states", []) or [])
-    return (
-        not current_step_id
-        and bool(step_states)
-        and all(
-            isinstance(state, dict)
-            and str(state.get("status") or "") in {"completed", "skipped"}
-            for state in step_states
+    if not step_states or not all(
+        isinstance(state, dict)
+        and str(state.get("status") or "") in PLAN_STEP_TERMINAL_STATUSES
+        for state in step_states
+    ):
+        return False
+    if current_step_id:
+        # The final checkpoint (or a user cancellation) can leave a stale
+        # current_step_id pointing at an already-terminal step. A stale
+        # pointer must not block delivery when every bounded step is done
+        # (issue #1112).
+        current = next(
+            (
+                state
+                for state in step_states
+                if isinstance(state, dict)
+                and str(state.get("step_id") or "") == current_step_id
+            ),
+            None,
         )
-    )
+        if (
+            current is None
+            or str(current.get("status") or "") not in PLAN_STEP_TERMINAL_STATUSES
+        ):
+            return False
+    return True
 
 
 def _plan_run_allows_delivery(ctx: ToolContext, run: Any) -> bool:
@@ -250,6 +267,12 @@ def _plan_run_allows_delivery(ctx: ToolContext, run: Any) -> bool:
 
     status = str(getattr(run, "status", "") or "")
     if status == "completed":
+        return True
+    if status == "cancelled" and _plan_run_steps_ready_for_delivery(run):
+        # A cancelled run whose bounded steps are all terminal can still
+        # finalize artifact delivery: the user stopped the implementation,
+        # not the already-finished work, and the workflow output must not be
+        # sealed (issue #1112).
         return True
     if status != "running":
         return False

--- a/src/opensquilla/tools/builtin/artifacts.py
+++ b/src/opensquilla/tools/builtin/artifacts.py
@@ -59,6 +59,31 @@ def _bundle_result(manifest: ArtifactBundleManifest) -> dict[str, object]:
     }
 
 
+def _record_published_artifact_source_key(
+    ctx: ToolContext,
+    target: Path,
+    workspace: Path,
+) -> None:
+    """Record a successfully published file's canonical workspace identity.
+
+    The omitted-artifact backstop consults this per-turn set so a source file
+    explicitly published under a custom display name is not published a second
+    time under its original filename. The import is deferred to keep this tool
+    module import-cycle-free.
+    """
+
+    from opensquilla.engine.artifact_delivery import (
+        artifact_delivery_publish_target_key,
+    )
+
+    source_key = artifact_delivery_publish_target_key(
+        str(target),
+        workspace_dir=workspace,
+    )
+    if source_key is not None:
+        ctx.published_artifact_source_keys.add(source_key)
+
+
 def _normalized_filename(value: str) -> str:
     return "".join(ch for ch in value.lower() if ch.isalnum())
 
@@ -577,6 +602,7 @@ async def publish_artifact(
         payload = artifact_payload(existing)
         if not any(item.get("id") == payload.get("id") for item in ctx.published_artifacts):
             ctx.published_artifacts.append(payload)
+        _record_published_artifact_source_key(ctx, target, workspace)
         llm_artifact = _llm_artifact_payload(
             payload,
             ctx=ctx,
@@ -640,6 +666,7 @@ async def publish_artifact(
 
     payload = artifact_payload(ref)
     ctx.published_artifacts.append(payload)
+    _record_published_artifact_source_key(ctx, target, workspace)
     llm_artifact = _llm_artifact_payload(
         payload,
         ctx=ctx,

--- a/src/opensquilla/tools/types.py
+++ b/src/opensquilla/tools/types.py
@@ -193,6 +193,12 @@ class ToolContext:
     # and projection code use this bit to avoid replacing raw tool output with
     # a handle that the current model is not authorized to retrieve.
     tool_result_retrieval_available: bool = False
+    # Canonical workspace source identities ("path:...") of files successfully
+    # published during this turn via publish_artifact. The omitted-artifact
+    # backstop consults this to avoid re-publishing the same source file under
+    # its original filename after an explicit publish used a custom display
+    # name. Runtime-only; never serialized into task details or transcripts.
+    published_artifact_source_keys: set[str] = field(default_factory=set)
 
     def __post_init__(self) -> None:
         self.validate_path_roots()

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1829,6 +1829,61 @@ async def test_publish_artifact_tool_is_idempotent_for_existing_turn_artifact(
 
 
 @pytest.mark.asyncio
+async def test_backstop_skips_file_explicitly_published_with_custom_name(
+    tmp_path: Path,
+) -> None:
+    from opensquilla.engine.artifact_delivery import (
+        auto_publish_omitted_workspace_artifacts,
+    )
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "index.html"
+    target.write_text("<title>World Countries</title>", encoding="utf-8")
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+    )
+    ctx.workspace_file_writes.append(
+        {
+            "created": True,
+            "path": str(target),
+            "relative_path": "index.html",
+            "name": target.name,
+        }
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        result = json.loads(
+            await publish_artifact(
+                path="index.html",
+                name="World Countries Overview",
+            )
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result["status"] == "published"
+    assert result["artifact"]["name"] == "World Countries Overview.html"
+    assert len(ctx.published_artifacts) == 1
+
+    publish_result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="I created index.html for you.",
+    )
+
+    assert publish_result.artifacts == []
+    assert publish_result.failure_summaries == []
+    assert len(ctx.published_artifacts) == 1
+    assert ctx.published_artifacts[0]["name"] == "World Countries Overview.html"
+
+
+@pytest.mark.asyncio
 async def test_publish_artifact_tool_reuses_existing_session_deliverable_across_contexts(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1252,6 +1252,89 @@ async def test_publish_artifact_allows_delivery_ready_running_plan_run(
 
 
 @pytest.mark.asyncio
+async def test_publish_artifact_allows_cancelled_plan_run_with_all_steps_terminal(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "report.txt").write_text("ready", encoding="utf-8")
+
+    class PlanStorage:
+        async def get_plan_run(self, run_id: str) -> SimpleNamespace:
+            assert run_id == "run-1"
+            # User cancelled after the final checkpoint: every bounded step is
+            # terminal but a stale current_step_id still points at the last
+            # step. The delivery channel must not be sealed (issue #1112).
+            return SimpleNamespace(
+                status="cancelled",
+                current_step_id="publish",
+                active_task_id=None,
+                step_states=[
+                    {"step_id": "build", "status": "completed"},
+                    {"step_id": "publish", "status": "completed"},
+                ],
+            )
+
+    ctx = ToolContext(
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+        plan_run_id="run-1",
+        plan_storage=PlanStorage(),
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        payload = json.loads(await publish_artifact(path="report.txt"))
+    finally:
+        current_tool_context.reset(token)
+
+    assert payload["status"] == "published"
+    assert len(ctx.published_artifacts) == 1
+
+
+@pytest.mark.asyncio
+async def test_publish_artifact_rejects_cancelled_plan_run_with_unfinished_steps(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "report.txt").write_text("ready", encoding="utf-8")
+
+    class PlanStorage:
+        async def get_plan_run(self, run_id: str) -> SimpleNamespace:
+            assert run_id == "run-1"
+            return SimpleNamespace(
+                status="cancelled",
+                current_step_id="build",
+                active_task_id=None,
+                step_states=[
+                    {"step_id": "build", "status": "in_progress"},
+                ],
+            )
+
+    ctx = ToolContext(
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+        plan_run_id="run-1",
+        plan_storage=PlanStorage(),
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        with pytest.raises(ToolError) as exc_info:
+            await publish_artifact(path="report.txt")
+    finally:
+        current_tool_context.reset(token)
+
+    assert "cancelled" in str(exc_info.value)
+    assert ctx.published_artifacts == []
+
+
+@pytest.mark.asyncio
 async def test_publish_artifact_rejects_paused_plan_run_without_retry(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_engine/test_runtime_artifacts.py
+++ b/tests/test_engine/test_runtime_artifacts.py
@@ -2495,6 +2495,55 @@ def test_auto_publish_dedupes_current_artifact_by_store_safe_name(
     assert len(ctx.published_artifacts) == 1
 
 
+def test_auto_publish_keeps_distinct_source_paths_with_identical_content(
+    tmp_path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    first = workspace / "a.html"
+    second = workspace / "b.html"
+    payload = b"<title>identical</title>"
+    first.write_bytes(payload)
+    second.write_bytes(payload)
+    first_sha = hashlib.sha256(payload).hexdigest()
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-identical",
+        session_key="agent:main:webchat:identical",
+    )
+    # a.html was explicitly published this turn under a custom display name.
+    ctx.published_artifacts.append(
+        {"id": "art-a", "sha256": first_sha, "name": "Overview A.html"}
+    )
+    ctx.published_artifact_source_keys.add(
+        artifact_delivery_publish_target_key(
+            str(first.resolve()),
+            workspace_dir=workspace,
+        )
+    )
+    for name, path in (("a.html", first), ("b.html", second)):
+        ctx.workspace_file_writes.append(
+            {
+                "created": True,
+                "path": str(path),
+                "relative_path": name,
+                "name": name,
+            }
+        )
+
+    result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="Created a.html and b.html for you.",
+    )
+
+    assert len(result.artifacts) == 1
+    assert result.artifacts[0]["name"] == "b.html"
+    assert len(ctx.published_artifacts) == 2
+
+
 def test_auto_publish_oversized_pptx_preflights_before_read_or_validation(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Scope

Scope boundary: the `publish_artifact` PlanRun delivery gate
(`src/opensquilla/tools/builtin/artifacts.py`).

Non-goals: no change to plan checkpointing, `plans.cancelRun`, the Goal-owned
path, or any public API / protocol. The final-step auto-checkpoint ordering
fix (#1152) is unchanged.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #1112

## Release Note

Release note: after a user cancels a Plan run whose bounded steps are all
terminal, `publish_artifact` can still finalize and deliver the generated
files instead of being permanently blocked by the delivery gate; a stale
`current_step_id` pointing at an already-completed step no longer blocks
delivery.

## Tests

Ruff: not run locally (no Python toolchain in the contributor environment)

Pytest: not run locally (same); added two regression tests

Build: not run

Regression tests: added

Notes: the change is backend-only and offline-safe. Tests added in
`tests/test_artifacts.py`:
- `test_publish_artifact_allows_cancelled_plan_run_with_all_steps_terminal`
- `test_publish_artifact_rejects_cancelled_plan_run_with_unfinished_steps`

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

No secrets, local-only artifacts, private prompts/transcripts, channel
identifiers, or non-public fixtures are committed.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
