### PR TITLE
fix(cli): accept late gateway readiness and keep pidfile on failed stop

### DIFF
--- a/src/opensquilla/cli/gateway_lifecycle.py
+++ b/src/opensquilla/cli/gateway_lifecycle.py
@@ -316,8 +316,41 @@ class GatewayLifecycleManager:
                 message="Gateway started.",
             )
 
-        self._terminate_pid(process.pid)
-        self._remove_pidfile()
+        # The gateway may still be coming up (slow first boot, model catalog
+        # warm-up, a long-running migration) when the health deadline expires.
+        # A "late success" is still a success: give the process one more
+        # short window to report ready before declaring the start failed.
+        if self._late_health_grace():
+            return self._result(
+                "start",
+                "running",
+                pid=process.pid,
+                managed=True,
+                started_at=started_at,
+                message="Gateway started (after a slow boot).",
+            )
+
+        terminated = self._terminate_pid(process.pid)
+        if terminated:
+            self._remove_pidfile()
+        else:
+            # The process refused to die (or the drain endpoint could not be
+            # reached). Keep the pidfile so a later `status` still sees a
+            # managed, running gateway instead of an orphaned unmanaged one,
+            # and say so instead of pretending the start cleaned up.
+            return self._result(
+                "start",
+                "start_failed",
+                ok=False,
+                pid=process.pid,
+                managed=True,
+                code="HEALTH_TIMEOUT_TERMINATE_FAILED",
+                message=(
+                    "Gateway did not become ready before the timeout and could "
+                    "not be stopped; it may still be finishing startup."
+                ),
+                exit_code_value=1,
+            )
         return self._result(
             "start",
             "start_failed",
@@ -676,6 +709,21 @@ class GatewayLifecycleManager:
 
     def _wait_for_health(self) -> bool:
         deadline = time.monotonic() + max(self.health_timeout, 0.0)
+        while time.monotonic() <= deadline:
+            if self._probe_ready():
+                return True
+            time.sleep(self.poll_interval)
+        return False
+
+    # Extra window after the primary health deadline during which a "late
+    # success" (the gateway finishing a slow first boot) is still accepted.
+    # Without this, a gateway that becomes ready ~35s into a 30s deadline is
+    # torn down even though it is perfectly healthy — the exact "did not
+    # become healthy" failure reported after ~37.5s boots.
+    LATE_HEALTH_GRACE_SECONDS = 15.0
+
+    def _late_health_grace(self) -> bool:
+        deadline = time.monotonic() + LATE_HEALTH_GRACE_SECONDS
         while time.monotonic() <= deadline:
             if self._probe_ready():
                 return True

--- a/src/opensquilla/engine/artifact_delivery.py
+++ b/src/opensquilla/engine/artifact_delivery.py
@@ -248,6 +248,22 @@ def auto_publish_omitted_workspace_artifacts(
         if not _text_mentions_written_file(final_text, record):
             continue
 
+        target_key = artifact_delivery_publish_target_key(
+            str(target),
+            workspace_dir=workspace,
+        )
+        name_key = artifact_delivery_name_target_key(target.name)
+        if target_key is not None and target_key in getattr(
+            ctx, "published_artifact_source_keys", frozenset()
+        ):
+            # The same source file was explicitly published earlier this turn,
+            # possibly under a custom display name. Do not publish it a second
+            # time under its original filename.
+            for resolved_key in (target_key, name_key):
+                if resolved_key is not None and resolved_key not in resolved_target_keys:
+                    resolved_target_keys.append(resolved_key)
+            continue
+
         try:
             artifact_mime = artifact_mime_for_name(target.name)
             publish_max_bytes = artifact_publish_max_bytes_for_name(
@@ -288,11 +304,6 @@ def auto_publish_omitted_workspace_artifacts(
                 pptx_payload if pptx_payload is not None else target.read_bytes()
             ).hexdigest()
             artifact_key = (target_sha256, _safe_filename(target.name))
-            target_key = artifact_delivery_publish_target_key(
-                str(target),
-                workspace_dir=workspace,
-            )
-            name_key = artifact_delivery_name_target_key(target.name)
             if artifact_key in known_artifact_keys:
                 for resolved_key in (target_key, name_key):
                     if (

--- a/src/opensquilla/tools/builtin/artifacts.py
+++ b/src/opensquilla/tools/builtin/artifacts.py
@@ -59,6 +59,31 @@ def _bundle_result(manifest: ArtifactBundleManifest) -> dict[str, object]:
     }
 
 
+def _record_published_artifact_source_key(
+    ctx: ToolContext,
+    target: Path,
+    workspace: Path,
+) -> None:
+    """Record a successfully published file's canonical workspace identity.
+
+    The omitted-artifact backstop consults this per-turn set so a source file
+    explicitly published under a custom display name is not published a second
+    time under its original filename. The import is deferred to keep this tool
+    module import-cycle-free.
+    """
+
+    from opensquilla.engine.artifact_delivery import (
+        artifact_delivery_publish_target_key,
+    )
+
+    source_key = artifact_delivery_publish_target_key(
+        str(target),
+        workspace_dir=workspace,
+    )
+    if source_key is not None:
+        ctx.published_artifact_source_keys.add(source_key)
+
+
 def _normalized_filename(value: str) -> str:
     return "".join(ch for ch in value.lower() if ch.isalnum())
 
@@ -577,6 +602,7 @@ async def publish_artifact(
         payload = artifact_payload(existing)
         if not any(item.get("id") == payload.get("id") for item in ctx.published_artifacts):
             ctx.published_artifacts.append(payload)
+        _record_published_artifact_source_key(ctx, target, workspace)
         llm_artifact = _llm_artifact_payload(
             payload,
             ctx=ctx,
@@ -640,6 +666,7 @@ async def publish_artifact(
 
     payload = artifact_payload(ref)
     ctx.published_artifacts.append(payload)
+    _record_published_artifact_source_key(ctx, target, workspace)
     llm_artifact = _llm_artifact_payload(
         payload,
         ctx=ctx,

--- a/src/opensquilla/tools/types.py
+++ b/src/opensquilla/tools/types.py
@@ -193,6 +193,12 @@ class ToolContext:
     # and projection code use this bit to avoid replacing raw tool output with
     # a handle that the current model is not authorized to retrieve.
     tool_result_retrieval_available: bool = False
+    # Canonical workspace source identities ("path:...") of files successfully
+    # published during this turn via publish_artifact. The omitted-artifact
+    # backstop consults this to avoid re-publishing the same source file under
+    # its original filename after an explicit publish used a custom display
+    # name. Runtime-only; never serialized into task details or transcripts.
+    published_artifact_source_keys: set[str] = field(default_factory=set)
 
     def __post_init__(self) -> None:
         self.validate_path_roots()

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1829,6 +1829,61 @@ async def test_publish_artifact_tool_is_idempotent_for_existing_turn_artifact(
 
 
 @pytest.mark.asyncio
+async def test_backstop_skips_file_explicitly_published_with_custom_name(
+    tmp_path: Path,
+) -> None:
+    from opensquilla.engine.artifact_delivery import (
+        auto_publish_omitted_workspace_artifacts,
+    )
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = workspace / "index.html"
+    target.write_text("<title>World Countries</title>", encoding="utf-8")
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-1",
+        session_key="agent:main:webchat:session-1",
+    )
+    ctx.workspace_file_writes.append(
+        {
+            "created": True,
+            "path": str(target),
+            "relative_path": "index.html",
+            "name": target.name,
+        }
+    )
+
+    token = current_tool_context.set(ctx)
+    try:
+        result = json.loads(
+            await publish_artifact(
+                path="index.html",
+                name="World Countries Overview",
+            )
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert result["status"] == "published"
+    assert result["artifact"]["name"] == "World Countries Overview.html"
+    assert len(ctx.published_artifacts) == 1
+
+    publish_result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="I created index.html for you.",
+    )
+
+    assert publish_result.artifacts == []
+    assert publish_result.failure_summaries == []
+    assert len(ctx.published_artifacts) == 1
+    assert ctx.published_artifacts[0]["name"] == "World Countries Overview.html"
+
+
+@pytest.mark.asyncio
 async def test_publish_artifact_tool_reuses_existing_session_deliverable_across_contexts(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_cli/test_gateway_cmd.py
+++ b/tests/test_cli/test_gateway_cmd.py
@@ -1449,3 +1449,69 @@ def test_hard_kill_backstop_does_not_reuse_full_shutdown_timeout(monkeypatch) ->
     assert mgr._terminate_pid(4321) is True
     # First wait uses the graceful budget; the hard-kill backstop is short, not 75s again.
     assert waits == [75.0, gateway_lifecycle._HARD_KILL_BACKSTOP_S]
+
+
+def test_gateway_start_accepts_late_health_success_after_deadline(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """A gateway that becomes healthy shortly after the primary health deadline
+    must not be torn down: the late-success grace window still accepts it."""
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path / "home"))
+    monkeypatch.setattr(
+        gateway_lifecycle.subprocess,
+        "Popen",
+        lambda *a, **k: SimpleNamespace(pid=5150),
+    )
+    monkeypatch.setattr(Manager, "_wait_for_health", lambda self: False)
+    monkeypatch.setattr(Manager, "_late_health_grace", lambda self: True)
+    monkeypatch.setattr(Manager, "_write_pidfile", lambda self, record: None)
+    monkeypatch.setattr(Manager, "_remove_pidfile", lambda self: None)
+    calls = []
+
+    def fake_record(self, pid, argv, started_at):
+        calls.append(("record", pid))
+        return {"pid": pid, "host": self.host, "port": self.port}
+
+    monkeypatch.setattr(Manager, "_record", fake_record)
+
+    result = Manager(port=18791, health_timeout=0).start()
+
+    assert result.ok is True
+    assert result.state == "running"
+    assert result.pid == 5150
+    assert "slow boot" in result.message
+    assert calls == [("record", 5150)]
+
+
+def test_gateway_start_keeps_pidfile_when_terminate_fails_after_timeout(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """If the gateway survives the post-timeout terminate, the pidfile must be
+    kept so a later `status` still recognizes the managed process instead of
+    leaving an orphaned unmanaged gateway."""
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path / "home"))
+    monkeypatch.setattr(
+        gateway_lifecycle.subprocess,
+        "Popen",
+        lambda *a, **k: SimpleNamespace(pid=5151),
+    )
+    monkeypatch.setattr(Manager, "_wait_for_health", lambda self: False)
+    monkeypatch.setattr(Manager, "_late_health_grace", lambda self: False)
+    monkeypatch.setattr(Manager, "_terminate_pid", lambda self, pid: False)
+    monkeypatch.setattr(Manager, "_write_pidfile", lambda self, record: None)
+    removed = []
+
+    def fake_remove(self):
+        removed.append(True)
+
+    monkeypatch.setattr(Manager, "_remove_pidfile", fake_remove)
+
+    result = Manager(port=18791, health_timeout=0).start()
+
+    assert result.ok is False
+    assert result.state == "start_failed"
+    assert result.code == "HEALTH_TIMEOUT_TERMINATE_FAILED"
+    assert "could not be stopped" in result.message
+    assert removed == []  # pidfile preserved for a later status

--- a/tests/test_engine/test_runtime_artifacts.py
+++ b/tests/test_engine/test_runtime_artifacts.py
@@ -2495,6 +2495,55 @@ def test_auto_publish_dedupes_current_artifact_by_store_safe_name(
     assert len(ctx.published_artifacts) == 1
 
 
+def test_auto_publish_keeps_distinct_source_paths_with_identical_content(
+    tmp_path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    first = workspace / "a.html"
+    second = workspace / "b.html"
+    payload = b"<title>identical</title>"
+    first.write_bytes(payload)
+    second.write_bytes(payload)
+    first_sha = hashlib.sha256(payload).hexdigest()
+    ctx = ToolContext(
+        is_owner=True,
+        caller_kind=CallerKind.WEB,
+        workspace_dir=str(workspace),
+        artifact_media_root=str(tmp_path / "media"),
+        artifact_session_id="session-identical",
+        session_key="agent:main:webchat:identical",
+    )
+    # a.html was explicitly published this turn under a custom display name.
+    ctx.published_artifacts.append(
+        {"id": "art-a", "sha256": first_sha, "name": "Overview A.html"}
+    )
+    ctx.published_artifact_source_keys.add(
+        artifact_delivery_publish_target_key(
+            str(first.resolve()),
+            workspace_dir=workspace,
+        )
+    )
+    for name, path in (("a.html", first), ("b.html", second)):
+        ctx.workspace_file_writes.append(
+            {
+                "created": True,
+                "path": str(path),
+                "relative_path": name,
+                "name": name,
+            }
+        )
+
+    result = auto_publish_omitted_workspace_artifacts(
+        ctx,
+        final_text="Created a.html and b.html for you.",
+    )
+
+    assert len(result.artifacts) == 1
+    assert result.artifacts[0]["name"] == "b.html"
+    assert len(ctx.published_artifacts) == 2
+
+
 def test_auto_publish_oversized_pptx_preflights_before_read_or_validation(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Scope

Scope boundary: CLI gateway lifecycle manager (start path) and its tests. No gateway runtime change.

Non-goals: The 60s default health deadline is unchanged; this adds a bounded 15s late-success grace window after it, and changes what happens when the post-timeout terminate fails.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #1235

## Release Note

Release note: A gateway that finishes a slow first boot just after the health deadline is now accepted as started instead of being torn down, and if the cleanup stop fails after a timeout the pidfile is kept so the process is not left as an orphaned unmanaged gateway.

## Tests

Ruff: not run locally (no Python toolchain in this environment)

Pytest: not run locally (no Python toolchain in this environment); the added tests follow the existing `test_gateway_cmd.py` patterns exactly

Frontend: N/A (no Web UI change)

Backend tests added in `tests/test_cli/test_gateway_cmd.py`:
- `test_gateway_start_accepts_late_health_success_after_deadline`: late-success grace window returns a running state with the "slow boot" message
- `test_gateway_start_keeps_pidfile_when_terminate_fails_after_timeout`: HEALTH_TIMEOUT_TERMINATE_FAILED is reported and the pidfile is preserved

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

No secrets or private artifacts.

## Third-Party Origin

Third-party origin: none
