### PR TITLE
feat(webui): allow cancelling a running MetaSkill install

### DIFF
--- a/opensquilla-webui/src/components/SidebarConversations.task-attention.test.ts
+++ b/opensquilla-webui/src/components/SidebarConversations.task-attention.test.ts
@@ -73,3 +73,86 @@ describe('SidebarConversations task attention', () => {
     expect(root.querySelector('.sidebar-history-run')).toBeNull()
   })
 })
+
+function groupRow(
+  parentKey: string,
+  count: number,
+  attention: SidebarSectionRow['taskAttention'],
+  children: SidebarSectionRow[],
+): SidebarSectionRow {
+  return {
+    rowKind: 'session',
+    key: parentKey,
+    title: parentKey,
+    effectiveAgentId: 'main',
+    agentName: 'Main',
+    sessionKind: 'chat',
+    depth: 0,
+    runStatus: 'idle',
+    runLabel: 'Idle',
+    taskAttention: 'none',
+    updatedAt: Date.now(),
+    hasContractGaps: false,
+    subagentGroup: { count, attention, children },
+  }
+}
+
+describe('SidebarConversations folded subagent groups', () => {
+  it('renders a collapsed group header with the child count by default', async () => {
+    const children = [0, 1, 2, 3].map(index => ({
+      ...taskRow(`child-${index}`, 'none'),
+      depth: 1,
+    }))
+    const root = await mountSidebar([groupRow('parent', 4, 'none', children)])
+
+    const groupHead = root.querySelector<HTMLElement>('.sidebar-subagent-group-head')!
+    expect(groupHead).not.toBeNull()
+    expect(groupHead.getAttribute('aria-expanded')).toBe('false')
+    expect(root.querySelector('[data-testid="sidebar-subagent-group-count"]')!.textContent).toBe('4')
+    // Children stay hidden while collapsed.
+    expect(root.querySelector('[data-session-key="child-0"]')).toBeNull()
+  })
+
+  it('expands the group on click and hides it again on a second click', async () => {
+    const children = [0, 1, 2, 3].map(index => ({
+      ...taskRow(`child-${index}`, 'none'),
+      depth: 1,
+    }))
+    const root = await mountSidebar([groupRow('parent', 4, 'none', children)])
+    const groupHead = root.querySelector<HTMLElement>('.sidebar-subagent-group-head')!
+
+    groupHead.click()
+    await nextTick()
+    expect(groupHead.getAttribute('aria-expanded')).toBe('true')
+    expect(root.querySelector('[data-session-key="child-0"]')).not.toBeNull()
+    expect(root.querySelector('[data-session-key="child-3"]')).not.toBeNull()
+
+    groupHead.click()
+    await nextTick()
+    // The TransitionGroup leave animation keeps a leaving row in the DOM for
+    // one frame; wait for it to settle before asserting the collapse.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    await nextTick()
+    expect(groupHead.getAttribute('aria-expanded')).toBe('false')
+    expect(root.querySelector('[data-session-key="child-0"]')).toBeNull()
+  })
+
+  it('surfaces a running group attention marker in the collapsed header', async () => {
+    const children = [0, 1, 2, 3].map(index => ({
+      ...taskRow(`child-${index}`, index === 1 ? 'running' : 'none'),
+      depth: 1,
+    }))
+    const root = await mountSidebar([groupRow('parent', 4, 'running', children)])
+
+    const marker = root.querySelector<HTMLElement>('[data-testid="sidebar-task-attention"]')!
+    expect(marker).not.toBeNull()
+    expect(marker.classList).toContain('sidebar-task-attention--running')
+    expect(marker.getAttribute('aria-label')).toBe('Task running')
+  })
+
+  it('keeps a plain row interactive when it is not a group', async () => {
+    const root = await mountSidebar([taskRow('plain', 'none')])
+    expect(root.querySelector('.sidebar-subagent-group-head')).toBeNull()
+    expect(root.querySelector('[data-session-key="plain"]')).not.toBeNull()
+  })
+})

--- a/opensquilla-webui/src/components/SidebarConversations.vue
+++ b/opensquilla-webui/src/components/SidebarConversations.vue
@@ -139,6 +139,16 @@ function taskAttentionLabel(attention: SessionTaskAttention | undefined): string
   return key ? t(key) : ''
 }
 
+function subagentGroupLabel(row: SidebarConversationItem): string {
+  if (!row.subagentGroup) return ''
+  const base = t('shared.sidebar.subagentGroupLabel', {
+    title: row.title,
+    count: row.subagentGroup.count,
+  })
+  const attention = taskAttentionLabel(row.subagentGroup.attention)
+  return attention ? `${base} — ${attention}` : base
+}
+
 /* ── Agent filter (lives within the Chats section) ─────────────────── */
 
 const agentFilter = ref('')
@@ -252,6 +262,43 @@ function filterCollapsedProjectRows<T extends SidebarConversationItem>(rows: T[]
   return result
 }
 
+/* ── Subagent group expansion ─────────────────────────────────────── */
+
+// Parent keys whose folded subagent group is expanded by the user. Kept in
+// memory only: the collapsed-by-default state is the stable presentation, and
+// an expansion is a temporary inspection choice like any other disclosure.
+const expandedSubagentGroups = ref<Set<string>>(new Set())
+
+function isSubagentGroupExpanded(row: SidebarConversationItem): boolean {
+  return Boolean(row.subagentGroup && expandedSubagentGroups.value.has(row.key))
+}
+
+function toggleSubagentGroup(row: SidebarConversationItem) {
+  if (!row.subagentGroup) return
+  const next = new Set(expandedSubagentGroups.value)
+  if (next.has(row.key)) next.delete(row.key)
+  else next.add(row.key)
+  expandedSubagentGroups.value = next
+}
+
+/** Flatten a row list, expanding any user-opened subagent groups. */
+function expandSubagentGroups<T extends SidebarDisplayRow>(rows: T[]): T[] {
+  const out: T[] = []
+  for (const row of rows) {
+    out.push(row)
+    if (!isSubagentGroupExpanded(row) || !row.subagentGroup) continue
+    for (const child of row.subagentGroup.children) {
+      out.push({
+        ...child,
+        displayZone: row.displayZone,
+        displayFamily: row.displayFamily,
+        displayProjectName: row.displayProjectName,
+      } as T)
+    }
+  }
+  return out
+}
+
 // Sections with at least one row, honoring the agent filter inside Chats.
 const filteredSections = computed(() => {
   return props.sections
@@ -292,7 +339,7 @@ const displayBlocks = computed<SidebarDisplayBlock[]>(() => {
       zone: 'pinned',
       label: t('shared.sidebar.pinned'),
       count: projection.pinned.length,
-      rows: projection.pinned,
+      rows: expandSubagentGroups(projection.pinned),
       showHeading: true,
     })
   }
@@ -302,7 +349,7 @@ const displayBlocks = computed<SidebarDisplayBlock[]>(() => {
       zone: 'projects',
       label: t('workspaces.projects'),
       count: projection.projectCount,
-      rows: filterCollapsedProjectRows(projection.projects),
+      rows: expandSubagentGroups(filterCollapsedProjectRows(projection.projects)),
       showHeading: true,
     })
   }
