### PR TITLE
feat(openai-bridge): 新增 OpenAI 兼容 HTTP 桥接，支持多智能体记忆隔离

### DIFF
--- a/src/opensquilla/agents/scope.py
+++ b/src/opensquilla/agents/scope.py
@@ -84,6 +84,22 @@ def _configured_agent_model(config: object | None, normalized_agent_id: str) -> 
     return _string_value(_configured_agent_field(config, normalized_agent_id, "model"))
 
 
+def is_isolated_custom_agent(config: object | None, agent_id: str) -> bool:
+    """Return True if *agent_id* is a custom agent with its own workspace.
+
+    Custom agents declared in ``[[agents]]`` with a ``workspace`` field are
+    memory-isolated: they must NOT fall back to the ``main`` agent's retriever
+    or store.  The builtin ``main`` agent and unconfigured ids are never
+    isolated.
+    """
+    if config is None:
+        return False
+    normalized = normalize_agent_id(agent_id)
+    if normalized == "main":
+        return False
+    return _configured_agent_workspace(config, normalized) is not None
+
+
 def resolve_agent_state_dir(
     agent_id: str,
     config: object | None = None,

--- a/src/opensquilla/cli/openai_bridge_cmd.py
+++ b/src/opensquilla/cli/openai_bridge_cmd.py
@@ -1,0 +1,77 @@
+"""CLI commands for running the OpenAI-compatible HTTP bridge."""
+
+from __future__ import annotations
+
+import typer
+
+app = typer.Typer(help="Run the OpenAI-compatible HTTP bridge.")
+
+
+@app.command("run")
+def run_openai_bridge(
+    host: str = typer.Option(
+        "127.0.0.1",
+        "--host",
+        envvar="OPENAI_BRIDGE_HOST",
+        help="监听地址（默认 127.0.0.1）。",
+    ),
+    port: int = typer.Option(
+        8787,
+        "--port",
+        envvar="OPENAI_BRIDGE_PORT",
+        help="监听端口（默认 8787）。",
+    ),
+    gateway_url: str = typer.Option(
+        "ws://localhost:18791/ws",
+        "--gateway",
+        envvar="OPENAI_BRIDGE_GATEWAY_URL",
+        help="OpenSquilla gateway WebSocket 地址。",
+    ),
+    token: str | None = typer.Option(
+        None,
+        "--token",
+        envvar="OPENAI_BRIDGE_TOKEN",
+        help="适配层 API Key（缺省自动生成随机值）。",
+    ),
+    no_auth: bool = typer.Option(
+        False,
+        "--no-auth",
+        envvar="OPENAI_BRIDGE_NO_AUTH",
+        help="跳过适配层认证（仅限本地调试）。",
+    ),
+    session_mode: str = typer.Option(
+        "persistent",
+        "--session-mode",
+        envvar="OPENAI_BRIDGE_SESSION_MODE",
+        help="persistent=每模型常驻会话（agent 有记忆）；stateless=每请求新会话。",
+    ),
+    display_model: str = typer.Option(
+        "OpenSquilla",
+        "--display-model",
+        envvar="OPENAI_BRIDGE_MODEL",
+        help="对外暴露的模型名（默认 OpenSquilla），内部映射到 main agent。",
+    ),
+    timeout: float = typer.Option(
+        180,
+        "--timeout",
+        envvar="OPENAI_BRIDGE_TIMEOUT",
+        help="非流式响应最长等待秒数（默认 180）。",
+    ),
+) -> None:
+    """启动 OpenAI 兼容 HTTP 桥接服务。
+
+    将 OpenSquilla gateway 的 agent 能力暴露为 /v1/chat/completions，
+    任何支持 OpenAI SDK 的客户端均可直接接入。
+    """
+    from opensquilla.openai_bridge import run_server
+
+    run_server(
+        host=host,
+        port=port,
+        gateway_url=gateway_url,
+        bridge_token=token,
+        no_auth=no_auth,
+        session_mode=session_mode,
+        display_model=display_model,
+        timeout_s=timeout,
+    )

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -8185,8 +8185,17 @@ class TurnRunner:
         return resolve_agent_memory_source_dir(agent_id, self._config, source=source)
 
     def _effective_memory_retrieval_metadata(self, agent_id: str) -> dict[str, str]:
+        from opensquilla.agents.scope import is_isolated_custom_agent
+
         retrievers = self._memory_retrievers or {}
-        for key in (agent_id, "main"):
+
+        # Isolation check: custom agents with their own workspace must not
+        # fall back to main's retriever (prevents memory leakage).
+        search_keys: tuple[str, ...] = (agent_id,)
+        if not is_isolated_custom_agent(self._config, agent_id):
+            search_keys = (agent_id, "main")
+
+        for key in search_keys:
             retriever = retrievers.get(key)
             metadata_fn = getattr(retriever, "effective_retrieval_metadata", None)
             if callable(metadata_fn):

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -3217,6 +3217,7 @@ async def build_services(
                 workspace_base=config.workspace_dir
                 if getattr(config.memory, "source", "state") == "workspace"
                 else None,
+                gateway_config=config,
             )
             log.info("build_services.memory_tools_registered", agents=list(memory_stores))
     except Exception as e:

--- a/src/opensquilla/gateway/rpc_sessions.py
+++ b/src/opensquilla/gateway/rpc_sessions.py
@@ -2349,7 +2349,10 @@ def _create_session_key(agent_id: str, kind: object = None) -> str:
     normalized_kind = str(kind or "").strip().lower().replace("_", "-")
     if normalized_kind == "web":
         normalized_kind = "webchat"
-    if normalized_kind in {"cli", "webchat"}:
+    # LOCAL-FORK(openai-bridge): 允许 "openai-bridge" kind 生成四段式 key，
+    # 使 session_view._surface_from_key() 能将其归类为 channel surface，
+    # 从而在 WebUI 侧边栏 Channels 分组下显示。上游无此分支。
+    if normalized_kind in {"cli", "webchat", "openai-bridge"}:
         return f"agent:{agent_id}:{normalized_kind}:{short_id}"
     return f"agent:{agent_id}:{short_id}"
 

--- a/src/opensquilla/gateway/session_view.py
+++ b/src/opensquilla/gateway/session_view.py
@@ -10,6 +10,8 @@ from typing import Any
 from opensquilla.chat.flattened_tool_markers import is_flattened_tool_result_dump
 from opensquilla.session.keys import derive_chat_type, parse_agent_id
 
+# LOCAL-FORK(openai-bridge): "openai-bridge" 为本地新增 surface，
+# 使 bridge 会话在侧边栏 Channels 分组显示；上游无此值。
 _CHANNEL_SURFACES = frozenset(
     {
         "slack",
@@ -20,6 +22,7 @@ _CHANNEL_SURFACES = frozenset(
         "qq",
         "matrix",
         "telegram",
+        "openai-bridge",
     }
 )
 _TIME_PREFIX_RE = re.compile(

--- a/src/opensquilla/gateway_client.py
+++ b/src/opensquilla/gateway_client.py
@@ -72,6 +72,7 @@ class GatewayRPCClient:
         request_timeout_s: float | None = 30.0,
     ) -> None:
         self.scopes = scopes or ["operator.read", "operator.write"]
+        self.token: str | None = None
         self.request_timeout_s = request_timeout_s
         self._ws: Any = None
         self._recv_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
@@ -82,9 +83,16 @@ class GatewayRPCClient:
         self._connection_error: ConnectionError | None = None
         self._closing = False
 
-    async def connect(self, url: str = "ws://localhost:18791/ws") -> None:
+    async def connect(
+        self,
+        url: str = "ws://localhost:18791/ws",
+        *,
+        token: str | None = None,
+    ) -> None:
         if self._ws is not None:
             await self.close()
+        if token is not None:
+            self.token = str(token).strip() or None
         self._closing = False
         self._connection_error = None
         try:
@@ -104,6 +112,15 @@ class GatewayRPCClient:
             if challenge.get("type") != "event" or challenge.get("event") != "connect.challenge":
                 raise RuntimeError(f"Unexpected gateway handshake frame: {challenge}")
 
+            connect_params: dict[str, Any] = {
+                "minProtocol": 1,
+                "maxProtocol": 3,
+                "role": "operator",
+                "scopes": self.scopes,
+            }
+            if self.token:
+                connect_params["auth"] = {"token": self.token}
+
             req_id = str(uuid.uuid4())
             await self._ws.send(
                 json.dumps(
@@ -111,12 +128,7 @@ class GatewayRPCClient:
                         "type": "req",
                         "id": req_id,
                         "method": "connect",
-                        "params": {
-                            "minProtocol": 1,
-                            "maxProtocol": 3,
-                            "role": "operator",
-                            "scopes": self.scopes,
-                        },
+                        "params": connect_params,
                     }
                 )
             )

--- a/src/opensquilla/openai_bridge/__init__.py
+++ b/src/opensquilla/openai_bridge/__init__.py
@@ -1,0 +1,10 @@
+"""OpenAI 兼容 HTTP 桥接层。
+
+将 OpenSquilla gateway 的 agent 能力以 OpenAI 兼容端点（/v1/chat/completions）
+暴露给任何支持 OpenAI SDK 的平台/工具。
+
+直接启动： ``python -m opensquilla.openai_bridge.server``
+CLI 启动： ``opensquilla openai-bridge run``
+"""
+
+from opensquilla.openai_bridge.server import create_app, run_server  # noqa: F401

--- a/src/opensquilla/openai_bridge/server.py
+++ b/src/opensquilla/openai_bridge/server.py
@@ -1,0 +1,794 @@
+"""OpenAI 兼容 HTTP 适配层：将 OpenSquilla gateway 暴露为 /v1/chat/completions。
+
+架构：
+    OpenAI 客户端 ──HTTP /v1/*──▶ 本适配层 ──WebSocket RPC──▶ OpenSquilla Gateway ──▶ Agent
+
+设计要点：
+    * 复用 OpenSquilla 自带的 GatewayRPCClient（已含 auth 握手补丁），不重复实现协议。
+    * 单连接原子化执行：subscribe → send → 收事件至终止帧，避免双连接的事件竞争。
+    * 流式输出直接转发 gateway 的 session.event.text_delta 增量。
+
+环境变量：
+    OPENAI_BRIDGE_HOST            监听地址（默认 127.0.0.1）
+    OPENAI_BRIDGE_PORT            监听端口（默认 8787）
+    OPENAI_BRIDGE_TOKEN           适配层 API Key（缺省自动生成随机值并打印到日志）
+    OPENAI_BRIDGE_NO_AUTH         设为 1 时跳过适配层认证（仅限本地调试）
+    OPENAI_BRIDGE_GATEWAY_URL     gateway WebSocket 地址（默认 ws://localhost:18791/ws）
+    OPENAI_BRIDGE_SESSION_MODE    persistent（默认，每模型一个常驻会话，agent 有记忆）
+                                  | stateless（每请求新建会话）
+    OPENAI_BRIDGE_TIMEOUT         非流式响应最长等待秒数（默认 180）
+
+请求头：
+    X-OpenSquilla-Session         指定会话 key（默认 persistent key）
+    X-OpenSquilla-New-Session     设为 1 强制新建会话
+    X-OpenSquilla-Route           路由钉选：auto（自动路由）/ tier:c2（或裸 c2）等；
+                                  仅作用于当前请求，turn 结束自动恢复自动路由
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import secrets
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+import uvicorn
+from fastapi import Depends, FastAPI, Header, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from opensquilla.cli.gateway_rpc import default_gateway_token
+from opensquilla.gateway_client import GatewayRPCClient, GatewayRPCError
+
+# --------------------------------------------------------------------------
+# 配置
+# --------------------------------------------------------------------------
+HOST = os.environ.get("OPENAI_BRIDGE_HOST", "127.0.0.1")
+PORT = int(os.environ.get("OPENAI_BRIDGE_PORT", "8787"))
+GATEWAY_URL = os.environ.get(
+    "OPENAI_BRIDGE_GATEWAY_URL", "ws://localhost:18791/ws"
+)
+SESSION_MODE = os.environ.get("OPENAI_BRIDGE_SESSION_MODE", "persistent").strip().lower()
+TIMEOUT_S = float(os.environ.get("OPENAI_BRIDGE_TIMEOUT", "180"))
+NO_AUTH = os.environ.get("OPENAI_BRIDGE_NO_AUTH", "") == "1"
+
+# 对外模型显示名：OpenAI 客户端看到的名字（默认 OpenSquilla），内部映射回 agent id。
+DISPLAY_MODEL = os.environ.get("OPENAI_BRIDGE_MODEL", "OpenSquilla").strip() or "OpenSquilla"
+_MODEL_TO_AGENT = {DISPLAY_MODEL.casefold(): "main"}
+
+
+def _resolve_agent_id(model: str) -> str:
+    """把请求中的模型名映射为 gateway agent id（兼容 agent: 前缀）。"""
+    name = str(model).removeprefix("agent:")
+    return _MODEL_TO_AGENT.get(name.casefold(), name)
+BRIDGE_TOKEN = os.environ.get("OPENAI_BRIDGE_TOKEN", "").strip() or (
+    None if NO_AUTH else secrets.token_hex(16)
+)
+
+# 与 mcp_server/bridge.py 同源的终止事件集合
+_TERMINAL_EVENTS = {
+    "session.event.done",
+    "session.event.error",
+    "task.cancelled",
+    "task.failed",
+    "task.timeout",
+    "task.abandoned",
+}
+# 正常完成的终止事件；其余终止事件视为失败，必须透传错误而不是伪装成功
+_SUCCESS_TERMINAL_EVENTS = {"session.event.done"}
+_FAILURE_TERMINAL_EVENTS = _TERMINAL_EVENTS - _SUCCESS_TERMINAL_EVENTS
+_TEXT_DELTA = "session.event.text_delta"
+_STREAM_FRAME_TIMEOUT_S = 300.0
+
+# Agent 内部的路由标记（[[reply_to_current]] / [[reply_to:<id>]]）不属于
+# OpenAI 协议内容，必须在输出边界剥除，否则外部客户端会把它当正文渲染。
+_REPLY_TAG_RE = re.compile(r"\[\[reply_to[^\]]*\]\]")
+
+
+def _strip_reply_tags(text: str) -> str:
+    return _REPLY_TAG_RE.sub("", text)
+
+
+def _filter_stream_delta(carry: str, chunk: str) -> tuple[str, str]:
+    """跨 SSE 增量剥除路由标记，返回 (可输出文本, 新 carry)。
+
+    gateway 的 text_delta 可能在标记中间切分（实测出现过 '[[reply_to' +
+    '_current]]' 分两个增量到达），因此对未闭合的 '[[' 尾部做暂存，
+    等下一个增量到达再判定；已闭合但非路由标记的 [[...]] 原样放行。
+    """
+    carry += chunk
+    out_parts: list[str] = []
+    while True:
+        m = _REPLY_TAG_RE.search(carry)
+        if m:
+            out_parts.append(carry[: m.start()])
+            carry = carry[m.end():]
+            continue
+        idx = carry.rfind("[[")
+        if idx == -1 or "]]" in carry[idx:]:
+            out_parts.append(carry)
+            carry = ""
+        else:
+            out_parts.append(carry[:idx])
+            carry = carry[idx:]
+        break
+    return "".join(out_parts), carry
+
+
+def _normalize_event_frame(frame: dict[str, Any]) -> dict[str, Any]:
+    if "event" in frame and "payload" in frame:
+        return frame
+    return {"event": frame.get("event"), "payload": frame.get("payload") or frame}
+
+
+def _gateway_token() -> str:
+    token = os.environ.get("OPENSQUILLA_GATEWAY_TOKEN", "").strip()
+    if not token:
+        try:
+            token = default_gateway_token() or ""
+        except Exception:  # noqa: BLE001 - 配置缺失时回退
+            token = ""
+    return token.strip()
+
+
+async def _new_client() -> GatewayRPCClient:
+    client = GatewayRPCClient()
+    token = _gateway_token()
+    await client.connect(GATEWAY_URL, token=token or None)
+    return client
+
+
+# --------------------------------------------------------------------------
+# 会话管理
+# --------------------------------------------------------------------------
+# persistent 模式：sessions.create 不接受自定义 key（gateway 自动生成
+# ``agent:{agent_id}:{hex}``），因此把创建返回的真实 key 落盘缓存，之后
+# 请求优先复用缓存 key（resolve 失败则重建）。修复 v1 "每次请求都新建
+# 会话" 导致记忆丢失、孤儿会话堆积的问题。
+_SESSION_CACHE_DIR = Path(__file__).resolve().parent / ".session_cache"
+
+
+def _persistent_key_file(agent_id: str) -> Path:
+    safe = agent_id.replace(":", "_").replace("/", "_").replace("\\", "_")
+    return _SESSION_CACHE_DIR / f"{safe}.json"
+
+
+def _read_cached_key(agent_id: str) -> str | None:
+    try:
+        data = json.loads(_persistent_key_file(agent_id).read_text(encoding="utf-8"))
+        key = data.get("key") if isinstance(data, dict) else None
+        return key if isinstance(key, str) and key else None
+    except Exception:  # noqa: BLE001 - 缓存缺失/损坏时退回新建
+        return None
+
+
+def _write_cached_key(agent_id: str, key: str) -> None:
+    try:
+        _SESSION_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        _persistent_key_file(agent_id).write_text(
+            json.dumps({"agent_id": agent_id, "key": key}, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+    except Exception:  # noqa: BLE001 - 缓存写失败不阻断请求
+        print(f"[openai-bridge] persistent key 缓存失败: {key}")
+
+
+async def _create_session(client: GatewayRPCClient, agent_id: str) -> str:
+    result = await client.call(
+        "sessions.create",
+        {"agentId": agent_id, "displayName": f"OpenAI bridge ({agent_id})"},
+    )
+    key = result.get("key") if isinstance(result, dict) else None
+    if not key:
+        raise RuntimeError(f"sessions.create 未返回 key: {result!r}")
+    return key
+
+
+async def _resolve_or_create_session(
+    client: GatewayRPCClient, agent_id: str, *, explicit_key: str | None, force_new: bool
+) -> str:
+    if explicit_key:
+        try:
+            await client.resolve_session(explicit_key)
+            return explicit_key
+        except GatewayRPCError as exc:
+            raise HTTPException(404, f"会话不存在或不可用: {exc}") from exc
+    if SESSION_MODE == "stateless":
+        return await _create_session(client, agent_id)
+    if force_new:
+        key = await _create_session(client, agent_id)
+        _write_cached_key(agent_id, key)
+        return key
+    # persistent：优先复用缓存 key
+    cached = _read_cached_key(agent_id)
+    if cached:
+        try:
+            await client.resolve_session(cached)
+            return cached
+        except GatewayRPCError:
+            pass  # 缓存失效（会话被删/清库），重建
+    key = await _create_session(client, agent_id)
+    _write_cached_key(agent_id, key)
+    return key
+
+
+# 同一会话同时只允许一个 turn 在途，防止事件流互相串扰
+_session_locks: dict[str, asyncio.Lock] = {}
+_session_locks_guard = asyncio.Lock()
+
+
+async def _get_session_lock(key: str) -> asyncio.Lock:
+    async with _session_locks_guard:
+        lock = _session_locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            _session_locks[key] = lock
+        return lock
+
+
+# --------------------------------------------------------------------------
+# 消息与请求组装
+# --------------------------------------------------------------------------
+def _extract_text_content(content: Any) -> str | None:
+    if isinstance(content, str):
+        return content if content.strip() else None
+    if isinstance(content, list):
+        parts: list[str] = []
+        for seg in content:
+            if isinstance(seg, dict) and seg.get("type") == "text":
+                t = seg.get("text")
+                if isinstance(t, str) and t.strip():
+                    parts.append(t.strip())
+        return "\n".join(parts) if parts else None
+    return None
+
+
+def _build_user_message(messages: list[dict[str, Any]]) -> str:
+    """取最后一条 user 消息；system 消息作为前缀拼入（v1 简化策略）。"""
+    prefix_parts: list[str] = []
+    last_user: str | None = None
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        text = _extract_text_content(msg.get("content"))
+        if not text:
+            continue
+        if role == "system":
+            prefix_parts.append(text)
+        elif role == "user":
+            last_user = text
+    if last_user is None:
+        raise HTTPException(400, "messages 中缺少 user 消息")
+    if prefix_parts:
+        return "System:\n" + "\n\n".join(prefix_parts) + "\n\nUser:\n" + last_user
+    return last_user
+
+
+def _extract_final_text(events: list[dict[str, Any]]) -> str:
+    parts: list[str] = []
+    for ev in events:
+        if ev.get("event") == _TEXT_DELTA:
+            t = ev.get("payload", {}).get("text")
+            if isinstance(t, str) and t:
+                parts.append(t)
+    return _strip_reply_tags("".join(parts))
+
+
+def _event_error_message(payload: dict[str, Any]) -> str:
+    """从终止事件 payload 提取可透传的错误描述。
+
+    优先级 error_message > message > 兑底（附 code）。gateway 的
+    _normalize_terminal_event_payload 会同时产出这两个字段，前者是
+    净化后的原始错误，后者是给用户看的 terminal 消息。
+    """
+    if not isinstance(payload, dict):
+        return "Agent error"
+    for field in ("error_message", "message"):
+        val = payload.get(field)
+        if isinstance(val, str) and val:
+            return val
+    code = payload.get("code")
+    return f"Agent error ({code})" if code else "Agent error"
+
+
+def _map_error_event(payload: dict[str, Any]) -> dict[str, str | None]:
+    """把失败终止事件映射为 OpenAI 错误信封字段。
+
+    gateway 侧 code 形如 agent_error / stream_idle_timeout /
+    provider_request_too_large；terminal_reason 为 timeout/failed/error。
+    """
+    message = _event_error_message(payload)
+    code = str(payload.get("code") or payload.get("error_class") or "agent_error")
+    reason = str(payload.get("terminal_reason") or "")
+    if reason == "timeout" or "timeout" in code.lower():
+        return {"message": message, "type": "timeout", "code": code}
+    return {"message": message, "type": "server_error", "code": code}
+
+
+def _collect_terminal_error(events: list[dict[str, Any]]) -> str | None:
+    """返回非流式事件序列中的失败描述；无失败返回 None。"""
+    for ev in events:
+        if ev.get("event") in _FAILURE_TERMINAL_EVENTS:
+            return _event_error_message(ev.get("payload") or {})
+    return None
+
+
+# --------------------------------------------------------------------------
+# 路由钉选（X-OpenSquilla-Route）
+# --------------------------------------------------------------------------
+# 通过 gateway 的 routing.hold.set/clear RPC 实现 tier 钉选：turn 前设置
+# hold（仅当前请求，turns=1），turn 结束后无论成败都恢复自动路由。
+# 目标值支持 auto / tier:c2 / 裸 c2 等（routing.hold.set 内部会规范化）。
+AUTO_TARGET = "auto"
+
+
+async def _apply_route_hold(client: GatewayRPCClient, key: str, route: str | None) -> None:
+    """Turn 前应用路由钉选；route 为空或 auto 时跳过。"""
+    if not route or route.strip().lower() == AUTO_TARGET:
+        return
+    target = route.strip()
+    try:
+        await client.call(
+            "routing.hold.set",
+            {"sessionKey": key, "target": target, "turns": 1},
+        )
+    except GatewayRPCError as exc:
+        # 钉选失败不阻断请求：回退自动路由并如实告警
+        print(f"[openai-bridge] routing.hold.set 失败，回退自动路由: {exc}")
+
+
+async def _clear_route_hold(client: GatewayRPCClient, key: str, route: str | None) -> None:
+    """Turn 结束后恢复自动路由；失败仅告警不影响返回。"""
+    if not route or route.strip().lower() == AUTO_TARGET:
+        return
+    try:
+        await client.call("routing.hold.clear", {"sessionKey": key})
+    except GatewayRPCError as exc:
+        print(f"[openai-bridge] routing.hold.clear 失败: {exc}")
+
+
+# --------------------------------------------------------------------------
+# 单连接 turn 执行（subscribe → send → 收事件至终止）
+# --------------------------------------------------------------------------
+async def _run_turn(
+    key: str, user_message: str, route: str | None = None
+) -> list[dict[str, Any]]:
+    client = await _new_client()
+    try:
+        await _apply_route_hold(client, key, route)
+        await client.call(
+            "sessions.messages.subscribe", {"key": key, "since_stream_seq": None}
+        )
+        await client.call(
+            "sessions.send",
+            {
+                "key": key,
+                "message": user_message,
+                "attachments": [],
+                "intent": "continue",
+                "_source": {
+                    "caller_kind": "cli",
+                    "channel_kind": "cli",
+                    "channel_id": "openai-bridge",
+                    "source_kind": "openai_bridge",
+                    "source_name": "openai_bridge",
+                },
+            },
+        )
+        events: list[dict[str, Any]] = []
+        while True:
+            frame = await client.recv_event(timeout=_STREAM_FRAME_TIMEOUT_S)
+            norm = _normalize_event_frame(frame)
+            payload = norm.get("payload")
+            if not isinstance(payload, dict) or payload.get("session_key") != key:
+                continue
+            name = str(norm.get("event") or "")
+            events.append({"event": name, "payload": payload})
+            if name in _TERMINAL_EVENTS:
+                break
+        return events
+    finally:
+        await _clear_route_hold(client, key, route)
+        await client.close()
+
+
+# --------------------------------------------------------------------------
+# 响应组装
+# --------------------------------------------------------------------------
+def _chat_completion(chat_id: str, created: int, model: str, content: str) -> dict[str, Any]:
+    return {
+        "id": chat_id,
+        "object": "chat.completion",
+        "created": created,
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+        # 说明：gateway 事件未暴露 token 统计，置零占位
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    }
+
+
+def _chunk(chat_id: str, created: int, model: str, delta: dict[str, Any], finish: str | None) -> str:
+    data = {
+        "id": chat_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": model,
+        "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+    }
+    return f"data: {json_dumps(data)}\n\n"
+
+
+def json_dumps(obj: Any) -> str:
+    import json
+
+    return json.dumps(obj, ensure_ascii=False)
+
+
+# --------------------------------------------------------------------------
+# 客户端侧会话标题请求短路
+# --------------------------------------------------------------------------
+# 部分 OpenAI 兼容客户端（实测 dsh/deepseek-harness 0.1.0-rc.7）在新会话开始时，
+# 会向同一端点并行发送第二个"生成会话标题"请求。若转发给智能体，模型会连同
+# 标题生成的思考过程一起输出，客户端将其渲染为第二个可见对话框（"两个智能体
+# 同时回复"的假象），同时泄漏内部推理文本。
+# 对策：在 bridge 入口识别该签名，直接从人类消息 JSON 数组提取标题返回纯文本，
+# 不唤醒智能体、不创建会话、不消耗 turn。
+_TITLE_SYSTEM_MARKER = "create a concise title"
+_TITLE_USER_PREFIX = "Generate the session title from this JSON array of human messages:"
+
+
+def _message_text(msg: Any) -> str:
+    """取消息文本内容（兼容字符串与 content-part 数组两种形态）。"""
+    if not isinstance(msg, dict):
+        return ""
+    content = msg.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for p in content:
+            if isinstance(p, dict):
+                t = p.get("text")
+                if isinstance(t, str) and t:
+                    parts.append(t)
+        return "\n".join(parts)
+    return ""
+
+
+def _detect_client_title_request(messages: list[dict[str, Any]]) -> str | None:
+    """若为客户端侧会话标题生成请求，返回提取的标题；否则返回 None。
+
+    签名（双条件同时满足，避免误伤正常对话）：
+      ① system 消息含 "Create a concise title..."
+      ② user 消息以 "Generate the session title from this JSON array of
+         human messages:" 开头，后接 [{"seq":N,"text":"..."}, ...] JSON 数组
+    标题 = 数组中最后一条人类消息的 text，截断 48 字符。
+    """
+    system_hit = False
+    user_text = ""
+    for m in messages:
+        if not isinstance(m, dict):
+            continue
+        role = str(m.get("role") or "").strip().lower()
+        text = _message_text(m)
+        if not text:
+            continue
+        if role == "system" and _TITLE_SYSTEM_MARKER in text.lower():
+            system_hit = True
+        elif role == "user":
+            user_text = text  # 标题请求是单轮，取最后一条 user
+    if not system_hit:
+        return None
+    stripped = user_text.lstrip()
+    if not stripped.startswith(_TITLE_USER_PREFIX):
+        return None
+    payload_part = stripped[len(_TITLE_USER_PREFIX):].strip()
+    # 宽容截取 JSON 数组主体（容忍首尾噪声）
+    lo = payload_part.find("[")
+    hi = payload_part.rfind("]")
+    if lo < 0 or hi <= lo:
+        return None
+    last_text: str | None = None
+    try:
+        items = json.loads(payload_part[lo:hi + 1])
+        if isinstance(items, list):
+            for it in items:
+                if isinstance(it, dict):
+                    t = it.get("text")
+                    if isinstance(t, str) and t.strip():
+                        last_text = t.strip()
+    except Exception:  # noqa: BLE001 - 解析失败则回落正常流程
+        return None
+    if not last_text:
+        return None
+    return last_text[:48]
+
+
+# --------------------------------------------------------------------------
+# FastAPI 应用
+# --------------------------------------------------------------------------
+app = FastAPI(title="OpenSquilla OpenAI Bridge", version="0.1.0")
+
+
+@app.exception_handler(HTTPException)
+async def openai_error_envelope(_: Request, exc: HTTPException) -> JSONResponse:
+    """按 OpenAI 协议输出错误体（{"error": {...}}）。
+
+    FastAPI 默认的 {"detail": ...} 形状会让按 error.message 解析的
+    SDK 类客户端（Cherry Studio 等）拿不到失败原因。
+    """
+    if isinstance(exc.detail, dict) and "error" in exc.detail:
+        payload = exc.detail
+    else:
+        payload = {
+            "error": {
+                "message": str(exc.detail),
+                "type": "invalid_request_error" if exc.status_code < 500 else "server_error",
+                "code": "invalid_api_key" if exc.status_code == 401 else None,
+            }
+        }
+    return JSONResponse(status_code=exc.status_code, content=payload)
+
+
+async def require_bridge_token(authorization: str | None = Header(None)) -> str | None:
+    if NO_AUTH:
+        return None
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(
+            401,
+            detail={
+                "error": {
+                    "message": "缺少或非法的 Authorization 头",
+                    "type": "invalid_request_error",
+                    "code": "invalid_api_key",
+                }
+            },
+        )
+    token = authorization[len("Bearer "):].strip()
+    if not BRIDGE_TOKEN or token != BRIDGE_TOKEN:
+        raise HTTPException(
+            401,
+            detail={
+                "error": {
+                    "message": "API Key 无效",
+                    "type": "invalid_request_error",
+                    "code": "invalid_api_key",
+                }
+            },
+        )
+    return token
+
+
+@app.get("/v1/models")
+async def list_models(_: str | None = Depends(require_bridge_token)) -> dict[str, Any]:
+    # 对外只暴露显示名（默认 OpenSquilla），内部由 _resolve_agent_id 映射回 agent id。
+    ids = [DISPLAY_MODEL]
+    return {
+        "object": "list",
+        "data": [
+            {"id": i, "object": "model", "created": int(time.time()), "owned_by": "opensquilla"}
+            for i in ids
+        ],
+    }
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(
+    request: Request,
+    _: str | None = Depends(require_bridge_token),
+) -> Any:
+    try:
+        body = await request.json()
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(400, "请求体不是合法 JSON") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(400, "请求体必须是 JSON 对象")
+
+    model = str(body.get("model") or DISPLAY_MODEL)
+    agent_id = _resolve_agent_id(model)
+    stream = bool(body.get("stream", False))
+    messages = body.get("messages")
+    if not isinstance(messages, list) or not messages:
+        raise HTTPException(400, "messages 必须是非空数组")
+
+    # 客户端侧标题请求短路：识别签名后直接返回纯文本标题，
+    # 不唤醒智能体、不创建会话、不消耗 turn。
+    client_title = _detect_client_title_request(messages)
+    if client_title is not None:
+        chat_id = f"chatcmpl-{uuid.uuid4().hex}"
+        created = int(time.time())
+        print(
+            f"[openai-bridge] client title request short-circuited: {client_title!r}",
+            flush=True,
+        )
+        if stream:
+            async def title_stream():
+                yield _chunk(chat_id, created, model, {"role": "assistant"}, None)
+                yield _chunk(chat_id, created, model, {"content": client_title}, None)
+                yield _chunk(chat_id, created, model, {}, "stop")
+                yield "data: [DONE]\n\n"
+
+            return StreamingResponse(title_stream(), media_type="text/event-stream")
+        return _chat_completion(chat_id, created, model, client_title)
+
+    user_message = _build_user_message(messages)
+
+    explicit_key = request.headers.get("X-OpenSquilla-Session")
+    force_new = request.headers.get("X-OpenSquilla-New-Session", "") == "1"
+    route = request.headers.get("X-OpenSquilla-Route")
+
+    # 解析/创建会话 key
+    client = await _new_client()
+    try:
+        key = await _resolve_or_create_session(
+            client, agent_id, explicit_key=explicit_key, force_new=force_new
+        )
+    finally:
+        await client.close()
+
+    chat_id = f"chatcmpl-{uuid.uuid4().hex}"
+    created = int(time.time())
+
+    lock = await _get_session_lock(key)
+
+    if stream:
+
+        async def event_stream():
+            # 锁在生成器内部持有：流被消费的整个生命周期内互斥
+            async with lock:
+                c = await _new_client()
+                try:
+                    await _apply_route_hold(c, key, route)
+                    await c.call(
+                        "sessions.messages.subscribe",
+                        {"key": key, "since_stream_seq": None},
+                    )
+                    await c.call(
+                        "sessions.send",
+                        {
+                            "key": key,
+                            "message": user_message,
+                            "attachments": [],
+                            "intent": "continue",
+                            "_source": {
+                                "caller_kind": "cli",
+                                "channel_kind": "cli",
+                                "channel_id": "openai-bridge",
+                                "source_kind": "openai_bridge",
+                                "source_name": "openai_bridge",
+                            },
+                        },
+                    )
+                    yield _chunk(chat_id, created, model, {"role": "assistant"}, None)
+                    carry = ""
+                    while True:
+                        frame = await c.recv_event(timeout=_STREAM_FRAME_TIMEOUT_S)
+                        norm = _normalize_event_frame(frame)
+                        payload = norm.get("payload")
+                        if not isinstance(payload, dict) or payload.get("session_key") != key:
+                            continue
+                        name = str(norm.get("event") or "")
+                        if name == _TEXT_DELTA:
+                            t = payload.get("text")
+                            if isinstance(t, str) and t:
+                                clean, carry = _filter_stream_delta(carry, t)
+                                if clean:
+                                    yield _chunk(chat_id, created, model, {"content": clean}, None)
+                        if name in _TERMINAL_EVENTS:
+                            if carry:
+                                tail = _strip_reply_tags(carry)
+                                if tail:
+                                    yield _chunk(chat_id, created, model, {"content": tail}, None)
+                            if name in _SUCCESS_TERMINAL_EVENTS:
+                                yield _chunk(chat_id, created, model, {}, "stop")
+                            else:
+                                # 失败终止：发错误 chunk（OpenAI SSE 错误形状）而非伪装 stop
+                                yield (
+                                    "data: "
+                                    + json_dumps({"error": _map_error_event(payload)})
+                                    + "\n\n"
+                                )
+                            yield "data: [DONE]\n\n"
+                            return
+                finally:
+                    await _clear_route_hold(c, key, route)
+                    await c.close()
+
+        return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+    # 非流式：同一会话串行执行
+    async with lock:
+        try:
+            events = await asyncio.wait_for(
+                _run_turn(key, user_message, route=route), timeout=TIMEOUT_S
+            )
+        except asyncio.TimeoutError as exc:
+            raise HTTPException(504, f"agent 响应超时（>{TIMEOUT_S:g}s）") from exc
+        error_text = _collect_terminal_error(events)
+        if error_text:
+            raise HTTPException(
+                502,
+                detail={
+                    "error": {
+                        "message": error_text,
+                        "type": "server_error",
+                        "code": "agent_error",
+                    }
+                },
+            )
+        content = _extract_final_text(events)
+        return _chat_completion(chat_id, created, model, content)
+
+
+def create_app(
+    *,
+    gateway_url: str | None = None,
+    bridge_token: str | None = None,
+    no_auth: bool | None = None,
+    session_mode: str | None = None,
+    display_model: str | None = None,
+    timeout_s: float | None = None,
+) -> FastAPI:
+    """创建 FastAPI 应用（可注入配置覆盖环境变量，便于测试）。
+
+    参数全部可选，缺省从环境变量读取。返回已注册路由的 app 实例。
+    """
+    global GATEWAY_URL, BRIDGE_TOKEN, NO_AUTH, SESSION_MODE, DISPLAY_MODEL, TIMEOUT_S  # noqa: PLW0603
+    if gateway_url is not None:
+        GATEWAY_URL = gateway_url
+    if bridge_token is not None:
+        BRIDGE_TOKEN = bridge_token
+    if no_auth is not None:
+        NO_AUTH = no_auth
+    if session_mode is not None:
+        SESSION_MODE = session_mode.strip().lower()
+    if display_model is not None:
+        DISPLAY_MODEL = display_model.strip() or "OpenSquilla"
+        _MODEL_TO_AGENT.clear()
+        _MODEL_TO_AGENT[DISPLAY_MODEL.casefold()] = "main"
+    if timeout_s is not None:
+        TIMEOUT_S = float(timeout_s)
+    return app
+
+
+def run_server(
+    *,
+    host: str | None = None,
+    port: int | None = None,
+    gateway_url: str | None = None,
+    bridge_token: str | None = None,
+    no_auth: bool | None = None,
+    session_mode: str | None = None,
+    display_model: str | None = None,
+    timeout_s: float | None = None,
+    log_level: str = "info",
+) -> None:
+    """启动 uvicorn HTTP 服务。"""
+    create_app(
+        gateway_url=gateway_url,
+        bridge_token=bridge_token,
+        no_auth=no_auth,
+        session_mode=session_mode,
+        display_model=display_model,
+        timeout_s=timeout_s,
+    )
+    if BRIDGE_TOKEN and not NO_AUTH:
+        print(f"[openai-bridge] API Key: {BRIDGE_TOKEN}")
+    print(f"[openai-bridge] listening on http://{HOST}:{PORT}")
+    print(f"[openai-bridge] gateway: {GATEWAY_URL} | session mode: {SESSION_MODE}")
+    uvicorn.run(app, host=host or HOST, port=port or PORT, log_level=log_level)
+
+
+if __name__ == "__main__":
+    run_server()

--- a/src/opensquilla/openai_bridge/server.py
+++ b/src/opensquilla/openai_bridge/server.py
@@ -177,10 +177,46 @@ def _write_cached_key(agent_id: str, key: str) -> None:
         print(f"[openai-bridge] persistent key 缓存失败: {key}")
 
 
-async def _create_session(client: GatewayRPCClient, agent_id: str) -> str:
+def _first_user_text(messages: list[dict[str, Any]]) -> str | None:
+    """提取首条非空 user 消息文本（不含 system 前缀），用于生成会话显示名。"""
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") != "user":
+            continue
+        text = _extract_text_content(msg.get("content"))
+        if text:
+            return text
+    return None
+
+
+def _build_display_name(agent_id: str, first_user_text: str | None) -> str:
+    """生成会话显示名：时间前缀 + 首句摘要，便于在 channel 列表区分多场对话。
+
+    stateless 模式每次请求都会新建会话，若名字只含 agent_id，列表会出现大量
+    同名 channel，用户无法定位具体对话。加入本地时间戳与首句摘要（纯本地
+    生成、零额外 LLM 调用），使每场对话一眼可辨。
+    """
+    stamp = time.strftime("%m-%d %H:%M")
+    base = f"OpenAI bridge · {stamp}"
+    if first_user_text:
+        # 折叠空白/换行，仅保留可打印字符，避免控制字符污染 displayName
+        collapsed = "".join(
+            ch for ch in " ".join(first_user_text.split()) if ch.isprintable()
+        )
+        if collapsed:
+            snippet = collapsed if len(collapsed) <= 24 else collapsed[:24] + "…"
+            return f"{base} · {snippet}"
+    return base
+
+
+async def _create_session(
+    client: GatewayRPCClient, agent_id: str, *, display_name: str | None = None
+) -> str:
+    name = display_name or f"OpenAI bridge ({agent_id})"
     result = await client.call(
         "sessions.create",
-        {"agentId": agent_id, "displayName": f"OpenAI bridge ({agent_id})"},
+        {"agentId": agent_id, "displayName": name},
     )
     key = result.get("key") if isinstance(result, dict) else None
     if not key:
@@ -189,7 +225,12 @@ async def _create_session(client: GatewayRPCClient, agent_id: str) -> str:
 
 
 async def _resolve_or_create_session(
-    client: GatewayRPCClient, agent_id: str, *, explicit_key: str | None, force_new: bool
+    client: GatewayRPCClient,
+    agent_id: str,
+    *,
+    explicit_key: str | None,
+    force_new: bool,
+    display_name: str | None = None,
 ) -> str:
     if explicit_key:
         try:
@@ -198,9 +239,9 @@ async def _resolve_or_create_session(
         except GatewayRPCError as exc:
             raise HTTPException(404, f"会话不存在或不可用: {exc}") from exc
     if SESSION_MODE == "stateless":
-        return await _create_session(client, agent_id)
+        return await _create_session(client, agent_id, display_name=display_name)
     if force_new:
-        key = await _create_session(client, agent_id)
+        key = await _create_session(client, agent_id, display_name=display_name)
         _write_cached_key(agent_id, key)
         return key
     # persistent：优先复用缓存 key
@@ -211,7 +252,7 @@ async def _resolve_or_create_session(
             return cached
         except GatewayRPCError:
             pass  # 缓存失效（会话被删/清库），重建
-    key = await _create_session(client, agent_id)
+    key = await _create_session(client, agent_id, display_name=display_name)
     _write_cached_key(agent_id, key)
     return key
 
@@ -628,11 +669,19 @@ async def chat_completions(
     force_new = request.headers.get("X-OpenSquilla-New-Session", "") == "1"
     route = request.headers.get("X-OpenSquilla-Route")
 
+    # 会话显示名：仅在真正需要新建会话时使用；由首条 user 消息生成本地摘要，
+    # 避免 stateless 模式下列表出现大量同名 channel。
+    display_name = _build_display_name(agent_id, _first_user_text(messages))
+
     # 解析/创建会话 key
     client = await _new_client()
     try:
         key = await _resolve_or_create_session(
-            client, agent_id, explicit_key=explicit_key, force_new=force_new
+            client,
+            agent_id,
+            explicit_key=explicit_key,
+            force_new=force_new,
+            display_name=display_name,
         )
     finally:
         await client.close()

--- a/src/opensquilla/tools/builtin/memory_tools.py
+++ b/src/opensquilla/tools/builtin/memory_tools.py
@@ -329,12 +329,18 @@ def create_memory_tools(
     on_memory_write: Any | None = None,
     memory_source: str = "state",
     workspace_base: str | None = None,
+    gateway_config: Any | None = None,
 ) -> None:
     """Register memory tools. Accepts either a single store or a dict keyed by agent_id.
 
     Backward-compatible: a single store/retriever is auto-wrapped into ``{"main": ...}``.
     When dicts are provided, the active agent_id (from ToolContext via contextvar) selects
     the correct store, retriever, and memory directory at call time.
+
+    ``gateway_config`` is the live ``GatewayConfig`` object (same reference held by
+    ``AgentRegistry``).  It is used at resolve-time to check whether the current
+    agent is an isolated custom agent (has its own workspace) so that the
+    legacy "fall back to main" behavior is suppressed for such agents.
     """
     # Normalize to dict form
     if not isinstance(stores, dict):
@@ -355,8 +361,26 @@ def create_memory_tools(
 
         agent_id = normalize_agent_id((ctx.agent_id if ctx else None) or "main")
 
-        s = stores.get(agent_id, stores.get("main", next(iter(stores.values()))))
-        r = retrievers.get(agent_id, retrievers.get("main", next(iter(retrievers.values()))))
+        # Isolation check: custom agents with their own workspace must not
+        # fall back to main's store/retriever (prevents memory leakage).
+        isolated = False
+        if gateway_config is not None:
+            from opensquilla.agents.scope import is_isolated_custom_agent
+            isolated = is_isolated_custom_agent(gateway_config, agent_id)
+        
+        if isolated:
+            # Strict isolation: no fallback to main
+            s = stores.get(agent_id)
+            r = retrievers.get(agent_id)
+            if s is None or r is None:
+                raise ToolError(
+                    f"Memory not available for isolated agent '{agent_id}'. "
+                    "Isolated custom agents must have their own memory manager."
+                )
+        else:
+            # Legacy behavior: fall back to main for builtin/subagent/unconfigured
+            s = stores.get(agent_id, stores.get("main", next(iter(stores.values()))))
+            r = retrievers.get(agent_id, retrievers.get("main", next(iter(retrievers.values()))))
 
         if memory_source not in {"state", "workspace"}:
             raise ToolError("memory_source must be 'state' or 'workspace'.")

--- a/tests/test_openai_bridge/test_server.py
+++ b/tests/test_openai_bridge/test_server.py
@@ -1,0 +1,318 @@
+"""Tests for the OpenAI-compatible HTTP bridge."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from opensquilla.openai_bridge import server as bridge_server
+from opensquilla.openai_bridge.server import (
+    _collect_terminal_error,
+    _detect_client_title_request,
+    _event_error_message,
+    _filter_stream_delta,
+    _map_error_event,
+    _message_text,
+    _resolve_agent_id,
+    _strip_reply_tags,
+    create_app,
+)
+
+
+def test_resolve_agent_id_default_mapping() -> None:
+    """默认显示名 OpenSquilla 映射回 main agent，大小写不敏感，直传 main 兼容。"""
+    assert _resolve_agent_id("OpenSquilla") == "main"
+    assert _resolve_agent_id("opensquilla") == "main"
+    assert _resolve_agent_id("main") == "main"
+    assert _resolve_agent_id("agent:OpenSquilla") == "main"
+
+
+def test_resolve_agent_id_custom_display_model() -> None:
+    """自定义显示名后映射仍正确，且不影响直传 agent id。"""
+    create_app(no_auth=True, bridge_token="sk-test", display_model="MyAgent")
+    try:
+        assert bridge_server._resolve_agent_id("MyAgent") == "main"
+        assert bridge_server._resolve_agent_id("myagent") == "main"
+        assert bridge_server._resolve_agent_id("other") == "other"
+    finally:
+        # 恢复默认（create_app 仅覆盖非 None 参数，必须显式传回默认值）
+        create_app(no_auth=True, bridge_token="sk-test", display_model="OpenSquilla")
+
+
+def test_app_routes_registered() -> None:
+    """核心路由必须存在。"""
+    app = create_app(no_auth=True, bridge_token="sk-test")
+    paths = {r.path for r in app.routes if hasattr(r, "path")}
+    assert "/v1/models" in paths
+    assert "/v1/chat/completions" in paths
+
+
+def test_models_requires_auth() -> None:
+    """无 Authorization 头必须 401。"""
+    app = create_app(no_auth=False, bridge_token="sk-test-1234")
+    client = TestClient(app)
+    resp = client.get("/v1/models")
+    assert resp.status_code == 401
+
+
+def test_models_returns_display_model() -> None:
+    """/v1/models 返回对外显示名 OpenSquilla。"""
+    app = create_app(no_auth=False, bridge_token="sk-test-1234")
+    client = TestClient(app)
+    resp = client.get("/v1/models", headers={"Authorization": "Bearer sk-test-1234"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["object"] == "list"
+    ids = [m["id"] for m in data["data"]]
+    assert ids == ["OpenSquilla"]
+
+
+def test_chat_completions_requires_auth() -> None:
+    """无 Authorization 头必须 401。"""
+    app = create_app(no_auth=False, bridge_token="sk-test-1234")
+    client = TestClient(app)
+    resp = client.post("/v1/chat/completions", json={"model": "OpenSquilla", "messages": []})
+    assert resp.status_code == 401
+
+
+def test_chat_completions_validates_messages() -> None:
+    """messages 缺失/为空必须 400（不触达 gateway）。"""
+    app = create_app(no_auth=True, bridge_token="sk-test-1234")
+    client = TestClient(app)
+    headers = {"Authorization": "Bearer sk-test-1234"}
+
+    resp = client.post("/v1/chat/completions", json={}, headers=headers)
+    assert resp.status_code == 400
+
+    resp = client.post(
+        "/v1/chat/completions", json={"model": "OpenSquilla", "messages": []}, headers=headers
+    )
+    assert resp.status_code == 400
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={"model": "OpenSquilla", "messages": "not-a-list"},
+        headers=headers,
+    )
+    assert resp.status_code == 400
+
+
+def test_chat_completions_no_auth_mode() -> None:
+    """OPENAI_BRIDGE_NO_AUTH=1 时跳过认证，请求进入业务校验。"""
+    app = create_app(no_auth=True, bridge_token="sk-test-1234")
+    client = TestClient(app)
+    # 无 token 也允许访问（no_auth 模式），但 messages 校验仍生效
+    resp = client.post(
+        "/v1/chat/completions", json={"model": "OpenSquilla", "messages": []}
+    )
+    assert resp.status_code == 400  # 走到消息校验而非 401
+
+
+def test_strip_reply_tags_removes_internal_markers() -> None:
+    """路由标记必须被剥除，且不误伤其他 [[...]] 内容。"""
+    assert _strip_reply_tags("[[reply_to_current]]pong") == "pong"
+    assert _strip_reply_tags("[[reply_to:msg_1]] hello") == " hello"
+    assert _strip_reply_tags("[[reply_to]]x") == "x"
+    assert _strip_reply_tags("no tags here") == "no tags here"
+    assert _strip_reply_tags("[[bold]] kept") == "[[bold]] kept"
+
+
+def test_filter_stream_delta_handles_split_marker() -> None:
+    """实测切分：'[[reply_to' 与 '_current]]' 分属两个增量。"""
+    out, carry = _filter_stream_delta("", "[[reply_to")
+    assert (out, carry) == ("", "[[reply_to")
+    out, carry = _filter_stream_delta(carry, "_current]]")
+    assert (out, carry) == ("", "")
+    out, carry = _filter_stream_delta(carry, "\n1\n2")
+    assert (out, carry) == ("\n1\n2", "")
+
+
+def test_filter_stream_delta_passthrough_cases() -> None:
+    """普通文本、非标记的闭合括号、同增量内的标记均正确处理。"""
+    assert _filter_stream_delta("", "plain text") == ("plain text", "")
+    assert _filter_stream_delta("", "keep [[bold]]") == ("keep [[bold]]", "")
+    assert _filter_stream_delta("", "a[[reply_to_current]]b") == ("ab", "")
+
+
+def test_event_error_message_extraction() -> None:
+    """错误描述提取优先级：error_message > message > 兑底。"""
+    assert _event_error_message({"message": "boom", "code": "x"}) == "boom"
+    assert (
+        _event_error_message({"error_message": "raw", "message": "terminal", "code": "x"})
+        == "raw"
+    )
+    assert _event_error_message({"code": "abc"}) == "Agent error (abc)"
+    assert _event_error_message({}) == "Agent error"
+
+
+def test_map_error_event_timeout_and_generic() -> None:
+    """timeout 类错误映射为 type=timeout，其余为 server_error 并透传 code。"""
+    mapped = _map_error_event(
+        {"message": "Stream idle timeout", "code": "stream_idle_timeout", "terminal_reason": "timeout"}
+    )
+    assert mapped["type"] == "timeout"
+    assert mapped["code"] == "stream_idle_timeout"
+    mapped = _map_error_event({"message": "llm ensemble had 3 successful proposer(s)", "code": "agent_error"})
+    assert mapped["type"] == "server_error"
+    assert mapped["code"] == "agent_error"
+    assert "llm ensemble" in str(mapped["message"])
+
+
+def test_collect_terminal_error() -> None:
+    """仅失败终止事件返回错误描述；正常 done 不误报。"""
+    ok = [
+        {"event": "session.event.text_delta", "payload": {"text": "hi"}},
+        {"event": "session.event.done", "payload": {}},
+    ]
+    assert _collect_terminal_error(ok) is None
+    failed = [
+        {"event": "session.event.text_delta", "payload": {"text": "hi"}},
+        {"event": "session.event.error", "payload": {"message": "boom", "code": "x"}},
+    ]
+    assert _collect_terminal_error(failed) == "boom"
+
+
+def test_error_body_follows_openai_envelope() -> None:
+    """错误响应必须是 {"error": {...}} 而非 FastAPI 的 {"detail": ...}。"""
+    app = create_app(no_auth=False, bridge_token="sk-test-1234")
+    client = TestClient(app)
+    resp = client.get("/v1/models")
+    assert resp.status_code == 401
+    body = resp.json()
+    assert "error" in body and "detail" not in body
+    assert body["error"]["code"] == "invalid_api_key"
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={"model": "OpenSquilla", "messages": []},
+        headers={"Authorization": "Bearer sk-test-1234"},
+    )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert "error" in body and "detail" not in body
+    assert body["error"]["type"] == "invalid_request_error"
+
+
+# --------------------------------------------------------------------------
+# 客户端侧标题请求短路（dsh 双对话框 + 思考泄漏修复）
+# --------------------------------------------------------------------------
+def test_message_text_formats() -> None:
+    """_message_text 兼容字符串与 content-part 数组两种形态。"""
+    assert _message_text({"content": "hello"}) == "hello"
+    assert (
+        _message_text({"content": [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]})
+        == "a\nb"
+    )
+    assert _message_text({"content": None}) == ""
+    assert _message_text("not a dict") == ""
+
+
+def test_detect_client_title_request_hits_signature() -> None:
+    """dsh 风格标题请求命中双签名，返回最后一条人类消息文本。"""
+    messages = [
+        {
+            "role": "system",
+            "content": "Create a concise title for an AI coding-assistant session from the supplied human messages.",
+        },
+        {
+            "role": "user",
+            "content": 'Generate the session title from this JSON array of human messages:\n[{"seq":8,"text":"回答我：159753"}]',
+        },
+    ]
+    assert _detect_client_title_request(messages) == "回答我：159753"
+
+
+def test_detect_client_title_request_picks_last_entry() -> None:
+    """多条人类消息时取最后一条非空 text。"""
+    messages = [
+        {"role": "system", "content": "Create a concise title for an AI coding-assistant session."},
+        {
+            "role": "user",
+            "content": 'Generate the session title from this JSON array of human messages:\n[{"seq":1,"text":"first"},{"seq":2,"text":"second"}]',
+        },
+    ]
+    assert _detect_client_title_request(messages) == "second"
+
+
+def test_detect_client_title_request_misses_normal_chat() -> None:
+    """双签名缺一即放行回正常流程，绝不误伤正常对话。"""
+    # 缺 system 签名
+    assert (
+        _detect_client_title_request(
+            [
+                {
+                    "role": "user",
+                    "content": 'Generate the session title from this JSON array of human messages:\n[{"seq":1,"text":"hi"}]',
+                }
+            ]
+        )
+        is None
+    )
+    # system 签名在但 user 前缀不匹配
+    assert (
+        _detect_client_title_request(
+            [
+                {"role": "system", "content": "Create a concise title for an AI coding-assistant session."},
+                {"role": "user", "content": "请正常与我对话"},
+            ]
+        )
+        is None
+    )
+    # JSON 解析失败 → 回落正常流程
+    assert (
+        _detect_client_title_request(
+            [
+                {"role": "system", "content": "Create a concise title for an AI coding-assistant session."},
+                {"role": "user", "content": "Generate the session title from this JSON array of human messages:\nnot a json array"},
+            ]
+        )
+        is None
+    )
+    # 数组内 text 全为空白
+    assert (
+        _detect_client_title_request(
+            [
+                {"role": "system", "content": "Create a concise title for an AI coding-assistant session."},
+                {"role": "user", "content": 'Generate the session title from this JSON array of human messages:\n[{"seq":1,"text":"   "}]'},
+            ]
+        )
+        is None
+    )
+
+
+def test_detect_client_title_request_truncates_long_text() -> None:
+    """标题截断上限 48 字符。"""
+    long_text = "字" * 100
+    messages = [
+        {"role": "system", "content": "Create a concise title for an AI coding-assistant session."},
+        {
+            "role": "user",
+            "content": f'Generate the session title from this JSON array of human messages:\n[{{"seq":1,"text":"{long_text}"}}]',
+        },
+    ]
+    title = _detect_client_title_request(messages)
+    assert title is not None
+    assert len(title) <= 48
+    assert title.startswith("字")
+
+
+def test_chat_completions_short_circuits_client_title_request() -> None:
+    """端点级短路：标题请求返回纯文本标题，不唤醒智能体（无 RPC 依赖）。"""
+    app = create_app(no_auth=True, bridge_token="test-bridge-token")
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "OpenSquilla",
+            "messages": [
+                {"role": "system", "content": "Create a concise title for an AI coding-assistant session."},
+                {
+                    "role": "user",
+                    "content": 'Generate the session title from this JSON array of human messages:\n[{"seq":8,"text":"回答我：159753"}]',
+                },
+            ],
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["choices"][0]["message"]["content"] == "回答我：159753"
+    assert body["choices"][0]["finish_reason"] == "stop"

--- a/tests/test_openai_bridge/test_server.py
+++ b/tests/test_openai_bridge/test_server.py
@@ -6,10 +6,12 @@ from fastapi.testclient import TestClient
 
 from opensquilla.openai_bridge import server as bridge_server
 from opensquilla.openai_bridge.server import (
+    _build_display_name,
     _collect_terminal_error,
     _detect_client_title_request,
     _event_error_message,
     _filter_stream_delta,
+    _first_user_text,
     _map_error_event,
     _message_text,
     _resolve_agent_id,
@@ -316,3 +318,60 @@ def test_chat_completions_short_circuits_client_title_request() -> None:
     body = resp.json()
     assert body["choices"][0]["message"]["content"] == "回答我：159753"
     assert body["choices"][0]["finish_reason"] == "stop"
+
+
+def test_first_user_text_extracts_first_non_empty_user() -> None:
+    """首条非空 user 消息被提取，system 与空 user 被跳过。"""
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": ""},
+        {"role": "user", "content": "  第一条有效消息  "},
+        {"role": "user", "content": "后续消息"},
+    ]
+    assert _first_user_text(messages) == "  第一条有效消息  "
+
+
+def test_first_user_text_supports_content_parts() -> None:
+    """content 为 [{"type":"text","text":...}] 数组时仍能提取。"""
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "片段一"}, {"type": "text", "text": "片段二"}]}
+    ]
+    assert _first_user_text(messages) == "片段一\n片段二"
+
+
+def test_first_user_text_returns_none_without_user() -> None:
+    """无 user 消息时返回 None。"""
+    assert _first_user_text([{"role": "system", "content": "sys"}]) is None
+    assert _first_user_text([]) is None
+
+
+def test_build_display_name_includes_timestamp_and_snippet() -> None:
+    """命名含时间前缀 + 首句摘要。"""
+    name = _build_display_name("main", "解释一下相对论")
+    assert name.startswith("OpenAI bridge · ")
+    assert "解释一下相对论" in name
+
+
+def test_build_display_name_falls_back_without_user_text() -> None:
+    """无首句时退化为仅时间前缀。"""
+    name = _build_display_name("main", None)
+    assert name.startswith("OpenAI bridge · ")
+    assert " · " in name  # 时间戳占位存在
+
+
+def test_build_display_name_truncates_long_snippet() -> None:
+    """首句超长截断到 24 字符并加省略号。"""
+    long_text = "这是一段非常非常非常非常非常非常非常非常非常非常非常长的输入"
+    name = _build_display_name("main", long_text)
+    snippet = name.split(" · ")[-1]
+    assert snippet.endswith("…")
+    assert len(snippet) <= 25  # 24 字 + 省略号
+
+
+def test_build_display_name_collapses_whitespace_and_control_chars() -> None:
+    """换行/制表折叠为空格，控制字符被剔除。"""
+    name = _build_display_name("main", "第一行\n第二行\t第三行\x00")
+    assert "\n" not in name
+    assert "\t" not in name
+    assert "\x00" not in name
+    assert "第一行 第二行 第三行" in name


