### PR TITLE
Fence gateway shutdown on live task drivers

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -556,6 +556,7 @@
       "tests/test_gateway/test_task_runtime_overflow_policy.py",
       "tests/test_gateway/test_task_runtime_reservations.py",
       "tests/test_gateway/test_task_runtime_reserved_slots.py",
+      "tests/test_gateway/test_task_runtime_shutdown_fence.py",
       "tests/test_gateway/test_task_runtime_terminal_cleanup.py",
       "tests/test_gateway/test_task_runtime_terminal_message.py",
       "tests/test_gateway/test_task_session_lifecycle.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -521,6 +521,7 @@
     "tests/test_gateway/test_task_runtime_overflow_policy.py": 0.023,
     "tests/test_gateway/test_task_runtime_reservations.py": 0.01,
     "tests/test_gateway/test_task_runtime_reserved_slots.py": 0.019,
+    "tests/test_gateway/test_task_runtime_shutdown_fence.py": 0.01,
     "tests/test_gateway/test_task_runtime_terminal_cleanup.py": 17.435,
     "tests/test_gateway/test_task_runtime_terminal_message.py": 0.052,
     "tests/test_gateway/test_task_session_lifecycle.py": 0.026,

--- a/src/opensquilla/cli/gateway_cmd.py
+++ b/src/opensquilla/cli/gateway_cmd.py
@@ -7,9 +7,12 @@ import json
 import os
 import signal
 import socket
+import sys
+import threading
 import time
 from collections.abc import Callable
 