@@ -322,7 +369,7 @@ const displayBlocks = computed<SidebarDisplayBlock[]>(() => {
         zone: 'recents',
         label: t('shared.sidebar.recents'),
         count: projection.recentCount,
-        rows: section.rows,
+        rows: expandSubagentGroups(section.rows),
         showHeading: index === 0,
         family: section.family,
         familyLabel: section.label,
@@ -1117,6 +1164,39 @@ function onSelectRow(row: SidebarConversationItem) {
               @keydown.esc.prevent="cancelRename"
               @blur="onRenameBlur"
             />
+
+            <button
+              v-else-if="row.rowKind === 'session' && row.subagentGroup"
+              type="button"
+              class="sidebar-history-item sidebar-subagent-group-head"
+              :class="{ 'is-expanded': isSubagentGroupExpanded(row) }"
+              :aria-expanded="isSubagentGroupExpanded(row)"
+              :aria-label="subagentGroupLabel(row)"
+              :title="subagentGroupLabel(row)"
+              @click="toggleSubagentGroup(row)"
+            >
+              <Icon
+                class="sidebar-subagent-group-chevron"
+                name="chevronRight"
+                :size="12"
+                aria-hidden="true"
+              />
+              <span class="sidebar-history-title">{{ row.title }}</span>
+              <span
+                class="sidebar-subagent-group-count"
+                data-testid="sidebar-subagent-group-count"
+                aria-hidden="true"
+              >{{ row.subagentGroup.count }}</span>
+              <span
+                v-if="!selectionMode && row.subagentGroup.attention !== 'none'"
+                class="sidebar-task-attention"
+                :class="`sidebar-task-attention--${row.subagentGroup.attention}`"
+                role="img"
+                :aria-label="taskAttentionLabel(row.subagentGroup.attention) || undefined"
+                :title="taskAttentionLabel(row.subagentGroup.attention) || undefined"
+                data-testid="sidebar-task-attention"
+              />
+            </button>
 
             <button
               v-else-if="row.rowKind === 'session'"

--- a/opensquilla-webui/src/components/skills/SkillsAddDrawer.test.ts
+++ b/opensquilla-webui/src/components/skills/SkillsAddDrawer.test.ts
@@ -47,6 +47,7 @@ function mountDrawer(options: {
   const installed: Array<[string, string, string]> = []
   const retried: Array<[string, boolean | undefined]> = []
   const cleared: SkillInstallSource[] = []
+  const cancelled: SkillInstallSource[] = []
 
   const Root = defineComponent({
     setup() {
@@ -75,6 +76,9 @@ function mountDrawer(options: {
           onRetry: (id: string, acknowledgeRisk?: boolean) => {
             retried.push([id, acknowledgeRisk])
           },
+          onCancelInstall: (source: SkillInstallSource) => {
+            cancelled.push(source)
+          },
           onClearActivity: (source: SkillInstallSource) => {
             cleared.push(source)
             activities.value[source] = { items: [], refreshWarning: '' }
@@ -101,6 +105,7 @@ function mountDrawer(options: {
     installed,
     retried,
     cleared,
+    cancelled,
   }
 }
 
@@ -792,5 +797,66 @@ describe('SkillsAddDrawer', () => {
     expect(result.textContent).toContain('Installation result unknown')
     expect(result.textContent).toContain('View details')
     expect(result.textContent).not.toContain('connection closed')
+  })
+
+  it('offers a cancel action while a queue for the visible source is running', async () => {
+    const queue: SkillInstallQueueItem[] = [{
+      id: 'q1',
+      identifier: '@acme/one',
+      source: 'github',
+      displayName: 'One',
+      status: 'installing',
+    }, {
+      id: 'q2',
+      identifier: '@acme/two',
+      source: 'github',
+      displayName: 'Two',
+      status: 'queued',
+    }]
+    const { cancelled } = mountDrawer({ queue, runningSource: 'github' })
+    document.querySelector<HTMLButtonElement>('#drawer-trigger')?.click()
+    await nextTick()
+
+    const cancelButton = document.querySelector<HTMLButtonElement>('[data-testid="skills-cancel-install"]')
+    expect(cancelButton).not.toBeNull()
+    cancelButton!.click()
+    await nextTick()
+
+    expect(cancelled).toEqual(['github'])
+  })
+
+  it('hides the cancel action when the running source differs from the visible one', async () => {
+    const queue: SkillInstallQueueItem[] = [{
+      id: 'q1',
+      identifier: '@acme/one',
+      source: 'clawhub',
+      displayName: 'One',
+      status: 'installing',
+    }]
+    mountDrawer({ queue, runningSource: 'clawhub' })
+    document.querySelector<HTMLButtonElement>('#drawer-trigger')?.click()
+    await nextTick()
+
+    // The drawer opens on the GitHub source by default, so the running
+    // ClawHub queue must not expose a cancel button here.
+    expect(document.querySelector('[data-testid="skills-cancel-install"]')).toBeNull()
+  })
+
+  it('renders a cancelled queue item with its dedicated status label', async () => {
+    const queue: SkillInstallQueueItem[] = [{
+      id: 'q1',
+      identifier: '@acme/one',
+      source: 'github',
+      displayName: 'One',
+      status: 'cancelled',
+    }]
+    mountDrawer({ queue })
+    document.querySelector<HTMLButtonElement>('#drawer-trigger')?.click()
+    await nextTick()
+
+    const item = document.querySelector<HTMLElement>('.sk-add-queue-item')
+    expect(item).not.toBeNull()
+    expect(item!.textContent).toContain('Cancelled')
+    expect(item!.getAttribute('data-status')).toBe('cancelled')
   })
 })

--- a/opensquilla-webui/src/components/skills/SkillsAddDrawer.vue
+++ b/opensquilla-webui/src/components/skills/SkillsAddDrawer.vue
@@ -104,6 +104,16 @@
                 </div>
                 <div class="sk-add-section-title__actions">
                   <button
+                    v-if="currentQueueRunning"
+                    class="btn btn--ghost btn--sm sk-add-cancel"
+                    type="button"
+                    data-testid="skills-cancel-install"
+                    @click="emit('cancelInstall', sourceMode)"
+                  >
+                    <Icon name="x" :size="14" />
+                    <span>{{ t('cronSkills.registry.cancelInstall') }}</span>
+                  </button>
+                  <button
                     class="btn btn--ghost btn--sm"
                     type="button"
                     :disabled="installControlsBlocked"
@@ -399,6 +409,7 @@ const emit = defineEmits<{
   installGithub: []
   install: [identifier: string, source: string, displayName: string]
   retry: [id: string, acknowledgeRisk?: boolean]
+  cancelInstall: [source: SkillInstallSource]
   clearActivity: [source: SkillInstallSource]
 }>()
 

--- a/opensquilla-webui/src/composables/skills/useSkillRegistry.test.ts
+++ b/opensquilla-webui/src/composables/skills/useSkillRegistry.test.ts
@@ -783,3 +783,74 @@ describe('useSkillRegistry install state', () => {
     ])
   })
 })
+
+describe('useSkillRegistry cancel install', () => {
+  function deferredInstall() {
+    const pending = {
+      resolveCall: (_value: unknown) => {},
+      rejectCall: (_reason?: unknown) => {},
+    }
+    const call = vi.fn((method: string) => {
+      if (method === 'skills.install') {
+        return new Promise((resolve, reject) => {
+          pending.resolveCall = resolve
+          pending.rejectCall = reject
+        })
+      }
+      throw new Error(`Unexpected RPC method: ${method}`)
+    })
+    return { call, pending }
+  }
+
+  it('marks queued items cancelled and never refreshes the catalog when cancelled mid-batch', async () => {
+    const { call, pending } = deferredInstall()
+    const loadData = vi.fn(async () => true)
+    const registry = useSkillRegistry({ call } as never, loadData)
+    registry.githubUrl.value = ['https://github.com/a/one', 'https://github.com/b/two', 'https://github.com/c/three'].join('\n')
+
+    const batch = registry.installGithub()
+    // First item is in flight; the rest are queued behind it.
+    await Promise.resolve()
+    expect(registry.installActivities.value.github.items[0].status).toBe('installing')
+
+    await registry.cancelInstall('github')
+    // The in-flight item settles with its real outcome.
+    pending.resolveCall({ success: true, installed: true, name: 'First' })
+    await batch
+
+    const statuses = registry.installActivities.value.github.items.map(item => item.status)
+    expect(statuses[0]).toBe('installed')
+    expect(statuses.slice(1)).toEqual(['cancelled', 'cancelled'])
+    expect(loadData).not.toHaveBeenCalled()
+    expect(registry.queueRunning.value).toBe(false)
+    expect(registry.mutationBusy.value).toBe(false)
+  })
+
+  it('keeps a failed in-flight outcome and still cancels the tail', async () => {
+    const { call, pending } = deferredInstall()
+    const loadData = vi.fn(async () => true)
+    const registry = useSkillRegistry({ call } as never, loadData)
+    registry.githubUrl.value = ['https://github.com/a/one', 'https://github.com/b/two', 'https://github.com/c/three'].join('\n')
+
+    const batch = registry.installGithub()
+    await Promise.resolve()
+    await registry.cancelInstall('github')
+    pending.rejectCall(new Error('network down'))
+    await batch
+
+    const statuses = registry.installActivities.value.github.items.map(item => item.status)
+    expect(statuses[0]).toBe('unknown')
+    expect(statuses.slice(1)).toEqual(['cancelled', 'cancelled'])
+    expect(registry.queueRunning.value).toBe(false)
+  })
+
+  it('is a no-op when the source is not currently running', async () => {
+    const call = vi.fn(async () => ({ success: true, installed: true }))
+    const registry = useSkillRegistry({ call } as never, vi.fn(async () => true))
+
+    await registry.cancelInstall('clawhub')
+
+    expect(registry.queueRunning.value).toBe(false)
+    expect(call).not.toHaveBeenCalled()
+  })
+})

--- a/opensquilla-webui/src/composables/skills/useSkillRegistry.ts
+++ b/opensquilla-webui/src/composables/skills/useSkillRegistry.ts
@@ -48,6 +48,7 @@ export type SkillInstallQueueStatus =
   | 'installed'
   | 'unchanged'
   | 'deferred'
+  | 'cancelled'
   | 'unknown'
   | 'failed'
 
@@ -199,6 +200,7 @@ export interface SkillRegistry {
   installGithub: () => Promise<void>
   installSkill: (identifier: string, source: string, displayName?: string) => Promise<void>
   retryQueueItem: (id: string, acknowledgeRisk?: boolean) => Promise<void>
+  cancelInstall: (source: SkillInstallSource) => Promise<void>
   clearInstallActivity: (source: SkillInstallSource) => void
   installDeps: (
     name: string,
@@ -229,6 +231,7 @@ export function useSkillRegistry(
   })
   const runningSource = ref<SkillInstallSource | null>(null)
   const queueRunning = computed(() => runningSource.value !== null)
+  const cancelRequested = ref<SkillInstallSource | null>(null)
   const mutationBusy = computed(() => mutationGate.busy.value)
   const installingDepsId = ref<string | null>(null)
   const uninstallingName = ref<string | null>(null)
@@ -335,6 +338,18 @@ export function useSkillRegistry(
     riskConfirmation = '',
   ) {
     for (const [index, item] of items.entries()) {
+      if (cancelRequested.value) {
+        // A cancellation was requested while an earlier item was installing.
+        // Anything not yet attempted is a pending install: mark it cancelled
+        // so the queue settles into an explicit cancelled state.
+        for (const pending of items.slice(index)) {
+          if (pending.status === 'queued') {
+            pending.status = 'cancelled'
+            pending.error = ''
+          }
+        }
+        break
+      }
       item.status = 'installing'
       item.error = ''
       item.result = undefined
@@ -363,12 +378,33 @@ export function useSkillRegistry(
       } finally {
         installingId.value = null
       }
+      if (cancelRequested.value) {
+        // The in-flight install already settled; it keeps its real outcome.
+        // Anything still queued is cancelled (handled by the loop guard).
+        continue
+      }
       if (!rateLimited) continue
       for (const deferred of items.slice(index + 1)) {
         deferred.status = 'deferred'
         deferred.error = ''
       }
       break
+    }
+  }
+
+  /**
+   * Ask the running queue for one source to stop. The current in-flight
+   * install is allowed to settle (its real outcome is preserved); every item
+   * that was still queued behind it is marked cancelled and the batch settles
+   * into the explicit cancelled state without touching the catalog. The
+   * running batch's `finally` block performs the actual cleanup, so this is a
+   * cheap flag flip even when a request is mid-flight.
+   */
+  async function cancelInstall(source: SkillInstallSource) {
+    if (runningSource.value !== source) return
+    cancelRequested.value = source
+    for (const item of installActivities.value[source].items) {
+      if (item.status === 'queued') item.status = 'cancelled'
     }
   }
 
@@ -379,6 +415,28 @@ export function useSkillRegistry(
       item.error ||= t('cronSkills.registry.installResultUnknown')
     }
     installActivities.value[source].phase = 'terminal'
+  }
+
+  function finishBatch(source: SkillInstallSource, items: SkillInstallQueueItem[]) {
+    const cancelled = cancelRequested.value === source
+    if (cancelled) {
+      // Cancellation is the user's explicit terminal state: keep any queued
+      // item marked cancelled (not "unknown"), never refresh the catalog, and
+      // release the mutation gate without pretending a partial failure.
+      for (const item of items) {
+        if (item.status === 'queued') {
+          item.status = 'cancelled'
+          item.error = ''
+        }
+      }
+    } else {
+      settleInterruptedItems(source)
+    }
+    installActivities.value[source].phase = 'terminal'
+    runningSource.value = null
+    installingId.value = null
+    cancelRequested.value = null
+    mutationGate.release('install_queue')
   }
 
   async function runNewBatch(requests: SkillInstallRequest[]) {
@@ -392,13 +450,11 @@ export function useSkillRegistry(
     runningSource.value = source
     try {
       await processQueueItems(activityItems)
+      if (cancelRequested.value === source) return
       removeSuccessfulGithubLines(activityItems)
       await refreshCatalogAfterBatch(source, activityItems)
     } finally {
-      settleInterruptedItems(source)
-      runningSource.value = null
-      installingId.value = null
-      mutationGate.release('install_queue')
+      finishBatch(source, activityItems)
     }
   }
 
@@ -456,15 +512,14 @@ export function useSkillRegistry(
     installActivities.value[source].refreshWarning = ''
     installActivities.value[source].phase = 'installing'
     runningSource.value = source
+    cancelRequested.value = null
     try {
       await processQueueItems([item], riskConfirmation)
+      if (cancelRequested.value === source) return
       removeSuccessfulGithubLines([item])
       await refreshCatalogAfterBatch(source, [item])
     } finally {
-      settleInterruptedItems(source)
-      runningSource.value = null
-      installingId.value = null
-      mutationGate.release('install_queue')
+      finishBatch(source, [item])
     }
   }
 
@@ -569,6 +624,7 @@ export function useSkillRegistry(
     installGithub,
     installSkill,
     retryQueueItem,
+    cancelInstall,
     clearInstallActivity,
     installDeps,
     uninstallSkill,

--- a/opensquilla-webui/src/composables/useSessions.sections.test.ts
+++ b/opensquilla-webui/src/composables/useSessions.sections.test.ts
@@ -381,3 +381,76 @@ describe('arrangeSidebarSections — manual session ordering', () => {
     ])
   })
 })
+
+describe('arrangeSidebarSections — folded subagent groups', () => {
+  function parentWithChildren(childCount: number) {
+    const parentKey = 'agent:main:webchat:parent'
+    const items = [session({ key: parentKey, title: 'Parent', updatedAt: 500 })]
+    for (let index = 0; index < childCount; index++) {
+      items.push(session({
+        key: `agent:main:subagent:child-${index}`,
+        title: `Child ${index}`,
+        updatedAt: 400 - index,
+        parent: { key: parentKey, spawnDepth: 1 },
+      }))
+    }
+    return { parentKey, items }
+  }
+
+  it('keeps one to three direct subagents inline (no group)', () => {
+    const { items } = parentWithChildren(3)
+    const rows = sectionFor(arrangeSidebarSections(items), 'chats').rows
+
+    expect(rows).toHaveLength(4)
+    expect(rows[0].subagentGroup).toBeUndefined()
+    expect(rows.map(row => row.depth)).toEqual([0, 1, 1, 1])
+  })
+
+  it('folds four or more direct subagents into a compact group row', () => {
+    const { items } = parentWithChildren(4)
+    const rows = sectionFor(arrangeSidebarSections(items), 'chats').rows
+
+    expect(rows).toHaveLength(1)
+    const group = rows[0]
+    expect(group.title).toBe('Parent')
+    expect(group.subagentGroup).toBeDefined()
+    expect(group.subagentGroup!.count).toBe(4)
+    expect(group.subagentGroup!.children).toHaveLength(4)
+    expect(group.subagentGroup!.children.map(child => child.depth)).toEqual([1, 1, 1, 1])
+  })
+
+  it('summarizes running attention from a folded child', () => {
+    const parentKey = 'agent:main:webchat:parent'
+    const items = [
+      session({ key: parentKey, title: 'Parent', updatedAt: 500 }),
+      ...([0, 1, 2, 3].map(index => session({
+        key: `agent:main:subagent:child-${index}`,
+        title: `Child ${index}`,
+        updatedAt: 400 - index,
+        runStatus: index === 2 ? 'running' : 'idle',
+        parent: { key: parentKey, spawnDepth: 1 },
+      }))),
+    ]
+    const rows = sectionFor(arrangeSidebarSections(items), 'chats').rows
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].subagentGroup!.attention).toBe('running')
+  })
+
+  it('does not fold grandchildren into the flat ledger for non-group parents', () => {
+    const parentKey = 'agent:main:webchat:parent'
+    const childKey = 'agent:main:subagent:child'
+    const sections = arrangeSidebarSections([
+      session({ key: parentKey, title: 'Parent', updatedAt: 500 }),
+      session({ key: childKey, title: 'Child', updatedAt: 400, parent: { key: parentKey, spawnDepth: 1 } }),
+      session({
+        key: 'agent:main:subagent:grandchild',
+        title: 'Grandchild',
+        updatedAt: 300,
+        parent: { key: childKey, spawnDepth: 2 },
+      }),
+    ])
+
+    expect(sectionFor(sections, 'chats').rows.map(row => row.depth)).toEqual([0, 1, 2])
+  })
+})

--- a/opensquilla-webui/src/composables/useSessions.ts
+++ b/opensquilla-webui/src/composables/useSessions.ts
@@ -382,6 +382,92 @@ export interface SessionLedgerEntry {
   depth: number
   /** Resolved parent title for subagent rows; empty for root rows. */
   parentTitle: string
+  /**
+   * True on a parent entry with at least `SUBAGENT_GROUP_THRESHOLD` direct
+   * subagent children. `arrangeSessionLedger` keeps the flat list unchanged;
+   * `arrangeSidebarSections` folds such parents into one compact group row.
+   */
+  subagentGroup?: boolean
+  /** Direct subagent children folded under this parent (>= threshold). */
+  subagentGroupChildren?: SessionLedgerEntry[]
+}
+
+/** Minimum direct subagent children before a parent renders as a group. */
+export const SUBAGENT_GROUP_THRESHOLD = 4
+
+/**
+ * Fold parents with many simultaneous subagents into one group entry. The
+ * input is the flat `arrangeSessionLedger` output; the output keeps every
+ * root and non-group row in order, but a flagged parent carries its direct
+ * subagent children (and their descendants) in `subagentGroupChildren`
+ * instead of listing them flat, so the sidebar renders one compact row.
+ */
+export function foldSubagentGroupEntries(
+  entries: readonly SessionLedgerEntry[],
+): SessionLedgerEntry[] {
+  const groupKeys = new Set(
+    entries.filter(entry => entry.subagentGroup).map(entry => entry.item.key),
+  )
+  if (groupKeys.size === 0) return [...entries]
+
+  // Build parent -> ordered direct children from the flat ledger so the
+  // folded subtree keeps the exact traversal order the flat list used.
+  const byParent = new Map<string, SessionLedgerEntry[]>()
+  for (const entry of entries) {
+    const parentKey = sessionParentKey(entry.item)
+    if (!parentKey) continue
+    const list = byParent.get(parentKey) || []
+    list.push(entry)
+    byParent.set(parentKey, list)
+  }
+
+  const collectSubtree = (parentKey: string, depth: number): SessionLedgerEntry[] => {
+    const children = byParent.get(parentKey) || []
+    return children.map(child => ({
+      item: child.item,
+      depth: Math.min(child.depth, depth),
+      parentTitle: child.parentTitle,
+      subagentGroupChildren: collectSubtree(child.item.key, depth + 1),
+    }))
+  }
+
+  const folded: SessionLedgerEntry[] = []
+  const consumed = new Set<string>()
+  for (const entry of entries) {
+    if (consumed.has(entry.item.key)) continue
+    if (entry.subagentGroup) {
+      folded.push({
+        item: entry.item,
+        depth: entry.depth,
+        parentTitle: entry.parentTitle,
+        subagentGroup: true,
+        subagentGroupChildren: collectSubtree(entry.item.key, entry.depth + 1),
+      })
+      consumed.add(entry.item.key)
+      continue
+    }
+    // Any row whose ancestor chain leads into a folded group is carried by
+    // that group's `subagentGroupChildren`; never list it flat again.
+    let cursor = entry.item
+    let insideGroup = false
+    for (let hop = 0; hop < 4; hop++) {
+      const parentKey = sessionParentKey(cursor)
+      if (!parentKey) break
+      if (groupKeys.has(parentKey)) {
+        insideGroup = true
+        break
+      }
+      const parentItem = entries.find(candidate => candidate.item.key === parentKey)?.item
+      if (!parentItem) break
+      cursor = parentItem
+    }
+    if (insideGroup) {
+      consumed.add(entry.item.key)
+      continue
+    }
+    folded.push(entry)
+  }
+  return folded
 }
 
 /**
@@ -405,8 +491,18 @@ export function arrangeSessionLedger(items: SessionItem[]): SessionLedgerEntry[]
   }
   const entries: SessionLedgerEntry[] = []
   const visit = (item: SessionItem, depth: number, parentTitle: string) => {
-    entries.push({ item, depth, parentTitle: depth > 0 ? parentTitle : '' })
-    for (const child of children.get(item.key) || []) {
+    const directChildren = children.get(item.key) || []
+    entries.push({
+      item,
+      depth,
+      parentTitle: depth > 0 ? parentTitle : '',
+      // Flag parents with many simultaneous subagents so the sidebar can fold
+      // them into one compact group row. The flat list is unchanged — every
+      // child is still listed — so SessionsView and other consumers are
+      // unaffected; only `arrangeSidebarSections` acts on the flag.
+      subagentGroup: depth === 0 && directChildren.length >= SUBAGENT_GROUP_THRESHOLD,
+    })
+    for (const child of directChildren) {
       visit(child, Math.min(depth + 1, 3), item.title)
     }
   }
@@ -449,6 +545,17 @@ export interface SidebarSectionRow {
   provisional?: boolean
   /** Local sidebar preference; never changes the underlying session contract. */
   pinned?: boolean
+  /**
+   * Present on a parent row whose direct subagents were folded into a compact
+   * group (>= SUBAGENT_GROUP_THRESHOLD). `children` holds the folded rows so
+   * the sidebar can expand the group on demand; `count` and `attention`
+   * summarize the group for the collapsed header.
+   */
+  subagentGroup?: {
+    count: number
+    attention: SessionTaskAttention
+    children: SidebarSectionRow[]
+  }
 }
 
 /** One collapsible family section with its recency-ordered rows. */