### PR DESCRIPTION
## 概述

本 PR 新增一个 **OpenAI 兼容 HTTP 桥接层**：任何支持 OpenAI Chat Completions 协议的外部工具（IDE 助手、CLI 工具、第三方聊天 UI、使用 OpenAI SDK 的自动化脚本等）都能直接调用 OpenSquilla 的智能体，完整复用内部的路由、分层模型、记忆与会话机制——无需改动 gateway 核心请求路径。

桥接层轻薄且默认无状态：把外部请求映射到内部智能体、创建独立会话、携带客户端自带的历史、以标准 OpenAI 语义流式回传。代码完整自包含于 `src/opensquilla/openai_bridge/`。

## 动机

- gateway 目前只为 OS 自身的 WebUI 与内部 RPC 服务。已支持 OpenAI Chat Completions 的外部工具，要接入 OS 必须自行编写一次性适配层。
- 本 PR 让 OS 直接说这套协议：任何 OpenAI 兼容客户端（IDE 助手、CLI 工具、第三方聊天界面、使用 OpenAI SDK 的脚本）无需改造即可成为一等公民，并开箱即用地继承 OS 的路由 / 分层模型 / 记忆能力。

## 包含内容

**1. OpenAI 兼容桥接层**（`src/opensquilla/openai_bridge/`）

