### PR TITLE
Make pending queue steering atomic

### DIFF
--- a/opensquilla-webui/src/components/chat/PendingQueue.test.ts
+++ b/opensquilla-webui/src/components/chat/PendingQueue.test.ts
@@ -25,6 +25,7 @@ async function mountQueue(
     pendingUiId?: string
     text: string
     pendingInputId?: string
+    pendingPersistenceState?: 'saving' | 'staged' | 'local_only' | 'retryable' | 'cancelling'
     deliveryState?: 'steering' | 'retryable'
     steerAttempt?: PendingSteerAttempt
     attachments?: Attachment[]

--- a/opensquilla-webui/src/components/chat/PendingQueue.test.ts
+++ b/opensquilla-webui/src/components/chat/PendingQueue.test.ts
@@ -24,6 +24,7 @@ async function mountQueue(
   items: Array<{
     pendingUiId?: string
     text: string
+    pendingInputId?: string
     deliveryState?: 'steering' | 'retryable'
     steerAttempt?: PendingSteerAttempt
     attachments?: Attachment[]
@@ -35,6 +36,7 @@ async function mountQueue(
   props: {
     imageBlockedMessage?: string
     steerAvailable?: boolean
+    durableSteerAvailable?: boolean
     steerUnavailableMessage?: string
   } = {},
 ) {
@@ -95,6 +97,22 @@ describe('PendingQueue', () => {
     expect(steer?.title).not.toContain('stale reason')
     expect(el.querySelector('.chat-pending-steer-status')).toBeNull()
     expect(steer?.getAttribute('aria-describedby')).toBeNull()
+    app.unmount()
+  })
+
+  it('keeps a durable queued item disabled until the gateway supports atomic steer', async () => {
+    const { app, el } = await mountQueue({}, [{
+      text: 'Durably queued guidance',
+      pendingInputId: 'pending-durable',
+      pendingPersistenceState: 'staged',
+    }], {
+      steerAvailable: true,
+      durableSteerAvailable: false,
+    })
+
+    const steer = el.querySelector<HTMLButtonElement>('.chat-pending-action--steer')
+    expect(steer?.disabled).toBe(true)
+    expect(steer?.title).toContain('gateway does not support')
     app.unmount()
   })
 

--- a/opensquilla-webui/src/components/chat/PendingQueue.vue
+++ b/opensquilla-webui/src/components/chat/PendingQueue.vue
@@ -142,6 +142,7 @@ const { t } = useI18n()
 interface PendingQueueItem {
   pendingUiId: string
   text: string
+  pendingInputId?: string
   displayTextOverride?: string
   hiddenControl?: boolean
   attachments?: Attachment[]
@@ -164,6 +165,7 @@ const props = withDefaults(defineProps<{
   reorderPending?: boolean
   imageBlockedMessage?: string
   steerAvailable?: boolean
+  durableSteerAvailable?: boolean
   steerUnavailableMessage?: string
 }>(), {
   reorderEnabled: true,
@@ -297,6 +299,11 @@ function attachmentBlockMessage(item: PendingQueueItem): string {
 function pendingSteerBlocker(item: PendingQueueItem): PendingSteerBlocker | null {
   if (isControlInput(item.text)) return 'controlInput'
   if (item.attachments?.length) return 'attachment'
+  if (
+    item.pendingInputId
+    && item.pendingPersistenceState === 'staged'
+    && props.durableSteerAvailable !== true
+  ) return 'capability'
   if (!props.steerAvailable && item.deliveryState !== 'retryable' && !isSteerRetry(item)) {
     return 'capability'
   }
@@ -318,6 +325,13 @@ function steerTitle(item: PendingQueueItem): string {
     case 'attachment':
       return attachmentBlockMessage(item) || t('chat.pending.steerUnavailable.attachment')
     case 'capability':
+      if (
+        item.pendingInputId
+        && item.pendingPersistenceState === 'staged'
+        && props.durableSteerAvailable !== true
+      ) {
+        return t('chat.pending.steerUnavailable.gatewayUnsupported')
+      }
       return props.steerUnavailableMessage?.trim() || t('chat.sendQueues')
     case 'otherDelivery':
       return t('chat.pending.steerUnavailable.deliveryInProgress')

--- a/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
@@ -3536,6 +3536,75 @@ describe('useChatSend attachment payloads', () => {
     expect(options.messages.value.filter(message => message.role === 'user')).toHaveLength(1)
   })
 
+  it('atomically steers a durable queued item with its staged identity', async () => {
+    const rpc = {
+      call: vi.fn().mockResolvedValue({
+        accepted: true,
+        turn_id: 'turn-current',
+        disposition: 'steering',
+      }),
+    }
+    const { api, stream } = makeOptions({
+      ...sameTurnSteerOptions(),
+      supportsMethod: method => (
+        method === 'sessions.steer.v2'
+        || method === 'sessions.pending_inputs.steer'
+      ),
+      rpc,
+    })
+    stream.isStreaming.value = true
+    const queued: ChatPendingItem = {
+      pendingUiId: 'pending-ui-durable-steer',
+      text: 'steer the staged message',
+      attachments: [],
+      intent: null,
+      pendingInputId: 'pending-durable-steer',
+      pendingClientRequestId: 'request-durable-steer',
+      pendingClientMessageId: 'message-durable-steer',
+      pendingRequestFingerprint: 'sha256:durable-steer',
+      pendingServerRevision: 3,
+      pendingPersistenceState: 'staged',
+    }
+
+    await expect(api.sendQueuedSteer(queued)).resolves.toBe('accepted')
+
+    expect(rpc.call).toHaveBeenCalledWith(
+      'sessions.pending_inputs.steer',
+      expect.objectContaining({
+        key: 'agent:main:webchat:test',
+        message: 'steer the staged message',
+        expected_turn_id: 'turn-current',
+        client_request_id: 'request-durable-steer',
+        client_message_id: 'message-durable-steer',
+        pendingInputId: 'pending-durable-steer',
+        requestFingerprint: 'sha256:durable-steer',
+        expectedRevision: 3,
+      }),
+    )
+  })
+
+  it('does not steer a durable queued item through an older gateway', async () => {
+    const { api, rpc, stream } = makeOptions({
+      ...sameTurnSteerOptions(),
+    })
+    stream.isStreaming.value = true
+    const queued: ChatPendingItem = {
+      pendingUiId: 'pending-ui-old-gateway',
+      text: 'keep this queued',
+      attachments: [],
+      intent: null,
+      pendingInputId: 'pending-old-gateway',
+      pendingClientRequestId: 'request-old-gateway',
+      pendingClientMessageId: 'message-old-gateway',
+      pendingRequestFingerprint: 'sha256:old-gateway',
+      pendingServerRevision: 1,
+      pendingPersistenceState: 'staged',
+    }
+
+    await expect(api.sendQueuedSteer(queued)).resolves.toBe('not_sent')
+    expect(rpc.call).not.toHaveBeenCalled()
+  })
+
   it('allows an explicit queued Steer while authoritative A is running', async () => {
     const taskOwnership = useChatTaskOwnership()
     taskOwnership.noteRunning('turn-current')

--- a/opensquilla-webui/src/composables/chat/useChatSend.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.ts
@@ -1728,6 +1728,23 @@ export function useChatSend(options: UseChatSendOptions) {
     if (!options.supportsMethod?.('sessions.steer.v2')) {
       return recovered ? 'retryable_failure' : 'not_sent'
     }
+    const durablePending = Boolean(
+      recovered?.request.pendingInputId
+      || (
+        pendingItem?.pendingPersistenceState === 'staged'
+        && pendingItem.pendingInputId
+        && pendingItem.pendingClientRequestId
+        && pendingItem.pendingClientMessageId
+        && pendingItem.pendingRequestFingerprint
+        && pendingItem.pendingServerRevision
+      ),
+    )
+    if (
+      durablePending
+      && !options.supportsMethod?.('sessions.pending_inputs.steer')
+    ) {
+      return recovered ? 'retryable_failure' : 'not_sent'
+    }
     if (
       !recovered
       && !canSteerPayload(
@@ -1747,12 +1764,36 @@ export function useChatSend(options: UseChatSendOptions) {
 
     const expectedTurnId = recovered?.request.expected_turn_id || capabilityExpectedTurnId()
     if (!expectedTurnId) return 'not_sent'
+    const pendingIdentity = pendingItem?.pendingPersistenceState === 'staged'
+      && pendingItem.pendingInputId
+      && pendingItem.pendingClientRequestId
+      && pendingItem.pendingClientMessageId
+      && pendingItem.pendingRequestFingerprint
+      && pendingItem.pendingServerRevision
+      ? {
+          pendingInputId: pendingItem.pendingInputId,
+          clientRequestId: pendingItem.pendingClientRequestId,
+          clientMessageId: pendingItem.pendingClientMessageId,
+          requestFingerprint: pendingItem.pendingRequestFingerprint,
+          expectedRevision: pendingItem.pendingServerRevision,
+        }
+      : null
+    if (durablePending && !pendingIdentity && !recovered?.request.pendingInputId) {
+      return recovered ? 'retryable_failure' : 'not_sent'
+    }
     const freshParams: SessionSteerV2Params = {
       key: requestSessionKey,
       message: text.trim(),
       expected_turn_id: expectedTurnId,
-      client_request_id: createClientRequestId(),
-      client_message_id: createClientMessageId(),
+      client_request_id: pendingIdentity?.clientRequestId || createClientRequestId(),
+      client_message_id: pendingIdentity?.clientMessageId || createClientMessageId(),
+      ...(pendingIdentity
+        ? {
+            pendingInputId: pendingIdentity.pendingInputId,
+            requestFingerprint: pendingIdentity.requestFingerprint,
+            expectedRevision: pendingIdentity.expectedRevision,
+          }
+        : {}),
       surface_id: 'webui',
       _source: chatSourceMetadata(options),
     }
@@ -1793,7 +1834,9 @@ export function useChatSend(options: UseChatSendOptions) {
     }
     try {
       const response = await options.rpc.call<SessionSteerV2Response>(
-        'sessions.steer.v2',
+        params.pendingInputId
+          ? 'sessions.pending_inputs.steer'
+          : 'sessions.steer.v2',
         params as unknown as Record<string, unknown>,
       )
       const sessionChanged = options.sessionKey.value !== requestSessionKey

--- a/opensquilla-webui/src/composables/chat/useChatSteerDelivery.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSteerDelivery.ts
@@ -87,6 +87,13 @@ export function snapshotSteerRequest(
     expected_turn_id: request.expected_turn_id,
     client_request_id: request.client_request_id,
     client_message_id: request.client_message_id,
+    ...(request.pendingInputId ? { pendingInputId: request.pendingInputId } : {}),
+    ...(request.requestFingerprint
+      ? { requestFingerprint: request.requestFingerprint }
+      : {}),
+    ...(request.expectedRevision !== undefined
+      ? { expectedRevision: request.expectedRevision }
+      : {}),
     ...(request.surface_id ? { surface_id: request.surface_id } : {}),
     ...(source ? { _source: source } : {}),
   })

--- a/opensquilla-webui/src/types/rpc.ts
+++ b/opensquilla-webui/src/types/rpc.ts
@@ -580,6 +580,9 @@ export interface SessionSteerV2Params {
   expected_turn_id: string
   client_request_id: string
   client_message_id: string
+  pendingInputId?: string
+  requestFingerprint?: string
+  expectedRevision?: number
   surface_id?: string
   _source?: { elevated?: string; runMode?: 'safe' | 'full' }
 }

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -541,6 +541,7 @@
       :reorder-pending="pendingQueueReorderPending"
       :image-blocked-message="queuedImageSendBlockedMessage"
       :steer-available="sameTurnSteerAvailable"
+      :durable-steer-available="rpc.supportsMethod('sessions.pending_inputs.steer')"
       :steer-unavailable-message="sameTurnSteerUnavailableMessage"
       @clear="clearPendingQueue"
       @edit="editPendingMessage"

--- a/src/opensquilla/gateway/rpc_sessions.py
+++ b/src/opensquilla/gateway/rpc_sessions.py
@@ -83,6 +83,7 @@ from opensquilla.gateway.subagent_announce import (
     quiesce_background_completion_sessions,
 )
 from opensquilla.gateway.turn_ingress import (
+    TurnRequestIdentity,
     accepted_turn_payload,
     complete_durable_ingress,
     request_fingerprint,
@@ -6750,8 +6751,178 @@ async def _steer_v2_response(
     return payload
 
 
+@_d.method("sessions.pending_inputs.steer", scope="operator.write")
+async def _handle_pending_inputs_steer(
+    params: dict | None,
+    ctx: RpcContext,
+) -> dict[str, Any]:
+    """Atomically convert one durable queued input into a same-turn steer."""
+
+    if not isinstance(params, dict):
+        raise ValueError("params must be an object")
+    key = _pending_input_key(params)
+    pending_input_id = _pending_input_param(
+        params,
+        "pendingInputId",
+        "pending_input_id",
+    )
+    client_request_id = _pending_input_param(
+        params,
+        "clientRequestId",
+        "client_request_id",
+    )
+    client_message_id = _pending_input_param(
+        params,
+        "clientMessageId",
+        "client_message_id",
+    )
+    supplied_fingerprint = _optional_string_param(
+        params,
+        "requestFingerprint",
+        "request_fingerprint",
+    )
+    if supplied_fingerprint is None:
+        raise RpcHandlerError(
+            "PENDING_INPUT_FINGERPRINT_REQUIRED",
+            "Pending input steer requires its staged fingerprint",
+            retryable=False,
+            accepted=False,
+        )
+    expected_revision = params.get(
+        "expectedRevision",
+        params.get("expected_revision"),
+    )
+    if (
+        isinstance(expected_revision, bool)
+        or not isinstance(expected_revision, int)
+        or expected_revision < 1
+    ):
+        raise ValueError("params.expectedRevision must be a positive integer")
+
+    storage = _pending_input_storage(ctx)
+    source_scope = _turn_source_scope(
+        _normalize_session_send_source_hint(params),
+        ctx,
+    )
+    async with _pending_input_lock_for(pending_input_id):
+        row = await storage.get_pending_chat_input(pending_input_id)
+        if row is None:
+            receipt = await storage.get_pending_chat_input_dispatch_receipt(
+                pending_input_id
+            )
+            if receipt is None or (
+                receipt.session_key != key
+                or receipt.source_scope != source_scope
+                or receipt.client_request_id != client_request_id
+                or receipt.client_message_id != client_message_id
+                or receipt.request_fingerprint != supplied_fingerprint
+            ):
+                raise RpcHandlerError(
+                    "PENDING_INPUT_NOT_FOUND",
+                    "Pending input no longer exists",
+                    retryable=False,
+                    accepted=False,
+                )
+            raw_message = params.get("message")
+            if not isinstance(raw_message, str) or not raw_message.strip():
+                raise ValueError("params.message must be a non-empty string")
+        else:
+            if (
+                row.session_key != key
+                or row.source_scope != source_scope
+                or row.client_request_id != client_request_id
+                or row.client_message_id != client_message_id
+                or row.request_fingerprint != supplied_fingerprint
+                or row.state_revision != expected_revision
+            ):
+                raise RpcHandlerError(
+                    "PENDING_INPUT_CONFLICT",
+                    "Pending input steer identity does not match the staged row",
+                    retryable=True,
+                    accepted=False,
+                )
+            payload = row.payload
+            raw_message = payload.get("message")
+            attachments = payload.get("attachments")
+            has_non_text_semantics = any(
+                payload.get(field) is not None
+                for field in (
+                    "intent",
+                    "model",
+                    "model_id",
+                    "workspaceId",
+                    "workspace_id",
+                    "collaborationMode",
+                    "collaboration_mode",
+                    "runMode",
+                    "run_mode",
+                )
+            )
+            if (
+                not isinstance(raw_message, str)
+                or not raw_message.strip()
+                or attachments not in (None, [])
+                or has_non_text_semantics
+            ):
+                expected_turn_id = _optional_string_param(
+                    params,
+                    "expected_turn_id",
+                    "expectedTurnId",
+                )
+                if expected_turn_id is None:
+                    raise ValueError("params.expected_turn_id is required")
+                return _steer_v2_failure(
+                    key=key,
+                    expected_turn_id=expected_turn_id,
+                    failure_code="STEER_UNSUPPORTED_INPUT",
+                    capability={
+                        "mode": "queue_only",
+                        "expected_turn_id": expected_turn_id,
+                        "input_kinds": ["text"],
+                        "reason": "text_only",
+                    },
+                )
+
+        steer_params = {
+            "key": key,
+            "message": raw_message,
+            "expected_turn_id": params.get(
+                "expected_turn_id",
+                params.get("expectedTurnId"),
+            ),
+            "client_request_id": client_request_id,
+            "client_message_id": client_message_id,
+            "surface_id": params.get("surface_id", params.get("surfaceId")),
+            "_source": (
+                row.payload.get("_source")
+                if row is not None and isinstance(row.payload.get("_source"), dict)
+                else params.get("_source")
+            ),
+        }
+        return await _handle_sessions_steer_v2_impl(
+            steer_params,
+            ctx,
+            pending_input_id=pending_input_id,
+            pending_input_fingerprint=supplied_fingerprint,
+            pending_input_revision=expected_revision,
+            pending_source_scope=source_scope,
+        )
+
+
 @_d.method("sessions.steer.v2", scope="operator.write")
 async def _handle_sessions_steer_v2(params: dict | None, ctx: RpcContext) -> dict:
+    return await _handle_sessions_steer_v2_impl(params, ctx)
+
+
+async def _handle_sessions_steer_v2_impl(
+    params: dict | None,
+    ctx: RpcContext,
+    *,
+    pending_input_id: str | None = None,
+    pending_input_fingerprint: str | None = None,
+    pending_input_revision: int | None = None,
+    pending_source_scope: str | None = None,
+) -> dict:
     """Durably attach text to one explicitly named running turn."""
 
     key = _require_key(params)
@@ -6895,21 +7066,35 @@ async def _handle_sessions_steer_v2(params: dict | None, ctx: RpcContext) -> dic
         _optional_string_param(params, "surface_id", "surfaceId")
         or default_surface_id
     )
-    source_scope = f"{_turn_source_scope(source_hint, ctx)}:steer.v2"[:256]
-    ingress_identity = request_identity(
-        params,
-        request_session_key=key,
-        source_scope=source_scope,
-        fingerprint_params={
-            "message": raw_message,
-            "intent": "steer.v2",
-            "queueMode": {
-                "expected_turn_id": expected_turn_id,
-                "client_message_id": client_message_id,
-                "surface_id": surface_id,
+    if pending_input_id is not None:
+        if (
+            pending_input_fingerprint is None
+            or pending_input_revision is None
+            or pending_source_scope is None
+        ):
+            raise ValueError("pending input steer guard must be complete")
+        ingress_identity = TurnRequestIdentity(
+            source_scope=pending_source_scope,
+            request_session_key=key,
+            client_request_id=client_request_id,
+            request_fingerprint=pending_input_fingerprint,
+        )
+    else:
+        source_scope = f"{_turn_source_scope(source_hint, ctx)}:steer.v2"[:256]
+        ingress_identity = request_identity(
+            params,
+            request_session_key=key,
+            source_scope=source_scope,
+            fingerprint_params={
+                "message": raw_message,
+                "intent": "steer.v2",
+                "queueMode": {
+                    "expected_turn_id": expected_turn_id,
+                    "client_message_id": client_message_id,
+                    "surface_id": surface_id,
+                },
             },
-        },
-    )
+        )
     log.info(
         "sessions.steer_v2.requested",
         session_key=key,
@@ -7003,6 +7188,9 @@ async def _handle_sessions_steer_v2(params: dict | None, ctx: RpcContext) -> dic
                 client_request_id=ingress_identity.client_request_id,
                 request_fingerprint=ingress_identity.request_fingerprint,
                 workspace_guard=workspace_guard,
+                pending_input_id=pending_input_id,
+                pending_input_fingerprint=pending_input_fingerprint,
+                pending_input_revision=pending_input_revision,
             ),
         )
 
@@ -7046,6 +7234,22 @@ async def _handle_sessions_steer_v2(params: dict | None, ctx: RpcContext) -> dic
             str(exc),
             details={"fallback_safe": False},
             retryable=False,
+            accepted=False,
+        ) from exc
+    except PendingChatInputNotFoundError as exc:
+        raise RpcHandlerError(
+            "PENDING_INPUT_NOT_FOUND",
+            "Pending input disappeared before steer acceptance",
+            details={"fallback_safe": False},
+            retryable=True,
+            accepted=False,
+        ) from exc
+    except PendingChatInputConflictError as exc:
+        raise RpcHandlerError(
+            "PENDING_INPUT_CONFLICT",
+            "Pending input changed before steer acceptance",
+            details={"fallback_safe": False},
+            retryable=True,
             accepted=False,
         ) from exc
     except ProjectWorkspaceStateError as exc:

--- a/src/opensquilla/gateway/scopes.py
+++ b/src/opensquilla/gateway/scopes.py
@@ -222,6 +222,7 @@ METHOD_SCOPES: dict[str, str] = {
     "sessions.pending_inputs.reorder": WRITE_SCOPE,
     "sessions.pending_inputs.cancel": WRITE_SCOPE,
     "sessions.pending_inputs.dispatch": WRITE_SCOPE,
+    "sessions.pending_inputs.steer": WRITE_SCOPE,
     "plans.capabilities": READ_SCOPE,
     "plans.setMode": WRITE_SCOPE,
     "plans.implement": WRITE_SCOPE,

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -38,6 +38,7 @@ from opensquilla.gateway.rpc_sessions import _normalize_terminal_event_payload
 from opensquilla.gateway.scopes import METHOD_SCOPES, READ_SCOPE, WRITE_SCOPE
 from opensquilla.gateway.session_lifecycle import SessionTaskSnapshot
 from opensquilla.gateway.session_streams import SessionStreamRegistry, get_session_streams
+from opensquilla.gateway.turn_ingress import request_fingerprint
 from opensquilla.gateway.uploads import set_upload_store
 from opensquilla.gateway.websocket import SubscriptionManager, WsConnection, get_registry
 from opensquilla.project_workspaces import ProjectWorkspaceStateError, project_path_key
@@ -77,6 +78,10 @@ def test_sessions_messages_hydrate_scope_contract() -> None:
 
 def test_sessions_steer_v2_scope_contract() -> None:
     assert METHOD_SCOPES["sessions.steer.v2"] == WRITE_SCOPE
+
+
+def test_sessions_pending_inputs_steer_scope_contract() -> None:
+    assert METHOD_SCOPES["sessions.pending_inputs.steer"] == WRITE_SCOPE
 
 
 @dataclass
@@ -4534,6 +4539,145 @@ class TestSessionsSend:
 
 
 class TestSessionsSteer:
+    @pytest.mark.asyncio
+    async def test_pending_input_steer_atomically_consumes_durable_row(
+        self,
+        dispatcher,
+        tmp_path,
+    ) -> None:
+        from opensquilla.gateway.routing import RouteEnvelope, SourceKind
+        from opensquilla.gateway.task_runtime import TaskRuntime
+        from opensquilla.session.manager import SessionManager
+        from opensquilla.session.models import SessionNode
+        from opensquilla.session.storage import SessionStorage
+
+        key = "agent:main:webchat:pending-steer"
+        store = SessionStorage(str(tmp_path / "pending-steer.db"))
+        await store.connect()
+        project = tmp_path / "pending-steer-project"
+        project.mkdir()
+        workspace = await store.create_or_restore_project_workspace(
+            path=str(project.resolve()),
+            path_key=project_path_key(project, strict=True),
+            display_name="pending-steer-project",
+            trusted_at=100,
+            now_ms=100,
+        )
+        await store.upsert_session(
+            SessionNode(
+                session_key=key,
+                session_id="session-pending-steer",
+                agent_id="main",
+                created_at=100,
+                updated_at=100,
+                workspace_id=workspace.workspace_id,
+            )
+        )
+        manager = SessionManager(store, inject_time_prefix=False)
+        started = asyncio.Event()
+        blocker = asyncio.Event()
+
+        async def _handler(_run: Any) -> None:
+            started.set()
+            await blocker.wait()
+
+        runtime = TaskRuntime(storage=store, turn_handler=_handler)
+        handle = await runtime.enqueue(
+            RouteEnvelope(
+                source_kind=SourceKind.WEB,
+                source_name="test",
+                agent_id="main",
+                session_key=key,
+                input_provenance={"kind": "test"},
+            ),
+            "first",
+        )
+        await asyncio.wait_for(started.wait(), timeout=2.0)
+        ctx = make_ctx(session_manager=manager, task_runtime=runtime)
+        payload = {
+            "key": key,
+            "message": "queued guidance",
+            "attachments": [],
+            "queueMode": "followup",
+            "clientRequestId": "request-pending-steer",
+            "clientMessageId": "client-pending-steer",
+            "_source": {"caller_kind": "web", "channel_kind": "web"},
+        }
+        fingerprint = request_fingerprint(payload)
+        row, replayed = await store.enqueue_pending_chat_input(
+            pending_input_id="pending-steer-1",
+            session_key=key,
+            source_scope="web:web:operator",
+            client_request_id="request-pending-steer",
+            client_message_id="client-pending-steer",
+            request_fingerprint=fingerprint,
+            payload=payload,
+        )
+        assert replayed is False
+        params = {
+            "key": key,
+            "message": "client echo must not replace the staged text",
+            "pendingInputId": row.pending_input_id,
+            "clientRequestId": row.client_request_id,
+            "clientMessageId": row.client_message_id,
+            "requestFingerprint": row.request_fingerprint,
+            "expectedRevision": row.state_revision,
+            "expected_turn_id": handle.task_id,
+            "surface_id": "webui",
+            "_source": {"caller_kind": "web", "channel_kind": "web"},
+        }
+        try:
+            mismatch = await dispatcher.dispatch(
+                "r-pending-steer-mismatch",
+                "sessions.pending_inputs.steer",
+                {**params, "expected_turn_id": "another-turn"},
+                ctx,
+            )
+            assert mismatch.ok is True
+            assert mismatch.payload["accepted"] is False
+            assert mismatch.payload["failure_code"] == "EXPECTED_TURN_MISMATCH"
+            assert [
+                item.pending_input_id
+                for item in await store.list_pending_chat_inputs(key)
+            ] == [row.pending_input_id]
+
+            accepted = await dispatcher.dispatch(
+                "r-pending-steer",
+                "sessions.pending_inputs.steer",
+                params,
+                ctx,
+            )
+            replay = await dispatcher.dispatch(
+                "r-pending-steer-replay",
+                "sessions.pending_inputs.steer",
+                params,
+                ctx,
+            )
+
+            assert accepted.ok is True
+            assert accepted.payload["accepted"] is True
+            assert accepted.payload["replayed"] is False
+            assert accepted.payload["turn_id"] == handle.task_id
+            assert replay.ok is True
+            assert replay.payload["accepted"] is True
+            assert replay.payload["replayed"] is True
+            assert replay.payload["user_message_id"] == accepted.payload["user_message_id"]
+            assert await store.list_pending_chat_inputs(key) == []
+
+            receipt = await store.get_pending_chat_input_dispatch_receipt(
+                row.pending_input_id
+            )
+            assert receipt is not None
+            assert receipt.client_request_id == row.client_request_id
+            transcript = await store.get_transcript("session-pending-steer")
+            assert len(transcript) == 1
+            assert transcript[0].content == "queued guidance"
+            assert transcript[0].turn_context["disposition"] == "steering"
+        finally:
+            await runtime.cancel(task_id=handle.task_id, source="test_cleanup")
+            await runtime.wait(handle.task_id, timeout=2.0)
+            await store.close()
+
     @pytest.mark.asyncio
     async def test_steer_v2_is_expected_turn_bound_and_idempotent(
         self,


### PR DESCRIPTION
## Scope
- add an operator-only RPC that atomically converts one durable pending input into a same-turn steer
- reuse the staged request identity and existing turn-acceptance transaction
- gate durable steering in the Web UI when the Gateway lacks the new capability
- preserve queued inputs on rejection and reject non-text semantics

## Target
- Base: main
- Fixes #1243

## Release note
- Yes: prevents guided queued messages from reappearing or executing again after session reload.

## Tests
- 79 focused Gateway pending-input, steer, and guest-policy tests passed
- 248 focused Web UI unit tests passed
- Full Gateway suite: 3219 passed, 12 skipped
- Full Web UI unit suite: 4038 passed
- Queue/Steer Chromium E2E: 5 passed
- Ruff, Mypy, Vue TypeScript, architecture, security, i18n, and production build passed

## Safety and compatibility
- additive RPC; no database migration or persisted-state schema change
- old Gateways keep durable steer disabled instead of using the unsafe legacy path
- anonymous Guest permissions are unchanged
- platform-neutral SQLite, RPC, and IndexedDB behavior; no filesystem or process differences

## Third-party origin
- None. Independently implemented; external repositories were consulted read-only for design research and no code, wording, fixtures, or identifiers were copied.