### PR TITLE
feat(webui): always show context-window usage in the chat header

### DIFF
--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -213,6 +213,7 @@
           :deliverable-count="chatRouteHeaderDeliverableCount"
           :share-mode="chatRouteHeaderShareMode"
           :shareable-message-count="chatRouteHeaderShareableMessageCount"
+          :context-warning="chatRouteHeaderContextWarning"
           @open-deliverables="chatRouteHeader.invoke('openDeliverables')"
           @start-share="chatRouteHeader.invoke('startShare')"
           @copy-session-key="chatRouteHeader.invoke('copySessionKey')"
@@ -546,6 +547,7 @@ const {
   deliverableCount: chatRouteHeaderDeliverableCount,
   shareMode: chatRouteHeaderShareMode,
   shareableMessageCount: chatRouteHeaderShareableMessageCount,
+  contextWarning: chatRouteHeaderContextWarning,
 } = chatRouteHeader.model
 const chatHeaderActionsRef = ref<ChatRouteHeaderHostHandle | null>(null)
 watch(chatHeaderActionsRef, host => chatRouteHeader.setHost(host), { flush: 'sync' })

--- a/opensquilla-webui/src/components/chat/ChatHeaderActions.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatHeaderActions.test.ts
@@ -4,6 +4,7 @@ import { createApp, nextTick, type App, type ComponentPublicInstance } from 'vue
 import { createI18n } from 'vue-i18n'
 
 import ChatHeaderActions from './ChatHeaderActions.vue'
+import type { ContextWarning } from '@/composables/chat/useChatUsageWidget'
 
 type Action = 'deliverables' | 'share' | 'copy-session-key'
 type LayoutName = 'wide' | 'compact' | 'tight'
@@ -12,14 +13,24 @@ type HeaderInstance = ComponentPublicInstance & {
   focusAction: (action: Action) => boolean
 }
 
-const BASE_PROPS = {
+const BASE_PROPS: {
+  title: string
+  copyState: string | null
+  copyIcon: string
+  copyLiveText: string
+  deliverableCount: number
+  shareMode: boolean
+  shareableMessageCount: number
+  contextWarning: ContextWarning | null
+} = {
   title: 'Responsive header test',
   copyState: null,
-  copyIcon: 'copy' as const,
+  copyIcon: 'copy',
   copyLiveText: '',
   deliverableCount: 2,
   shareMode: false,
   shareableMessageCount: 3,
+  contextWarning: null,
 }
 
 const messages = {
@@ -32,6 +43,9 @@ const messages = {
     share: 'Share',
     shareSelectHint: 'Select messages to share',
     shareSendFirst: 'Send a message first to share',
+    contextPressure: 'Context {pct}%',
+    contextPressureInfoTitle: 'Context window {used}k / {window}k tokens',
+    contextPressureTitle: 'Context window {used}k / {window}k tokens — nearing compaction',
   },
 }
 
@@ -632,5 +646,46 @@ describe('ChatHeaderActions', () => {
     const tight = await mountHeader(120)
     expect(tight.instance.focusAction('deliverables')).toBe(true)
     expect(document.activeElement).toBe(trigger(tight.el))
+  })
+
+  describe('context-pressure chip', () => {
+    it('renders the percentage once context usage is known', async () => {
+      const { el } = await mountHeader(800, {
+        contextWarning: { pct: 42, usedK: 54, windowK: 128, warning: false },
+      })
+      const chip = el.querySelector<HTMLElement>('.chat-ctx-warn')!
+      expect(chip).not.toBeNull()
+      expect(chip.textContent).toBe('Context 42%')
+      expect(chip.classList.contains('chat-ctx-warn--active')).toBe(false)
+      expect(chip.getAttribute('title')).toBe('Context window 54k / 128k tokens')
+    })
+
+    it('stays hidden while context usage is unknown', async () => {
+      const { el } = await mountHeader(800, { contextWarning: null })
+      expect(el.querySelector('.chat-ctx-warn')).toBeNull()
+    })
+
+    it('switches to the warning style and copy at the warning ratio', async () => {
+      const { el } = await mountHeader(800, {
+        contextWarning: { pct: 87, usedK: 111, windowK: 128, warning: true },
+      })
+      const chip = el.querySelector<HTMLElement>('.chat-ctx-warn')!
+      expect(chip.textContent).toBe('Context 87%')
+      expect(chip.classList.contains('chat-ctx-warn--active')).toBe(true)
+      expect(chip.getAttribute('title'))
+        .toBe('Context window 111k / 128k tokens — nearing compaction')
+    })
+
+    it.each([
+      { layout: 'compact', width: 400 },
+      { layout: 'tight', width: 120 },
+    ] as const)('keeps the chip visible in the $layout header', async ({ width }) => {
+      const { el } = await mountHeader(width, {
+        contextWarning: { pct: 30, usedK: 38, windowK: 128, warning: false },
+      })
+      const chip = el.querySelector<HTMLElement>('.chat-ctx-warn')!
+      expect(chip).not.toBeNull()
+      expect(chip.textContent).toBe('Context 30%')
+    })
   })
 })

