### PR TITLE
feat(webui): collapse large subagent groups in the sidebar

### DIFF
--- a/opensquilla-webui/src/components/SidebarConversations.task-attention.test.ts
+++ b/opensquilla-webui/src/components/SidebarConversations.task-attention.test.ts
@@ -73,3 +73,86 @@ describe('SidebarConversations task attention', () => {
     expect(root.querySelector('.sidebar-history-run')).toBeNull()
   })
 })
+
+function groupRow(
+  parentKey: string,
+  count: number,
+  attention: SidebarSectionRow['taskAttention'],
+  children: SidebarSectionRow[],
+): SidebarSectionRow {
+  return {
+    rowKind: 'session',
+    key: parentKey,
+    title: parentKey,
+    effectiveAgentId: 'main',
+    agentName: 'Main',
+    sessionKind: 'chat',
+    depth: 0,
+    runStatus: 'idle',
+    runLabel: 'Idle',
+    taskAttention: 'none',
+    updatedAt: Date.now(),
+    hasContractGaps: false,
+    subagentGroup: { count, attention, children },
+  }
+}
+
+describe('SidebarConversations folded subagent groups', () => {
+  it('renders a collapsed group header with the child count by default', async () => {
+    const children = [0, 1, 2, 3].map(index => ({
+      ...taskRow(`child-${index}`, 'none'),
+      depth: 1,
+    }))
+    const root = await mountSidebar([groupRow('parent', 4, 'none', children)])
+
+    const groupHead = root.querySelector<HTMLElement>('.sidebar-subagent-group-head')!
+    expect(groupHead).not.toBeNull()
+    expect(groupHead.getAttribute('aria-expanded')).toBe('false')
+    expect(root.querySelector('[data-testid="sidebar-subagent-group-count"]')!.textContent).toBe('4')
+    // Children stay hidden while collapsed.
+    expect(root.querySelector('[data-session-key="child-0"]')).toBeNull()
+  })
+
+  it('expands the group on click and hides it again on a second click', async () => {
+    const children = [0, 1, 2, 3].map(index => ({
+      ...taskRow(`child-${index}`, 'none'),
+      depth: 1,
+    }))
+    const root = await mountSidebar([groupRow('parent', 4, 'none', children)])
+    const groupHead = root.querySelector<HTMLElement>('.sidebar-subagent-group-head')!
+
+    groupHead.click()
+    await nextTick()
+    expect(groupHead.getAttribute('aria-expanded')).toBe('true')
+    expect(root.querySelector('[data-session-key="child-0"]')).not.toBeNull()
+    expect(root.querySelector('[data-session-key="child-3"]')).not.toBeNull()
+
+    groupHead.click()
+    await nextTick()
+    // The TransitionGroup leave animation keeps a leaving row in the DOM for
+    // one frame; wait for it to settle before asserting the collapse.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    await nextTick()
+    expect(groupHead.getAttribute('aria-expanded')).toBe('false')
+    expect(root.querySelector('[data-session-key="child-0"]')).toBeNull()
+  })
+
+  it('surfaces a running group attention marker in the collapsed header', async () => {
+    const children = [0, 1, 2, 3].map(index => ({
+      ...taskRow(`child-${index}`, index === 1 ? 'running' : 'none'),
+      depth: 1,
+    }))
+    const root = await mountSidebar([groupRow('parent', 4, 'running', children)])
+
+    const marker = root.querySelector<HTMLElement>('[data-testid="sidebar-task-attention"]')!
+    expect(marker).not.toBeNull()
+    expect(marker.classList).toContain('sidebar-task-attention--running')
+    expect(marker.getAttribute('aria-label')).toBe('Task running')
+  })
+
+  it('keeps a plain row interactive when it is not a group', async () => {
+    const root = await mountSidebar([taskRow('plain', 'none')])
+    expect(root.querySelector('.sidebar-subagent-group-head')).toBeNull()
+    expect(root.querySelector('[data-session-key="plain"]')).not.toBeNull()
+  })
+})

--- a/opensquilla-webui/src/components/SidebarConversations.vue
+++ b/opensquilla-webui/src/components/SidebarConversations.vue
@@ -139,6 +139,16 @@ function taskAttentionLabel(attention: SessionTaskAttention | undefined): string
   return key ? t(key) : ''
 }
 
