### PR TITLE
Reorganize settings information architecture

### DIFF
--- a/desktop/electron/scripts/test-desktop-theme-flow.mjs
+++ b/desktop/electron/scripts/test-desktop-theme-flow.mjs
@@ -212,10 +212,10 @@ try {
   await page.waitForURL(url => url.pathname.includes('/control/settings'), {
     timeout: 20_000,
   })
-  const appearanceTab = page.locator('#settings-rail-appearance')
-  await appearanceTab.waitFor({ state: 'visible', timeout: 20_000 })
-  await appearanceTab.click()
-  await page.waitForURL(url => url.pathname.endsWith('/control/settings/appearance'), {
+  const interfaceTab = page.locator('#settings-rail-interface')
+  await interfaceTab.waitFor({ state: 'visible', timeout: 20_000 })
+  await interfaceTab.click()
+  await page.waitForURL(url => url.pathname.endsWith('/control/settings/interface'), {
     timeout: 20_000,
   })
   await page.waitForSelector('input[name="appearance-theme"][value="system"]', {

--- a/opensquilla-webui/e2e/settings-modal.spec.ts
+++ b/opensquilla-webui/e2e/settings-modal.spec.ts
@@ -1,13 +1,18 @@
 import { test, expect } from '@playwright/test'
 
 const CONTROL_URL = '/control/'
-// Backend-config sections carry a readiness/status dot; Connection is the first
-// entry (live socket state). Memory & Profile is an RPC action surface that
-// deliberately stays outside config save state; the remaining entries below
-// are ordinary client-only preferences.
-// (Runtime exists too, but it is desktop-only so the web rail hides it.)
-const SECTIONS = ['Connection', 'Model Service', 'Model Routing', 'Capabilities', 'Behavior', 'Privacy']
-const CLIENT_SECTIONS = ['Sandbox', 'Memory & Profile', 'Appearance', 'Keyboard', 'Advanced']
+// Gateway and config-backed pages expose live/save status in their accessible
+// tab names. Interface, Shortcuts, and Advanced are browser-local pages.
+const SECTIONS = [
+  'Gateway',
+  'Model Service',
+  'Model Routing',
+  'Capabilities',
+  'General',
+  'Security & Privacy',
+  'Memory',
+]
+const CLIENT_SECTIONS = ['Interface', 'Shortcuts', 'Advanced']
 
 const settingsRow = (page: import('@playwright/test').Page) =>
   page.locator('.sidebar-foot button')
@@ -26,6 +31,10 @@ async function openFromSidebar(page: import('@playwright/test').Page) {
 }
 
 test.describe('Settings modal', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('opensquilla-locale', 'en'))
+  })
+
   test('opens from the sidebar with the curated section rail and readiness banner', async ({ page }) => {
     await openFromSidebar(page)
 
@@ -100,18 +109,23 @@ test.describe('Settings modal', () => {
     await expect(page).not.toHaveURL(/\/settings/)
   })
 
-  test('opens Memory & Profile as a first-level action route without global save state', async ({ page }) => {
+  test('opens Memory as a first-level page and profile import as its nested route', async ({ page }) => {
     await openFromSidebar(page)
 
-    const memoryTab = dialog(page).getByRole('tab', { name: 'Memory & Profile', exact: true })
+    const memoryTab = railTab(page, 'Memory')
     await memoryTab.click()
 
     await expect(memoryTab).toHaveAttribute('aria-selected', 'true')
     await expect(page).toHaveURL(/\/settings\/memory$/)
+    await expect(dialog(page).getByRole('heading', { name: 'Memory', exact: true })).toBeVisible()
+    const profileRow = dialog(page).locator('.control-row', { hasText: 'Profile import' })
+    await profileRow.getByRole('button', { name: 'Open' }).click()
+    await expect(page).toHaveURL(/\/settings\/profileImport$/)
     await expect(
       dialog(page).getByRole('heading', { name: 'Import memory from another AI' }),
     ).toBeVisible()
     await expect(dialog(page).locator('[data-testid="settings-memory-panel"]')).toBeVisible()
+    await expect(memoryTab).toHaveAttribute('aria-selected', 'true')
     await expect(dialog(page).locator('.settings-dirtybar')).toBeHidden()
   })
 
@@ -283,12 +297,13 @@ test.describe('Settings modal', () => {
     await expect(page.getByLabel('Message to send')).toBeVisible()
   })
 
-  test('cold deep link to /settings/connection closes home and moves focus to the sidebar', async ({ page }) => {
+  test('legacy /settings/connection deep link opens Gateway and preserves its subsection', async ({ page }) => {
     // Land directly on a section with no in-app invoker.
     await page.goto(CONTROL_URL + 'settings/connection')
     await page.waitForSelector('.conn-pill', { timeout: 10000 })
     await expect(dialog(page)).toBeVisible()
-    await expect(railTab(page, 'Connection')).toHaveAttribute('aria-selected', 'true')
+    await expect(railTab(page, 'Gateway')).toHaveAttribute('aria-selected', 'true')
+    await expect(page).toHaveURL(/\/settings\/gateway#connection$/)
     // Connection renders even before/without a loaded config gate.
     await expect(dialog(page).getByRole('heading', { name: 'Connection' })).toBeVisible()
 

--- a/opensquilla-webui/e2e/sidebar.spec.ts
+++ b/opensquilla-webui/e2e/sidebar.spec.ts
@@ -16,6 +16,10 @@ async function openControl(page: Page, path = '') {
 }
 
 test.describe('Sidebar', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('opensquilla-locale', 'en'))
+  })
+
   test('desktop separator resizes, persists, and collapses only on pointer release', async ({ page }) => {
     await page.addInitScript(() => {
       if (sessionStorage.getItem('sidebar-resize-e2e-seeded')) return
@@ -225,7 +229,7 @@ test.describe('Sidebar', () => {
       )
     })).toBeLessThanOrEqual(0.00001)
 
-    await openControl(page, 'settings/appearance')
+    await openControl(page, 'settings/interface')
     const wide = page.getByTestId('settings-sidebar-width-wide')
     await wide.locator('..').click()
     await page.getByRole('dialog').getByRole('button', { name: 'Close' }).focus()
@@ -238,7 +242,7 @@ test.describe('Sidebar', () => {
   test('Appearance provides a click-only alternative for preset, custom width, and collapse', async ({ page }) => {
     await page.addInitScript(() => localStorage.removeItem('opensquilla.sidebar.width.v1'))
     await page.setViewportSize({ width: 1440, height: 900 })
-    await openControl(page, 'settings/appearance')
+    await openControl(page, 'settings/interface')
 
     const sidebar = page.locator('.sidebar')
     const sidebarWidth = async () => Math.round((await sidebar.boundingBox())?.width || 0)

--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -794,7 +794,7 @@ function pickTheme(mode: ThemeMode) {
 function openMoreThemes() {
   themeMenuOpen.value = false
   handleNavClick()
-  router.push('/settings/appearance')
+  router.push('/settings/interface')
 }
 
 useDocumentEvent('click', (e) => {
@@ -1660,13 +1660,13 @@ function openSettings() {
 // Topbar connection pill (web): jump straight to the Connection section so the
 // gateway link can be inspected or re-pointed.
 function openConnectionSettings() {
-  router.push('/settings/connection')
+  router.push('/settings/gateway#connection')
 }
 
 // Compact chat headers hand off to the complete Desktop update workflow rather
 // than recreating update actions inside the status summary.
 function openDesktopRuntimeSettings() {
-  router.push('/settings/runtime')
+  router.push('/settings/gateway#runtime')
 }
 
 function scheduleSessionRefresh() {

--- a/opensquilla-webui/src/components/i18n-components.test.ts
+++ b/opensquilla-webui/src/components/i18n-components.test.ts
@@ -5,6 +5,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import i18n from '@/i18n'
 import { useAppStore } from '@/stores/app'
 import SettingsAppearancePanel from '@/components/settings/SettingsAppearancePanel.vue'
+import SettingsLanguageControl from '@/components/settings/SettingsLanguageControl.vue'
 import LanguageSwitcher from '@/components/LanguageSwitcher.vue'
 import {
   TOOL_DETAIL_DISPLAY_STORAGE_KEY,
@@ -59,9 +60,9 @@ describe('SettingsAppearancePanel — Tool details row', () => {
   })
 })
 
-describe('SettingsAppearancePanel — Language row', () => {
+describe('SettingsLanguageControl — General language row', () => {
   it('renders a Language radiogroup with native English / 中文 labels', async () => {
-    const { el } = await mount(SettingsAppearancePanel)
+    const { el } = await mount(SettingsLanguageControl)
     const group = el.querySelector('[data-testid="settings-language-group"]')
     expect(group).toBeTruthy()
     expect(el.querySelector('[data-testid="settings-language-en"]')).toBeTruthy()
@@ -71,9 +72,9 @@ describe('SettingsAppearancePanel — Language row', () => {
   })
 
   it('switching the radio sets the locale, persists it, and reactively localizes the panel', async () => {
-    const { el } = await mount(SettingsAppearancePanel)
+    const { el } = await mount(SettingsLanguageControl)
     const store = useAppStore()
-    expect(el.querySelector('.control-section__title')!.textContent).toContain('Appearance')
+    expect(el.querySelector('.control-row__label')!.textContent).toContain('Language')
 
     const zh = el.querySelector('[data-testid="settings-language-zh-Hans"]') as HTMLInputElement
     zh.checked = true
@@ -84,9 +85,9 @@ describe('SettingsAppearancePanel — Language row', () => {
 
     expect(localStorage.getItem('opensquilla-locale')).toBe('zh-Hans')
     expect(document.documentElement.getAttribute('lang')).toBe('zh-Hans')
-    // section title re-renders in Chinese (reactive t())
+    // The General row re-renders in Chinese (reactive t()).
     await vi.waitFor(() =>
-      expect(el.querySelector('.control-section__title')!.textContent).toContain('外观'))
+      expect(el.querySelector('.control-row__label')!.textContent).toContain('语言'))
   })
 })
 

--- a/opensquilla-webui/src/components/settings/DesktopCloseBehaviorSetting.vue
+++ b/opensquilla-webui/src/components/settings/DesktopCloseBehaviorSetting.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, shallowRef } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useToasts } from '@/composables/useToasts'
+import {
+  usePlatform,
+  type DesktopMainWindowCloseBehavior,
+  type DesktopPreferences,
+} from '@/platform'
+
+const { t } = useI18n()
+const { pushToast } = useToasts()
+const platform = usePlatform()
+
+const preferences = shallowRef<DesktopPreferences | null>(null)
+const value = ref<DesktopMainWindowCloseBehavior>('quit')
+const saving = ref(false)
+const loading = ref(false)
+const loadError = ref('')
+
+const available = computed(() => (
+  typeof platform.settings.getDesktopPreferences === 'function'
+  && typeof platform.settings.saveDesktopPreferences === 'function'
+))
+const unavailableSelection = computed(() => (
+  preferences.value !== null
+  && !preferences.value.canRunInBackground
+  && value.value !== 'quit'
+))
+
+async function load() {
+  if (!available.value || !platform.settings.getDesktopPreferences) return
+  loading.value = true
+  try {
+    const next = await platform.settings.getDesktopPreferences()
+    preferences.value = next
+    value.value = next.mainWindowCloseBehavior
+    loadError.value = ''
+  } catch (error) {
+    loadError.value = error instanceof Error ? error.message : String(error)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function save(event: Event) {
+  const next = (event.target as HTMLSelectElement).value as DesktopMainWindowCloseBehavior
+  const previous = preferences.value?.mainWindowCloseBehavior
+  if (!previous || !platform.settings.saveDesktopPreferences) return
+  value.value = next
+  saving.value = true
+  try {
+    const saved = await platform.settings.saveDesktopPreferences({
+      mainWindowCloseBehavior: next,
+    })
+    preferences.value = saved
+    value.value = saved.mainWindowCloseBehavior
+  } catch (error) {
+    value.value = previous
+    pushToast(t('setup.runtime.closeBehaviorSaveFailed', {
+      error: error instanceof Error ? error.message : String(error),
+    }), { tone: 'danger' })
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(() => { void load() })
+</script>
+
+<template>
+  <div
+    v-if="preferences || loadError"
+    class="control-row desktop-preferences"
+    data-testid="desktop-close-behavior"
+  >
+    <div class="control-row__label-block">
+      <label
+        :for="preferences ? 'desktop-close-behavior-select' : undefined"
+        class="control-row__label"
+      >{{ t('setup.runtime.closeBehaviorLabel') }}</label>
+      <span id="desktop-close-behavior-description" class="control-row__desc">
+        {{ t('setup.runtime.closeBehaviorDesc') }}
+        <template v-if="preferences && !preferences.canRunInBackground && !unavailableSelection">
+          {{ t('setup.runtime.closeBehaviorBackgroundUnavailable') }}
+        </template>
+      </span>
+    </div>
+    <div v-if="preferences" class="control-row__control">
+      <span v-if="saving" class="desktop-preferences__saving" role="status">
+        {{ t('setup.runtime.closeBehaviorSaving') }}
+      </span>
+      <span
+        v-else-if="unavailableSelection"
+        id="desktop-close-behavior-mismatch"
+        class="desktop-preferences__error"
+        role="alert"
+        data-testid="desktop-close-behavior-mismatch"
+      >{{ t('setup.runtime.closeBehaviorFallbackQuit') }}</span>
+      <select
+        id="desktop-close-behavior-select"
+        class="control-input desktop-preferences__select"
+        data-testid="desktop-close-behavior-select"
+        :value="value"
+        :disabled="saving"
+        :aria-describedby="unavailableSelection
+          ? 'desktop-close-behavior-description desktop-close-behavior-mismatch'
+          : 'desktop-close-behavior-description'"
+        @change="save"
+      >
+        <option value="background" :disabled="!preferences.canRunInBackground">
+          {{ t('setup.runtime.closeBehaviorBackground') }}
+        </option>
+        <option value="quit">{{ t('setup.runtime.closeBehaviorQuit') }}</option>
+        <option value="ask" :disabled="!preferences.canRunInBackground">
+          {{ t('setup.runtime.closeBehaviorAsk') }}
+        </option>
+      </select>
+    </div>
+    <div v-else class="control-row__control">
+      <span class="desktop-preferences__error" role="alert" data-testid="desktop-close-behavior-error">
+        {{ t('setup.runtime.closeBehaviorReadFailed', { error: loadError }) }}
+      </span>
+      <button
+        type="button"
+        class="btn btn--ghost"
+        data-testid="desktop-close-behavior-retry"
+        :disabled="loading"
+        @click="load"
+      >{{ t('setup.runtime.closeBehaviorRetry') }}</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.desktop-preferences__select { min-width: 220px; }
+.desktop-preferences__saving { color: var(--text-dim); font-size: var(--fs-xs); }
+.desktop-preferences__error { color: var(--danger); font-size: var(--fs-xs); }
+</style>

--- a/opensquilla-webui/src/components/settings/DesktopPreviewModeSetting.vue
+++ b/opensquilla-webui/src/components/settings/DesktopPreviewModeSetting.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { onMounted, ref, shallowRef } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useToasts } from '@/composables/useToasts'
+import { usePlatform, type DesktopPreferences, type WorkbenchPreviewMode } from '@/platform'
+
+const { t } = useI18n()
+const { pushToast } = useToasts()
+const platform = usePlatform()
+const preferences = shallowRef<DesktopPreferences | null>(null)
+const value = ref<WorkbenchPreviewMode>('full')
+const saving = ref(false)
+
+async function load() {
+  if (!platform.settings.getDesktopPreferences || !platform.settings.saveDesktopPreferences) return
+  try {
+    const next = await platform.settings.getDesktopPreferences()
+    preferences.value = next
+    value.value = next.workbenchPreviewMode ?? 'full'
+  } catch {
+    // This optional desktop preference stays hidden when an older shell or an
+    // unavailable bridge cannot provide it.
+  }
+}
+
+async function save(event: Event) {
+  const next = (event.target as HTMLSelectElement).value as WorkbenchPreviewMode
+  const previous = value.value
+  if (!platform.settings.saveDesktopPreferences) return
+  value.value = next
+  saving.value = true
+  try {
+    const saved = await platform.settings.saveDesktopPreferences({ workbenchPreviewMode: next })
+    preferences.value = saved
+    value.value = saved.workbenchPreviewMode ?? next
+  } catch (error) {
+    value.value = previous
+    pushToast(t('setup.runtime.previewModeSaveFailed', {
+      error: error instanceof Error ? error.message : String(error),
+    }), { tone: 'danger' })
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(() => { void load() })
+</script>
+
+<template>
+  <div v-if="preferences" class="control-row" data-testid="desktop-preview-mode">
+    <div class="control-row__label-block">
+      <label for="desktop-preview-mode-select" class="control-row__label">
+        {{ t('setup.runtime.previewModeLabel') }}
+      </label>
+      <span id="desktop-preview-mode-description" class="control-row__desc">
+        {{ t('setup.runtime.previewModeDesc') }}
+      </span>
+    </div>
+    <div class="control-row__control">
+      <span
+        v-if="preferences.workbenchPreviewForcedOffline"
+        id="desktop-preview-mode-forced"
+        class="desktop-preferences__error"
+        role="status"
+        data-testid="desktop-preview-mode-forced"
+      >{{ t('setup.runtime.previewModeForcedOffline') }}</span>
+      <span v-else-if="saving" class="desktop-preferences__saving" role="status">
+        {{ t('setup.runtime.previewModeSaving') }}
+      </span>
+      <select
+        id="desktop-preview-mode-select"
+        class="control-input desktop-preferences__select"
+        data-testid="desktop-preview-mode-select"
+        :value="value"
+        :disabled="saving"
+        :aria-describedby="preferences.workbenchPreviewForcedOffline
+          ? 'desktop-preview-mode-description desktop-preview-mode-forced'
+          : 'desktop-preview-mode-description'"
+        @change="save"
+      >
+        <option value="full">{{ t('setup.runtime.previewModeFull') }}</option>
+        <option value="offline">{{ t('setup.runtime.previewModeOffline') }}</option>
+      </select>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.desktop-preferences__select { min-width: 220px; }
+.desktop-preferences__saving { color: var(--text-dim); font-size: var(--fs-xs); }
+.desktop-preferences__error { color: var(--danger); font-size: var(--fs-xs); }
+</style>

--- a/opensquilla-webui/src/components/settings/DesktopRuntimePanel.preferences.test.ts
+++ b/opensquilla-webui/src/components/settings/DesktopRuntimePanel.preferences.test.ts
@@ -22,14 +22,19 @@ function desktopApi(overrides: Record<string, unknown> = {}) {
   }
 }
 
-async function mountPanel(api: ReturnType<typeof desktopApi>) {
+async function mountPanel(
+  api: ReturnType<typeof desktopApi>,
+  kind: 'close' | 'preview' = 'close',
+) {
   vi.resetModules()
   document.body.innerHTML = ''
   setDesktopApi(api)
   const { createApp, nextTick } = await import('vue')
   const i18n = (await import('@/i18n')).default
   i18n.global.locale.value = 'en'
-  const Component = (await import('./DesktopRuntimePanel.vue')).default
+  const Component = kind === 'close'
+    ? (await import('./DesktopCloseBehaviorSetting.vue')).default
+    : (await import('./DesktopPreviewModeSetting.vue')).default
   const el = document.createElement('div')
   document.body.appendChild(el)
   const app = createApp(Component)
@@ -246,7 +251,7 @@ describe('DesktopRuntimePanel close behavior preference', () => {
         workbenchPreviewForcedOffline: false,
       }),
       saveDesktopPreferences,
-    }))
+    }), 'preview')
     const select = findPreviewModeSelect(el)
 
     expect(select.value).toBe('offline')
@@ -274,7 +279,7 @@ describe('DesktopRuntimePanel close behavior preference', () => {
         workbenchPreviewForcedOffline: true,
       }),
       saveDesktopPreferences: vi.fn(),
-    }))
+    }), 'preview')
 
     expect(findPreviewModeSelect(el).value).toBe('full')
     const warning = el.querySelector<HTMLElement>('[data-testid="desktop-preview-mode-forced"]')

--- a/opensquilla-webui/src/components/settings/DesktopRuntimePanel.vue
+++ b/opensquilla-webui/src/components/settings/DesktopRuntimePanel.vue
@@ -6,10 +6,7 @@ import GatewayStatusBlock from '@/components/settings/GatewayStatusBlock.vue'
 import SettingsUpdatePanel from '@/components/settings/SettingsUpdatePanel.vue'
 import {
   usePlatform,
-  type DesktopMainWindowCloseBehavior,
-  type DesktopPreferences,
   type GatewayStatus,
-  type WorkbenchPreviewMode,
 } from '@/platform'
 import { useToasts } from '@/composables/useToasts'
 
@@ -23,15 +20,6 @@ const { pushToast } = useToasts()
 const loading = ref(true)
 const busy = ref(false)
 const gateway = shallowRef<GatewayStatus | null>(null)
-const desktopPreferences = shallowRef<DesktopPreferences | null>(null)
-const closeBehavior = ref<DesktopMainWindowCloseBehavior>('quit')
-const previewMode = ref<WorkbenchPreviewMode>('full')
-const preferencesSaving = ref(false)
-// Read-failure state, tracked separately from the loaded value: a failed read
-// keeps the preference row visible with an inline error and Retry, while an
-// older shell without the preference bridge still hides the row entirely.
-const preferencesLoadError = ref('')
-const preferencesLoading = ref(false)
 
 const STATUS_KEYS: Record<string, string> = {
   starting: 'setup.runtime.statusStarting',
@@ -50,95 +38,6 @@ const logAvailable = computed(() => Boolean(gateway.value?.logPath))
 const logHint = computed(() => gateway.value?.logPath || t('setup.runtime.noLogPath'))
 const canRevealLog = computed(() => Boolean(platform.gateway.revealLog))
 const canRestart = computed(() => Boolean(platform.gateway.retryStartup))
-const canManageDesktopPreferences = computed(() => (
-  typeof platform.settings.getDesktopPreferences === 'function'
-  && typeof platform.settings.saveDesktopPreferences === 'function'
-))
-
-const CLOSE_BEHAVIORS = new Set<DesktopMainWindowCloseBehavior>([
-  'background',
-  'quit',
-  'ask',
-])
-
-// The shell owns the stored preference, so a value that needs background
-// support this platform lacks is never rewritten from here — the row calls
-// the mismatch out next to the select instead.
-const closeBehaviorUnavailable = computed(() => (
-  desktopPreferences.value !== null
-  && !desktopPreferences.value.canRunInBackground
-  && closeBehavior.value !== 'quit'
-))
-
-async function loadDesktopPreferences() {
-  if (!canManageDesktopPreferences.value || !platform.settings.getDesktopPreferences) return
-  preferencesLoading.value = true
-  try {
-    const preferences = await platform.settings.getDesktopPreferences()
-    desktopPreferences.value = preferences
-    closeBehavior.value = preferences.mainWindowCloseBehavior
-    previewMode.value = preferences.workbenchPreviewMode ?? 'full'
-    preferencesLoadError.value = ''
-  } catch (err) {
-    preferencesLoadError.value = err instanceof Error ? err.message : String(err)
-  } finally {
-    preferencesLoading.value = false
-  }
-}
-
-async function savePreviewMode(event: Event) {
-  const value = (event.target as HTMLSelectElement).value as WorkbenchPreviewMode
-  const previous = previewMode.value
-  if (
-    (value !== 'full' && value !== 'offline')
-    || !platform.settings.saveDesktopPreferences
-  ) return
-
-  previewMode.value = value
-  preferencesSaving.value = true
-  try {
-    const saved = await platform.settings.saveDesktopPreferences({
-      workbenchPreviewMode: value,
-    })
-    desktopPreferences.value = saved
-    closeBehavior.value = saved.mainWindowCloseBehavior
-    previewMode.value = saved.workbenchPreviewMode ?? value
-  } catch (err) {
-    previewMode.value = previous
-    pushToast(t('setup.runtime.previewModeSaveFailed', {
-      error: err instanceof Error ? err.message : String(err),
-    }), { tone: 'danger' })
-  } finally {
-    preferencesSaving.value = false
-  }
-}
-
-async function saveCloseBehavior(event: Event) {
-  const value = (event.target as HTMLSelectElement).value as DesktopMainWindowCloseBehavior
-  const previous = desktopPreferences.value?.mainWindowCloseBehavior
-  if (
-    !previous
-    || !CLOSE_BEHAVIORS.has(value)
-    || !platform.settings.saveDesktopPreferences
-  ) return
-
-  closeBehavior.value = value
-  preferencesSaving.value = true
-  try {
-    const saved = await platform.settings.saveDesktopPreferences({
-      mainWindowCloseBehavior: value,
-    })
-    desktopPreferences.value = saved
-    closeBehavior.value = saved.mainWindowCloseBehavior
-  } catch (err) {
-    closeBehavior.value = previous
-    pushToast(t('setup.runtime.closeBehaviorSaveFailed', {
-      error: err instanceof Error ? err.message : String(err),
-    }), { tone: 'danger' })
-  } finally {
-    preferencesSaving.value = false
-  }
-}
 
 async function loadStatus(): Promise<GatewayStatus | null> {
   loading.value = true
@@ -193,7 +92,6 @@ async function restartGateway(): Promise<GatewayStatus | null> {
 
 onMounted(() => {
   void loadStatus()
-  void loadDesktopPreferences()
 })
 </script>
 
@@ -237,135 +135,6 @@ onMounted(() => {
       </button>
     </div>
 
-    <div
-      v-if="desktopPreferences || preferencesLoadError"
-      class="control-row desktop-preferences"
-      data-testid="desktop-close-behavior"
-    >
-      <div class="control-row__label-block">
-        <!-- The select only exists once preferences load, so the association is
-             dropped in the read-failure branch — a `for` pointing at a missing
-             id resolves to nothing for assistive tech. -->
-        <label
-          :for="desktopPreferences ? 'desktop-close-behavior-select' : undefined"
-          class="control-row__label"
-        >
-          {{ t('setup.runtime.closeBehaviorLabel') }}
-        </label>
-        <span id="desktop-close-behavior-description" class="control-row__desc">
-          {{ t('setup.runtime.closeBehaviorDesc') }}
-          <template
-            v-if="desktopPreferences && !desktopPreferences.canRunInBackground
-              && !closeBehaviorUnavailable"
-          >
-            {{ t('setup.runtime.closeBehaviorBackgroundUnavailable') }}
-          </template>
-        </span>
-      </div>
-      <div v-if="desktopPreferences" class="control-row__control">
-        <span
-          v-if="preferencesSaving"
-          class="desktop-preferences__saving"
-          role="status"
-        >
-          {{ t('setup.runtime.closeBehaviorSaving') }}
-        </span>
-        <span
-          v-else-if="closeBehaviorUnavailable"
-          id="desktop-close-behavior-mismatch"
-          class="desktop-preferences__error"
-          role="alert"
-          data-testid="desktop-close-behavior-mismatch"
-        >
-          {{ t('setup.runtime.closeBehaviorFallbackQuit') }}
-        </span>
-        <select
-          id="desktop-close-behavior-select"
-          class="control-input desktop-preferences__select"
-          data-testid="desktop-close-behavior-select"
-          :value="closeBehavior"
-          :disabled="preferencesSaving"
-          :aria-describedby="closeBehaviorUnavailable
-            ? 'desktop-close-behavior-description desktop-close-behavior-mismatch'
-            : 'desktop-close-behavior-description'"
-          @change="saveCloseBehavior"
-        >
-          <option value="background" :disabled="!desktopPreferences.canRunInBackground">
-            {{ t('setup.runtime.closeBehaviorBackground') }}
-          </option>
-          <option value="quit">{{ t('setup.runtime.closeBehaviorQuit') }}</option>
-          <option value="ask" :disabled="!desktopPreferences.canRunInBackground">
-            {{ t('setup.runtime.closeBehaviorAsk') }}
-          </option>
-        </select>
-      </div>
-      <div v-else class="control-row__control">
-        <span
-          class="desktop-preferences__error"
-          role="alert"
-          data-testid="desktop-close-behavior-error"
-        >
-          {{ t('setup.runtime.closeBehaviorReadFailed', { error: preferencesLoadError }) }}
-        </span>
-        <button
-          type="button"
-          class="btn btn--ghost"
-          data-testid="desktop-close-behavior-retry"
-          :disabled="preferencesLoading"
-          @click="loadDesktopPreferences"
-        >
-          {{ t('setup.runtime.closeBehaviorRetry') }}
-        </button>
-      </div>
-    </div>
-
-    <div
-      v-if="desktopPreferences"
-      class="control-row desktop-preferences"
-      data-testid="desktop-preview-mode"
-    >
-      <div class="control-row__label-block">
-        <label for="desktop-preview-mode-select" class="control-row__label">
-          {{ t('setup.runtime.previewModeLabel') }}
-        </label>
-        <span id="desktop-preview-mode-description" class="control-row__desc">
-          {{ t('setup.runtime.previewModeDesc') }}
-        </span>
-      </div>
-      <div class="control-row__control">
-        <span
-          v-if="desktopPreferences.workbenchPreviewForcedOffline"
-          id="desktop-preview-mode-forced"
-          class="desktop-preferences__error"
-          role="status"
-          data-testid="desktop-preview-mode-forced"
-        >
-          {{ t('setup.runtime.previewModeForcedOffline') }}
-        </span>
-        <span
-          v-else-if="preferencesSaving"
-          class="desktop-preferences__saving"
-          role="status"
-        >
-          {{ t('setup.runtime.previewModeSaving') }}
-        </span>
-        <select
-          id="desktop-preview-mode-select"
-          class="control-input desktop-preferences__select"
-          data-testid="desktop-preview-mode-select"
-          :value="previewMode"
-          :disabled="preferencesSaving"
-          :aria-describedby="desktopPreferences.workbenchPreviewForcedOffline
-            ? 'desktop-preview-mode-description desktop-preview-mode-forced'
-            : 'desktop-preview-mode-description'"
-          @change="savePreviewMode"
-        >
-          <option value="full">{{ t('setup.runtime.previewModeFull') }}</option>
-          <option value="offline">{{ t('setup.runtime.previewModeOffline') }}</option>
-        </select>
-      </div>
-    </div>
-
     <SettingsUpdatePanel />
   </section>
 </template>
@@ -383,21 +152,4 @@ onMounted(() => {
   gap: var(--sp-2);
 }
 
-.desktop-preferences {
-  margin-top: var(--sp-2);
-}
-
-.desktop-preferences__select {
-  min-width: 220px;
-}
-
-.desktop-preferences__saving {
-  color: var(--text-dim);
-  font-size: var(--fs-xs);
-}
-
-.desktop-preferences__error {
-  color: var(--danger);
-  font-size: var(--fs-xs);
-}
 </style>

--- a/opensquilla-webui/src/components/settings/SettingsAdvancedPanel.vue
+++ b/opensquilla-webui/src/components/settings/SettingsAdvancedPanel.vue
@@ -2,7 +2,6 @@
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ControlSwitch from '@/components/ControlSwitch.vue'
-import MemoryLearningGroup from '@/components/settings/MemoryLearningGroup.vue'
 
 const { t } = useI18n()
 const emit = defineEmits<{
@@ -83,6 +82,8 @@ const agentConfigAriaLabel = computed(() =>
       <p class="control-section__desc">{{ t('setup.advanced.desc') }} <em>{{ t('setup.advanced.reload') }}</em> {{ t('setup.advanced.descReloadSuffix') }}</p>
     </div>
 
+    <h4 class="advanced-group">{{ t('setup.advanced.experimentsGroup') }}</h4>
+
     <label class="control-row">
       <div class="control-row__label-block">
         <span class="control-row__label">{{ t('setup.advanced.foldLabel') }}</span>
@@ -135,8 +136,6 @@ const agentConfigAriaLabel = computed(() =>
       </div>
     </label>
 
-    <MemoryLearningGroup />
-
     <label class="control-row">
       <div class="control-row__label-block">
         <span class="control-row__label">{{ t('setup.advanced.runTraceLabel') }}</span>
@@ -147,6 +146,8 @@ const agentConfigAriaLabel = computed(() =>
         <ControlSwitch name="labs_run_trace" :checked="runTrace" :aria-label="t('setup.advanced.runTraceAria')" @change="setRunTrace" />
       </div>
     </label>
+
+    <h4 class="advanced-group advanced-group--management">{{ t('setup.advanced.managementGroup') }}</h4>
 
     <div class="control-row">
       <div class="control-row__label-block">
@@ -185,6 +186,16 @@ const agentConfigAriaLabel = computed(() =>
 </template>
 
 <style scoped>
+.advanced-group {
+  color: var(--text-dim);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.08em;
+  margin: var(--sp-4) 0 var(--sp-1);
+  text-transform: uppercase;
+}
+
+.advanced-group--management { margin-top: var(--sp-6); }
+
 .labs-hint {
   border: 1px solid color-mix(in srgb, var(--warn) 35%, var(--border));
   border-radius: var(--radius-full);

--- a/opensquilla-webui/src/components/settings/SettingsAppearancePanel.vue
+++ b/opensquilla-webui/src/components/settings/SettingsAppearancePanel.vue
@@ -3,7 +3,6 @@ import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAppStore, type ThemeMode } from '@/stores/app'
 import { themePickerOptions } from '@/themes/registry'
-import { SUPPORTED_LOCALES, type LocaleCode } from '@/i18n'
 import Icon from '@/components/Icon.vue'
 import ControlSwitch from '@/components/ControlSwitch.vue'
 import { useBgm } from '@/composables/useBgm'
@@ -25,9 +24,8 @@ import {
 
 // Client-only preferences: applied instantly to this browser and persisted via
 // the app store. No readiness state; never part of the settings dirty bar.
-// This is the canonical home for theme AND language — the sidebar theme button
-// and the topbar LanguageSwitcher are reactive shortcuts over the SAME store, so
-// the surfaces can never drift.
+// These client-only preferences apply instantly and never enter the settings
+// dirty bar. Language now lives in General with other app-wide defaults.
 const appStore = useAppStore()
 const { t } = useI18n()
 
@@ -36,16 +34,6 @@ const { t } = useI18n()
 // and links here via "More themes…"; this panel is the home for the full set.
 const themeOptions = themePickerOptions({ scope: 'all' })
 
-// Native language names — deliberately NOT translated.
-const LOCALE_LABELS: Record<LocaleCode, string> = {
-  en: 'English',
-  'zh-Hans': '中文',
-  ja: '日本語',
-  fr: 'Français',
-  de: 'Deutsch',
-  es: 'Español',
-}
-const localeOptions = SUPPORTED_LOCALES.map((code) => ({ code, label: LOCALE_LABELS[code] }))
 const toolDetailOptions = TOOL_DETAIL_DISPLAY_MODES.map(mode => ({
   mode,
   labelKey: `settings.appearance.toolDetails${mode[0].toUpperCase()}${mode.slice(1)}`,
@@ -53,10 +41,6 @@ const toolDetailOptions = TOOL_DETAIL_DISPLAY_MODES.map(mode => ({
 
 function pickTheme(mode: ThemeMode) {
   appStore.setTheme(mode)
-}
-
-function pickLocale(code: LocaleCode) {
-  void appStore.setLocale(code)
 }
 
 const {
@@ -273,39 +257,6 @@ onBeforeUnmount(stopCustomStepRepeat)
 
     <div class="control-row control-row--stack">
       <div class="control-row__label-block">
-        <span class="control-row__label">{{ t('settings.appearance.languageLabel') }}</span>
-        <span class="control-row__desc">{{ t('settings.appearance.languageDesc') }}</span>
-      </div>
-      <div class="control-row__control">
-        <div
-          class="appearance-theme"
-          role="radiogroup"
-          :aria-label="t('settings.appearance.languageLabel')"
-          data-testid="settings-language-group"
-        >
-          <label
-            v-for="opt in localeOptions"
-            :key="opt.code"
-            class="appearance-theme__opt"
-            :class="{ 'is-active': appStore.locale === opt.code }"
-          >
-            <input
-              class="appearance-theme__radio"
-              type="radio"
-              name="appearance-locale"
-              :value="opt.code"
-              :checked="appStore.locale === opt.code"
-              :data-testid="`settings-language-${opt.code}`"
-              @change="pickLocale(opt.code)"
-            >
-            <span>{{ opt.label }}</span>
-          </label>
-        </div>
-      </div>
-    </div>
-
-    <div class="control-row control-row--stack">
-      <div class="control-row__label-block">
         <span class="control-row__label">{{ t('settings.appearance.toolDetailsLabel') }}</span>
         <span class="control-row__desc">{{ t('settings.appearance.toolDetailsDesc') }}</span>
       </div>
@@ -500,8 +451,7 @@ onBeforeUnmount(stopCustomStepRepeat)
 
 <style scoped>
 .appearance-theme {
-  /* Wraps to multiple rows so many themes / locales never overflow or crush the
-     row (the parent row is .control-row--stack, so this fills the width). */
+  /* Wraps so the complete theme list never overflows or crushes the row. */
   display: flex;
   flex-wrap: wrap;
   gap: 2px;

--- a/opensquilla-webui/src/components/settings/SettingsDialog.save-pending.test.ts
+++ b/opensquilla-webui/src/components/settings/SettingsDialog.save-pending.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, reactive, ref, type App } from 'vue'
+import { createPinia } from 'pinia'
 import i18n, { loadLocaleMessages } from '@/i18n'
 import SettingsDialog from './SettingsDialog.vue'
 
@@ -13,8 +14,8 @@ const confirmAction = vi.fn()
 
 vi.mock('@/composables/setup/useSetupCatalog', () => ({
   SETTINGS_SECTIONS: [
-    { id: 'behavior', label: 'Behavior', icon: 'chat', group: 'preferences' },
-    { id: 'capabilities', label: 'Capabilities', icon: 'star', group: 'capabilities' },
+    { id: 'general', label: 'General', icon: 'settings', client: false, group: 'preferences' },
+    { id: 'capabilities', label: 'Capabilities', icon: 'skills', client: false, group: 'ai' },
   ],
   useSetupCatalog: () => catalogApi,
 }))
@@ -37,7 +38,7 @@ vi.mock('@/platform', () => ({
 let app: App<Element> | null = null
 
 function mockCatalog() {
-  const section = ref('behavior')
+  const section = ref('general')
   const saveAllPending = ref(true)
   const providerSavePending = ref(false)
   const providerDraftDirty = ref(false)
@@ -57,6 +58,7 @@ function mockCatalog() {
       statusText: 'Automatic titles are off.',
     }),
     privacyPanel: ref({}),
+    memoryPanel: ref({ autoCapture: true }),
     modelStrategyPanel: ref({}),
     presetPanel: ref(null),
     channelsPanel: ref({}),
@@ -72,7 +74,7 @@ function mockCatalog() {
     sectionStatus: () => ({ label: 'Ready', tone: 'is-ok' }),
     sectionDirty: () => true,
     providerDraftDirty,
-    dirtySections: ref([{ id: 'behavior', label: 'Behavior' }]),
+    dirtySections: ref([{ id: 'general', label: 'General' }]),
     hasUnsavedChanges,
     saveAllPending,
     providerSavePending,
@@ -104,6 +106,7 @@ async function mountDialog() {
   document.body.appendChild(el)
   app = createApp(SettingsDialog)
   app.use(i18n)
+  app.use(createPinia())
   app.mount(el)
   await nextTick()
   await nextTick()
@@ -117,9 +120,9 @@ beforeEach(() => {
   confirmAction.mockResolvedValue(true)
   leaveGuard = null
   routeState = reactive({
-    params: { section: 'behavior' },
+    params: { section: 'general' },
     hash: '',
-    path: '/settings/behavior',
+    path: '/settings/general',
   })
   routerMock = {
     options: { history: { state: { back: '/sessions' } } },

--- a/opensquilla-webui/src/components/settings/SettingsDialog.vue
+++ b/opensquilla-webui/src/components/settings/SettingsDialog.vue
@@ -21,7 +21,7 @@
                  tab stop. Rendered when the group changes so each bin is headed
                  once. Hidden on the mobile horizontal strip. -->
             <span
-              v-if="i === 0 || s.group !== visibleSections[i - 1].group"
+              v-if="s.group && (i === 0 || s.group !== visibleSections[i - 1]?.group)"
               class="settings-rail__group"
               role="presentation"
               aria-hidden="true"
@@ -40,7 +40,7 @@
               <Icon :name="s.icon" :size="16" aria-hidden="true" />
               <span class="settings-rail__label">{{ t('settings.rail.' + s.id) }}</span>
               <span v-if="sectionDirty(s.id)" class="settings-rail__dirty" aria-hidden="true"></span>
-              <span v-if="!s.client && s.id === 'connection'" class="settings-rail__dot" :class="sectionStatus(s.id).tone" aria-hidden="true"></span>
+              <span v-if="s.id === 'gateway'" class="settings-rail__dot" :class="sectionStatus(s.id).tone" aria-hidden="true"></span>
               <span v-else-if="!s.client && sectionStatus(s.id).tone === 'is-warn'" class="settings-rail__warn" aria-hidden="true">!</span>
             </button>
           </template>
@@ -74,29 +74,53 @@
             :disabled="saveAllPending"
             :aria-busy="saveAllPending ? 'true' : undefined"
           >
-          <!-- Connection renders regardless of load state: it is how you point
-               the UI at a reachable gateway when nothing has loaded yet. -->
-          <SetupConnectionPanel v-if="section === 'connection'" />
+          <!-- Gateway remains available even when config readiness cannot load,
+               because this is where users recover the connection/runtime. -->
+          <SettingsGatewayPanel
+            v-if="section === 'gateway'"
+            :is-desktop="isDesktop"
+          />
 
-          <!-- Runtime (desktop only) also renders regardless of load state: it
-               reports the owned gateway and offers logs/restart precisely for
-               when the gateway is down and config never loaded. -->
-          <DesktopRuntimePanel v-else-if="section === 'runtime' && isDesktop" />
-
-          <!-- Memory import is an action flow with its own RPC capability gate,
-               rather than a config-backed form. It remains usable even when
-               readiness catalog loading is unavailable. -->
-          <SettingsMemoryPanel v-else-if="section === 'memory'" />
-
-          <SandboxSettingsPanel v-else-if="section === 'sandbox'" />
+          <!-- Profile import is nested under Memory and owns its RPC gate. -->
+          <SettingsMemoryPanel v-else-if="section === 'profileImport'" />
 
           <!-- Optional cross-installation discovery is deliberately mounted
                only when the user opens this section. It never runs at app or
                Settings-dialog startup. -->
           <DataMigrationPanel v-else-if="section === 'dataMigration'" />
 
-          <!-- Config-backed sections wait for readiness so their baselines are
-               final before any field can be edited. -->
+          <!-- Mixed pages render their local controls immediately and gate only
+               the config-backed rows on catalog readiness. -->
+          <SettingsGeneralPanel
+            v-else-if="section === 'general'"
+            :panel="behaviorPanel"
+            :loaded="loaded"
+            :is-desktop="isDesktop"
+            @update-auto-session-titles="setAutoSessionTitles"
+          />
+          <SettingsSecurityPrivacyPanel
+            v-else-if="section === 'securityPrivacy'"
+            :panel="privacyPanel"
+            :loaded="loaded"
+            :is-desktop="isDesktop"
+            @update-network-reporting-enabled="setNetworkReportingEnabled"
+          />
+          <SettingsMemoryOverviewPanel
+            v-else-if="section === 'memory'"
+            :auto-capture="memoryPanel.autoCapture"
+            :loaded="loaded"
+            @update-auto-capture="setMemoryAutoCapture"
+            @open-profile-import="openProfileImport"
+          />
+          <SettingsAppearancePanel v-else-if="section === 'interface'" />
+          <SettingsKeyboardPanel v-else-if="section === 'shortcuts'" />
+          <SettingsAdvancedPanel
+            v-else-if="section === 'advanced'"
+            @open-agent-configuration="openAgentConfiguration"
+            @open-data-maintenance="openDataMaintenance"
+          />
+
+          <!-- AI configuration pages wait for complete readiness baselines. -->
           <div v-else-if="!loaded" class="settings-loading" role="status">
             <LoadingSpinner />
             <strong>{{ t('settings.rail.' + section) }}</strong>
@@ -128,17 +152,6 @@
               @activate-provider="activateProvider"
               @update-image-generation-opt-in="setProviderImageGenerationOptIn"
             />
-            <SetupBehaviorPanel
-              v-else-if="section === 'behavior'"
-              :panel="behaviorPanel"
-              @update-auto-session-titles="setAutoSessionTitles"
-            />
-            <SettingsPrivacyPanel
-              v-else-if="section === 'privacy'"
-              :panel="privacyPanel"
-              @update-disable-network-observability="setDisableNetworkObservability"
-              @update-memory-auto-capture="setMemoryAutoCapture"
-            />
             <SetupModelStrategyPanel
               v-else-if="section === 'modelStrategy'"
               :panel="modelStrategyPanel"
@@ -169,13 +182,6 @@
               @image-provider-change="onImageProviderChange"
               @use-image-recommendation="useImageRecommendation"
               @reset-capability="resetCapability"
-            />
-            <SettingsAppearancePanel v-else-if="section === 'appearance'" />
-            <SettingsKeyboardPanel v-else-if="section === 'keyboard'" />
-            <SettingsAdvancedPanel
-              v-else-if="section === 'advanced'"
-              @open-agent-configuration="openAgentConfiguration"
-              @open-data-maintenance="openDataMaintenance"
             />
           </template>
           </fieldset>
@@ -232,21 +238,24 @@ import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/Icon.vue'
 import LoadingSpinner from '@/components/LoadingSpinner.vue'
-import SetupBehaviorPanel from '@/components/setup/SetupBehaviorPanel.vue'
-import SetupConnectionPanel from '@/components/settings/SetupConnectionPanel.vue'
 import SetupProviderPanel from '@/components/setup/SetupProviderPanel.vue'
 import SetupModelStrategyPanel from '@/components/setup/SetupModelStrategyPanel.vue'
 import SetupCapabilitiesPanel from '@/components/setup/SetupCapabilitiesPanel.vue'
-import SettingsPrivacyPanel from '@/components/settings/SettingsPrivacyPanel.vue'
 import SettingsAppearancePanel from '@/components/settings/SettingsAppearancePanel.vue'
 import SettingsKeyboardPanel from '@/components/settings/SettingsKeyboardPanel.vue'
 import SettingsAdvancedPanel from '@/components/settings/SettingsAdvancedPanel.vue'
 import SettingsMemoryPanel from '@/components/settings/SettingsMemoryPanel.vue'
-import SandboxSettingsPanel from '@/components/settings/SandboxSettingsPanel.vue'
-import DesktopRuntimePanel from '@/components/settings/DesktopRuntimePanel.vue'
+import SettingsGatewayPanel from '@/components/settings/SettingsGatewayPanel.vue'
+import SettingsGeneralPanel from '@/components/settings/SettingsGeneralPanel.vue'
+import SettingsSecurityPrivacyPanel from '@/components/settings/SettingsSecurityPrivacyPanel.vue'
+import SettingsMemoryOverviewPanel from '@/components/settings/SettingsMemoryOverviewPanel.vue'
 import DataMigrationPanel from '@/components/settings/DataMigrationPanel.vue'
 import { useSetupCatalog, SETTINGS_SECTIONS } from '@/composables/setup/useSetupCatalog'
-import { parseProviderHash, sectionFromRouteParam } from '@/composables/setup/useSettingsSection'
+import {
+  parseProviderHash,
+  sectionFromRouteParam,
+  settingsSectionAliasFor,
+} from '@/composables/setup/useSettingsSection'
 import { useConfirm } from '@/composables/useConfirm'
 import { usePlatform } from '@/platform'
 import '@/styles/settings-forms.css'
@@ -256,8 +265,8 @@ const router = useRouter()
 const { t } = useI18n()
 const { confirm, confirmState } = useConfirm()
 
-// Desktop owns a local gateway, so it exposes a Runtime section the web build
-// hides. `desktopOnly` sections are filtered out everywhere else.
+// The catalog retains the desktopOnly capability for future destinations. The
+// consolidated rail currently shares all ten destinations across surfaces.
 const isDesktop = usePlatform().capabilities.isDesktop
 const visibleSections = computed(() => SETTINGS_SECTIONS.filter(s => !s.desktopOnly || isDesktop))
 
@@ -268,6 +277,7 @@ const {
   providerPanel,
   behaviorPanel,
   privacyPanel,
+  memoryPanel,
   modelStrategyPanel,
   presetPanel,
   capabilitiesPanel,
@@ -287,7 +297,7 @@ const {
   requestAddProvider,
   cancelProviderEdit,
   setAutoSessionTitles,
-  setDisableNetworkObservability,
+  setNetworkReportingEnabled,
   setMemoryAutoCapture,
   setProviderImageGenerationOptIn,
   setModelStrategy,
@@ -331,7 +341,9 @@ const {
 // the parent selected while its nested route is open so the rail communicates
 // hierarchy without advertising migration during normal Settings use.
 const activeRailSection = computed(() => (
-  section.value === 'dataMigration' ? 'advanced' : section.value
+  section.value === 'dataMigration'
+    ? 'advanced'
+    : section.value === 'profileImport' ? 'memory' : section.value
 ))
 
 const modalRef = ref<HTMLElement | null>(null)
@@ -455,6 +467,13 @@ const routeParam = computed(() => route.params.section)
 // readiness is known; it is a routing sentinel, never a real rail section.
 const wantsAutoSection = computed(() => routeParam.value === 'auto')
 
+const COMPOSITE_HASH_TARGETS: Record<string, string> = {
+  '#connection': 'settings-gateway-connection',
+  '#runtime': 'settings-gateway-runtime',
+  '#privacy': 'settings-security-privacy',
+  '#sandbox': 'settings-security-sandbox',
+}
+
 // Reflect the active section in the URL with replace (not push) so the browser
 // Back button exits Settings in one step rather than walking section history.
 // Only replace when the section actually changes — an unconditional replace on
@@ -468,23 +487,42 @@ function selectSection(id: string) {
   }
 }
 
-// Resolve the section the route is asking for. Connection works before config
-// loads; the auto sentinel waits for readiness; everything else maps the param
-// (or the default) straight through.
+// Resolve aliases and nested destinations. Old URLs are canonicalized with a
+// subsection hash so bookmarks keep landing on their original content.
 function applyRouteSection() {
   if (wantsAutoSection.value) {
     if (loaded.value && !userNavigated) selectInitialSection('auto')
     return
   }
   const resolved = sectionFromRouteParam(routeParam.value)
-  if (resolved === 'dataMigration') {
+  const alias = settingsSectionAliasFor(routeParam.value)
+  if (alias) {
+    void router.replace({
+      path: `/settings/${alias.section}`,
+      hash: route.hash || alias.hash || '',
+    })
+  }
+  if (resolved === 'dataMigration' || resolved === 'profileImport') {
     setSection(resolved)
     return
   }
-  // A desktopOnly section requested where it is unavailable (e.g. a stale
-  // /settings/runtime deep link on web) has no rail entry or panel branch; fall
-  // back to the default so the dialog never renders an empty body.
+  // A future surface-specific destination requested where unavailable has no
+  // rail entry or panel branch; fall back so the dialog never renders empty.
   setSection(visibleSections.value.some(s => s.id === resolved) ? resolved : 'provider')
+}
+
+function focusCompositeHash(): boolean {
+  const targetId = COMPOSITE_HASH_TARGETS[route.hash]
+  if (!targetId) return false
+  const target = document.getElementById(targetId)
+  if (!target) return false
+  target.scrollIntoView({ block: 'start', inline: 'nearest', behavior: 'auto' })
+  target.focus({ preventScroll: true })
+  return true
+}
+
+function applyCompositeHash() {
+  void nextTick(() => { focusCompositeHash() })
 }
 
 // `#provider-<id>` deep links land on the Provider section with that provider
@@ -608,6 +646,12 @@ async function openDataMaintenance() {
   panelRef.value?.querySelector<HTMLElement>('[data-testid="data-migration-heading"]')?.focus()
 }
 
+async function openProfileImport() {
+  selectSection('profileImport')
+  await nextTick()
+  panelRef.value?.querySelector<HTMLElement>('[data-testid="memory-import-heading"]')?.focus()
+}
+
 // One discard prompt shared by every exit path: requestClose (Escape, the
 // close button, backdrop click) and the history-back leave guard below.
 function confirmDiscard(): Promise<boolean> {
@@ -690,7 +734,10 @@ watch(routeParam, () => applyRouteSection())
 // A provider deep-link hash can arrive (or change) after mount. (Legacy
 // #channel- hashes never reach this dialog: a router guard rewrites them to
 // the /channels workspace before the settings route resolves.)
-watch(() => route.hash, () => { applyProviderHash() })
+watch(() => route.hash, () => {
+  applyProviderHash()
+  applyCompositeHash()
+})
 
 // Whenever the active section changes (rail click, deep link, Back), bring its
 // tab into view on the horizontally-scrolling mobile rail.
@@ -698,6 +745,7 @@ watch(section, () => {
   scrollActiveTabIntoView()
   resetActivePanelScroll()
   applyProviderHash()
+  applyCompositeHash()
 })
 
 // The auto deep link lands on its readiness-derived section once config is
@@ -705,7 +753,10 @@ watch(section, () => {
 watch(loaded, (isLoaded) => {
   if (isLoaded && wantsAutoSection.value && !userNavigated) selectInitialSection('auto')
   // Catalog data is required to validate a provider hash, so (re)try now.
-  if (isLoaded) { applyProviderHash() }
+  if (isLoaded) {
+    applyProviderHash()
+    applyCompositeHash()
+  }
 })
 
 onMounted(() => {
@@ -721,7 +772,9 @@ onMounted(() => {
   document.addEventListener('keydown', onDocumentKeydown)
   mq = window.matchMedia('(max-width: 768px)')
   mq.addEventListener('change', onViewportChange)
-  nextTick(() => closeBtn.value?.focus())
+  nextTick(() => {
+    if (!focusCompositeHash()) closeBtn.value?.focus()
+  })
 })
 
 onUnmounted(() => {

--- a/opensquilla-webui/src/components/settings/SettingsGatewayPanel.vue
+++ b/opensquilla-webui/src/components/settings/SettingsGatewayPanel.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import SetupConnectionPanel from '@/components/settings/SetupConnectionPanel.vue'
+import DesktopRuntimePanel from '@/components/settings/DesktopRuntimePanel.vue'
+
+defineProps<{ isDesktop: boolean }>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <section class="control-section">
+    <div class="control-section__head">
+      <h3 class="control-section__title">{{ t('settings.gateway.title') }}</h3>
+      <p class="control-section__desc">{{ t('settings.gateway.desc') }}</p>
+    </div>
+
+    <div id="settings-gateway-connection" class="settings-composite" tabindex="-1">
+      <SetupConnectionPanel />
+    </div>
+    <div
+      v-if="isDesktop"
+      id="settings-gateway-runtime"
+      class="settings-composite"
+      tabindex="-1"
+    >
+      <DesktopRuntimePanel />
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.settings-composite + .settings-composite {
+  border-top: 1px solid var(--border);
+  margin-top: var(--sp-5);
+  padding-top: var(--sp-5);
+}
+
+.settings-composite:focus { outline: none; }
+</style>

--- a/opensquilla-webui/src/components/settings/SettingsGeneralPanel.vue
+++ b/opensquilla-webui/src/components/settings/SettingsGeneralPanel.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import LoadingSpinner from '@/components/LoadingSpinner.vue'
+import SetupBehaviorPanel from '@/components/setup/SetupBehaviorPanel.vue'
+import DesktopCloseBehaviorSetting from '@/components/settings/DesktopCloseBehaviorSetting.vue'
+import SettingsLanguageControl from '@/components/settings/SettingsLanguageControl.vue'
+
+interface BehaviorPanelContract {
+  autoSessionTitles: boolean
+  autoSessionTitlesDirty: boolean
+  statusText: string
+}
+
+defineProps<{
+  panel: BehaviorPanelContract
+  loaded: boolean
+  isDesktop: boolean
+}>()
+
+const emit = defineEmits<{
+  updateAutoSessionTitles: [enabled: boolean]
+}>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <section class="control-section">
+    <div class="control-section__head">
+      <h3 class="control-section__title">{{ t('settings.general.title') }}</h3>
+      <p class="control-section__desc">{{ t('settings.general.desc') }}</p>
+    </div>
+
+    <SettingsLanguageControl />
+    <SetupBehaviorPanel
+      v-if="loaded"
+      embedded
+      :panel="panel"
+      @update-auto-session-titles="emit('updateAutoSessionTitles', $event)"
+    />
+    <div v-else class="general-loading" role="status">
+      <LoadingSpinner />
+      <span>{{ t('shared.loading') }}</span>
+    </div>
+    <DesktopCloseBehaviorSetting v-if="isDesktop" />
+  </section>
+</template>
+
+<style scoped>
+.general-loading {
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-muted);
+  display: flex;
+  font-size: var(--fs-sm);
+  gap: var(--sp-2);
+  padding: var(--sp-4) 0;
+}
+</style>

--- a/opensquilla-webui/src/components/settings/SettingsLanguageControl.vue
+++ b/opensquilla-webui/src/components/settings/SettingsLanguageControl.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { SUPPORTED_LOCALES, type LocaleCode } from '@/i18n'
+import { useAppStore } from '@/stores/app'
+
+const { t } = useI18n()
+const appStore = useAppStore()
+
+// Native names remain readable after switching to an unfamiliar locale.
+const LOCALE_LABELS: Record<LocaleCode, string> = {
+  en: 'English',
+  'zh-Hans': '中文',
+  ja: '日本語',
+  fr: 'Français',
+  de: 'Deutsch',
+  es: 'Español',
+}
+
+const localeOptions = SUPPORTED_LOCALES.map(code => ({ code, label: LOCALE_LABELS[code] }))
+
+function pickLocale(code: LocaleCode) {
+  void appStore.setLocale(code)
+}
+</script>
+
+<template>
+  <div class="control-row control-row--stack">
+    <div class="control-row__label-block">
+      <span class="control-row__label">{{ t('settings.appearance.languageLabel') }}</span>
+      <span class="control-row__desc">{{ t('settings.appearance.languageDesc') }}</span>
+    </div>
+    <div class="control-row__control">
+      <div
+        class="language-options"
+        role="radiogroup"
+        :aria-label="t('settings.appearance.languageLabel')"
+        data-testid="settings-language-group"
+      >
+        <label
+          v-for="option in localeOptions"
+          :key="option.code"
+          class="language-options__item"
+          :class="{ 'is-active': appStore.locale === option.code }"
+        >
+          <input
+            class="language-options__radio"
+            type="radio"
+            name="settings-locale"
+            :value="option.code"
+            :checked="appStore.locale === option.code"
+            :data-testid="`settings-language-${option.code}`"
+            @change="pickLocale(option.code)"
+          >
+          <span>{{ option.label }}</span>
+        </label>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.language-options {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  padding: 2px;
+}
+
+.language-options__item {
+  align-items: center;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: var(--fs-sm);
+  padding: 6px var(--sp-3);
+  position: relative;
+}
+
+.language-options__item:hover { color: var(--text); }
+.language-options__item.is-active {
+  background: var(--bg-surface);
+  box-shadow: var(--shadow-xs);
+  color: var(--text);
+}
+.language-options__item:focus-within {
+  outline: 2px solid color-mix(in srgb, var(--accent) 45%, transparent);
+  outline-offset: 2px;
+}
+.language-options__radio {
+  height: 1px;
+  margin: 0;
+  opacity: 0;
+  position: absolute;
+  width: 1px;
+}
+</style>

--- a/opensquilla-webui/src/components/settings/SettingsMemoryOverviewPanel.vue
+++ b/opensquilla-webui/src/components/settings/SettingsMemoryOverviewPanel.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import ControlSwitch from '@/components/ControlSwitch.vue'
+import LoadingSpinner from '@/components/LoadingSpinner.vue'
+import MemoryLearningGroup from '@/components/settings/MemoryLearningGroup.vue'
+
+defineProps<{
+  autoCapture: boolean
+  loaded: boolean
+}>()
+
+const emit = defineEmits<{
+  updateAutoCapture: [enabled: boolean]
+  openProfileImport: []
+}>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <section class="control-section">
+    <div class="control-section__head">
+      <h3 class="control-section__title">{{ t('settings.memoryOverview.title') }}</h3>
+      <p class="control-section__desc">{{ t('settings.memoryOverview.desc') }}</p>
+    </div>
+
+    <label v-if="loaded" class="control-row">
+      <div class="control-row__label-block">
+        <span class="control-row__label">{{ t('settings.memoryOverview.autoCaptureLabel') }}</span>
+        <span class="control-row__desc">{{ t('settings.memoryOverview.autoCaptureDesc') }}</span>
+      </div>
+      <div class="control-row__control">
+        <ControlSwitch
+          :checked="autoCapture"
+          name="memory_auto_capture"
+          :aria-label="t('settings.memoryOverview.autoCaptureLabel')"
+          @change="emit('updateAutoCapture', $event)"
+        />
+      </div>
+    </label>
+    <div v-else class="memory-loading" role="status">
+      <LoadingSpinner />
+      <span>{{ t('shared.loading') }}</span>
+    </div>
+
+    <details class="memory-learning">
+      <summary>{{ t('settings.memoryOverview.learningSummary') }}</summary>
+      <p>{{ t('settings.memoryOverview.learningDesc') }}</p>
+      <MemoryLearningGroup />
+    </details>
+
+    <div class="control-row">
+      <div class="control-row__label-block">
+        <span class="control-row__label">{{ t('settings.memoryOverview.profileImportLabel') }}</span>
+        <span class="control-row__desc">{{ t('settings.memoryOverview.profileImportDesc') }}</span>
+      </div>
+      <div class="control-row__control">
+        <button type="button" class="btn btn--ghost" @click="emit('openProfileImport')">
+          {{ t('settings.memoryOverview.profileImportAction') }}
+        </button>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.memory-loading {
+  align-items: center;
+  color: var(--text-muted);
+  display: flex;
+  font-size: var(--fs-sm);
+  gap: var(--sp-2);
+  padding: var(--sp-4) 0;
+}
+
+.memory-learning {
+  border-bottom: 1px solid var(--border);
+  padding: var(--sp-4) 0;
+}
+
+.memory-learning > summary {
+  color: var(--text);
+  cursor: pointer;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+}
+
+.memory-learning > p {
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  line-height: 1.55;
+  margin: var(--sp-2) 0;
+}
+</style>

--- a/opensquilla-webui/src/components/settings/SettingsMemoryPanel.vue
+++ b/opensquilla-webui/src/components/settings/SettingsMemoryPanel.vue
@@ -893,7 +893,11 @@ onUnmounted(() => {
 <template>
   <section class="memory-import" data-testid="settings-memory-panel">
     <header class="memory-import__head">
-      <h3 class="memory-import__title">{{ t('settings.memoryImport.title') }}</h3>
+      <h3
+        class="memory-import__title"
+        data-testid="memory-import-heading"
+        tabindex="-1"
+      >{{ t('settings.memoryImport.title') }}</h3>
       <p class="memory-import__description">{{ t('settings.memoryImport.description') }}</p>
     </header>
 

--- a/opensquilla-webui/src/components/settings/SettingsPrivacyPanel.vue
+++ b/opensquilla-webui/src/components/settings/SettingsPrivacyPanel.vue
@@ -5,11 +5,8 @@ import ControlSwitch from '@/components/ControlSwitch.vue'
 const { t } = useI18n()
 
 interface PrivacyPanelContract {
-  disableNetworkObservability: boolean
-  disableNetworkObservabilityDirty: boolean
-  memoryAutoCapture: boolean
-  memoryAutoCaptureDirty: boolean
-  statusText: string
+  networkReportingEnabled: boolean
+  networkReportingForcedOff: boolean
 }
 
 defineProps<{
@@ -17,46 +14,33 @@ defineProps<{
 }>()
 
 const emit = defineEmits<{
-  updateDisableNetworkObservability: [enabled: boolean]
-  updateMemoryAutoCapture: [enabled: boolean]
+  updateNetworkReportingEnabled: [enabled: boolean]
 }>()
 </script>
 
 <template>
-  <section class="control-section">
-    <div class="control-section__head">
-      <h3 class="control-section__title">{{ t('setup.privacy.title') }}</h3>
-      <p class="control-section__desc">{{ panel.statusText }}</p>
-    </div>
-
+  <div class="settings-subsection" id="settings-security-privacy" tabindex="-1">
     <label class="control-row">
       <div class="control-row__label-block">
-        <span class="control-row__label">{{ t('setup.privacy.memoryAutoCaptureLabel') }}</span>
-        <span class="control-row__desc">{{ t('setup.privacy.memoryAutoCaptureDesc') }}</span>
+        <span class="control-row__label">{{ t('setup.privacy.networkReportingLabel') }}</span>
+        <span class="control-row__desc">{{ t('setup.privacy.networkReportingDesc') }}</span>
+        <span v-if="panel.networkReportingForcedOff" class="control-row__desc">
+          {{ t('setup.privacy.statusDisabledByEnv') }}
+        </span>
       </div>
       <div class="control-row__control">
         <ControlSwitch
-          :checked="panel.memoryAutoCapture"
-          name="setup_memory_auto_capture"
-          :aria-label="t('setup.privacy.memoryAutoCaptureLabel')"
-          @change="(value) => emit('updateMemoryAutoCapture', value)"
-        />
-      </div>
-    </label>
-
-    <label class="control-row">
-      <div class="control-row__label-block">
-        <span class="control-row__label">{{ t('setup.privacy.disableNetworkObservabilityLabel') }}</span>
-        <span class="control-row__desc">{{ t('setup.privacy.disableNetworkObservabilityDesc') }}</span>
-      </div>
-      <div class="control-row__control">
-        <ControlSwitch
-          :checked="panel.disableNetworkObservability"
+          :checked="panel.networkReportingEnabled"
+          :disabled="panel.networkReportingForcedOff"
           name="setup_disable_network_observability"
-          :aria-label="t('setup.privacy.disableNetworkObservabilityLabel')"
-          @change="(value) => emit('updateDisableNetworkObservability', value)"
+          :aria-label="t('setup.privacy.networkReportingLabel')"
+          @change="(value) => emit('updateNetworkReportingEnabled', value)"
         />
       </div>
     </label>
-  </section>
+  </div>
 </template>
+
+<style scoped>
+.settings-subsection:focus { outline: none; }
+</style>

--- a/opensquilla-webui/src/components/settings/SettingsSecurityPrivacyPanel.vue
+++ b/opensquilla-webui/src/components/settings/SettingsSecurityPrivacyPanel.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import LoadingSpinner from '@/components/LoadingSpinner.vue'
+import DesktopPreviewModeSetting from '@/components/settings/DesktopPreviewModeSetting.vue'
+import SandboxSettingsPanel from '@/components/settings/SandboxSettingsPanel.vue'
+import SettingsPrivacyPanel from '@/components/settings/SettingsPrivacyPanel.vue'
+
+interface PrivacyPanelContract {
+  networkReportingEnabled: boolean
+  networkReportingForcedOff: boolean
+}
+
+defineProps<{
+  panel: PrivacyPanelContract
+  loaded: boolean
+  isDesktop: boolean
+}>()
+
+const emit = defineEmits<{
+  updateNetworkReportingEnabled: [enabled: boolean]
+}>()
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <section class="control-section">
+    <div class="control-section__head">
+      <h3 class="control-section__title">{{ t('settings.securityPrivacy.title') }}</h3>
+      <p class="control-section__desc">{{ t('settings.securityPrivacy.desc') }}</p>
+    </div>
+
+    <SettingsPrivacyPanel
+      v-if="loaded"
+      :panel="panel"
+      @update-network-reporting-enabled="emit('updateNetworkReportingEnabled', $event)"
+    />
+    <div v-else class="security-loading" role="status">
+      <LoadingSpinner />
+      <span>{{ t('shared.loading') }}</span>
+    </div>
+
+    <div v-if="isDesktop" class="security-subsection">
+      <DesktopPreviewModeSetting />
+    </div>
+
+    <div id="settings-security-sandbox" class="security-subsection" tabindex="-1">
+      <SandboxSettingsPanel />
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.security-loading {
+  align-items: center;
+  color: var(--text-muted);
+  display: flex;
+  font-size: var(--fs-sm);
+  gap: var(--sp-2);
+  padding: var(--sp-4) 0;
+}
+
+.security-subsection {
+  border-top: 1px solid var(--border);
+  margin-top: var(--sp-5);
+  padding-top: var(--sp-5);
+}
+
+.security-subsection:focus { outline: none; }
+</style>

--- a/opensquilla-webui/src/components/setup/SetupBehaviorPanel.vue
+++ b/opensquilla-webui/src/components/setup/SetupBehaviorPanel.vue
@@ -12,6 +12,7 @@ interface BehaviorPanelContract {
 
 defineProps<{
   panel: BehaviorPanelContract
+  embedded?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -20,8 +21,8 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <section class="control-section">
-    <div class="control-section__head">
+  <section class="control-section" :class="{ 'control-section--embedded': embedded }">
+    <div v-if="!embedded" class="control-section__head">
       <h3 class="control-section__title">{{ t('setup.behavior.title') }}</h3>
       <p class="control-section__desc">{{ panel.statusText }}</p>
     </div>
@@ -41,3 +42,7 @@ const emit = defineEmits<{
     </label>
   </section>
 </template>
+
+<style scoped>
+.control-section--embedded { display: contents; }
+</style>

--- a/opensquilla-webui/src/components/setup/SetupCapabilitiesPanel.vue
+++ b/opensquilla-webui/src/components/setup/SetupCapabilitiesPanel.vue
@@ -210,7 +210,12 @@ function resetLabel(capabilityId: CapabilityId): string {
 
 <template>
   <div class="setup-capabilities">
-    <p class="setup-capabilities__intro">{{ t('setup.capabilities.intro') }}</p>
+    <div class="control-section__head">
+      <h3 class="control-section__title">{{ t('settings.rail.capabilities') }}</h3>
+      <p class="control-section__desc setup-capabilities__intro">
+        {{ t('setup.capabilities.intro') }}
+      </p>
+    </div>
 
     <section
       v-for="capability in ([

--- a/opensquilla-webui/src/composables/setup/settingsSections.ts
+++ b/opensquilla-webui/src/composables/setup/settingsSections.ts
@@ -2,50 +2,34 @@
 // the catalog composable and the route↔section mapping helpers can import it
 // without forming an import cycle.
 
-// `group` bins the flat rail into labelled sections in the dialog. It is purely
-// presentational: section ids, routes, panels, readiness, and save behaviour are
-// unchanged — the rail is only reordered and captioned. Order matters because the
-// rail (and the dirty-bar summary) reads top-to-bottom; it now mirrors the setup
-// dependency order (Model Service → Model Routing → Capabilities) so the coupled
-// panels sit adjacent instead of being split by Behavior/Privacy.
+// `group` bins the canonical Settings destinations into labelled rail sections.
+// Order matters for both navigation and the dirty-bar summary; AI configuration
+// follows dependency order, while ordinary preferences precede safety and data.
 export const SETTINGS_SECTIONS = [
-  // --- Gateway: host/connection state, renders before config loads ---
-  // Connection carries a live status dot (driven by the gateway socket state,
-  // not readiness RPC) so it works before any config loads. It applies on
-  // Connect and never enters the dirty bar, so it is excluded from save/discard.
-  { id: 'connection', label: 'Connection', icon: 'home', client: false, desktopOnly: false, group: 'gateway' },
-  // Runtime is desktop-only: the owned local gateway's status, log, restart, and
-  // update controls. It is client-like (no readiness/RPC state, never dirty) and hidden on
-  // web, where the host does not own a gateway process.
-  { id: 'runtime', label: 'Runtime', icon: 'monitor', client: true, desktopOnly: true, group: 'gateway' },
+  // Gateway is the recovery/operations entry point on every surface. Desktop
+  // augments it with local runtime controls, but the rail destination is shared.
+  { id: 'gateway', label: 'Gateway', icon: 'home', client: false, desktopOnly: false, group: null },
   // --- AI configuration: Model Service -> Model Routing ---
   { id: 'provider', label: 'Model Service', icon: 'agents', client: false, desktopOnly: false, group: 'ai' },
   { id: 'modelStrategy', label: 'Model Routing', icon: 'router', client: false, desktopOnly: false, group: 'ai' },
-  { id: 'capabilities', label: 'Capabilities', icon: 'skills', client: false, desktopOnly: false, group: 'capabilities' },
-  // --- Preferences: assistant behaviour + local app settings ---
-  { id: 'behavior', label: 'Behavior', icon: 'chat', client: false, desktopOnly: false, group: 'preferences' },
-  { id: 'privacy', label: 'Privacy', icon: 'shield', client: false, desktopOnly: false, group: 'preferences' },
-  // Sandbox policy is versioned independently from the main config form and
-  // owns its own conflict-aware save controls.
-  { id: 'sandbox', label: 'Sandbox', icon: 'shield', client: true, desktopOnly: false, group: 'preferences' },
-  // Profile import is a gateway action surface, not a config form. Marking it
-  // client-like keeps it out of readiness and the global dirty/save bar; the
-  // panel owns its RPC feature gate, progress, confirmation, and recovery.
-  { id: 'memory', label: 'Memory & Profile', icon: 'user', client: true, desktopOnly: false, group: 'preferences' },
-  // Client-only sections carry no readiness/RPC state: they edit local browser
-  // preferences that apply instantly and never enter the dirty bar. The status
-  // dot is suppressed for them in the rail.
-  { id: 'appearance', label: 'Appearance', icon: 'monitor', client: true, desktopOnly: false, group: 'preferences' },
-  { id: 'keyboard', label: 'Keyboard', icon: 'keyboard', client: true, desktopOnly: false, group: 'preferences' },
-  { id: 'advanced', label: 'Advanced', icon: 'gauge', client: true, desktopOnly: false, group: 'preferences' },
+  { id: 'capabilities', label: 'Capabilities', icon: 'skills', client: false, desktopOnly: false, group: 'ai' },
+  // --- Preferences: ordinary user-facing defaults and local UI settings ---
+  { id: 'general', label: 'General', icon: 'settings', client: false, desktopOnly: false, group: 'preferences' },
+  { id: 'interface', label: 'Interface', icon: 'monitor', client: true, desktopOnly: false, group: 'preferences' },
+  { id: 'shortcuts', label: 'Shortcuts', icon: 'keyboard', client: true, desktopOnly: false, group: 'preferences' },
+  // --- Safety and data: privacy, sandbox policy, and memory lifecycle ---
+  { id: 'securityPrivacy', label: 'Security & Privacy', icon: 'shield', client: false, desktopOnly: false, group: 'safetyData' },
+  { id: 'memory', label: 'Memory', icon: 'user', client: false, desktopOnly: false, group: 'safetyData' },
+  // Advanced remains a quiet standalone destination at the bottom of the rail.
+  { id: 'advanced', label: 'Advanced', icon: 'gauge', client: true, desktopOnly: false, group: null },
 ] as const
 
 // Data maintenance is a nested Advanced destination rather than a first-level
 // rail tab. Keep its stable route id here so existing deep links continue to
 // resolve without making the destination prominent in Settings navigation.
-export const NESTED_SETTINGS_SECTION_IDS = ['dataMigration'] as const
+export const NESTED_SETTINGS_SECTION_IDS = ['dataMigration', 'profileImport'] as const
 
 export type SettingsRailSectionId = (typeof SETTINGS_SECTIONS)[number]['id']
 export type NestedSettingsSectionId = (typeof NESTED_SETTINGS_SECTION_IDS)[number]
 export type SettingsSectionId = SettingsRailSectionId | NestedSettingsSectionId
-export type SettingsSectionGroup = (typeof SETTINGS_SECTIONS)[number]['group']
+export type SettingsSectionGroup = Exclude<(typeof SETTINGS_SECTIONS)[number]['group'], null>

--- a/opensquilla-webui/src/composables/setup/useSettingsSection.test.ts
+++ b/opensquilla-webui/src/composables/setup/useSettingsSection.test.ts
@@ -1,10 +1,30 @@
 import { describe, it, expect } from 'vitest'
-import { sectionFromRouteParam, isKnownSectionParam, parseProviderHash } from './useSettingsSection'
+import {
+  isKnownSectionParam,
+  parseProviderHash,
+  sectionFromRouteParam,
+  settingsSectionAliasFor,
+} from './useSettingsSection'
 import { SETTINGS_SECTIONS } from './settingsSections'
 import en from '@/locales/en.json'
 import zhHans from '@/locales/zh-Hans.json'
 
 describe('settings section IA', () => {
+  it('exposes the approved ten first-level settings pages in order', () => {
+    expect(SETTINGS_SECTIONS.map(section => section.id)).toEqual([
+      'gateway',
+      'provider',
+      'modelStrategy',
+      'capabilities',
+      'general',
+      'interface',
+      'shortcuts',
+      'securityPrivacy',
+      'memory',
+      'advanced',
+    ])
+  })
+
   it('has one Model Strategy section instead of split Router and Ensemble sections', () => {
     const ids = SETTINGS_SECTIONS.map(s => s.id)
     expect(ids).toContain('modelStrategy')
@@ -59,16 +79,41 @@ describe('settings section IA', () => {
     expect(SETTINGS_SECTIONS.find(s => s.id === 'provider')?.label).toBe('Model Service')
   })
 
-  it('keeps Memory & Profile as a first-level action panel outside global save state', () => {
+  it('keeps Memory as a first-level settings panel and nests profile import', () => {
     const memory = SETTINGS_SECTIONS.find(s => s.id === 'memory')
     expect(memory).toMatchObject({
-      label: 'Memory & Profile',
-      group: 'preferences',
-      client: true,
+      label: 'Memory',
+      group: 'safetyData',
+      client: false,
       desktopOnly: false,
     })
-    expect(en.settings.rail.memory).toBe('Memory & Profile')
-    expect(zhHans.settings.rail.memory).toBe('记忆与画像')
+    expect(en.settings.rail.memory).toBe('Memory')
+    expect(zhHans.settings.rail.memory).toBe('记忆')
+    expect(SETTINGS_SECTIONS.map(s => s.id)).not.toContain('profileImport')
+    expect(sectionFromRouteParam('profileImport')).toBe('profileImport')
+  })
+
+  it('preserves aliases for pages consolidated into the ten-section IA', () => {
+    expect(sectionFromRouteParam('connection')).toBe('gateway')
+    expect(sectionFromRouteParam('runtime')).toBe('gateway')
+    expect(sectionFromRouteParam('behavior')).toBe('general')
+    expect(sectionFromRouteParam('appearance')).toBe('interface')
+    expect(sectionFromRouteParam('keyboard')).toBe('shortcuts')
+    expect(sectionFromRouteParam('privacy')).toBe('securityPrivacy')
+    expect(sectionFromRouteParam('sandbox')).toBe('securityPrivacy')
+  })
+
+  it('keeps canonical subsection hashes beside their legacy route aliases', () => {
+    expect(settingsSectionAliasFor('connection')).toEqual({
+      section: 'gateway',
+      hash: '#connection',
+    })
+    expect(settingsSectionAliasFor('sandbox')).toEqual({
+      section: 'securityPrivacy',
+      hash: '#sandbox',
+    })
+    expect(settingsSectionAliasFor('behavior')).toEqual({ section: 'general' })
+    expect(settingsSectionAliasFor('does-not-exist')).toBeNull()
   })
 
   it('aliases stale Router and Ensemble deep links to Model Strategy', () => {

--- a/opensquilla-webui/src/composables/setup/useSettingsSection.ts
+++ b/opensquilla-webui/src/composables/setup/useSettingsSection.ts
@@ -6,10 +6,27 @@ import {
 } from '@/composables/setup/settingsSections'
 
 const DEFAULT_SECTION: SettingsSectionId = 'provider'
-const SECTION_ALIASES: Record<string, SettingsSectionId> = {
-  router: 'modelStrategy',
-  ensemble: 'modelStrategy',
-  chatModel: 'provider',
+export interface SettingsSectionAlias {
+  section: SettingsSectionId
+  hash?: string
+}
+
+const SECTION_ALIASES: Record<string, SettingsSectionAlias> = {
+  connection: { section: 'gateway', hash: '#connection' },
+  runtime: { section: 'gateway', hash: '#runtime' },
+  behavior: { section: 'general' },
+  appearance: { section: 'interface' },
+  keyboard: { section: 'shortcuts' },
+  privacy: { section: 'securityPrivacy', hash: '#privacy' },
+  sandbox: { section: 'securityPrivacy', hash: '#sandbox' },
+  router: { section: 'modelStrategy' },
+  ensemble: { section: 'modelStrategy' },
+  chatModel: { section: 'provider' },
+}
+
+export function settingsSectionAliasFor(value: unknown): SettingsSectionAlias | null {
+  if (typeof value !== 'string') return null
+  return SECTION_ALIASES[value] || null
 }
 
 function sectionIdFor(value: unknown): SettingsSectionId | null {
@@ -18,7 +35,7 @@ function sectionIdFor(value: unknown): SettingsSectionId | null {
   if (canonical) return canonical.id
   const nested = NESTED_SETTINGS_SECTION_IDS.find(id => id === value)
   if (nested) return nested
-  return SECTION_ALIASES[value] || null
+  return settingsSectionAliasFor(value)?.section || null
 }
 
 export function sectionFromRouteParam(param: unknown): SettingsSectionId {

--- a/opensquilla-webui/src/composables/setup/useSetupCatalog.privacy.test.ts
+++ b/opensquilla-webui/src/composables/setup/useSetupCatalog.privacy.test.ts
@@ -72,7 +72,7 @@ afterEach(() => {
 })
 
 describe('useSetupCatalog privacy settings', () => {
-  it('moves automatic memory capture into the privacy dirty/save flow', async () => {
+  it('tracks and saves automatic memory capture from the Memory section', async () => {
     mockConfigSequence([
       {
         privacy: { disable_network_observability: false },
@@ -87,16 +87,15 @@ describe('useSetupCatalog privacy settings', () => {
 
     api.setMemoryAutoCapture(false)
 
-    expect(api.sectionDirty('privacy')).toBe(true)
+    expect(api.sectionDirty('memory')).toBe(true)
     expect(api.sectionDirty('capabilities')).toBe(false)
     await api.saveDirtySections()
     expect(rpcCall).toHaveBeenCalledWith('config.patch.safe', {
       patches: {
-        'privacy.disable_network_observability': false,
         'memory.auto_capture_enabled': false,
       },
     })
-    expect(api.sectionDirty('privacy')).toBe(false)
+    expect(api.sectionDirty('memory')).toBe(false)
     app.unmount()
   })
 
@@ -108,14 +107,14 @@ describe('useSetupCatalog privacy settings', () => {
     const { api, app } = await mountCatalog()
 
     api.setDisableNetworkObservability(true)
-    expect(api.sectionDirty('privacy')).toBe(true)
+    expect(api.sectionDirty('securityPrivacy')).toBe(true)
 
     await api.savePrivacy()
 
     expect(rpcCall).toHaveBeenCalledWith('config.patch.safe', {
       patches: { 'privacy.disable_network_observability': true },
     })
-    expect(api.sectionDirty('privacy')).toBe(false)
+    expect(api.sectionDirty('securityPrivacy')).toBe(false)
     expect(pushToast).toHaveBeenCalledWith('Privacy saved.')
     app.unmount()
   })
@@ -143,16 +142,16 @@ describe('useSetupCatalog privacy settings', () => {
 
     api.setDisableNetworkObservability(true)
     api.setAutoSessionTitles(true)
-    expect(api.sectionDirty('privacy')).toBe(true)
-    expect(api.sectionDirty('behavior')).toBe(true)
+    expect(api.sectionDirty('securityPrivacy')).toBe(true)
+    expect(api.sectionDirty('general')).toBe(true)
 
     await api.saveDirtySections()
 
     expect(rpcCall).toHaveBeenCalledWith('config.patch.safe', {
       patches: { 'privacy.disable_network_observability': true },
     })
-    expect(api.privacyPanel.value.disableNetworkObservability).toBe(true)
-    expect(api.sectionDirty('privacy')).toBe(true)
+    expect(api.privacyPanel.value.networkReportingEnabled).toBe(false)
+    expect(api.sectionDirty('securityPrivacy')).toBe(true)
     app.unmount()
   })
 
@@ -167,11 +166,11 @@ describe('useSetupCatalog privacy settings', () => {
     ])
     const { api, app } = await mountCatalog()
 
-    expect(api.privacyPanel.value.disableNetworkObservability).toBe(false)
-    expect(api.privacyPanel.value.statusText).toBe(
-      'Network reporting is off because an environment setting disables it.',
-    )
-    expect(api.sectionDirty('privacy')).toBe(false)
+    expect(api.privacyPanel.value).toMatchObject({
+      networkReportingEnabled: false,
+      networkReportingForcedOff: true,
+    })
+    expect(api.sectionDirty('securityPrivacy')).toBe(false)
     app.unmount()
   })
 
@@ -188,10 +187,11 @@ describe('useSetupCatalog privacy settings', () => {
 
     api.setDisableNetworkObservability(false)
 
-    expect(api.privacyPanel.value.statusText).toBe(
-      'Network reporting is on.',
-    )
-    expect(api.sectionDirty('privacy')).toBe(true)
+    expect(api.privacyPanel.value).toMatchObject({
+      networkReportingEnabled: true,
+      networkReportingForcedOff: false,
+    })
+    expect(api.sectionDirty('securityPrivacy')).toBe(true)
     app.unmount()
   })
 })
@@ -252,7 +252,7 @@ describe('useSetupCatalog capability reset', () => {
     api.setAutoSessionTitles(true)
     api.updateCapabilityField('image', 'apiKey', 'test-inline-key')
 
-    expect(api.sectionDirty('behavior')).toBe(true)
+    expect(api.sectionDirty('general')).toBe(true)
     expect(api.sectionDirty('capabilities')).toBe(true)
     await api.resetCapability('image_generation')
 
@@ -263,7 +263,7 @@ describe('useSetupCatalog capability reset', () => {
       capabilityId: 'image_generation',
     })
     expect(api.sectionDirty('capabilities')).toBe(false)
-    expect(api.sectionDirty('behavior')).toBe(true)
+    expect(api.sectionDirty('general')).toBe(true)
     app.unmount()
   })
 
@@ -3296,8 +3296,9 @@ describe('useSetupCatalog configured provider management', () => {
     api.updateCapabilityField('search', 'maxResults', 25)
     api.updateCapabilityField('image', 'size', '512x512')
     api.updateCapabilityField('audio', 'ttsVoice', 'draft-voice')
-    expect(api.sectionDirty('behavior')).toBe(true)
-    expect(api.sectionDirty('privacy')).toBe(true)
+    expect(api.sectionDirty('general')).toBe(true)
+    expect(api.sectionDirty('securityPrivacy')).toBe(true)
+    expect(api.sectionDirty('memory')).toBe(true)
     expect(api.sectionDirty('capabilities')).toBe(true)
 
     await api.requestSelectConfiguredProvider('deepseek')
@@ -3305,18 +3306,17 @@ describe('useSetupCatalog configured provider management', () => {
     await expect(api.saveProvider()).resolves.toBe(true)
 
     expect(api.behaviorPanel.value.autoSessionTitles).toBe(true)
-    expect(api.privacyPanel.value).toMatchObject({
-      disableNetworkObservability: true,
-      memoryAutoCapture: false,
-    })
+    expect(api.privacyPanel.value.networkReportingEnabled).toBe(false)
+    expect(api.memoryPanel.value.autoCapture).toBe(false)
     expect(api.capabilitiesPanel.value.form).toMatchObject({
       searchMaxResults: 25,
       memoryModel: 'server-refreshed-model',
       imageSize: '512x512',
       audioTtsVoice: 'draft-voice',
     })
-    expect(api.sectionDirty('behavior')).toBe(true)
-    expect(api.sectionDirty('privacy')).toBe(true)
+    expect(api.sectionDirty('general')).toBe(true)
+    expect(api.sectionDirty('securityPrivacy')).toBe(true)
+    expect(api.sectionDirty('memory')).toBe(true)
     expect(api.sectionDirty('capabilities')).toBe(true)
     expect(api.providerDraftDirty.value).toBe(false)
     expect(api.providerPanel.value.providerSelected).toBe('deepseek')
@@ -3539,7 +3539,7 @@ describe('useSetupCatalog configured provider management', () => {
     await expect(save).resolves.toBe(true)
 
     expect(api.behaviorPanel.value.autoSessionTitles).toBe(true)
-    expect(api.sectionDirty('behavior')).toBe(true)
+    expect(api.sectionDirty('general')).toBe(true)
     expect(api.providerDraftDirty.value).toBe(false)
     app.unmount()
   })
@@ -3914,18 +3914,17 @@ describe('useSetupCatalog configured provider management', () => {
     })
     expect(api.sectionDirty('modelStrategy')).toBe(false)
     expect(api.behaviorPanel.value.autoSessionTitles).toBe(true)
-    expect(api.privacyPanel.value).toMatchObject({
-      disableNetworkObservability: true,
-      memoryAutoCapture: false,
-    })
+    expect(api.privacyPanel.value.networkReportingEnabled).toBe(false)
+    expect(api.memoryPanel.value.autoCapture).toBe(false)
     expect(api.capabilitiesPanel.value.form).toMatchObject({
       searchMaxResults: 25,
       memoryModel: 'server-refreshed-model',
       imageSize: '512x512',
       audioTtsVoice: 'draft-voice',
     })
-    expect(api.sectionDirty('behavior')).toBe(true)
-    expect(api.sectionDirty('privacy')).toBe(true)
+    expect(api.sectionDirty('general')).toBe(true)
+    expect(api.sectionDirty('securityPrivacy')).toBe(true)
+    expect(api.sectionDirty('memory')).toBe(true)
     expect(api.sectionDirty('capabilities')).toBe(true)
     app.unmount()
   })
@@ -5075,7 +5074,7 @@ describe('useSetupCatalog configured provider management', () => {
     expect(api.providerPanel.value.llmTimeoutSeconds).toBe(321)
     expect(api.modelStrategyPanel.value.single.model).toBe('gpt-4.1')
     expect(api.providerDraftDirty.value).toBe(true)
-    expect(api.sectionDirty('behavior')).toBe(true)
+    expect(api.sectionDirty('general')).toBe(true)
     expect(api.sectionDirty('modelStrategy')).toBe(true)
     app.unmount()
   })

--- a/opensquilla-webui/src/composables/setup/useSetupCatalog.ts
+++ b/opensquilla-webui/src/composables/setup/useSetupCatalog.ts
@@ -1378,14 +1378,6 @@ const networkObservabilityDisabledByEnvironment = computed(() => (
   currentEffectiveNetworkObservabilityDisabled.value && !currentDisableNetworkObservability.value
 ))
 const privacyDirty = computed(() => disableNetworkObservability.value !== currentDisableNetworkObservability.value)
-const privacyStatusText = computed(() => {
-  if (networkObservabilityDisabledByEnvironment.value && !disableNetworkObservability.value) {
-    return t('setup.privacy.statusDisabledByEnv')
-  }
-  return disableNetworkObservability.value
-    ? t('setup.privacy.statusDisabled')
-    : t('setup.privacy.statusEnabled')
-})
 
 
 const modelSummary = computed(() => {
@@ -1865,11 +1857,15 @@ const behaviorPanel = behaviorForm.createPanel({
 })
 
 const privacyPanel = computed(() => ({
-  disableNetworkObservability: disableNetworkObservability.value,
-  disableNetworkObservabilityDirty: privacyDirty.value,
-  memoryAutoCapture: promotedForm.memoryAutoCapture.value,
-  memoryAutoCaptureDirty: promotedForm.captureDirty.value,
-  statusText: privacyStatusText.value,
+  networkReportingEnabled: !(
+    disableNetworkObservability.value || networkObservabilityDisabledByEnvironment.value
+  ),
+  networkReportingForcedOff: networkObservabilityDisabledByEnvironment.value,
+}))
+
+const memoryPanel = computed(() => ({
+  autoCapture: promotedForm.memoryAutoCapture.value,
+  autoCaptureDirty: promotedForm.captureDirty.value,
 }))
 
 const isOpenrouterProvider = computed(() => currentProvider.value.toLowerCase() === 'openrouter')
@@ -2229,7 +2225,7 @@ function firstActionSection(): SettingsSectionId {
 }
 
 function sectionStatus(sectionId: string): { label: string; tone: string } {
-  if (sectionId === 'connection') {
+  if (sectionId === 'gateway') {
     if (rpc.isConnected) return { label: t('setup.connection.connected'), tone: 'is-ok' }
     if (rpc.isConnecting) return { label: t('setup.connection.connecting'), tone: 'is-muted' }
     return { label: t('setup.connection.disconnected'), tone: 'is-warn' }
@@ -2238,11 +2234,16 @@ function sectionStatus(sectionId: string): { label: string; tone: string } {
     if (providerEnvMissing.value) return { label: t('setup.readiness.needsAction'), tone: 'is-warn' }
     return detailStepStatus((status.value.sectionDetails || {}).llm || (status.value.sectionDetails || {}).provider)
   }
-  // Behavior/Privacy/Ensemble are always-valid preference toggles, not
+  // General/Security/Memory are always-valid preference toggles, not
   // readiness milestones — a neutral dot (rather than a green "Live" that
   // overstates earned readiness) is honest; the dirty pip already signals
   // unsaved edits.
-  if (sectionId === 'behavior' || sectionId === 'privacy' || sectionId === 'ensemble') {
+  if (
+    sectionId === 'general'
+    || sectionId === 'securityPrivacy'
+    || sectionId === 'memory'
+    || sectionId === 'ensemble'
+  ) {
     return { label: t('setup.status.appliesOnSave'), tone: 'is-muted' }
   }
   if (sectionId === 'modelStrategy' && !hasSavedProvider.value) {
@@ -2306,7 +2307,8 @@ const providerDirty = computed(() => (
   || (editingPrimaryProvider.value && promotedForm.contextWindowDirty.value)
 ))
 const behaviorDirty = computed(() => behaviorForm.isDirty.value)
-const privacySectionDirty = computed(() => privacyDirty.value || promotedForm.captureDirty.value)
+const securityPrivacyDirty = computed(() => privacyDirty.value)
+const memorySettingsDirty = computed(() => promotedForm.captureDirty.value)
 const modelStrategyDirty = computed(() => (
   routerForm.isDirty.value
   || ensembleForm.isDirty.value
@@ -2324,8 +2326,9 @@ function sectionDirty(sectionId: string): boolean {
   // Provider drafts are intentionally absent from the global settings dirty
   // state. Their editor owns an explicit Save changes action.
   if (sectionId === 'provider') return false
-  if (sectionId === 'behavior') return behaviorDirty.value
-  if (sectionId === 'privacy') return privacySectionDirty.value
+  if (sectionId === 'general') return behaviorDirty.value
+  if (sectionId === 'securityPrivacy') return securityPrivacyDirty.value
+  if (sectionId === 'memory') return memorySettingsDirty.value
   if (sectionId === 'modelStrategy') return modelStrategyDirty.value
   if (sectionId === 'capabilities') return capabilitiesDirty.value
   return false
@@ -2343,7 +2346,8 @@ async function saveDirtySections() {
     // otherwise refresh the catalog and make later dirty flags disappear while
     // their drafts are still waiting to be persisted.
     const work = {
-      privacy: privacySectionDirty.value,
+      privacy: securityPrivacyDirty.value,
+      memoryCapture: memorySettingsDirty.value,
       provider: false,
       behavior: behaviorDirty.value,
       modelStrategy: modelStrategyDirty.value,
@@ -2371,6 +2375,7 @@ async function saveDirtySections() {
     const selectedProviderId = normalizeProviderId(providerForm.selectedProvider.value)
     const restoreProfileSelection = providerSelectionKind.value !== 'primary'
     if (work.privacy && !(await savePrivacy(disableNetworkObservability.value, { reload: false }))) return
+    if (work.memoryCapture && !(await saveMemoryAutoCapture({ reload: false }))) return
     if (work.behavior && !(await saveBehavior({ reload: false }))) return
     if (work.modelStrategy && !(await saveModelStrategy({
       reload: false,
@@ -2682,6 +2687,11 @@ function setAutoSessionTitles(enabled: boolean) {
 
 function setDisableNetworkObservability(enabled: boolean) {
   disableNetworkObservability.value = enabled
+}
+
+function setNetworkReportingEnabled(enabled: boolean) {
+  if (networkObservabilityDisabledByEnvironment.value) return
+  setDisableNetworkObservability(!enabled)
 }
 
 function setMemoryAutoCapture(enabled: boolean) {
@@ -3628,7 +3638,6 @@ async function savePrivacy(
   try {
     const restart = await safePatchConfig({
       'privacy.disable_network_observability': value,
-      ...promotedForm.memoryPatches(),
     })
     if (options.reload === false) {
       config.value = {
@@ -3644,6 +3653,29 @@ async function savePrivacy(
       await loadData()
     }
     pushToast(restart ? t('setup.toast.privacySavedRestart') : t('setup.toast.privacySaved'))
+    return true
+  } catch (err) {
+    pushToast(saveFailedMessage(err), { tone: 'danger' })
+    return false
+  }
+}
+
+async function saveMemoryAutoCapture(options: SaveOptions = {}): Promise<boolean> {
+  try {
+    const restart = await safePatchConfig(promotedForm.memoryPatches())
+    if (options.reload === false) {
+      config.value = {
+        ...config.value,
+        memory: {
+          ...(config.value.memory || {}),
+          auto_capture_enabled: promotedForm.memoryAutoCapture.value,
+        },
+      }
+      promotedForm.initMemoryCaptureFromConfig(config.value)
+    } else {
+      await loadData()
+    }
+    pushToast(restart ? t('setup.toast.memorySavedRestart') : t('setup.toast.memorySaved'))
     return true
   } catch (err) {
     pushToast(saveFailedMessage(err), { tone: 'danger' })
@@ -3919,6 +3951,7 @@ async function copyConfigPath() {
     providerPanel,
     behaviorPanel,
     privacyPanel,
+    memoryPanel,
     modelStrategyPanel,
     routerPanel,
     presetPanel,
@@ -3952,6 +3985,7 @@ async function copyConfigPath() {
     cancelProviderEdit,
     setAutoSessionTitles,
     setDisableNetworkObservability,
+    setNetworkReportingEnabled,
     setMemoryAutoCapture,
     setProviderImageGenerationOptIn,
     setModelStrategy: modelStrategyForm.setStrategy,
@@ -3998,6 +4032,7 @@ async function copyConfigPath() {
     saveProvider,
     saveBehavior,
     savePrivacy,
+    saveMemoryAutoCapture,
     saveRouter,
     saveEnsemble,
     saveModelStrategy,

--- a/opensquilla-webui/src/i18n/i18n.test.ts
+++ b/opensquilla-webui/src/i18n/i18n.test.ts
@@ -327,7 +327,6 @@ describe('catalog parity', () => {
       'chat.routeFeedback.',
     ]
     const ensembleKeys = new Set([
-      'settings.rail.ensemble',
       'setup.provider.activateEnsembleOnPreserved',
       'setup.provider.routingDesc',
       'setup.toast.ensembleSaved',
@@ -343,12 +342,10 @@ describe('catalog parity', () => {
 
     expect(deprecated).toEqual([])
     expect({
-      rail: zhHans.settings.rail.ensemble,
       setup: zhHans.setup.router.summaryEnsemble,
       composer: zhHans.chat.composer.modelRoutingEnsemble,
       runtime: zhHans.chat.routerFx.ensembleSelecting,
     }).toEqual({
-      rail: '模型融合',
       setup: 'AI 智能融合路由',
       composer: 'AI 智能融合路由',
       runtime: 'AI 智能融合路由 · 正在选择候选',

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -283,8 +283,8 @@
   },
   "settings": {
     "appearance": {
-      "title": "Darstellung",
-      "desc": "Design, Sprache und lokale Oberflächeneinstellungen für diesen Browser. Voreinstellungen werden sofort übernommen; eine benutzerdefinierte Breite wird mit Anwenden bestätigt.",
+      "title": "Oberfläche",
+      "desc": "Design und lokale Oberflächeneinstellungen für diesen Browser. Voreinstellungen werden sofort übernommen; eine benutzerdefinierte Breite wird mit Anwenden bestätigt.",
       "themeLabel": "Design",
       "themeDesc": "Dem System folgen oder hell bzw. dunkel erzwingen. Der Schalter in der Seitenleiste ist eine Verknüpfung zu dieser Einstellung.",
       "languageLabel": "Sprache",
@@ -533,26 +533,44 @@
       "discardBody": "Es gibt ungespeicherte Änderungen. Beim Schließen gehen sie verloren.",
       "discardConfirmPrimary": "Änderungen verwerfen"
     },
+    "gateway": {
+      "title": "Gateway",
+      "desc": "Mit dem Gateway verbinden und auf dem Desktop die lokale Laufzeit verwalten."
+    },
+    "general": {
+      "title": "Allgemein",
+      "desc": "App-weite Sprache, Sitzungs- und Desktop-Fensterstandards festlegen."
+    },
+    "securityPrivacy": {
+      "title": "Sicherheit & Datenschutz",
+      "desc": "Diagnoseeinstellungen, Desktop-Vorschauen und Werkzeugisolierung verwalten."
+    },
+    "memoryOverview": {
+      "title": "Speicher",
+      "desc": "Festlegen, was OpenSquilla speichert, und optionale Lernfunktionen verwalten.",
+      "autoCaptureLabel": "Automatisches Speichern",
+      "autoCaptureDesc": "OpenSquilla darf nützliche Gesprächsinhalte im Langzeitspeicher sichern.",
+      "learningSummary": "Speicher und Selbstlernen (erweitert)",
+      "learningDesc": "Optionale Lernfunktionen können zusätzliche Modell-Tokens verwenden und einen Neustart erfordern.",
+      "profileImportLabel": "Profilimport",
+      "profileImportDesc": "Kompatible Identitäts- und Speicherdaten prüfen und importieren.",
+      "profileImportAction": "Öffnen"
+    },
     "rail": {
-      "connection": "Verbindung",
-      "runtime": "Laufzeit",
+      "gateway": "Gateway",
       "provider": "Modelldienst",
       "modelStrategy": "Modellrouting",
-      "behavior": "Verhalten",
-      "privacy": "Datenschutz",
-      "sandbox": "Sandbox",
-      "memory": "Gedächtnis und Profil",
-      "router": "Router",
-      "ensemble": "Ensemble",
       "capabilities": "Fähigkeiten",
-      "appearance": "Darstellung",
-      "keyboard": "Tastatur",
+      "general": "Allgemein",
+      "interface": "Oberfläche",
+      "shortcuts": "Tastenkürzel",
+      "securityPrivacy": "Sicherheit & Datenschutz",
+      "memory": "Speicher",
       "advanced": "Erweitert",
       "groups": {
-        "gateway": "Gateway",
         "ai": "AI-Konfiguration",
         "preferences": "Einstellungen",
-        "capabilities": "Fähigkeiten"
+        "safetyData": "Sicherheit & Daten"
       }
     }
   },
@@ -585,7 +603,7 @@
       "advancedTitle": "Erweitert · integrierte CLI",
       "hintBundled": "Diese Befehle verwenden die in der App integrierte CLI; zum Ausführen in ein Terminal einfügen.",
       "hintDev": "Dev-Modus: Befehle laufen über uv aus dem Quell-Checkout.",
-      "restartHint": "Zum Anwenden Einstellungen → Runtime → Neu starten der App verwenden."
+      "restartHint": "Zum Anwenden Einstellungen → Gateway → Neu starten verwenden."
     },
     "common": {
       "apiKey": "API-Schlüssel",
@@ -1520,7 +1538,7 @@
       "migrationCompleteDismiss": "Ausblenden"
     },
     "keyboard": {
-      "title": "Tastatur",
+      "title": "Tastenkürzel",
       "desc": "Globale Tastenkürzel für diesen Browser. Änderungen werden sofort übernommen — kein Speichern nötig.",
       "addModifier": "{modifier} (und optional ⇧ / ⌥) zur Taste hinzufügen.",
       "conflict": "Bereits verwendet von „{label}“.",
@@ -1534,6 +1552,8 @@
       "desc": "Experimentelle Client-Einstellungen für diesen Browser. Sie werden sofort übernommen — kein Speichern nötig. Markierte Elemente",
       "reload": "neu laden",
       "descReloadSuffix": "werden nach einer Seitenaktualisierung wirksam.",
+      "experimentsGroup": "Experimente",
+      "managementGroup": "Verwaltung",
       "foldLabel": "Neue Live-Turn-Darstellung",
       "foldDesc": "Erstellt die gestreamte Arbeitskarte aus einem geordneten Ereignisprotokoll. Nur zur vorübergehenden Rückkehr zur kompatiblen Darstellung ausschalten.",
       "foldAria": "Neue Live-Turn-Darstellung (wird nach dem Neuladen wirksam)",
@@ -1560,15 +1580,9 @@
       "runTraceAria": "Run-Trace-Schublade in Protokollen (wird nach dem Neuladen wirksam)"
     },
     "privacy": {
-      "title": "Datenschutz",
-      "statusEnabled": "Netzwerkberichte sind eingeschaltet.",
-      "statusDisabled": "Netzwerkberichte sind ausgeschaltet.",
-      "statusDisabledByEnv": "Netzwerkberichte sind ausgeschaltet, weil eine Umgebungsvariable sie deaktiviert.",
-      "disableNetworkObservabilityLabel": "Netzwerkberichte ausschalten",
-      "disableNetworkObservabilityDesc": "Stoppt Installations- und tägliche Nutzungstelemetrie, Updateprüfungen im Hintergrund sowie pseudonyme Sitzungskennungen und den standardmäßig gesendeten optionalen sitzungsübergreifenden Header X-OpenSquilla-Install-Id, die ausschließlich an die offizielle TokenRhythm-HTTPS-API gesendet werden. Die persistierte Installationskennung kann aus lokalen MAC-/IP-Daten abgeleitet werden; Rohadressen werden nie gesendet. CI/Tests und der alte Telemetrie-Opt-out unterdrücken sie ebenfalls, der reine Update-Opt-out dagegen nicht. Ihre eigenen Modellanfragen funktionieren weiterhin.",
-      "memoryAutoCaptureLabel": "Automatisches Speichern",
-      "memoryAutoCaptureDesc": "OpenSquilla darf nützliche Gesprächsinhalte im Langzeitspeicher sichern.",
-      "save": "Datenschutz speichern"
+      "statusDisabledByEnv": "Durch eine Umgebungseinstellung deaktiviert.",
+      "networkReportingLabel": "Diagnose und Updates",
+      "networkReportingDesc": "Begrenzte Produktdiagnosedaten senden und nach Updates suchen. Gesprächsinhalte, Dateien und Inhalte von Modellanfragen werden nicht hochgeladen."
     },
     "toast": {
       "loadFailed": "Einstellungen konnten nicht geladen werden: {error}",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -283,8 +283,8 @@
   },
   "settings": {
     "appearance": {
-      "title": "Appearance",
-      "desc": "Theme, language, and browser-local interface preferences. Presets apply instantly; custom widths use Apply.",
+      "title": "Interface",
+      "desc": "Theme and browser-local interface preferences. Presets apply instantly; custom widths use Apply.",
       "themeLabel": "Theme",
       "themeDesc": "Follow your system, or force light or dark. The sidebar toggle is a shortcut to this same setting.",
       "languageLabel": "Language",
@@ -584,26 +584,44 @@
       "discardBody": "You have unsaved edits. Closing now will lose them.",
       "discardConfirmPrimary": "Discard changes"
     },
+    "gateway": {
+      "title": "Gateway",
+      "desc": "Connect to the Gateway and, on Desktop, manage the local runtime."
+    },
+    "general": {
+      "title": "General",
+      "desc": "App-wide language, session, and Desktop window defaults."
+    },
+    "securityPrivacy": {
+      "title": "Security & Privacy",
+      "desc": "Manage diagnostic preferences, Desktop previews, and tool isolation."
+    },
+    "memoryOverview": {
+      "title": "Memory",
+      "desc": "Choose what OpenSquilla remembers and manage optional learning features.",
+      "autoCaptureLabel": "Automatic memory capture",
+      "autoCaptureDesc": "Allow OpenSquilla to save useful conversation highlights into long-term memory.",
+      "learningSummary": "Memory and self-learning (advanced)",
+      "learningDesc": "Optional learning controls can use additional model tokens and may require a restart.",
+      "profileImportLabel": "Profile import",
+      "profileImportDesc": "Review and import compatible identity and memory data.",
+      "profileImportAction": "Open"
+    },
     "rail": {
-      "connection": "Connection",
-      "runtime": "Runtime",
+      "gateway": "Gateway",
       "provider": "Model Service",
       "modelStrategy": "Model Routing",
-      "behavior": "Behavior",
-      "privacy": "Privacy",
-      "sandbox": "Sandbox",
-      "memory": "Memory & Profile",
-      "router": "Router",
-      "ensemble": "Ensemble",
       "capabilities": "Capabilities",
-      "appearance": "Appearance",
-      "keyboard": "Keyboard",
+      "general": "General",
+      "interface": "Interface",
+      "shortcuts": "Shortcuts",
+      "securityPrivacy": "Security & Privacy",
+      "memory": "Memory",
       "advanced": "Advanced",
       "groups": {
-        "gateway": "Gateway",
         "ai": "AI configuration",
         "preferences": "Preferences",
-        "capabilities": "Capabilities"
+        "safetyData": "Safety & Data"
       }
     }
   },
@@ -636,7 +654,7 @@
       "advancedTitle": "Advanced · built-in CLI",
       "hintBundled": "These commands use the CLI bundled with the app; paste into a terminal to run.",
       "hintDev": "Dev mode: commands run from the source checkout via uv.",
-      "restartHint": "Use the app's Settings → Runtime → Restart to apply."
+      "restartHint": "Use the app's Settings → Gateway → Restart to apply."
     },
     "common": {
       "apiKey": "API key",
@@ -1571,7 +1589,7 @@
       "migrationCompleteDismiss": "Dismiss"
     },
     "keyboard": {
-      "title": "Keyboard",
+      "title": "Shortcuts",
       "desc": "Global shortcuts for this browser. Changes apply instantly — no save needed.",
       "addModifier": "Add {modifier} (and optionally ⇧ / ⌥) to the key.",
       "conflict": "Already used by “{label}”.",
@@ -1585,6 +1603,8 @@
       "desc": "Experimental client preferences for this browser. They apply instantly — no save needed. Items marked",
       "reload": "reload",
       "descReloadSuffix": "take effect after a page refresh.",
+      "experimentsGroup": "Experiments",
+      "managementGroup": "Management",
       "foldLabel": "New live turn renderer",
       "foldDesc": "Build the streaming work card from an ordered event log. Turn off only to temporarily restore the compatibility renderer.",
       "foldAria": "New live turn renderer (takes effect after reload)",
@@ -1611,15 +1631,9 @@
       "runTraceAria": "Run-trace drawer in Logs (takes effect after reload)"
     },
     "privacy": {
-      "title": "Privacy",
-      "statusEnabled": "Network reporting is on.",
-      "statusDisabled": "Network reporting is off.",
-      "statusDisabledByEnv": "Network reporting is off because an environment setting disables it.",
-      "disableNetworkObservabilityLabel": "Turn off network reporting",
-      "disableNetworkObservabilityDesc": "Stops install and daily usage telemetry, background update checks, pseudonymous session identifiers, and the optional cross-session X-OpenSquilla-Install-Id header sent by default only to the official TokenRhythm HTTPS API. That persisted ID may be derived from local MAC/IP data; raw addresses are never sent. CI/tests and the legacy telemetry opt-out also suppress it; the update-check opt-out alone does not. Your own model requests keep working.",
-      "memoryAutoCaptureLabel": "Automatic memory capture",
-      "memoryAutoCaptureDesc": "Allow OpenSquilla to save useful conversation highlights into long-term memory.",
-      "save": "Save privacy"
+      "statusDisabledByEnv": "Disabled by an environment setting.",
+      "networkReportingLabel": "Diagnostics and updates",
+      "networkReportingDesc": "Share limited product diagnostics and check for updates. Conversation content, files, and model request content are not uploaded."
     },
     "toast": {
       "loadFailed": "Failed to load settings: {error}",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -283,8 +283,8 @@
   },
   "settings": {
     "appearance": {
-      "title": "Apariencia",
-      "desc": "Tema, idioma y preferencias de interfaz locales de este navegador. Los preajustes se aplican al instante; usa Aplicar para un ancho personalizado.",
+      "title": "Interfaz",
+      "desc": "Tema y preferencias de interfaz locales de este navegador. Los preajustes se aplican al instante; usa Aplicar para un ancho personalizado.",
       "themeLabel": "Tema",
       "themeDesc": "Sigue tu sistema o fuerza el modo claro u oscuro. El conmutador de la barra lateral es un atajo a este mismo ajuste.",
       "languageLabel": "Idioma",
@@ -533,26 +533,44 @@
       "discardBody": "Tienes ediciones sin guardar. Si cierras ahora se perderán.",
       "discardConfirmPrimary": "Descartar cambios"
     },
+    "gateway": {
+      "title": "Puerta de enlace",
+      "desc": "Conecta con la puerta de enlace y, en escritorio, gestiona el entorno local."
+    },
+    "general": {
+      "title": "General",
+      "desc": "Configura el idioma, las sesiones y las ventanas para toda la aplicación."
+    },
+    "securityPrivacy": {
+      "title": "Seguridad y privacidad",
+      "desc": "Gestiona las preferencias de diagnóstico, las vistas previas y el aislamiento de herramientas."
+    },
+    "memoryOverview": {
+      "title": "Memoria",
+      "desc": "Elige qué recuerda OpenSquilla y gestiona las funciones opcionales de aprendizaje.",
+      "autoCaptureLabel": "Captura automática de memoria",
+      "autoCaptureDesc": "Permite que OpenSquilla guarde información útil de las conversaciones en la memoria a largo plazo.",
+      "learningSummary": "Memoria y autoaprendizaje (avanzado)",
+      "learningDesc": "Las funciones de aprendizaje opcionales pueden usar tokens adicionales y requerir un reinicio.",
+      "profileImportLabel": "Importación del perfil",
+      "profileImportDesc": "Revisa e importa datos compatibles de identidad y memoria.",
+      "profileImportAction": "Abrir"
+    },
     "rail": {
-      "connection": "Conexión",
-      "runtime": "Tiempo de ejecución",
+      "gateway": "Puerta de enlace",
       "provider": "Servicio de modelos",
       "modelStrategy": "Enrutamiento de modelos",
-      "behavior": "Comportamiento",
-      "privacy": "Privacidad",
-      "sandbox": "Sandbox",
-      "memory": "Memoria y perfil",
-      "router": "Enrutador",
-      "ensemble": "Conjunto",
       "capabilities": "Capacidades",
-      "appearance": "Apariencia",
-      "keyboard": "Teclado",
+      "general": "General",
+      "interface": "Interfaz",
+      "shortcuts": "Atajos",
+      "securityPrivacy": "Seguridad y privacidad",
+      "memory": "Memoria",
       "advanced": "Avanzado",
       "groups": {
-        "gateway": "Puerta de enlace",
         "ai": "Configuración de IA",
         "preferences": "Preferencias",
-        "capabilities": "Capacidades"
+        "safetyData": "Seguridad y datos"
       }
     }
   },
@@ -585,7 +603,7 @@
       "advancedTitle": "Avanzado · CLI integrada",
       "hintBundled": "Estos comandos usan la CLI integrada en la aplicación; pégalos en una terminal para ejecutarlos.",
       "hintDev": "Modo dev: los comandos se ejecutan desde el checkout del código fuente vía uv.",
-      "restartHint": "Usa Ajustes → Runtime → Reiniciar de la aplicación para aplicar."
+      "restartHint": "Usa Ajustes → Puerta de enlace → Reiniciar para aplicar."
     },
     "common": {
       "apiKey": "Clave de API",
@@ -1520,7 +1538,7 @@
       "migrationCompleteDismiss": "Cerrar"
     },
     "keyboard": {
-      "title": "Teclado",
+      "title": "Atajos",
       "desc": "Atajos globales para este navegador. Los cambios se aplican al instante; no es necesario guardar.",
       "addModifier": "Añade {modifier} (y opcionalmente ⇧ / ⌥) a la tecla.",
       "conflict": "Ya lo usa «{label}».",
@@ -1534,6 +1552,8 @@
       "desc": "Preferencias experimentales del cliente para este navegador. Se aplican al instante; no es necesario guardar. Los elementos marcados con",
       "reload": "recargar",
       "descReloadSuffix": "surten efecto tras actualizar la página.",
+      "experimentsGroup": "Experimentos",
+      "managementGroup": "Gestión",
       "foldLabel": "Nuevo renderizado de turnos en vivo",
       "foldDesc": "Construye la tarjeta de trabajo en streaming desde un registro ordenado de eventos. Desactívalo solo para restaurar temporalmente el renderizado compatible.",
       "foldAria": "Nuevo renderizado de turnos en vivo (surte efecto tras recargar)",
@@ -1560,15 +1580,9 @@
       "runTraceAria": "Panel de traza de ejecución en Registros (surte efecto tras recargar)"
     },
     "privacy": {
-      "title": "Privacidad",
-      "statusEnabled": "Los informes de red están activados.",
-      "statusDisabled": "Los informes de red están desactivados.",
-      "statusDisabledByEnv": "Los informes de red están desactivados por una variable de entorno.",
-      "disableNetworkObservabilityLabel": "Desactivar los informes de red",
-      "disableNetworkObservabilityDesc": "Detiene la telemetría de instalación y de uso diario, las comprobaciones de actualizaciones en segundo plano, los identificadores seudónimos de sesión y la cabecera opcional X-OpenSquilla-Install-Id entre sesiones, enviada de forma predeterminada solo a la API HTTPS oficial de TokenRhythm. El ID de instalación persistente puede derivarse de datos MAC/IP locales; nunca se envían las direcciones originales. Los entornos CI/pruebas y la exclusión heredada de telemetría también lo suprimen; desactivar solo las actualizaciones no. Tus propias solicitudes de modelo siguen funcionando.",
-      "memoryAutoCaptureLabel": "Captura automática de memoria",
-      "memoryAutoCaptureDesc": "Permite que OpenSquilla guarde información útil de las conversaciones en la memoria a largo plazo.",
-      "save": "Guardar privacidad"
+      "statusDisabledByEnv": "Desactivados por una configuración del entorno.",
+      "networkReportingLabel": "Diagnóstico y actualizaciones",
+      "networkReportingDesc": "Comparte datos limitados de diagnóstico del producto y busca actualizaciones. No se suben conversaciones, archivos ni el contenido de solicitudes al modelo."
     },
     "toast": {
       "loadFailed": "No se pudieron cargar los ajustes: {error}",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -283,8 +283,8 @@
   },
   "settings": {
     "appearance": {
-      "title": "Apparence",
-      "desc": "Thème, langue et préférences d'interface locales à ce navigateur. Les préréglages s'appliquent immédiatement ; utilisez Appliquer pour une largeur personnalisée.",
+      "title": "Interface",
+      "desc": "Thème et préférences d'interface locales à ce navigateur. Les préréglages s'appliquent immédiatement ; utilisez Appliquer pour une largeur personnalisée.",
       "themeLabel": "Thème",
       "themeDesc": "Suivez votre système, ou forcez le mode clair ou sombre. Le bouton de la barre latérale est un raccourci vers ce même paramètre.",
       "languageLabel": "Langue",
@@ -533,26 +533,44 @@
       "discardBody": "Vous avez des modifications non enregistrées. Fermer maintenant les perdra.",
       "discardConfirmPrimary": "Abandonner les modifications"
     },
+    "gateway": {
+      "title": "Passerelle",
+      "desc": "Connectez-vous à la passerelle et, sur ordinateur, gérez l'environnement local."
+    },
+    "general": {
+      "title": "Général",
+      "desc": "Définissez la langue, les sessions et le comportement des fenêtres pour toute l'application."
+    },
+    "securityPrivacy": {
+      "title": "Sécurité et confidentialité",
+      "desc": "Gérez les préférences de diagnostic, les aperçus sur ordinateur et l'isolation des outils."
+    },
+    "memoryOverview": {
+      "title": "Mémoire",
+      "desc": "Choisissez ce qu'OpenSquilla mémorise et gérez les fonctions d'apprentissage facultatives.",
+      "autoCaptureLabel": "Capture automatique de la mémoire",
+      "autoCaptureDesc": "Autorise OpenSquilla à enregistrer les informations utiles des conversations dans la mémoire à long terme.",
+      "learningSummary": "Mémoire et auto-apprentissage (avancé)",
+      "learningDesc": "Les fonctions d'apprentissage facultatives peuvent utiliser des jetons supplémentaires et nécessiter un redémarrage.",
+      "profileImportLabel": "Importation du profil",
+      "profileImportDesc": "Examinez et importez des données d'identité et de mémoire compatibles.",
+      "profileImportAction": "Ouvrir"
+    },
     "rail": {
-      "connection": "Connexion",
-      "runtime": "Environnement d'exécution",
+      "gateway": "Passerelle",
       "provider": "Service de modèles",
       "modelStrategy": "Routage des modèles",
-      "behavior": "Comportement",
-      "privacy": "Confidentialité",
-      "sandbox": "Bac à sable",
-      "memory": "Mémoire et profil",
-      "router": "Routeur",
-      "ensemble": "Ensemble",
       "capabilities": "Capacités",
-      "appearance": "Apparence",
-      "keyboard": "Clavier",
+      "general": "Général",
+      "interface": "Interface",
+      "shortcuts": "Raccourcis",
+      "securityPrivacy": "Sécurité et confidentialité",
+      "memory": "Mémoire",
       "advanced": "Avancé",
       "groups": {
-        "gateway": "Passerelle",
         "ai": "Configuration IA",
         "preferences": "Préférences",
-        "capabilities": "Capacités"
+        "safetyData": "Sécurité et données"
       }
     }
   },
@@ -585,7 +603,7 @@
       "advancedTitle": "Avancé · CLI intégrée",
       "hintBundled": "Ces commandes utilisent la CLI intégrée à l'application ; collez-les dans un terminal pour les exécuter.",
       "hintDev": "Mode dev : les commandes s'exécutent depuis la copie source via uv.",
-      "restartHint": "Utilisez Réglages → Runtime → Redémarrer de l'application pour appliquer."
+      "restartHint": "Utilisez Réglages → Passerelle → Redémarrer pour appliquer."
     },
     "common": {
       "apiKey": "Clé API",
@@ -1520,7 +1538,7 @@
       "migrationCompleteDismiss": "Fermer"
     },
     "keyboard": {
-      "title": "Clavier",
+      "title": "Raccourcis",
       "desc": "Raccourcis globaux pour ce navigateur. Les changements s'appliquent immédiatement — aucun enregistrement nécessaire.",
       "addModifier": "Ajoutez {modifier} (et éventuellement ⇧ / ⌥) à la touche.",
       "conflict": "Déjà utilisé par « {label} ».",
@@ -1534,6 +1552,8 @@
       "desc": "Préférences client expérimentales pour ce navigateur. Elles s'appliquent immédiatement — aucun enregistrement nécessaire. Les éléments marqués",
       "reload": "recharger",
       "descReloadSuffix": "prennent effet après un rafraîchissement de la page.",
+      "experimentsGroup": "Expériences",
+      "managementGroup": "Gestion",
       "foldLabel": "Nouveau rendu des tours en direct",
       "foldDesc": "Construit la carte de travail en streaming à partir d'un journal d'événements ordonné. Désactivez-le uniquement pour rétablir temporairement le rendu compatible.",
       "foldAria": "Nouveau rendu des tours en direct (prend effet après rechargement)",
@@ -1560,15 +1580,9 @@
       "runTraceAria": "Tiroir de trace d'exécution dans les Journaux (prend effet après rechargement)"
     },
     "privacy": {
-      "title": "Confidentialité",
-      "statusEnabled": "Les rapports réseau sont activés.",
-      "statusDisabled": "Les rapports réseau sont désactivés.",
-      "statusDisabledByEnv": "Les rapports réseau sont désactivés par une variable d'environnement.",
-      "disableNetworkObservabilityLabel": "Désactiver les rapports réseau",
-      "disableNetworkObservabilityDesc": "Arrête la télémétrie d'installation et d'usage quotidien, les vérifications de mise à jour en arrière-plan, les identifiants pseudonymes de session et l'en-tête intersession facultatif X-OpenSquilla-Install-Id, envoyé par défaut uniquement à l'API HTTPS officielle de TokenRhythm. L'identifiant d'installation persistant peut être dérivé de données MAC/IP locales ; les adresses brutes ne sont jamais envoyées. Les environnements CI/test et l'ancien refus de télémétrie le suppriment aussi ; le refus des seules mises à jour ne le fait pas. Vos propres requêtes de modèle continuent de fonctionner.",
-      "memoryAutoCaptureLabel": "Capture automatique de la mémoire",
-      "memoryAutoCaptureDesc": "Autorise OpenSquilla à enregistrer les informations utiles des conversations dans la mémoire à long terme.",
-      "save": "Enregistrer la confidentialité"
+      "statusDisabledByEnv": "Désactivés par un paramètre d’environnement.",
+      "networkReportingLabel": "Diagnostics et mises à jour",
+      "networkReportingDesc": "Partage des données de diagnostic produit limitées et recherche les mises à jour. Le contenu des conversations, les fichiers et les requêtes de modèle ne sont pas envoyés."
     },
     "toast": {
       "loadFailed": "Échec du chargement des paramètres : {error}",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -283,8 +283,8 @@
   },
   "settings": {
     "appearance": {
-      "title": "外観",
-      "desc": "このブラウザーのテーマ、言語、ローカルの表示設定です。プリセットは即時に反映され、カスタム幅は「適用」で確定します。",
+      "title": "インターフェース",
+      "desc": "このブラウザーのテーマとローカルの表示設定です。プリセットは即時に反映され、カスタム幅は「適用」で確定します。",
       "themeLabel": "テーマ",
       "themeDesc": "システムに従うか、ライトまたはダークを指定します。サイドバーの切り替えはこの設定へのショートカットです。",
       "languageLabel": "言語",
@@ -533,26 +533,44 @@
       "discardBody": "未保存の編集があります。今閉じると失われます。",
       "discardConfirmPrimary": "変更を破棄"
     },
+    "gateway": {
+      "title": "ゲートウェイ",
+      "desc": "ゲートウェイへ接続し、デスクトップではローカルランタイムも管理します。"
+    },
+    "general": {
+      "title": "一般",
+      "desc": "アプリ全体の言語、セッション、デスクトップウィンドウの既定値を設定します。"
+    },
+    "securityPrivacy": {
+      "title": "セキュリティとプライバシー",
+      "desc": "診断設定、デスクトッププレビュー、ツール分離を管理します。"
+    },
+    "memoryOverview": {
+      "title": "メモリ",
+      "desc": "OpenSquilla が記憶する内容と任意の学習機能を管理します。",
+      "autoCaptureLabel": "自動メモリ",
+      "autoCaptureDesc": "OpenSquilla が会話の有用な情報を長期メモリに保存することを許可します。",
+      "learningSummary": "メモリと自己学習（詳細）",
+      "learningDesc": "任意の学習機能は追加のモデルトークンを使い、再起動が必要な場合があります。",
+      "profileImportLabel": "プロフィールのインポート",
+      "profileImportDesc": "互換性のある ID とメモリのデータを確認して取り込みます。",
+      "profileImportAction": "開く"
+    },
     "rail": {
-      "connection": "接続",
-      "runtime": "ランタイム",
+      "gateway": "ゲートウェイ",
       "provider": "モデルサービス",
       "modelStrategy": "モデルルーティング",
-      "behavior": "動作",
-      "privacy": "プライバシー",
-      "sandbox": "サンドボックス",
-      "memory": "メモリとプロフィール",
-      "router": "ルーター",
-      "ensemble": "アンサンブル",
       "capabilities": "機能",
-      "appearance": "外観",
-      "keyboard": "キーボード",
+      "general": "一般",
+      "interface": "インターフェース",
+      "shortcuts": "ショートカット",
+      "securityPrivacy": "セキュリティとプライバシー",
+      "memory": "メモリ",
       "advanced": "詳細設定",
       "groups": {
-        "gateway": "ゲートウェイ",
         "ai": "AI 設定",
         "preferences": "環境設定",
-        "capabilities": "機能"
+        "safetyData": "セキュリティとデータ"
       }
     }
   },
@@ -585,7 +603,7 @@
       "advancedTitle": "詳細 · 内蔵 CLI",
       "hintBundled": "これらのコマンドはアプリ内蔵の CLI を使用します。ターミナルに貼り付けて実行できます。",
       "hintDev": "開発モード：コマンドは uv 経由でソースチェックアウトから実行されます。",
-      "restartHint": "アプリの「設定 → ランタイム → 再起動」で反映してください。"
+      "restartHint": "アプリの「設定 → ゲートウェイ → 再起動」で反映してください。"
     },
     "common": {
       "apiKey": "API キー",
@@ -1520,7 +1538,7 @@
       "migrationCompleteDismiss": "閉じる"
     },
     "keyboard": {
-      "title": "キーボード",
+      "title": "ショートカット",
       "desc": "このブラウザーのグローバルショートカットです。変更は即時に反映され、保存は不要です。",
       "addModifier": "キーに {modifier}（および任意で ⇧ / ⌥）を追加します。",
       "conflict": "すでに「{label}」で使用されています。",
@@ -1534,6 +1552,8 @@
       "desc": "このブラウザー向けの実験的なクライアント設定です。即時に反映されます。次のマークが付いた項目は",
       "reload": "再読み込み",
       "descReloadSuffix": "ページ更新後に有効になります。",
+      "experimentsGroup": "実験機能",
+      "managementGroup": "管理",
       "foldLabel": "新しいライブターン描画",
       "foldDesc": "順序付きイベントログからストリーミング中の作業カードを描画します。互換描画へ一時的に戻す場合のみオフにします。",
       "foldAria": "新しいライブターン描画（再読み込み後に有効）",
@@ -1560,15 +1580,9 @@
       "runTraceAria": "ログの実行トレースドロワー（再読み込み後に有効）"
     },
     "privacy": {
-      "title": "プライバシー",
-      "statusEnabled": "ネットワーク報告はオンです。",
-      "statusDisabled": "ネットワーク報告はオフです。",
-      "statusDisabledByEnv": "環境変数の設定により、ネットワーク報告はオフになっています。",
-      "disableNetworkObservabilityLabel": "ネットワーク報告をオフにする",
-      "disableNetworkObservabilityDesc": "インストールおよび日次使用量テレメトリ、バックグラウンドの更新確認、公式 TokenRhythm HTTPS API にのみ送信されるセッション用の仮名識別子と、デフォルトで送信されるセッションをまたぐ任意の X-OpenSquilla-Install-Id ヘッダーを停止します。永続化されたインストール ID はローカルの MAC/IP データから派生する場合がありますが、生のアドレスは送信されません。CI/テスト環境および旧テレメトリ拒否設定でも抑制されますが、更新確認だけを無効にしても抑制されません。自分で開始したモデルリクエストはそのまま動作します。",
-      "memoryAutoCaptureLabel": "自動メモリ",
-      "memoryAutoCaptureDesc": "OpenSquilla が会話の有用な情報を長期メモリに保存することを許可します。",
-      "save": "プライバシーを保存"
+      "statusDisabledByEnv": "環境設定により無効になっています。",
+      "networkReportingLabel": "診断とアップデート",
+      "networkReportingDesc": "限定的な製品診断データを送信してアップデートを確認します。会話内容、ファイル、モデルリクエストの内容はアップロードされません。"
     },
     "toast": {
       "loadFailed": "設定の読み込みに失敗しました: {error}",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -283,8 +283,8 @@
   },
   "settings": {
     "appearance": {
-      "title": "外观",
-      "desc": "此浏览器的主题、语言和本地界面偏好。预设即时生效；自定义宽度需点击应用。",
+      "title": "界面",
+      "desc": "此浏览器的主题和本地界面偏好。预设即时生效；自定义宽度需点击应用。",
       "themeLabel": "主题",
       "themeDesc": "跟随系统，或强制使用浅色或深色。侧边栏的切换按钮是此设置的快捷方式。",
       "languageLabel": "语言",
@@ -584,26 +584,44 @@
       "discardBody": "有尚未保存的编辑，现在关闭将丢失它们。",
       "discardConfirmPrimary": "放弃修改"
     },
+    "gateway": {
+      "title": "网关",
+      "desc": "连接网关；在桌面端还可管理本地运行时。"
+    },
+    "general": {
+      "title": "通用",
+      "desc": "设置全局语言、会话和桌面窗口默认行为。"
+    },
+    "securityPrivacy": {
+      "title": "安全与隐私",
+      "desc": "管理诊断偏好、桌面预览和工具隔离。"
+    },
+    "memoryOverview": {
+      "title": "记忆",
+      "desc": "选择 OpenSquilla 记住的内容，并管理可选学习功能。",
+      "autoCaptureLabel": "自动记忆",
+      "autoCaptureDesc": "允许 OpenSquilla 将对话中有用的信息保存到长期记忆。",
+      "learningSummary": "记忆与自学习（高级）",
+      "learningDesc": "可选学习功能可能消耗额外模型 Token，并可能需要重启。",
+      "profileImportLabel": "画像导入",
+      "profileImportDesc": "检查并导入兼容的身份与记忆数据。",
+      "profileImportAction": "打开"
+    },
     "rail": {
-      "connection": "连接",
-      "runtime": "运行时",
+      "gateway": "网关",
       "provider": "模型服务",
       "modelStrategy": "模型路由",
-      "behavior": "行为",
-      "privacy": "隐私",
-      "sandbox": "沙箱",
-      "memory": "记忆与画像",
-      "router": "路由",
-      "ensemble": "模型融合",
       "capabilities": "能力",
-      "appearance": "外观",
-      "keyboard": "键盘",
+      "general": "通用",
+      "interface": "界面",
+      "shortcuts": "快捷键",
+      "securityPrivacy": "安全与隐私",
+      "memory": "记忆",
       "advanced": "高级",
       "groups": {
-        "gateway": "网关",
         "ai": "AI 配置",
         "preferences": "偏好设置",
-        "capabilities": "能力"
+        "safetyData": "安全与数据"
       }
     }
   },
@@ -636,7 +654,7 @@
       "advancedTitle": "高级 · 内置 CLI",
       "hintBundled": "以下命令使用应用内置的 CLI，可直接粘贴到终端运行。",
       "hintDev": "开发模式：命令经 uv 从源码检出运行。",
-      "restartHint": "请用应用的「设置 → 运行时 → 重启」来生效。"
+      "restartHint": "请用应用的「设置 → 网关 → 重启」来生效。"
     },
     "common": {
       "apiKey": "API 密钥",
@@ -1571,7 +1589,7 @@
       "migrationCompleteDismiss": "关闭提示"
     },
     "keyboard": {
-      "title": "键盘",
+      "title": "快捷键",
       "desc": "此浏览器的全局快捷键。更改会立即生效——无需保存。",
       "addModifier": "在按键中加入 {modifier}（并可选加入 ⇧ / ⌥）。",
       "conflict": "已被“{label}”占用。",
@@ -1585,6 +1603,8 @@
       "desc": "此浏览器的实验性客户端偏好。它们会立即生效——无需保存。标记为",
       "reload": "重新加载",
       "descReloadSuffix": "的项目会在刷新页面后生效。",
+      "experimentsGroup": "实验功能",
+      "managementGroup": "管理",
       "foldLabel": "新版实时回合渲染",
       "foldDesc": "根据有序事件日志渲染流式工作卡片；仅在需要临时回退兼容渲染时关闭。",
       "foldAria": "新版实时回合渲染（重新加载后生效）",
@@ -1611,15 +1631,9 @@
       "runTraceAria": "日志中的运行追踪抽屉（重新加载后生效）"
     },
     "privacy": {
-      "title": "隐私",
-      "statusEnabled": "网络上报已开启。",
-      "statusDisabled": "网络上报已关闭。",
-      "statusDisabledByEnv": "网络上报已被环境变量设置关闭。",
-      "disableNetworkObservabilityLabel": "关闭网络上报",
-      "disableNetworkObservabilityDesc": "停止安装与每日用量遥测、后台更新检查，以及仅发往官方 TokenRhythm HTTPS API 的会话级伪匿名标识和默认发送的可选跨会话 X-OpenSquilla-Install-Id 请求头。该持久化安装 ID 可能由本机 MAC/IP 派生，但绝不发送原始地址；CI/测试环境与旧遥测退出开关也会抑制它，单独关闭更新检查则不会。你主动发起的模型请求不受影响。",
-      "memoryAutoCaptureLabel": "自动记忆",
-      "memoryAutoCaptureDesc": "允许 OpenSquilla 将对话中有用的信息保存到长期记忆。",
-      "save": "保存隐私设置"
+      "statusDisabledByEnv": "已由环境设置关闭。",
+      "networkReportingLabel": "诊断与更新",
+      "networkReportingDesc": "发送有限的产品诊断数据并检查更新；不会上传对话内容、文件或模型请求内容。"
     },
     "toast": {
       "loadFailed": "加载设置失败：{error}",

--- a/opensquilla-webui/vite.config.ts
+++ b/opensquilla-webui/vite.config.ts
@@ -35,7 +35,17 @@ export default defineConfig({
         },
       },
       // RpcClient connects to ws://<host>/ws for the live chat/event stream.
-      '/ws': { target: gatewayTarget, ws: true, changeOrigin: true },
+      // Match the HTTP development proxy above: once Vite rewrites Host to the
+      // gateway, forwarding the browser's Vite Origin would fail the gateway's
+      // same-origin WebSocket guard. This proxy is only exposed by `npm run dev`.
+      '/ws': {
+        target: gatewayTarget,
+        ws: true,
+        changeOrigin: true,
+        configure: (proxy) => {
+          proxy.on('proxyReqWs', (proxyReq) => proxyReq.removeHeader('origin'))
+        },
+      },
       // Backend-owned static assets (brand mark, share-export images, …) that the
       // app loads from `${base}/static/*`. Scope to /control/static ONLY — the
       // bare /control prefix is the SPA router base and must stay with Vite, or


### PR DESCRIPTION
## Scope

- consolidate Settings into ten canonical destinations: Gateway; Model Service; Model Routing; Capabilities; General; Interface; Shortcuts; Security & Privacy; Memory; and Advanced
- merge Connection and desktop Runtime under Gateway, combine ordinary behavior/language preferences under General, and place sandbox/network controls under Security & Privacy
- make Memory a first-level overview with profile import as a nested route
- preserve legacy Settings deep links by canonicalizing old route ids and retaining subsection hashes
- simplify network-reporting language and keep the environment-forced-off state explicit
- make the Vite development WebSocket proxy match the HTTP proxy origin handling
- keep all six locales at full key parity

## Branch target

`main`

## Linked issue

None.

## Release note

User-facing: reorganizes Settings navigation and labels, including Behavior → General, Appearance → Interface, Keyboard → Shortcuts, and the new combined Security & Privacy page.

## Tests

- rebased onto `origin/main` at `4ecac3a68` before the final local validation
- `npm run typecheck`
- affected unit suite: 260 passed across Settings routing/catalog, i18n, desktop preferences, save-pending, and Memory panels
- `npm run build:artifact`
- `desktop/electron: OPENSQUILLA_DESKTOP_GATEWAY_PORT=18894 npm run test:theme-flow`
- isolated Playwright route regressions verified Memory overview/import, the legacy Connection alias, `/config`, and retired editor controls; the pre-existing cold-start focus assertion passed 4/5 repeated runs while the route and subsection assertions passed throughout
- broader unit run: 4,012 passed; 30 default-parallel 5-second timeouts. Every failed file passed single-worker except three unrelated Channels tests, which passed 62/62 with a 15-second timeout.

The broader Settings E2E file already contains stale assertions on `main` for the removed readiness banner and retired routing visual-mode selector; this PR validates the IA-specific routes without expanding into that unrelated cleanup.

## Safety and compatibility

- front-end only; no backend RPC, config schema, persisted state, or database changes
- old Settings URLs remain compatible through canonical route aliases and subsection hashes
- desktop-only controls remain capability-gated after moving into shared pages
- the WebSocket proxy change is limited to the Vite development server
- platform-neutral navigation/content change; desktop-specific controls continue to use the existing platform bridge

## Third-party origin

None.
