### PR TITLE
fix(webui): treat a zero ledger total as authoritative

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatRenderedMessages.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRenderedMessages.test.ts
@@ -2128,6 +2128,78 @@ describe('useChatRenderedMessages ensemble metadata', () => {
     ])
   })
 
+  it('keeps an authoritative zero ledger total over stale breakdown subtotals', () => {
+    const api = renderedMessagesFor([{
+      role: 'assistant',
+      text: 'settled free turn',
+      ts: 0,
+      usage: {
+        // Authoritative ledger total for the turn: genuinely $0.
+        cost_usd: 0,
+        // A richer historical projection can still carry non-zero per-row
+        // subtotals from an earlier receipt. They must not win.
+        model_usage_breakdown: [
+          {
+            role: 'proposer',
+            provider: 'tokenrhythm',
+            model: 'deepseek-v4-flash-0731',
+            cost_usd: 0.01,
+            cost_source: 'provider_billed',
+          },
+          {
+            role: 'aggregator',
+            provider: 'tokenrhythm',
+            model: 'deepseek-v4-flash-0731',
+            cost_usd: 0.02,
+            cost_source: 'provider_billed',
+          },
+        ],
+        ensemble_trace: {
+          profile: 'custom_b5',
+          llm_request_count: 2,
+          fallback_used: false,
+        },
+      },
+    }])
+
+    expect(api.renderedMessages.value[0].meta?.ensemble?.costUsd).toBe(0)
+  })
+
+  it('falls back to breakdown subtotals when the ledger omits a cost field', () => {
+    const api = renderedMessagesFor([{
+      role: 'assistant',
+      text: 'legacy row without a ledger total',
+      ts: 0,
+      usage: {
+        // No cost_usd/costUsd key at all — legacy shape, so the per-row
+        // subtotals remain the only available signal.
+        model_usage_breakdown: [
+          {
+            role: 'proposer',
+            provider: 'tokenrhythm',
+            model: 'deepseek-v4-flash-0731',
+            cost_usd: 0.01,
+            cost_source: 'provider_billed',
+          },
+          {
+            role: 'aggregator',
+            provider: 'tokenrhythm',
+            model: 'deepseek-v4-flash-0731',
+            cost_usd: 0.02,
+            cost_source: 'provider_billed',
+          },
+        ],
+        ensemble_trace: {
+          profile: 'custom_b5',
+          llm_request_count: 2,
+          fallback_used: false,
+        },
+      },
+    }])
+
+    expect(api.renderedMessages.value[0].meta?.ensemble?.costUsd).toBeCloseTo(0.03, 10)
+  })
+
   it('preserves candidate terminal status from the ensemble trace after settlement', () => {
     const api = renderedMessagesFor([
       {

--- a/opensquilla-webui/src/composables/chat/useChatRenderedMessages.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRenderedMessages.ts
@@ -843,7 +843,13 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
       .filter((row): row is ChatEnsembleMetaModel => row !== null)
     const uniqueModels = new Set(models.map(row => `${row.role}:${row.provider}:${row.model}`))
     const rowCost = models.reduce((sum, row) => sum + row.costUsd, 0)
-    const explicitCost = numeric(usage.cost_usd ?? usage.costUsd)
+    // The ledger total is authoritative whenever it is present, including a
+    // legitimate 0. Probe for the field rather than for a positive number, or
+    // a settled $0 turn falls back to stale non-zero breakdown subtotals that
+    // a richer historical projection may still carry.
+    const rawCost = usage.cost_usd ?? usage.costUsd
+    const hasExplicitCost = rawCost !== undefined && rawCost !== null && Number.isFinite(Number(rawCost))
+    const explicitCost = numeric(rawCost)
     const savedUsd = Math.max(0, numeric(usage.total_savings_usd ?? usage.totalSavingsUsd ?? usage.savings_usd ?? usage.savingsUsd))
     const savedPct = Math.max(0, numeric(usage.total_savings_pct ?? usage.totalSavingsPct ?? usage.savings_pct ?? usage.savingsPct))
 
@@ -857,7 +863,7 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
       requestCount: Math.max(0, numeric(trace?.llm_request_count), breakdown.length),
       fallbackUsed: trace?.fallback_used === true || trace?.fallbackUsed === true,
       fallbackReason: String(trace?.fallback_reason || trace?.fallbackReason || ''),
-      costUsd: explicitCost > 0 ? explicitCost : rowCost,
+      costUsd: hasExplicitCost ? explicitCost : rowCost,
       savedUsd,
       savedPct,
       models,


### PR DESCRIPTION
## Problem

`ensembleMeta` in `useChatRenderedMessages.ts` reads the turn cost through `numeric()`, which collapses a missing field and a real `0` onto the same value. It then picks between the ledger total and the summed per-row breakdown with `explicitCost > 0`.

That predicate cannot distinguish "the ledger says $0" from "the ledger said nothing". A settled turn whose authoritative total is genuinely $0 falls through to the row sum, so the UI re-displays stale non-zero subtotals that a richer historical projection may still carry — contradicting the rule that ledger numeric totals are authoritative.

## Fix

Probe for the field rather than for a positive number. `??` skips only `null`/`undefined`, so a legitimate `0` survives:

```ts
const rawCost = usage.cost_usd ?? usage.costUsd
const hasExplicitCost = rawCost !== undefined && rawCost !== null && Number.isFinite(Number(rawCost))
const explicitCost = numeric(rawCost)
// ...
costUsd: hasExplicitCost ? explicitCost : rowCost,
```

Legacy rows that carry no ledger total keep falling back to the row sum, so nothing else changes.

## Tests

Two cases added to `useChatRenderedMessages.test.ts`:

- ledger `cost_usd: 0` alongside non-zero breakdown rows → expects `0`
- no cost field at all → expects the `0.03` row sum

Both were confirmed to fail against the old predicate (`AssertionError: expected 0.03 to be +0`) before the fix was applied.

## Verification

- `vitest run useChatRenderedMessages.test.ts` — 52 passed
- `npm run typecheck` (11 architecture guards + `vue-tsc --noEmit`) — exit 0

## Note

Found while reviewing #1254, but this bug predates it and reproduces on `main` unchanged, so it is split out here to be reviewed and merged independently.