+function subagentGroupLabel(row: SidebarConversationItem): string {
+  if (!row.subagentGroup) return ''
+  const base = t('shared.sidebar.subagentGroupLabel', {
+    title: row.title,
+    count: row.subagentGroup.count,
+  })
+  const attention = taskAttentionLabel(row.subagentGroup.attention)
+  return attention ? `${base} — ${attention}` : base
+}
+
 /* ── Agent filter (lives within the Chats section) ─────────────────── */
 
 const agentFilter = ref('')
@@ -252,6 +262,43 @@ function filterCollapsedProjectRows<T extends SidebarConversationItem>(rows: T[]
   return result
 }
 
+/* ── Subagent group expansion ─────────────────────────────────────── */
+
+// Parent keys whose folded subagent group is expanded by the user. Kept in
+// memory only: the collapsed-by-default state is the stable presentation, and
+// an expansion is a temporary inspection choice like any other disclosure.
+const expandedSubagentGroups = ref<Set<string>>(new Set())
+
+function isSubagentGroupExpanded(row: SidebarConversationItem): boolean {
+  return Boolean(row.subagentGroup && expandedSubagentGroups.value.has(row.key))
+}
+
+function toggleSubagentGroup(row: SidebarConversationItem) {
+  if (!row.subagentGroup) return
+  const next = new Set(expandedSubagentGroups.value)
+  if (next.has(row.key)) next.delete(row.key)
+  else next.add(row.key)
+  expandedSubagentGroups.value = next
+}
+
+/** Flatten a row list, expanding any user-opened subagent groups. */
+function expandSubagentGroups<T extends SidebarDisplayRow>(rows: T[]): T[] {
+  const out: T[] = []
+  for (const row of rows) {
+    out.push(row)
+    if (!isSubagentGroupExpanded(row) || !row.subagentGroup) continue
+    for (const child of row.subagentGroup.children) {
+      out.push({
+        ...child,
+        displayZone: row.displayZone,
+        displayFamily: row.displayFamily,
+        displayProjectName: row.displayProjectName,
+      } as T)
+    }
+  }
+  return out
+}
+
 // Sections with at least one row, honoring the agent filter inside Chats.
 const filteredSections = computed(() => {
   return props.sections
@@ -292,7 +339,7 @@ const displayBlocks = computed<SidebarDisplayBlock[]>(() => {
       zone: 'pinned',
       label: t('shared.sidebar.pinned'),
       count: projection.pinned.length,
-      rows: projection.pinned,
+      rows: expandSubagentGroups(projection.pinned),
       showHeading: true,
     })
   }
@@ -302,7 +349,7 @@ const displayBlocks = computed<SidebarDisplayBlock[]>(() => {
       zone: 'projects',
       label: t('workspaces.projects'),
       count: projection.projectCount,
-      rows: filterCollapsedProjectRows(projection.projects),
+      rows: expandSubagentGroups(filterCollapsedProjectRows(projection.projects)),
       showHeading: true,
     })
   }
@@ -322,7 +369,7 @@ const displayBlocks = computed<SidebarDisplayBlock[]>(() => {
         zone: 'recents',
         label: t('shared.sidebar.recents'),
         count: projection.recentCount,
-        rows: section.rows,
+        rows: expandSubagentGroups(section.rows),
         showHeading: index === 0,
         family: section.family,
         familyLabel: section.label,
@@ -1117,6 +1164,39 @@ function onSelectRow(row: SidebarConversationItem) {
               @keydown.esc.prevent="cancelRename"
               @blur="onRenameBlur"
             />
+
+            <button
+              v-else-if="row.rowKind === 'session' && row.subagentGroup"
+              type="button"
+              class="sidebar-history-item sidebar-subagent-group-head"
+              :class="{ 'is-expanded': isSubagentGroupExpanded(row) }"
+              :aria-expanded="isSubagentGroupExpanded(row)"
+              :aria-label="subagentGroupLabel(row)"
+              :title="subagentGroupLabel(row)"
+              @click="toggleSubagentGroup(row)"
+            >
+              <Icon
+                class="sidebar-subagent-group-chevron"
+                name="chevronRight"
+                :size="12"
+                aria-hidden="true"
+              />
+              <span class="sidebar-history-title">{{ row.title }}</span>
+              <span
+                class="sidebar-subagent-group-count"
+                data-testid="sidebar-subagent-group-count"
+                aria-hidden="true"
+              >{{ row.subagentGroup.count }}</span>
+              <span
+                v-if="!selectionMode && row.subagentGroup.attention !== 'none'"
+                class="sidebar-task-attention"
+                :class="`sidebar-task-attention--${row.subagentGroup.attention}`"
+                role="img"
+                :aria-label="taskAttentionLabel(row.subagentGroup.attention) || undefined"
+                :title="taskAttentionLabel(row.subagentGroup.attention) || undefined"
+                data-testid="sidebar-task-attention"
+              />
+            </button>
 
             <button
               v-else-if="row.rowKind === 'session'"

--- a/opensquilla-webui/src/composables/useSessions.sections.test.ts
+++ b/opensquilla-webui/src/composables/useSessions.sections.test.ts
@@ -381,3 +381,76 @@ describe('arrangeSidebarSections — manual session ordering', () => {
     ])
   })
 })
