### PR TITLE
Constrain queued message bubbles

### DIFF
--- a/opensquilla-webui/e2e/queue-steer.spec.ts
+++ b/opensquilla-webui/e2e/queue-steer.spec.ts
@@ -270,6 +270,44 @@ function acceptedSteer(
 }
 
 test.describe('Queue/Steer composer semantics', () => {
+  test('a long queued message stays inside the composer width and ellipsizes', async ({ page }) => {
+    await installMockGateway(page)
+    await openRunningSession(page)
+
+    const longText = 'queued-message-without-breaks-'.repeat(80)
+    const composer = page.getByRole('textbox', { name: MESSAGE_TEXTBOX_NAME })
+    await composer.fill(longText)
+    await composer.press('Enter')
+
+    const card = page.locator('.chat-pending-card').filter({ hasText: longText })
+    const queue = page.locator('.chat-pending')
+    const pendingText = card.locator('.chat-pending-text')
+    await expect(card).toBeVisible()
+    const layout = await page.evaluate(() => {
+      const card = document.querySelector('.chat-pending-card') as HTMLElement
+      const queue = document.querySelector('.chat-pending') as HTMLElement
+      const text = document.querySelector('.chat-pending-text') as HTMLElement
+      const cardRect = card.getBoundingClientRect()
+      const queueRect = queue.getBoundingClientRect()
+      return {
+        cardLeft: cardRect.left,
+        cardRight: cardRect.right,
+        queueLeft: queueRect.left,
+        queueRight: queueRect.right,
+        textClientWidth: text.clientWidth,
+        textScrollWidth: text.scrollWidth,
+        textOverflow: getComputedStyle(text).textOverflow,
+        whiteSpace: getComputedStyle(text).whiteSpace,
+      }
+    })
+    expect(layout.cardLeft).toBeGreaterThanOrEqual(layout.queueLeft - 0.5)
+    expect(layout.cardRight).toBeLessThanOrEqual(layout.queueRight + 0.5)
+    expect(layout.textScrollWidth).toBeGreaterThan(layout.textClientWidth)
+    expect(layout.textOverflow).toBe('ellipsis')
+    expect(layout.whiteSpace).toBe('nowrap')
+    await expect(pendingText).toHaveAttribute('title', longText)
+  })
+
   test('STORAGE_BUSY and an unknown response retain one exact-id Retry', async ({ page }) => {
     const state = await installMockGateway(page)
     await openRunningSession(page)

--- a/opensquilla-webui/e2e/queue-steer.spec.ts
+++ b/opensquilla-webui/e2e/queue-steer.spec.ts
@@ -270,43 +270,48 @@ function acceptedSteer(
 }
 
 test.describe('Queue/Steer composer semantics', () => {
-  test('a long queued message stays inside the composer width and ellipsizes', async ({ page }) => {
-    await installMockGateway(page)
-    await openRunningSession(page)
+  for (const viewport of [
+    { label: 'desktop', width: 1280, height: 720 },
+    { label: 'narrow', width: 390, height: 720 },
+  ]) {
+    test(`a long queued message stays inside the composer width and ellipsizes at ${viewport.label} width`, async ({ page }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height })
+      await installMockGateway(page)
+      await openRunningSession(page)
 
-    const longText = 'queued-message-without-breaks-'.repeat(80)
-    const composer = page.getByRole('textbox', { name: MESSAGE_TEXTBOX_NAME })
-    await composer.fill(longText)
-    await composer.press('Enter')
+      const longText = 'queued-message-without-breaks-'.repeat(80)
+      const composer = page.getByRole('textbox', { name: MESSAGE_TEXTBOX_NAME })
+      await composer.fill(longText)
+      await composer.press('Enter')
 
-    const card = page.locator('.chat-pending-card').filter({ hasText: longText })
-    const queue = page.locator('.chat-pending')
-    const pendingText = card.locator('.chat-pending-text')
-    await expect(card).toBeVisible()
-    const layout = await page.evaluate(() => {
-      const card = document.querySelector('.chat-pending-card') as HTMLElement
-      const queue = document.querySelector('.chat-pending') as HTMLElement
-      const text = document.querySelector('.chat-pending-text') as HTMLElement
-      const cardRect = card.getBoundingClientRect()
-      const queueRect = queue.getBoundingClientRect()
-      return {
-        cardLeft: cardRect.left,
-        cardRight: cardRect.right,
-        queueLeft: queueRect.left,
-        queueRight: queueRect.right,
-        textClientWidth: text.clientWidth,
-        textScrollWidth: text.scrollWidth,
-        textOverflow: getComputedStyle(text).textOverflow,
-        whiteSpace: getComputedStyle(text).whiteSpace,
-      }
+      const card = page.locator('.chat-pending-card').filter({ hasText: longText })
+      const pendingText = card.locator('.chat-pending-text')
+      await expect(card).toBeVisible()
+      const layout = await page.evaluate(() => {
+        const card = document.querySelector('.chat-pending-card') as HTMLElement
+        const queue = document.querySelector('.chat-pending') as HTMLElement
+        const text = document.querySelector('.chat-pending-text') as HTMLElement
+        const cardRect = card.getBoundingClientRect()
+        const queueRect = queue.getBoundingClientRect()
+        return {
+          cardLeft: cardRect.left,
+          cardRight: cardRect.right,
+          queueLeft: queueRect.left,
+          queueRight: queueRect.right,
+          textClientWidth: text.clientWidth,
+          textScrollWidth: text.scrollWidth,
+          textOverflow: getComputedStyle(text).textOverflow,
+          whiteSpace: getComputedStyle(text).whiteSpace,
+        }
+      })
+      expect(layout.cardLeft).toBeGreaterThanOrEqual(layout.queueLeft - 0.5)
+      expect(layout.cardRight).toBeLessThanOrEqual(layout.queueRight + 0.5)
+      expect(layout.textScrollWidth).toBeGreaterThan(layout.textClientWidth)
+      expect(layout.textOverflow).toBe('ellipsis')
+      expect(layout.whiteSpace).toBe('nowrap')
+      await expect(pendingText).toHaveAttribute('title', longText)
     })
-    expect(layout.cardLeft).toBeGreaterThanOrEqual(layout.queueLeft - 0.5)
-    expect(layout.cardRight).toBeLessThanOrEqual(layout.queueRight + 0.5)
-    expect(layout.textScrollWidth).toBeGreaterThan(layout.textClientWidth)
-    expect(layout.textOverflow).toBe('ellipsis')
-    expect(layout.whiteSpace).toBe('nowrap')
-    await expect(pendingText).toHaveAttribute('title', longText)
-  })
+  }
 
   test('STORAGE_BUSY and an unknown response retain one exact-id Retry', async ({ page }) => {
     const state = await installMockGateway(page)

--- a/opensquilla-webui/src/components/chat/PendingQueue.vue
+++ b/opensquilla-webui/src/components/chat/PendingQueue.vue
@@ -536,6 +536,7 @@ onBeforeUnmount(() => {
   position: relative;
   display: flex;
   align-items: center;
+  min-width: 0;
   min-height: 50px;
   gap: 10px;
   padding: 9px 10px 9px 15px;


### PR DESCRIPTION
## Scope
- allow queued-message cards to shrink within the pending grid
- preserve the existing single-line ellipsis and full-text title behavior
- cover both desktop and narrow responsive layouts with real Chromium regressions

## Target
- Base: main
- Fixes #1241

## Release note
- Yes: long queued messages no longer stretch the bubble beyond the composer.

## Tests
- Queue/Steer Chromium E2E: 6 passed, including desktop and 390px long-message layout cases
- Full Web UI unit suite: 4038 passed
- Vue TypeScript, architecture, security, i18n, and production build passed

## Safety and compatibility
- CSS-only runtime change; no API, configuration, database, or persisted-state changes
- standard CSS behavior shared by browser and Windows, macOS, and Linux desktop renderers

## Third-party origin
- None. Independently implemented; external repositories were consulted read-only for design research and no code, wording, fixtures, or identifiers were copied.