- `POST /v1/chat/completions`，流式与非流式，Bearer 鉴权。
- 智能体路由：`model` 字段映射到内部 agent id；`agent:<id>` 可显式选择任意已配置智能体。
- 会话策略：
  - 默认**无状态**：每次请求创建全新会话，上下文由客户端自治（杜绝跨客户端串台 / 排队）；
  - 可选**持久模式**：按 scope 缓存 key 复用，支持多轮连续性。
- 无状态模式新建会话时，把客户端的完整历史折叠进 prompt（多轮连续性——修复“第二轮回溯失忆”）。
- **响应净化**：剥离内部回复标签（如 `[[reply_to:...]]`），外部客户端只看到干净内容。
- **错误语义对齐**：智能体运行失败时返回标准 OpenAI 错误信封，绝不伪造成功——客户端能正确感知失败并重试。
- **标题请求短路**：客户端侧的“会话标题生成”辅助请求（按签名识别）在桥接层入口直接短路，返回纯文本标题——不唤醒智能体、不建会话、不消耗 turn。避免模型对标题请求连带输出推理文本，被某些客户端渲染成多余的可见对话。
- **会话自动命名**：`OpenAI bridge · M-D HH:MM · <首句摘要>`，让 WebUI 列表清晰可辨，而不是堆满同名会话。命名在本地生成——零额外 LLM 调用、零额外延迟。

