### PR TITLE
Handle image input for text-only model selections

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -51,6 +51,7 @@
       "tests/test_contrib/test_codetask/test_codetask_inputs.py",
       "tests/test_contrib/test_codetask/test_codetask_retry_loop.py",
       "tests/test_engine/test_agent_deepseek_dsml_dispatch.py",
+      "tests/test_engine/test_agent_image_capability_guard.py",
       "tests/test_engine/test_agent_provider_identity.py",
       "tests/test_engine/test_agent_transactional_tool_publication.py",
       "tests/test_engine/test_attachment_aware_routing.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -196,6 +196,7 @@
     "tests/test_engine/test_agent_canonical_text_contract.py": 0.01,
     "tests/test_engine/test_agent_deepseek_dsml_dispatch.py": 0.01,
     "tests/test_engine/test_agent_finalize_evidence_gate.py": 11.076,
+    "tests/test_engine/test_agent_image_capability_guard.py": 0.01,
     "tests/test_engine/test_agent_injection_provider.py": 0.01,
     "tests/test_engine/test_agent_invalid_provider_response.py": 1.924,
     "tests/test_engine/test_agent_llm_budget.py": 24.998,

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -364,6 +364,10 @@ _PROVIDER_OUTPUT_CONTINUE_PROMPT = (
     "been written. If a tool call was interrupted or incomplete, regenerate a complete "
     "tool call from scratch."
 )
+UNSUPPORTED_IMAGE_INPUT_REPLY = (
+    "当前选择的模型暂不支持查看图片，因此无法分析你上传的图片。"
+    "请切换到支持图片的模型，或将图片中的文字和关键信息粘贴到消息中后重试。"
+)
 _TEXT_ONLY_TOOL_RECOVERY_LIMIT = 2
 _TEXT_ONLY_TOOL_RECOVERY_MESSAGE = (
     "[Runtime recovery]\n"
@@ -4104,6 +4108,25 @@ class Agent:
             )
             return False
 
