### PR TITLE
Make CI evidence downloads and pricing tests deterministic

### DIFF
--- a/.github/scripts/ci_attestation.py
+++ b/.github/scripts/ci_attestation.py
@@ -47,6 +47,35 @@ class AttestationError(RuntimeError):
     """A queue attestation could not be trusted."""
 
 
+class _SafeArtifactRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Follow artifact redirects without forwarding GitHub API credentials."""
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        redirected = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if redirected is None:
+            return None
+
+        source = urllib.parse.urlsplit(req.full_url)
+        target = urllib.parse.urlsplit(redirected.full_url)
+        if target.scheme.lower() != "https":
+            raise AttestationError("artifact download redirect must use HTTPS")
+        if (source.scheme.lower(), source.netloc.lower()) != (
+            target.scheme.lower(),
+            target.netloc.lower(),
+        ):
+            for header in ("Authorization", "Accept", "X-GitHub-Api-Version"):
+                redirected.remove_header(header)
+        return redirected
+
+
 def _git(*args: str, cwd: Path) -> str:
     completed = subprocess.run(
         ["git", *args],
@@ -202,7 +231,8 @@ def _request_bytes(url: str, token: str) -> bytes:
             "X-GitHub-Api-Version": "2022-11-28",
         },
     )
-    with urllib.request.urlopen(request, timeout=60) as response:
+    opener = urllib.request.build_opener(_SafeArtifactRedirectHandler())
+    with opener.open(request, timeout=60) as response:
         return response.read()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,9 +85,10 @@ def _isolate_provider_credentials(
     monkeypatch: pytest.MonkeyPatch,
     request: pytest.FixtureRequest,
 ) -> None:
-    """Keep default tests offline even when local env files have API keys."""
+    """Keep default tests offline despite local credentials or live-pricing settings."""
     if any(request.node.get_closest_marker(marker) for marker in _LIVE_MARKERS):
         return
+    monkeypatch.setenv("OPENSQUILLA_OPENROUTER_LIVE_PRICING", "0")
     for env_key in _PROVIDER_ENV_KEYS:
         # An explicit empty value prevents build_services.load_env() from
         # rehydrating credentials from a repository or profile .env file.

--- a/tests/test_ci/test_ci_attestation.py
+++ b/tests/test_ci/test_ci_attestation.py
@@ -4,7 +4,9 @@ import io
 import json
 import runpy
 import subprocess
+import urllib.request
 import zipfile
+from email.message import Message
 from pathlib import Path
 from typing import Any
 
@@ -14,10 +16,55 @@ MODULE: dict[str, Any] = runpy.run_path(
     ".github/scripts/ci_attestation.py", run_name="ci_attestation"
 )
 AttestationError = MODULE["AttestationError"]
+SafeArtifactRedirectHandler = MODULE["_SafeArtifactRedirectHandler"]
 create_attestation = MODULE["create_attestation"]
 policy_digest = MODULE["policy_digest"]
 validate_candidate = MODULE["validate_candidate"]
 verify_queue = MODULE["verify_queue"]
+
+
+def _artifact_redirect(newurl: str) -> urllib.request.Request:
+    request = urllib.request.Request(
+        "https://api.github.com/repos/opensquilla/opensquilla/actions/artifacts/1/zip",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": "Bearer synthetic-token",
+            "User-Agent": "opensquilla-ci-attestation",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    redirected = SafeArtifactRedirectHandler().redirect_request(
+        request,
+        None,
+        302,
+        "Found",
+        Message(),
+        newurl,
+    )
+    assert redirected is not None
+    return redirected
+
+
+def test_artifact_redirect_strips_api_credentials_cross_origin() -> None:
+    redirected = _artifact_redirect(
+        "https://productionresultssa.blob.core.windows.net/actions-results/attestation.zip"
+    )
+
+    assert redirected.get_header("Authorization") is None
+    assert redirected.get_header("Accept") is None
+    assert redirected.get_header("X-Github-Api-Version") is None
+
+
+def test_artifact_redirect_preserves_api_credentials_same_origin() -> None:
+    redirected = _artifact_redirect("https://api.github.com/artifact-download")
+
+    assert redirected.get_header("Authorization") == "Bearer synthetic-token"
+    assert redirected.get_header("Accept") == "application/vnd.github+json"
+
+
+def test_artifact_redirect_rejects_non_https_target() -> None:
+    with pytest.raises(AttestationError, match="must use HTTPS"):
+        _artifact_redirect("http://artifact-storage.example.invalid/attestation.zip")
 
 
 def _git(repo: Path, *args: str) -> str:

--- a/tests/test_engine/test_pricing.py
+++ b/tests/test_engine/test_pricing.py
@@ -8,6 +8,7 @@ from opensquilla.engine.pricing import (
     PricingCache,
     lookup_price,
     reset_live_price_cache_for_tests,
+    resolve_model_price,
     seed_live_price_cache_for_tests,
 )
 
@@ -17,6 +18,22 @@ def reset_pricing_cache() -> Iterator[None]:
     reset_live_price_cache_for_tests()
     yield
     reset_live_price_cache_for_tests()
+
+
+def test_default_test_session_disables_live_pricing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_fetch(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("default tests must not fetch live OpenRouter pricing")
+
+    monkeypatch.setattr(
+        "opensquilla.engine.pricing._fetch_live_openrouter_price",
+        unexpected_fetch,
+    )
+
+    resolved = resolve_model_price("vendor/synthetic-model", provider="openrouter")
+
+    assert resolved.source == "default"
 
 
 def test_deepseek_v4_pro_static_price_matches_current_official(


### PR DESCRIPTION
## Scope

- Strip GitHub API-only headers when artifact downloads redirect to cross-origin storage, while rejecting non-HTTPS redirects.
- Keep ordinary pytest runs offline by disabling live OpenRouter pricing unless a live-marked or explicitly controlled test opts in.
- Add redirect security and default pricing-isolation regression coverage.

## Target

`main`

## Linked issue

None.

## Release note

None. This changes CI and test reliability only.

## Verification

- `uv run pytest -q tests/test_ci/test_ci_attestation.py tests/test_engine/test_pricing.py tests/test_engine/test_agent_max_iterations.py::test_agent_enriches_model_usage_breakdown_with_estimated_costs tests/test_engine/test_agent_llm_budget.py::test_with_model_usage_cost_fields_prices_unbilled_cache_reads_cache_aware` — 67 passed.
- Repeated the three pricing isolation regressions with `OPENSQUILLA_OPENROUTER_LIVE_PRICING=1` in the parent environment — 3 passed.
- Expanded CI/pricing/agent regression set — 451 passed, 2 skipped; the only local failure was the router artifact manifest freshness check because this worktree contains Git LFS pointer files instead of materialized router binaries.
- `uv run ruff check src tests .github/scripts` — passed.
- Downloaded the existing PR #1226 `ci-attestation` artifact through the fixed helper — succeeded and contained only `ci-attestation.json`.

## Safety and compatibility

- Merge queue verification remains fail-closed.
- Authorization is preserved for same-origin GitHub API redirects and removed only when the origin changes.
- Production live-pricing behavior is unchanged; only non-live pytest sessions are isolated.
- Platform-neutral; no persisted state, configuration, public API, or upgrade contract changes.

## Third-party origin

None.