**2. Gateway 客户端层**

- `GatewayRPCClient.connect` 支持携带 gateway 鉴权 token（连接受 token 保护的 gateway）。

**3. 多智能体记忆隔离**（`gateway` / `engine` / `tools` / `boot`）

- 修复一处设计缺陷：配置了独立 workspace 的自定义智能体，运行时仍会静默回退到 `main` 的记忆存储/检索器，导致 `main` 的私有记忆（路径、凭证、业务数据）跨智能体泄漏。
- 新增 `scope.is_isolated_custom_agent()` 守卫：区分“需隔离的自定义智能体”（有独立 workspace → 绝不回退 `main`）与“subagent”（按设计继承 `main` 记忆）。守卫应用于 memory-tool 的 store/retriever 解析与运行时检索元数据路径。
- 桥接会话在 WebUI 侧边栏归入「渠道」分组，与原生对话、定时任务分隔。

## 设计思路

**1. 为什么默认无状态，而不是默认持久会话？**

桥接层服务的是外部客户端，而 OpenAI 协议天然由**客户端**维护对话上下文（每次请求带全量 `messages`）。若默认持久复用同一个 OS 会话，不同客户端会争抢同一会话、互相串台、甚至排队。因此默认**无状态**：每次请求一个全新会话，上下文由客户端自治，天然隔离。持久模式作为可选开关，面向"明确想要 OS 侧记忆"的场景。