+import structlog
 import typer
 
 from opensquilla.cli.gateway_lifecycle import (
@@ -29,11 +32,58 @@ from opensquilla.gateway.config import GatewayConfig, is_public_bind, resolve_li
 from opensquilla.gateway.config_migration import ConfigParseError
 from opensquilla.paths import default_opensquilla_home
 
+log = structlog.get_logger(__name__)
+
 _SHUTDOWN_SIGNALS: tuple[signal.Signals, ...] = tuple(
     sig
     for sig in (getattr(signal, "SIGINT", None), getattr(signal, "SIGTERM", None))
     if sig is not None
 )
+
+
+def _flush_shutdown_streams() -> None:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.flush()
+        except Exception:
+            pass
+
+
+def _force_process_exit(exit_code: int) -> None:
+    """End the real Gateway process without running cancellation cleanup again."""
+
+    os._exit(exit_code)
+
+
+class _GatewayShutdownWatchdog:
+    """Process boundary for a close path that cannot cooperatively finish."""
+
+    def __init__(self, *, timeout: float, exit_code: int) -> None:
+        self._timeout = max(0.0, timeout)
+        self._exit_code = exit_code
+        self._disarmed = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="opensquilla-gateway-shutdown-watchdog",
+            daemon=True,
+        )
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def disarm(self) -> None:
+        self._disarmed.set()
+
+    def _run(self) -> None:
+        if self._disarmed.wait(self._timeout):
+            return
+        log.error(
+            "gateway.shutdown_watchdog_expired",
+            timeout=self._timeout,
+            exit_code=self._exit_code,
+        )
+        _flush_shutdown_streams()
+        _force_process_exit(self._exit_code)
 
 
 def _install_shutdown_handlers(
@@ -217,7 +267,7 @@ def run_gateway(
             "self-disable that pill.[/yellow]"
         )
 
-    async def _run() -> None:
+    async def _run() -> bool:
         # Subscription manager is gateway-specific (WS event routing)
         from opensquilla.gateway.websocket import SubscriptionManager
 
@@ -264,24 +314,66 @@ def run_gateway(
                 app.state.request_shutdown = _request_shutdown
         server_task = server._task
         waiter = asyncio.ensure_future(shutdown.wait())
+        close_reason = shutdown_reason
+        explicit_shutdown = False
         try:
             await asyncio.wait(
                 {server_task, waiter}, return_when=asyncio.FIRST_COMPLETED
             )
-            await server.close(shutdown_reason)
+            close_reason = shutdown_reason
+            explicit_shutdown = shutdown.is_set()
         except (KeyboardInterrupt, asyncio.CancelledError):
             # Fallback for platforms where add_signal_handler is unavailable
             # (Windows / non-main-thread): SIGINT arrives as KeyboardInterrupt.
             shutdown.set()
-            await server.close("keyboard_interrupt")
+            close_reason = "keyboard_interrupt"
+            explicit_shutdown = True
         finally:
             waiter.cancel()
             _remove_shutdown_handlers(loop, installed_signals)
-        if shutdown.is_set():
+
+        exit_code = 0 if explicit_shutdown else 1
+        watchdog = _GatewayShutdownWatchdog(
+            timeout=gateway_shutdown_deadline(),
+            exit_code=exit_code,
+        )
+        watchdog.start()
+        close_result = await server.close(close_reason)
+        clean = close_result is None or bool(getattr(close_result, "clean", False))
+        if not clean:
+            log.error(
+                "gateway.shutdown_incomplete_force_exit",
+                reason=close_reason,
+                exit_code=exit_code,
+                remaining_drivers=getattr(
+                    close_result,
+                    "remaining_driver_count",
+                    None,
+                ),
+                remaining_reservations=getattr(
+                    close_result,
+                    "remaining_reservation_count",
+                    None,
+                ),
+                remaining_auxiliary=getattr(
+                    close_result,
+                    "remaining_auxiliary_count",
+                    None,
+                ),
+            )
+            watchdog.disarm()
+            _flush_shutdown_streams()
+            _force_process_exit(exit_code)
+            return explicit_shutdown
+        watchdog.disarm()
+        if explicit_shutdown:
             console.print("\n[yellow]Gateway stopped.[/yellow]")
+        return explicit_shutdown
 
     try:
-        asyncio.run(_run())
+        explicit_shutdown = asyncio.run(_run())
+        if not explicit_shutdown:
+            raise typer.Exit(code=1)
     except ValueError as exc:
         from opensquilla.onboarding.next_steps import env_recovery_commands
         from opensquilla.onboarding.status import get_onboarding_status

--- a/src/opensquilla/cli/gateway_cmd.py
+++ b/src/opensquilla/cli/gateway_cmd.py
@@ -45,8 +45,9 @@ def _flush_shutdown_streams() -> None:
     for stream in (sys.stdout, sys.stderr):
         try:
             stream.flush()
-        except Exception:
-            pass
+        except (OSError, ValueError):
+            # A closed or failed stream must not prevent the watchdog exit.
+            continue
 
 
 def _force_process_exit(exit_code: int) -> None:
@@ -314,7 +315,6 @@ def run_gateway(
                 app.state.request_shutdown = _request_shutdown
         server_task = server._task
         waiter = asyncio.ensure_future(shutdown.wait())
-        close_reason = shutdown_reason
         explicit_shutdown = False
         try:
             await asyncio.wait(

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -2340,7 +2340,10 @@ class GatewayServer:
                     await close_active_clients()
                     log.info("gateway.mcp_clients_closed")
                 except ImportError:
-                    pass
+                    log.debug(
+                        "gateway.mcp_clients_close_skipped_import_unavailable",
+                        exc_info=True,
+                    )
             else:
                 log.warning("gateway.mcp_clients_close_skipped_for_live_runtime")
 

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -2358,8 +2358,9 @@ class GatewayServer:
             # Always stop the serve task so it is never left pending, even when a
             # teardown step above raised (close() is now invoked on every shutdown,
             # not only on Ctrl+C, so the serve task is typically still running). A
-            # teardown exception still propagates after this runs; the pid lock is
-            # released regardless in the inner finally.
+            # teardown exception still propagates after this runs. The pid lock
+            # is released only after a clean runtime shutdown; otherwise process
+            # exit remains the ownership fence.
             try:
                 if self._server is not None:
                     self._server.should_exit = True

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -55,6 +55,7 @@ from opensquilla.gateway.session_lifecycle import (
 )
 from opensquilla.gateway.session_services import get_session_lock, get_session_storage
 from opensquilla.gateway.session_streams import get_session_streams, reset_session_streams
+from opensquilla.gateway.task_runtime import TaskRuntimeShutdownResult
 from opensquilla.gateway.terminal_activity import (
     append_activity_phase,
     is_usage_accounting_barrier,
@@ -2236,12 +2237,21 @@ class GatewayServer:
         finally:
             self._pid_lock = None
 
-    async def close(self, reason: str = "shutdown") -> None:
+    async def close(
+        self,
+        reason: str = "shutdown",
+    ) -> TaskRuntimeShutdownResult | None:
         """Gracefully shut down: stop channels, broadcast shutdown, close WS, stop server."""
+        runtime_shutdown_result: TaskRuntimeShutdownResult | None = None
+        runtime_shutdown_clean = bool(
+            self._services is None
+            or getattr(self._services, "task_runtime", None) is None
+        )
         try:
-            # Drain in-flight turns FIRST so replies are not lost.
-            # task_runtime.shutdown() waits for all running turns to complete before
-            # returning; only then do we stop channel delivery.
+            # Drain in-flight turns FIRST so replies are not lost. A bounded
+            # shutdown can report residual drivers; in that case transports are
+            # stopped below but stateful dependencies stay open until the process
+            # watchdog terminates the Gateway.
             drain_budget = gateway_graceful_timeout()
             goal_service = (
                 getattr(self._services, "goal_service", None)
@@ -2255,13 +2265,40 @@ class GatewayServer:
                     log.debug("gateway.goal_service_shutdown_failed", exc_info=True)
             if self._services is not None and self._services.task_runtime is not None:
                 try:
-                    await self._services.task_runtime.shutdown(
+                    runtime_shutdown_result = await self._services.task_runtime.shutdown(
                         graceful=True, graceful_timeout=drain_budget
                     )
+                    runtime_shutdown_clean = (
+                        runtime_shutdown_result is None
+                        or runtime_shutdown_result.clean
+                    )
                 except Exception:
-                    pass
+                    runtime_shutdown_clean = False
+                    runtime_shutdown_result = TaskRuntimeShutdownResult(
+                        clean=False,
+                        elapsed_ms=0,
+                        abandoned_task_count=0,
+                        remaining_driver_count=0,
+                        remaining_reservation_count=0,
+                        remaining_auxiliary_count=0,
+                    )
+                    log.exception("gateway.task_runtime_shutdown_failed")
 
-            if self._background_completion_manager is not None:
+            if runtime_shutdown_result is not None and not runtime_shutdown_result.clean:
+                log.error(
+                    "gateway.task_runtime_shutdown_incomplete",
+                    elapsed_ms=runtime_shutdown_result.elapsed_ms,
+                    abandoned_tasks=runtime_shutdown_result.abandoned_task_count,
+                    remaining_drivers=runtime_shutdown_result.remaining_driver_count,
+                    remaining_reservations=(
+                        runtime_shutdown_result.remaining_reservation_count
+                    ),
+                    remaining_auxiliary=(
+                        runtime_shutdown_result.remaining_auxiliary_count
+                    ),
+                )
+
+            if self._background_completion_manager is not None and runtime_shutdown_clean:
                 try:
                     await self._background_completion_manager.close(timeout=drain_budget)
                 except Exception:
@@ -2275,6 +2312,10 @@ class GatewayServer:
                 except Exception:
                     pass
                 self._background_completion_manager = None
+            elif self._background_completion_manager is not None:
+                log.warning(
+                    "gateway.background_completion_close_skipped_for_live_runtime"
+                )
 
             # Stop channels after task_runtime is drained (no in-flight turns remain)
             live_channel_manager = self._channel_manager
@@ -2292,15 +2333,24 @@ class GatewayServer:
                 await conn.close()
 
             # Close MCP clients
-            try:
-                from opensquilla.mcp.discovery import close_active_clients
+            if runtime_shutdown_clean:
+                try:
+                    from opensquilla.mcp.discovery import close_active_clients
 
-                await close_active_clients()
-                log.info("gateway.mcp_clients_closed")
-            except ImportError:
-                pass
+                    await close_active_clients()
+                    log.info("gateway.mcp_clients_closed")
+                except ImportError:
+                    pass
+            else:
+                log.warning("gateway.mcp_clients_close_skipped_for_live_runtime")
 
-            log.info("gateway.stopped", reason=reason)
+            if runtime_shutdown_clean:
+                log.info("gateway.stopped", reason=reason)
+            else:
+                log.warning(
+                    "gateway.transports_stopped_with_runtime_residuals",
+                    reason=reason,
+                )
         finally:
             # Always stop the serve task so it is never left pending, even when a
             # teardown step above raised (close() is now invoked on every shutdown,
@@ -2331,13 +2381,17 @@ class GatewayServer:
                         preview_task.cancel()
                 if preview_socket is not None:
                     preview_socket.close()
-                if self._services is not None:
+                if self._services is not None and runtime_shutdown_clean:
                     try:
                         await self._services.close()
                     except Exception:
                         log.debug("gateway.services_close_failed", exc_info=True)
+                elif self._services is not None:
+                    log.warning("gateway.services_close_skipped_for_live_runtime")
             finally:
-                self._release_pid_lock()
+                if runtime_shutdown_clean:
+                    self._release_pid_lock()
+        return runtime_shutdown_result
 
 
 def build_flush_service(

--- a/src/opensquilla/gateway/channel_dispatch.py
+++ b/src/opensquilla/gateway/channel_dispatch.py
@@ -737,7 +737,10 @@ async def run_channel_dispatch(
         await status_reactor.received(msg)
 
         if task_runtime is not None:
-            from opensquilla.gateway.task_runtime import TaskQueueFullError
+            from opensquilla.gateway.task_runtime import (
+                TaskQueueFullError,
+                TaskRuntimeShuttingDownError,
+            )
 
             # Cap check BEFORE enqueue/append: reject early so no transcript
             # entry is written and no runtime turn is started when the channel
@@ -896,6 +899,17 @@ async def run_channel_dispatch(
                     await channel.send(
                         _route_envelope_reply_message(
                             workspace_message,
+                            route_envelope,
+                        )
+                    )
+                    if delivery_store is not None:
+                        delivery_store.fail_inbound(ingress_claim, exc)
+                    continue
+                if isinstance(exc, TaskRuntimeShuttingDownError):
+                    await status_reactor.failed(msg)
+                    await channel.send(
+                        _route_envelope_reply_message(
+                            "The Gateway is shutting down. Please retry after it restarts.",
                             route_envelope,
                         )
                     )
@@ -1588,7 +1602,10 @@ async def _dispatch_combined_message_after_debounce(channel: Any, combined: Any,
     status_reactor = _status_reactor(channel)
     await status_reactor.received(msg)
     raw_content = getattr(combined, "raw_content", None) or msg.content
-    from opensquilla.gateway.task_runtime import TaskQueueFullError
+    from opensquilla.gateway.task_runtime import (
+        TaskQueueFullError,
+        TaskRuntimeShuttingDownError,
+    )
 
     # Cap check BEFORE enqueue/append: reject early so no transcript entry is
     # written and no runtime turn is started (accept-then-drop fix).
@@ -1693,6 +1710,15 @@ async def _dispatch_combined_message_after_debounce(channel: Any, combined: Any,
             await channel.send(
                 _route_envelope_reply_message(
                     workspace_message,
+                    route_envelope,
+                )
+            )
+            return
+        if isinstance(exc, TaskRuntimeShuttingDownError):
+            await status_reactor.failed(msg)
+            await channel.send(
+                _route_envelope_reply_message(
+                    "The Gateway is shutting down. Please retry after it restarts.",
                     route_envelope,
                 )
             )

--- a/src/opensquilla/gateway/rpc_sessions.py
+++ b/src/opensquilla/gateway/rpc_sessions.py
@@ -4920,7 +4920,6 @@ async def _handle_sessions_send_impl(
                 _commit_with_session_admission()
             )
         except TaskRuntimeShuttingDownError as exc:
-            _consumed_file_uuids = []
             _cleanup_rejected_guest_profile()
             raise RpcHandlerError(
                 "UNAVAILABLE",
@@ -4930,7 +4929,6 @@ async def _handle_sessions_send_impl(
                 accepted=False,
             ) from exc
         except TaskQueueFullError as exc:
-            _consumed_file_uuids = []
             _cleanup_rejected_guest_profile()
             raise RpcHandlerError(
                 "QUEUE_FULL",
@@ -4943,7 +4941,6 @@ async def _handle_sessions_send_impl(
                 accepted=False,
             ) from exc
         except StorageBusyError as exc:
-            _consumed_file_uuids = []
             _cleanup_rejected_guest_profile()
             raise RpcHandlerError(
                 "STORAGE_BUSY",

--- a/src/opensquilla/gateway/rpc_sessions.py
+++ b/src/opensquilla/gateway/rpc_sessions.py
@@ -4640,7 +4640,10 @@ async def _handle_sessions_send_impl(
         assert persisted_entry is not None
         atomic_task_runtime = task_runtime
 
-        from opensquilla.gateway.task_runtime import TaskQueueFullError
+        from opensquilla.gateway.task_runtime import (
+            TaskQueueFullError,
+            TaskRuntimeShuttingDownError,
+        )
 
         meta_launch_promotion: str | None = None
 
@@ -4916,6 +4919,16 @@ async def _handle_sessions_send_impl(
             acceptance = await complete_durable_ingress(
                 _commit_with_session_admission()
             )
+        except TaskRuntimeShuttingDownError as exc:
+            _consumed_file_uuids = []
+            _cleanup_rejected_guest_profile()
+            raise RpcHandlerError(
+                "UNAVAILABLE",
+                "The Gateway is shutting down. Retry after it restarts.",
+                details={"session_key": exc.session_key},
+                retryable=True,
+                accepted=False,
+            ) from exc
         except TaskQueueFullError as exc:
             _consumed_file_uuids = []
             _cleanup_rejected_guest_profile()
@@ -5617,9 +5630,15 @@ async def _handle_sessions_send_impl(
             # the user can retry against the same uuid.
             _consumed_file_uuids = []  # noqa: F841 – explicit no-evict marker
             _cleanup_rejected_guest_profile()
-            from opensquilla.gateway.task_runtime import TaskQueueFullError
+            from opensquilla.gateway.task_runtime import (
+                TaskQueueFullError,
+                TaskRuntimeShuttingDownError,
+            )
 
-            if not isinstance(exc, TaskQueueFullError):
+            if not isinstance(
+                exc,
+                (TaskQueueFullError, TaskRuntimeShuttingDownError),
+            ):
                 if legacy_meta_launch_promotion == "promoted":
                     from opensquilla.engine.steps.meta_command import (
                         pending_meta_launch_restage,
@@ -5636,7 +5655,9 @@ async def _handle_sessions_send_impl(
             # storage error under load), surface a non-retryable error and
             # hand the orphan message_id to the client as an idempotency
             # token — clients must dedup before retrying.
-            orphan_id, rollback_ok = await _rollback_persisted_user_message("queue_full")
+            shutting_down = isinstance(exc, TaskRuntimeShuttingDownError)
+            rollback_reason = "runtime_shutting_down" if shutting_down else "queue_full"
+            orphan_id, rollback_ok = await _rollback_persisted_user_message(rollback_reason)
 
             if rollback_ok:
                 if legacy_meta_launch_promotion == "promoted":
@@ -5648,6 +5669,18 @@ async def _handle_sessions_send_impl(
                         key,
                         client_request_id=ingress_identity.client_request_id,
                     )
+                if shutting_down:
+                    raise RpcHandlerError(
+                        "UNAVAILABLE",
+                        "The Gateway is shutting down. Retry after it restarts.",
+                        details={
+                            "session_key": exc.session_key,
+                            "rollback_message_id": orphan_id,
+                        },
+                        retryable=True,
+                        accepted=False,
+                    ) from exc
+                assert isinstance(exc, TaskQueueFullError)
                 raise RpcHandlerError(
                     "QUEUE_FULL",
                     "The session task queue is full. Try again after queued work completes.",
@@ -5668,6 +5701,22 @@ async def _handle_sessions_send_impl(
                     key,
                     client_request_id=ingress_identity.client_request_id,
                 )
+            if shutting_down:
+                raise RpcHandlerError(
+                    "UNAVAILABLE",
+                    (
+                        "The Gateway is shutting down and the accepted transcript "
+                        "entry could not be rolled back."
+                    ),
+                    details={
+                        "session_key": exc.session_key,
+                        "orphan_message_id": orphan_id,
+                        "remediation": "client must dedup by message_id before retry",
+                    },
+                    retryable=False,
+                    accepted=True,
+                ) from exc
+            assert isinstance(exc, TaskQueueFullError)
             raise RpcHandlerError(
                 "QUEUE_FULL_DIRTY",
                 (

--- a/src/opensquilla/gateway/task_runtime.py
+++ b/src/opensquilla/gateway/task_runtime.py
@@ -3148,8 +3148,7 @@ class TaskRuntime:
             )
             if not state_waiter.done():
                 state_waiter.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await state_waiter
+                await asyncio.gather(state_waiter, return_exceptions=True)
             if not done:
                 return False
 

--- a/src/opensquilla/gateway/task_runtime.py
+++ b/src/opensquilla/gateway/task_runtime.py
@@ -3035,13 +3035,17 @@ class TaskRuntime:
         ):
             return await self._shutdown_result(started, abandoned_task_count)
 
+        # Claim and persist the timeout terminal state before delivering the
+        # final cancellation. Otherwise the driver can win the cancellation
+        # race, publish an earlier classification, and leave the shutdown
+        # coordinator without a durable ABANDONED record at return time.
+        marked_abandoned = await self._mark_unfinished_abandoned()
         timed_out_tasks = await self._request_shutdown_cancellation(
             source="gateway_shutdown_timeout",
             reason="shutdown_timeout",
             cancelled_drivers=cancelled_drivers,
             force=True,
         )
-        marked_abandoned = await self._mark_unfinished_abandoned()
         abandoned_task_count = max(timed_out_tasks, marked_abandoned)
         return await self._shutdown_result(started, abandoned_task_count)
 
@@ -5877,7 +5881,7 @@ class TaskRuntime:
     async def _mark_unfinished_abandoned(self) -> int:
         async with self._state_lock:
             unfinished = [
-                task for task in self._tasks.values() if task.status not in TERMINAL_STATUSES
+                task for task in self._tasks.values() if not task.terminal_closing
             ]
         for task in unfinished:
             await self._mark_terminal(

--- a/src/opensquilla/gateway/task_runtime.py
+++ b/src/opensquilla/gateway/task_runtime.py
@@ -221,6 +221,18 @@ class TaskHandle:
     status: AgentTaskStatus
 
 
+@dataclass(frozen=True, slots=True)
+class TaskRuntimeShutdownResult:
+    """Observable outcome of one process-lifetime runtime shutdown."""
+
+    clean: bool
+    elapsed_ms: int
+    abandoned_task_count: int
+    remaining_driver_count: int
+    remaining_reservation_count: int
+    remaining_auxiliary_count: int
+
+
 @dataclass(frozen=True)
 class SteerAdmissionResult:
     """Result of one expected-turn same-turn input admission."""
@@ -879,6 +891,14 @@ class TaskQueueFullError(RuntimeError):
         self.max_pending = max_pending
 
 
+class TaskRuntimeShuttingDownError(RuntimeError):
+    """Raised when new root work arrives after shutdown admission closes."""
+
+    def __init__(self, *, session_key: str) -> None:
+        super().__init__(f"task runtime is shutting down; rejected session '{session_key}'")
+        self.session_key = session_key
+
+
 class _CollectIdentityRebindError(RuntimeError):
     """Legacy collect could not durably bind its prompt to the queued turn."""
 
@@ -1011,6 +1031,8 @@ class TaskRuntime:
         # follow-up write cannot rely on the durable-task event alone.
         self._driver_tasks_by_session: dict[str, set[asyncio.Task[None]]] = {}
         self._driver_state_changed = asyncio.Event()
+        self._closing = False
+        self._shutdown_task: asyncio.Task[TaskRuntimeShutdownResult] | None = None
         self._terminal_fallback_records: dict[str, AgentTaskRecord] = {}
         self._pending_by_session: dict[str, list[_RuntimeTask]] = {}
         self._running_by_session: dict[str, _RuntimeTask] = {}
@@ -1432,6 +1454,8 @@ class TaskRuntime:
 
         async with self.collect_admission(key):
             async with self._state_lock:
+                if self._closing:
+                    return False
                 busy = bool(
                     self._pending_by_session.get(key)
                     or self._running_by_session.get(key)
@@ -1441,6 +1465,7 @@ class TaskRuntime:
                 if busy:
                     return False
                 self._auxiliary_tasks_by_session[key] = current
+                self._signal_driver_state_changed()
 
         execution_lock = self._session_execution_locks.setdefault(key, asyncio.Lock())
         try:
@@ -1460,6 +1485,7 @@ class TaskRuntime:
             async with self._state_lock:
                 if self._auxiliary_tasks_by_session.get(key) is current:
                     self._auxiliary_tasks_by_session.pop(key, None)
+                    self._signal_driver_state_changed()
 
     @contextlib.asynccontextmanager
     async def quiesce_sessions(
@@ -1758,6 +1784,7 @@ class TaskRuntime:
         update_envelope_cache: bool = True,
         overflow_policy: PendingOverflowPolicy | str | None = None,
         bypass_pending_limit: bool = False,
+        _allow_during_shutdown: bool = False,
     ) -> TaskReservation:
         """Reserve queue admission without persistence, cancellation, or execution."""
 
@@ -1925,6 +1952,10 @@ class TaskRuntime:
         )
 
         async with self._state_lock:
+            if self._closing and not _allow_during_shutdown:
+                raise TaskRuntimeShuttingDownError(
+                    session_key=envelope.session_key,
+                )
             if (
                 not bypass_pending_limit
                 and queue_mode not in {QueueMode.STEER.value, QueueMode.INTERRUPT.value}
@@ -1963,6 +1994,7 @@ class TaskRuntime:
             self._reservations_by_session.setdefault(envelope.session_key, []).append(
                 reservation
             )
+            self._signal_driver_state_changed()
         try:
             runtime_task.envelope = _materialize_guest_task_envelope(
                 runtime_task.envelope,
@@ -1993,6 +2025,7 @@ class TaskRuntime:
                     reservation.overflow_victim.task_id
                 )
             reservation.aborted = True
+            self._signal_driver_state_changed()
         _cleanup_guest_profile(reservation.runtime_task)
 
     async def _emit_queued_activation(
@@ -2908,7 +2941,7 @@ class TaskRuntime:
         timeout: float = 5.0,
         graceful: bool = False,
         graceful_timeout: float | None = None,
-    ) -> None:
+    ) -> TaskRuntimeShutdownResult:
         """Shut down all in-flight tasks.
 
         Parameters
@@ -2929,78 +2962,222 @@ class TaskRuntime:
         graceful_timeout:
             Deadline (seconds) for the graceful drain phase.  ``None`` means
             wait indefinitely (use with care in production; set a finite value).
+
+        The first call closes admission and owns the shutdown budgets. Concurrent
+        and later callers await that same process-lifetime shutdown result.
         """
-        auxiliary_tasks = [
-            task
-            for task in self._auxiliary_tasks_by_session.values()
-            if not task.done()
-        ]
+        async with self._state_lock:
+            shutdown_task = self._shutdown_task
+            if shutdown_task is None:
+                self._closing = True
+                shutdown_task = asyncio.create_task(
+                    self._shutdown_impl(
+                        cancel=cancel,
+                        timeout=timeout,
+                        graceful=graceful,
+                        graceful_timeout=graceful_timeout,
+                    )
+                )
+                self._shutdown_task = shutdown_task
+                self._signal_driver_state_changed()
+        return await asyncio.shield(shutdown_task)
+
+    async def _shutdown_impl(
+        self,
+        *,
+        cancel: bool,
+        timeout: float,
+        graceful: bool,
+        graceful_timeout: float | None,
+    ) -> TaskRuntimeShutdownResult:
+        started = time.monotonic()
+        abandoned_task_count = 0
+
+        async with self._state_lock:
+            auxiliary_tasks = {
+                task
+                for task in self._auxiliary_tasks_by_session.values()
+                if not task.done()
+            }
         for auxiliary_task in auxiliary_tasks:
             auxiliary_task.cancel()
-        tasks = [
-            task.asyncio_task
-            for task in self._tasks.values()
-            if task.asyncio_task is not None and not task.asyncio_task.done()
-        ]
-        if auxiliary_tasks:
-            await asyncio.gather(*auxiliary_tasks, return_exceptions=True)
-        if not tasks:
-            return
 
         if graceful:
-            # Phase 1: wait for all tasks to finish naturally.
-            try:
-                await asyncio.wait_for(
-                    asyncio.gather(*tasks, return_exceptions=True),
-                    timeout=graceful_timeout,
-                )
-                return
-            except TimeoutError:
-                log.warning(
-                    "task_runtime.graceful_shutdown_timeout",
-                    graceful_timeout=graceful_timeout,
-                    remaining=sum(1 for t in tasks if not t.done()),
-                )
-            # Phase 2: cancel whatever is still running after the drain timeout.
-            tasks = [t for t in tasks if not t.done()]
+            graceful_deadline = (
+                None
+                if graceful_timeout is None
+                else time.monotonic() + max(0.0, graceful_timeout)
+            )
+            if await self._wait_for_shutdown_quiescence(deadline=graceful_deadline):
+                return await self._shutdown_result(started, abandoned_task_count)
+            drivers, reservations, auxiliaries = await self._shutdown_counts()
+            log.warning(
+                "task_runtime.graceful_shutdown_timeout",
+                graceful_timeout=graceful_timeout,
+                remaining_drivers=drivers,
+                remaining_reservations=reservations,
+                remaining_auxiliary=auxiliaries,
+            )
 
+        cancel_deadline = time.monotonic() + max(0.0, timeout)
+        cancelled_drivers: set[asyncio.Task[None]] = set()
         if cancel:
+            await self._request_shutdown_cancellation(
+                source="gateway_shutdown",
+                reason="graceful_timeout" if graceful else "shutdown",
+                cancelled_drivers=cancelled_drivers,
+            )
+        if await self._wait_for_shutdown_quiescence(
+            deadline=cancel_deadline,
+            cancel_source=("gateway_shutdown" if cancel else None),
+            cancel_reason=("graceful_timeout" if graceful else "shutdown"),
+            cancelled_drivers=cancelled_drivers,
+        ):
+            return await self._shutdown_result(started, abandoned_task_count)
+
+        timed_out_tasks = await self._request_shutdown_cancellation(
+            source="gateway_shutdown_timeout",
+            reason="shutdown_timeout",
+            cancelled_drivers=cancelled_drivers,
+            force=True,
+        )
+        marked_abandoned = await self._mark_unfinished_abandoned()
+        abandoned_task_count = max(timed_out_tasks, marked_abandoned)
+        return await self._shutdown_result(started, abandoned_task_count)
+
+    async def _request_shutdown_cancellation(
+        self,
+        *,
+        source: str,
+        reason: str,
+        cancelled_drivers: set[asyncio.Task[None]],
+        force: bool = False,
+    ) -> int:
+        """Cancel every currently visible driver once per shutdown phase."""
+
+        async with self._state_lock:
             runtime_tasks = [
-                runtime_task
-                for runtime_task in list(self._tasks.values())
-                if runtime_task.asyncio_task in tasks
+                task
+                for task in self._tasks.values()
+                if task.status not in TERMINAL_STATUSES
+                and (
+                    force
+                    or not task.cancel_requested
+                    or task.cancel_source != source
+                )
             ]
+            drivers = {
+                driver
+                for session_drivers in self._driver_tasks_by_session.values()
+                for driver in session_drivers
+                if not driver.done()
+            }
+            runtime_drivers = {
+                task.asyncio_task
+                for task in runtime_tasks
+                if task.asyncio_task is not None
+            }
+            for task in runtime_tasks:
+                if task.asyncio_task is not None:
+                    cancelled_drivers.add(task.asyncio_task)
+
+        if runtime_tasks:
             await self._cancel_runtime_tasks(
                 runtime_tasks,
-                source="gateway_shutdown",
-                reason=("graceful_timeout" if graceful else "shutdown"),
+                source=source,
+                reason=reason,
             )
-        if tasks:
-            done, pending = await asyncio.wait(tasks, timeout=timeout)
-            if pending:
-                pending_drivers = set(pending)
-                async with self._state_lock:
-                    for runtime_task in self._tasks.values():
-                        if (
-                            runtime_task.asyncio_task in pending_drivers
-                            and not runtime_task.terminal_closing
-                        ):
-                            # The driver cancellation below is an implementation
-                            # detail of the expired shutdown wait. Preserve the
-                            # public ABANDONED contract regardless of whether its
-                            # CancelledError branch or the fallback marker wins.
-                            runtime_task.cancel_requested = True
-                            runtime_task.cancel_source = "gateway_shutdown_timeout"
-                            runtime_task.cancel_reason = "shutdown_timeout"
-            for task in pending:
-                task.cancel()
-            if pending:
-                await self._mark_unfinished_abandoned()
-            for task in done:
-                try:
-                    task.result()
-                except (asyncio.CancelledError, Exception):
-                    pass
+        for driver in drivers:
+            if driver not in runtime_drivers and (
+                force or driver not in cancelled_drivers
+            ):
+                driver.cancel()
+                cancelled_drivers.add(driver)
+        return len(runtime_tasks)
+
+    async def _wait_for_shutdown_quiescence(
+        self,
+        *,
+        deadline: float | None,
+        cancel_source: str | None = None,
+        cancel_reason: str | None = None,
+        cancelled_drivers: set[asyncio.Task[None]] | None = None,
+    ) -> bool:
+        """Wait for the driver registry and admission gap to reach a fixed point."""
+
+        if cancelled_drivers is None:
+            cancelled_drivers = set()
+        while True:
+            if cancel_source is not None:
+                await self._request_shutdown_cancellation(
+                    source=cancel_source,
+                    reason=cancel_reason or "shutdown",
+                    cancelled_drivers=cancelled_drivers,
+                )
+
+            async with self._state_lock:
+                state_changed = self._driver_state_changed
+                drivers = {
+                    driver
+                    for session_drivers in self._driver_tasks_by_session.values()
+                    for driver in session_drivers
+                }
+                reservations = sum(
+                    len(items) for items in self._reservations_by_session.values()
+                )
+                auxiliaries = {
+                    task for task in self._auxiliary_tasks_by_session.values()
+                }
+            if not drivers and reservations == 0 and not auxiliaries:
+                return True
+
+            remaining = None if deadline is None else deadline - time.monotonic()
+            if remaining is not None and remaining <= 0:
+                return False
+
+            state_waiter = asyncio.create_task(state_changed.wait())
+            waiters: set[asyncio.Task[Any]] = {
+                state_waiter,
+                *(driver for driver in drivers if not driver.done()),
+                *(task for task in auxiliaries if not task.done()),
+            }
+            done, _pending = await asyncio.wait(
+                waiters,
+                timeout=remaining,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if not state_waiter.done():
+                state_waiter.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await state_waiter
+            if not done:
+                return False
+
+    async def _shutdown_counts(self) -> tuple[int, int, int]:
+        async with self._state_lock:
+            drivers = sum(
+                len(items) for items in self._driver_tasks_by_session.values()
+            )
+            reservations = sum(
+                len(items) for items in self._reservations_by_session.values()
+            )
+            auxiliaries = len(self._auxiliary_tasks_by_session)
+        return drivers, reservations, auxiliaries
+
+    async def _shutdown_result(
+        self,
+        started: float,
+        abandoned_task_count: int,
+    ) -> TaskRuntimeShutdownResult:
+        drivers, reservations, auxiliaries = await self._shutdown_counts()
+        return TaskRuntimeShutdownResult(
+            clean=drivers == 0 and reservations == 0 and auxiliaries == 0,
+            elapsed_ms=max(0, int((time.monotonic() - started) * 1000)),
+            abandoned_task_count=abandoned_task_count,
+            remaining_driver_count=drivers,
+            remaining_reservation_count=reservations,
+            remaining_auxiliary_count=auxiliaries,
+        )
 
     async def apply_overflow_policy(
         self,
@@ -4510,6 +4687,11 @@ class TaskRuntime:
                 message_count=max(1, len(message_ids)),
                 fresh_user_session=False,
                 update_envelope_cache=False,
+                # These inputs were accepted before shutdown admission closed.
+                # Their durable ownership transfer must still complete, but the
+                # ``activate=False`` shutdown path below leaves execution for
+                # startup recovery.
+                _allow_during_shutdown=True,
             )
             if atomic_promotion:
                 promote_inputs_fn = cast(
@@ -5693,7 +5875,7 @@ class TaskRuntime:
                 exc_info=True,
             )
 
-    async def _mark_unfinished_abandoned(self) -> None:
+    async def _mark_unfinished_abandoned(self) -> int:
         async with self._state_lock:
             unfinished = [
                 task for task in self._tasks.values() if task.status not in TERMINAL_STATUSES
@@ -5706,6 +5888,7 @@ class TaskRuntime:
                 promote_pending_steers=True,
                 activate_promoted_steers=False,
             )
+        return len(unfinished)
 
     def _remove_pending(self, task: _RuntimeTask) -> None:
         pending = self._pending_by_session.get(task.envelope.session_key)

--- a/src/opensquilla/tools/builtin/sessions.py
+++ b/src/opensquilla/tools/builtin/sessions.py
@@ -362,6 +362,10 @@ async def sessions_send(session_key: str, message: str) -> str:
                         f"Session '{session_key}' task queue is full. "
                         "Try again after queued work completes."
                     ) from exc
+                if type(exc).__name__ == "TaskRuntimeShuttingDownError":
+                    raise SafeToolError(
+                        "The Gateway is shutting down. Retry after it restarts."
+                    ) from exc
                 raise
             return json.dumps(
                 {

--- a/tests/test_cli/test_gateway_cmd.py
+++ b/tests/test_cli/test_gateway_cmd.py
@@ -10,9 +10,11 @@ import sys
 import tomllib
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from urllib.error import URLError
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from opensquilla.cli import gateway_cmd, gateway_lifecycle
@@ -720,13 +722,16 @@ def test_gateway_run_uses_config_host_port_when_flags_are_omitted(
     monkeypatch.setattr(gateway_cmd, "_gateway_bind_available", lambda *_args: True)
     monkeypatch.setattr(gateway_cmd, "start_gateway_server", fake_start_gateway_server)
 
-    gateway_cmd.run_gateway(
-        port=None,
-        bind=None,
-        listen="",
-        debug=False,
-        config_path=str(custom_config),
-    )
+    with pytest.raises(typer.Exit) as exc_info:
+        gateway_cmd.run_gateway(
+            port=None,
+            bind=None,
+            listen="",
+            debug=False,
+            config_path=str(custom_config),
+        )
+
+    assert exc_info.value.exit_code == 1
 
     assert captured["config"].host == "127.0.0.2"
     assert captured["config"].port == 19999
@@ -763,13 +768,16 @@ def test_gateway_run_records_cli_flags_as_runtime_overrides(
     monkeypatch.setattr(gateway_cmd, "_gateway_bind_available", lambda *_args: True)
     monkeypatch.setattr(gateway_cmd, "start_gateway_server", fake_start_gateway_server)
 
-    gateway_cmd.run_gateway(
-        port=18888,
-        bind=None,
-        listen="0.0.0.0",
-        debug=True,
-        config_path=str(custom_config),
-    )
+    with pytest.raises(typer.Exit) as exc_info:
+        gateway_cmd.run_gateway(
+            port=18888,
+            bind=None,
+            listen="0.0.0.0",
+            debug=True,
+            config_path=str(custom_config),
+        )
+
+    assert exc_info.value.exit_code == 1
 
     overrides = captured["config"].runtime_field_overrides()
     assert overrides["host"] == ("127.0.0.1", "0.0.0.0")
@@ -810,13 +818,16 @@ def test_gateway_run_flags_do_not_leak_into_config_via_unrelated_persist(
     monkeypatch.setattr(gateway_cmd, "_gateway_bind_available", lambda *_args: True)
     monkeypatch.setattr(gateway_cmd, "start_gateway_server", fake_start_gateway_server)
 
-    gateway_cmd.run_gateway(
-        port=None,
-        bind=None,
-        listen="0.0.0.0",
-        debug=True,
-        config_path=str(custom_config),
-    )
+    with pytest.raises(typer.Exit) as exc_info:
+        gateway_cmd.run_gateway(
+            port=None,
+            bind=None,
+            listen="0.0.0.0",
+            debug=True,
+            config_path=str(custom_config),
+        )
+
+    assert exc_info.value.exit_code == 1
 
     boot_config = captured["config"]
     assert boot_config.host == "0.0.0.0"
@@ -872,13 +883,16 @@ def test_gateway_run_keeps_missing_explicit_config_path_for_setup(
     monkeypatch.setattr(gateway_cmd, "_gateway_bind_available", lambda *_args: True)
     monkeypatch.setattr(gateway_cmd, "start_gateway_server", fake_start_gateway_server)
 
-    gateway_cmd.run_gateway(
-        port=19876,
-        bind=None,
-        listen="",
-        debug=False,
-        config_path=str(custom_config),
-    )
+    with pytest.raises(typer.Exit) as exc_info:
+        gateway_cmd.run_gateway(
+            port=19876,
+            bind=None,
+            listen="",
+            debug=False,
+            config_path=str(custom_config),
+        )
+
+    assert exc_info.value.exit_code == 1
 
     assert captured["config"].config_path == str(custom_config)
     assert not custom_config.exists()
@@ -1260,10 +1274,12 @@ def test_gateway_run_drains_when_server_task_exits_on_its_own(
     _install_fake_start(_SelfExitingServer(), holder, monkeypatch)
     monkeypatch.setattr(gateway_cmd, "_gateway_bind_available", lambda *_args: True)
 
-    gateway_cmd.run_gateway(
-        port=None, bind=None, listen="", debug=False, config_path=str(config)
-    )
+    with pytest.raises(typer.Exit) as exc_info:
+        gateway_cmd.run_gateway(
+            port=None, bind=None, listen="", debug=False, config_path=str(config)
+        )
 
+    assert exc_info.value.exit_code == 1
     assert holder["server"].closed == ["shutdown"]
 
 
@@ -1328,6 +1344,55 @@ def test_gateway_run_drains_via_http_shutdown_trigger(tmp_path, monkeypatch) -> 
     )
 
     assert holder["server"].closed == ["api_shutdown"]
+
+
+def test_gateway_run_force_exits_after_incomplete_shutdown(tmp_path, monkeypatch) -> None:
+    config = tmp_path / "gw.toml"
+    config.write_text('host = "127.0.0.1"\nport = 18791\n', encoding="utf-8")
+
+    class _IncompleteServer(_ShutdownProbeServer):
+        async def close(self, reason: str) -> Any:
+            await super().close(reason)
+            return SimpleNamespace(
+                clean=False,
+                remaining_driver_count=1,
+                remaining_reservation_count=0,
+                remaining_auxiliary_count=0,
+            )
+
+    server = _IncompleteServer(fire="api_shutdown", via="http")
+    holder: dict = {}
+    exits: list[int] = []
+    _install_fake_start(server, holder, monkeypatch)
+    monkeypatch.setattr(gateway_cmd, "_gateway_bind_available", lambda *_args: True)
+    monkeypatch.setattr(gateway_cmd, "_force_process_exit", exits.append)
+
+    gateway_cmd.run_gateway(
+        port=None, bind=None, listen="", debug=False, config_path=str(config)
+    )
+
+    assert holder["server"].closed == ["api_shutdown"]
+    assert exits == [0]
+
+
+def test_gateway_shutdown_watchdog_can_be_disarmed_or_force_exit(monkeypatch) -> None:
+    exits: list[int] = []
+    fired = gateway_cmd.threading.Event()
+
+    def force_exit(exit_code: int) -> None:
+        exits.append(exit_code)
+        fired.set()
+
+    monkeypatch.setattr(gateway_cmd, "_force_process_exit", force_exit)
+    disarmed = gateway_cmd._GatewayShutdownWatchdog(timeout=0.01, exit_code=0)
+    disarmed.start()
+    disarmed.disarm()
+    assert fired.wait(0.05) is False
+
+    armed = gateway_cmd._GatewayShutdownWatchdog(timeout=0.01, exit_code=1)
+    armed.start()
+    assert fired.wait(1.0) is True
+    assert exits == [1]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gateway/test_channel_dispatch_ghost_turn.py
+++ b/tests/test_gateway/test_channel_dispatch_ghost_turn.py
@@ -18,7 +18,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from opensquilla.gateway.task_runtime import TaskQueueFullError
+from opensquilla.gateway.task_runtime import (
+    TaskQueueFullError,
+    TaskRuntimeShuttingDownError,
+)
 
 # ── Minimal fakes ────────────────────────────────────────────────────────────
 
@@ -116,7 +119,7 @@ async def _dispatch_one(
                 attachments=[],
                 config=None,
             )
-    except TaskQueueFullError:
+    except (TaskQueueFullError, TaskRuntimeShuttingDownError):
         return False
     return True
 
@@ -138,6 +141,21 @@ async def test_ac1_1_no_append_on_queue_full() -> None:
         f"append_message was called {len(sm.append_calls)} time(s) "
         "even though enqueue raised TaskQueueFullError"
     )
+
+
+@pytest.mark.asyncio
+async def test_no_append_when_runtime_is_shutting_down() -> None:
+    sm = _FakeSessionManager()
+    tr = _FakeTurnRunner()
+    runtime = MagicMock()
+    runtime.enqueue = AsyncMock(
+        side_effect=TaskRuntimeShuttingDownError(session_key="s:test")
+    )
+
+    success = await _dispatch_one(sm, tr, "s:test", runtime)
+
+    assert success is False
+    assert sm.append_calls == []
 
 
 # ── cross-thread concurrent test, 50 loops, random.shuffle ─────────────────

--- a/tests/test_gateway/test_graceful_shutdown_drain.py
+++ b/tests/test_gateway/test_graceful_shutdown_drain.py
@@ -101,8 +101,10 @@ async def test_graceful_shutdown_drains_inflight() -> None:
     await asyncio.wait_for(task_started.wait(), timeout=5.0)
 
     # Graceful shutdown: must wait for the 300 ms task to finish.
-    await runtime.shutdown(graceful=True, graceful_timeout=10.0)
+    result = await runtime.shutdown(graceful=True, graceful_timeout=10.0)
 
+    assert result.clean is True
+    assert result.remaining_driver_count == 0
     assert completed == [h.task_id], (
         f"Task did not complete before shutdown returned: completed={completed}"
     )
@@ -140,4 +142,11 @@ async def test_graceful_shutdown_timeout_fallback_is_clean() -> None:
 
     # Tiny graceful_timeout so we hit the fallback-to-cancel path.
     # Must not raise.
-    await runtime.shutdown(graceful=True, graceful_timeout=0.05, timeout=2.0)
+    result = await runtime.shutdown(
+        graceful=True,
+        graceful_timeout=0.05,
+        timeout=2.0,
+    )
+
+    assert result.clean is True
+    assert result.remaining_driver_count == 0

--- a/tests/test_gateway/test_router_boot.py
+++ b/tests/test_gateway/test_router_boot.py
@@ -242,6 +242,55 @@ def test_gateway_server_close_releases_pid_lock_when_shutdown_step_fails() -> No
     asyncio.run(run_case())
 
 
+def test_gateway_server_incomplete_runtime_keeps_services_and_pid_lock_open() -> None:
+    from opensquilla.gateway import boot
+    from opensquilla.gateway.task_runtime import TaskRuntimeShutdownResult
+
+    released: list[str] = []
+    services_closed: list[str] = []
+    expected = TaskRuntimeShutdownResult(
+        clean=False,
+        elapsed_ms=25,
+        abandoned_task_count=1,
+        remaining_driver_count=1,
+        remaining_reservation_count=0,
+        remaining_auxiliary_count=0,
+    )
+
+    class FakePidLock:
+        def release(self) -> None:
+            released.append("released")
+
+    class FakeRuntime:
+        async def shutdown(self, **_kwargs: Any) -> Any:
+            return expected
+
+    class FakeServices:
+        task_runtime = FakeRuntime()
+        goal_service = None
+
+        async def close(self) -> None:
+            services_closed.append("closed")
+
+    pid_lock = FakePidLock()
+    server = boot.GatewayServer(
+        app=SimpleNamespace(),
+        config=GatewayConfig(),
+        _services=FakeServices(),  # type: ignore[arg-type]
+        _pid_lock=pid_lock,
+    )
+
+    async def run_case() -> None:
+        result = await server.close()
+
+        assert result is expected
+        assert services_closed == []
+        assert released == []
+        assert server._pid_lock is pid_lock
+
+    asyncio.run(run_case())
+
+
 def test_start_gateway_server_releases_pid_lock_when_build_services_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_gateway/test_task_runtime_shutdown_fence.py
+++ b/tests/test_gateway/test_task_runtime_shutdown_fence.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from opensquilla.gateway.routing import RouteEnvelope, SourceKind
+from opensquilla.gateway.task_runtime import (
+    TaskRuntime,
+    TaskRuntimeShuttingDownError,
+)
+from opensquilla.session.models import AgentTaskRecord, AgentTaskStatus
+
+
+@dataclass
+class _Storage:
+    records: dict[str, AgentTaskRecord] = field(default_factory=dict)
+
+    async def create_agent_task(self, record: AgentTaskRecord) -> None:
+        self.records[record.task_id] = record
+
+    async def update_agent_task(self, task_id: str, **fields: Any) -> None:
+        record = self.records.get(task_id)
+        if record is None:
+            return
+        for name, value in fields.items():
+            setattr(record, name, value)
+
+    async def get_agent_task(self, task_id: str) -> AgentTaskRecord | None:
+        return self.records.get(task_id)
+
+    async def list_agent_tasks(self, **_: Any) -> list[AgentTaskRecord]:
+        return list(self.records.values())
+
+
+def _envelope(session_key: str = "agent-1::shutdown-fence") -> RouteEnvelope:
+    return RouteEnvelope(
+        source_kind=SourceKind.WEB,
+        source_name="shutdown-test",
+        agent_id="agent-1",
+        session_key=session_key,
+        input_provenance={"kind": "synthetic-test"},
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "shutdown_kwargs",
+    [
+        {"timeout": 0.02},
+        {"graceful": True, "graceful_timeout": 0.01, "timeout": 0.02},
+    ],
+    ids=("immediate-cancel", "graceful-fallback"),
+)
+async def test_shutdown_timeout_reports_and_tracks_residual_driver(
+    shutdown_kwargs: dict[str, Any],
+) -> None:
+    storage = _Storage()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    cancellation_count = 0
+
+    async def handler(_run: Any) -> None:
+        nonlocal cancellation_count
+        started.set()
+        while not release.is_set():
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                cancellation_count += 1
+
+    runtime = TaskRuntime(storage=storage, turn_handler=handler)
+    handle = await runtime.enqueue(_envelope(), "stubborn")
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    driver = runtime._tasks[handle.task_id].asyncio_task
+    assert driver is not None
+
+    result = await asyncio.wait_for(
+        runtime.shutdown(**shutdown_kwargs),
+        timeout=1.0,
+    )
+
+    assert result.clean is False
+    assert result.abandoned_task_count == 1
+    assert result.remaining_driver_count == 1
+    assert result.remaining_reservation_count == 0
+    assert result.remaining_auxiliary_count == 0
+    assert driver.done() is False
+    assert runtime._tasks == {}
+    assert runtime._running_by_session == {}
+    assert driver in runtime._driver_tasks_by_session[_envelope().session_key]
+    record = await runtime.status(handle.task_id)
+    assert record.status == AgentTaskStatus.ABANDONED
+    assert record.terminal_reason == "shutdown_timeout"
+    assert cancellation_count >= 2
+
+    release.set()
+    await asyncio.wait_for(driver, timeout=1.0)
+    assert driver.done() is True
+    assert driver.cancelled() is False
+    assert runtime._driver_tasks_by_session == {}
+    settled = await runtime.status(handle.task_id)
+    assert settled.status == AgentTaskStatus.ABANDONED
+    assert settled.terminal_reason == "shutdown_timeout"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_shutdown_is_single_flight_and_closes_admission() -> None:
+    storage = _Storage()
+    started = asyncio.Event()
+
+    async def handler(_run: Any) -> None:
+        started.set()
+        await asyncio.sleep(60)
+
+    runtime = TaskRuntime(storage=storage, turn_handler=handler)
+    await runtime.enqueue(_envelope(), "cooperative")
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    first = asyncio.create_task(runtime.shutdown(timeout=1.0))
+    second = asyncio.create_task(runtime.shutdown(timeout=0.0, cancel=False))
+    first_result, second_result = await asyncio.wait_for(
+        asyncio.gather(first, second),
+        timeout=2.0,
+    )
+
+    assert first_result is second_result
+    assert first_result.clean is True
+    with pytest.raises(TaskRuntimeShuttingDownError):
+        await runtime.reserve(_envelope("agent-1::late-root"), "late")
+
+
+@pytest.mark.asyncio
+async def test_shutdown_observes_reservation_activated_after_close_started() -> None:
+    storage = _Storage()
+    started = asyncio.Event()
+
+    async def handler(_run: Any) -> None:
+        started.set()
+        await asyncio.sleep(60)
+
+    runtime = TaskRuntime(storage=storage, turn_handler=handler)
+    reservation = await runtime.reserve(_envelope(), "commit-gap")
+    await storage.create_agent_task(reservation.task_record)
+
+    closing = asyncio.create_task(runtime.shutdown(timeout=1.0))
+    await asyncio.sleep(0)
+    handle = await runtime.activate(reservation)
+    driver = runtime._tasks[handle.task_id].asyncio_task
+    assert driver is not None
+
+    result = await asyncio.wait_for(closing, timeout=2.0)
+
+    assert result.clean is True
+    assert driver.done() is True
+    assert runtime._driver_tasks_by_session == {}
+    assert runtime._reservations_by_session == {}
+
+
+@pytest.mark.asyncio
+async def test_graceful_timeout_sets_system_source_before_cancelling() -> None:
+    storage = _Storage()
+    started = asyncio.Event()
+
+    async def handler(_run: Any) -> None:
+        started.set()
+        await asyncio.sleep(60)
+
+    runtime = TaskRuntime(storage=storage, turn_handler=handler)
+    handle = await runtime.enqueue(_envelope(), "graceful-timeout")
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    result = await asyncio.wait_for(
+        runtime.shutdown(graceful=True, graceful_timeout=0.01, timeout=1.0),
+        timeout=2.0,
+    )
+
+    assert result.clean is True
+    record = await runtime.status(handle.task_id)
+    assert record.status == AgentTaskStatus.CANCELLED
+    assert record.terminal_reason == "cancelled"
+    assert record.details["cancellation"] == {
+        "source": "gateway_shutdown",
+        "reason": "graceful_timeout",
+    }

--- a/tests/test_gateway/test_turn_ingress_rpc.py
+++ b/tests/test_gateway/test_turn_ingress_rpc.py
@@ -2541,6 +2541,39 @@ async def test_sessions_send_queue_full_is_unaccepted_and_does_not_persist_messa
 
 
 @pytest.mark.asyncio
+async def test_sessions_send_during_shutdown_is_unavailable_without_persistence(
+    tmp_path: Path,
+) -> None:
+    async with _open_real_stack(tmp_path / "sessions.db") as stack:
+        result = await stack.runtime.shutdown(timeout=1.0)
+        assert result.clean is True
+
+        response = await get_dispatcher().dispatch(
+            "rpc-runtime-shutting-down",
+            "sessions.send",
+            {
+                "key": SESSION_KEY,
+                "message": "must not be persisted",
+                "clientRequestId": CLIENT_REQUEST_ID,
+                "queueMode": "followup",
+            },
+            stack.context,
+        )
+
+        assert response.ok is False
+        assert response.error is not None
+        assert response.error.code == "UNAVAILABLE"
+        assert response.error.retryable is True
+        assert response.error.accepted is False
+        assert _table_counts(stack.db_path) == {
+            "transcript_entries": 0,
+            "agent_tasks": 0,
+            "turn_ingress_receipts": 0,
+        }
+        _assert_no_runtime_acceptance_state(stack.runtime)
+
+
+@pytest.mark.asyncio
 async def test_collect_mode_atomically_merges_message_and_receipt_into_queued_task(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_tools/test_sessions_send_errors.py
+++ b/tests/test_tools/test_sessions_send_errors.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 from opensquilla.engine.types import ToolCall
+from opensquilla.gateway.task_runtime import TaskRuntimeShuttingDownError
 from opensquilla.tools.builtin import sessions as sessions_tools
 from opensquilla.tools.dispatch import build_tool_handler
 from opensquilla.tools.registry import ToolRegistry
@@ -15,6 +16,11 @@ from opensquilla.tools.types import ToolContext, ToolError, ToolSpec, current_to
 class _TerminalSessionManager:
     async def get_session(self, session_key: str) -> object:
         return SimpleNamespace(session_key=session_key, status="done")
+
+
+class _ActiveSessionManager:
+    async def get_session(self, session_key: str) -> object:
+        return SimpleNamespace(session_key=session_key, status="active")
 
 
 def _sessions_send_registry() -> ToolRegistry:
@@ -57,6 +63,21 @@ async def test_sessions_send_terminal_session_error_is_user_actionable(
     assert payload["error_class"] == "SafeToolError"
     assert "terminated" in payload["user_message"]
     assert "internal error" not in payload["user_message"]
+
+
+@pytest.mark.asyncio
+async def test_sessions_send_shutdown_error_is_user_actionable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ClosingRuntime:
+        async def send(self, session_key: str, *_args, **_kwargs) -> None:
+            raise TaskRuntimeShuttingDownError(session_key=session_key)
+
+    monkeypatch.setattr(sessions_tools, "_session_manager", _ActiveSessionManager())
+    monkeypatch.setattr(sessions_tools, "_task_runtime", ClosingRuntime())
+
+    with pytest.raises(ToolError, match="Gateway is shutting down"):
+        await sessions_tools.sessions_send("agent:main:target", "hello")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope

- make `TaskRuntime.shutdown()` a single-flight, admission-closing, bounded shutdown coordinator
- use the live driver registry as the authoritative completion fence and return a structured shutdown result
- preserve accepted reservations and steer recovery across the shutdown race without starting untracked work
- keep stateful Gateway dependencies and the PID lock alive when residual drivers remain
- add a cross-platform process watchdog and map shutdown admission rejection to existing `UNAVAILABLE` semantics

## Target

- Base branch: `main`
- Linked issue: None

## Release note

Required: Gateway stop, restart, and upgrade now report and safely contain agent drivers that do not finish within the shutdown budget.

## Verification

- `ruff check` on all changed source and test files
- `mypy` on all six changed source files
- 587 focused regression tests covering TaskRuntime shutdown, reservations, terminal cleanup, Gateway boot, CLI lifecycle, RPC ingress, queued-input steer, channels, and session tools
- `git diff --check origin/main...HEAD`

## Safety and compatibility

- no database migration, config key, RPC schema, WebSocket payload, or client UI change
- existing callers may ignore the new immutable shutdown result
- closing admission reuses the existing `UNAVAILABLE` code with `retryable=true` and `accepted=false`
- watchdog behavior uses platform-neutral Python threading plus the existing process lifecycle boundary; POSIX and Windows external kill fallbacks remain unchanged
- stateful services are deliberately left open only when a residual driver may still access them; the process watchdog then performs the final bounded exit

## Third-party origin

None. The implementation and tests are original; local reference repositories were consulted only for general lifecycle design patterns.
