### PR TITLE
fix(config): actionable diagnostics + backup for hand-edited config.toml

### DIFF
--- a/src/opensquilla/cli/gateway_cmd.py
+++ b/src/opensquilla/cli/gateway_cmd.py
@@ -25,7 +25,12 @@ from opensquilla.gateway.boot import (
     gateway_shutdown_deadline,
     start_gateway_server,
 )
-from opensquilla.gateway.config import GatewayConfig, is_public_bind, resolve_listen_address
+from opensquilla.gateway.config import (
+    ConfigValidationError,
+    GatewayConfig,
+    is_public_bind,
+    resolve_listen_address,
+)
 from opensquilla.gateway.config_migration import ConfigParseError
 from opensquilla.paths import default_opensquilla_home
 
@@ -112,6 +117,13 @@ def _gateway_bind_available(host: str, port: int) -> bool:
 def _load_gateway_config(config_path: str | None, *, read_only: bool = False) -> GatewayConfig:
     try:
         return GatewayConfig.load(config_path, read_only=read_only)
+    except ConfigValidationError as exc:
+        console.print(f"[red]Invalid gateway config:[/red] {exc}")
+        console.print(
+            "Fix the keys listed above, or restore the newest valid backup with "
+            "[bold]opensquilla recovery recover-config --home <profile>[/bold]."
+        )
+        raise typer.Exit(code=1) from None
     except ConfigParseError as exc:
         console.print(f"[red]Invalid gateway config:[/red] {exc}")
         console.print(

--- a/src/opensquilla/engine/artifact_delivery.py
+++ b/src/opensquilla/engine/artifact_delivery.py
@@ -248,6 +248,22 @@ def auto_publish_omitted_workspace_artifacts(
         if not _text_mentions_written_file(final_text, record):
             continue
 
+        target_key = artifact_delivery_publish_target_key(
+            str(target),
+            workspace_dir=workspace,
+        )
+        name_key = artifact_delivery_name_target_key(target.name)
+        if target_key is not None and target_key in getattr(
+            ctx, "published_artifact_source_keys", frozenset()
+        ):
+            # The same source file was explicitly published earlier this turn,
+            # possibly under a custom display name. Do not publish it a second
+            # time under its original filename.
+            for resolved_key in (target_key, name_key):
+                if resolved_key is not None and resolved_key not in resolved_target_keys:
+                    resolved_target_keys.append(resolved_key)
+            continue
+
         try:
             artifact_mime = artifact_mime_for_name(target.name)
             publish_max_bytes = artifact_publish_max_bytes_for_name(
@@ -288,11 +304,6 @@ def auto_publish_omitted_workspace_artifacts(
                 pptx_payload if pptx_payload is not None else target.read_bytes()
             ).hexdigest()
             artifact_key = (target_sha256, _safe_filename(target.name))
-            target_key = artifact_delivery_publish_target_key(
-                str(target),
-                workspace_dir=workspace,
-            )
-            name_key = artifact_delivery_name_target_key(target.name)
             if artifact_key in known_artifact_keys:
                 for resolved_key in (target_key, name_key):
                     if (

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -19,6 +19,7 @@ from pydantic import (
     Field,
     PrivateAttr,
     SerializeAsAny,
+    ValidationError,
     field_validator,
     model_validator,
 )
@@ -30,6 +31,7 @@ from opensquilla.gateway.config_migration import (
     LATEST_CONFIG_VERSION,
     ConfigParseError,
     backup_and_write_migrated_config,
+    make_config_backup,
     migrate_config_payload,
 )
 from opensquilla.paths import default_opensquilla_home, native_io_path
@@ -3275,7 +3277,11 @@ class GatewayConfig(BaseSettings):
             except (tomllib.TOMLDecodeError, UnicodeDecodeError) as exc:
                 raise ConfigParseError(target, exc) from exc
         migration = migrate_config_payload(data)
-        cfg = cls(**migration.payload)
+        try:
+            cfg = cls(**migration.payload)
+        except ValidationError as exc:
+            backup = _auto_backup_invalid_config(target, exc)
+            raise ConfigValidationError(target, exc, backup=backup) from exc
         cfg._mark_env_absorbed_secrets(data)
         cls._apply_profile_path_overrides(cfg, target)
         if migration.changed:
@@ -3317,7 +3323,18 @@ class GatewayConfig(BaseSettings):
                     except (tomllib.TOMLDecodeError, UnicodeDecodeError) as exc:
                         raise ConfigParseError(path, exc) from exc
                 migration = migrate_config_payload(data, emit_diagnostics=not read_only)
-                cfg = cls(**migration.payload)
+                _warn_unknown_config_keys(path, migration.payload)
+                try:
+                    cfg = cls(**migration.payload)
+                except ValidationError as exc:
+                    # A hand-edited config.toml (e.g. an agent writing fields
+                    # that do not exist in the schema) must not dead-end the
+                    # gateway with a bare "exited code=1". Surface every
+                    # offending key with its location, keep a timestamped
+                    # backup of the file the operator can restore, and raise a
+                    # dedicated error the boot/CLI layer can render.
+                    backup = _auto_backup_invalid_config(path, exc)
+                    raise ConfigValidationError(path, exc, backup=backup) from exc
                 cls._apply_profile_path_overrides(cfg, path)
                 if migration.changed and not read_only:
                     _rewrite_migrated_config_best_effort(path, migration)
@@ -3360,6 +3377,145 @@ class GatewayConfig(BaseSettings):
 
 
 # --- bind-address resolution ----------------------------------------------
+
+class ConfigValidationError(ValueError):
+    """A user config file failed schema validation with field-level detail.
+
+    ``load`` raises this (instead of a bare ``pydantic.ValidationError``) so
+    the boot/CLI surfaces can tell the operator exactly which keys are wrong
+    and where a timestamped backup of the original file was kept — turning a
+    silent ``gateway exited code=1`` into an actionable message.
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        error: ValidationError,
+        backup: Path | None = None,
+    ) -> None:
+        self.path = Path(path)
+        self.backup = backup
+        self.field_errors = _config_validation_field_errors(error)
+        super().__init__(self._format_message())
+
+    def _format_message(self) -> str:
+        lines = [
+            f"config validation failed in {self.path}",
+            "The following fields could not be parsed or are not recognized:",
+        ]
+        for entry in self.field_errors:
+            location = ".".join(str(part) for part in entry["loc"]) or "<root>"
+            kind = entry["type"]
+            lines.append(f"  - {location}: {entry['msg']} (error {kind})")
+        if self.backup is not None:
+            lines.append(
+                f"A backup of the original file is available at {self.backup}"
+            )
+        lines.append(
+            "Fix the keys above, or restore the backup, and restart the gateway."
+        )
+        return "\n".join(lines)
+
+
+def _config_validation_field_errors(error: ValidationError) -> list[dict[str, Any]]:
+    """Return a stable, message-safe summary of a pydantic ValidationError."""
+    errors = getattr(error, "errors", None)
+    if not callable(errors):
+        return []
+    try:
+        raw = errors()
+    except Exception:
+        return []
+    out: list[dict[str, Any]] = []
+    for item in raw if isinstance(raw, list) else []:
+        if not isinstance(item, dict):
+            continue
+        out.append({
+            "loc": item.get("loc", ()),
+            "msg": str(item.get("msg", "")),
+            "type": str(item.get("type", "")),
+        })
+    return out
+
+
+def _resolve_annotation(name: str) -> Any:
+    """Resolve a string annotation to a class within this module's namespace."""
+    target = name
+    if target.startswith("'") and target.endswith("'"):
+        target = target[1:-1]
+    if "[" in target:
+        target = target.split("[", 1)[0]
+    resolved = globals().get(target)
+    if resolved is not None:
+        return resolved
+    module = __import__("opensquilla.gateway.config", fromlist=[target])
+    return getattr(module, target, None)
+
+
+def _auto_backup_invalid_config(path: Path, _error: ValidationError) -> Path | None:
+    """Best-effort timestamped backup of a config that failed validation.
+
+    The backup is created with the shared ``make_config_backup`` helper so it
+    follows the same ``config.toml.backup.<stamp>`` naming scheme as every
+    other managed config backup; failures to back up are non-fatal because
+    the diagnostic itself is the primary recovery aid.
+    """
+    try:
+        return make_config_backup(path)
+    except Exception:
+        return None
+
+
+def _warn_unknown_config_keys(path: Path, payload: dict[str, Any]) -> None:
+    """Warn about top-level and one-level-deep keys outside the schema.
+
+    ``GatewayConfig`` (like most of its nested models) tolerates unknown keys
+    so old configs keep loading, which means a hand-edited typo such as
+    ``[image_generation] edit_primary`` silently no-ops instead of failing.
+    Logging the unknown keys turns that silent ignore into an actionable
+    hint at boot without breaking downgrade compatibility.
+    """
+    try:
+        model_fields = GatewayConfig.model_fields
+    except Exception:
+        return
+    unknown: list[str] = []
+    for key, value in payload.items():
+        if key in model_fields or key == "config_version":
+            continue
+        unknown.append(key)
+        # One level deeper: nested model sections (e.g. image_generation)
+        # that accept extras also swallow typos inside them.
+        if not isinstance(value, dict):
+            continue
+        field_info = model_fields.get(key)
+        nested_model = getattr(field_info, "annotation", None)
+        if isinstance(nested_model, str):
+            # ``from __future__ import annotations`` keeps the annotation a
+            # string until pydantic resolves it; resolve defensively.
+            try:
+                nested_model = _resolve_annotation(nested_model)
+            except Exception:
+                nested_model = None
+        if nested_model is None:
+            continue
+        try:
+            nested_fields = getattr(nested_model, "model_fields", None)
+        except Exception:
+            nested_fields = None
+        if not nested_fields:
+            continue
+        for nested_key in value:
+            if nested_key not in nested_fields:
+                unknown.append(f"{key}.{nested_key}")
+    if not unknown:
+        return
+    logging.getLogger(__name__).warning(
+        "config.unknown_keys path=%s keys=%s "
+        "(ignored; check spelling or restore a backup)",
+        path,
+        ", ".join(sorted(unknown)),
+    )
 
 
 def _rewrite_migrated_config_best_effort(path: Path, migration: Any) -> None:

--- a/src/opensquilla/tools/builtin/artifacts.py
+++ b/src/opensquilla/tools/builtin/artifacts.py
@@ -59,6 +59,31 @@ def _bundle_result(manifest: ArtifactBundleManifest) -> dict[str, object]:
     }
 
 
+def _record_published_artifact_source_key(
+    ctx: ToolContext,
+    target: Path,
+    workspace: Path,
+) -> None:
+    """Record a successfully published file's canonical workspace identity.
+
+    The omitted-artifact backstop consults this per-turn set so a source file
+    explicitly published under a custom display name is not published a second
+    time under its original filename. The import is deferred to keep this tool
+    module import-cycle-free.
+    """
+
+    from opensquilla.engine.artifact_delivery import (
+        artifact_delivery_publish_target_key,
+    )
+
+    source_key = artifact_delivery_publish_target_key(
+        str(target),
+        workspace_dir=workspace,
+    )
+    if source_key is not None:
+        ctx.published_artifact_source_keys.add(source_key)
+
+
 def _normalized_filename(value: str) -> str:
     return "".join(ch for ch in value.lower() if ch.isalnum())
 
@@ -577,6 +602,7 @@ async def publish_artifact(
         payload = artifact_payload(existing)
         if not any(item.get("id") == payload.get("id") for item in ctx.published_artifacts):
             ctx.published_artifacts.append(payload)
+        _record_published_artifact_source_key(ctx, target, workspace)
         llm_artifact = _llm_artifact_payload(
             payload,
             ctx=ctx,
@@ -640,6 +666,7 @@ async def publish_artifact(
 
     payload = artifact_payload(ref)
     ctx.published_artifacts.append(payload)
+    _record_published_artifact_source_key(ctx, target, workspace)
     llm_artifact = _llm_artifact_payload(
         payload,
         ctx=ctx,

--- a/src/opensquilla/tools/types.py
+++ b/src/opensquilla/tools/types.py
@@ -193,6 +193,12 @@ class ToolContext:
     # and projection code use this bit to avoid replacing raw tool output with
     # a handle that the current model is not authorized to retrieve.
     tool_result_retrieval_available: bool = False
+    # Canonical workspace source identities ("path:...") of files successfully
+    # published during this turn via publish_artifact. The omitted-artifact
+    # backstop consults this to avoid re-publishing the same source file under
+    # its original filename after an explicit publish used a custom display
+    # name. Runtime-only; never serialized into task details or transcripts.
+    published_artifact_source_keys: set[str] = field(default_factory=set)
 
     def __post_init__(self) -> None:
         self.validate_path_roots()

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1829,6 +1829,61 @@ async def test_publish_artifact_tool_is_idempotent_for_existing_turn_artifact(
 
 
 @pytest.mark.asyncio
+async def test_backstop_skips_file_explicitly_published_with_custom_name(
+    tmp_path: Path,
+) -> None:
+    from opensquilla.engine.artifact_delivery import (
+        auto_publish_omitted_workspace_artifacts,
+    )
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "index.html"
+    target.write_text("<title>World Countries</title>", encoding="utf-8")
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+    )
+    ctx.workspace_file_writes.append(
+        {
+            "created": True,
+            "path": str(target),
+            "relative_path": "index.html",
+            "name": target.name,
+        }
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        result = json.loads(
+            await publish_artifact(
+                path="index.html",
+                name="World Countries Overview",
+            )
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result["status"] == "published"
+    assert result["artifact"]["name"] == "World Countries Overview.html"
+    assert len(ctx.published_artifacts) == 1
+
+    publish_result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="I created index.html for you.",
+    )
+
+    assert publish_result.artifacts == []
+    assert publish_result.failure_summaries == []
+    assert len(ctx.published_artifacts) == 1
+    assert ctx.published_artifacts[0]["name"] == "World Countries Overview.html"
+
+
+@pytest.mark.asyncio
 async def test_publish_artifact_tool_reuses_existing_session_deliverable_across_contexts(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_cli/test_gateway_cmd.py
+++ b/tests/test_cli/test_gateway_cmd.py
@@ -209,6 +209,25 @@ def test_gateway_run_reports_invalid_config_without_traceback(
     assert "Traceback" not in output
 
 
+def test_gateway_run_reports_config_validation_error_with_field_detail(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    target = tmp_path / "custom.toml"
+    target.write_text("log_file_backup_count = -1\n", encoding="utf-8")
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path / "home"))
+
+    result = runner.invoke(app, ["gateway", "run", "--config", str(target)])
+
+    assert result.exit_code == 1
+    output = result.stdout + (result.stderr or "")
+    compact = "".join(output.split())
+    assert "Invalid gateway config" in output
+    assert "log_file_backup_count" in compact
+    assert "recoveryrecover-config" in compact
+    assert "Traceback" not in output
+
+
 def test_gateway_run_memory_recovery_command_is_bare_on_windows(
     tmp_path,
     monkeypatch,

--- a/tests/test_engine/test_runtime_artifacts.py
+++ b/tests/test_engine/test_runtime_artifacts.py
@@ -2495,6 +2495,55 @@ def test_auto_publish_dedupes_current_artifact_by_store_safe_name(
     assert len(ctx.published_artifacts) == 1
 
 
+def test_auto_publish_keeps_distinct_source_paths_with_identical_content(
+    tmp_path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    first = workspace / "a.html"
+    second = workspace / "b.html"
+    payload = b"<title>identical</title>"
+    first.write_bytes(payload)
+    second.write_bytes(payload)
+    first_sha = hashlib.sha256(payload).hexdigest()
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-identical",
+        session_key="agent:main:webchat:identical",
+    )
+    # a.html was explicitly published this turn under a custom display name.
+    ctx.published_artifacts.append(
+        {"id": "art-a", "sha256": first_sha, "name": "Overview A.html"}
+    )
+    ctx.published_artifact_source_keys.add(
+        artifact_delivery_publish_target_key(
+            str(first.resolve()),
+            workspace_dir=workspace,
+        )
+    )
+    for name, path in (("a.html", first), ("b.html", second)):
+        ctx.workspace_file_writes.append(
+            {
+                "created": True,
+                "path": str(path),
+                "relative_path": name,
+                "name": name,
+            }
+        )
+
+    result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="Created a.html and b.html for you.",
+    )
+
+    assert len(result.artifacts) == 1
+    assert result.artifacts[0]["name"] == "b.html"
+    assert len(ctx.published_artifacts) == 2
+
+
 def test_auto_publish_oversized_pptx_preflights_before_read_or_validation(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_gateway/test_config_version.py
+++ b/tests/test_gateway/test_config_version.py
@@ -135,6 +135,67 @@ def test_config_parse_error_names_the_offending_file(tmp_path: Path) -> None:
         GatewayConfig.load_from_toml(toml_path)
 
 
+def test_config_validation_error_lists_unknown_fields_and_backs_up(
+    tmp_path: Path,
+) -> None:
+    from opensquilla.gateway.config import ConfigValidationError
+
+    toml_path = tmp_path / "config.toml"
+    # A hand-edited config with a value outside the schema's constraints —
+    # the exact "agent hallucinated a config edit" scenario from the issue.
+    # The backup + field-level diagnostic are the recovery aids.
+    toml_path.write_text(
+        "log_file_backup_count = -1\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ConfigValidationError) as excinfo:
+        GatewayConfig.load(toml_path)
+    error = excinfo.value
+    assert str(toml_path) in str(error)
+    assert error.field_errors
+    assert error.field_errors[0]["loc"] == ("log_file_backup_count",)
+    assert error.backup is not None
+    assert error.backup.exists()
+    assert error.backup.read_text(encoding="utf-8") == "log_file_backup_count = -1\n"
+    # The original file is left untouched so the operator can fix or restore.
+    assert toml_path.read_text(encoding="utf-8") == "log_file_backup_count = -1\n"
+
+
+def test_config_validation_error_also_raised_from_load_from_toml(
+    tmp_path: Path,
+) -> None:
+    from opensquilla.gateway.config import ConfigValidationError
+
+    toml_path = tmp_path / "config.toml"
+    toml_path.write_text("log_file_backup_count = -1\n", encoding="utf-8")
+
+    with pytest.raises(ConfigValidationError) as excinfo:
+        GatewayConfig.load_from_toml(toml_path)
+    assert excinfo.value.field_errors[0]["loc"] == ("log_file_backup_count",)
+    assert excinfo.value.backup is not None
+
+
+def test_config_unknown_keys_warn_without_failing(tmp_path: Path, caplog: Any) -> None:
+    toml_path = tmp_path / "config.toml"
+    # An unknown top-level section and an unknown key inside a nested model
+    # section must not fail loading (extra keys are tolerated for downgrade
+    # compatibility) but should produce an actionable boot-time warning.
+    toml_path.write_text(
+        "[image_generation]\nedit_primary = 'openai/gpt-image-1'\n",
+        encoding="utf-8",
+    )
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="opensquilla.gateway.config"):
+        cfg = GatewayConfig.load(toml_path)
+
+    assert cfg.image_generation.primary == "openai/gpt-image-1"
+    assert "config.unknown_keys" in caplog.text
+    assert "image_generation.edit_primary" in caplog.text
+
+
 def test_migrated_config_write_syncs_before_publication(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Scope

Scope boundary: gateway config loading (GatewayConfig.load / load_from_toml), the gateway CLI error surface, and their tests. No schema changes, no RPC changes.

Non-goals: The recovery flow (recover-config) is untouched — it already reads configs independently. Unknown keys remain tolerated (downgrade compatibility is preserved); they now produce a boot-time warning instead of a silent no-op.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #1173

## Release Note

Release note: If a hand-edited config.toml fails validation, the gateway now reports exactly which fields are wrong (with locations and error kinds) instead of exiting with no diagnosis, and keeps a timestamped backup of the original file so configured providers, models, and API keys are never lost to a one-key typo.

## Tests

Ruff: not run locally (no Python toolchain in this environment)

Pytest: not run locally (no Python toolchain in this environment); the added tests follow the existing `test_config_version.py` and `test_gateway_cmd.py` patterns exactly

Frontend: N/A (no Web UI change)

Backend tests added:
- `test_config_version.py`: ConfigValidationError lists the offending field with location + error kind, creates a timestamped backup, and preserves the original file; the same error is raised from `load_from_toml`; unknown nested keys (e.g. `image_generation.edit_primary`) produce a warning without failing the load
- `test_gateway_cmd.py`: `gateway run` on a validation-invalid config prints the field detail and the recovery hint without a traceback

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

No secrets or private artifacts. Backups are created with the existing `make_config_backup` helper (0600 mode, same naming scheme as all managed config backups).

## Third-Party Origin

Third-party origin: none
