### PR TITLE
Accept late Desktop Gateway readiness

### DIFF
--- a/desktop/electron/scripts/test-desktop-gateway-lifecycle.mjs
+++ b/desktop/electron/scripts/test-desktop-gateway-lifecycle.mjs
@@ -3,7 +3,92 @@ import assert from 'node:assert/strict'
 import {
   lifecycleAllowsProcessSpawn,
   stopAndJoinLifecycleProcesses,
+  waitForGatewayReadiness,
 } from '../dist/gateway-lifecycle.js'
+
+function fakeClock() {
+  let current = 0
+  return {
+    now: () => current,
+    sleep: async (milliseconds) => {
+      current += milliseconds
+    },
+  }
+}
+
+async function runReadinessBeforePrimaryDeadlineCase() {
+  const clock = fakeClock()
+  let probes = 0
+  const result = await waitForGatewayReadiness({
+    probe: async () => ++probes === 2,
+    primaryTimeoutMs: 10,
+    lateGraceMs: 10,
+    pollIntervalMs: 5,
+    ...clock,
+  })
+
+  assert.deepEqual(result, { status: 'ready', late: false })
+  assert.equal(probes, 2)
+}
+
+async function runLateReadinessCase() {
+  const clock = fakeClock()
+  const result = await waitForGatewayReadiness({
+    probe: async () => clock.now() >= 15,
+    primaryTimeoutMs: 10,
+    lateGraceMs: 10,
+    pollIntervalMs: 5,
+    ...clock,
+  })
+
+  assert.deepEqual(result, { status: 'ready', late: true })
+  assert.equal(clock.now(), 15)
+}
+
+async function runReadinessTimeoutCase() {
+  const clock = fakeClock()
+  const result = await waitForGatewayReadiness({
+    probe: async () => false,
+    primaryTimeoutMs: 10,
+    lateGraceMs: 10,
+    pollIntervalMs: 6,
+    ...clock,
+  })
+
+  assert.deepEqual(result, { status: 'timeout' })
+  assert.equal(clock.now(), 20)
+}
+
+async function runReadinessExitCase() {
+  const clock = fakeClock()
+  const result = await waitForGatewayReadiness({
+    probe: async () => false,
+    exitMessage: () => clock.now() >= 5 ? 'gateway exited' : null,
+    primaryTimeoutMs: 10,
+    lateGraceMs: 10,
+    pollIntervalMs: 5,
+    ...clock,
+  })
+
+  assert.deepEqual(result, { status: 'exited', message: 'gateway exited' })
+  assert.equal(clock.now(), 5)
+}
+
+async function runReadinessExitDuringSuccessfulProbeCase() {
+  let exited = false
+  const result = await waitForGatewayReadiness({
+    probe: async () => {
+      exited = true
+      return true
+    },
+    exitMessage: () => exited ? 'gateway exited during probe' : null,
+    primaryTimeoutMs: 10,
+    lateGraceMs: 10,
+    pollIntervalMs: 5,
+  })
+
+  assert.deepEqual(result, { status: 'exited', message: 'gateway exited during probe' })
+}
 
 async function runStoppingSetOnlyCase() {
   const stopping = { name: 'already-stopping', live: true }
@@ -122,5 +207,10 @@ await runCurrentPlusStoppingCase()
 await runLatePublishedChildCase()
 await runFailClosedCase()
 await runPendingSpawnAdmissionCase()
+await runReadinessBeforePrimaryDeadlineCase()
+await runLateReadinessCase()
+await runReadinessTimeoutCase()
+await runReadinessExitCase()
+await runReadinessExitDuringSuccessfulProbeCase()
 
 console.log('desktop gateway lifecycle tests passed')

--- a/desktop/electron/scripts/test-desktop-gateway-lifecycle.mjs
+++ b/desktop/electron/scripts/test-desktop-gateway-lifecycle.mjs
@@ -10,6 +10,9 @@ function fakeClock() {
   let current = 0
   return {
     now: () => current,
+    advance: (milliseconds) => {
+      current += milliseconds
+    },
     sleep: async (milliseconds) => {
       current += milliseconds
     },
@@ -88,6 +91,36 @@ async function runReadinessExitDuringSuccessfulProbeCase() {
   })
 
   assert.deepEqual(result, { status: 'exited', message: 'gateway exited during probe' })
+}
+
+async function runProbeCrossesDeadlineCase() {
+  const clock = fakeClock()
+  const result = await waitForGatewayReadiness({
+    probe: async (remainingMs) => {
+      clock.advance(remainingMs + 1)
+      return true
+    },
+    primaryTimeoutMs: 10,
+    lateGraceMs: 10,
+    pollIntervalMs: 5,
+    ...clock,
+  })
+
+  assert.deepEqual(result, { status: 'timeout' })
+  assert.equal(clock.now(), 21, 'readiness after the hard deadline is rejected')
+}
+
+async function runNeverResolvingProbeCase() {
+  const startedAt = performance.now()
+  const result = await waitForGatewayReadiness({
+    probe: async () => await new Promise(() => {}),
+    primaryTimeoutMs: 5,
+    lateGraceMs: 10,
+    pollIntervalMs: 2,
+  })
+
+  assert.deepEqual(result, { status: 'timeout' })
+  assert.ok(performance.now() - startedAt < 250, 'a stuck probe cannot escape the hard budget')
 }
 
 async function runStoppingSetOnlyCase() {
@@ -212,5 +245,7 @@ await runLateReadinessCase()
 await runReadinessTimeoutCase()
 await runReadinessExitCase()
 await runReadinessExitDuringSuccessfulProbeCase()
+await runProbeCrossesDeadlineCase()
+await runNeverResolvingProbeCase()
 
 console.log('desktop gateway lifecycle tests passed')

--- a/desktop/electron/scripts/test-desktop-gateway-ownership.mjs
+++ b/desktop/electron/scripts/test-desktop-gateway-ownership.mjs
@@ -27,6 +27,7 @@ import {
   requestVerifiedDesktopGatewayShutdown,
   sameDesktopGatewayOwnershipInstance,
   verifyDesktopGatewayOwnership,
+  verifyDesktopGatewayLaunchOwnership,
   waitForDesktopGatewayOwnershipRelease,
 } from '../dist/desktop-gateway-ownership.js'
 import {
@@ -100,6 +101,52 @@ assert.equal(
   false,
   'the per-launch nonce remains mandatory',
 )
+
+{
+  const authority = {
+    instanceNonce: nonce,
+    profileFingerprint: record.profile_fingerprint,
+    port: record.port,
+  }
+  let challengeCalls = 0
+  assert.equal(
+    await verifyDesktopGatewayLaunchOwnership('/profile/current', authority, {
+      load: () => ({ status: 'valid', record }),
+      verify: async () => {
+        challengeCalls += 1
+        return true
+      },
+    }),
+    true,
+    'a matching launch record plus identity challenge proves the listener',
+  )
+  assert.equal(challengeCalls, 1)
+
+  assert.equal(
+    await verifyDesktopGatewayLaunchOwnership('/profile/current', authority, {
+      load: () => ({
+        status: 'valid',
+        record: { ...record, instance_nonce: 'x'.repeat(43) },
+      }),
+      verify: async () => {
+        challengeCalls += 1
+        return true
+      },
+    }),
+    false,
+    'a healthy foreign listener cannot inherit authority from a live launcher child',
+  )
+  assert.equal(challengeCalls, 1, 'a foreign record is rejected before any challenge')
+
+  assert.equal(
+    await verifyDesktopGatewayLaunchOwnership('/profile/current', authority, {
+      load: () => ({ status: 'valid', record }),
+      verify: async () => false,
+    }),
+    false,
+    'a matching record without a successful identity challenge fails closed',
+  )
+}
 
 const root = mkdtempSync(join(tmpdir(), 'opensquilla-desktop-gateway-owner-'))
 try {

--- a/desktop/electron/src/boot.html
+++ b/desktop/electron/src/boot.html
@@ -945,14 +945,17 @@
 
     let retryStartupInFlight = false;
     async function retryStartup() {
-      if (!api || typeof api.retryStartup !== 'function' || retryStartupInFlight) return null;
+      const resumeStartup = typeof api?.resumeStartup === 'function'
+        ? api.resumeStartup
+        : api?.retryStartup;
+      if (typeof resumeStartup !== 'function' || retryStartupInFlight) return null;
       const retryButton = document.getElementById('retry');
       const recoveryRetryButton = document.getElementById('recoveryRetry');
       retryStartupInFlight = true;
       retryButton.disabled = true;
       recoveryRetryButton.disabled = true;
       try {
-        const result = await api.retryStartup();
+        const result = await resumeStartup();
         if (result && result.ok === false) {
           applyError({ message: result.error || msg.errorDefault });
         }

--- a/desktop/electron/src/desktop-gateway-ownership.ts
+++ b/desktop/electron/src/desktop-gateway-ownership.ts
@@ -38,6 +38,11 @@ export interface DesktopGatewayLaunchAuthority {
   port: number
 }
 
+export interface DesktopGatewayLaunchVerificationOptions {
+  load?: (ownershipDir: string) => DesktopGatewayOwnershipRecordLoad
+  verify?: (record: DesktopGatewayOwnershipRecord) => Promise<boolean>
+}
+
 /**
  * Bind a record to the launch secret and profile, not the immediate child PID.
  * In development `uv run` is the Electron ChildProcess while the Python
@@ -50,6 +55,24 @@ export function desktopGatewayOwnershipMatchesLaunch(
   return record.instance_nonce === authority.instanceNonce
     && record.profile_fingerprint === authority.profileFingerprint
     && record.port === authority.port
+}
+
+/**
+ * Prove that a ready loopback listener is the Gateway from this exact launch.
+ * A live launcher child and successful health/control probes are deliberately
+ * insufficient because another listener can win the probe-to-bind race.
+ */
+export async function verifyDesktopGatewayLaunchOwnership(
+  ownershipDir: string,
+  authority: DesktopGatewayLaunchAuthority,
+  options: DesktopGatewayLaunchVerificationOptions = {},
+): Promise<boolean> {
+  const loaded = (options.load ?? loadDesktopGatewayOwnershipRecord)(ownershipDir)
+  if (
+    loaded.status !== 'valid'
+    || !desktopGatewayOwnershipMatchesLaunch(loaded.record, authority)
+  ) return false
+  return await (options.verify ?? verifyDesktopGatewayOwnership)(loaded.record)
 }
 
 export interface DesktopGatewayIdentityPayload {

--- a/desktop/electron/src/gateway-lifecycle.ts
+++ b/desktop/electron/src/gateway-lifecycle.ts
@@ -1,3 +1,5 @@
+import { performance } from 'node:perf_hooks'
+
 export interface LifecycleProcessDrainOptions<T> {
   currentProcess: () => T | null
   stopCurrentProcess: (process: T) => void
@@ -7,7 +9,7 @@ export interface LifecycleProcessDrainOptions<T> {
 }
 
 export interface GatewayReadinessWaitOptions {
-  probe: () => Promise<boolean>
+  probe: (remainingMs: number) => Promise<boolean>
   exitMessage?: () => string | null
   primaryTimeoutMs: number
   lateGraceMs: number
@@ -30,7 +32,7 @@ export type GatewayReadinessWaitResult =
 export async function waitForGatewayReadiness(
   options: GatewayReadinessWaitOptions,
 ): Promise<GatewayReadinessWaitResult> {
-  const now = options.now ?? Date.now
+  const now = options.now ?? (() => performance.now())
   const sleep = options.sleep ?? ((milliseconds: number) => (
     new Promise<void>((resolve) => setTimeout(resolve, milliseconds))
   ))
@@ -44,14 +46,26 @@ export async function waitForGatewayReadiness(
     if (beforeProbeExit) return { status: 'exited', message: beforeProbeExit }
 
     const elapsedBeforeProbe = Math.max(0, now() - startedAt)
-    if (elapsedBeforeProbe > totalTimeoutMs) return { status: 'timeout' }
-    const ready = await options.probe()
+    const remainingBeforeProbeMs = totalTimeoutMs - elapsedBeforeProbe
+    if (remainingBeforeProbeMs <= 0) return { status: 'timeout' }
+
+    let probeTimeout: NodeJS.Timeout | null = null
+    const ready = await Promise.race<boolean | null>([
+      options.probe(remainingBeforeProbeMs),
+      new Promise<null>((resolveTimeout) => {
+        probeTimeout = setTimeout(() => resolveTimeout(null), remainingBeforeProbeMs)
+      }),
+    ]).finally(() => {
+      if (probeTimeout) clearTimeout(probeTimeout)
+    })
 
     const afterProbeExit = options.exitMessage?.()
     if (afterProbeExit) return { status: 'exited', message: afterProbeExit }
-    if (ready) return { status: 'ready', late: elapsedBeforeProbe >= primaryTimeoutMs }
 
     const elapsedAfterProbe = Math.max(0, now() - startedAt)
+    if (ready === null || elapsedAfterProbe >= totalTimeoutMs) return { status: 'timeout' }
+    if (ready) return { status: 'ready', late: elapsedAfterProbe >= primaryTimeoutMs }
+
     const remainingMs = totalTimeoutMs - elapsedAfterProbe
     if (remainingMs <= 0) return { status: 'timeout' }
     await sleep(Math.min(pollIntervalMs, remainingMs))

--- a/desktop/electron/src/gateway-lifecycle.ts
+++ b/desktop/electron/src/gateway-lifecycle.ts
@@ -6,6 +6,58 @@ export interface LifecycleProcessDrainOptions<T> {
   maxRounds?: number
 }
 
+export interface GatewayReadinessWaitOptions {
+  probe: () => Promise<boolean>
+  exitMessage?: () => string | null
+  primaryTimeoutMs: number
+  lateGraceMs: number
+  pollIntervalMs: number
+  now?: () => number
+  sleep?: (milliseconds: number) => Promise<void>
+}
+
+export type GatewayReadinessWaitResult =
+  | { status: 'ready'; late: boolean }
+  | { status: 'exited'; message: string }
+  | { status: 'timeout' }
+
+/**
+ * Wait for a spawned Gateway without turning the first readiness deadline into
+ * an irreversible failure. The late window remains bounded, and child exit is
+ * checked on both sides of every probe so a dead process never consumes the
+ * remainder of the startup budget.
+ */
+export async function waitForGatewayReadiness(
+  options: GatewayReadinessWaitOptions,
+): Promise<GatewayReadinessWaitResult> {
+  const now = options.now ?? Date.now
+  const sleep = options.sleep ?? ((milliseconds: number) => (
+    new Promise<void>((resolve) => setTimeout(resolve, milliseconds))
+  ))
+  const primaryTimeoutMs = Math.max(0, options.primaryTimeoutMs)
+  const totalTimeoutMs = primaryTimeoutMs + Math.max(0, options.lateGraceMs)
+  const pollIntervalMs = Math.max(1, options.pollIntervalMs)
+  const startedAt = now()
+
+  while (true) {
+    const beforeProbeExit = options.exitMessage?.()
+    if (beforeProbeExit) return { status: 'exited', message: beforeProbeExit }
+
+    const elapsedBeforeProbe = Math.max(0, now() - startedAt)
+    if (elapsedBeforeProbe > totalTimeoutMs) return { status: 'timeout' }
+    const ready = await options.probe()
+
+    const afterProbeExit = options.exitMessage?.()
+    if (afterProbeExit) return { status: 'exited', message: afterProbeExit }
+    if (ready) return { status: 'ready', late: elapsedBeforeProbe >= primaryTimeoutMs }
+
+    const elapsedAfterProbe = Math.max(0, now() - startedAt)
+    const remainingMs = totalTimeoutMs - elapsedAfterProbe
+    if (remainingMs <= 0) return { status: 'timeout' }
+    await sleep(Math.min(pollIntervalMs, remainingMs))
+  }
+}
+
 export function lifecycleAllowsProcessSpawn(
   lifecycleClosing: boolean,
   profileWriterAdmissionClosed: boolean,

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -7592,9 +7592,12 @@ async function findGatewayPort(): Promise<number> {
   throw new Error('No free OpenSquilla desktop gateway port found in 18791-18830.')
 }
 
-async function healthCheck(url: string): Promise<boolean> {
+async function healthCheck(url: string, timeoutMs = 1000): Promise<boolean> {
   try {
-    const response = await fetch(`${url}/healthz`, { signal: AbortSignal.timeout(1000) })
+    const boundedTimeoutMs = Math.max(1, Math.min(1000, Math.floor(timeoutMs)))
+    const response = await fetch(`${url}/healthz`, {
+      signal: AbortSignal.timeout(boundedTimeoutMs),
+    })
     if (!response.ok) return false
     const payload = await response.json().catch(() => null)
     return Boolean(payload && payload.ok === true)
@@ -7666,7 +7669,7 @@ function classifyGatewayExitMessage(message: string, outputTail: string): string
 
 async function waitForGateway(url: string, earlyExitMessage?: () => string | null): Promise<void> {
   const result = await waitForGatewayReadiness({
-    probe: () => healthCheck(url),
+    probe: (remainingMs) => healthCheck(url, remainingMs),
     exitMessage: earlyExitMessage,
     primaryTimeoutMs: 45_000,
     lateGraceMs: 15_000,
@@ -7754,6 +7757,28 @@ async function verifyOwnedGatewayLaunch(
   })
 }
 
+async function discardUnverifiedOwnedGatewayChild(
+  child: ChildProcessWithoutNullStreams,
+): Promise<boolean> {
+  if (gatewayProcess !== child) return false
+  trackStoppingGatewayProcess(child)
+  gatewayProcess = null
+  gatewayState.status = 'stopped'
+  gatewayState.error = undefined
+  // Do not issue any URL-based shutdown request: the listener just failed the
+  // exact launch proof. Signal only the ChildProcess tree created by Electron.
+  hardTerminateGatewayProcess(child)
+  const exited = await waitForGatewayProcessExit(child, 10_000)
+  if (!exited) {
+    // Restore the exact handle as current authority so the caller can surface
+    // the failed stop and a later retry can join it. The stopping-set admission
+    // gate prevents a successor from being spawned while this child is live.
+    if (!gatewayProcess) gatewayProcess = child
+    throw new Error(desktopGatewayStillRunningMessage())
+  }
+  return true
+}
+
 async function resumeOwnedGatewayStartup(): Promise<GatewayState | null> {
   const child = gatewayProcess
   if (
@@ -7786,9 +7811,10 @@ async function resumeOwnedGatewayStartup(): Promise<GatewayState | null> {
     throw new Error(childExitMessage() || 'Desktop gateway changed while startup resumed.')
   }
   if (!await verifyOwnedGatewayLaunch(child)) {
-    throw new Error(
-      'OPENSQUILLA_GATEWAY_IDENTITY_MISMATCH: The healthy listener is not the Desktop Gateway from this launch.',
-    )
+    if (!await discardUnverifiedOwnedGatewayChild(child)) {
+      throw new Error('Desktop gateway changed during ownership verification.')
+    }
+    return null
   }
   if (
     gatewayProcess !== child
@@ -8139,12 +8165,7 @@ async function startGateway(): Promise<GatewayState> {
     // Never send a shutdown request to the unverified listener. Terminate only
     // the exact child handle we spawned, then let port recovery choose another
     // loopback port once that child has released its profile writer lease.
-    if (gatewayProcess === child) {
-      trackStoppingGatewayProcess(child)
-      gatewayProcess = null
-      hardTerminateGatewayProcess(child)
-      await waitForGatewayProcessExit(child)
-    }
+    await discardUnverifiedOwnedGatewayChild(child)
     throw new Error(
       'OPENSQUILLA_GATEWAY_PORT_IN_USE: Gateway port is already in use by an unverified listener.',
     )
@@ -8656,19 +8677,27 @@ async function openOrResumeDesktopApp(): Promise<void> {
           }
         }
       } catch (error) {
-        if (gatewayState.status !== 'ready') {
-          gatewayState.status = 'error'
-          gatewayState.error = error instanceof Error ? error.message : String(error)
+        const authoritative = !isQuitting
+          && revision === desktopOpenFlowRevision
+          && requestedProfileKey === desktopProfileKey()
+        if (authoritative) {
+          if (gatewayState.status !== 'ready') {
+            gatewayState.status = 'error'
+            gatewayState.error = error instanceof Error ? error.message : String(error)
+          }
+          desktopLog('desktop_open_failed', {
+            profileKind: 'primary',
+            gatewayPid: gatewayProcess?.pid,
+            gatewayStatus: gatewayState.status,
+            error: error instanceof Error ? error.message : String(error),
+          })
+          if (currentMainWindow()) sendBootError(error)
         }
-        desktopLog('desktop_open_failed', {
-          profileKind: 'primary',
-          gatewayPid: gatewayProcess?.pid,
-          gatewayStatus: gatewayState.status,
-          error: error instanceof Error ? error.message : String(error),
-        })
-        if (currentMainWindow()) sendBootError(error)
       }
-      if (revision === desktopOpenFlowRevision) return
+      if (
+        revision === desktopOpenFlowRevision
+        && requestedProfileKey === desktopProfileKey()
+      ) return
       if (gatewayProfileKey && gatewayProfileKey !== desktopProfileKey()) {
         if (gatewayProcess && gatewayState.owned) await stopOwnedGatewayAndWait()
         else clearReusableGatewayState()
@@ -8733,9 +8762,11 @@ async function requestOwnedGatewayShutdown(
   ) {
     if (await requestVerifiedDesktopGatewayShutdown(loaded.record)) return true
   }
-  // Backward compatibility for a child from an older runtime that predates the
-  // Desktop ownership protocol. Failure falls back to signaling this exact
-  // ChildProcess handle, never to PID-file or port-based process discovery.
+  // A known launch context that cannot prove its listener must never send an
+  // unauthenticated shutdown request to that URL. The caller will signal only
+  // the exact ChildProcess handle. Keep the legacy URL path solely for handles
+  // created before this Electron process could attach a launch context.
+  if (context) return false
   return await requestGatewayShutdown(url)
 }
 

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -501,6 +501,12 @@ function invalidateDesktopOpenFlow(): number {
   return desktopOpenFlowRevision
 }
 
+function desktopOpenAuthorityIsCurrent(revision: number, profileKey: string): boolean {
+  return !isQuitting
+    && revision === desktopOpenFlowRevision
+    && profileKey === desktopProfileKey()
+}
+
 function beginDesktopWriterOperation(label: string): () => void {
   return desktopWriters.begin(label)
 }
@@ -7723,7 +7729,9 @@ function liveLifecycleOwnedGatewayProcesses(): ChildProcessWithoutNullStreams[] 
   return [...children].filter((child) => !hasGatewayProcessExited(child))
 }
 
-async function reuseHealthyGatewayState(): Promise<GatewayState | null> {
+async function reuseHealthyGatewayState(
+  isCurrent: () => boolean,
+): Promise<GatewayState | null> {
   if (gatewayProfileKey !== desktopProfileKey()) return null
   if (!gatewayState.url) return null
   if (gatewayState.status !== 'ready' && !gatewayProcess) return null
@@ -7731,7 +7739,9 @@ async function reuseHealthyGatewayState(): Promise<GatewayState | null> {
   // resumeOwnedGatewayStartup; a healthy port alone is not ownership proof.
   if (gatewayProcess && gatewayState.owned) return null
 
-  if (await healthCheck(gatewayState.url)) {
+  const healthy = await healthCheck(gatewayState.url)
+  if (!isCurrent()) return null
+  if (healthy) {
     gatewayState.status = 'ready'
     gatewayState.error = undefined
     sendBootStatus('control')
@@ -7779,7 +7789,10 @@ async function discardUnverifiedOwnedGatewayChild(
   return true
 }
 
-async function resumeOwnedGatewayStartup(): Promise<GatewayState | null> {
+async function resumeOwnedGatewayStartup(
+  isCurrent: () => boolean,
+): Promise<GatewayState | null> {
+  if (!isCurrent()) throw new Error('Desktop startup was superseded by a newer lifecycle operation.')
   const child = gatewayProcess
   if (
     !child
@@ -7798,6 +7811,7 @@ async function resumeOwnedGatewayStartup(): Promise<GatewayState | null> {
   gatewayState.error = undefined
   sendBootStatus('gateway-health')
   await waitForGateway(url, childExitMessage)
+  if (!isCurrent()) throw new Error('Desktop startup was superseded during health verification.')
   await waitForControlUi(url, childExitMessage)
 
   // Health alone never grants ownership. The same exact child and profile that
@@ -7807,6 +7821,7 @@ async function resumeOwnedGatewayStartup(): Promise<GatewayState | null> {
     gatewayProcess !== child
     || hasGatewayProcessExited(child)
     || gatewayProfileKey !== desktopProfileKey()
+    || !isCurrent()
   ) {
     throw new Error(childExitMessage() || 'Desktop gateway changed while startup resumed.')
   }
@@ -7820,6 +7835,7 @@ async function resumeOwnedGatewayStartup(): Promise<GatewayState | null> {
     gatewayProcess !== child
     || hasGatewayProcessExited(child)
     || gatewayProfileKey !== desktopProfileKey()
+    || !isCurrent()
   ) {
     throw new Error(childExitMessage() || 'Desktop gateway changed during ownership verification.')
   }
@@ -7915,8 +7931,14 @@ async function recoverVerifiedOrphanGatewayBeforeSpawn(
 }
 
 async function startGateway(): Promise<GatewayState> {
-  const reusableGateway = forceOnboardingOnNextStartup ? null : await reuseHealthyGatewayState()
+  const startupRevision = desktopOpenFlowRevision
+  const startupProfileKey = desktopProfileKey()
+  const isCurrent = () => desktopOpenAuthorityIsCurrent(startupRevision, startupProfileKey)
+  const reusableGateway = forceOnboardingOnNextStartup
+    ? null
+    : await reuseHealthyGatewayState(isCurrent)
   if (reusableGateway) return reusableGateway
+  if (!isCurrent()) throw new Error('Desktop startup was superseded by a newer open request.')
   artifactPreviewLeaseBroker.clear()
 
   assertSupportedMacInstallLocation()
@@ -7938,7 +7960,7 @@ async function startGateway(): Promise<GatewayState> {
 
   const resumedGateway = forceOnboardingOnNextStartup
     ? null
-    : await resumeOwnedGatewayStartup()
+    : await resumeOwnedGatewayStartup(isCurrent)
   if (resumedGateway) return resumedGateway
 
   if (gatewayProcess && gatewayState.owned) {
@@ -7964,12 +7986,15 @@ async function startGateway(): Promise<GatewayState> {
   const activeProfile = activeDesktopProfile()
   const overrideUrl = process.env.OPENSQUILLA_DESKTOP_GATEWAY_URL
   if (overrideUrl) {
+    if (!isCurrent()) throw new Error('Desktop startup was superseded before Gateway override validation.')
     sendBootStatus('gateway-health')
     gatewayState.url = overrideUrl.replace(/\/$/, '')
     gatewayState.port = Number(new URL(gatewayState.url).port || 0)
     gatewayState.owned = false
     gatewayProfileKey = desktopProfileKey(activeProfile)
-    gatewayState.status = (await healthCheck(gatewayState.url)) ? 'ready' : 'error'
+    const overrideReady = await healthCheck(gatewayState.url)
+    if (!isCurrent()) throw new Error('Desktop startup was superseded during Gateway override validation.')
+    gatewayState.status = overrideReady ? 'ready' : 'error'
     if (gatewayState.status !== 'ready') {
       throw new Error(`Configured gateway is not healthy: ${gatewayState.url}`)
     }
@@ -7978,9 +8003,11 @@ async function startGateway(): Promise<GatewayState> {
 
   sendBootStatus('gateway-health')
   await recoverVerifiedOrphanGatewayBeforeSpawn()
+  if (!isCurrent()) throw new Error('Desktop startup was superseded during Gateway recovery.')
 
   sendBootStatus('profile')
   const connection = await runOnboarding()
+  if (!isCurrent()) throw new Error('Desktop startup was superseded during profile setup.')
   forceOnboardingOnNextStartup = false
   const apiKey = decryptApiKey(connection)
   // Keyless providers (e.g. Ollama) ship requiresApiKey=false and are accepted
@@ -8013,6 +8040,7 @@ async function startGateway(): Promise<GatewayState> {
     }
     throw new Error('Gateway startup was cancelled by an active lifecycle or profile operation.')
   }
+  if (!isCurrent()) throw new Error('Desktop startup was superseded before Gateway spawn.')
   const url = `http://127.0.0.1:${port}`
   const logDir = desktopLogsDir()
   mkdirSync(logDir, { recursive: true })
@@ -8157,7 +8185,7 @@ async function startGateway(): Promise<GatewayState> {
   // endpoint belongs to someone else (e.g. a CLI `opensquilla gateway run` on the
   // same port). Surface it as a port conflict so recovery advances to the next
   // port instead of silently attaching the window to the wrong profile.
-  if (hasGatewayProcessExited(child) || gatewayProcess !== child) {
+  if (hasGatewayProcessExited(child) || gatewayProcess !== child || !isCurrent()) {
     throw new Error(childExitMessage
       || 'OPENSQUILLA_GATEWAY_PORT_IN_USE: desktop gateway did not keep the port bind.')
   }
@@ -8170,7 +8198,7 @@ async function startGateway(): Promise<GatewayState> {
       'OPENSQUILLA_GATEWAY_PORT_IN_USE: Gateway port is already in use by an unverified listener.',
     )
   }
-  if (hasGatewayProcessExited(child) || gatewayProcess !== child) {
+  if (hasGatewayProcessExited(child) || gatewayProcess !== child || !isCurrent()) {
     throw new Error(childExitMessage
       || 'OPENSQUILLA_GATEWAY_PORT_IN_USE: desktop gateway changed during ownership verification.')
   }
@@ -8439,7 +8467,7 @@ function ensureGatewayStarted(): Promise<GatewayState> {
 
 async function loadControlUiIntoCurrentWindow(
   gatewayUrl: string,
-  isCurrent: () => boolean = () => true,
+  isCurrent: () => boolean,
 ): Promise<boolean> {
   if (!isCurrent()) return false
   const window = currentMainWindow()
@@ -8669,17 +8697,23 @@ async function openOrResumeDesktopApp(): Promise<void> {
           if (revision === desktopOpenFlowRevision && requestedProfileKey === desktopProfileKey()) {
             const reusableGateway = forceOnboardingOnNextStartup
               ? null
-              : await reuseHealthyGatewayState()
+              : await reuseHealthyGatewayState(
+                () => desktopOpenAuthorityIsCurrent(revision, requestedProfileKey),
+              )
+            if (!desktopOpenAuthorityIsCurrent(revision, requestedProfileKey)) {
+              throw new Error('Desktop startup was superseded by a newer open request.')
+            }
             const gateway = reusableGateway ?? await ensureGatewayStarted()
-            if (revision === desktopOpenFlowRevision && requestedProfileKey === desktopProfileKey()) {
-              await loadControlUiIntoCurrentWindow(gateway.url)
+            if (desktopOpenAuthorityIsCurrent(revision, requestedProfileKey)) {
+              await loadControlUiIntoCurrentWindow(
+                gateway.url,
+                () => desktopOpenAuthorityIsCurrent(revision, requestedProfileKey),
+              )
             }
           }
         }
       } catch (error) {
-        const authoritative = !isQuitting
-          && revision === desktopOpenFlowRevision
-          && requestedProfileKey === desktopProfileKey()
+        const authoritative = desktopOpenAuthorityIsCurrent(revision, requestedProfileKey)
         if (authoritative) {
           if (gatewayState.status !== 'ready') {
             gatewayState.status = 'error'
@@ -8694,10 +8728,7 @@ async function openOrResumeDesktopApp(): Promise<void> {
           if (currentMainWindow()) sendBootError(error)
         }
       }
-      if (
-        revision === desktopOpenFlowRevision
-        && requestedProfileKey === desktopProfileKey()
-      ) return
+      if (desktopOpenAuthorityIsCurrent(revision, requestedProfileKey)) return
       if (gatewayProfileKey && gatewayProfileKey !== desktopProfileKey()) {
         if (gatewayProcess && gatewayState.owned) await stopOwnedGatewayAndWait()
         else clearReusableGatewayState()
@@ -12601,7 +12632,11 @@ async function resumeBootStartup(): Promise<{ ok: boolean; error?: string }> {
   try {
     const gateway = pendingStart
       ? await pendingStart
-      : await resumeOwnedGatewayStartup()
+      : initialAuthority
+        ? await resumeOwnedGatewayStartup(
+          () => bootResumeAuthorityIsCurrent(initialAuthority),
+        )
+        : null
     if (!gateway) {
       // With no exact live child to resume, use the normal open flow so profile
       // inspection and recovery gates still run before any replacement spawn.

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -8689,6 +8689,9 @@ async function openOrResumeDesktopApp(): Promise<void> {
     while (!isQuitting) {
       const revision = desktopOpenFlowRevision
       const requestedProfileKey = desktopProfileKey()
+      let operationIsCurrent = () => (
+        desktopOpenAuthorityIsCurrent(revision, requestedProfileKey)
+      )
       await createMainWindow()
       focusMainWindow()
 
@@ -8698,22 +8701,38 @@ async function openOrResumeDesktopApp(): Promise<void> {
             const reusableGateway = forceOnboardingOnNextStartup
               ? null
               : await reuseHealthyGatewayState(
-                () => desktopOpenAuthorityIsCurrent(revision, requestedProfileKey),
+                operationIsCurrent,
               )
-            if (!desktopOpenAuthorityIsCurrent(revision, requestedProfileKey)) {
+            if (!operationIsCurrent()) {
               throw new Error('Desktop startup was superseded by a newer open request.')
             }
             const gateway = reusableGateway ?? await ensureGatewayStarted()
-            if (desktopOpenAuthorityIsCurrent(revision, requestedProfileKey)) {
+            const gatewayUrl = gateway.url
+            const expectedOwned = gateway.owned
+            const expectedChild = expectedOwned ? gatewayProcess : null
+            operationIsCurrent = () => (
+              desktopOpenAuthorityIsCurrent(revision, requestedProfileKey)
+              && gatewayState.url === gatewayUrl
+              && gatewayState.owned === expectedOwned
+              && (
+                !expectedOwned
+                || (
+                  expectedChild !== null
+                  && gatewayProcess === expectedChild
+                  && !hasGatewayProcessExited(expectedChild)
+                )
+              )
+            )
+            if (operationIsCurrent()) {
               await loadControlUiIntoCurrentWindow(
-                gateway.url,
-                () => desktopOpenAuthorityIsCurrent(revision, requestedProfileKey),
+                gatewayUrl,
+                operationIsCurrent,
               )
             }
           }
         }
       } catch (error) {
-        const authoritative = desktopOpenAuthorityIsCurrent(revision, requestedProfileKey)
+        const authoritative = operationIsCurrent()
         if (authoritative) {
           if (gatewayState.status !== 'ready') {
             gatewayState.status = 'error'

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -36,6 +36,7 @@ import {
 import {
   lifecycleAllowsProcessSpawn,
   stopAndJoinLifecycleProcesses,
+  waitForGatewayReadiness,
 } from './gateway-lifecycle.js'
 import { buildCliInvocation } from './cli-invocation.js'
 import {
@@ -7662,15 +7663,20 @@ function classifyGatewayExitMessage(message: string, outputTail: string): string
 }
 
 async function waitForGateway(url: string, earlyExitMessage?: () => string | null): Promise<void> {
-  const startedAt = Date.now()
-  while (Date.now() - startedAt < 45_000) {
-    const earlyExit = earlyExitMessage?.()
-    if (earlyExit) throw new Error(earlyExit)
-    if (await healthCheck(url)) return
-    await new Promise((resolveWait) => setTimeout(resolveWait, 500))
+  const result = await waitForGatewayReadiness({
+    probe: () => healthCheck(url),
+    exitMessage: earlyExitMessage,
+    primaryTimeoutMs: 45_000,
+    lateGraceMs: 15_000,
+    pollIntervalMs: 500,
+  })
+  if (result.status === 'ready') {
+    if (result.late) {
+      desktopLog('gateway_health_ready_after_primary_deadline', { port: gatewayState.port })
+    }
+    return
   }
-  const earlyExit = earlyExitMessage?.()
-  if (earlyExit) throw new Error(earlyExit)
+  if (result.status === 'exited') throw new Error(result.message)
   throw new Error(`Gateway did not become healthy at ${url}`)
 }
 
@@ -7716,6 +7722,9 @@ async function reuseHealthyGatewayState(): Promise<GatewayState | null> {
   if (gatewayProfileKey !== desktopProfileKey()) return null
   if (!gatewayState.url) return null
   if (gatewayState.status !== 'ready' && !gatewayProcess) return null
+  // A live owned child must pass the exact-child and profile checks in
+  // resumeOwnedGatewayStartup; a healthy port alone is not ownership proof.
+  if (gatewayProcess && gatewayState.owned) return null
 
   if (await healthCheck(gatewayState.url)) {
     gatewayState.status = 'ready'
@@ -7729,6 +7738,44 @@ async function reuseHealthyGatewayState(): Promise<GatewayState | null> {
     gatewayState.status = 'stopped'
   }
   return null
+}
+
+async function resumeOwnedGatewayStartup(): Promise<GatewayState | null> {
+  const child = gatewayProcess
+  if (
+    !child
+    || !gatewayState.owned
+    || !gatewayState.url
+    || gatewayProfileKey !== desktopProfileKey()
+    || hasGatewayProcessExited(child)
+  ) return null
+
+  const url = gatewayState.url
+  const childExitMessage = (): string | null => {
+    if (gatewayProcess === child && !hasGatewayProcessExited(child)) return null
+    return gatewayState.error || 'gateway exited before becoming healthy'
+  }
+  gatewayState.status = 'starting'
+  gatewayState.error = undefined
+  sendBootStatus('gateway-health')
+  await waitForGateway(url, childExitMessage)
+  await waitForControlUi(url, childExitMessage)
+
+  // Health alone never grants ownership. The same exact child and profile that
+  // entered this resume path must still be current after both asynchronous
+  // probes, otherwise a concurrent restart or profile switch won the race.
+  if (
+    gatewayProcess !== child
+    || hasGatewayProcessExited(child)
+    || gatewayProfileKey !== desktopProfileKey()
+  ) {
+    throw new Error(childExitMessage() || 'Desktop gateway changed while startup resumed.')
+  }
+
+  gatewayState.status = 'ready'
+  gatewayState.error = undefined
+  sendBootStatus('control')
+  return gatewayState
 }
 
 const VERIFIED_ORPHAN_GATEWAY_RELEASE_TIMEOUT_MS = 80_000
@@ -7836,6 +7883,11 @@ async function startGateway(): Promise<GatewayState> {
     })
     throw new Error(desktopGatewayStillRunningMessage())
   }
+
+  const resumedGateway = forceOnboardingOnNextStartup
+    ? null
+    : await resumeOwnedGatewayStartup()
+  if (resumedGateway) return resumedGateway
 
   if (gatewayProcess && gatewayState.owned) {
     if (hasGatewayProcessExited(gatewayProcess)) {
@@ -12427,11 +12479,40 @@ ipcMain.handle('desktop:boot:state', () => ({
   gateway: { ...gatewayState },
   recovery: recoveryStateSnapshot(),
 }))
+ipcMain.handle('desktop:boot:resume', async () => {
+  bootError = null
+  await currentMainWindow()?.loadFile(bootPagePath()).catch(() => null)
+  try {
+    const gateway = gatewayStartPromise
+      ? await gatewayStartPromise
+      : await resumeOwnedGatewayStartup()
+    if (!gateway) {
+      // With no exact live child to resume, use the normal open flow so profile
+      // inspection and recovery gates still run before any replacement spawn.
+      void openOrResumeDesktopApp()
+      return { ok: true }
+    }
+    await loadControlUiIntoCurrentWindow(gateway.url)
+    return { ok: true }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (gatewayState.status !== 'ready') {
+      gatewayState.status = 'error'
+      gatewayState.error = message
+    }
+    desktopLog('gateway_start_resume_failed', {
+      gatewayPid: gatewayProcess?.pid,
+      gatewayStatus: gatewayState.status,
+      error: message,
+    })
+    sendBootError(message)
+    return { ok: false, error: message }
+  }
+})
 ipcMain.handle('desktop:boot:retry', async () => {
-  // Backs both the boot-error "Retry" button and the Control UI "Restart
-  // runtime" action. If a start attempt is already in flight, join it and clear
-  // the stale bootError so the reloaded splash shows live progress instead of
-  // instantly re-rendering the previous error panel.
+  // The Control UI "Restart runtime" action intentionally forces a new child.
+  // The boot page uses desktop:boot:resume instead so a slow owned child can be
+  // accepted after it becomes healthy instead of being torn down first.
   if (gatewayStartPromise) {
     bootError = null
     void openOrResumeDesktopApp()

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -27,6 +27,7 @@ import {
   desktopProfileFingerprint,
   loadDesktopGatewayOwnershipRecord,
   requestVerifiedDesktopGatewayShutdown,
+  verifyDesktopGatewayLaunchOwnership,
   waitForDesktopGatewayOwnershipRelease,
   type DesktopGatewayOwnershipRecord,
 } from './desktop-gateway-ownership.js'
@@ -493,6 +494,7 @@ const gatewayProcessTreeChildren = new WeakSet<ChildProcessWithoutNullStreams>()
 const desktopWriters = new DesktopWriterAdmission()
 let desktopOpenFlowRevision = 0
 let desktopOpenFlowPromise: Promise<void> | null = null
+let bootResumePromise: Promise<{ ok: boolean; error?: string }> | null = null
 
 function invalidateDesktopOpenFlow(): number {
   desktopOpenFlowRevision += 1
@@ -7740,6 +7742,18 @@ async function reuseHealthyGatewayState(): Promise<GatewayState | null> {
   return null
 }
 
+async function verifyOwnedGatewayLaunch(
+  child: ChildProcessWithoutNullStreams,
+): Promise<boolean> {
+  const context = gatewayProcessOwnershipContexts.get(child)
+  if (!context) return false
+  return await verifyDesktopGatewayLaunchOwnership(context.ownershipDir, {
+    instanceNonce: context.nonce,
+    profileFingerprint: context.profileFingerprint,
+    port: context.port,
+  })
+}
+
 async function resumeOwnedGatewayStartup(): Promise<GatewayState | null> {
   const child = gatewayProcess
   if (
@@ -7770,6 +7784,18 @@ async function resumeOwnedGatewayStartup(): Promise<GatewayState | null> {
     || gatewayProfileKey !== desktopProfileKey()
   ) {
     throw new Error(childExitMessage() || 'Desktop gateway changed while startup resumed.')
+  }
+  if (!await verifyOwnedGatewayLaunch(child)) {
+    throw new Error(
+      'OPENSQUILLA_GATEWAY_IDENTITY_MISMATCH: The healthy listener is not the Desktop Gateway from this launch.',
+    )
+  }
+  if (
+    gatewayProcess !== child
+    || hasGatewayProcessExited(child)
+    || gatewayProfileKey !== desktopProfileKey()
+  ) {
+    throw new Error(childExitMessage() || 'Desktop gateway changed during ownership verification.')
   }
 
   gatewayState.status = 'ready'
@@ -8109,6 +8135,24 @@ async function startGateway(): Promise<GatewayState> {
     throw new Error(childExitMessage
       || 'OPENSQUILLA_GATEWAY_PORT_IN_USE: desktop gateway did not keep the port bind.')
   }
+  if (!await verifyOwnedGatewayLaunch(child)) {
+    // Never send a shutdown request to the unverified listener. Terminate only
+    // the exact child handle we spawned, then let port recovery choose another
+    // loopback port once that child has released its profile writer lease.
+    if (gatewayProcess === child) {
+      trackStoppingGatewayProcess(child)
+      gatewayProcess = null
+      hardTerminateGatewayProcess(child)
+      await waitForGatewayProcessExit(child)
+    }
+    throw new Error(
+      'OPENSQUILLA_GATEWAY_PORT_IN_USE: Gateway port is already in use by an unverified listener.',
+    )
+  }
+  if (hasGatewayProcessExited(child) || gatewayProcess !== child) {
+    throw new Error(childExitMessage
+      || 'OPENSQUILLA_GATEWAY_PORT_IN_USE: desktop gateway changed during ownership verification.')
+  }
   sendBootStatus('control')
   gatewayState.status = 'ready'
   return gatewayState
@@ -8372,23 +8416,30 @@ function ensureGatewayStarted(): Promise<GatewayState> {
   return gatewayStartPromise
 }
 
-async function loadControlUiIntoCurrentWindow(gatewayUrl: string): Promise<void> {
+async function loadControlUiIntoCurrentWindow(
+  gatewayUrl: string,
+  isCurrent: () => boolean = () => true,
+): Promise<boolean> {
+  if (!isCurrent()) return false
   const window = currentMainWindow()
-  if (!window) return
+  if (!window) return false
 
   sendBootStatus('control')
   if (isCurrentWindowAtControlUi(window, gatewayUrl)) {
+    if (!isCurrent()) return false
     sendBootStatus('ready')
-    return
+    return true
   }
 
   try {
     await loadControlUi(window, gatewayUrl)
   } catch (error) {
-    if (window.isDestroyed()) return
+    if (window.isDestroyed()) return false
     throw error
   }
+  if (!isCurrent()) return false
   sendBootStatus('ready')
+  return true
 }
 
 // Bring the main window back to the boot splash when a gateway failure happens
@@ -12479,12 +12530,46 @@ ipcMain.handle('desktop:boot:state', () => ({
   gateway: { ...gatewayState },
   recovery: recoveryStateSnapshot(),
 }))
-ipcMain.handle('desktop:boot:resume', async () => {
+
+interface BootResumeAuthority {
+  child: ChildProcessWithoutNullStreams
+  profileKey: string
+  openFlowRevision: number
+}
+
+function currentBootResumeAuthority(): BootResumeAuthority | null {
+  if (
+    !gatewayProcess
+    || !gatewayState.owned
+    || !gatewayProfileKey
+    || hasGatewayProcessExited(gatewayProcess)
+  ) return null
+  return {
+    child: gatewayProcess,
+    profileKey: gatewayProfileKey,
+    openFlowRevision: desktopOpenFlowRevision,
+  }
+}
+
+function bootResumeAuthorityIsCurrent(authority: BootResumeAuthority): boolean {
+  return !isQuitting
+    && gatewayProcess === authority.child
+    && !hasGatewayProcessExited(authority.child)
+    && gatewayState.owned
+    && gatewayProfileKey === authority.profileKey
+    && desktopProfileKey() === authority.profileKey
+    && desktopOpenFlowRevision === authority.openFlowRevision
+}
+
+async function resumeBootStartup(): Promise<{ ok: boolean; error?: string }> {
+  const pendingStart = gatewayStartPromise
+  const initialAuthority = pendingStart ? null : currentBootResumeAuthority()
   bootError = null
   await currentMainWindow()?.loadFile(bootPagePath()).catch(() => null)
+  if (initialAuthority && !bootResumeAuthorityIsCurrent(initialAuthority)) return { ok: true }
   try {
-    const gateway = gatewayStartPromise
-      ? await gatewayStartPromise
+    const gateway = pendingStart
+      ? await pendingStart
       : await resumeOwnedGatewayStartup()
     if (!gateway) {
       // With no exact live child to resume, use the normal open flow so profile
@@ -12492,10 +12577,21 @@ ipcMain.handle('desktop:boot:resume', async () => {
       void openOrResumeDesktopApp()
       return { ok: true }
     }
-    await loadControlUiIntoCurrentWindow(gateway.url)
+    const authority = pendingStart ? currentBootResumeAuthority() : initialAuthority
+    if (!authority || !bootResumeAuthorityIsCurrent(authority)) return { ok: true }
+    await loadControlUiIntoCurrentWindow(
+      gateway.url,
+      () => bootResumeAuthorityIsCurrent(authority),
+    )
     return { ok: true }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
+    // The original open flow owns errors from a pending initial start. For a
+    // direct resume, an exit handler or a newer quit/reset/restart owns any
+    // state after this exact child/profile/revision loses authority.
+    if (pendingStart || !initialAuthority || !bootResumeAuthorityIsCurrent(initialAuthority)) {
+      return { ok: false, error: message }
+    }
     if (gatewayState.status !== 'ready') {
       gatewayState.status = 'error'
       gatewayState.error = message
@@ -12507,6 +12603,17 @@ ipcMain.handle('desktop:boot:resume', async () => {
     })
     sendBootError(message)
     return { ok: false, error: message }
+  }
+}
+
+ipcMain.handle('desktop:boot:resume', async () => {
+  if (bootResumePromise) return await bootResumePromise
+  const promise = resumeBootStartup()
+  bootResumePromise = promise
+  try {
+    return await promise
+  } finally {
+    if (bootResumePromise === promise) bootResumePromise = null
   }
 })
 ipcMain.handle('desktop:boot:retry', async () => {

--- a/desktop/electron/src/preload.cts
+++ b/desktop/electron/src/preload.cts
@@ -58,6 +58,7 @@ contextBridge.exposeInMainWorld('opensquillaDesktop', {
   saveOnboarding: (payload: unknown) => ipcRenderer.invoke('desktop:onboarding:save', payload),
   cancelOnboarding: () => ipcRenderer.invoke('desktop:onboarding:cancel'),
   getBootState: () => ipcRenderer.invoke('desktop:boot:state'),
+  resumeStartup: () => ipcRenderer.invoke('desktop:boot:resume'),
   retryStartup: () => ipcRenderer.invoke('desktop:boot:retry'),
   quitApp: () => ipcRenderer.invoke('desktop:boot:quit'),
   getRecoveryState: () => ipcRenderer.invoke('desktop:recovery:state'),

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -371,9 +371,27 @@ def test_desktop_gateway_ready_requires_exact_launch_identity() -> None:
     assert "gatewayProcessOwnershipContexts.get(child)" in verifier
     assert "verifyDesktopGatewayLaunchOwnership" in verifier
     assert "await verifyOwnedGatewayLaunch(child)" in start
-    assert "hardTerminateGatewayProcess(child)" in start
     assert "requestGatewayShutdown" not in start
     assert "unverified listener" in start
+
+    discard = _section(
+        main_ts,
+        "async function discardUnverifiedOwnedGatewayChild",
+        "async function resumeOwnedGatewayStartup",
+    )
+    assert "gatewayProcess = null" in discard
+    assert "hardTerminateGatewayProcess(child)" in discard
+    assert "requestGatewayShutdown" not in discard
+
+    shutdown = _section(
+        main_ts,
+        "async function requestOwnedGatewayShutdown",
+        "async function downloadDiagnostics",
+    )
+    assert "if (context) return false" in shutdown
+    assert shutdown.index("if (context) return false") < shutdown.index(
+        "return await requestGatewayShutdown(url)"
+    )
 
 
 def test_desktop_boot_resume_fences_stale_async_state_and_ready_events() -> None:
@@ -410,6 +428,26 @@ def test_desktop_boot_resume_fences_stale_async_state_and_ready_events() -> None
     final_fence = control_load.index("if (!isCurrent()) return false", load)
     ready = control_load.rindex("sendBootStatus('ready')")
     assert first_fence < load < final_fence < ready
+
+
+def test_desktop_open_flow_rejects_stale_start_errors() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    open_flow = _section(
+        main_ts,
+        "async function openOrResumeDesktopApp",
+        "const GATEWAY_SHUTDOWN_KILL_AFTER_MS",
+    )
+    catch = open_flow.index("} catch (error) {")
+    authority = open_flow.index("const authoritative = !isQuitting", catch)
+    status = open_flow.index("gatewayState.status = 'error'", authority)
+    state_error = open_flow.index("gatewayState.error =", status)
+    send_error = open_flow.index("sendBootError(error)", state_error)
+    loop_fence = open_flow.index("revision === desktopOpenFlowRevision", send_error)
+
+    assert catch < authority < status < state_error < send_error < loop_fence
+    assert "requestedProfileKey === desktopProfileKey()" in open_flow[
+        authority:status
+    ]
 
 
 def test_desktop_shared_spawn_gate_blocks_still_stopping_gateways() -> None:

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -268,12 +268,10 @@ def test_desktop_retry_waits_for_all_owned_gateways_and_fails_closed() -> None:
         "ipcMain.handle('desktop:boot:quit'",
     )
 
-    # Retry backs both the boot-error button and the Control UI "Restart runtime"
-    # action, so it forces a real restart: an in-flight start is joined (clearing
-    # the stale error), otherwise every lifecycle-owned gateway is torn down and
-    # awaited before respawn rather than reused. The join result is a hard safety
-    # boundary: timing out must leave the old runtime authoritative and must not
-    # clear its reusable state or start a competing writer.
+    # The Control UI "Restart runtime" action forces a real restart: an in-flight
+    # start is joined, otherwise every lifecycle-owned gateway is torn down and
+    # awaited before respawn rather than reused. The boot page has a separate
+    # non-destructive resume path below.
     assert "if (gatewayStartPromise)" in retry
     join_call = "const exited = await stopAndJoinAllLifecycleOwnedGateways()"
     assert join_call in retry
@@ -304,6 +302,46 @@ def test_desktop_retry_waits_for_all_owned_gateways_and_fails_closed() -> None:
         "openOrResumeDesktopApp()"
     )
     assert success.index("openOrResumeDesktopApp()") < success.index("return { ok: true }")
+
+
+def test_desktop_boot_resume_waits_for_the_existing_owned_gateway() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    preload = _read("desktop/electron/src/preload.cts")
+    resume_handler = _section(
+        main_ts,
+        "ipcMain.handle('desktop:boot:resume'",
+        "ipcMain.handle('desktop:boot:retry'",
+    )
+    start = _section(
+        main_ts,
+        "async function startGateway(): Promise<GatewayState>",
+        "async function startGatewayWithPortRecovery()",
+    )
+    resume_owned = _section(
+        main_ts,
+        "async function resumeOwnedGatewayStartup",
+        "const VERIFIED_ORPHAN_GATEWAY_RELEASE_TIMEOUT_MS",
+    )
+
+    assert "resumeStartup: () => ipcRenderer.invoke('desktop:boot:resume')" in preload
+    assert "const gateway = gatewayStartPromise" in resume_handler
+    assert "await resumeOwnedGatewayStartup()" in resume_handler
+    assert "if (!gateway)" in resume_handler
+    assert "void openOrResumeDesktopApp()" in resume_handler
+    assert "await loadControlUiIntoCurrentWindow(gateway.url)" in resume_handler
+    assert "stopAndJoinAllLifecycleOwnedGateways" not in resume_handler
+    assert "clearReusableGatewayState" not in resume_handler
+    assert "stopGateway()" not in resume_handler
+
+    assert "await resumeOwnedGatewayStartup()" in start
+    assert start.index("await resumeOwnedGatewayStartup()") < start.index(
+        "if (gatewayProcess && gatewayState.owned)"
+    )
+    assert "gatewayProcess === child" in resume_owned
+    assert "gatewayProfileKey !== desktopProfileKey()" in resume_owned
+    assert "await waitForGateway(url, childExitMessage)" in resume_owned
+    assert "await waitForControlUi(url, childExitMessage)" in resume_owned
+    assert "gatewayState.status = 'ready'" in resume_owned
 
 
 def test_desktop_shared_spawn_gate_blocks_still_stopping_gateways() -> None:
@@ -348,7 +386,10 @@ def test_boot_retry_surfaces_failed_restart_and_prevents_repeat_clicks() -> None
 
     assert "retryButton.disabled = true" in retry_flow
     assert "recoveryRetryButton.disabled = true" in retry_flow
-    assert "const result = await api.retryStartup()" in retry_flow
+    assert "typeof api?.resumeStartup === 'function'" in retry_flow
+    assert "api.resumeStartup" in retry_flow
+    assert "api?.retryStartup" in retry_flow
+    assert "const result = await resumeStartup()" in retry_flow
     assert "result && result.ok === false" in retry_flow
     assert "result.error || msg.errorDefault" in retry_flow
     assert "applyError({ message: result.error || msg.errorDefault })" in retry_flow
@@ -356,9 +397,9 @@ def test_boot_retry_surfaces_failed_restart_and_prevents_repeat_clicks() -> None
     assert "retryButton.disabled = false" in retry_flow
     assert "recoveryRetryButton.disabled = false" in retry_flow
     assert retry_flow.index("retryButton.disabled = true") < retry_flow.index(
-        "await api.retryStartup()"
+        "await resumeStartup()"
     )
-    assert retry_flow.index("await api.retryStartup()") < retry_flow.index(
+    assert retry_flow.index("await resumeStartup()") < retry_flow.index(
         "retryButton.disabled = false"
     )
     assert (
@@ -1315,8 +1356,11 @@ def test_desktop_gateway_exit_classifies_newer_config_validation_errors() -> Non
     assert "appendGatewayOutputTail(gatewayOutputTail, chunk)" in start
     assert "classifyGatewayExitMessage(exitMessage, gatewayOutputTail)" in start
     assert "await waitForGateway(url, () => childExitMessage)" in start
-    assert "earlyExitMessage?: () => string | null" in wait
-    assert "if (earlyExit) throw new Error(earlyExit)" in wait
+    assert "waitForGatewayReadiness({" in wait
+    assert "primaryTimeoutMs: 45_000" in wait
+    assert "lateGraceMs: 15_000" in wait
+    assert "exitMessage: earlyExitMessage" in wait
+    assert "if (result.status === 'exited') throw new Error(result.message)" in wait
 
 
 def test_start_gateway_enriches_child_path_for_code_task_builds() -> None:

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -35,8 +35,8 @@ def test_desktop_resume_is_visible_first_and_single_flight() -> None:
 
     assert resume.index("await createMainWindow()") < resume.index("ensureGatewayStarted()")
     assert "focusMainWindow()" in resume
-    assert "reuseHealthyGatewayState()" in resume
-    assert "loadControlUiIntoCurrentWindow(gateway.url)" in resume
+    assert "reuseHealthyGatewayState(" in resume
+    assert "loadControlUiIntoCurrentWindow(" in resume
 
 
 def test_desktop_gateway_completion_uses_current_live_window() -> None:
@@ -330,7 +330,7 @@ def test_desktop_boot_resume_waits_for_the_existing_owned_gateway() -> None:
 
     assert "resumeStartup: () => ipcRenderer.invoke('desktop:boot:resume')" in preload
     assert "const pendingStart = gatewayStartPromise" in resume_flow
-    assert "await resumeOwnedGatewayStartup()" in resume_flow
+    assert "await resumeOwnedGatewayStartup(" in resume_flow
     assert "if (!gateway)" in resume_flow
     assert "void openOrResumeDesktopApp()" in resume_flow
     assert "await loadControlUiIntoCurrentWindow(" in resume_flow
@@ -343,8 +343,8 @@ def test_desktop_boot_resume_waits_for_the_existing_owned_gateway() -> None:
     assert "bootResumePromise = promise" in resume_handler
     assert "bootResumePromise = null" in resume_handler
 
-    assert "await resumeOwnedGatewayStartup()" in start
-    assert start.index("await resumeOwnedGatewayStartup()") < start.index(
+    assert "await resumeOwnedGatewayStartup(isCurrent)" in start
+    assert start.index("await resumeOwnedGatewayStartup(isCurrent)") < start.index(
         "if (gatewayProcess && gatewayState.owned)"
     )
     assert "gatewayProcess === child" in resume_owned
@@ -352,6 +352,7 @@ def test_desktop_boot_resume_waits_for_the_existing_owned_gateway() -> None:
     assert "await waitForGateway(url, childExitMessage)" in resume_owned
     assert "await waitForControlUi(url, childExitMessage)" in resume_owned
     assert "await verifyOwnedGatewayLaunch(child)" in resume_owned
+    assert "|| !isCurrent()" in resume_owned
     assert "gatewayState.status = 'ready'" in resume_owned
 
 
@@ -429,6 +430,24 @@ def test_desktop_boot_resume_fences_stale_async_state_and_ready_events() -> None
     ready = control_load.rindex("sendBootStatus('ready')")
     assert first_fence < load < final_fence < ready
 
+    resume_owned = _section(
+        main_ts,
+        "async function resumeOwnedGatewayStartup",
+        "const VERIFIED_ORPHAN_GATEWAY_RELEASE_TIMEOUT_MS",
+    )
+    assert resume_owned.rindex("|| !isCurrent()") < resume_owned.index(
+        "gatewayState.status = 'ready'"
+    )
+
+    open_flow = _section(
+        main_ts,
+        "async function openOrResumeDesktopApp",
+        "const GATEWAY_SHUTDOWN_KILL_AFTER_MS",
+    )
+    load_index = open_flow.index("await loadControlUiIntoCurrentWindow(")
+    load_call = open_flow[load_index : load_index + 300]
+    assert "desktopOpenAuthorityIsCurrent(revision, requestedProfileKey)" in load_call
+
 
 def test_desktop_open_flow_rejects_stale_start_errors() -> None:
     main_ts = _read("desktop/electron/src/main.ts")
@@ -438,16 +457,14 @@ def test_desktop_open_flow_rejects_stale_start_errors() -> None:
         "const GATEWAY_SHUTDOWN_KILL_AFTER_MS",
     )
     catch = open_flow.index("} catch (error) {")
-    authority = open_flow.index("const authoritative = !isQuitting", catch)
+    authority = open_flow.index("const authoritative = desktopOpenAuthorityIsCurrent", catch)
     status = open_flow.index("gatewayState.status = 'error'", authority)
     state_error = open_flow.index("gatewayState.error =", status)
     send_error = open_flow.index("sendBootError(error)", state_error)
-    loop_fence = open_flow.index("revision === desktopOpenFlowRevision", send_error)
+    loop_fence = open_flow.index("desktopOpenAuthorityIsCurrent", send_error)
 
     assert catch < authority < status < state_error < send_error < loop_fence
-    assert "requestedProfileKey === desktopProfileKey()" in open_flow[
-        authority:status
-    ]
+    assert "revision, requestedProfileKey" in open_flow[authority:status]
 
 
 def test_desktop_shared_spawn_gate_blocks_still_stopping_gateways() -> None:
@@ -1053,14 +1070,11 @@ def test_reset_desktop_settings_forces_onboarding_before_gateway_reuse() -> None
 
     assert "let forceOnboardingOnNextStartup = false" in main_ts
     assert "function clearReusableGatewayState(): void" in main_ts
-    reuse_guard = (
-        "const reusableGateway = forceOnboardingOnNextStartup ? null : "
-        "await reuseHealthyGatewayState()"
-    )
-    assert reuse_guard in start
+    assert "const reusableGateway = forceOnboardingOnNextStartup" in start
+    assert "await reuseHealthyGatewayState(isCurrent)" in start
     assert "forceOnboardingOnNextStartup = false" in start
     assert "forceOnboardingOnNextStartup" in resume
-    assert "await reuseHealthyGatewayState()" in resume
+    assert "await reuseHealthyGatewayState(" in resume
     assert "resetDesktopSettingsThroughCleanup()" in reset
     assert "inspectDesktopCleanup('reset-current-settings')" in cleanup_reset
     assert "desktopCleanupPreviews.consume(" in cleanup_reset
@@ -1328,11 +1342,9 @@ def test_start_gateway_reuses_healthy_gateway_before_spawn() -> None:
 
     assert "await healthCheck(gatewayState.url)" in reuse
     assert "gatewayState.status = 'ready'" in reuse
-    reuse_guard = (
-        "const reusableGateway = forceOnboardingOnNextStartup ? null : "
-        "await reuseHealthyGatewayState()"
-    )
+    reuse_guard = "const reusableGateway = forceOnboardingOnNextStartup"
     assert reuse_guard in start
+    assert "await reuseHealthyGatewayState(isCurrent)" in start
     assert start.index(reuse_guard) < start.index("const overrideUrl")
     assert "if (reusableGateway) return reusableGateway" in start
     assert "hasGatewayProcessExited(gatewayProcess)" in start

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -446,7 +446,21 @@ def test_desktop_boot_resume_fences_stale_async_state_and_ready_events() -> None
     )
     load_index = open_flow.index("await loadControlUiIntoCurrentWindow(")
     load_call = open_flow[load_index : load_index + 300]
-    assert "desktopOpenAuthorityIsCurrent(revision, requestedProfileKey)" in load_call
+    assert "operationIsCurrent" in load_call
+
+    authority_capture = open_flow[
+        open_flow.index("const gatewayUrl = gateway.url") : load_index
+    ]
+    for exact_gateway_fence in [
+        "const expectedOwned = gateway.owned",
+        "const expectedChild = expectedOwned ? gatewayProcess : null",
+        "gatewayState.url === gatewayUrl",
+        "gatewayState.owned === expectedOwned",
+        "gatewayProcess === expectedChild",
+        "!hasGatewayProcessExited(expectedChild)",
+    ]:
+        assert exact_gateway_fence in authority_capture
+    assert "const authoritative = operationIsCurrent()" in open_flow
 
 
 def test_desktop_open_flow_rejects_stale_start_errors() -> None:
@@ -457,14 +471,14 @@ def test_desktop_open_flow_rejects_stale_start_errors() -> None:
         "const GATEWAY_SHUTDOWN_KILL_AFTER_MS",
     )
     catch = open_flow.index("} catch (error) {")
-    authority = open_flow.index("const authoritative = desktopOpenAuthorityIsCurrent", catch)
+    authority = open_flow.index("const authoritative = operationIsCurrent()", catch)
     status = open_flow.index("gatewayState.status = 'error'", authority)
     state_error = open_flow.index("gatewayState.error =", status)
     send_error = open_flow.index("sendBootError(error)", state_error)
     loop_fence = open_flow.index("desktopOpenAuthorityIsCurrent", send_error)
 
     assert catch < authority < status < state_error < send_error < loop_fence
-    assert "revision, requestedProfileKey" in open_flow[authority:status]
+    assert "operationIsCurrent()" in open_flow[authority:status]
 
 
 def test_desktop_shared_spawn_gate_blocks_still_stopping_gateways() -> None:

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -307,6 +307,11 @@ def test_desktop_retry_waits_for_all_owned_gateways_and_fails_closed() -> None:
 def test_desktop_boot_resume_waits_for_the_existing_owned_gateway() -> None:
     main_ts = _read("desktop/electron/src/main.ts")
     preload = _read("desktop/electron/src/preload.cts")
+    resume_flow = _section(
+        main_ts,
+        "async function resumeBootStartup()",
+        "ipcMain.handle('desktop:boot:resume'",
+    )
     resume_handler = _section(
         main_ts,
         "ipcMain.handle('desktop:boot:resume'",
@@ -324,14 +329,19 @@ def test_desktop_boot_resume_waits_for_the_existing_owned_gateway() -> None:
     )
 
     assert "resumeStartup: () => ipcRenderer.invoke('desktop:boot:resume')" in preload
-    assert "const gateway = gatewayStartPromise" in resume_handler
-    assert "await resumeOwnedGatewayStartup()" in resume_handler
-    assert "if (!gateway)" in resume_handler
-    assert "void openOrResumeDesktopApp()" in resume_handler
-    assert "await loadControlUiIntoCurrentWindow(gateway.url)" in resume_handler
-    assert "stopAndJoinAllLifecycleOwnedGateways" not in resume_handler
-    assert "clearReusableGatewayState" not in resume_handler
-    assert "stopGateway()" not in resume_handler
+    assert "const pendingStart = gatewayStartPromise" in resume_flow
+    assert "await resumeOwnedGatewayStartup()" in resume_flow
+    assert "if (!gateway)" in resume_flow
+    assert "void openOrResumeDesktopApp()" in resume_flow
+    assert "await loadControlUiIntoCurrentWindow(" in resume_flow
+    assert "bootResumeAuthorityIsCurrent(authority)" in resume_flow
+    assert "if (pendingStart || !initialAuthority" in resume_flow
+    assert "stopAndJoinAllLifecycleOwnedGateways" not in resume_flow
+    assert "clearReusableGatewayState" not in resume_flow
+    assert "stopGateway()" not in resume_flow
+    assert "if (bootResumePromise) return await bootResumePromise" in resume_handler
+    assert "bootResumePromise = promise" in resume_handler
+    assert "bootResumePromise = null" in resume_handler
 
     assert "await resumeOwnedGatewayStartup()" in start
     assert start.index("await resumeOwnedGatewayStartup()") < start.index(
@@ -341,7 +351,65 @@ def test_desktop_boot_resume_waits_for_the_existing_owned_gateway() -> None:
     assert "gatewayProfileKey !== desktopProfileKey()" in resume_owned
     assert "await waitForGateway(url, childExitMessage)" in resume_owned
     assert "await waitForControlUi(url, childExitMessage)" in resume_owned
+    assert "await verifyOwnedGatewayLaunch(child)" in resume_owned
     assert "gatewayState.status = 'ready'" in resume_owned
+
+
+def test_desktop_gateway_ready_requires_exact_launch_identity() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    start = _section(
+        main_ts,
+        "async function startGateway(): Promise<GatewayState>",
+        "async function startGatewayWithPortRecovery()",
+    )
+    verifier = _section(
+        main_ts,
+        "async function verifyOwnedGatewayLaunch",
+        "async function resumeOwnedGatewayStartup",
+    )
+
+    assert "gatewayProcessOwnershipContexts.get(child)" in verifier
+    assert "verifyDesktopGatewayLaunchOwnership" in verifier
+    assert "await verifyOwnedGatewayLaunch(child)" in start
+    assert "hardTerminateGatewayProcess(child)" in start
+    assert "requestGatewayShutdown" not in start
+    assert "unverified listener" in start
+
+
+def test_desktop_boot_resume_fences_stale_async_state_and_ready_events() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    authority = _section(
+        main_ts,
+        "function bootResumeAuthorityIsCurrent",
+        "async function resumeBootStartup",
+    )
+    resume_flow = _section(
+        main_ts,
+        "async function resumeBootStartup",
+        "ipcMain.handle('desktop:boot:resume'",
+    )
+    control_load = _section(
+        main_ts,
+        "async function loadControlUiIntoCurrentWindow",
+        "async function restoreMainWindowToBootPage",
+    )
+
+    for fence in [
+        "!isQuitting",
+        "gatewayProcess === authority.child",
+        "gatewayProfileKey === authority.profileKey",
+        "desktopOpenFlowRevision === authority.openFlowRevision",
+    ]:
+        assert fence in authority
+    assert "if (initialAuthority && !bootResumeAuthorityIsCurrent" in resume_flow
+    assert "if (!authority || !bootResumeAuthorityIsCurrent" in resume_flow
+    assert "!bootResumeAuthorityIsCurrent(initialAuthority)" in resume_flow
+
+    first_fence = control_load.index("if (!isCurrent()) return false")
+    load = control_load.index("await loadControlUi(window, gatewayUrl)")
+    final_fence = control_load.index("if (!isCurrent()) return false", load)
+    ready = control_load.rindex("sendBootStatus('ready')")
+    assert first_fence < load < final_fence < ready
 
 
 def test_desktop_shared_spawn_gate_blocks_still_stopping_gateways() -> None:


### PR DESCRIPTION
## Scope

- Keep the Desktop Gateway readiness wait bounded while accepting health that arrives just after the existing 45-second primary deadline.
- Resume the exact Desktop-owned child from the boot error page instead of routing that button through the destructive runtime-restart action.
- Require the existing launch record and HMAC identity challenge before either initial startup or resume can publish an owned Gateway as ready.
- Fence resume work by exact child, profile, open-flow revision, and quit state so stale async completion cannot overwrite a newer lifecycle operation.
- Preserve the existing Control UI "Restart runtime" stop/join/respawn behavior.
- Add deterministic readiness-boundary, launch-identity, and Desktop startup contract coverage.

## Root Cause

Electron spawns the Desktop Gateway directly and owns its readiness state. The existing wait treated the 45-second health deadline as terminal even though the child remained alive. The boot-page Retry button then shared the Control UI restart IPC, so it stopped a Gateway that could already have become healthy and repeated the cold start.

## Non-goals

- No Python CLI Gateway lifecycle changes.
- No Gateway boot optimization or migration changes.
- No changes to the ownership protocol/schema, port range, profile recovery, persisted state, config schemas, or public network exposure.

## Branch

Base branch: `main`

Target exception: N/A

## Issue

Fixes #1235

## Release Note

A slow Desktop Gateway can now finish startup during a bounded late-readiness window, and the boot-page Retry action resumes the exact owned process instead of restarting it.

## Tests

- `uv run pytest -q tests/test_desktop/test_electron_startup_contract.py` — 117 passed
- `uv run pytest -q tests/test_desktop` — 131 passed
- `uvx ruff check tests/test_desktop/test_electron_startup_contract.py` — passed
- Electron TypeScript build (`tsc -p tsconfig.json`) — passed
- `scripts/test-desktop-gateway-ownership.mjs` — passed
- `scripts/test-desktop-gateway-lifecycle.mjs` — passed
- `scripts/test-desktop-window-lifecycle.mjs` — passed
- `git diff --check` — passed

The Electron accessibility helper could not complete locally because its first-run Electron binary download stalled; no Windows packaged-app live reproduction was performed.

## Compatibility

The change is additive at the preload IPC surface and does not alter persisted config, databases, profile layout, the ownership protocol, or existing Control UI restart behavior. The readiness coordinator is platform-neutral; Windows is the reported environment and remains the priority packaged validation target.

## Safety

Late readiness is accepted only for the same live ChildProcess and Desktop profile that entered the resume path, after the existing per-launch nonce record and HMAC identity challenge prove the loopback listener. A healthy port alone never grants ownership. Resume completion is single-flight and lifecycle-fenced; normal recovery inspection remains mandatory when no exact child can be resumed.

No secrets, private data, generated transcripts, or machine-specific paths are included.

## Existing Candidate

PR #1249 was evaluated but not replayed: it modifies the Python CLI path that Desktop does not use, includes an unrelated commit, and has no code CI evidence. This PR is an independent Desktop-layer implementation.

## Third-Party Origin

Third-party origin: none