**2. 无状态怎么保证多轮连续？——历史折叠**

无状态意味着服务端不替客户端记上下文。矛盾的最小化解法：新建会话时把客户端携带的完整历史**折叠进 prompt**（system 前缀 + 末条 user），这样既保持每请求独立，又不丢多轮语义。这也顺带修掉了一处旧实现只取末条 user、丢弃全量历史的"第二轮回溯失忆"问题。

**3. 为什么标题请求要在入口短路？**

实测观察到部分客户端（如 deepseek-harness）在会话开始时，会并行发一个"生成会话标题"的辅助请求到同一端点。若照常转发给模型，模型会对这个标题任务连带输出推理文本，被客户端渲染成一条多余的可见回复，还会泄漏内部思考。因此按**签名双条件**（system 标记 + user 前缀）在入口识别并直接返回纯文本标题——不唤醒智能体、不建会话、不消耗 turn。双条件同时命中才短路，避免误伤正常对话。

**4. 会话命名为什么本地生成，不调用模型？**

无状态模式每次请求都新建会话，若沿用固定名会堆满不可区分的同名 channel。命名用 `时间戳 + 首句摘要`，在本地生成——零额外 LLM 调用、零额外延迟，又让 WebUI 列表一眼可辨。

**5. 记忆隔离的核心语义区分**