+
+describe('arrangeSidebarSections — folded subagent groups', () => {
+  function parentWithChildren(childCount: number) {
+    const parentKey = 'agent:main:webchat:parent'
+    const items = [session({ key: parentKey, title: 'Parent', updatedAt: 500 })]
+    for (let index = 0; index < childCount; index++) {
+      items.push(session({
+        key: `agent:main:subagent:child-${index}`,
+        title: `Child ${index}`,
+        updatedAt: 400 - index,
+        parent: { key: parentKey, spawnDepth: 1 },
+      }))
+    }
+    return { parentKey, items }
+  }
+
+  it('keeps one to three direct subagents inline (no group)', () => {
+    const { items } = parentWithChildren(3)
+    const rows = sectionFor(arrangeSidebarSections(items), 'chats').rows
+
+    expect(rows).toHaveLength(4)
+    expect(rows[0].subagentGroup).toBeUndefined()
+    expect(rows.map(row => row.depth)).toEqual([0, 1, 1, 1])
+  })
+
+  it('folds four or more direct subagents into a compact group row', () => {
+    const { items } = parentWithChildren(4)
+    const rows = sectionFor(arrangeSidebarSections(items), 'chats').rows
+
+    expect(rows).toHaveLength(1)
+    const group = rows[0]
+    expect(group.title).toBe('Parent')
+    expect(group.subagentGroup).toBeDefined()
+    expect(group.subagentGroup!.count).toBe(4)
+    expect(group.subagentGroup!.children).toHaveLength(4)
+    expect(group.subagentGroup!.children.map(child => child.depth)).toEqual([1, 1, 1, 1])
+  })
+
+  it('summarizes running attention from a folded child', () => {
+    const parentKey = 'agent:main:webchat:parent'
+    const items = [
+      session({ key: parentKey, title: 'Parent', updatedAt: 500 }),
+      ...([0, 1, 2, 3].map(index => session({
+        key: `agent:main:subagent:child-${index}`,
+        title: `Child ${index}`,
+        updatedAt: 400 - index,
+        runStatus: index === 2 ? 'running' : 'idle',
+        parent: { key: parentKey, spawnDepth: 1 },
+      }))),
+    ]
+    const rows = sectionFor(arrangeSidebarSections(items), 'chats').rows
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].subagentGroup!.attention).toBe('running')
+  })
+
+  it('does not fold grandchildren into the flat ledger for non-group parents', () => {
+    const parentKey = 'agent:main:webchat:parent'
+    const childKey = 'agent:main:subagent:child'
+    const sections = arrangeSidebarSections([
+      session({ key: parentKey, title: 'Parent', updatedAt: 500 }),
+      session({ key: childKey, title: 'Child', updatedAt: 400, parent: { key: parentKey, spawnDepth: 1 } }),
+      session({
+        key: 'agent:main:subagent:grandchild',
+        title: 'Grandchild',
+        updatedAt: 300,
+        parent: { key: childKey, spawnDepth: 2 },
+      }),
+    ])
+
+    expect(sectionFor(sections, 'chats').rows.map(row => row.depth)).toEqual([0, 1, 2])
+  })
+})