+    def _provider_local_terminal_reply(
+        self,
+        messages: list[Message],
+        config: ChatConfig,
+    ) -> str | None:
+        local_reply = getattr(self.provider, "local_terminal_reply", None)
+        if not callable(local_reply):
+            return None
+        try:
+            reply = local_reply(messages, config)
+        except Exception as exc:  # noqa: BLE001 - optional preflight must be isolated
+            logger.warning(
+                "provider.local_terminal_reply_failed",
+                session_key=self._session_key,
+                error=str(exc),
+            )
+            return None
+        return reply if isinstance(reply, str) and reply else None
+
     @staticmethod
     def _tool_call_string_arg(
         tool_call: ToolCall | None,
@@ -6589,6 +6612,28 @@ class Agent:
             _ = terminates  # always terminates today; reserved for future
             return
 
+        current_turn_image_count = self._count_image_blocks(extra_messages or [])
+        model_supports_vision = bool(
+            getattr(self.config.model_capabilities, "supports_vision", False)
+        )
+        if current_turn_image_count > 0 and not model_supports_vision:
+            self.config.metadata["image_input_mode"] = "rejected"
+            self.config.metadata["image_input_reason"] = "vision_unsupported"
+            self.config.metadata["image_input_count"] = current_turn_image_count
+            self._write_turn_call_log(
+                "image_input_preflight",
+                action="terminal_reply",
+                reason="vision_unsupported",
+                model=self.config.model_id or "",
+                image_count=current_turn_image_count,
+            )
+            async for ev in self._emit_terminal_text(
+                UNSUPPORTED_IMAGE_INPUT_REPLY,
+                iterations=0,
+            ):
+                yield ev
+            return
+
         # Use the system prompt from config (wired by gateway via identity.prompt)
         if self._context is None:
             self._context = ContextAssembly(
@@ -8045,6 +8090,28 @@ class Agent:
                         self._provider_call_tool_result_retrieval_available = (
                             previous_call_retrieval
                         )
+                    local_terminal_reply = self._provider_local_terminal_reply(
+                        request_messages,
+                        chat_cfg,
+                    )
+                    if local_terminal_reply is not None:
+                        assistant_text_parts = [local_terminal_reply]
+                        attempt_user_visible_emitted = True
+                        _got_done_event = True
+                        provider_done_for_log = ProviderDoneEvent(
+                            stop_reason="end_turn",
+                            input_tokens=0,
+                            output_tokens=0,
+                            model=self.config.model_id or "",
+                        )
+                        self._write_turn_call_log(
+                            "provider_local_terminal_reply",
+                            reason=self.config.metadata.get("image_input_reason", ""),
+                            iteration=iterations,
+                            attempt=_call_attempt,
+                        )
+                        yield TextDeltaEvent(text=local_terminal_reply)
+                        break
                     validation_error = validate_provider_chat_request(
                         self.provider,
                         request_messages,

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -368,6 +368,16 @@ UNSUPPORTED_IMAGE_INPUT_REPLY = (
     "当前选择的模型暂不支持查看图片，因此无法分析你上传的图片。"
     "请切换到支持图片的模型，或将图片中的文字和关键信息粘贴到消息中后重试。"
 )
+
+
+def model_explicitly_lacks_vision(capabilities: Any) -> bool:
+    """Return true only when capability data explicitly denies vision."""
+
+    return capabilities is not None and not bool(
+        getattr(capabilities, "supports_vision", False)
+    )
+
+
 _TEXT_ONLY_TOOL_RECOVERY_LIMIT = 2
 _TEXT_ONLY_TOOL_RECOVERY_MESSAGE = (
     "[Runtime recovery]\n"
@@ -6613,10 +6623,9 @@ class Agent:
             return
 
         current_turn_image_count = self._count_image_blocks(extra_messages or [])
-        model_supports_vision = bool(
-            getattr(self.config.model_capabilities, "supports_vision", False)
-        )
-        if current_turn_image_count > 0 and not model_supports_vision:
+        if current_turn_image_count > 0 and model_explicitly_lacks_vision(
+            self.config.model_capabilities
+        ):
             self.config.metadata["image_input_mode"] = "rejected"
             self.config.metadata["image_input_reason"] = "vision_unsupported"
             self.config.metadata["image_input_count"] = current_turn_image_count

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -100,7 +100,7 @@ from opensquilla.contracts.attachments import (
     normalize_attachment_mime as _normalize_attachment_mime,
 )
 from opensquilla.contracts.turn_execution import TurnExecutionContext
-from opensquilla.engine.agent import Agent, ToolHandler
+from opensquilla.engine.agent import UNSUPPORTED_IMAGE_INPUT_REPLY, Agent, ToolHandler
 from opensquilla.engine.agent_injection import PendingInputProvider
 from opensquilla.engine.cache_break_monitor import notify_compaction
 from opensquilla.engine.hooks import (
@@ -221,9 +221,13 @@ from opensquilla.observability.trace import TraceContext, TraceEvent, write_trac
 from opensquilla.observability.turn_call_log import TurnCallLogger, is_turn_call_log_enabled
 from opensquilla.paths import media_root_from_config
 from opensquilla.provider import (
+    DoneEvent as ProviderDoneEvent,
+)
+from opensquilla.provider import (
     ErrorEvent as ProviderErrorEvent,
 )
 from opensquilla.provider import (
+    ModelCapabilities,
     ProviderActivityEvent,
     ProviderFailureKind,
     ProviderHeartbeatEvent,
@@ -233,6 +237,9 @@ from opensquilla.provider import (
 )
 from opensquilla.provider import (
     ReasoningDeltaEvent as ProviderReasoningDeltaEvent,
+)
+from opensquilla.provider import (
+    TextDeltaEvent as ProviderTextDeltaEvent,
 )
 from opensquilla.provider import (
     ToolUseDeltaEvent as ProviderToolUseDeltaEvent,
@@ -254,12 +261,13 @@ from opensquilla.provider.protocol import (
     validate_provider_chat_request,
 )
 from opensquilla.provider.types import (
-    EnsembleProgressEvent as ProviderEnsembleProgressEvent,
-)
-from opensquilla.provider.types import (
+    ContentBlockImage,
     ProviderGenerationResetEvent,
     ProviderRequestCorrelation,
     derive_provider_request_correlation,
+)
+from opensquilla.provider.types import (
+    EnsembleProgressEvent as ProviderEnsembleProgressEvent,
 )
 from opensquilla.router_control import (
     RouterControlHoldStore,
@@ -1654,6 +1662,16 @@ def _fallback_deployment_identity(config: Any) -> _FallbackDeploymentIdentity:
     )
 
 
+def _count_image_blocks(messages: Sequence[Any]) -> int:
+    count = 0
+    for message in messages:
+        content = getattr(message, "content", None)
+        if not isinstance(content, list):
+            continue
+        count += sum(1 for block in content if isinstance(block, ContentBlockImage))
+    return count
+
+
 _SELECTOR_PRE_TEXT_REASONING_LIMIT_BYTES: Final[int] = 2 * 1024 * 1024
 _SELECTOR_REASONING_PULSE_INTERVAL_SECONDS: Final[float] = 5.0
 _SELECTOR_MAX_RETRY_AFTER_SECONDS: Final[float] = 900.0
@@ -2169,6 +2187,9 @@ class _SelectorFallbackProvider:
         self._fallback_deployment_limits: dict[
             _FallbackDeploymentIdentity, tuple[int, int]
         ] = {}
+        self._fallback_deployment_capabilities: dict[
+            _FallbackDeploymentIdentity, ModelCapabilities
+        ] = {}
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._provider, name)
@@ -2344,15 +2365,18 @@ class _SelectorFallbackProvider:
 
     def configure_fallback_deployment_limits(
         self,
-        limits: Sequence[tuple[Any, int, int]],
+        limits: Sequence[tuple[Any, int, int] | tuple[Any, int, int, Any]],
     ) -> None:
-        """Install exact limit-relevant deployment budgets in private memory."""
+        """Install exact deployment budgets and capabilities in private memory."""
 
         normalized: dict[_FallbackDeploymentIdentity, tuple[int, int]] = {}
+        normalized_capabilities: dict[
+            _FallbackDeploymentIdentity, ModelCapabilities
+        ] = {}
         for item in limits:
-            if not isinstance(item, tuple) or len(item) != 3:
+            if not isinstance(item, tuple) or len(item) not in {3, 4}:
                 continue
-            deployment, raw_context, raw_max = item
+            deployment, raw_context, raw_max = item[:3]
             identity = _fallback_deployment_identity(deployment)
             if not identity.provider or not identity.model:
                 continue
@@ -2362,7 +2386,11 @@ class _SelectorFallbackProvider:
             except (TypeError, ValueError):
                 continue
             normalized[identity] = (context_window, effective_max_tokens)
+            capabilities = item[3] if len(item) == 4 else None
+            if isinstance(capabilities, ModelCapabilities):
+                normalized_capabilities[identity] = capabilities
         self._fallback_deployment_limits = normalized
+        self._fallback_deployment_capabilities = normalized_capabilities
 
     def configure_fallback_limits(
         self,
@@ -2488,12 +2516,45 @@ class _SelectorFallbackProvider:
         ).strip()
         model = str(getattr(current_config, "model", "") or "").strip()
         if model and getattr(config, "model_capabilities", None) is not None:
-            try:
-                updates["model_capabilities"] = shared_catalog().get_capabilities(
-                    model,
-                    provider_name=provider_id,
-                    base_url=str(getattr(current_config, "base_url", "") or ""),
+            deployment_capabilities = (
+                self._fallback_deployment_capabilities.get(
+                    _fallback_deployment_identity(current_config)
                 )
+                if current_config is not None
+                else None
+            )
+            try:
+                if deployment_capabilities is not None:
+                    resolved_capabilities = deployment_capabilities
+                else:
+                    catalog = shared_catalog()
+                    deployment_resolver = getattr(
+                        catalog,
+                        "resolve_deployment_capabilities",
+                        None,
+                    )
+                    if callable(deployment_resolver):
+                        resolved_capabilities = deployment_resolver(
+                            model,
+                            provider=provider_id,
+                            api_key=str(
+                                getattr(current_config, "api_key", "") or ""
+                            ),
+                            base_url=str(
+                                getattr(current_config, "base_url", "") or ""
+                            ),
+                        )
+                    elif provider_id.strip().lower() == "tokenrhythm":
+                        resolved_capabilities = ModelCapabilities()
+                    else:
+                        resolved_capabilities = catalog.get_capabilities(
+                            model,
+                            provider_name=provider_id,
+                            base_url=str(
+                                getattr(current_config, "base_url", "") or ""
+                            ),
+                        )
+                updates["model_capabilities"] = resolved_capabilities
             except Exception as exc:  # noqa: BLE001 - optional capability refinement
                 log.warning(
                     "selector_fallback_capability_rebind_failed",
@@ -2501,6 +2562,7 @@ class _SelectorFallbackProvider:
                     model=model,
                     error=type(exc).__name__,
                 )
+                updates["model_capabilities"] = ModelCapabilities()
 
         try:
             inherited_proof_cap = max(
@@ -2668,8 +2730,50 @@ class _SelectorFallbackProvider:
             return False
         self._note_fallback_hop()
         self._skip_benched_fallbacks()
-        self._realign_routed_model_after_fallback()
         return True
+
+    def _reject_unsupported_image_input(
+        self,
+        messages: list[Any],
+        config: Any,
+        *,
+        reason: str,
+    ) -> int:
+        """Record a local image rejection for the active physical leg."""
+
+        image_count = _count_image_blocks(messages)
+        if image_count <= 0 or bool(
+            getattr(
+                getattr(config, "model_capabilities", None),
+                "supports_vision",
+                False,
+            )
+        ):
+            return 0
+        if self._turn_metadata is not None:
+            self._turn_metadata["image_input_mode"] = "rejected"
+            self._turn_metadata["image_input_reason"] = reason
+            self._turn_metadata["image_input_count"] = image_count
+        return image_count
+
+    def local_terminal_reply(
+        self,
+        messages: list[Any],
+        config: Any,
+    ) -> str | None:
+        """Return a capability rejection before Agent reserves another call."""
+
+        active_config = self._config_for_active_leg(config)
+        reason = (
+            "fallback_vision_unsupported" if self._used_fallback else "vision_unsupported"
+        )
+        if self._reject_unsupported_image_input(
+            messages,
+            active_config,
+            reason=reason,
+        ):
+            return UNSUPPORTED_IMAGE_INPUT_REPLY
+        return None
 
     def project_final_request(
         self,
@@ -2728,11 +2832,6 @@ class _SelectorFallbackProvider:
         *,
         execution_context: TurnExecutionContext | None = None,
     ) -> AsyncIterator[Any]:
-        validation_error = validate_provider_chat_request(self._provider, messages)
-        if validation_error is not None:
-            yield validation_error
-            return
-
         emitted_user_visible_content = False
         pre_text_buffer = _SelectorPreTextBuffer()
         primary_activity_id = uuid.uuid4().hex
@@ -2742,6 +2841,24 @@ class _SelectorFallbackProvider:
         active_provider = self._provider
         active_provider_id, active_model = self._active_deployment()
         active_config = self._config_for_active_leg(config)
+        local_terminal_reply = self.local_terminal_reply(messages, config)
+        if local_terminal_reply is not None:
+            yield ProviderTextDeltaEvent(text=UNSUPPORTED_IMAGE_INPUT_REPLY)
+            yield ProviderDoneEvent(
+                stop_reason="end_turn",
+                input_tokens=0,
+                output_tokens=0,
+                model=active_model,
+            )
+            return
+
+        validation_error = validate_provider_chat_request(active_provider, messages)
+        if validation_error is not None:
+            yield validation_error
+            return
+
+        if self._used_fallback:
+            self._realign_routed_model_after_fallback()
         record_execution_leg(
             self._turn_metadata,
             provider=active_provider_id,
@@ -2917,6 +3034,32 @@ class _SelectorFallbackProvider:
                             yield buffered_event
                         yield event
                         return
+                    self._note_fallback_hop()
+                    if local_admission_escalation and self._turn_metadata is not None:
+                        self._turn_metadata["router_fallback_reason"] = (
+                            "local_admission_escalation"
+                        )
+                    self._skip_benched_fallbacks()
+                    # Close the failed physical leg before reserving the next
+                    # one; otherwise an early-consumer break can defer unknown
+                    # coverage until async-generator GC.
+                    await primary_stream.aclose()
+                    fallback_provider = self._provider
+                    fallback_provider_id, fallback_model = self._active_deployment()
+                    fallback_config = self._config_for_active_leg(config)
+                    if self._reject_unsupported_image_input(
+                        messages,
+                        fallback_config,
+                        reason="fallback_vision_unsupported",
+                    ):
+                        yield ProviderTextDeltaEvent(text=UNSUPPORTED_IMAGE_INPUT_REPLY)
+                        yield ProviderDoneEvent(
+                            stop_reason="end_turn",
+                            input_tokens=0,
+                            output_tokens=0,
+                            model=fallback_model,
+                        )
+                        return
                     fallback_authority_config = getattr(
                         self._selector,
                         "current_config",
@@ -2962,20 +3105,7 @@ class _SelectorFallbackProvider:
                             )
                             return
                         await asyncio.sleep(retry_after_hint)
-                    self._note_fallback_hop()
-                    if local_admission_escalation and self._turn_metadata is not None:
-                        self._turn_metadata["router_fallback_reason"] = (
-                            "local_admission_escalation"
-                        )
-                    self._skip_benched_fallbacks()
                     self._realign_routed_model_after_fallback()
-                    # Close the failed physical leg before reserving the next
-                    # one; otherwise an early-consumer break can defer unknown
-                    # coverage until async-generator GC.
-                    await primary_stream.aclose()
-                    fallback_provider = self._provider
-                    fallback_provider_id, fallback_model = self._active_deployment()
-                    fallback_config = self._config_for_active_leg(config)
                     # The phase frame is yielded before the fallback adapter is
                     # even asked for its first event, making ordering observable
                     # and preventing a fast fallback token from racing the UI.
@@ -5196,6 +5326,15 @@ class TurnRunner:
                     },
                 )
 
+            current_turn_image_count = _count_image_blocks(extra_msgs or [])
+            image_input_preflight_blocked = bool(
+                current_turn_image_count > 0
+                and not getattr(model_caps, "supports_vision", False)
+            )
+            if image_input_preflight_blocked:
+                turn.metadata["image_input_mode"] = "rejected"
+                turn.metadata["image_input_reason"] = "vision_unsupported"
+                turn.metadata["image_input_count"] = current_turn_image_count
             # 6. Compaction (t3 + preflight) + history load + request-context
             # prepend. CompactionAndHistoryStage owns the four-call sequence
             # (t3_upgrade → preflight → load_history → prepend_request_context_prompt).
@@ -5589,6 +5728,7 @@ class TurnRunner:
                         consumer_admission_fingerprint=(
                             consumer_admission_fingerprint
                         ),
+                        skip_compaction=image_input_preflight_blocked,
                     )
                 )
             ch_out = ch_outcome.require_output()

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -100,7 +100,12 @@ from opensquilla.contracts.attachments import (
     normalize_attachment_mime as _normalize_attachment_mime,
 )
 from opensquilla.contracts.turn_execution import TurnExecutionContext
-from opensquilla.engine.agent import UNSUPPORTED_IMAGE_INPUT_REPLY, Agent, ToolHandler
+from opensquilla.engine.agent import (
+    UNSUPPORTED_IMAGE_INPUT_REPLY,
+    Agent,
+    ToolHandler,
+    model_explicitly_lacks_vision,
+)
 from opensquilla.engine.agent_injection import PendingInputProvider
 from opensquilla.engine.cache_break_monitor import notify_compaction
 from opensquilla.engine.hooks import (
@@ -2527,7 +2532,7 @@ class _SelectorFallbackProvider:
             getattr(current_config, "provider", "") or self.provider_name
         ).strip()
         model = str(getattr(current_config, "model", "") or "").strip()
-        if model and getattr(config, "model_capabilities", None) is not None:
+        if model:
             deployment_capabilities = (
                 self._fallback_deployment_capabilities.get(
                     _fallback_deployment_identity(current_config)
@@ -5349,7 +5354,7 @@ class TurnRunner:
             current_turn_image_count = _count_image_blocks(extra_msgs or [])
             image_input_preflight_blocked = bool(
                 current_turn_image_count > 0
-                and not getattr(model_caps, "supports_vision", False)
+                and model_explicitly_lacks_vision(model_caps)
             )
             if image_input_preflight_blocked:
                 turn.metadata["image_input_mode"] = "rejected"

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -2183,6 +2183,8 @@ class _SelectorFallbackProvider:
         # no-op, keeping the default fallback path byte-identical.
         self._health_ledger = health_ledger
         self._used_fallback = False
+        self._pending_fallback_hops = 0
+        self._last_executed_model = ""
         self._fallback_limits: dict[tuple[str, str], tuple[int, int]] = {}
         self._fallback_deployment_limits: dict[
             _FallbackDeploymentIdentity, tuple[int, int]
@@ -2319,18 +2321,28 @@ class _SelectorFallbackProvider:
                 metadata[savings_key] = 0.0
 
     def _note_fallback_hop(self) -> None:
-        """Count each selector fallback actually taken this turn.
+        """Remember a selected fallback until its provider call starts.
 
-        Read at turn finalize by the router decision record
-        (engine/steps/router_decision_record.py) so persisted rows report
-        how many hops away from the routed model the executed one is.
+        Selection alone is not execution: local capability validation may end
+        the turn before the newly selected provider is called.
         """
         self._used_fallback = True
+        self._pending_fallback_hops += 1
+
+    def _commit_fallback_hops(self) -> None:
+        """Publish fallback telemetry once the selected leg will execute."""
+
+        pending_hops = self._pending_fallback_hops
+        if pending_hops <= 0:
+            return
+        self._pending_fallback_hops = 0
         metadata = self._turn_metadata
         if metadata is None:
             return
         try:
-            metadata["router_fallback_hops"] = int(metadata.get("router_fallback_hops") or 0) + 1
+            metadata["router_fallback_hops"] = (
+                int(metadata.get("router_fallback_hops") or 0) + pending_hops
+            )
             metadata.setdefault("router_fallback_reason", "selector_fallback")
         except Exception:  # noqa: BLE001 — telemetry only
             pass
@@ -2738,16 +2750,18 @@ class _SelectorFallbackProvider:
         config: Any,
         *,
         reason: str,
+        reject_unknown_capability: bool,
     ) -> int:
         """Record a local image rejection for the active physical leg."""
 
         image_count = _count_image_blocks(messages)
-        if image_count <= 0 or bool(
-            getattr(
-                getattr(config, "model_capabilities", None),
-                "supports_vision",
-                False,
-            )
+        capabilities = getattr(config, "model_capabilities", None)
+        if image_count <= 0:
+            return 0
+        if capabilities is None and not reject_unknown_capability:
+            return 0
+        if capabilities is not None and bool(
+            getattr(capabilities, "supports_vision", False)
         ):
             return 0
         if self._turn_metadata is not None:
@@ -2771,6 +2785,7 @@ class _SelectorFallbackProvider:
             messages,
             active_config,
             reason=reason,
+            reject_unknown_capability=self._used_fallback,
         ):
             return UNSUPPORTED_IMAGE_INPUT_REPLY
         return None
@@ -2848,7 +2863,7 @@ class _SelectorFallbackProvider:
                 stop_reason="end_turn",
                 input_tokens=0,
                 output_tokens=0,
-                model=active_model,
+                model=self._last_executed_model or active_model,
             )
             return
 
@@ -2858,7 +2873,9 @@ class _SelectorFallbackProvider:
             return
 
         if self._used_fallback:
+            self._commit_fallback_hops()
             self._realign_routed_model_after_fallback()
+        self._last_executed_model = active_model
         record_execution_leg(
             self._turn_metadata,
             provider=active_provider_id,
@@ -3035,10 +3052,6 @@ class _SelectorFallbackProvider:
                         yield event
                         return
                     self._note_fallback_hop()
-                    if local_admission_escalation and self._turn_metadata is not None:
-                        self._turn_metadata["router_fallback_reason"] = (
-                            "local_admission_escalation"
-                        )
                     self._skip_benched_fallbacks()
                     # Close the failed physical leg before reserving the next
                     # one; otherwise an early-consumer break can defer unknown
@@ -3051,13 +3064,14 @@ class _SelectorFallbackProvider:
                         messages,
                         fallback_config,
                         reason="fallback_vision_unsupported",
+                        reject_unknown_capability=True,
                     ):
                         yield ProviderTextDeltaEvent(text=UNSUPPORTED_IMAGE_INPUT_REPLY)
                         yield ProviderDoneEvent(
                             stop_reason="end_turn",
                             input_tokens=0,
                             output_tokens=0,
-                            model=fallback_model,
+                            model=self._last_executed_model or active_model,
                         )
                         return
                     fallback_authority_config = getattr(
@@ -3105,7 +3119,13 @@ class _SelectorFallbackProvider:
                             )
                             return
                         await asyncio.sleep(retry_after_hint)
+                    self._commit_fallback_hops()
+                    if local_admission_escalation and self._turn_metadata is not None:
+                        self._turn_metadata["router_fallback_reason"] = (
+                            "local_admission_escalation"
+                        )
                     self._realign_routed_model_after_fallback()
+                    self._last_executed_model = fallback_model
                     # The phase frame is yielded before the fallback adapter is
                     # even asked for its first event, making ordering observable
                     # and preventing a fast fallback token from racing the UI.

--- a/src/opensquilla/engine/turn_runner/agent_bootstrap_stage.py
+++ b/src/opensquilla/engine/turn_runner/agent_bootstrap_stage.py
@@ -837,7 +837,9 @@ class AgentBootstrapStage:
             tuple[str, str],
             tuple[int, int, ModelCapabilities | None],
         ] = {}
-        private_fallback_limits: list[tuple[Any, int, int]] = []
+        private_fallback_limits: list[
+            tuple[Any, int, int, ModelCapabilities | None]
+        ] = []
         fallback_deployment_configs = getattr(
             inp.provider,
             "fallback_deployment_configs",
@@ -874,6 +876,7 @@ class AgentBootstrapStage:
                         deployment,
                         fallback_catalog.context_window,
                         effective_max_tokens,
+                        fallback_catalog.capabilities,
                     )
                 )
                 fallback_capabilities.setdefault(

--- a/src/opensquilla/engine/turn_runner/compaction_and_history_stage.py
+++ b/src/opensquilla/engine/turn_runner/compaction_and_history_stage.py
@@ -9,7 +9,8 @@ stream-consumer loop.
 
 Side-effect contract:
 
-- ``t3_upgrade.maybe_compact`` and ``preflight.maybe_compact`` MAY mutate
+- Unless ``skip_compaction`` is requested, ``t3_upgrade.maybe_compact`` and
+  ``preflight.maybe_compact`` MAY mutate
   the DB transcript via ``SessionManager.compact``. They MAY also mutate
   the runner's per-turn ``has_compacted_this_turn`` flag and the
   per-session compaction-failure circuit state. All exceptions other
@@ -226,12 +227,14 @@ class CompactionAndHistoryStageInput:
     )
     consumer_admission: Any | None = field(default=None, repr=False)
     consumer_admission_fingerprint: str = ""
+    skip_compaction: bool = False
 
 @dataclass(frozen=True)
 class CompactionAndHistoryStageOutput:
     """The pieces of state subsequent stages and the harness consume.
 
-    - ``t3_upgrade_status``: one of the four ``_T3_*`` sentinels.
+    - ``t3_upgrade_status``: one of the four ``_T3_*`` sentinels, or
+      ``"skipped"`` when an upstream terminal preflight suppresses compaction.
       Surfaced for observability + the equivalence harness snapshot;
       NOT consumed by downstream stages. It is used only
       to decide whether to call preflight (folded into the stage body).
@@ -265,8 +268,8 @@ class CompactionAndHistoryStage:
     and before the attachment-build + stream-consumer steps. The four
     ports execute strictly sequentially:
 
-    1. ``t3_upgrade.maybe_compact`` (always called).
-    2. ``preflight.maybe_compact`` (called ONLY when t3 returned
+    1. ``t3_upgrade.maybe_compact`` (unless ``skip_compaction`` is set).
+    2. ``preflight.maybe_compact`` (called ONLY when compaction is enabled and t3 returned
        ``_T3_NOT_APPLICABLE`` or ``_T3_FLUSH_FAILED``).
     3. ``history_loader.load`` (always called).
     4. ``request_context_prepender.prepend`` (always called; pure).
@@ -316,47 +319,23 @@ class CompactionAndHistoryStage:
         )
         compaction_model = inp.compaction_model or inp.resolved_model
 
-        # 1. T3-upgrade compaction. Hook fires around the call so even a
-        #    no-op path's observability is uniform.
-        t3_state = CompactionState(
-            session_key=inp.session_key,
-            agent_id=inp.agent_id,
-            total_tokens=0,
-            threshold_tokens=compaction_context_window_tokens,
-            extra={"phase": "t3_upgrade"},
-        )
-        await self._fire_before_compact(t3_state)
-        t3_status = await self._t3_upgrade.maybe_compact(
-            session_key=inp.session_key,
-            turn=inp.turn,
-            context_window_tokens=compaction_context_window_tokens,
-            compaction_provider=compaction_provider,
-            compaction_model=compaction_model,
-            compaction_plan=inp.compaction_plan,
-            history_capacity_tokens=inp.history_capacity_tokens,
-            history_capacity_chars=inp.history_capacity_chars,
-            history_has_persisted_user=inp.history_has_persisted_user,
-            bound_user_message_id=inp.bound_user_message_id,
-            provider_request_correlation=inp.provider_request_correlation,
-            consumer_admission=inp.consumer_admission,
-            consumer_admission_fingerprint=inp.consumer_admission_fingerprint,
-        )
-        await self._fire_after_compact(t3_state, {"status": t3_status})
-
-        # 2. Preflight compaction (fall-through cases only).
         preflight_invoked = False
-        if t3_status in {_T3_NOT_APPLICABLE, _T3_FLUSH_FAILED}:
-            preflight_invoked = True
-            preflight_state = CompactionState(
+        if inp.skip_compaction:
+            t3_status = "skipped"
+        else:
+            # 1. T3-upgrade compaction. Hook fires around the call so even a
+            #    no-op path's observability is uniform.
+            t3_state = CompactionState(
                 session_key=inp.session_key,
                 agent_id=inp.agent_id,
                 total_tokens=0,
                 threshold_tokens=compaction_context_window_tokens,
-                extra={"phase": "preflight"},
+                extra={"phase": "t3_upgrade"},
             )
-            await self._fire_before_compact(preflight_state)
-            await self._preflight.maybe_compact(
+            await self._fire_before_compact(t3_state)
+            t3_status = await self._t3_upgrade.maybe_compact(
                 session_key=inp.session_key,
+                turn=inp.turn,
                 context_window_tokens=compaction_context_window_tokens,
                 compaction_provider=compaction_provider,
                 compaction_model=compaction_model,
@@ -369,7 +348,34 @@ class CompactionAndHistoryStage:
                 consumer_admission=inp.consumer_admission,
                 consumer_admission_fingerprint=inp.consumer_admission_fingerprint,
             )
-            await self._fire_after_compact(preflight_state, {"status": "ran"})
+            await self._fire_after_compact(t3_state, {"status": t3_status})
+
+            # 2. Preflight compaction (fall-through cases only).
+            if t3_status in {_T3_NOT_APPLICABLE, _T3_FLUSH_FAILED}:
+                preflight_invoked = True
+                preflight_state = CompactionState(
+                    session_key=inp.session_key,
+                    agent_id=inp.agent_id,
+                    total_tokens=0,
+                    threshold_tokens=compaction_context_window_tokens,
+                    extra={"phase": "preflight"},
+                )
+                await self._fire_before_compact(preflight_state)
+                await self._preflight.maybe_compact(
+                    session_key=inp.session_key,
+                    context_window_tokens=compaction_context_window_tokens,
+                    compaction_provider=compaction_provider,
+                    compaction_model=compaction_model,
+                    compaction_plan=inp.compaction_plan,
+                    history_capacity_tokens=inp.history_capacity_tokens,
+                    history_capacity_chars=inp.history_capacity_chars,
+                    history_has_persisted_user=inp.history_has_persisted_user,
+                    bound_user_message_id=inp.bound_user_message_id,
+                    provider_request_correlation=inp.provider_request_correlation,
+                    consumer_admission=inp.consumer_admission,
+                    consumer_admission_fingerprint=inp.consumer_admission_fingerprint,
+                )
+                await self._fire_after_compact(preflight_state, {"status": "ran"})
 
         # 3. Load history (transcript + reconstructed messages + durable summary).
         compaction_summary_context = await self._history_loader.load(

--- a/tests/functional/test_gateway_attachment_history_e2e.py
+++ b/tests/functional/test_gateway_attachment_history_e2e.py
@@ -21,6 +21,7 @@ import pytest
 import opensquilla.engine.steps.squilla_router as squilla_router_step
 from opensquilla.attachment_refs import transcript_material_path
 from opensquilla.engine import Agent, AgentConfig
+from opensquilla.engine.agent import UNSUPPORTED_IMAGE_INPUT_REPLY
 from opensquilla.engine.runtime import TurnRunner
 from opensquilla.gateway import rpc_sessions as _rpc_sessions  # noqa: F401
 from opensquilla.gateway.agent_tasks import get_agent_task_registry
@@ -151,6 +152,22 @@ class _EventSink:
         meta: dict[str, Any] | None = None,  # noqa: ARG002
     ) -> None:
         self.events.append((event, dict(payload or {})))
+
+
+class _UsageSink:
+    def __init__(self) -> None:
+        self.started: list[Any] = []
+        self.finalized: list[tuple[Any, Any]] = []
+        self.unknown: list[tuple[Any, str]] = []
+
+    async def start(self, call: Any) -> None:
+        self.started.append(call)
+
+    async def finalize(self, call: Any, result: Any) -> None:
+        self.finalized.append((call, result))
+
+    async def mark_unknown(self, call: Any, reason: str) -> None:
+        self.unknown.append((call, reason))
 
 
 class _TextTierStrategy:
@@ -330,11 +347,13 @@ async def _e2e_stack(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
             _VISION_MODEL: vision_provider,
         }
     )
+    usage_sink = _UsageSink()
     runner = TurnRunner(
         provider_selector=selector,
         session_manager=manager,
         config=config,
         model_catalog=_FakeModelCatalog(),
+        usage_event_sink=usage_sink,
     )
     bootstrap_configs: list[AgentConfig] = []
     original_bootstrap_run = runner._agent_bootstrap_stage.run
@@ -384,12 +403,66 @@ async def _e2e_stack(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
             "store": store,
             "subscription_manager": subscription_manager,
             "text_provider": text_provider,
+            "usage_sink": usage_sink,
             "vision_provider": vision_provider,
         }
     finally:
         get_registry().unregister(sink.conn_id)
         set_upload_store(None)
         await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_gateway_single_text_model_returns_friendly_reply_without_provider_call(
+    _e2e_stack: dict[str, Any],
+) -> None:
+    config: GatewayConfig = _e2e_stack["config"]
+    manager: SessionManager = _e2e_stack["manager"]
+    subscription_manager: SubscriptionManager = _e2e_stack["subscription_manager"]
+    sink: _EventSink = _e2e_stack["sink"]
+    gate_provider: _RecordingProvider = _e2e_stack["gate_provider"]
+    text_provider: _RecordingProvider = _e2e_stack["text_provider"]
+    vision_provider: _RecordingProvider = _e2e_stack["vision_provider"]
+    usage_sink: _UsageSink = _e2e_stack["usage_sink"]
+    config.squilla_router.enabled = False
+    key = "agent:main:single-text-model-image"
+    await manager.create(session_key=key, agent_id="main")
+    subscription_manager.subscribe_messages(sink.conn_id, key)
+    for index in range(6):
+        await manager.append_message(key, "user", f"history-{index}:" + "u" * 5_000)
+        await manager.append_message(key, "assistant", "a" * 5_000)
+
+    file_uuid = await _upload_png(_e2e_stack["app"])
+    gate_calls_before = len(gate_provider.calls)
+    text_calls_before = len(text_provider.calls)
+    vision_calls_before = len(vision_provider.calls)
+    usage_started_before = len(usage_sink.started)
+    usage_finalized_before = len(usage_sink.finalized)
+    usage_unknown_before = len(usage_sink.unknown)
+    await _send_session_turn(
+        ctx=_e2e_stack["ctx"],
+        key=key,
+        sink=sink,
+        message="请分析这张图片。",
+        attachments=[_file_uuid_attachment(file_uuid)],
+    )
+
+    assert len(gate_provider.calls) == gate_calls_before
+    assert len(text_provider.calls) == text_calls_before
+    assert len(vision_provider.calls) == vision_calls_before
+    assert len(usage_sink.started) == usage_started_before
+    assert len(usage_sink.finalized) == usage_finalized_before
+    assert len(usage_sink.unknown) == usage_unknown_before
+    deltas = _event_payloads(sink, "session.event.text_delta")
+    assert deltas[-1]["text"] == UNSUPPORTED_IMAGE_INPUT_REPLY
+    assert _event_payloads(sink, "session.event.error") == []
+    done = _event_payloads(sink, "session.event.done")[-1]
+    assert done["text"] == UNSUPPORTED_IMAGE_INPUT_REPLY
+    assert done["input_tokens"] == 0
+    assert done["output_tokens"] == 0
+    transcript = await manager.get_transcript(key)
+    assert transcript[-1].role == "assistant"
+    assert transcript[-1].content == UNSUPPORTED_IMAGE_INPUT_REPLY
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/test_agent_image_capability_guard.py
+++ b/tests/test_engine/test_agent_image_capability_guard.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import base64
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from opensquilla.engine import Agent, AgentConfig
+from opensquilla.engine.agent import UNSUPPORTED_IMAGE_INPUT_REPLY
+from opensquilla.engine.types import DoneEvent, ErrorEvent, TextDeltaEvent
+from opensquilla.provider import ChatConfig, Message, ModelCapabilities
+from opensquilla.provider.types import ContentBlockImage
+
+
+class _RecordingProvider:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def chat(
+        self,
+        messages: list[Message],
+        tools: list[Any] | None = None,
+        config: ChatConfig | None = None,
+    ) -> AsyncIterator[Any]:
+        self.calls.append({"messages": messages, "tools": tools, "config": config})
+        return self._stream()
+
+    async def _stream(self) -> AsyncIterator[Any]:
+        from opensquilla.provider import DoneEvent as ProviderDoneEvent
+        from opensquilla.provider import TextDeltaEvent as ProviderTextDeltaEvent
+
+        yield ProviderTextDeltaEvent(text="image accepted")
+        yield ProviderDoneEvent(stop_reason="end_turn", input_tokens=3, output_tokens=2)
+
+
+def _image_message() -> Message:
+    return Message(
+        role="user",
+        content=[
+            ContentBlockImage(
+                media_type="image/png",
+                data=base64.b64encode(b"synthetic image").decode("ascii"),
+            )
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_vision_model_returns_friendly_reply_without_provider_call() -> None:
+    provider = _RecordingProvider()
+    config = AgentConfig(
+        model_id="text-only-model",
+        model_capabilities=ModelCapabilities(supports_vision=False),
+    )
+    agent = Agent(provider=provider, config=config)
+
+    events = [
+        event
+        async for event in agent.run_turn(
+            "请分析这张图片。",
+            extra_messages=[_image_message()],
+        )
+    ]
+
+    assert provider.calls == []
+    assert [event.text for event in events if isinstance(event, TextDeltaEvent)] == [
+        UNSUPPORTED_IMAGE_INPUT_REPLY
+    ]
+    assert not any(isinstance(event, ErrorEvent) for event in events)
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.text == UNSUPPORTED_IMAGE_INPUT_REPLY
+    assert done.input_tokens == 0
+    assert done.output_tokens == 0
+    assert done.cost_usd == 0.0
+    assert config.metadata["image_input_mode"] == "rejected"
+    assert config.metadata["image_input_reason"] == "vision_unsupported"
+    assert config.metadata["image_input_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_vision_model_still_receives_current_turn_image() -> None:
+    provider = _RecordingProvider()
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            max_iterations=1,
+            model_id="vision-model",
+            model_capabilities=ModelCapabilities(supports_vision=True),
+        ),
+    )
+
+    events = [
+        event
+        async for event in agent.run_turn(
+            "Describe this image.",
+            extra_messages=[_image_message()],
+        )
+    ]
+
+    assert any(isinstance(event, DoneEvent) for event in events)
+    assert len(provider.calls) == 1
+    assert any(
+        isinstance(block, ContentBlockImage)
+        for message in provider.calls[0]["messages"]
+        if isinstance(message.content, list)
+        for block in message.content
+    )

--- a/tests/test_engine/test_agent_image_capability_guard.py
+++ b/tests/test_engine/test_agent_image_capability_guard.py
@@ -106,3 +106,27 @@ async def test_vision_model_still_receives_current_turn_image() -> None:
         if isinstance(message.content, list)
         for block in message.content
     )
+
+
+@pytest.mark.asyncio
+async def test_unknown_model_capability_defers_to_provider() -> None:
+    provider = _RecordingProvider()
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            max_iterations=1,
+            model_id="custom-model",
+            model_capabilities=None,
+        ),
+    )
+
+    events = [
+        event
+        async for event in agent.run_turn(
+            "Describe this image.",
+            extra_messages=[_image_message()],
+        )
+    ]
+
+    assert any(isinstance(event, DoneEvent) for event in events)
+    assert len(provider.calls) == 1

--- a/tests/test_engine/test_selector_fallback_routed_model.py
+++ b/tests/test_engine/test_selector_fallback_routed_model.py
@@ -95,6 +95,7 @@ async def test_fallback_realigns_only_when_provider_call_starts() -> None:
     assert metadata["routed_model"] == "cheap/fallback"
     assert metadata["executed_provider"] == "fallback-provider"
     assert metadata["executed_model"] == "cheap/fallback"
+    assert metadata["router_fallback_hops"] == 1
     assert metadata["router_fallback_reason"] == "selector_fallback"
     assert metadata["savings_pct"] == 0.0
     assert metadata["savings_max_price_per_m"] == 0.0
@@ -946,6 +947,50 @@ async def test_tokenrhythm_tool_reasoning_fallback_rebuilds_from_canonical_histo
     assert any(event.kind == "done" and event.text == "done" for event in events)
 
 
+async def test_unknown_primary_capability_defers_to_provider_image_validation() -> None:
+    class _Provider:
+        provider_name = "ensemble"
+
+        def __init__(self) -> None:
+            self.validation_calls = 0
+            self.calls = 0
+
+        def validate_chat_request(self, messages):
+            del messages
+            self.validation_calls += 1
+            return ErrorEvent(
+                message="ensemble rejects image input",
+                code="ensemble_multimodal_unsupported",
+            )
+
+        async def chat(self, messages, tools=None, config=None):
+            del messages, tools, config
+            self.calls += 1
+            yield DoneEvent(model="ensemble/model")
+
+    class _Selector:
+        active_provider_id = "ensemble"
+        current_config = SimpleNamespace(provider="ensemble", model="ensemble/model")
+
+    provider = _Provider()
+    wrapper = _SelectorFallbackProvider(provider, _Selector())
+    messages = [
+        Message(
+            role="user",
+            content=[ContentBlockImage(media_type="image/png", data="c3ludGhldGlj")],
+        )
+    ]
+
+    events = [event async for event in wrapper.chat(messages, config=ChatConfig())]
+
+    assert provider.validation_calls == 1
+    assert provider.calls == 0
+    assert [event.code for event in events if isinstance(event, ErrorEvent)] == [
+        "ensemble_multimodal_unsupported"
+    ]
+    assert not any(isinstance(event, TextDeltaEvent) for event in events)
+
+
 async def test_image_request_does_not_call_text_only_fallback(monkeypatch: Any) -> None:
     class _Catalog:
         def get_capabilities(
@@ -1047,12 +1092,15 @@ async def test_image_request_does_not_call_text_only_fallback(monkeypatch: Any) 
         UNSUPPORTED_IMAGE_INPUT_REPLY
     ]
     done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.model == "vision-primary"
     assert done.input_tokens == 0
     assert done.output_tokens == 0
     assert metadata["image_input_mode"] == "rejected"
     assert metadata["image_input_reason"] == "fallback_vision_unsupported"
     assert metadata["routed_model"] == "vision-primary"
     assert metadata["executed_model"] == "vision-primary"
+    assert "router_fallback_hops" not in metadata
+    assert "router_fallback_reason" not in metadata
     assert metadata["savings_pct"] == 17.0
     assert [leg["model"] for leg in metadata["execution_legs"]] == [
         "vision-primary"
@@ -1178,6 +1226,8 @@ async def test_invalid_response_fallback_rejects_image_before_text_only_call(
     assert metadata["image_input_reason"] == "fallback_vision_unsupported"
     assert metadata["routed_model"] == "vision-primary"
     assert metadata["executed_model"] == "vision-primary"
+    assert "router_fallback_hops" not in metadata
+    assert "router_fallback_reason" not in metadata
     assert metadata["savings_pct"] == 17.0
     assert [leg["model"] for leg in metadata["execution_legs"]] == [
         "vision-primary"

--- a/tests/test_engine/test_selector_fallback_routed_model.py
+++ b/tests/test_engine/test_selector_fallback_routed_model.py
@@ -430,7 +430,7 @@ def test_fallback_leg_never_increases_small_explicit_output_limit() -> None:
     assert wrapper.fallback_after_invalid_response("upstream 503") is True
     fallback_config = wrapper._config_for_active_leg(config)
 
-    assert fallback_config is config
+    assert fallback_config.max_tokens == config.max_tokens
     assert fallback_config.max_tokens == 4_096
 
 
@@ -440,7 +440,9 @@ def test_unknown_fallback_limit_does_not_apply_generic_default() -> None:
 
     assert wrapper.fallback_after_invalid_response("upstream 503") is True
 
-    assert wrapper._config_for_active_leg(config) is config
+    fallback_config = wrapper._config_for_active_leg(config)
+    assert fallback_config.max_tokens == config.max_tokens
+    assert fallback_config.model_capabilities.supports_vision is False
 
 
 def test_each_hop_uses_the_active_physical_models_own_output_limit() -> None:
@@ -569,10 +571,7 @@ def test_tokenrhythm_same_model_fallback_uses_exact_private_config_identity() ->
     wrapper.configure_fallback_limits(
         {("tokenrhythm", "shared/model"): (1_000_000, 131_072)}
     )
-    original = ChatConfig(
-        max_tokens=131_072,
-        model_capabilities=ModelCapabilities(supports_vision=True),
-    )
+    original = ChatConfig(max_tokens=131_072, model_capabilities=None)
 
     assert wrapper.fallback_after_invalid_response("first failure") is True
     first_fallback_config = wrapper._config_for_active_leg(original)
@@ -630,7 +629,9 @@ def test_dynamic_tokenrhythm_fallback_without_exact_limit_is_not_cross_clamped()
     original = ChatConfig(max_tokens=131_072)
 
     assert wrapper.fallback_after_invalid_response("dynamic plugin fallback") is True
-    assert wrapper._config_for_active_leg(original) is original
+    fallback_config = wrapper._config_for_active_leg(original)
+    assert fallback_config.max_tokens == original.max_tokens
+    assert fallback_config.model_capabilities.supports_vision is False
 
 
 PRIMARY_MODEL = "routed-primary"
@@ -989,6 +990,59 @@ async def test_unknown_primary_capability_defers_to_provider_image_validation() 
         "ensemble_multimodal_unsupported"
     ]
     assert not any(isinstance(event, TextDeltaEvent) for event in events)
+
+
+async def test_unknown_primary_uses_known_vision_fallback_for_image() -> None:
+    class _Provider:
+        provider_name = "openrouter"
+
+        def __init__(self, *, fails: bool) -> None:
+            self.fails = fails
+            self.calls = 0
+
+        async def chat(self, messages, tools=None, config=None):
+            del messages, tools, config
+            self.calls += 1
+            if self.fails:
+                yield ErrorEvent(message="primary unavailable", code="503")
+                return
+            yield TextDeltaEvent(text="image accepted by fallback")
+            yield DoneEvent(model="vision-fallback")
+
+    primary_config = SimpleNamespace(provider="openrouter", model="unknown-primary")
+    fallback_config = SimpleNamespace(provider="openrouter", model="vision-fallback")
+
+    class _Selector:
+        active_provider_id = "openrouter"
+
+        def __init__(self) -> None:
+            self.primary = _Provider(fails=True)
+            self.fallback = _Provider(fails=False)
+            self.current_config = primary_config
+
+        def next_fallback_after_failure(self, _exc: Exception) -> _Provider:
+            self.current_config = fallback_config
+            return self.fallback
+
+    selector = _Selector()
+    wrapper = _SelectorFallbackProvider(selector.primary, selector)
+    wrapper.configure_fallback_deployment_limits(
+        [(fallback_config, 0, 0, ModelCapabilities(supports_vision=True))]
+    )
+    messages = [
+        Message(
+            role="user",
+            content=[ContentBlockImage(media_type="image/png", data="c3ludGhldGlj")],
+        )
+    ]
+
+    events = [event async for event in wrapper.chat(messages, config=ChatConfig())]
+
+    assert selector.primary.calls == 1
+    assert selector.fallback.calls == 1
+    assert [event.text for event in events if isinstance(event, TextDeltaEvent)] == [
+        "image accepted by fallback"
+    ]
 
 
 async def test_image_request_does_not_call_text_only_fallback(monkeypatch: Any) -> None:

--- a/tests/test_engine/test_selector_fallback_routed_model.py
+++ b/tests/test_engine/test_selector_fallback_routed_model.py
@@ -16,7 +16,7 @@ from typing import Any
 
 from opensquilla.context_budget import ContextBudgetGovernor
 from opensquilla.engine import ToolResult
-from opensquilla.engine.agent import Agent
+from opensquilla.engine.agent import UNSUPPORTED_IMAGE_INPUT_REPLY, Agent
 from opensquilla.engine.agent_injection import ListPendingInputProvider
 from opensquilla.engine.pipeline import TurnContext
 from opensquilla.engine.runtime import TurnRunner, _SelectorFallbackProvider
@@ -32,6 +32,7 @@ from opensquilla.provider import (
     ErrorEvent,
     Message,
     ModelCapabilities,
+    ProviderActivityEvent,
     ProviderRequestCorrelation,
     TextDeltaEvent,
     ToolDefinition,
@@ -40,6 +41,7 @@ from opensquilla.provider import (
     ToolUseStartEvent,
 )
 from opensquilla.provider.openai import OpenAIProvider
+from opensquilla.provider.types import ContentBlockImage
 from opensquilla.tools.types import CallerKind, ToolContext
 
 
@@ -48,14 +50,24 @@ class _StubSelector:
         self._fallback_model = fallback_model
 
     def next_fallback_after_failure(self, exc: Exception) -> object:
-        return object()
+        del exc
+        return _SuccessfulProvider()
 
     @property
     def current_config(self) -> SimpleNamespace:
         return SimpleNamespace(provider="fallback-provider", model=self._fallback_model)
 
 
-def test_fallback_realigns_routed_model_and_drops_savings() -> None:
+class _SuccessfulProvider:
+    provider_name = "fallback-provider"
+
+    async def chat(self, messages, tools=None, config=None):
+        del messages, tools, config
+        yield TextDeltaEvent(text="ok")
+        yield DoneEvent(model="cheap/fallback")
+
+
+async def test_fallback_realigns_only_when_provider_call_starts() -> None:
     metadata: dict[str, object] = {
         "routed_model": "expensive/model",
         "savings_pct": 12.5,
@@ -63,12 +75,22 @@ def test_fallback_realigns_routed_model_and_drops_savings() -> None:
         "savings_routed_price_per_m": 0.5,
     }
     wrapper = _SelectorFallbackProvider(
-        object(),
+        _SuccessfulProvider(),
         _StubSelector("cheap/fallback"),
         turn_metadata=metadata,
     )
 
     assert wrapper.fallback_after_invalid_response("upstream 503") is True
+    assert metadata["routed_model"] == "expensive/model"
+    assert "executed_model" not in metadata
+
+    _ = [
+        event
+        async for event in wrapper.chat(
+            [Message(role="user", content="hello")],
+            config=ChatConfig(),
+        )
+    ]
 
     assert metadata["routed_model"] == "cheap/fallback"
     assert metadata["executed_provider"] == "fallback-provider"
@@ -528,20 +550,37 @@ def test_tokenrhythm_same_model_fallback_uses_exact_private_config_identity() ->
     )
     wrapper.configure_fallback_deployment_limits(
         [
-            (fallback_same_model, 64_000, 8_192),
-            (fallback_other_model, 32_000, 4_096),
+            (
+                fallback_same_model,
+                64_000,
+                8_192,
+                ModelCapabilities(supports_vision=False),
+            ),
+            (
+                fallback_other_model,
+                32_000,
+                4_096,
+                ModelCapabilities(supports_vision=True),
+            ),
         ]
     )
     # A sanitized provider/model-only compatibility limit would be wrong for B.
     wrapper.configure_fallback_limits(
         {("tokenrhythm", "shared/model"): (1_000_000, 131_072)}
     )
-    original = ChatConfig(max_tokens=131_072)
+    original = ChatConfig(
+        max_tokens=131_072,
+        model_capabilities=ModelCapabilities(supports_vision=True),
+    )
 
     assert wrapper.fallback_after_invalid_response("first failure") is True
-    assert wrapper._config_for_active_leg(original).max_tokens == 8_192
+    first_fallback_config = wrapper._config_for_active_leg(original)
+    assert first_fallback_config.max_tokens == 8_192
+    assert first_fallback_config.model_capabilities.supports_vision is False
     assert wrapper.fallback_after_invalid_response("second failure") is True
-    assert wrapper._config_for_active_leg(original).max_tokens == 4_096
+    second_fallback_config = wrapper._config_for_active_leg(original)
+    assert second_fallback_config.max_tokens == 4_096
+    assert second_fallback_config.model_capabilities.supports_vision is True
 
     serialized = json.dumps(metadata, sort_keys=True)
     assert "synthetic-key-a" not in serialized
@@ -905,6 +944,244 @@ async def test_tokenrhythm_tool_reasoning_fallback_rebuilds_from_canonical_histo
     assert primary_wire_tool_call["reasoning_content"] == ""
     assert fallback_wire_tool_call["reasoning_content"] == long_reasoning
     assert any(event.kind == "done" and event.text == "done" for event in events)
+
+
+async def test_image_request_does_not_call_text_only_fallback(monkeypatch: Any) -> None:
+    class _Catalog:
+        def get_capabilities(
+            self,
+            model_id: str,
+            provider_name: str = "openrouter",
+            base_url: str = "",
+        ) -> ModelCapabilities:
+            del model_id, provider_name, base_url
+            return ModelCapabilities(supports_vision=False)
+
+    class _Provider:
+        provider_name = "openrouter"
+
+        def __init__(self, *, fails: bool) -> None:
+            self.fails = fails
+            self.calls = 0
+
+        async def chat(self, messages, tools=None, config=None):
+            del messages, tools, config
+            self.calls += 1
+            if self.fails:
+                yield ErrorEvent(
+                    message="rate limited",
+                    code="429",
+                    retry_after_s=901.0,
+                )
+                return
+            yield TextDeltaEvent(text="fallback must not run")
+            yield DoneEvent(model="text-fallback")
+
+    class _Selector:
+        def __init__(self) -> None:
+            self.primary = _Provider(fails=True)
+            self.fallback = _Provider(fails=False)
+            self.current_config = SimpleNamespace(
+                provider="openrouter",
+                model="vision-primary",
+                api_key="synthetic-shared-key",
+                base_url="https://openrouter.ai/api/v1",
+                org_id="",
+                proxy="http://127.0.0.1:8118",
+            )
+
+        @property
+        def active_provider_id(self) -> str:
+            return "openrouter"
+
+        def next_fallback_after_failure(self, _exc: Exception) -> _Provider:
+            self.current_config = SimpleNamespace(
+                provider="openrouter",
+                model="text-fallback",
+                api_key="synthetic-shared-key",
+                base_url="https://openrouter.ai/api/v1",
+                org_id="",
+                proxy="http://127.0.0.1:8118",
+            )
+            return self.fallback
+
+    monkeypatch.setattr("opensquilla.engine.runtime.shared_catalog", lambda: _Catalog())
+    selector = _Selector()
+    metadata: dict[str, Any] = {
+        "routed_model": "vision-primary",
+        "executed_provider": "openrouter",
+        "executed_model": "vision-primary",
+        "savings_pct": 17.0,
+    }
+    wrapper = _SelectorFallbackProvider(
+        selector.primary,
+        selector,
+        turn_metadata=metadata,
+    )
+    messages = [
+        Message(
+            role="user",
+            content=[ContentBlockImage(media_type="image/png", data="c3ludGhldGlj")],
+        )
+    ]
+
+    events = [
+        event
+        async for event in wrapper.chat(
+            messages,
+            config=ChatConfig(
+                model_capabilities=ModelCapabilities(supports_vision=True)
+            ),
+        )
+    ]
+
+    assert selector.primary.calls == 1
+    assert selector.fallback.calls == 0
+    assert not any(
+        isinstance(event, ProviderActivityEvent)
+        and event.phase in {"retry_wait", "fallback"}
+        for event in events
+    )
+    assert not any(isinstance(event, ErrorEvent) for event in events)
+    assert [event.text for event in events if isinstance(event, TextDeltaEvent)] == [
+        UNSUPPORTED_IMAGE_INPUT_REPLY
+    ]
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.input_tokens == 0
+    assert done.output_tokens == 0
+    assert metadata["image_input_mode"] == "rejected"
+    assert metadata["image_input_reason"] == "fallback_vision_unsupported"
+    assert metadata["routed_model"] == "vision-primary"
+    assert metadata["executed_model"] == "vision-primary"
+    assert metadata["savings_pct"] == 17.0
+    assert [leg["model"] for leg in metadata["execution_legs"]] == [
+        "vision-primary"
+    ]
+
+
+async def test_invalid_response_fallback_rejects_image_before_text_only_call(
+    monkeypatch: Any,
+) -> None:
+    class _Catalog:
+        def get_capabilities(
+            self,
+            model_id: str,
+            provider_name: str = "openrouter",
+            base_url: str = "",
+        ) -> ModelCapabilities:
+            del model_id, provider_name, base_url
+            return ModelCapabilities(supports_vision=False)
+
+    class _Provider:
+        provider_name = "openrouter"
+
+        def __init__(self, *, empty: bool) -> None:
+            self.empty = empty
+            self.calls = 0
+            self.validation_calls = 0
+
+        def validate_chat_request(self, messages):
+            del messages
+            self.validation_calls += 1
+            if not self.empty:
+                return ErrorEvent(
+                    message="text-only fallback rejects image input",
+                    code="unsupported_image",
+                )
+            return None
+
+        async def chat(self, messages, tools=None, config=None):
+            del messages, tools, config
+            self.calls += 1
+            if self.empty:
+                yield DoneEvent(
+                    stop_reason="stop",
+                    input_tokens=3,
+                    output_tokens=0,
+                    model="vision-primary",
+                )
+                return
+            yield TextDeltaEvent(text="fallback must not run")
+            yield DoneEvent(model="text-fallback")
+
+    class _Selector:
+        def __init__(self) -> None:
+            self.primary = _Provider(empty=True)
+            self.fallback = _Provider(empty=False)
+            self.current_config = SimpleNamespace(
+                provider="openrouter",
+                model="vision-primary",
+                base_url="",
+            )
+
+        @property
+        def active_provider_id(self) -> str:
+            return "openrouter"
+
+        def next_fallback_after_failure(self, _exc: Exception) -> _Provider:
+            self.current_config = SimpleNamespace(
+                provider="openrouter",
+                model="text-fallback",
+                base_url="",
+            )
+            return self.fallback
+
+    monkeypatch.setattr("opensquilla.engine.runtime.shared_catalog", lambda: _Catalog())
+    selector = _Selector()
+    metadata: dict[str, Any] = {
+        "routed_model": "vision-primary",
+        "executed_provider": "openrouter",
+        "executed_model": "vision-primary",
+        "savings_pct": 17.0,
+    }
+    wrapper = _SelectorFallbackProvider(
+        selector.primary,
+        selector,
+        turn_metadata=metadata,
+    )
+    agent = Agent(
+        provider=wrapper,
+        config=AgentConfig(
+            max_provider_retries=0,
+            max_turn_llm_calls=1,
+            model_id="vision-primary",
+            model_capabilities=ModelCapabilities(supports_vision=True),
+        ),
+    )
+    image_message = Message(
+        role="user",
+        content=[ContentBlockImage(media_type="image/png", data="c3ludGhldGlj")],
+    )
+
+    events = [
+        event
+        async for event in agent.run_turn(
+            "Describe the image.",
+            extra_messages=[image_message],
+        )
+    ]
+
+    assert selector.primary.calls == 1
+    assert selector.fallback.calls == 0
+    assert selector.primary.validation_calls == 2
+    assert selector.fallback.validation_calls == 0
+    assert not any(event.kind == "error" for event in events)
+    assert any(
+        event.kind == "warning" and event.code == "provider_empty_retry"
+        for event in events
+    )
+    done = next(event for event in events if isinstance(event, EngineDoneEvent))
+    assert done.text == UNSUPPORTED_IMAGE_INPUT_REPLY
+    assert done.input_tokens == 3
+    assert done.output_tokens == 0
+    assert metadata["image_input_mode"] == "rejected"
+    assert metadata["image_input_reason"] == "fallback_vision_unsupported"
+    assert metadata["routed_model"] == "vision-primary"
+    assert metadata["executed_model"] == "vision-primary"
+    assert metadata["savings_pct"] == 17.0
+    assert [leg["model"] for leg in metadata["execution_legs"]] == [
+        "vision-primary"
+    ]
 
 
 async def test_local_admission_failure_escalates_to_larger_authorized_leg(

--- a/tests/test_engine/turn_runner/test_compaction_and_history_stage_snapshot.py
+++ b/tests/test_engine/turn_runner/test_compaction_and_history_stage_snapshot.py
@@ -27,7 +27,14 @@ import pytest
 
 from opensquilla.engine.hooks.types import CompactionState
 from opensquilla.engine.runtime import TurnRunner
+from opensquilla.engine.turn_runner import (
+    AttachmentMaterializationStats,
+    AttachmentStageOutput,
+)
+from opensquilla.engine.turn_runner.outcome import StageOutcome
 from opensquilla.engine.types import ErrorEvent
+from opensquilla.provider import Message
+from opensquilla.provider.types import ContentBlockImage
 
 # Reuse upstream patch helpers from's equivalence harness — this
 # stage sits AFTER AgentBootstrapStage's slice so the same upstream
@@ -473,6 +480,35 @@ async def test_compaction_and_history_stage_snapshot(
         call_log["history"][0]["trim_last_user"]
         is case["history_has_persisted_user"]
     )
+
+
+@pytest.mark.asyncio
+async def test_unknown_vision_capability_does_not_skip_compaction() -> None:
+    case = dict(_CASE_BASE)
+    runner, call_log = _setup_runner(case)
+    image_message = Message(
+        role="user",
+        content=[ContentBlockImage(media_type="image/png", data="c3ludGhldGlj")],
+    )
+
+    async def _attachment_run(_inp: Any) -> StageOutcome[AttachmentStageOutput]:
+        return StageOutcome.success(
+            AttachmentStageOutput(
+                extra_messages=[image_message],
+                turn_input="",
+                stats=AttachmentMaterializationStats(image_count=1),
+            )
+        )
+
+    runner._attachment_stage = SimpleNamespace(run=_attachment_run)
+
+    captured, _yielded, raised = await _drive(runner, case)
+
+    assert raised is None
+    assert captured is not None
+    assert len(call_log["t3"]) == 1
+    assert len(call_log["preflight"]) == 1
+    assert len(call_log["history"]) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/turn_runner/test_compaction_and_history_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_compaction_and_history_stage_unit.py
@@ -129,6 +129,7 @@ def _make_input(
     history_has_persisted_user: bool = True,
     bound_user_message_id: str | None = None,
     context_window_tokens: int = 200_000,
+    skip_compaction: bool = False,
 ) -> CompactionAndHistoryStageInput:
     if agent is None:
         agent = _make_agent_stub(request_context_prompt=request_context_prompt)
@@ -142,6 +143,7 @@ def _make_input(
         agent_id=agent_id,
         history_has_persisted_user=history_has_persisted_user,
         bound_user_message_id=bound_user_message_id,
+        skip_compaction=skip_compaction,
     )
 
 
@@ -212,6 +214,22 @@ async def test_t3_handled_skips_preflight() -> None:
     assert len(t3.calls) == 1
     assert len(preflight.calls) == 0
     assert len(history.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_explicit_skip_bypasses_compaction_but_still_loads_history() -> None:
+    hook = _RecordingCompactionHook()
+    stage, t3, preflight, history, prepender = _make_stage(hooks=(hook,))
+
+    outcome = await stage.run(_make_input(skip_compaction=True))
+
+    assert outcome.output.t3_upgrade_status == "skipped"
+    assert outcome.output.preflight_invoked is False
+    assert t3.calls == []
+    assert preflight.calls == []
+    assert len(history.calls) == 1
+    assert len(prepender.calls) == 1
+    assert hook.events == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope

Fixes #1237.

When the selected single model cannot process images, return a deterministic friendly assistant reply instead of sending the image to the provider or surfacing a provider error.

## Root cause

Image attachments reached provider and compaction paths before the selected physical model capability was enforced. Selector fallback legs could also inherit primary-model vision metadata, including across TokenRhythm credential authorities.

## Implementation

- Reject current-turn image input locally for non-vision models with a fixed user-facing reply and zero new provider usage.
- Skip auxiliary compaction calls for terminally rejected image turns while still loading history for transcript consistency.
- Re-check exact physical fallback capabilities before validation, retry waits, activity events, call-budget admission, or provider dispatch.
- Keep fallback capability snapshots private and keyed by exact deployment identity, including credential authority.
- Preserve execution-model and cost attribution when a fallback is selected but never called.

## Tests

- 206 focused and adjacent tests passed, including provider activity and Retry-After behavior.
- Broader related sweep: 570 passed, 2 skipped.
- Ruff and Mypy passed for all touched source and test files.
- Two unrelated non-image attachment E2E failures (`checkpoint workspace_dir is not configured`) were reproduced unchanged on origin/main and are not caused by this patch.

## Safety and compatibility

No schema, public API, configuration, or migration changes. Vision-capable models keep the existing request path. Unknown or failed fallback capability resolution is fail-closed for image input. Rollback is a single commit revert.

## Live limitations

No live reporter environment or credentials were available; behavior is covered by deterministic unit, integration, and gateway E2E tests.

## Third-party origin

The implementation is original. No third-party code, fixtures, comments, or identifiers were copied.