### PR TITLE
Keep Composer Add menu clear of active Goal progress

### DIFF
--- a/opensquilla-webui/e2e/goal-mode.spec.ts
+++ b/opensquilla-webui/e2e/goal-mode.spec.ts
@@ -426,6 +426,96 @@ test('Goal mode renders mocked continuation snapshots without correctness pollin
   expect(gateway.methods.filter(method => forbiddenGoalMethods.includes(method))).toEqual([])
 })
 
+test('Composer Add menu stays above active Goal progress across responsive layouts', async ({ page }) => {
+  await page.setViewportSize({ width: 1368, height: 546 })
+  await page.emulateMedia({ colorScheme: 'dark', reducedMotion: 'no-preference' })
+  const gateway = await installFakeGoalGateway(page)
+  await page.goto(CONTROL_URL + 'chat?session=' + encodeURIComponent(SESSION_KEY))
+  await expect(page.locator('.conn-pill.connected')).toBeVisible({ timeout: 10_000 })
+  await expect(page.locator('.chat-textarea')).toBeEditable({ timeout: 10_000 })
+
+  gateway.emitGoal(goalSnapshot({
+    stateRevision: 2,
+    objective: 'Verify a responsive Goal workflow with a deliberately long objective that wraps on narrow windows without covering the Composer Add menu.',
+  }))
+  const goalDock = page.locator('.goal-run-dock')
+  await expect(goalDock).toBeVisible()
+
+  const addButton = page.getByRole('button', { name: 'Add', exact: true })
+  await addButton.click()
+  const addMenu = page.locator('.composer-add-menu')
+  await expect(addMenu).toBeVisible()
+
+  const assertClearance = async () => {
+    await expect.poll(async () => page.evaluate(() => {
+      const menu = document.querySelector<HTMLElement>('.composer-add-menu')
+      const goal = document.querySelector<HTMLElement>('.goal-run-dock')
+      if (!menu || !goal) return -1
+      return Math.floor(goal.getBoundingClientRect().top - menu.getBoundingClientRect().bottom)
+    })).toBeGreaterThanOrEqual(8)
+
+    const frames = await page.evaluate(async () => {
+      const samples: Array<{ clearance: number; menuTop: number }> = []
+      for (let index = 0; index < 12; index += 1) {
+        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
+        const menu = document.querySelector<HTMLElement>('.composer-add-menu')!
+        const goal = document.querySelector<HTMLElement>('.goal-run-dock')!
+        samples.push({
+          clearance: goal.getBoundingClientRect().top - menu.getBoundingClientRect().bottom,
+          menuTop: menu.getBoundingClientRect().top,
+        })
+      }
+      return samples
+    })
+    expect(frames.every(frame => frame.clearance >= 7)).toBe(true)
+    expect(frames.every(frame => frame.menuTop >= 7)).toBe(true)
+  }
+
+  await assertClearance()
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.emulateMedia({ colorScheme: 'light', reducedMotion: 'reduce' })
+  await assertClearance()
+
+  await addMenu.getByRole('menuitem', { name: /Attach files/ }).focus()
+  await expect(addMenu.getByRole('menuitem', { name: /Attach files/ })).toBeFocused()
+  await addMenu.press('Escape')
+  await expect(addMenu).toHaveCount(0)
+
+  await page.evaluate(() => {
+    localStorage.setItem('opensquilla.composerFx', JSON.stringify({ enabled: false }))
+  })
+  await page.reload()
+  await expect(page.locator('.conn-pill.connected')).toBeVisible({ timeout: 10_000 })
+  await expect(page.locator('.chat-textarea')).toBeEditable({ timeout: 10_000 })
+  await expect(page.locator('.chat')).not.toHaveClass(/chat--composer-floating/)
+
+  gateway.emitGoal(goalSnapshot({
+    stateRevision: 3,
+    objective: 'Verify the same Goal and Add menu clearance in the original docked Composer layout.',
+  }))
+  await expect(goalDock).toBeVisible()
+  await addButton.click()
+  await expect(addMenu).toBeVisible()
+  await assertClearance()
+
+  gateway.emitGoal(goalSnapshot({
+    status: 'complete',
+    stateRevision: 4,
+    activeTaskId: null,
+    executionState: 'idle',
+    turnsSettled: 1,
+    terminalReason: 'complete',
+    finishedAt: 4_000,
+  }))
+  await expect(goalDock).toHaveCount(0)
+  await expect.poll(async () => page.evaluate(() => {
+    const menu = document.querySelector<HTMLElement>('.composer-add-menu')
+    const button = document.querySelector<HTMLElement>('.chat-plus-btn')
+    if (!menu || !button) return 1
+    return Math.ceil(menu.getBoundingClientRect().bottom - button.getBoundingClientRect().top)
+  })).toBeLessThanOrEqual(-7)
+})
+
 test('Goal mode continues through a real Gateway, refresh, and deterministic provider', async ({
   page,
   baseURL,

--- a/opensquilla-webui/src/components/chat/ChatComposer.vue
+++ b/opensquilla-webui/src/components/chat/ChatComposer.vue
@@ -97,6 +97,7 @@
               </button>
               <ChatComposerAddMenu
                 v-if="addMenuOpen"
+                :avoid-element="addMenuAvoidElement"
                 :attachments-disabled="replanActive"
                 :goal-mode-active="goalDraftArmed"
                 :goal-mode-available="goalModeAvailable === true"
@@ -404,6 +405,7 @@ const props = withDefaults(defineProps<{
   modelRoutingSettingsBusy: boolean
   codingModeEnabled?: boolean
   codingModeSettingsBusy?: boolean
+  addMenuAvoidElement?: HTMLElement | null
   goalDraftArmed?: boolean
   goalModeAvailable?: boolean
   goalModeBusy?: boolean

--- a/opensquilla-webui/src/components/chat/ChatComposerAddMenu.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatComposerAddMenu.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import ChatComposerAddMenu from './ChatComposerAddMenu.vue'
 import addMenuSource from './ChatComposerAddMenu.vue?raw'
+import { resolveComposerAddMenuPlacement } from '@/utils/chat/composerAddMenuPlacement'
 
 const chatViewStyles = readFileSync(
   'src/styles/chat-view.css',
@@ -73,13 +74,38 @@ afterEach(() => {
 })
 
 describe('ChatComposerAddMenu', () => {
-  it('escapes the Composer stacking context and renders above Goal progress', () => {
+  it('escapes the Composer stacking context and supports collision-aware placement', () => {
     expect(chatViewStyles).toContain('.chat-composer-dock > .chat-composer')
     expect(chatViewStyles).toContain('z-index: auto')
     expect(chatViewStyles).toContain('.goal-run-dock')
     expect(chatViewStyles).toContain('z-index: 3')
     expect(addMenuSource).toContain('.composer-add-menu')
     expect(addMenuSource).toContain('z-index: 30')
+    expect(addMenuSource).toContain('--composer-add-menu-lift')
+    expect(addMenuSource).toContain('avoidElement')
+  })
+
+  it('lifts above the Goal boundary and remains stable when remeasured', () => {
+    const initial = resolveComposerAddMenuPlacement({
+      menuBottom: 410,
+      currentLift: 0,
+      boundaryTop: 330,
+    })
+    expect(initial).toEqual({ lift: 88, maxHeight: 314 })
+
+    expect(resolveComposerAddMenuPlacement({
+      menuBottom: 322,
+      currentLift: initial.lift,
+      boundaryTop: 330,
+    })).toEqual(initial)
+  })
+
+  it('does not move a menu that already clears the Goal boundary', () => {
+    expect(resolveComposerAddMenuPlacement({
+      menuBottom: 280,
+      currentLift: 0,
+      boundaryTop: 330,
+    })).toEqual({ lift: 0, maxHeight: 314 })
   })
 
   it('offers file attachment plus on-demand Plan and Goal mode entries', async () => {

--- a/opensquilla-webui/src/components/chat/ChatComposerAddMenu.vue
+++ b/opensquilla-webui/src/components/chat/ChatComposerAddMenu.vue
@@ -3,6 +3,7 @@
     ref="rootRef"
     tabindex="-1"
     class="composer-add-menu"
+    :class="{ 'is-positioned': positioned }"
     role="menu"
     :aria-label="t('chat.add')"
     @keydown.esc.stop="$emit('close')"
@@ -70,11 +71,13 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/Icon.vue'
+import { resolveComposerAddMenuPlacement } from '@/utils/chat/composerAddMenuPlacement'
 
-defineProps<{
+const props = defineProps<{
+  avoidElement?: HTMLElement | null
   attachmentsDisabled?: boolean
   goalModeActive: boolean
   goalModeAvailable: boolean
@@ -94,6 +97,45 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const rootRef = ref<HTMLElement | null>(null)
+const positioned = ref(false)
+let placementFrame: number | null = null
+let currentLift = 0
+let currentMaxHeight: number | null = null
+
+function updatePlacement() {
+  const root = rootRef.value
+  if (!root) return
+
+  const boundaryTop = props.avoidElement?.getBoundingClientRect().top ?? null
+  if (boundaryTop === null) {
+    if (currentMaxHeight !== null) {
+      currentLift = 0
+      currentMaxHeight = null
+      root.style.removeProperty('--composer-add-menu-lift')
+      root.style.removeProperty('max-height')
+    }
+  } else {
+    const placement = resolveComposerAddMenuPlacement({
+      menuBottom: root.getBoundingClientRect().bottom,
+      currentLift,
+      boundaryTop,
+    })
+    if (placement.lift !== currentLift) {
+      currentLift = placement.lift
+      root.style.setProperty('--composer-add-menu-lift', `${placement.lift}px`)
+    }
+    if (placement.maxHeight !== currentMaxHeight) {
+      currentMaxHeight = placement.maxHeight
+      root.style.setProperty('max-height', `${placement.maxHeight}px`)
+    }
+  }
+  positioned.value = true
+}
+
+function trackPlacement() {
+  updatePlacement()
+  placementFrame = window.requestAnimationFrame(trackPlacement)
+}
 
 function attachFiles() {
   emit('attachFiles')
@@ -110,13 +152,27 @@ function activateGoalMode() {
   emit('close')
 }
 
-onMounted(() => rootRef.value?.focus())
+onMounted(async () => {
+  updatePlacement()
+  await nextTick()
+  rootRef.value?.focus()
+  if (typeof window.requestAnimationFrame === 'function') {
+    placementFrame = window.requestAnimationFrame(trackPlacement)
+  }
+})
+
+onBeforeUnmount(() => {
+  if (placementFrame !== null) {
+    window.cancelAnimationFrame(placementFrame)
+    placementFrame = null
+  }
+})
 </script>
 
 <style scoped>
 .composer-add-menu {
   position: absolute;
-  bottom: calc(100% + 8px);
+  bottom: calc(100% + 8px + var(--composer-add-menu-lift, 0px));
   left: 0;
   z-index: 30;
   display: grid;
@@ -126,6 +182,12 @@ onMounted(() => rootRef.value?.focus())
   border-radius: var(--radius-md);
   background: var(--bg-surface);
   box-shadow: var(--shadow-xl);
+  overflow-y: auto;
+  visibility: hidden;
+}
+
+.composer-add-menu.is-positioned {
+  visibility: visible;
 }
 
 .composer-add-menu__heading {

--- a/opensquilla-webui/src/utils/chat/composerAddMenuPlacement.ts
+++ b/opensquilla-webui/src/utils/chat/composerAddMenuPlacement.ts
@@ -1,0 +1,35 @@
+const DEFAULT_GAP = 8
+const DEFAULT_VIEWPORT_PADDING = 8
+
+interface ComposerAddMenuPlacementInput {
+  menuBottom: number
+  currentLift: number
+  boundaryTop: number
+  gap?: number
+  viewportPadding?: number
+}
+
+interface ComposerAddMenuPlacement {
+  lift: number
+  maxHeight: number
+}
+
+/**
+ * Keep the Composer Add menu above an in-flow run surface without changing
+ * its normal anchor. `menuBottom + currentLift` reconstructs the menu's
+ * unshifted bottom, making repeated measurements stable after the lift has
+ * already been applied.
+ */
+export function resolveComposerAddMenuPlacement({
+  menuBottom,
+  currentLift,
+  boundaryTop,
+  gap = DEFAULT_GAP,
+  viewportPadding = DEFAULT_VIEWPORT_PADDING,
+}: ComposerAddMenuPlacementInput): ComposerAddMenuPlacement {
+  const unshiftedBottom = menuBottom + currentLift
+  return {
+    lift: Math.max(0, Math.ceil(unshiftedBottom - boundaryTop + gap)),
+    maxHeight: Math.max(0, Math.floor(boundaryTop - gap - viewportPadding)),
+  }
+}

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -485,7 +485,7 @@
     <!-- Long-running goal progress lives in the same dock as plan execution so
          the active objective stays visible above the composer across turns. -->
     <Transition name="goal-run-dock">
-      <div v-if="activeGoalRun" class="goal-run-dock">
+      <div v-if="activeGoalRun" ref="goalRunDockRef" class="goal-run-dock">
         <GoalRibbon
           :goal="activeGoalRun"
           :elapsed="goalElapsed"
@@ -594,6 +594,7 @@
       :goal-mode-available="goalUiAvailable"
       :goal-mode-busy="goalBusy || planModeBusy || replanActive"
       :goal-mode-existing="goalComposerExisting"
+      :add-menu-avoid-element="goalRunDockRef"
       :voice-busy="voiceBusy"
       :voice-recording="voiceRecording"
       :voice-ready="voiceReady"
@@ -1065,6 +1066,7 @@ const pendingAutoSendSessionKey = ref('')
 
 const chatRootRef = ref<HTMLElement | null>(null)
 const threadRef = ref<HTMLElement | null>(null)
+const goalRunDockRef = ref<HTMLElement | null>(null)
 const messageListRef = ref<ChatMessageListVirtualizer | null>(null)
 const bottomSentinelRef = ref<HTMLElement | null>(null)
 let bottomIntersectionObserver: IntersectionObserver | null = null


### PR DESCRIPTION
## Scope

- Measure the active Goal dock as the Composer Add menu opens.
- Lift the Add menu only by the amount needed to maintain an 8px gap above Goal progress.
- Keep the menu inside the available viewport height and avoid a first-frame overlap flash.
- Restore the existing anchored position automatically when no Goal is active.
- Add deterministic placement tests and real-browser responsive geometry coverage.

## Branch target

`main`

## Linked issue

Fixes #1265

## Release note

Fixed the Composer Add menu obscuring active Goal progress.

## Verification

- `npm run test:unit -- --run src/components/chat/ChatComposerAddMenu.test.ts src/components/chat/ChatComposer.popovers.test.ts src/components/chat/GoalRibbon.test.ts src/views/ChatView.goal-composer-mode.test.ts src/views/ChatView.goal-outcome.test.ts` — 52 passed.
- `npx playwright test e2e/goal-mode.spec.ts --project=chromium --grep "mocked continuation|Composer Add menu stays above"` — 2 passed.
- Headed Chromium smoke for the new Goal/Add-menu geometry case — passed.
- `npm run build` — typecheck, architecture/theme/i18n guards, production build, and artifact verification passed.

The browser regression covers 1368x546 and 390x844 viewports, light/dark media, reduced motion, floating and docked Composer layouts, keyboard dismissal, and Goal completion.

## Safety and compatibility

- Frontend-only and platform-neutral.
- No backend, RPC, configuration, database, persisted state, migration, or public protocol changes.
- No changes to Goal/Plan execution, attachment handling, Composer dimensions, floating preference, or retract behavior.
- Existing installations and desktop clients require no migration.

## Third-party origin

None.