--- a/opensquilla-webui/src/components/chat/ChatHeaderActions.vue
+++ b/opensquilla-webui/src/components/chat/ChatHeaderActions.vue
@@ -24,6 +24,17 @@
 
     <span class="chat-header__spacer" aria-hidden="true"></span>
 
+    <span
+      v-if="contextWarning"
+      class="chat-ctx-warn"
+      :class="{ 'chat-ctx-warn--active': contextWarning.warning }"
+      :title="t(contextWarning.warning ? 'chat.contextPressureTitle' : 'chat.contextPressureInfoTitle', {
+        used: contextWarning.usedK,
+        window: contextWarning.windowK,
+        pct: contextWarning.pct,
+      })"
+    >{{ t('chat.contextPressure', { pct: contextWarning.pct }) }}</span>
+
     <div v-if="layout === 'wide'" class="chat-header__actions">
       <button
         v-if="deliverableCount > 0"
@@ -171,6 +182,7 @@ import Icon from '@/components/Icon.vue'
 import { useDialogLayer } from '@/composables/useDialogA11y'
 import { useChatTopbarPopoverCoordination } from '@/composables/useChatTopbarPopoverCoordinator'
 import { useDocumentEvent } from '@/composables/useDocumentEvent'
+import type { ContextWarning } from '@/composables/chat/useChatUsageWidget'
 import {
   resolveSessionHeaderLayout,
   type SessionHeaderLayout,
@@ -189,6 +201,7 @@ const props = defineProps<{
   deliverableCount: number
   shareMode: boolean
   shareableMessageCount: number
+  contextWarning: ContextWarning | null
 }>()
 
 const emit = defineEmits<{
@@ -573,6 +586,28 @@ defineExpose({ focusAction, closeMenu })
   background: var(--topbar-state-fill);
   border-color: var(--topbar-state-border);
   color: var(--topbar-state-channel);
+}
+
+.chat-ctx-warn {
+  align-items: center;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  color: var(--text-muted);
+  display: inline-flex;
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
+  line-height: 1;
+  min-height: 26px;
+  padding: 0 0.625rem;
+  white-space: nowrap;
+}
+
+.chat-ctx-warn--active {
+  background: color-mix(in srgb, var(--warn) 12%, var(--bg-surface));
+  border-color: color-mix(in srgb, var(--warn) 34%, var(--border));
+  color: var(--warn);
 }
 
 .chat-header__count-badge {

--- a/opensquilla-webui/src/composables/chat/useChatRouteHeaderBridge.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRouteHeaderBridge.test.ts
@@ -47,6 +47,7 @@ function owner(title: string): {
       deliverableCount: ref(0),
       shareMode: ref(false),
       shareableMessageCount: ref(1),
+      contextWarning: ref(null),
     },
     commands: {
       openDeliverables: vi.fn(),

--- a/opensquilla-webui/src/composables/chat/useChatRouteHeaderBridge.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRouteHeaderBridge.ts
@@ -8,6 +8,7 @@ import {
   type InjectionKey,
   type Ref,
 } from 'vue'
+import type { ContextWarning } from '@/composables/chat/useChatUsageWidget'
 import type { IconName } from '@/utils/icons'
 
 export type ChatRouteHeaderAction =
@@ -24,6 +25,7 @@ export interface ChatRouteHeaderModel {
   deliverableCount: Readonly<Ref<number>>
   shareMode: Readonly<Ref<boolean>>
   shareableMessageCount: Readonly<Ref<number>>
+  contextWarning: Readonly<Ref<ContextWarning | null>>
 }
 
 export interface ChatRouteHeaderCommands {
@@ -54,6 +56,7 @@ export interface ChatRouteHeaderBridge {
     deliverableCount: ComputedRef<number>
     shareMode: ComputedRef<boolean>
     shareableMessageCount: ComputedRef<number>
+    contextWarning: ComputedRef<ContextWarning | null>
   }
   register: (
     model: ChatRouteHeaderModel,
@@ -129,6 +132,7 @@ export function provideChatRouteHeaderBridge(): ChatRouteHeaderBridge {
       deliverableCount: computed(() => ownerValue('deliverableCount', 0)),
       shareMode: computed(() => ownerValue('shareMode', false)),
       shareableMessageCount: computed(() => ownerValue('shareableMessageCount', 0)),
+      contextWarning: computed(() => ownerValue('contextWarning', null)),
     },
     register(model, commands) {
       closeMenu()

--- a/opensquilla-webui/src/composables/chat/useChatUsageWidget.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatUsageWidget.test.ts
@@ -4,6 +4,13 @@ import { describe, expect, it, vi } from 'vitest'
 import { useChatUsageWidget } from './useChatUsageWidget'
 import type { RpcCallOptions } from '@/lib/rpc'
 
+function makeRpc(sessions: unknown[] = []) {
+  return {
+    waitForConnection: vi.fn().mockResolvedValue(undefined),
+    call: vi.fn().mockResolvedValue({ sessions }),
+  }
+}
+
 describe('useChatUsageWidget background reads', () => {
   it('uses the injected bounded options without changing its public loader', async () => {
     const readCallOptions: RpcCallOptions = {
@@ -11,16 +18,11 @@ describe('useChatUsageWidget background reads', () => {
       timeoutAction: 'reconnect',
       abortAction: 'reconnect',
     }
-    const rpc = {
-      waitForConnection: vi.fn().mockResolvedValue(undefined),
-      call: vi.fn().mockResolvedValue({
-        sessions: [{
-          sessionKey: 'agent:main:webchat:usage',
-          inputTokens: 12,
-          outputTokens: 8,
-        }],
-      }),
-    }
+    const rpc = makeRpc([{
+      sessionKey: 'agent:main:webchat:usage',
+      inputTokens: 12,
+      outputTokens: 8,
+    }])
     const api = useChatUsageWidget({
       rpc,
       readCallOptions,
@@ -44,5 +46,79 @@ describe('useChatUsageWidget background reads', () => {
       readCallOptions,
     )
     expect(api.usageAccum.value).toMatchObject({ input: 12, output: 8 })
+  })
+})
+
+describe('useChatUsageWidget context warning', () => {
+  function contextStatus(status: Record<string, number>) {
+    return {
+      sessionKey: 'agent:main:webchat:usage',
+      contextStatus: status,
+    }
+  }
+
+  it('is null while no session or no context status is available', async () => {
+    const api = useChatUsageWidget({
+      rpc: makeRpc(),
+      sessionKey: ref('agent:main:webchat:usage'),
+      tokenVizEnabled: () => false,
+    })
+    await api.loadCurrentSessionUsage()
+    expect(api.contextWarning.value).toBeNull()
+  })
+
+  it('reports the percentage below the warning ratio without a warning flag', async () => {
+    const api = useChatUsageWidget({
+      rpc: makeRpc([contextStatus({
+        contextTokens: 54_000,
+        contextWindowTokens: 128_000,
+        pressure: 0.42,
+        warningRatio: 0.85,
+      })]),
+      sessionKey: ref('agent:main:webchat:usage'),
+      tokenVizEnabled: () => false,
+    })
+    await api.loadCurrentSessionUsage()
+    expect(api.contextWarning.value).toEqual({
+      pct: 42,
+      usedK: 54,
+      windowK: 128,
+      warning: false,
+    })
+  })
+
+  it('flags the warning once pressure crosses the ratio', async () => {
+    const api = useChatUsageWidget({
+      rpc: makeRpc([contextStatus({
+        contextTokens: 111_000,
+        contextWindowTokens: 128_000,
+        pressure: 0.87,
+        warningRatio: 0.85,
+      })]),
+      sessionKey: ref('agent:main:webchat:usage'),
+      tokenVizEnabled: () => false,
+    })
+    await api.loadCurrentSessionUsage()
+    expect(api.contextWarning.value).toEqual({
+      pct: 87,
+      usedK: 111,
+      windowK: 128,
+      warning: true,
+    })
+  })
+
+  it('stays null when usage or the window is unknown', async () => {
+    const api = useChatUsageWidget({
+      rpc: makeRpc([contextStatus({
+        contextTokens: 54_000,
+        contextWindowTokens: 0,
+        pressure: 0.42,
+        warningRatio: 0.85,
+      })]),
+      sessionKey: ref('agent:main:webchat:usage'),
+      tokenVizEnabled: () => false,
+    })
+    await api.loadCurrentSessionUsage()
+    expect(api.contextWarning.value).toBeNull()
   })
 })

--- a/opensquilla-webui/src/composables/chat/useChatUsageWidget.ts
+++ b/opensquilla-webui/src/composables/chat/useChatUsageWidget.ts
@@ -59,6 +59,8 @@ export interface ContextWarning {
   pct: number
   usedK: number
   windowK: number
+  /** True when pressure has crossed the gateway warning ratio (0.85). */
+  warning: boolean
 }
 
 interface UsageStatusSession {
@@ -103,21 +105,23 @@ export function useChatUsageWidget(options: UseChatUsageWidgetOptions) {
   const lastSavingsPopupIdentity = ref('')
   const contextStatus = ref<ContextStatus | null>(null)
 
-  // Surfaced as a topbar chip only once the session's context window crosses the
-  // gateway's warning ratio (0.85) — a proactive heads-up before compaction,
-  // independent of any compaction event. Null when below threshold or unknown.
+  // Surfaced as a topbar chip whenever the session's context window is known.
+  // `warning` is true once pressure crosses the gateway's warning ratio (0.85)
+  // — a proactive heads-up before compaction, independent of any compaction
+  // event. Null when the window or usage is unknown.
   const contextWarning = computed<ContextWarning | null>(() => {
     const cs = contextStatus.value
     if (!cs) return null
     const pressure = Number(cs.pressure ?? 0)
     const ratio = Number(cs.warningRatio ?? cs.warning_ratio ?? 0.85)
     const windowTokens = Number(cs.contextWindowTokens ?? cs.context_window_tokens ?? 0)
-    if (!(ratio > 0) || !(windowTokens > 0) || pressure < ratio) return null
+    if (!(pressure > 0) || !(windowTokens > 0)) return null
     const used = Number(cs.contextTokens ?? cs.context_tokens ?? 0)
     return {
       pct: Math.round(Math.min(1, pressure) * 100),
       usedK: Math.round(used / 1000),
       windowK: Math.round(windowTokens / 1000),
+      warning: ratio > 0 && pressure >= ratio,
     }
   })
 

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -3322,6 +3322,7 @@
     "deliverables": "Ergebnisse",
     "deliverablesCount": "Ergebnisse ({count})",
     "contextPressure": "Kontext {pct} %",
+    "contextPressureInfoTitle": "Kontextfenster {used}k / {window}k Tokens",
     "contextPressureTitle": "Kontextfenster {used}k / {window}k Tokens — nahe der Komprimierungsschwelle",
     "sessionDeliverables": "Sitzungsergebnisse",
     "noDeliverables": "Noch keine Ergebnisse.",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -3375,6 +3375,7 @@
     "deliverables": "Deliverables",
     "deliverablesCount": "Deliverables ({count})",
     "contextPressure": "Context {pct}%",
+    "contextPressureInfoTitle": "Context window {used}k / {window}k tokens",
     "contextPressureTitle": "Context window {used}k / {window}k tokens — nearing compaction",
     "sessionDeliverables": "Session deliverables",
     "noDeliverables": "No deliverables yet.",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -3322,6 +3322,7 @@
     "deliverables": "Entregables",
     "deliverablesCount": "Entregables ({count})",
     "contextPressure": "Contexto {pct} %",
+    "contextPressureInfoTitle": "Ventana de contexto {used}k / {window}k tokens",
     "contextPressureTitle": "Ventana de contexto {used}k / {window}k tokens — cerca del umbral de compactación",
     "sessionDeliverables": "Entregables de la sesión",
     "noDeliverables": "Aún no hay entregables.",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -3322,6 +3322,7 @@
     "deliverables": "Livrables",
     "deliverablesCount": "Livrables ({count})",
     "contextPressure": "Contexte {pct} %",
+    "contextPressureInfoTitle": "Fenêtre de contexte {used}k / {window}k jetons",
     "contextPressureTitle": "Fenêtre de contexte {used}k / {window}k jetons — proche du seuil de compactage",
     "sessionDeliverables": "Livrables de la session",
     "noDeliverables": "Aucun livrable pour l'instant.",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -3322,6 +3322,7 @@
     "deliverables": "成果物",
     "deliverablesCount": "成果物 ({count})",
     "contextPressure": "コンテキスト {pct}%",
+    "contextPressureInfoTitle": "コンテキストウィンドウ {used}k / {window}k トークン",
     "contextPressureTitle": "コンテキストウィンドウ {used}k / {window}k トークン — 圧縮しきい値に接近",
     "sessionDeliverables": "セッションの成果物",
     "noDeliverables": "成果物はまだありません。",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -3375,6 +3375,7 @@
     "deliverables": "产物",
     "deliverablesCount": "产物（{count}）",
     "contextPressure": "上下文 {pct}%",
+    "contextPressureInfoTitle": "上下文窗口 {used}k / {window}k tokens",
     "contextPressureTitle": "上下文窗口 {used}k / {window}k tokens — 接近压缩阈值",
     "sessionDeliverables": "会话产物",
     "noDeliverables": "暂无产物。",

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -1661,6 +1661,7 @@ const chatUsageWidget = useChatUsageWidget({
 const {
   usageAccum,
   usageModel,
+  contextWarning,
   resetSavingsPopupCooldown,
   saveWidgetState,
   restoreWidgetState,
@@ -4294,6 +4295,7 @@ const chatRouteHeaderRegistration = chatRouteHeader.register({
   deliverableCount: headerDeliverableCount,
   shareMode,
   shareableMessageCount,
+  contextWarning,
 }, {
   openDeliverables,
   startShare: startShareMode,

--- a/src/opensquilla/engine/artifact_delivery.py
+++ b/src/opensquilla/engine/artifact_delivery.py
@@ -248,6 +248,22 @@ def auto_publish_omitted_workspace_artifacts(
         if not _text_mentions_written_file(final_text, record):
             continue
 
+        target_key = artifact_delivery_publish_target_key(
+            str(target),
+            workspace_dir=workspace,
+        )
+        name_key = artifact_delivery_name_target_key(target.name)
+        if target_key is not None and target_key in getattr(
+            ctx, "published_artifact_source_keys", frozenset()
+        ):
+            # The same source file was explicitly published earlier this turn,
+            # possibly under a custom display name. Do not publish it a second
+            # time under its original filename.
+            for resolved_key in (target_key, name_key):
+                if resolved_key is not None and resolved_key not in resolved_target_keys:
+                    resolved_target_keys.append(resolved_key)
+            continue
+
         try:
             artifact_mime = artifact_mime_for_name(target.name)
             publish_max_bytes = artifact_publish_max_bytes_for_name(
@@ -288,11 +304,6 @@ def auto_publish_omitted_workspace_artifacts(
                 pptx_payload if pptx_payload is not None else target.read_bytes()
             ).hexdigest()
             artifact_key = (target_sha256, _safe_filename(target.name))
-            target_key = artifact_delivery_publish_target_key(
-                str(target),
-                workspace_dir=workspace,
-            )
-            name_key = artifact_delivery_name_target_key(target.name)
             if artifact_key in known_artifact_keys:
                 for resolved_key in (target_key, name_key):
                     if (

--- a/src/opensquilla/tools/builtin/artifacts.py
+++ b/src/opensquilla/tools/builtin/artifacts.py
@@ -59,6 +59,31 @@ def _bundle_result(manifest: ArtifactBundleManifest) -> dict[str, object]:
     }
 
 
+def _record_published_artifact_source_key(
+    ctx: ToolContext,
+    target: Path,
+    workspace: Path,
+) -> None:
+    """Record a successfully published file's canonical workspace identity.
+
+    The omitted-artifact backstop consults this per-turn set so a source file
+    explicitly published under a custom display name is not published a second
+    time under its original filename. The import is deferred to keep this tool
+    module import-cycle-free.
+    """
+
+    from opensquilla.engine.artifact_delivery import (
+        artifact_delivery_publish_target_key,
+    )
+
+    source_key = artifact_delivery_publish_target_key(
+        str(target),
+        workspace_dir=workspace,
+    )
+    if source_key is not None:
+        ctx.published_artifact_source_keys.add(source_key)
+
+
 def _normalized_filename(value: str) -> str:
     return "".join(ch for ch in value.lower() if ch.isalnum())
 
@@ -577,6 +602,7 @@ async def publish_artifact(
         payload = artifact_payload(existing)
         if not any(item.get("id") == payload.get("id") for item in ctx.published_artifacts):
             ctx.published_artifacts.append(payload)
+        _record_published_artifact_source_key(ctx, target, workspace)
         llm_artifact = _llm_artifact_payload(
             payload,
             ctx=ctx,
@@ -640,6 +666,7 @@ async def publish_artifact(
 
     payload = artifact_payload(ref)
     ctx.published_artifacts.append(payload)
+    _record_published_artifact_source_key(ctx, target, workspace)
     llm_artifact = _llm_artifact_payload(
         payload,
         ctx=ctx,

--- a/src/opensquilla/tools/types.py
+++ b/src/opensquilla/tools/types.py
@@ -193,6 +193,12 @@ class ToolContext:
     # and projection code use this bit to avoid replacing raw tool output with
     # a handle that the current model is not authorized to retrieve.
     tool_result_retrieval_available: bool = False
+    # Canonical workspace source identities ("path:...") of files successfully
+    # published during this turn via publish_artifact. The omitted-artifact
+    # backstop consults this to avoid re-publishing the same source file under
+    # its original filename after an explicit publish used a custom display
+    # name. Runtime-only; never serialized into task details or transcripts.
+    published_artifact_source_keys: set[str] = field(default_factory=set)
 
     def __post_init__(self) -> None:
         self.validate_path_roots()

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1829,6 +1829,61 @@ async def test_publish_artifact_tool_is_idempotent_for_existing_turn_artifact(
 
 
 @pytest.mark.asyncio
+async def test_backstop_skips_file_explicitly_published_with_custom_name(
+    tmp_path: Path,
+) -> None:
+    from opensquilla.engine.artifact_delivery import (
+        auto_publish_omitted_workspace_artifacts,
+    )
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "index.html"
+    target.write_text("<title>World Countries</title>", encoding="utf-8")
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+    )
+    ctx.workspace_file_writes.append(
+        {
+            "created": True,
+            "path": str(target),
+            "relative_path": "index.html",
+            "name": target.name,
+        }
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        result = json.loads(
+            await publish_artifact(
+                path="index.html",
+                name="World Countries Overview",
+            )
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result["status"] == "published"
+    assert result["artifact"]["name"] == "World Countries Overview.html"
+    assert len(ctx.published_artifacts) == 1
+
+    publish_result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="I created index.html for you.",
+    )
+
+    assert publish_result.artifacts == []
+    assert publish_result.failure_summaries == []
+    assert len(ctx.published_artifacts) == 1
+    assert ctx.published_artifacts[0]["name"] == "World Countries Overview.html"
+
+
+@pytest.mark.asyncio
 async def test_publish_artifact_tool_reuses_existing_session_deliverable_across_contexts(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_engine/test_runtime_artifacts.py
+++ b/tests/test_engine/test_runtime_artifacts.py
@@ -2495,6 +2495,55 @@ def test_auto_publish_dedupes_current_artifact_by_store_safe_name(
     assert len(ctx.published_artifacts) == 1
 
 
+def test_auto_publish_keeps_distinct_source_paths_with_identical_content(
+    tmp_path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    first = workspace / "a.html"
+    second = workspace / "b.html"
+    payload = b"<title>identical</title>"
+    first.write_bytes(payload)
+    second.write_bytes(payload)
+    first_sha = hashlib.sha256(payload).hexdigest()
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-identical",
+        session_key="agent:main:webchat:identical",
+    )
+    # a.html was explicitly published this turn under a custom display name.
+    ctx.published_artifacts.append(
+        {"id": "art-a", "sha256": first_sha, "name": "Overview A.html"}
+    )
+    ctx.published_artifact_source_keys.add(
+        artifact_delivery_publish_target_key(
+            str(first.resolve()),
+            workspace_dir=workspace,
+        )
+    )
+    for name, path in (("a.html", first), ("b.html", second)):
+        ctx.workspace_file_writes.append(
+            {
+                "created": True,
+                "path": str(path),
+                "relative_path": name,
+                "name": name,
+            }
+        )
+
+    result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="Created a.html and b.html for you.",
+    )
+
+    assert len(result.artifacts) == 1
+    assert result.artifacts[0]["name"] == "b.html"
+    assert len(ctx.published_artifacts) == 2
+
+
 def test_auto_publish_oversized_pptx_preflights_before_read_or_validation(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Scope

Scope boundary: Web UI only. The context-pressure chip in the chat header, its data path (contextWarning through the chat route-header bridge), the ContextWarning shape, and the six locale strings it needs.

Non-goals: No gateway/RPC change - usage.status already reports contextTokens, contextWindowTokens, and pressure for every session. The 0.85 warning threshold and its styling are unchanged.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #1075

## Release Note

Release note: The chat header now always shows the current context-window usage (e.g. "Context 42%") once it is known, instead of only after the session crosses the ~85% warning threshold. The detailed token count stays in the tooltip; the existing warning styling still appears at the threshold.

## Tests

Ruff: N/A (no Python changed)

Pytest: N/A (no Python changed)

Build: npm run typecheck - all 11 architecture guards pass, including i18n key parity across the six locales; vue-tsc --noEmit clean

Regression tests: added/updated
- useChatUsageWidget.test.ts: percentage below threshold without warning flag; warning flag at/above ratio; null when usage or window unknown
- ChatHeaderActions.test.ts: chip renders the percentage, stays hidden when unknown, switches style+tooltip at the warning ratio, and remains visible in compact and tight headers
- useChatRouteHeaderBridge.test.ts: owner model now includes contextWarning

Notes:
- 57 tests pass across the three modified suites; the contract/i18n suites (39 tests) also pass

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

No secrets or private artifacts.

## Third-Party Origin

Third-party origin: none
