### PR TITLE
Hide endpoint caps for zero usage rows

### DIFF
--- a/opensquilla-webui/src/components/usage/UsageChart.test.ts
+++ b/opensquilla-webui/src/components/usage/UsageChart.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+
+import { createApp, nextTick } from 'vue'
+import { afterEach, describe, expect, it } from 'vitest'
+import i18n from '@/i18n'
+import type { ChartRow } from '@/types/usage'
+import UsageChart from './UsageChart.vue'
+
+const mounted: Array<ReturnType<typeof createApp>> = []
+
+afterEach(() => {
+  mounted.splice(0).forEach(app => app.unmount())
+  document.body.innerHTML = ''
+})
+
+function chartRow(label: string, totalPct: number): ChartRow {
+  return {
+    sessionKey: null,
+    label,
+    inputPct: totalPct,
+    outputPct: 0,
+    totalPct,
+    valueLabel: totalPct > 0 ? '1' : '0',
+  }
+}
+
+function rowByLabel(root: HTMLElement, label: string): HTMLElement {
+  const row = Array.from(root.querySelectorAll<HTMLElement>('.usage-bar-row'))
+    .find(candidate => candidate.querySelector('.usage-bar-row__label')?.textContent === label)
+  if (!row) throw new Error(`Missing usage chart row: ${label}`)
+  return row
+}
+
+describe('UsageChart endpoint cap', () => {
+  it('omits the cap for an exact zero while retaining non-zero endpoints', async () => {
+    i18n.global.locale.value = 'en'
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    const app = createApp(UsageChart, {
+      chartMode: 'tokens',
+      range: '7',
+      caption: 'Daily usage',
+      rows: [
+        chartRow('zero', 0),
+        chartRow('half', 50),
+        chartRow('tiny-positive', 0.01),
+      ],
+    })
+    app.use(i18n)
+    app.mount(root)
+    mounted.push(app)
+    await nextTick()
+
+    const zero = rowByLabel(root, 'zero')
+    expect(zero.querySelector('.usage-bar-row__cap')).toBeNull()
+    expect(parseFloat(
+      zero.querySelector<HTMLElement>('.usage-bar-row__fill--input')?.style.width || '',
+    )).toBe(0)
+
+    const halfCap = rowByLabel(root, 'half')
+      .querySelector<HTMLElement>('.usage-bar-row__cap')
+    expect(halfCap).not.toBeNull()
+    expect(parseFloat(halfCap?.style.left || '')).toBe(50)
+
+    const tinyCap = rowByLabel(root, 'tiny-positive')
+      .querySelector<HTMLElement>('.usage-bar-row__cap')
+    expect(tinyCap).not.toBeNull()
+    expect(parseFloat(tinyCap?.style.left || '')).toBe(0)
+  })
+})

--- a/opensquilla-webui/src/components/usage/UsageChart.vue
+++ b/opensquilla-webui/src/components/usage/UsageChart.vue
@@ -61,7 +61,11 @@
             class="usage-bar-row__fill usage-bar-row__fill--output"
             :style="`width:${row.outputPct.toFixed(1)}%`"
           />
-          <span class="usage-bar-row__cap" :style="`left:${Math.min(100, row.totalPct).toFixed(1)}%`" />
+          <span
+            v-if="row.totalPct > 0"
+            class="usage-bar-row__cap"
+            :style="`left:${Math.min(100, row.totalPct).toFixed(1)}%`"
+          />
         </span>
         <span class="usage-bar-row__value usage-mono">{{ row.valueLabel }}</span>
       </component>


### PR DESCRIPTION
## Scope

- Do not render the Usage chart endpoint cap for exact-zero rows.
- Preserve non-zero endpoint caps, including tiny positive values.
- Add component regression coverage for zero and non-zero rows.

## Target

- Base: `main`

## Linked issue

- None (tracked in Feishu as `recvsxzN381MbS`).

## Release note

- Fixed the Usage chart showing endpoint lines on zero-token and zero-cost rows.

## Tests

- `npm run test:unit -- src/components/usage/UsageChart.test.ts src/composables/usage/useUsageChartRows.test.ts`
- `npm run test:unit` (338 files, 4039 tests)
- `npm run typecheck`
- `npm run build:artifact`

## Safety

- Frontend-only conditional rendering; no RPC, database, configuration, persisted state, or public type changes.
- Platform-neutral across Linux, macOS, and Windows.
- No upgrade migration is required; existing installations receive the fix with the updated Web UI artifact.

## Third-party origin

- None.