--- a/opensquilla-webui/src/composables/useSessions.ts
+++ b/opensquilla-webui/src/composables/useSessions.ts
@@ -382,6 +382,92 @@ export interface SessionLedgerEntry {
   depth: number
   /** Resolved parent title for subagent rows; empty for root rows. */
   parentTitle: string
+  /**
+   * True on a parent entry with at least `SUBAGENT_GROUP_THRESHOLD` direct
+   * subagent children. `arrangeSessionLedger` keeps the flat list unchanged;
+   * `arrangeSidebarSections` folds such parents into one compact group row.
+   */
+  subagentGroup?: boolean
+  /** Direct subagent children folded under this parent (>= threshold). */
+  subagentGroupChildren?: SessionLedgerEntry[]
+}
+
+/** Minimum direct subagent children before a parent renders as a group. */
+export const SUBAGENT_GROUP_THRESHOLD = 4
+
+/**
+ * Fold parents with many simultaneous subagents into one group entry. The
+ * input is the flat `arrangeSessionLedger` output; the output keeps every
+ * root and non-group row in order, but a flagged parent carries its direct
+ * subagent children (and their descendants) in `subagentGroupChildren`
+ * instead of listing them flat, so the sidebar renders one compact row.
+ */
+export function foldSubagentGroupEntries(
+  entries: readonly SessionLedgerEntry[],
+): SessionLedgerEntry[] {
+  const groupKeys = new Set(
+    entries.filter(entry => entry.subagentGroup).map(entry => entry.item.key),
+  )
+  if (groupKeys.size === 0) return [...entries]
+
+  // Build parent -> ordered direct children from the flat ledger so the
+  // folded subtree keeps the exact traversal order the flat list used.
+  const byParent = new Map<string, SessionLedgerEntry[]>()
+  for (const entry of entries) {
+    const parentKey = sessionParentKey(entry.item)
+    if (!parentKey) continue
+    const list = byParent.get(parentKey) || []
+    list.push(entry)
+    byParent.set(parentKey, list)
+  }
+
+  const collectSubtree = (parentKey: string, depth: number): SessionLedgerEntry[] => {
+    const children = byParent.get(parentKey) || []
+    return children.map(child => ({
+      item: child.item,
+      depth: Math.min(child.depth, depth),
+      parentTitle: child.parentTitle,
+      subagentGroupChildren: collectSubtree(child.item.key, depth + 1),
+    }))
+  }
+
+  const folded: SessionLedgerEntry[] = []
+  const consumed = new Set<string>()
+  for (const entry of entries) {
+    if (consumed.has(entry.item.key)) continue
+    if (entry.subagentGroup) {
+      folded.push({
+        item: entry.item,
+        depth: entry.depth,
+        parentTitle: entry.parentTitle,
+        subagentGroup: true,
+        subagentGroupChildren: collectSubtree(entry.item.key, entry.depth + 1),
+      })
+      consumed.add(entry.item.key)
+      continue
+    }
+    // Any row whose ancestor chain leads into a folded group is carried by
+    // that group's `subagentGroupChildren`; never list it flat again.
+    let cursor = entry.item
+    let insideGroup = false
+    for (let hop = 0; hop < 4; hop++) {
+      const parentKey = sessionParentKey(cursor)
+      if (!parentKey) break
+      if (groupKeys.has(parentKey)) {
+        insideGroup = true
+        break
+      }
+      const parentItem = entries.find(candidate => candidate.item.key === parentKey)?.item
+      if (!parentItem) break
+      cursor = parentItem
+    }
+    if (insideGroup) {
+      consumed.add(entry.item.key)
+      continue
+    }
+    folded.push(entry)
+  }
+  return folded
 }
 
 /**
@@ -405,8 +491,18 @@ export function arrangeSessionLedger(items: SessionItem[]): SessionLedgerEntry[]
   }
   const entries: SessionLedgerEntry[] = []
   const visit = (item: SessionItem, depth: number, parentTitle: string) => {
-    entries.push({ item, depth, parentTitle: depth > 0 ? parentTitle : '' })
-    for (const child of children.get(item.key) || []) {
+    const directChildren = children.get(item.key) || []
+    entries.push({
+      item,
+      depth,
+      parentTitle: depth > 0 ? parentTitle : '',
+      // Flag parents with many simultaneous subagents so the sidebar can fold
+      // them into one compact group row. The flat list is unchanged — every
+      // child is still listed — so SessionsView and other consumers are
+      // unaffected; only `arrangeSidebarSections` acts on the flag.
+      subagentGroup: depth === 0 && directChildren.length >= SUBAGENT_GROUP_THRESHOLD,
+    })
+    for (const child of directChildren) {
       visit(child, Math.min(depth + 1, 3), item.title)
     }
   }
@@ -449,6 +545,17 @@ export interface SidebarSectionRow {
   provisional?: boolean
   /** Local sidebar preference; never changes the underlying session contract. */
   pinned?: boolean