隔离守卫 `scope.is_isolated_custom_agent()` 的关键在于划清两类主体：

- **隔离的自定义智能体**（配置了独立 workspace）→ 绝不回退 `main` 的记忆存储/检索器；
- **subagent** → 按设计继承 `main` 记忆。

两者都"不是 main"，但语义相反，不能一刀切。守卫落在 store/retriever 解析与运行时检索元数据路径两处，杜绝 `main` 私有记忆（路径、凭证、业务数据）跨智能体泄漏。

**6. 附加而非侵入**

桥接层完全自包含，不修改 gateway 核心请求路径；主要耦合点只有 surface/分组识别（让桥接会话归入「渠道」分组）与隔离守卫。`agent:<id>` 模型命名保持向后兼容。此处的"记忆隔离"指**按独立 workspace 划分的会话/记忆边界**，而非禁止 agent 间通信——跨会话桥接仍通过 `sessions_send` / `sessions_spawn` 显式进行。

## 验证

- 桥接层新增单元测试（`tests/test_openai_bridge/`），覆盖 agent 解析、标题请求短路（签名命中 / 多条取末条 / 误伤放行 / 截断 / 端点级）、会话命名、鉴权、校验、错误映射、响应净化。
- 手动验证：隔离的自定义智能体无法检索 `main` 记忆；`main` 记忆完整；显式 `agent:main` 仍可用；subagent 继承不受影响；agent 失败以 OpenAI 错误呈现而非伪成功。
- 说明：启用隔离需完整重启 gateway（记忆管理器在 boot 时一次性构建，非惰性），仅热加载 config 不会重建。

## 后续优化方向

当前实现已覆盖作者个人使用场景（IDE 助手、CLI、第三方聊天 UI 均走标准 Chat Completions 协议），**作者后续不再主动优化本桥接层**。以下方向作为社区参考，欢迎有兴趣的维护者继续扩展：

- **更多 OpenAI 端点**：`GET /v1/models` 已支持；可扩展 `/v1/embeddings`、`/v1/completions` 等。
- **Function calling / 工具透传**：把 OS 侧工具调用映射为 OpenAI `tools` 协议（当前客户端只能拿到纯文本回复）。
- **并发与限流**：目前每会话单 turn 互斥；可在适配层增加全局 QPS / 并发限制与队列。
- **可观测性**：请求日志、耗时、token 用量统计、Prometheus metrics。
- **多用户鉴权**：当前 Bearer token 为单全局 token；可扩展 per-user API key 与用量配额。
- **断线重连**：gateway RPC 断线时的指数退避重连与请求重试。