### PR TITLE
Isolate RpcClient listener failures

### DIFF
--- a/opensquilla-webui/src/lib/rpc.test.ts
+++ b/opensquilla-webui/src/lib/rpc.test.ts
@@ -73,6 +73,7 @@ describe('RpcClient', () => {
     vi.clearAllTimers()
     vi.useRealTimers()
     vi.unstubAllGlobals()
+    vi.restoreAllMocks()
   })
 
   it('persists one random guest session key and sends it in every handshake', () => {
@@ -528,6 +529,113 @@ describe('RpcClient', () => {
     expect(retrySocket).toBeDefined()
     establishConnection(retrySocket)
     await expect(client.waitForConnection(25)).resolves.toBeUndefined()
+    client.disconnect()
+  })
+
+  it('isolates _hello listener failures and continues connection maintenance', async () => {
+    const client = new RpcClient()
+    const error = new Error('hello listener failed')
+    const throwingListener = vi.fn(() => { throw error })
+    const siblingListener = vi.fn()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    client.on('_hello', throwingListener)
+    client.on('_hello', siblingListener)
+    client.connect('ws://rpc.test')
+    const socket = MockWebSocket.instances[0]
+
+    expect(() => establishConnection(socket)).not.toThrow()
+    expect(throwingListener).toHaveBeenCalledOnce()
+    expect(siblingListener).toHaveBeenCalledOnce()
+    expect(consoleError).toHaveBeenCalledWith('[rpc] "_hello" listener failed', error)
+
+    await vi.advanceTimersByTimeAsync(55_000)
+    expect(socket.sent).toContain('{"type":"ping"}')
+    socket.close()
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(MockWebSocket.instances).toHaveLength(2)
+    client.disconnect()
+  })
+
+  it('isolates event listener failures and still notifies siblings and wildcard listeners', () => {
+    const client = new RpcClient()
+    const error = new Error('event listener failed')
+    const wildcardError = new Error('wildcard listener failed')
+    const siblingListener = vi.fn()
+    const wildcardListener = vi.fn()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    client.connect('ws://rpc.test')
+    const socket = MockWebSocket.instances[0]
+    establishConnection(socket)
+    client.on('demo.event', () => { throw error })
+    client.on('demo.event', siblingListener)
+    client.on('*', () => { throw wildcardError })
+    client.on('*', wildcardListener)
+
+    expect(() => socket.receive({
+      type: 'event',
+      event: 'demo.event',
+      payload: { ok: true },
+      meta: { source: 'test' },
+    })).not.toThrow()
+    expect(siblingListener).toHaveBeenCalledWith({ ok: true }, { source: 'test' })
+    expect(wildcardListener).toHaveBeenCalledWith(
+      'demo.event',
+      { ok: true },
+      { source: 'test' },
+    )
+    expect(consoleError).toHaveBeenCalledWith('[rpc] "demo.event" listener failed', error)
+    expect(consoleError).toHaveBeenCalledWith('[rpc] "*" listener failed', wildcardError)
+    client.disconnect()
+  })
+
+  it('isolates _state listener failures so normal close still reconnects', async () => {
+    const client = new RpcClient()
+    const error = new Error('state listener failed')
+    const siblingListener = vi.fn()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    client.connect('ws://rpc.test')
+    const socket = MockWebSocket.instances[0]
+    establishConnection(socket)
+    client.on('_state', () => { throw error })
+    client.on('_state', siblingListener)
+
+    expect(() => socket.close()).not.toThrow()
+    expect(client.state).toBe('disconnected')
+    expect(siblingListener).toHaveBeenCalledWith('disconnected')
+    expect(consoleError).toHaveBeenCalledWith('[rpc] "_state" listener failed', error)
+
+    await vi.advanceTimersByTimeAsync(999)
+    expect(MockWebSocket.instances).toHaveLength(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(MockWebSocket.instances).toHaveLength(2)
+    client.disconnect()
+  })
+
+  it('isolates _gap listener failures so sequence gaps still close and reconnect', async () => {
+    const client = new RpcClient()
+    const error = new Error('gap listener failed')
+    const siblingListener = vi.fn()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    client.connect('ws://rpc.test')
+    const socket = MockWebSocket.instances[0]
+    establishConnection(socket)
+    client.on('_gap', () => { throw error })
+    client.on('_gap', siblingListener)
+    socket.receive({ type: 'event', event: 'demo.event', seq: 1 })
+
+    expect(() => socket.receive({ type: 'event', event: 'demo.event', seq: 3 })).not.toThrow()
+    expect(siblingListener).toHaveBeenCalledWith({
+      expected: 2,
+      actual: 3,
+      event: 'demo.event',
+    })
+    expect(consoleError).toHaveBeenCalledWith('[rpc] "_gap" listener failed', error)
+    expect(socket.readyState).toBe(MockWebSocket.CLOSED)
+
+    await vi.advanceTimersByTimeAsync(999)
+    expect(MockWebSocket.instances).toHaveLength(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(MockWebSocket.instances).toHaveLength(2)
     client.disconnect()
   })
 

--- a/opensquilla-webui/src/lib/rpc.ts
+++ b/opensquilla-webui/src/lib/rpc.ts
@@ -284,6 +284,18 @@ export class RpcClient {
     return () => this._listeners.get(event)?.delete(handler);
   }
 
+  private _emit(event: string, ...args: unknown[]): void {
+    const handlers = this._listeners.get(event);
+    if (!handlers) return;
+    for (const handler of handlers) {
+      try {
+        handler(...args);
+      } catch (error) {
+        console.error(`[rpc] "${event}" listener failed`, error);
+      }
+    }
+  }
+
   get state(): ConnectionState {
     return this._state;
   }
@@ -471,8 +483,7 @@ export class RpcClient {
         // before connect completes.
         this._reconnectAttempt = 0;
         this._setState('connected');
-        const helloHandlers = this._listeners.get('_hello');
-        if (helloHandlers) helloHandlers.forEach((h) => h(data));
+        this._emit('_hello', data);
         this._startPing();
         this._startTickWatch();
         return;
@@ -500,10 +511,8 @@ export class RpcClient {
         }
       } else if (data.type === 'event') {
         const meta = data.meta || {};
-        const handlers = this._listeners.get(data.event ?? '');
-        if (handlers) handlers.forEach((h) => h(data.payload, meta));
-        const wild = this._listeners.get('*');
-        if (wild) wild.forEach((h) => h(data.event, data.payload, meta));
+        this._emit(data.event ?? '', data.payload, meta);
+        this._emit('*', data.event, data.payload, meta);
       }
     };
 
@@ -721,8 +730,7 @@ export class RpcClient {
     this._wakeProbeTimer = setTimeout(() => {
       if (!this._isCurrentSocket(socket, generation)) return;
       this._clearWakeProbe(generation);
-      const handlers = this._listeners.get('_gap');
-      if (handlers) handlers.forEach((h) => h({ reason: 'wake_probe_timeout' }));
+      this._emit('_gap', { reason: 'wake_probe_timeout' });
       this._retireCurrentSocket(new Error('Wake probe timed out'), true);
     }, WAKE_PROBE_TIMEOUT_MS);
   }
@@ -750,8 +758,7 @@ export class RpcClient {
     const seq = data.seq;
     if (this._lastSeq > 0 && seq !== this._lastSeq + 1) {
       const detail = { expected: this._lastSeq + 1, actual: seq, event: data.event };
-      const handlers = this._listeners.get('_gap');
-      if (handlers) handlers.forEach((h) => h(detail));
+      this._emit('_gap', detail);
       try {
         this._ws?.close();
       } catch {}
@@ -770,8 +777,7 @@ export class RpcClient {
       if (!this._ws || this._ws.readyState !== WebSocket.OPEN) return;
       const idleMs = Date.now() - this._lastFrameAt;
       if (idleMs <= this._tickTimeoutMs) return;
-      const handlers = this._listeners.get('_gap');
-      if (handlers) handlers.forEach((h) => h({ reason: 'tick_timeout', idleMs }));
+      this._emit('_gap', { reason: 'tick_timeout', idleMs });
       try {
         this._ws.close();
       } catch {}
@@ -805,7 +811,6 @@ export class RpcClient {
   private _setState(s: ConnectionState): void {
     if (this._state === s) return;
     this._state = s;
-    const handlers = this._listeners.get('_state');
-    if (handlers) handlers.forEach((h) => h(s));
+    this._emit('_state', s);
   }
 }


### PR DESCRIPTION
## Scope

- Isolate synchronous `RpcClient` listener failures so one callback cannot stop sibling listeners.
- Route hello, named event, wildcard, state, and gap notifications through the same guarded emitter.
- Preserve listener order, live `Set` iteration semantics, and the existing heartbeat, close, and reconnect sequence.
- Add regression coverage for listener fan-out, error reporting, heartbeat startup, socket retirement, and reconnect scheduling.

## Branch target

`main`

## Linked issue

None.

## Release note

Yes — Web UI RPC listener errors are now logged and isolated instead of interrupting other listeners or automatic reconnection.

## Test results

- `cd opensquilla-webui && ./node_modules/.bin/vitest run src/lib/rpc.test.ts --reporter=dot --no-color` — 32 passed.
- `cd opensquilla-webui && npm run typecheck` — passed, including architecture, security, theme, i18n, and Vue TypeScript checks.
- Real Chromium connected to a local Gateway: the expected listener error produced no uncaught `pageerror`, the sibling listener ran, and a normal WebSocket close reconnected to `connected` after creating a replacement socket.
- `git diff --check origin/main...HEAD` — passed.

## Safety and compatibility

- No public API, RPC wire format, Gateway/provider behavior, configuration, or persisted state changes.
- The only behavior change is that synchronous listener exceptions are logged and contained per listener.
- Browser-only TypeScript change; platform-neutral across Linux, macOS, and Windows.
- Asynchronous listener promise rejections remain outside the synchronous callback contract.

## Third-party origin

None. No third-party code or generated source was incorporated.