+  /**
+   * Present on a parent row whose direct subagents were folded into a compact
+   * group (>= SUBAGENT_GROUP_THRESHOLD). `children` holds the folded rows so
+   * the sidebar can expand the group on demand; `count` and `attention`
+   * summarize the group for the collapsed header.
+   */
+  subagentGroup?: {
+    count: number
+    attention: SessionTaskAttention
+    children: SidebarSectionRow[]
+  }
 }
 
 /** One collapsible family section with its recency-ordered rows. */
@@ -546,6 +653,29 @@ export function arrangeSidebarSections(
     pinned: pinnedKeys.has(item.key),
   })
 
+  /** Convert one ledger entry (possibly a folded subagent group) to a row. */
+  const entryToRow = (entry: SessionLedgerEntry, depthOverride?: number): SidebarSectionRow => {
+    const row = toRow(entry.item, depthOverride ?? entry.depth)
+    const children = entry.subagentGroupChildren
+    if (!children?.length) return row
+    const childRows = children.map(child => entryToRow(child))
+    const attention: SessionTaskAttention = childRows.some(r => r.taskAttention === 'running')
+      ? 'running'
+      : childRows.some(r => r.taskAttention === 'failed')
+        ? 'failed'
+        : childRows.some(r => r.taskAttention === 'completed')
+          ? 'completed'
+          : 'none'
+    return {
+      ...row,
+      subagentGroup: {
+        count: childRows.length,
+        attention,
+        children: childRows,
+      },
+    }
+  }
+
   type WorkspaceBucket = {
     title: string
     displayPath?: string
@@ -562,7 +692,7 @@ export function arrangeSidebarSections(
     let index = 0
 
     for (const entry of entries) {
-      const row = toRow(entry.item, entry.depth)
+      const row = entryToRow(entry)
       const workspace = entry.item.workspace
       if (!workspace) {
         topLevel.push({ kind: 'row', row, index: index++ })
@@ -666,7 +796,7 @@ export function arrangeSidebarSections(
         })
       } else {
         rows.push(...projectEntries.map(entry => ({
-          ...toRow(entry.item, Math.min(entry.depth + 1, 4)),
+          ...entryToRow(entry, Math.min(entry.depth + 1, 4)),
           workspaceId: project.id,
         })))
       }
@@ -674,7 +804,7 @@ export function arrangeSidebarSections(
     rows.push(
       ...entries
         .filter(entry => !entry.item.workspaceId)
-        .map(entry => toRow(entry.item, entry.depth)),
+        .map(entry => entryToRow(entry)),
     )
     // Sessions belonging to a removed project remain durable but hidden until
     // that project is restored to the canonical project list.
@@ -687,7 +817,11 @@ export function arrangeSidebarSections(
     if (family === 'chats') {
       // Recency-sort first so the ledger's root ordering follows recency, then
       // flatten parent → child so subagents indent directly beneath their chat.
-      const ledger = arrangeSessionLedger([...bucket].sort(bySidebarOrder))
+      // Parents with SUBAGENT_GROUP_THRESHOLD+ direct subagents fold them into
+      // one compact group row instead of pushing every child into the ledger.
+      const ledger = foldSubagentGroupEntries(
+        arrangeSessionLedger([...bucket].sort(bySidebarOrder)),
+      )
       rows = projects === undefined
         ? arrangeWorkspaceRows(ledger)
         : arrangePersistedProjectRows(ledger, projects)

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -4087,6 +4087,7 @@
       "taskRunning": "Aufgabe wird ausgeführt",
       "taskCompletedUnread": "Aufgabe abgeschlossen, Ergebnis nicht angesehen",
       "taskUnfinishedUnread": "Aufgabe nicht abgeschlossen, Details nicht angesehen",
+      "subagentGroupLabel": "{title}: {count} Unteragenten",
       "contractGap": "Backend-Vertragsfelder von session-list-v1 fehlen",
       "contractGapBadge": "Lücke",
       "rowActions": "Aktionen für {title}",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -4140,6 +4140,7 @@
       "taskRunning": "Task running",
       "taskCompletedUnread": "Task completed, result not viewed",
       "taskUnfinishedUnread": "Task unfinished, details not viewed",
+      "subagentGroupLabel": "{title}: {count} subagents",
       "contractGap": "Backend session-list-v1 contract fields are missing",
       "contractGapBadge": "Gap",
       "rowActions": "Actions for {title}",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -4087,6 +4087,7 @@
       "taskRunning": "Tarea en curso",
       "taskCompletedUnread": "Tarea completada, resultado sin ver",
       "taskUnfinishedUnread": "Tarea sin completar, detalles sin ver",
+      "subagentGroupLabel": "{title}: {count} subagentes",
       "contractGap": "Faltan campos del contrato session-list-v1 del backend",
       "contractGapBadge": "Laguna",
       "rowActions": "Acciones para {title}",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -4087,6 +4087,7 @@
       "taskRunning": "Tâche en cours",
       "taskCompletedUnread": "Tâche terminée, résultat non consulté",
       "taskUnfinishedUnread": "Tâche inachevée, détails non consultés",
+      "subagentGroupLabel": "{title} : {count} sous-agents",
       "contractGap": "Des champs du contrat backend session-list-v1 sont manquants",
       "contractGapBadge": "Lacune",
       "rowActions": "Actions pour {title}",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -4087,6 +4087,7 @@
       "taskRunning": "タスクを実行中",
       "taskCompletedUnread": "タスク完了、結果は未確認",
       "taskUnfinishedUnread": "タスク未完了、詳細は未確認",
+      "subagentGroupLabel": "{title}：{count} サブエージェント",
       "contractGap": "バックエンドの session-list-v1 契約フィールドが不足しています",
       "contractGapBadge": "不足",
       "rowActions": "{title} のアクション",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -4140,6 +4140,7 @@
       "taskRunning": "任务运行中",
       "taskCompletedUnread": "任务已完成，结果未查看",
       "taskUnfinishedUnread": "任务未完成，详情未查看",
+      "subagentGroupLabel": "{title}：{count} 个子代理",
       "contractGap": "缺少后端 session-list-v1 契约字段",
       "contractGapBadge": "缺失",
       "rowActions": "{title} 的操作",

--- a/opensquilla-webui/src/styles/control-visual-system.css
+++ b/opensquilla-webui/src/styles/control-visual-system.css
@@ -792,6 +792,41 @@ summary.control-row--divider:focus-visible {
   pointer-events: none;
 }
 
+/* ── Sidebar: folded subagent group header ─────────────────────────── */
+
+.sidebar-subagent-group-head {
+  color: var(--sidebar-text);
+  gap: 6px;
+}
+.sidebar-subagent-group-head .sidebar-history-title {
+  flex: 1;
+}
+.sidebar-subagent-group-chevron {
+  color: var(--sidebar-text-soft);
+  flex-shrink: 0;
+  transition: transform var(--dur-base) var(--ease-standard);
+}
+.sidebar-subagent-group-head.is-expanded .sidebar-subagent-group-chevron {
+  transform: rotate(90deg);
+}
+.sidebar-subagent-group-count {
+  align-items: center;
+  background: var(--sidebar-control-bg);
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-full);
+  color: var(--sidebar-text-soft);
+  display: inline-flex;
+  flex-shrink: 0;
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
+  height: 18px;
+  justify-content: center;
+  line-height: 1;
+  min-width: 18px;
+  padding-inline: 5px;
+}
+
 /* ── Sidebar: inline rename input ──────────────────────────────────── */
 
 .sidebar-history-rename {

--- a/src/opensquilla/engine/artifact_delivery.py
+++ b/src/opensquilla/engine/artifact_delivery.py
@@ -248,6 +248,22 @@ def auto_publish_omitted_workspace_artifacts(
         if not _text_mentions_written_file(final_text, record):
             continue
 
+        target_key = artifact_delivery_publish_target_key(
+            str(target),
+            workspace_dir=workspace,
+        )
+        name_key = artifact_delivery_name_target_key(target.name)
+        if target_key is not None and target_key in getattr(
+            ctx, "published_artifact_source_keys", frozenset()
+        ):
+            # The same source file was explicitly published earlier this turn,
+            # possibly under a custom display name. Do not publish it a second
+            # time under its original filename.
+            for resolved_key in (target_key, name_key):
+                if resolved_key is not None and resolved_key not in resolved_target_keys:
+                    resolved_target_keys.append(resolved_key)
+            continue
+
         try:
             artifact_mime = artifact_mime_for_name(target.name)
             publish_max_bytes = artifact_publish_max_bytes_for_name(
@@ -288,11 +304,6 @@ def auto_publish_omitted_workspace_artifacts(
                 pptx_payload if pptx_payload is not None else target.read_bytes()
             ).hexdigest()
             artifact_key = (target_sha256, _safe_filename(target.name))
-            target_key = artifact_delivery_publish_target_key(
-                str(target),
-                workspace_dir=workspace,
-            )
-            name_key = artifact_delivery_name_target_key(target.name)
             if artifact_key in known_artifact_keys:
                 for resolved_key in (target_key, name_key):
                     if (

--- a/src/opensquilla/tools/builtin/artifacts.py
+++ b/src/opensquilla/tools/builtin/artifacts.py
@@ -59,6 +59,31 @@ def _bundle_result(manifest: ArtifactBundleManifest) -> dict[str, object]:
     }
 
 
+def _record_published_artifact_source_key(
+    ctx: ToolContext,
+    target: Path,
+    workspace: Path,
+) -> None:
+    """Record a successfully published file's canonical workspace identity.
+
+    The omitted-artifact backstop consults this per-turn set so a source file
+    explicitly published under a custom display name is not published a second
+    time under its original filename. The import is deferred to keep this tool
+    module import-cycle-free.
+    """
+
+    from opensquilla.engine.artifact_delivery import (
+        artifact_delivery_publish_target_key,
+    )
+
+    source_key = artifact_delivery_publish_target_key(
+        str(target),
+        workspace_dir=workspace,
+    )
+    if source_key is not None:
+        ctx.published_artifact_source_keys.add(source_key)
+
+
 def _normalized_filename(value: str) -> str:
     return "".join(ch for ch in value.lower() if ch.isalnum())
 
@@ -577,6 +602,7 @@ async def publish_artifact(
         payload = artifact_payload(existing)
         if not any(item.get("id") == payload.get("id") for item in ctx.published_artifacts):
             ctx.published_artifacts.append(payload)
+        _record_published_artifact_source_key(ctx, target, workspace)
         llm_artifact = _llm_artifact_payload(
             payload,
             ctx=ctx,
@@ -640,6 +666,7 @@ async def publish_artifact(
 
     payload = artifact_payload(ref)
     ctx.published_artifacts.append(payload)
+    _record_published_artifact_source_key(ctx, target, workspace)
     llm_artifact = _llm_artifact_payload(
         payload,
         ctx=ctx,

--- a/src/opensquilla/tools/types.py
+++ b/src/opensquilla/tools/types.py
@@ -193,6 +193,12 @@ class ToolContext:
     # and projection code use this bit to avoid replacing raw tool output with
     # a handle that the current model is not authorized to retrieve.
     tool_result_retrieval_available: bool = False
+    # Canonical workspace source identities ("path:...") of files successfully
+    # published during this turn via publish_artifact. The omitted-artifact
+    # backstop consults this to avoid re-publishing the same source file under
+    # its original filename after an explicit publish used a custom display
+    # name. Runtime-only; never serialized into task details or transcripts.
+    published_artifact_source_keys: set[str] = field(default_factory=set)
 
     def __post_init__(self) -> None:
         self.validate_path_roots()

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1829,6 +1829,61 @@ async def test_publish_artifact_tool_is_idempotent_for_existing_turn_artifact(
 
 
 @pytest.mark.asyncio
+async def test_backstop_skips_file_explicitly_published_with_custom_name(
+    tmp_path: Path,
+) -> None:
+    from opensquilla.engine.artifact_delivery import (
+        auto_publish_omitted_workspace_artifacts,
+    )
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "index.html"
+    target.write_text("<title>World Countries</title>", encoding="utf-8")
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+    )
+    ctx.workspace_file_writes.append(
+        {
+            "created": True,
+            "path": str(target),
+            "relative_path": "index.html",
+            "name": target.name,
+        }
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        result = json.loads(
+            await publish_artifact(
+                path="index.html",
+                name="World Countries Overview",
+            )
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result["status"] == "published"
+    assert result["artifact"]["name"] == "World Countries Overview.html"
+    assert len(ctx.published_artifacts) == 1
+
+    publish_result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="I created index.html for you.",
+    )
+
+    assert publish_result.artifacts == []
+    assert publish_result.failure_summaries == []
+    assert len(ctx.published_artifacts) == 1
+    assert ctx.published_artifacts[0]["name"] == "World Countries Overview.html"
+
+
+@pytest.mark.asyncio
 async def test_publish_artifact_tool_reuses_existing_session_deliverable_across_contexts(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_engine/test_runtime_artifacts.py
+++ b/tests/test_engine/test_runtime_artifacts.py
@@ -2495,6 +2495,55 @@ def test_auto_publish_dedupes_current_artifact_by_store_safe_name(
     assert len(ctx.published_artifacts) == 1
 
 
+def test_auto_publish_keeps_distinct_source_paths_with_identical_content(
+    tmp_path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    first = workspace / "a.html"
+    second = workspace / "b.html"
+    payload = b"<title>identical</title>"
+    first.write_bytes(payload)
+    second.write_bytes(payload)
+    first_sha = hashlib.sha256(payload).hexdigest()
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-identical",
+        session_key="agent:main:webchat:identical",
+    )
+    # a.html was explicitly published this turn under a custom display name.
+    ctx.published_artifacts.append(
+        {"id": "art-a", "sha256": first_sha, "name": "Overview A.html"}
+    )
+    ctx.published_artifact_source_keys.add(
+        artifact_delivery_publish_target_key(
+            str(first.resolve()),
+            workspace_dir=workspace,
+        )
+    )
+    for name, path in (("a.html", first), ("b.html", second)):
+        ctx.workspace_file_writes.append(
+            {
+                "created": True,
+                "path": str(path),
+                "relative_path": name,
+                "name": name,
+            }
+        )
+
+    result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="Created a.html and b.html for you.",
+    )
+
+    assert len(result.artifacts) == 1
+    assert result.artifacts[0]["name"] == "b.html"
+    assert len(ctx.published_artifacts) == 2
+
+
 def test_auto_publish_oversized_pptx_preflights_before_read_or_validation(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Scope

Scope boundary: Web UI sidebar only (SidebarConversations + useSessions ledger arrangement + shared sidebar styles + six locale strings).

Non-goals: No gateway/RPC change. SessionsView (the separate ledger view) keeps the flat per-child list; only the sidebar folds groups. Parent-session selection, rename/delete, drag ordering, and hover cards are unchanged for the expanded children.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #1209

## Release Note

Release note: When one session spawns four or more subagent sessions at once, the sidebar now shows one compact, collapsible group row (parent title + child count + attention summary) instead of pushing every child row into the task list. Clicking the header expands the children inline; clicking again collapses them.

## Tests

Ruff: N/A (no Python changed)

Pytest: N/A (no Python changed)

Build: `npm run typecheck` — all 11 architecture guards pass, including i18n key parity across the six locales; `vue-tsc --noEmit` clean

Regression tests: added/updated
- `useSessions.sections.test.ts` (21 tests): 1-3 subagents stay inline; 4+ fold into one group row with count and depth-preserved children; running attention summarized on the group; non-group parents keep flat grandchildren
- `SidebarConversations.task-attention.test.ts` (5 tests): collapsed header with count + aria-expanded=false; click expands children and second click collapses; running attention marker in the header; plain rows unaffected

Notes:
- 58 tests pass across the six sidebar-related suites (sections, task-attention, workspaces, bulk-actions, pagination, utils)

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

No secrets or private artifacts.

## Third-Party Origin

Third-party origin: none