@@ -546,6 +653,29 @@ export function arrangeSidebarSections(
     pinned: pinnedKeys.has(item.key),
   })
 
+  /** Convert one ledger entry (possibly a folded subagent group) to a row. */
+  const entryToRow = (entry: SessionLedgerEntry, depthOverride?: number): SidebarSectionRow => {
+    const row = toRow(entry.item, depthOverride ?? entry.depth)
+    const children = entry.subagentGroupChildren
+    if (!children?.length) return row
+    const childRows = children.map(child => entryToRow(child))
+    const attention: SessionTaskAttention = childRows.some(r => r.taskAttention === 'running')
+      ? 'running'
+      : childRows.some(r => r.taskAttention === 'failed')
+        ? 'failed'
+        : childRows.some(r => r.taskAttention === 'completed')
+          ? 'completed'
+          : 'none'
+    return {
+      ...row,
+      subagentGroup: {
+        count: childRows.length,
+        attention,
+        children: childRows,
+      },
+    }
+  }
+
   type WorkspaceBucket = {
     title: string
     displayPath?: string
@@ -562,7 +692,7 @@ export function arrangeSidebarSections(
     let index = 0
 
     for (const entry of entries) {
-      const row = toRow(entry.item, entry.depth)
+      const row = entryToRow(entry)
       const workspace = entry.item.workspace
       if (!workspace) {
         topLevel.push({ kind: 'row', row, index: index++ })
@@ -666,7 +796,7 @@ export function arrangeSidebarSections(
         })
       } else {
         rows.push(...projectEntries.map(entry => ({
-          ...toRow(entry.item, Math.min(entry.depth + 1, 4)),
+          ...entryToRow(entry, Math.min(entry.depth + 1, 4)),
           workspaceId: project.id,
         })))
       }
@@ -674,7 +804,7 @@ export function arrangeSidebarSections(
     rows.push(
       ...entries
         .filter(entry => !entry.item.workspaceId)
-        .map(entry => toRow(entry.item, entry.depth)),
+        .map(entry => entryToRow(entry)),
     )
     // Sessions belonging to a removed project remain durable but hidden until
     // that project is restored to the canonical project list.
@@ -687,7 +817,11 @@ export function arrangeSidebarSections(
     if (family === 'chats') {
       // Recency-sort first so the ledger's root ordering follows recency, then
       // flatten parent → child so subagents indent directly beneath their chat.
-      const ledger = arrangeSessionLedger([...bucket].sort(bySidebarOrder))
+      // Parents with SUBAGENT_GROUP_THRESHOLD+ direct subagents fold them into
+      // one compact group row instead of pushing every child into the ledger.
+      const ledger = foldSubagentGroupEntries(
+        arrangeSessionLedger([...bucket].sort(bySidebarOrder)),
+      )
       rows = projects === undefined
         ? arrangeWorkspaceRows(ledger)
         : arrangePersistedProjectRows(ledger, projects)

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -2879,6 +2879,7 @@
       "sourceInstalling": "Installation von {name} läuft",
       "sourceFailures": "{count} fehlgeschlagen",
       "clearActivity": "Aktivität löschen",
+      "cancelInstall": "Installation abbrechen",
       "expandActivity": "Installationsaktivität erweitern",
       "collapseActivity": "Installationsaktivität einklappen",
       "queueStatus": {
@@ -2887,6 +2888,7 @@
         "installed": "Installiert",
         "unchanged": "Bereits aktuell",
         "deferred": "Nicht versucht",
+        "cancelled": "Abgebrochen",
         "failed": "Fehlgeschlagen"
       },
       "installingProgress": "Installation {current} von {total}…",

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -4087,6 +4087,7 @@
       "taskRunning": "Aufgabe wird ausgeführt",
       "taskCompletedUnread": "Aufgabe abgeschlossen, Ergebnis nicht angesehen",
       "taskUnfinishedUnread": "Aufgabe nicht abgeschlossen, Details nicht angesehen",
+      "subagentGroupLabel": "{title}: {count} Unteragenten",
       "contractGap": "Backend-Vertragsfelder von session-list-v1 fehlen",
       "contractGapBadge": "Lücke",
       "rowActions": "Aktionen für {title}",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -2930,6 +2930,7 @@
       "sourceInstalling": "Installing {name}",
       "sourceFailures": "{count} failed",
       "clearActivity": "Clear activity",
+      "cancelInstall": "Cancel install",
       "expandActivity": "Expand install activity",
       "collapseActivity": "Collapse install activity",
       "queueStatus": {
@@ -2938,6 +2939,7 @@
         "installed": "Installed",
         "unchanged": "Already current",
         "deferred": "Not attempted",
+        "cancelled": "Cancelled",
         "failed": "Failed"
       },
       "installingProgress": "Installing {current} of {total}…",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -4140,6 +4140,7 @@
       "taskRunning": "Task running",
       "taskCompletedUnread": "Task completed, result not viewed",
       "taskUnfinishedUnread": "Task unfinished, details not viewed",
+      "subagentGroupLabel": "{title}: {count} subagents",
       "contractGap": "Backend session-list-v1 contract fields are missing",
       "contractGapBadge": "Gap",
       "rowActions": "Actions for {title}",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -4087,6 +4087,7 @@
       "taskRunning": "Tarea en curso",
       "taskCompletedUnread": "Tarea completada, resultado sin ver",
       "taskUnfinishedUnread": "Tarea sin completar, detalles sin ver",
+      "subagentGroupLabel": "{title}: {count} subagentes",
       "contractGap": "Faltan campos del contrato session-list-v1 del backend",
       "contractGapBadge": "Laguna",
       "rowActions": "Acciones para {title}",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -2879,6 +2879,7 @@
       "sourceInstalling": "Instalando {name}",
       "sourceFailures": "{count} con error",
       "clearActivity": "Borrar actividad",
+      "cancelInstall": "Cancelar instalación",
       "expandActivity": "Expandir actividad de instalación",
       "collapseActivity": "Contraer actividad de instalación",
       "queueStatus": {
@@ -2887,6 +2888,7 @@
         "installed": "Instalado",
         "unchanged": "Ya está actualizado",
         "deferred": "No intentado",
+        "cancelled": "Cancelado",
         "failed": "Falló"
       },
       "installingProgress": "Instalando {current} de {total}…",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -4087,6 +4087,7 @@
       "taskRunning": "Tâche en cours",
       "taskCompletedUnread": "Tâche terminée, résultat non consulté",
       "taskUnfinishedUnread": "Tâche inachevée, détails non consultés",
+      "subagentGroupLabel": "{title} : {count} sous-agents",
       "contractGap": "Des champs du contrat backend session-list-v1 sont manquants",
       "contractGapBadge": "Lacune",
       "rowActions": "Actions pour {title}",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -2879,6 +2879,7 @@
       "sourceInstalling": "Installation de {name}",
       "sourceFailures": "{count} en échec",
       "clearActivity": "Effacer l’activité",
+      "cancelInstall": "Annuler l’installation",
       "expandActivity": "Développer l’activité d’installation",
       "collapseActivity": "Réduire l’activité d’installation",
       "queueStatus": {
@@ -2887,6 +2888,7 @@
         "installed": "Installé",
         "unchanged": "Déjà à jour",
         "deferred": "Non tentée",
+        "cancelled": "Annulée",
         "failed": "Échec"
       },
       "installingProgress": "Installation {current} sur {total}…",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -2879,6 +2879,7 @@
       "sourceInstalling": "{name} をインストール中",
       "sourceFailures": "{count} 件失敗",
       "clearActivity": "履歴を消去",
+      "cancelInstall": "インストールをキャンセル",
       "expandActivity": "インストール状況を展開",
       "collapseActivity": "インストール状況を折りたたむ",
       "queueStatus": {
@@ -2887,6 +2888,7 @@
         "installed": "インストール済み",
         "unchanged": "すでに最新",
         "deferred": "未実行",
+        "cancelled": "キャンセル済み",
         "failed": "失敗"
       },
       "installingProgress": "{total} 件中 {current} 件目をインストール中…",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -4087,6 +4087,7 @@
       "taskRunning": "タスクを実行中",
       "taskCompletedUnread": "タスク完了、結果は未確認",
       "taskUnfinishedUnread": "タスク未完了、詳細は未確認",
+      "subagentGroupLabel": "{title}：{count} サブエージェント",
       "contractGap": "バックエンドの session-list-v1 契約フィールドが不足しています",
       "contractGapBadge": "不足",
       "rowActions": "{title} のアクション",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -2930,6 +2930,7 @@
       "sourceInstalling": "正在安装 {name}",
       "sourceFailures": "{count} 项失败",
       "clearActivity": "清除活动",
+      "cancelInstall": "取消安装",
       "expandActivity": "展开安装活动",
       "collapseActivity": "收起安装活动",
       "queueStatus": {
@@ -2938,6 +2939,7 @@
         "installed": "已安装",
         "unchanged": "已是最新",
         "deferred": "未尝试",
+        "cancelled": "已取消",
         "failed": "失败"
       },
       "installingProgress": "正在安装第 {current}/{total} 项…",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -4140,6 +4140,7 @@
       "taskRunning": "任务运行中",
       "taskCompletedUnread": "任务已完成，结果未查看",
       "taskUnfinishedUnread": "任务未完成，详情未查看",
+      "subagentGroupLabel": "{title}：{count} 个子代理",
       "contractGap": "缺少后端 session-list-v1 契约字段",
       "contractGapBadge": "缺失",
       "rowActions": "{title} 的操作",

--- a/opensquilla-webui/src/styles/control-visual-system.css
+++ b/opensquilla-webui/src/styles/control-visual-system.css
@@ -792,6 +792,41 @@ summary.control-row--divider:focus-visible {
   pointer-events: none;
 }
 
+/* ── Sidebar: folded subagent group header ─────────────────────────── */
+
+.sidebar-subagent-group-head {
+  color: var(--sidebar-text);
+  gap: 6px;
+}
+.sidebar-subagent-group-head .sidebar-history-title {
+  flex: 1;
+}
+.sidebar-subagent-group-chevron {
+  color: var(--sidebar-text-soft);
+  flex-shrink: 0;
+  transition: transform var(--dur-base) var(--ease-standard);
+}
+.sidebar-subagent-group-head.is-expanded .sidebar-subagent-group-chevron {
+  transform: rotate(90deg);
+}
+.sidebar-subagent-group-count {
+  align-items: center;
+  background: var(--sidebar-control-bg);
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-full);
+  color: var(--sidebar-text-soft);
+  display: inline-flex;
+  flex-shrink: 0;
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
+  height: 18px;
+  justify-content: center;
+  line-height: 1;
+  min-width: 18px;
+  padding-inline: 5px;
+}
+
 /* ── Sidebar: inline rename input ──────────────────────────────────── */
 
 .sidebar-history-rename {

--- a/opensquilla-webui/src/views/SkillsView.vue
+++ b/opensquilla-webui/src/views/SkillsView.vue
@@ -173,6 +173,7 @@
       @install-github="installGithub"
       @install="installSkill"
       @retry="retryQueueItem"
+      @cancel-install="cancelInstall"
       @clear-activity="clearInstallActivity"
     />
 
@@ -345,6 +346,7 @@ const {
   installGithub,
   installSkill,
   retryQueueItem,
+  cancelInstall,
   clearInstallActivity,
   installDeps,
   uninstallSkill,

--- a/src/opensquilla/engine/artifact_delivery.py
+++ b/src/opensquilla/engine/artifact_delivery.py
@@ -248,6 +248,22 @@ def auto_publish_omitted_workspace_artifacts(
         if not _text_mentions_written_file(final_text, record):
             continue
 
+        target_key = artifact_delivery_publish_target_key(
+            str(target),
+            workspace_dir=workspace,
+        )
+        name_key = artifact_delivery_name_target_key(target.name)
+        if target_key is not None and target_key in getattr(
+            ctx, "published_artifact_source_keys", frozenset()
+        ):
+            # The same source file was explicitly published earlier this turn,
+            # possibly under a custom display name. Do not publish it a second
+            # time under its original filename.
+            for resolved_key in (target_key, name_key):
+                if resolved_key is not None and resolved_key not in resolved_target_keys:
+                    resolved_target_keys.append(resolved_key)
+            continue
+
         try:
             artifact_mime = artifact_mime_for_name(target.name)
             publish_max_bytes = artifact_publish_max_bytes_for_name(
@@ -288,11 +304,6 @@ def auto_publish_omitted_workspace_artifacts(
                 pptx_payload if pptx_payload is not None else target.read_bytes()
             ).hexdigest()
             artifact_key = (target_sha256, _safe_filename(target.name))
-            target_key = artifact_delivery_publish_target_key(
-                str(target),
-                workspace_dir=workspace,
-            )
-            name_key = artifact_delivery_name_target_key(target.name)
             if artifact_key in known_artifact_keys:
                 for resolved_key in (target_key, name_key):
                     if (

--- a/src/opensquilla/tools/builtin/artifacts.py
+++ b/src/opensquilla/tools/builtin/artifacts.py
@@ -59,6 +59,31 @@ def _bundle_result(manifest: ArtifactBundleManifest) -> dict[str, object]:
     }
 
 
+def _record_published_artifact_source_key(
+    ctx: ToolContext,
+    target: Path,
+    workspace: Path,
+) -> None:
+    """Record a successfully published file's canonical workspace identity.
+
+    The omitted-artifact backstop consults this per-turn set so a source file
+    explicitly published under a custom display name is not published a second
+    time under its original filename. The import is deferred to keep this tool
+    module import-cycle-free.
+    """
+
+    from opensquilla.engine.artifact_delivery import (
+        artifact_delivery_publish_target_key,
+    )
+
+    source_key = artifact_delivery_publish_target_key(
+        str(target),
+        workspace_dir=workspace,
+    )
+    if source_key is not None:
+        ctx.published_artifact_source_keys.add(source_key)
+
+
 def _normalized_filename(value: str) -> str:
     return "".join(ch for ch in value.lower() if ch.isalnum())
 
@@ -577,6 +602,7 @@ async def publish_artifact(
         payload = artifact_payload(existing)
         if not any(item.get("id") == payload.get("id") for item in ctx.published_artifacts):
             ctx.published_artifacts.append(payload)
+        _record_published_artifact_source_key(ctx, target, workspace)
         llm_artifact = _llm_artifact_payload(
             payload,
             ctx=ctx,
@@ -640,6 +666,7 @@ async def publish_artifact(
 
     payload = artifact_payload(ref)
     ctx.published_artifacts.append(payload)
+    _record_published_artifact_source_key(ctx, target, workspace)
     llm_artifact = _llm_artifact_payload(
         payload,
         ctx=ctx,

--- a/src/opensquilla/tools/types.py
+++ b/src/opensquilla/tools/types.py
@@ -193,6 +193,12 @@ class ToolContext:
     # and projection code use this bit to avoid replacing raw tool output with
     # a handle that the current model is not authorized to retrieve.
     tool_result_retrieval_available: bool = False
+    # Canonical workspace source identities ("path:...") of files successfully
+    # published during this turn via publish_artifact. The omitted-artifact
+    # backstop consults this to avoid re-publishing the same source file under
+    # its original filename after an explicit publish used a custom display
+    # name. Runtime-only; never serialized into task details or transcripts.
+    published_artifact_source_keys: set[str] = field(default_factory=set)
 
     def __post_init__(self) -> None:
         self.validate_path_roots()

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1829,6 +1829,61 @@ async def test_publish_artifact_tool_is_idempotent_for_existing_turn_artifact(
 
 
 @pytest.mark.asyncio
+async def test_backstop_skips_file_explicitly_published_with_custom_name(
+    tmp_path: Path,
+) -> None:
+    from opensquilla.engine.artifact_delivery import (
+        auto_publish_omitted_workspace_artifacts,
+    )
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "index.html"
+    target.write_text("<title>World Countries</title>", encoding="utf-8")
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+    )
+    ctx.workspace_file_writes.append(
+        {
+            "created": True,
+            "path": str(target),
+            "relative_path": "index.html",
+            "name": target.name,
+        }
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        result = json.loads(
+            await publish_artifact(
+                path="index.html",
+                name="World Countries Overview",
+            )
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result["status"] == "published"
+    assert result["artifact"]["name"] == "World Countries Overview.html"
+    assert len(ctx.published_artifacts) == 1
+
+    publish_result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="I created index.html for you.",
+    )
+
+    assert publish_result.artifacts == []
+    assert publish_result.failure_summaries == []
+    assert len(ctx.published_artifacts) == 1
+    assert ctx.published_artifacts[0]["name"] == "World Countries Overview.html"
+
+
+@pytest.mark.asyncio
 async def test_publish_artifact_tool_reuses_existing_session_deliverable_across_contexts(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_engine/test_runtime_artifacts.py
+++ b/tests/test_engine/test_runtime_artifacts.py
@@ -2495,6 +2495,55 @@ def test_auto_publish_dedupes_current_artifact_by_store_safe_name(
     assert len(ctx.published_artifacts) == 1
 
 
+def test_auto_publish_keeps_distinct_source_paths_with_identical_content(
+    tmp_path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    first = workspace / "a.html"
+    second = workspace / "b.html"
+    payload = b"<title>identical</title>"
+    first.write_bytes(payload)
+    second.write_bytes(payload)
+    first_sha = hashlib.sha256(payload).hexdigest()
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-identical",
+        session_key="agent:main:webchat:identical",
+    )
+    # a.html was explicitly published this turn under a custom display name.
+    ctx.published_artifacts.append(
+        {"id": "art-a", "sha256": first_sha, "name": "Overview A.html"}
+    )
+    ctx.published_artifact_source_keys.add(
+        artifact_delivery_publish_target_key(
+            str(first.resolve()),
+            workspace_dir=workspace,
+        )
+    )
+    for name, path in (("a.html", first), ("b.html", second)):
+        ctx.workspace_file_writes.append(
+            {
+                "created": True,
+                "path": str(path),
+                "relative_path": name,
+                "name": name,
+            }
+        )
+
+    result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="Created a.html and b.html for you.",
+    )
+
+    assert len(result.artifacts) == 1
+    assert result.artifacts[0]["name"] == "b.html"
+    assert len(ctx.published_artifacts) == 2
+
+
 def test_auto_publish_oversized_pptx_preflights_before_read_or_validation(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Scope

Scope boundary: Web UI only. The MetaSkill install queue in the Skills drawer, its cancellation flag, the cancelled queue-item status, and the six locale strings.

Non-goals: No gateway/RPC change. The install RPC itself stays as-is; cancellation stops the *client-side queue* from starting any further installs, preserves the real outcome of the one already in flight, and settles the batch into an explicit cancelled state (the backend task for the in-flight item is allowed to finish).

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #1210

## Release Note

Release note: While a MetaSkill install batch is running, the Skills drawer now shows a Cancel action. Cancelling stops further installs, keeps the already-completed item's result, marks the rest as Cancelled, and lets you safely retry.

## Tests

Ruff: N/A (no Python changed)

Pytest: N/A (no Python changed)

Build: `npm run typecheck` — all 11 architecture guards pass, including i18n key parity across the six locales; `vue-tsc --noEmit` clean

Regression tests: added/updated
- `useSkillRegistry.test.ts` (31 tests): mid-batch cancellation preserves the in-flight installed outcome and cancels the tail without refreshing the catalog; a failed in-flight outcome keeps its status and the tail is still cancelled; cancel is a no-op when the source is not running
- `SkillsAddDrawer.test.ts` (21 tests): Cancel button shown while the visible source is running and emits cancelInstall; hidden when the running source differs from the visible one; cancelled queue item renders its dedicated status label

Notes:
- 81 tests pass across the six skills suites (registry, drawer, catalog, cards, stats)

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

No secrets or private artifacts.

## Third-Party Origin

Third-party origin: none
