### PR TITLE
Make desktop onboarding startup reliable and observable

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -1122,6 +1122,7 @@
       "tests/test_desktop/test_electron_dependency_security.py",
       "tests/test_desktop/test_electron_startup_contract.py",
       "tests/test_desktop/test_gateway_tls_runtime.py",
+      "tests/test_desktop/test_onboarding_main_process_flow_contract.py",
       "tests/test_dist/test_workspace_state.py",
       "tests/test_engine/test_agent_finalize_evidence_gate.py",
       "tests/test_engine/test_agent_invalid_provider_response.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -192,6 +192,7 @@
     "tests/test_desktop/test_electron_dependency_security.py": 0.01,
     "tests/test_desktop/test_electron_startup_contract.py": 0.147,
     "tests/test_desktop/test_gateway_tls_runtime.py": 0.01,
+    "tests/test_desktop/test_onboarding_main_process_flow_contract.py": 0.01,
     "tests/test_dist/test_workspace_state.py": 0.01,
     "tests/test_engine/test_agent_canonical_text_contract.py": 0.01,
     "tests/test_engine/test_agent_deepseek_dsml_dispatch.py": 0.01,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,6 +492,8 @@ jobs:
           node scripts/test-desktop-renderer-log.mjs
           node scripts/test-artifact-preview-lease-broker.mjs
           node scripts/test-native-workbench-surface.mjs
+          node scripts/test-onboarding-flow-coordinator.mjs
+          node scripts/test-onboarding-save-telemetry.mjs
           node ../../.github/scripts/verify-sandbox-package.mjs --source
 
   ubuntu-quality:
@@ -1212,9 +1214,15 @@ jobs:
                 'native-workbench-v2:scripts/test-native-workbench-v2-electron.mjs'
                 'unsafe-legacy-recovery-no-write:scripts/test-unsafe-legacy-recovery-no-write.mjs'
               )
+              if [[ "${RUNNER_OS}" == "macOS" ]]; then
+                entries+=(
+                  'onboarding-flow:scripts/test-onboarding-flow.mjs'
+                )
+              fi
               ;;
             profiles)
               entries=(
+                'onboarding-flow:scripts/test-onboarding-flow.mjs'
                 'profile-consolidation-flow:scripts/test-profile-consolidation-flow.mjs'
                 'primary-repair-accessibility:scripts/test-primary-repair-accessibility.mjs'
                 'profile-import-flow:scripts/test-profile-import-flow.mjs'

--- a/desktop/electron/package.json
+++ b/desktop/electron/package.json
@@ -50,6 +50,8 @@
     "test:preview-lease-broker": "npm run build && node scripts/test-artifact-preview-lease-broker.mjs",
     "test:desktop-workbench": "npm run build && node scripts/test-artifact-preview-lease-broker.mjs && node scripts/test-native-workbench-surface.mjs && node scripts/test-native-workbench-surface-electron.mjs && node scripts/test-native-workbench-v2-electron.mjs",
     "test:mock-update-flow": "npm run build && node scripts/test-mock-update-flow.mjs",
+    "test:onboarding-coordinator": "npm run build && node scripts/test-onboarding-flow-coordinator.mjs",
+    "test:onboarding-telemetry": "npm run build && node scripts/test-onboarding-save-telemetry.mjs",
     "test:onboarding-flow": "npm run build && node scripts/test-onboarding-flow.mjs",
     "start": "electron .",
     "pack": "npm run build && electron-builder --dir && npm run verify:package",

--- a/desktop/electron/scripts/test-onboarding-flow-coordinator.mjs
+++ b/desktop/electron/scripts/test-onboarding-flow-coordinator.mjs
@@ -1,0 +1,109 @@
+import { strict as assert } from 'node:assert'
+import { OnboardingFlowCoordinator } from '../dist/onboarding-flow-coordinator.js'
+
+function deferred() {
+  let resolvePromise
+  let rejectPromise
+  const promise = new Promise((resolve, reject) => {
+    resolvePromise = resolve
+    rejectPromise = reject
+  })
+  return { promise, resolve: resolvePromise, reject: rejectPromise }
+}
+
+function flow() {
+  return {
+    state: 'editing',
+    savePayload: null,
+    savePromise: null,
+  }
+}
+
+async function verifyExactPayloadSingleFlight() {
+  const coordinator = new OnboardingFlowCoordinator()
+  const current = flow()
+  const gate = deferred()
+  let runs = 0
+  assert.equal(coordinator.activate(current), true)
+
+  const payload = {
+    provider: 'synthetic',
+    model: 'model-a',
+    routerTiers: { c1: { provider: 'synthetic', model: 'model-a' } },
+  }
+  const first = coordinator.requestSave(current, payload, async () => {
+    runs += 1
+    await gate.promise
+    assert.equal(coordinator.complete(current), true)
+    return { ok: true }
+  })
+  const same = coordinator.requestSave(
+    current,
+    structuredClone(payload),
+    async () => ({ ok: false }),
+  )
+  const different = coordinator.requestSave(
+    current,
+    { ...structuredClone(payload), model: 'model-b' },
+    async () => ({ ok: false }),
+  )
+
+  assert.equal(first.kind, 'started')
+  assert.equal(same.kind, 'joined')
+  assert.equal(different.kind, 'conflict')
+  assert.strictEqual(same.promise, first.promise)
+  assert.equal(runs, 0, 'save work must not start before the flight is published')
+  await Promise.resolve()
+  assert.equal(runs, 1, 'joined requests must execute the save exactly once')
+
+  gate.resolve()
+  assert.deepEqual(await first.promise, { ok: true })
+  assert.deepEqual(await same.promise, { ok: true })
+  assert.equal(current.state, 'completed')
+  assert.equal(current.savePromise, null)
+  assert.equal(coordinator.active, null)
+}
+
+async function verifyAbandonedFlowCannotCompleteOrReplaceCurrentFlow() {
+  const coordinator = new OnboardingFlowCoordinator()
+  const abandoned = flow()
+  const abandonedGate = deferred()
+  assert.equal(coordinator.activate(abandoned), true)
+
+  const abandonedSave = coordinator.requestSave(abandoned, { provider: 'old' }, async () => {
+    await abandonedGate.promise
+    return { completed: coordinator.complete(abandoned) }
+  })
+  assert.equal(abandonedSave.kind, 'started')
+  assert.equal(coordinator.abandon(abandoned), true)
+  assert.equal(coordinator.activate(flow()), false, 'a detached save must retain flow ownership')
+
+  abandonedGate.resolve()
+  assert.deepEqual(await abandonedSave.promise, { completed: false })
+  assert.equal(abandoned.state, 'abandoned')
+  assert.equal(coordinator.active, null)
+
+  const replacement = flow()
+  const replacementGate = deferred()
+  assert.equal(coordinator.activate(replacement), true)
+  const replacementSave = coordinator.requestSave(
+    replacement,
+    { provider: 'new' },
+    async () => {
+      await replacementGate.promise
+      return { completed: coordinator.complete(replacement) }
+    },
+  )
+  assert.equal(replacementSave.kind, 'started')
+  assert.equal(coordinator.complete(abandoned), false)
+  assert.strictEqual(coordinator.active, replacement)
+
+  replacementGate.resolve()
+  assert.deepEqual(await replacementSave.promise, { completed: true })
+  assert.equal(replacement.state, 'completed')
+  assert.equal(coordinator.active, null)
+}
+
+await verifyExactPayloadSingleFlight()
+await verifyAbandonedFlowCannotCompleteOrReplaceCurrentFlow()
+console.log('onboarding flow coordinator tests passed')

--- a/desktop/electron/scripts/test-onboarding-flow.mjs
+++ b/desktop/electron/scripts/test-onboarding-flow.mjs
@@ -426,7 +426,7 @@ async function verifySubmitFeedbackAndSingleFlight() {
     await verifyBootPhaseTimer(app)
     const submitClockOrigin = Date.now()
     await page.clock.install({ time: submitClockOrigin })
-    await page.clock.pauseAt(submitClockOrigin)
+    await page.clock.pauseAt(submitClockOrigin + 1_000)
     const apiKey = page.locator('#apiKey')
     await apiKey.fill('synthetic-submit-key')
     await page.locator('#onboardingLocale').selectOption('de')

--- a/desktop/electron/scripts/test-onboarding-flow.mjs
+++ b/desktop/electron/scripts/test-onboarding-flow.mjs
@@ -10,6 +10,19 @@ const scriptDir = dirname(fileURLToPath(import.meta.url))
 const packageRoot = resolve(scriptDir, '..')
 const repoRoot = resolve(packageRoot, '../..')
 const screenshotPath = String(process.env.OPENSQUILLA_DESKTOP_ONBOARDING_SCREENSHOT || '').trim()
+const ONBOARDING_TELEMETRY_EVENTS = new Set([
+  'onboarding_save_started',
+  'onboarding_save_stage_started',
+  'onboarding_save_stage_finished',
+  'onboarding_save_finished',
+])
+const ONBOARDING_TELEMETRY_STAGES = [
+  'primary_recovery_inspect',
+  'pending_setup_read',
+  'settings_persist',
+  'local_finalize',
+  'flow_handoff',
+]
 
 async function waitFor(check, label, timeoutMs = 60_000) {
   const startedAt = Date.now()
@@ -27,6 +40,79 @@ async function waitFor(check, label, timeoutMs = 60_000) {
   throw new Error(`Timed out waiting for ${label}.${suffix}`)
 }
 
+async function readOnboardingTelemetry(userDataDir) {
+  const source = await readFile(join(userDataDir, 'logs', 'desktop.log'), 'utf8')
+  return source
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+    .filter((record) => ONBOARDING_TELEMETRY_EVENTS.has(record.event))
+}
+
+function assertOnboardingTelemetrySchema(records, expectedSecret) {
+  assert.equal(records.length, 12, 'one successful save must emit one bounded trace')
+  const attempt = records[0]?.attempt
+  assert.equal(Number.isInteger(attempt) && attempt > 0, true)
+  assert.equal(records.every((record) => record.attempt === attempt), true)
+  assert.deepEqual(
+    Object.keys(records[0]).sort(),
+    ['at', 'attempt', 'event', 'packaged'],
+  )
+  assert.equal(records[0].event, 'onboarding_save_started')
+  assert.equal(records[0].packaged, false)
+
+  const observedStages = []
+  let cursor = 1
+  for (const stage of ONBOARDING_TELEMETRY_STAGES) {
+    const started = records[cursor]
+    const finished = records[cursor + 1]
+    cursor += 2
+    assert.deepEqual(Object.keys(started).sort(), ['at', 'attempt', 'event', 'stage'])
+    assert.deepEqual(
+      Object.keys(finished).sort(),
+      ['at', 'attempt', 'durationMs', 'event', 'outcome', 'stage'],
+    )
+    assert.equal(started.event, 'onboarding_save_stage_started')
+    assert.equal(started.stage, stage)
+    assert.equal(finished.event, 'onboarding_save_stage_finished')
+    assert.equal(finished.stage, stage)
+    assert.equal(finished.outcome, 'completed')
+    assert.equal(Number.isFinite(finished.durationMs), true)
+    assert.equal(Number.isInteger(finished.durationMs), true)
+    assert.ok(finished.durationMs >= 0)
+    observedStages.push(stage)
+  }
+  assert.deepEqual(observedStages, ONBOARDING_TELEMETRY_STAGES)
+
+  const terminal = records[cursor]
+  assert.deepEqual(
+    Object.keys(terminal).sort(),
+    [
+      'at',
+      'attempt',
+      'event',
+      'lastStage',
+      'outcome',
+      'settingsPersistedConfirmed',
+      'totalDurationMs',
+      'writerAdmitted',
+    ],
+  )
+  assert.equal(terminal.event, 'onboarding_save_finished')
+  assert.equal(terminal.outcome, 'ok')
+  assert.equal(terminal.writerAdmitted, true)
+  assert.equal(terminal.settingsPersistedConfirmed, true)
+  assert.equal(terminal.lastStage, 'flow_handoff')
+  assert.equal(Number.isFinite(terminal.totalDurationMs), true)
+  assert.equal(Number.isInteger(terminal.totalDurationMs), true)
+  assert.ok(terminal.totalDurationMs >= 0)
+  assert.equal(
+    JSON.stringify(records).includes(expectedSecret),
+    false,
+    'local onboarding timing records must never contain the submitted secret',
+  )
+}
+
 async function setupWindow(app) {
   return await waitFor(async () => {
     for (const page of app.windows()) {
@@ -38,29 +124,433 @@ async function setupWindow(app) {
   }, 'desktop onboarding window')
 }
 
-const userDataRoot = await mkdtemp(join(tmpdir(), 'opensquilla-electron-onboarding-test-'))
-const userDataDir = join(userDataRoot, 'chromium-user-data')
-const isolatedHome = join(userDataRoot, 'home')
-await mkdir(isolatedHome, { recursive: true })
-const app = await electron.launch({
-  args: [
-    '--use-mock-keychain',
-    `--user-data-dir=${userDataDir}`,
-    packageRoot,
-  ],
-  env: {
-    ...process.env,
-    HOME: isolatedHome,
-    USERPROFILE: isolatedHome,
-    OPENSQUILLA_DESKTOP_REPO_ROOT: repoRoot,
-    OPENSQUILLA_DESKTOP_SECRET_STORAGE: 'plain',
-    OPENSQUILLA_DESKTOP_GATEWAY_PORT: '18897',
-    OPENSQUILLA_DESKTOP_DISABLE_AUTO_UPDATE: '1',
-    OPENSQUILLA_DESKTOP_MOCK_UPDATE_VERSION: '',
-    LANG: 'en_US.UTF-8',
-    LC_ALL: 'en_US.UTF-8',
-  },
-})
+async function bootWindow(app) {
+  return await waitFor(async () => {
+    for (const page of app.windows()) {
+      if (page.isClosed()) continue
+      await page.waitForLoadState('domcontentloaded', { timeout: 5_000 }).catch(() => {})
+      if (await page.locator('#phase, #timer').count().catch(() => 0) === 2) return page
+    }
+    return null
+  }, 'desktop boot window')
+}
+
+async function sendBootEvent(app, channel, payload) {
+  await app.evaluate(({ BrowserWindow }, event) => {
+    const window = BrowserWindow.getAllWindows().find((candidate) => (
+      !candidate.isDestroyed() && candidate.webContents.getURL().includes('boot.html')
+    ))
+    if (!window) throw new Error('Desktop boot window is unavailable.')
+    window.webContents.send(event.channel, event.payload)
+  }, { channel, payload })
+}
+
+async function bootElapsedSeconds(page) {
+  const text = (await page.locator('#timer').innerText()).trim()
+  const match = /^(\d+(?:\.\d+)?)s$/.exec(text)
+  assert.ok(match, `unexpected boot timer text: ${text}`)
+  return Number(match[1])
+}
+
+function boxesOverlap(left, right) {
+  return left.x < right.x + right.width
+    && left.x + left.width > right.x
+    && left.y < right.y + right.height
+    && left.y + left.height > right.y
+}
+
+async function assertSubmitActionsDoNotOverlap(page) {
+  const boxes = {
+    cancel: await page.locator('#cancel').boundingBox(),
+    submitStatus: await page.locator('#submitStatus').boundingBox(),
+    finish: await page.locator('#finish').boundingBox(),
+  }
+  for (const [name, box] of Object.entries(boxes)) {
+    assert.ok(box, `${name} must have a visible bounding box`)
+  }
+  for (const [leftName, rightName] of [
+    ['cancel', 'submitStatus'],
+    ['cancel', 'finish'],
+    ['submitStatus', 'finish'],
+  ]) {
+    assert.equal(
+      boxesOverlap(boxes[leftName], boxes[rightName]),
+      false,
+      `${leftName} must not overlap ${rightName} in the default onboarding window`,
+    )
+  }
+}
+
+async function verifyBootPhaseTimer(app) {
+  const page = await bootWindow(app)
+  const phase = page.locator('#phase')
+  const timer = page.locator('#timer')
+  assert.equal(await phase.getAttribute('role'), 'status')
+  assert.equal(await phase.getAttribute('aria-live'), 'polite')
+  assert.equal(await phase.getAttribute('aria-atomic'), 'true')
+  assert.equal(await timer.getAttribute('aria-hidden'), 'true')
+  assert.equal(await page.locator('section.status').getAttribute('aria-live'), null)
+
+  const staleStatus = {
+    phaseId: 'gateway-start',
+    label: 'Synthetic gateway start',
+    at: new Date(Date.now() - 3_000).toISOString(),
+  }
+  await sendBootEvent(app, 'desktop:boot:status', staleStatus)
+  const anchoredElapsed = await waitFor(async () => {
+    const value = await bootElapsedSeconds(page)
+    return value >= 2 ? value : null
+  }, 'boot timer to include elapsed phase age')
+
+  const activeStatus = {
+    phaseId: 'gateway-health',
+    label: 'Synthetic gateway health',
+    at: new Date().toISOString(),
+  }
+  await sendBootEvent(app, 'desktop:boot:status', activeStatus)
+  const resetElapsed = await waitFor(async () => {
+    const value = await bootElapsedSeconds(page)
+    return value < anchoredElapsed - 1 ? value : null
+  }, 'boot timer to reset for a new phase identity')
+
+  await delay(350)
+  const beforeReplay = await bootElapsedSeconds(page)
+  await sendBootEvent(app, 'desktop:boot:status', activeStatus)
+  await delay(350)
+  const afterReplay = await bootElapsedSeconds(page)
+  assert.ok(
+    afterReplay > beforeReplay && afterReplay > resetElapsed,
+    'replaying one BootStatus identity must not reset its elapsed timer',
+  )
+
+  const repeatedPhaseWithNewTimestamp = { ...activeStatus, at: new Date().toISOString() }
+  await sendBootEvent(app, 'desktop:boot:status', repeatedPhaseWithNewTimestamp)
+  const repeatedPhaseReset = await waitFor(async () => {
+    const value = await bootElapsedSeconds(page)
+    return value < afterReplay ? value : null
+  }, 'boot timer to reset for a repeated phase with a new timestamp')
+  assert.ok(Number.isFinite(repeatedPhaseReset) && repeatedPhaseReset >= 0)
+
+  const invalidTimestampLabel = 'Synthetic invalid timestamp'
+  await sendBootEvent(app, 'desktop:boot:status', {
+    phaseId: 'gateway-start',
+    label: invalidTimestampLabel,
+    at: 'not-a-date',
+  })
+  const invalidTimestampValue = await waitFor(async () => {
+    if ((await phase.innerText()).trim() !== invalidTimestampLabel) return null
+    const value = await bootElapsedSeconds(page)
+    return Number.isFinite(value) && value >= 0 && value < 2 ? { value } : null
+  }, 'invalid boot timestamp to clamp near zero')
+  assert.ok(invalidTimestampValue.value >= 0 && invalidTimestampValue.value < 2)
+
+  const futureTimestampLabel = 'Synthetic future timestamp'
+  await sendBootEvent(app, 'desktop:boot:status', {
+    phaseId: 'control',
+    label: futureTimestampLabel,
+    at: new Date(Date.now() + 60_000).toISOString(),
+  })
+  const futureTimestampValue = await waitFor(async () => {
+    if ((await phase.innerText()).trim() !== futureTimestampLabel) return null
+    const value = await bootElapsedSeconds(page)
+    return Number.isFinite(value) && value >= 0 && value < 2 ? { value } : null
+  }, 'future boot timestamp to clamp near zero')
+  assert.ok(futureTimestampValue.value >= 0 && futureTimestampValue.value < 2)
+
+  await sendBootEvent(app, 'desktop:boot:error', { message: 'Synthetic boot pause.' })
+  await delay(150)
+  const frozenText = await timer.innerText()
+  await delay(350)
+  assert.equal(await timer.innerText(), frozenText, 'boot errors must freeze the elapsed timer')
+
+  await sendBootEvent(app, 'desktop:boot:status', {
+    phaseId: 'profile',
+    label: 'Synthetic retry',
+    at: new Date().toISOString(),
+  })
+  await delay(350)
+  assert.notEqual(await timer.innerText(), frozenText, 'a new retry status must resume phase timing')
+}
+
+async function launchIsolatedOnboarding(prefix, gatewayPort) {
+  const userDataRoot = await mkdtemp(join(tmpdir(), prefix))
+  const userDataDir = join(userDataRoot, 'chromium-user-data')
+  const isolatedHome = join(userDataRoot, 'home')
+  await mkdir(isolatedHome, { recursive: true })
+  const app = await electron.launch({
+    args: [
+      '--use-mock-keychain',
+      `--user-data-dir=${userDataDir}`,
+      packageRoot,
+    ],
+    env: {
+      ...process.env,
+      HOME: isolatedHome,
+      USERPROFILE: isolatedHome,
+      OPENSQUILLA_DESKTOP_REPO_ROOT: repoRoot,
+      OPENSQUILLA_DESKTOP_SECRET_STORAGE: 'plain',
+      OPENSQUILLA_DESKTOP_GATEWAY_PORT: String(gatewayPort),
+      OPENSQUILLA_DESKTOP_DISABLE_AUTO_UPDATE: '1',
+      OPENSQUILLA_DESKTOP_MOCK_UPDATE_VERSION: '',
+      LANG: 'en_US.UTF-8',
+      LC_ALL: 'en_US.UTF-8',
+    },
+  })
+  return { app, userDataDir, userDataRoot }
+}
+
+async function installPendingSaveStub(app) {
+  await app.evaluate(({ ipcMain }) => {
+    const state = {
+      callCount: 0,
+      lastPayload: null,
+      pending: null,
+    }
+    globalThis.__opensquillaOnboardingSaveTest = state
+    ipcMain.removeHandler('desktop:onboarding:save')
+    ipcMain.handle('desktop:onboarding:save', (_event, payload) => {
+      state.callCount += 1
+      state.lastPayload = payload
+      return new Promise((resolveSave, rejectSave) => {
+        state.pending = { resolveSave, rejectSave }
+      })
+    })
+  })
+}
+
+async function pendingSaveState(app) {
+  return await app.evaluate(() => {
+    const state = globalThis.__opensquillaOnboardingSaveTest
+    return {
+      callCount: state?.callCount || 0,
+      hasPending: Boolean(state?.pending),
+      lastPayload: state?.lastPayload || null,
+    }
+  })
+}
+
+async function settlePendingSave(app, outcome) {
+  await app.evaluate((_electron, nextOutcome) => {
+    const state = globalThis.__opensquillaOnboardingSaveTest
+    if (!state?.pending) throw new Error('No synthetic onboarding save is pending.')
+    const pending = state.pending
+    state.pending = null
+    if (nextOutcome.reject) {
+      pending.rejectSave(new Error(nextOutcome.error))
+      return
+    }
+    pending.resolveSave(nextOutcome.result)
+  }, outcome)
+}
+
+async function assertSubmitPending(
+  page,
+  app,
+  expectedCallCount,
+  {
+    initialStatus = 'Preparing desktop profile',
+    savingLabel = 'Saving setup…',
+  } = {},
+) {
+  const form = page.locator('#setup-form')
+  const finish = page.locator('#finish')
+  const cardBody = page.locator('.card-body')
+  const locale = page.locator('#onboardingLocale')
+  const cancel = page.locator('#cancel')
+  const submitStatus = page.locator('#submitStatus')
+  const providerSelectToggle = page.locator('#providerSelectToggle')
+  const providerSelectPanel = page.locator('#providerSelectPanel')
+  await waitFor(async () => {
+    const state = await pendingSaveState(app)
+    return state.callCount === expectedCallCount
+      && state.hasPending
+      && await finish.isDisabled()
+      && await form.getAttribute('aria-busy') === 'true'
+  }, 'visible single-flight onboarding submit state')
+  assert.equal(await finish.isDisabled(), true)
+  assert.equal(await finish.evaluate((button) => button.classList.contains('is-loading')), true)
+  assert.equal(await form.getAttribute('aria-busy'), 'true')
+  assert.equal(await cardBody.evaluate((card) => card.inert), true)
+  assert.equal(await locale.isDisabled(), true)
+  assert.equal(await cancel.isDisabled(), false)
+  assert.equal(await providerSelectToggle.getAttribute('aria-expanded'), 'false')
+  assert.equal(await providerSelectPanel.isHidden(), true)
+  assert.equal(await submitStatus.isVisible(), true)
+  assert.equal(await submitStatus.getAttribute('role'), 'status')
+  assert.equal(await submitStatus.getAttribute('aria-live'), 'polite')
+  assert.equal(await submitStatus.getAttribute('aria-atomic'), 'true')
+  assert.equal((await submitStatus.innerText()).trim(), initialStatus)
+  assert.equal((await finish.innerText()).trim(), savingLabel)
+}
+
+async function assertSubmitRestored(
+  page,
+  expectedError,
+  expectedApiKey,
+  expectedFinishLabel = 'Start OpenSquilla',
+) {
+  const form = page.locator('#setup-form')
+  const finish = page.locator('#finish')
+  const cardBody = page.locator('.card-body')
+  const locale = page.locator('#onboardingLocale')
+  const errorBox = page.locator('#error')
+  const submitStatus = page.locator('#submitStatus')
+  await waitFor(async () => (
+    await form.getAttribute('aria-busy') === 'false'
+      && !await finish.isDisabled()
+      && (await errorBox.innerText()).includes(expectedError)
+  ), 'restored onboarding submit state')
+  assert.equal(await finish.isDisabled(), false)
+  assert.equal(await finish.evaluate((button) => button.classList.contains('is-loading')), false)
+  assert.equal(await form.getAttribute('aria-busy'), 'false')
+  assert.equal(await cardBody.evaluate((card) => card.inert), false)
+  assert.equal(await locale.isDisabled(), false)
+  assert.equal(await page.locator('#apiKey').inputValue(), expectedApiKey)
+  assert.equal((await finish.innerText()).trim(), expectedFinishLabel)
+  assert.equal((await submitStatus.innerText()).trim(), '')
+  assert.match(await errorBox.innerText(), new RegExp(expectedError))
+  assert.equal(
+    await errorBox.evaluate((element) => document.activeElement === element),
+    true,
+    'submit failure must move focus to the global error',
+  )
+}
+
+async function verifySubmitFeedbackAndSingleFlight() {
+  const { app, userDataDir, userDataRoot } = await launchIsolatedOnboarding(
+    'opensquilla-electron-onboarding-submit-test-',
+    18896,
+  )
+  try {
+    const page = await setupWindow(app)
+    await verifyBootPhaseTimer(app)
+    const submitClockOrigin = Date.now()
+    await page.clock.install({ time: submitClockOrigin })
+    await page.clock.pauseAt(submitClockOrigin)
+    const apiKey = page.locator('#apiKey')
+    await apiKey.fill('synthetic-submit-key')
+    await page.locator('#onboardingLocale').selectOption('de')
+    await installPendingSaveStub(app)
+
+    await page.locator('#providerSelectToggle').click()
+    assert.equal(await page.locator('#providerSelectToggle').getAttribute('aria-expanded'), 'true')
+    assert.equal(await page.locator('#providerSelectPanel').isVisible(), true)
+    await page.locator('#finish').click()
+    await assertSubmitPending(page, app, 1, {
+      initialStatus: 'Desktop-Profil wird vorbereitet',
+      savingLabel: 'Einrichtung wird gespeichert…',
+    })
+    const immediateSubmitStatus = (await page.locator('#submitStatus').innerText()).trim()
+    await page.clock.fastForward(7_999)
+    assert.equal(
+      (await page.locator('#submitStatus').innerText()).trim(),
+      immediateSubmitStatus,
+      'slow feedback must not appear before the 8 second boundary',
+    )
+    await page.clock.fastForward(1)
+    const slowSubmitStatus = await waitFor(async () => {
+      const value = (await page.locator('#submitStatus').innerText()).trim()
+      return value && value !== immediateSubmitStatus ? value : null
+    }, 'slow onboarding feedback')
+    assert.equal(
+      slowSubmitStatus,
+      'Die Ersteinrichtung dauert normalerweise 10–20 Sekunden. Lassen Sie dieses Fenster geöffnet.',
+    )
+    assert.equal(await page.locator('#submitStatus').isVisible(), true)
+    assert.equal(await page.locator('#finish').isDisabled(), true)
+    assert.equal((await page.locator('#finish').innerText()).trim(), 'Einrichtung wird gespeichert…')
+    await assertSubmitActionsDoNotOverlap(page)
+    const firstState = await pendingSaveState(app)
+    assert.equal(firstState.lastPayload?.apiKey, 'synthetic-submit-key')
+
+    await page.locator('#finish').evaluate((button) => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    })
+    await delay(100)
+    assert.equal(
+      (await pendingSaveState(app)).callCount,
+      1,
+      'a pending onboarding save must ignore repeated click events',
+    )
+
+    await settlePendingSave(app, {
+      reject: false,
+      result: { ok: false, error: 'Synthetic onboarding save was refused.' },
+    })
+    await assertSubmitRestored(
+      page,
+      'Synthetic onboarding save was refused.',
+      'synthetic-submit-key',
+      'OpenSquilla starten',
+    )
+    await page.clock.fastForward(8_000)
+    assert.equal(
+      (await page.locator('#submitStatus').innerText()).trim(),
+      '',
+      'a failed save must cancel stale slow-feedback timers',
+    )
+    await page.locator('#onboardingLocale').selectOption('en')
+
+    await page.locator('#finish').click()
+    await assertSubmitPending(page, app, 2)
+    await settlePendingSave(app, {
+      reject: true,
+      error: 'Synthetic onboarding save rejected.',
+    })
+    await assertSubmitRestored(page, 'Synthetic onboarding save rejected.', 'synthetic-submit-key')
+
+    await page.locator('#finish').click()
+    await assertSubmitPending(page, app, 3)
+    await settlePendingSave(app, {
+      reject: false,
+      result: { ok: true },
+    })
+    await delay(100)
+    assert.equal(
+      (await pendingSaveState(app)).callCount,
+      3,
+      'a successful onboarding save must not submit again',
+    )
+    assert.equal(await page.locator('#finish').isDisabled(), true)
+    assert.equal(
+      await page.locator('#finish').evaluate((button) => button.classList.contains('is-loading')),
+      true,
+    )
+    assert.equal(await page.locator('#setup-form').getAttribute('aria-busy'), 'true')
+    assert.equal(
+      (await page.locator('#submitStatus').innerText()).trim(),
+      'Preparing desktop profile',
+    )
+    await page.clock.fastForward(8_000)
+    assert.equal(
+      (await page.locator('#submitStatus').innerText()).trim(),
+      'Preparing desktop profile',
+      'a successful save must clear its slow-feedback timer while the window closes',
+    )
+  } catch (error) {
+    const windows = await Promise.all(app.windows().map(async (page) => ({
+      closed: page.isClosed(),
+      title: await page.title().catch(() => ''),
+      url: page.url(),
+    })))
+    const desktopLog = await readFile(join(userDataDir, 'logs', 'desktop.log'), 'utf8')
+      .catch(() => '<desktop log unavailable>')
+    throw new Error(
+      `${error?.message || error}\nWindows: ${JSON.stringify(windows)}\nDesktop log:\n${desktopLog}`,
+      { cause: error },
+    )
+  } finally {
+    await app.close().catch(() => {})
+    await rm(userDataRoot, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+await verifySubmitFeedbackAndSingleFlight()
+
+const { app, userDataDir, userDataRoot } = await launchIsolatedOnboarding(
+  'opensquilla-electron-onboarding-test-',
+  18897,
+)
 
 try {
   const page = await setupWindow(app)
@@ -372,6 +862,13 @@ try {
     return { credential, config }
   }, 'saved simple onboarding credential and config')
   const { credential, config } = saved
+  const onboardingTelemetry = await waitFor(async () => {
+    const records = await readOnboardingTelemetry(userDataDir)
+    return records.some((record) => (
+      record.event === 'onboarding_save_finished' && record.outcome === 'ok'
+    )) ? records : null
+  }, 'completed local onboarding timing trace')
+  assertOnboardingTelemetrySchema(onboardingTelemetry, 'synthetic-tokenrhythm-key')
   assert.equal(credential.provider, 'tokenrhythm')
   assert.equal(credential.modelRoutingMode, 'squilla_router')
   assert.equal(credential.routerMode, 'recommended')

--- a/desktop/electron/scripts/test-onboarding-save-telemetry.mjs
+++ b/desktop/electron/scripts/test-onboarding-save-telemetry.mjs
@@ -1,0 +1,206 @@
+import { strict as assert } from 'node:assert'
+import { OnboardingSaveTelemetry } from '../dist/onboarding-save-telemetry.js'
+
+function clock(...ticks) {
+  return () => {
+    assert.ok(ticks.length > 0, 'test clock exhausted')
+    return ticks.shift()
+  }
+}
+
+async function verifyCompletedStageAndSuccessfulTerminalRecord() {
+  const entries = []
+  const telemetry = new OnboardingSaveTelemetry(
+    7,
+    true,
+    (event, detail) => entries.push({ event, detail: structuredClone(detail) }),
+    clock(100, 110, 119, 125, 132, 140),
+  )
+
+  const inspected = await telemetry.stage('primary_recovery_inspect', async () => 'ready')
+  const handedOff = telemetry.stageSync('flow_handoff', () => true)
+  telemetry.markWriterAdmitted()
+  telemetry.markSettingsPersistedConfirmed()
+  const returned = telemetry.recordReturned({ ok: true })
+  telemetry.finish()
+  telemetry.finish()
+
+  assert.equal(inspected, 'ready')
+  assert.equal(handedOff, true)
+  assert.deepEqual(returned, { ok: true })
+  assert.deepEqual(entries, [
+    {
+      event: 'onboarding_save_started',
+      detail: { attempt: 7, packaged: true },
+    },
+    {
+      event: 'onboarding_save_stage_started',
+      detail: { attempt: 7, stage: 'primary_recovery_inspect' },
+    },
+    {
+      event: 'onboarding_save_stage_finished',
+      detail: {
+        attempt: 7,
+        stage: 'primary_recovery_inspect',
+        durationMs: 9,
+        outcome: 'completed',
+      },
+    },
+    {
+      event: 'onboarding_save_stage_started',
+      detail: { attempt: 7, stage: 'flow_handoff' },
+    },
+    {
+      event: 'onboarding_save_stage_finished',
+      detail: {
+        attempt: 7,
+        stage: 'flow_handoff',
+        durationMs: 7,
+        outcome: 'completed',
+      },
+    },
+    {
+      event: 'onboarding_save_finished',
+      detail: {
+        attempt: 7,
+        totalDurationMs: 40,
+        outcome: 'ok',
+        writerAdmitted: true,
+        settingsPersistedConfirmed: true,
+        lastStage: 'flow_handoff',
+      },
+    },
+  ])
+}
+
+async function verifyThrownStageIsRethrownAndTerminallyRecorded() {
+  const entries = []
+  const sentinel = new Error('must remain private')
+  const telemetry = new OnboardingSaveTelemetry(
+    8,
+    false,
+    (event, detail) => entries.push({ event, detail: structuredClone(detail) }),
+    clock(5, 10, 16, 20),
+  )
+
+  await assert.rejects(
+    telemetry.stage('settings_persist', async () => {
+      throw sentinel
+    }),
+    (error) => error === sentinel,
+  )
+  telemetry.finish()
+
+  assert.deepEqual(entries.at(-2), {
+    event: 'onboarding_save_stage_finished',
+    detail: {
+      attempt: 8,
+      stage: 'settings_persist',
+      durationMs: 6,
+      outcome: 'threw',
+    },
+  })
+  assert.deepEqual(entries.at(-1), {
+    event: 'onboarding_save_finished',
+    detail: {
+      attempt: 8,
+      totalDurationMs: 15,
+      outcome: 'threw',
+      writerAdmitted: false,
+      settingsPersistedConfirmed: false,
+      lastStage: 'settings_persist',
+    },
+  })
+  assert.equal(JSON.stringify(entries).includes(sentinel.message), false)
+}
+
+function verifyReturnedFailureLogsOnlyTheTypedCode() {
+  const entries = []
+  const telemetry = new OnboardingSaveTelemetry(
+    9,
+    false,
+    (event, detail) => entries.push({ event, detail: structuredClone(detail) }),
+    clock(0, 25),
+  )
+  const returned = telemetry.recordReturned({
+    ok: false,
+    code: 'recovery_required',
+    error: 'secret-bearing renderer message',
+  })
+  telemetry.finish()
+
+  assert.equal(returned.error, 'secret-bearing renderer message')
+  assert.deepEqual(entries.at(-1), {
+    event: 'onboarding_save_finished',
+    detail: {
+      attempt: 9,
+      totalDurationMs: 25,
+      outcome: 'returned_error',
+      writerAdmitted: false,
+      settingsPersistedConfirmed: false,
+      lastStage: null,
+      code: 'recovery_required',
+    },
+  })
+  assert.equal(JSON.stringify(entries).includes(returned.error), false)
+}
+
+async function verifyTelemetrySinkCannotBreakObservedWork() {
+  const telemetry = new OnboardingSaveTelemetry(
+    10,
+    false,
+    () => {
+      throw new Error('log sink unavailable')
+    },
+    clock(0, 1, 2, 3),
+  )
+  assert.equal(await telemetry.stage('pending_setup_read', async () => 42), 42)
+  assert.deepEqual(telemetry.recordReturned({ ok: true }), { ok: true })
+  assert.doesNotThrow(() => telemetry.finish())
+}
+
+async function verifyInvalidClockValuesProduceFiniteDurations() {
+  const entries = []
+  const telemetry = new OnboardingSaveTelemetry(
+    11,
+    false,
+    (event, detail) => entries.push({ event, detail: structuredClone(detail) }),
+    clock(100, Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY, Number.NaN),
+  )
+  await telemetry.stage('local_finalize', async () => undefined)
+  telemetry.recordReturned({ ok: true })
+  telemetry.finish()
+
+  const stageFinished = entries.find((entry) => entry.event === 'onboarding_save_stage_finished')
+  const saveFinished = entries.find((entry) => entry.event === 'onboarding_save_finished')
+  assert.equal(stageFinished.detail.durationMs, 0)
+  assert.equal(saveFinished.detail.totalDurationMs, 0)
+  assert.equal(Number.isFinite(stageFinished.detail.durationMs), true)
+  assert.equal(Number.isFinite(saveFinished.detail.totalDurationMs), true)
+}
+
+async function verifyDecreasingClockClampsDurationsToZero() {
+  const entries = []
+  const telemetry = new OnboardingSaveTelemetry(
+    12,
+    false,
+    (event, detail) => entries.push({ event, detail: structuredClone(detail) }),
+    clock(100, 50, 40, 30),
+  )
+  await telemetry.stage('pending_setup_read', async () => undefined)
+  telemetry.recordReturned({ ok: true })
+  telemetry.finish()
+
+  const stageFinished = entries.find((entry) => entry.event === 'onboarding_save_stage_finished')
+  const saveFinished = entries.find((entry) => entry.event === 'onboarding_save_finished')
+  assert.equal(stageFinished.detail.durationMs, 0)
+  assert.equal(saveFinished.detail.totalDurationMs, 0)
+}
+
+await verifyCompletedStageAndSuccessfulTerminalRecord()
+await verifyThrownStageIsRethrownAndTerminallyRecorded()
+verifyReturnedFailureLogsOnlyTheTypedCode()
+await verifyTelemetrySinkCannotBreakObservedWork()
+await verifyInvalidClockValuesProduceFiniteDurations()
+await verifyDecreasingClockClampsDurationsToZero()
+console.log('onboarding save telemetry tests passed')

--- a/desktop/electron/src/boot.html
+++ b/desktop/electron/src/boot.html
@@ -520,11 +520,11 @@
         <p class="subtitle" data-i18n="subtitle">Starting the desktop control surface.</p>
       </section>
 
-      <section class="status" aria-live="polite">
+      <section class="status">
         <div class="status-line" aria-hidden="true"></div>
         <div class="status-copy">
-          <span class="phase" id="phase" data-i18n="phaseDefault">Preparing desktop profile</span>
-          <span class="timer" id="timer">00.0s</span>
+          <span class="phase" id="phase" data-i18n="phaseDefault" role="status" aria-live="polite" aria-atomic="true">Preparing desktop profile</span>
+          <span class="timer" id="timer" aria-hidden="true">00.0s</span>
         </div>
         <div class="steps" aria-hidden="true">
           <span class="step active" data-step="profile" data-i18n="stepProfile">Profile</span>
@@ -738,7 +738,8 @@
     };
     let msg = MESSAGES.en;
 
-    const started = performance.now();
+    let phaseStartedAt = performance.now();
+    let phaseStatusIdentity = '';
     const phase = document.getElementById('phase');
     const timer = document.getElementById('timer');
     const errorPanel = document.getElementById('errorPanel');
@@ -796,6 +797,17 @@
 
     function applyStatus(payload) {
       const phaseId = payload && payload.phaseId ? String(payload.phaseId) : 'profile';
+      const statusAt = payload && payload.at ? String(payload.at) : '';
+      const statusIdentity = phaseId + '\u0000' + statusAt;
+      if (statusIdentity !== phaseStatusIdentity) {
+        phaseStatusIdentity = statusIdentity;
+        const statusAtMs = Date.parse(statusAt);
+        const wallAgeMs = Number.isFinite(statusAtMs) ? Date.now() - statusAtMs : 0;
+        // Anchor once from the main-process wall-clock timestamp, then use the
+        // renderer's monotonic clock. Invalid or future timestamps start at zero.
+        phaseStartedAt = performance.now() - Math.max(0, wallAgeMs);
+        updateTimer();
+      }
       // The label is already localized by the main process; fall back to the
       // local default phase string only when no label was provided.
       phase.textContent = payload && payload.label ? String(payload.label) : msg.phaseDefault;
@@ -971,7 +983,7 @@
     }
 
     function updateTimer() {
-      timer.textContent = `${((performance.now() - started) / 1000).toFixed(1).padStart(4, '0')}s`;
+      timer.textContent = `${((performance.now() - phaseStartedAt) / 1000).toFixed(1).padStart(4, '0')}s`;
     }
     let timerInterval = setInterval(updateTimer, 100);
 

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -39,6 +39,11 @@ import {
   stopAndJoinLifecycleProcesses,
   waitForGatewayReadiness,
 } from './gateway-lifecycle.js'
+import {
+  OnboardingFlowCoordinator,
+  type CoordinatedOnboardingFlow,
+} from './onboarding-flow-coordinator.js'
+import { OnboardingSaveTelemetry } from './onboarding-save-telemetry.js'
 import { buildCliInvocation } from './cli-invocation.js'
 import {
   cleanupSelectorArgs,
@@ -227,6 +232,25 @@ interface OnboardingProbeResult {
   failureKind: string
   message: string
   latencyMs: number
+}
+
+type OnboardingSaveErrorCode =
+  | 'onboarding_inactive'
+  | 'save_in_progress'
+  | 'recovery_required'
+  | 'lifecycle_deferred'
+
+type OnboardingSaveResult =
+  | { ok: true }
+  | { ok: false; code: OnboardingSaveErrorCode; error: string }
+
+interface OnboardingFlow extends CoordinatedOnboardingFlow<
+  OnboardingPayload,
+  OnboardingSaveResult
+> {
+  window: BrowserWindow | null
+  resolve: ((credential: DesktopConnection) => void) | null
+  reject: ((error: Error) => void) | null
 }
 
 interface DesktopSettingsPayload extends OnboardingPayload {}
@@ -468,8 +492,12 @@ function nativeWorkbenchFailureReason(event: NativeWorkbenchSurfaceEvent): strin
 }
 
 let gatewayStartPromise: Promise<GatewayState> | null = null
-let resolveOnboarding: ((credential: DesktopConnection) => void) | null = null
-let rejectOnboarding: ((error: Error) => void) | null = null
+let onboardingSaveTelemetryAttempt = 0
+const onboardingFlows = new OnboardingFlowCoordinator<
+  OnboardingPayload,
+  OnboardingSaveResult,
+  OnboardingFlow
+>()
 let secretStorageBackendCache: SecretEncryption | null = null
 let macCodeSignatureDiagnosticCache: string | null = null
 let bootStatus: BootStatus = {
@@ -3900,6 +3928,8 @@ const ONBOARDING_SCRIPT_MESSAGES: Record<DesktopLocale, Record<string, string>> 
     directModelRequiredDirect: 'Direct model is required for Direct single model mode.',
     defaultTierRequiresModel: 'Default router tier requires a model.',
     searchApiKeyRequired: '{label} search API key is required.',
+    savingSetup: 'Saving setup…',
+    setupTakingLonger: 'First-time setup usually takes 10–20 seconds. Please keep this window open.',
     stepLabel: 'Step {n}',
   },
   'zh-Hans': {
@@ -3946,6 +3976,8 @@ const ONBOARDING_SCRIPT_MESSAGES: Record<DesktopLocale, Record<string, string>> 
     directModelRequiredDirect: '直连单模型模式需要直连模型。',
     defaultTierRequiresModel: '默认路由层级需要一个模型。',
     searchApiKeyRequired: '需要 {label} 搜索 API 密钥。',
+    savingSetup: '正在保存设置…',
+    setupTakingLonger: '首次设置通常需要 10–20 秒，请保持此窗口打开。',
     stepLabel: '步骤 {n}',
   },
   ja: {
@@ -3992,6 +4024,8 @@ const ONBOARDING_SCRIPT_MESSAGES: Record<DesktopLocale, Record<string, string>> 
     directModelRequiredDisabled: 'Smart Router を無効にする場合は直接モデルが必要です。',
     defaultTierRequiresModel: 'デフォルトのルーターティアにはモデルが必要です。',
     searchApiKeyRequired: '{label} の検索 API キーが必要です。',
+    savingSetup: '設定を保存しています…',
+    setupTakingLonger: '初回セットアップには通常10～20秒かかります。このウィンドウを開いたままお待ちください。',
     stepLabel: 'ステップ {n}',
   },
   fr: {
@@ -4038,6 +4072,8 @@ const ONBOARDING_SCRIPT_MESSAGES: Record<DesktopLocale, Record<string, string>> 
     directModelRequiredDisabled: 'Un modèle direct est requis lorsque Smart Router est désactivé.',
     defaultTierRequiresModel: 'Le niveau de routeur par défaut nécessite un modèle.',
     searchApiKeyRequired: 'La clé API de recherche {label} est requise.',
+    savingSetup: 'Enregistrement…',
+    setupTakingLonger: 'La configuration initiale prend généralement 10 à 20 secondes. Gardez cette fenêtre ouverte.',
     stepLabel: 'Étape {n}',
   },
   de: {
@@ -4084,6 +4120,8 @@ const ONBOARDING_SCRIPT_MESSAGES: Record<DesktopLocale, Record<string, string>> 
     directModelRequiredDisabled: 'Ein direktes Modell ist erforderlich, wenn Smart Router deaktiviert ist.',
     defaultTierRequiresModel: 'Die Standard-Routerstufe erfordert ein Modell.',
     searchApiKeyRequired: 'Der Such-API-Schlüssel für {label} ist erforderlich.',
+    savingSetup: 'Einrichtung wird gespeichert…',
+    setupTakingLonger: 'Die Ersteinrichtung dauert normalerweise 10–20 Sekunden. Lassen Sie dieses Fenster geöffnet.',
     stepLabel: 'Schritt {n}',
   },
   es: {
@@ -4130,6 +4168,8 @@ const ONBOARDING_SCRIPT_MESSAGES: Record<DesktopLocale, Record<string, string>> 
     directModelRequiredDisabled: 'Se requiere un modelo directo cuando Smart Router está desactivado.',
     defaultTierRequiresModel: 'El nivel de enrutador predeterminado requiere un modelo.',
     searchApiKeyRequired: 'Se requiere la clave API de búsqueda de {label}.',
+    savingSetup: 'Guardando la configuración…',
+    setupTakingLonger: 'La configuración inicial suele tardar entre 10 y 20 segundos. Mantén esta ventana abierta.',
     stepLabel: 'Paso {n}',
   },
 }
@@ -5626,6 +5666,16 @@ function onboardingHtml(
       border-top: 1px solid var(--line);
       padding-top: 16px;
     }
+    .actions > button { flex: 0 0 auto; }
+    .submit-status {
+      flex: 1 1 auto;
+      min-width: 0;
+      padding: 0 8px;
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.35;
+      text-align: center;
+    }
     button {
       min-height: 36px;
       border: 1px solid transparent;
@@ -5640,6 +5690,10 @@ function onboardingHtml(
     }
     .secondary:hover { color: var(--ink); }
     .primary {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
       background: var(--primary);
       border-radius: 8px;
       color: #fff;
@@ -5650,6 +5704,19 @@ function onboardingHtml(
       background: var(--primary-hover);
     }
     .primary:disabled { opacity: 0.55; cursor: not-allowed; }
+    .primary.is-loading::before {
+      width: 12px;
+      height: 12px;
+      flex: 0 0 auto;
+      border: 2px solid rgba(255, 255, 255, 0.45);
+      border-top-color: #fff;
+      border-radius: 50%;
+      content: "";
+      animation: onboarding-submit-spin 700ms linear infinite;
+    }
+    @keyframes onboarding-submit-spin {
+      to { transform: rotate(360deg); }
+    }
     .error {
       min-height: 18px;
       color: #b42318;
@@ -5692,6 +5759,9 @@ function onboardingHtml(
         transition-duration: 0.01ms !important;
         animation-duration: 0.01ms !important;
         animation-iteration-count: 1 !important;
+      }
+      .primary.is-loading::before {
+        animation: none !important;
       }
     }
   </style>
@@ -5784,10 +5854,11 @@ function onboardingHtml(
         </div>
         <footer class="actions">
           <button class="secondary" type="button" id="cancel" data-i18n="onboarding.step1.quit">${ot('onboarding.step1.quit')}</button>
+          <span class="submit-status" id="submitStatus" role="status" aria-live="polite" aria-atomic="true"></span>
           <button class="primary" type="button" id="finish" data-i18n="onboarding.step5.finish">${ot('onboarding.step5.finish')}</button>
         </footer>
       </section>
-      <div class="error" id="error" role="alert" aria-live="assertive"></div>
+      <div class="error" id="error" role="alert" aria-live="assertive" tabindex="-1"></div>
     </form>
   </main>
   <script>
@@ -5815,6 +5886,11 @@ function onboardingHtml(
     let searchSectionOpen = false;
     let routerTiers = clone(routerProfiles.openrouter);
     let modelEditorOpen = false;
+    let submitting = false;
+    const SUBMIT_SLOW_FEEDBACK_MS = 8_000;
+    let submitSlowTimer = null;
+    const setupForm = document.getElementById('setup-form');
+    const cardBody = document.querySelector('.card-body');
     const provider = document.getElementById('provider');
     const baseUrl = document.getElementById('baseUrl');
     const model = document.getElementById('model');
@@ -5835,6 +5911,7 @@ function onboardingHtml(
     const searchApiKey = document.getElementById('searchApiKey');
     const searchApiKeyError = document.getElementById('searchApiKeyError');
     const finish = document.getElementById('finish');
+    const submitStatus = document.getElementById('submitStatus');
     const searchProvider = document.getElementById('searchProvider');
 	    const searchProviderGrid = document.getElementById('searchProviderGrid');
 	    const searchKeyLabel = document.getElementById('searchKeyLabel');
@@ -5850,6 +5927,26 @@ function onboardingHtml(
     const providerOptions = document.getElementById('providerOptions');
     function clone(value) {
       return JSON.parse(JSON.stringify(value || {}));
+    }
+    function deepFreeze(value) {
+      if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+      Object.values(value).forEach((item) => deepFreeze(item));
+      return Object.freeze(value);
+    }
+    function onboardingPayloadSnapshot() {
+      return deepFreeze({
+        provider: provider.value,
+        apiKey: apiKey.value,
+        baseUrl: baseUrl.value,
+        model: model.value,
+        modelRoutingMode: modelRoutingMode.value,
+        routerMode: routerMode.value,
+        routerDefaultTier: 'c1',
+        routerTiers: clone(routerTiers),
+        searchProvider: searchProvider.value,
+        searchApiKey: searchApiKey.value,
+        locale: activeLocale,
+      });
     }
     function currentProvider() {
       return providers.find((item) => item.id === provider.value) || providers[0];
@@ -6074,6 +6171,33 @@ function onboardingHtml(
       syncProviderDefaults(false);
       syncSearchProviderControls();
     }
+    function clearSubmitSlowTimer() {
+      if (submitSlowTimer !== null) clearTimeout(submitSlowTimer);
+      submitSlowTimer = null;
+    }
+    function setSubmitting(next) {
+      clearSubmitSlowTimer();
+      submitting = Boolean(next);
+      if (submitting) setProviderPickerOpen(false);
+      setupForm.setAttribute('aria-busy', String(submitting));
+      finish.setAttribute('aria-busy', String(submitting));
+      finish.disabled = submitting;
+      finish.classList.toggle('is-loading', submitting);
+      cardBody.inert = submitting;
+      onboardingLocale.disabled = submitting;
+      if (submitting) {
+        finish.textContent = t.savingSetup;
+        submitStatus.textContent = desktopMessage(activeLocale, 'boot.profile');
+        submitSlowTimer = setTimeout(() => {
+          submitSlowTimer = null;
+          if (submitting) submitStatus.textContent = t.setupTakingLonger;
+        }, SUBMIT_SLOW_FEEDBACK_MS);
+      } else {
+        finish.textContent = desktopMessage(activeLocale, 'onboarding.step5.finish');
+        submitStatus.textContent = '';
+      }
+    }
+    window.addEventListener('pagehide', clearSubmitSlowTimer);
 	    onboardingLocale.addEventListener('change', () => {
 	      applyLocale(onboardingLocale.value);
 	    });
@@ -6149,28 +6273,34 @@ function onboardingHtml(
       window.opensquillaDesktop.cancelOnboarding();
     });
     finish.addEventListener('click', async () => {
+      if (submitting) return;
       clearValidationErrors();
       const issue = validateStep();
       if (issue) {
         presentValidationIssue(issue);
         return;
       }
+      const payload = onboardingPayloadSnapshot();
+      setSubmitting(true);
+      let succeeded = false;
       try {
-        await window.opensquillaDesktop.saveOnboarding({
-          provider: provider.value,
-          apiKey: apiKey.value,
-          baseUrl: baseUrl.value,
-          model: model.value,
-          modelRoutingMode: modelRoutingMode.value,
-          routerMode: routerMode.value,
-          routerDefaultTier: 'c1',
-          routerTiers,
-          searchProvider: searchProvider.value,
-          searchApiKey: searchApiKey.value,
-          locale: activeLocale,
-        });
+        const result = await window.opensquillaDesktop.saveOnboarding(payload);
+        if (!result || result.ok !== true) {
+          throw new Error(
+            result && result.error
+              ? String(result.error)
+              : 'OpenSquilla setup could not be saved.',
+          );
+        }
+        succeeded = true;
+        clearSubmitSlowTimer();
       } catch (error) {
         errorBox.textContent = error && error.message ? error.message : String(error);
+      } finally {
+        if (!succeeded) {
+          setSubmitting(false);
+          errorBox.focus({ preventScroll: false });
+        }
       }
     });
     function applyMigrationPrefill(prefill) {
@@ -6200,7 +6330,24 @@ function onboardingHtml(
 </html>`
 }
 
+function abandonOnboardingFlow(
+  flow: OnboardingFlow,
+  error: Error,
+  closeWindow: boolean,
+): void {
+  if (!onboardingFlows.abandon(flow)) return
+  const reject = flow.reject
+  flow.resolve = null
+  flow.reject = null
+  const window = flow.window
+  if (closeWindow && window && !window.isDestroyed()) window.close()
+  reject?.(error)
+}
+
 async function runOnboarding(): Promise<DesktopConnection> {
+  // A detached save retains coordinator ownership until it settles, preventing
+  // Retry from opening a replacement flow that the old completion could affect.
+  await onboardingFlows.waitForAbandonedSave()
   const pendingProviderSetup = await loadPendingMigrationProviderSetup()
   const existing = await loadDesktopCredential()
   // A saved credential encrypted with the OS keychain that this session cannot
@@ -6233,10 +6380,13 @@ async function runOnboarding(): Promise<DesktopConnection> {
   }
 
   return new Promise((resolveCredential, rejectCredential) => {
-    resolveOnboarding = resolveCredential
-    rejectOnboarding = rejectCredential
+    if (onboardingFlows.active) {
+      focusOnboardingWindow()
+      rejectCredential(new Error('OpenSquilla setup is already in progress.'))
+      return
+    }
     const parentWindow = currentMainWindow()
-    onboardingWindow = new BrowserWindow({
+    const window = new BrowserWindow({
       width: 1040,
       height: 820,
       minWidth: 900,
@@ -6256,9 +6406,24 @@ async function runOnboarding(): Promise<DesktopConnection> {
         sandbox: true,
       },
     })
-    installEditingContextMenu(onboardingWindow)
+    const flow: OnboardingFlow = {
+      window,
+      state: 'editing',
+      resolve: resolveCredential,
+      reject: rejectCredential,
+      savePayload: null,
+      savePromise: null,
+    }
+    if (!onboardingFlows.activate(flow)) {
+      window.destroy()
+      focusOnboardingWindow()
+      rejectCredential(new Error('OpenSquilla setup is already in progress.'))
+      return
+    }
+    onboardingWindow = window
+    installEditingContextMenu(window)
 
-    onboardingWindow.webContents.setWindowOpenHandler(({ url }) => {
+    window.webContents.setWindowOpenHandler(({ url }) => {
       if (url === TOKENRHYTHM_REGISTER_URL) {
         void shell.openExternal(TOKENRHYTHM_REGISTER_URL)
       }
@@ -6274,32 +6439,34 @@ async function runOnboarding(): Promise<DesktopConnection> {
         void shell.openExternal(TOKENRHYTHM_REGISTER_URL)
       }
     }
-    onboardingWindow.webContents.on('will-navigate', guardOnboardingNavigation)
-    onboardingWindow.webContents.on('will-redirect', guardOnboardingNavigation)
+    window.webContents.on('will-navigate', guardOnboardingNavigation)
+    window.webContents.on('will-redirect', guardOnboardingNavigation)
     // Rebuild the app menu so View → Reload is disabled while onboarding is open.
     createApplicationMenu()
 
-    onboardingWindow.once('ready-to-show', () => {
-      if (!onboardingWindow || onboardingWindow.isDestroyed()) return
-      onboardingWindow.show()
-      onboardingWindow?.focus()
+    window.once('ready-to-show', () => {
+      if (flow.window !== window || window.isDestroyed() || flow.state === 'abandoned') return
+      window.show()
+      window.focus()
     })
-    onboardingWindow.on('closed', () => {
-      onboardingWindow = null
+    window.on('closed', () => {
+      if (onboardingWindow === window) onboardingWindow = null
+      if (flow.window === window) flow.window = null
       // Re-enable View → Reload now that the wizard is gone.
       createApplicationMenu()
-      if (rejectOnboarding) {
-        const reject = rejectOnboarding
-        resolveOnboarding = null
-        rejectOnboarding = null
-        reject(new Error('OpenSquilla setup was closed.'))
+      if (flow.state !== 'completed' && flow.state !== 'abandoned') {
+        abandonOnboardingFlow(flow, new Error('OpenSquilla setup was closed.'), false)
       }
     })
 
-    onboardingWindow.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(onboardingHtml(
+    window.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(onboardingHtml(
       pendingProviderSetup,
     ))}`).catch((error) => {
-      rejectCredential(error instanceof Error ? error : new Error(String(error)))
+      abandonOnboardingFlow(
+        flow,
+        error instanceof Error ? error : new Error(String(error)),
+        true,
+      )
     })
   })
 }
@@ -12360,10 +12527,150 @@ function trustedControlUiIpc(event: Electron.IpcMainInvokeEvent): boolean {
   return gatewayState.owned && trustedMainWindowControlIpc(event)
 }
 
-function trustedOnboardingIpc(event: Electron.IpcMainInvokeEvent): boolean {
-  const window = currentOnboardingWindow()
-  if (!window || event.sender !== window.webContents) return false
+function trustedOnboardingIpc(
+  event: Electron.IpcMainInvokeEvent,
+  flow = onboardingFlows.active,
+): boolean {
+  const window = flow?.window
+  if (!flow || !onboardingFlows.isCurrent(flow) || !window || window.isDestroyed()) return false
+  if (event.sender !== window.webContents) return false
   return (event.senderFrame?.url || event.sender.getURL()).startsWith('data:text/html')
+}
+
+function onboardingSaveFailure(
+  code: OnboardingSaveErrorCode,
+  error: string,
+): OnboardingSaveResult {
+  return { ok: false, code, error }
+}
+
+function completeOnboardingFlow(flow: OnboardingFlow, credential: DesktopConnection): boolean {
+  const window = flow.window
+  if (
+    !window
+    || window.isDestroyed()
+    || !onboardingFlows.complete(flow)
+  ) return false
+
+  const resolve = flow.resolve
+  flow.resolve = null
+  flow.reject = null
+  window.close()
+  resolve?.(credential)
+  return true
+}
+
+async function performOnboardingSave(
+  flow: OnboardingFlow,
+  payload: OnboardingPayload,
+): Promise<OnboardingSaveResult> {
+  const telemetry = new OnboardingSaveTelemetry(
+    ++onboardingSaveTelemetryAttempt,
+    app.isPackaged,
+    (event, detail) => desktopLog(event, detail),
+  )
+  try {
+    // Keep the existing writer-admission boundary: lifecycle drains do not need
+    // to wait for an inspect that has not begun a settings write.
+    let recoveryRequired: boolean
+    try {
+      recoveryRequired = await telemetry.stage(
+        'primary_recovery_inspect',
+        () => refreshPrimaryRecoveryAfterImportAttempt(),
+      )
+    } catch (error) {
+      if (flow.state === 'saving') flow.state = 'editing'
+      throw error
+    }
+    if (recoveryRequired) {
+      if (flow.state === 'saving') flow.state = 'editing'
+      return telemetry.recordReturned(onboardingSaveFailure(
+        'recovery_required',
+        'The primary profile requires recovery before setup can write to it.',
+      ))
+    }
+    if (!onboardingFlows.canComplete(flow)) {
+      return telemetry.recordReturned(onboardingSaveFailure(
+        'onboarding_inactive',
+        'OpenSquilla setup is no longer active.',
+      ))
+    }
+
+    let finishWriter: (() => void) | null = null
+    try {
+      finishWriter = beginDesktopWriterOperation('complete desktop onboarding')
+      telemetry.markWriterAdmitted()
+    } catch {
+      if (flow.state === 'saving') flow.state = 'editing'
+      return telemetry.recordReturned(onboardingSaveFailure(
+        'lifecycle_deferred',
+        'OpenSquilla is finishing another profile or lifecycle operation.',
+      ))
+    }
+
+    let credential: DesktopConnection
+    try {
+      // Re-read the marker only after reserving the writer. Credential/config,
+      // locale, and marker removal then converge as one lifecycle operation that
+      // update/quit must drain. Imported .env bytes are deliberately untouched.
+      const pendingMigration = await telemetry.stage(
+        'pending_setup_read',
+        () => readPendingMigrationProviderSetup(),
+      )
+      credential = await telemetry.stage('settings_persist', async () => {
+        if (pendingMigration?.phase === 'needs-setup' && pendingMigration.provider) {
+          return await saveImportedDesktopCredential(
+            pendingMigration,
+            pendingMigration.committedTransactionId,
+            String(payload.apiKey || ''),
+            true,
+          )
+        }
+        return await saveDesktopCredential(payload, true)
+      })
+      telemetry.markSettingsPersistedConfirmed()
+      await telemetry.stage('local_finalize', async () => {
+        applyDesktopLocaleChoice(payload.locale)
+        await clearPendingMigrationProviderSetup()
+      })
+    } catch (error) {
+      if (flow.state === 'saving') flow.state = 'editing'
+      throw error
+    } finally {
+      finishWriter()
+    }
+
+    return telemetry.stageSync('flow_handoff', () => {
+      if (!onboardingFlows.canComplete(flow)) {
+        return telemetry.recordReturned(onboardingSaveFailure(
+          'onboarding_inactive',
+          'OpenSquilla setup is no longer active.',
+        ))
+      }
+      // Quit deferral deliberately leaves isQuitting=false while it drains writers,
+      // so admission/exit phase are authoritative alongside the boolean latch.
+      if (desktopWriters.closed || isQuitting || appExitPhase !== 'running') {
+        abandonOnboardingFlow(
+          flow,
+          new Error('OpenSquilla setup completed, but startup was deferred by an active lifecycle operation.'),
+          true,
+        )
+        return telemetry.recordReturned(onboardingSaveFailure(
+          'lifecycle_deferred',
+          'Setup was saved; startup was deferred by an active lifecycle operation.',
+        ))
+      }
+      if (!completeOnboardingFlow(flow, credential)) {
+        return telemetry.recordReturned(onboardingSaveFailure(
+          'onboarding_inactive',
+          'OpenSquilla setup is no longer active.',
+        ))
+      }
+      return telemetry.recordReturned({ ok: true })
+    })
+  } finally {
+    telemetry.finish()
+  }
 }
 
 async function withRecoveryOperation<T>(
@@ -12745,7 +13052,8 @@ ipcMain.handle('desktop:onboarding:defaults', () => ({
   },
 }))
 ipcMain.handle('desktop:onboarding:probe', async (event, payload: OnboardingProbePayload) => {
-  if (!resolveOnboarding || !trustedOnboardingIpc(event)) {
+  const flow = onboardingFlows.active
+  if (!flow || flow.state !== 'editing' || !trustedOnboardingIpc(event, flow)) {
     return {
       ok: false,
       failureKind: 'unavailable',
@@ -12769,50 +13077,36 @@ ipcMain.handle('desktop:onboarding:save', async (event, payload: OnboardingPaylo
   // same preload bridge is attached to the Control UI window, so without this
   // guard any script on the gateway-served page could rewrite the credential and
   // regenerate config.toml outside onboarding.
-  if (!resolveOnboarding || !trustedOnboardingIpc(event)) {
-    return { ok: false, error: 'No trusted onboarding is in progress.' }
+  const flow = onboardingFlows.active
+  if (!flow || !trustedOnboardingIpc(event, flow)) {
+    return onboardingSaveFailure('onboarding_inactive', 'No trusted onboarding is in progress.')
   }
-  if (await refreshPrimaryRecoveryAfterImportAttempt()) {
-    return {
-      ok: false,
-      error: 'The primary profile requires recovery before setup can write to it.',
-    }
+  const requestPayload = payload && typeof payload === 'object' ? payload : {}
+  const request = onboardingFlows.requestSave(
+    flow,
+    requestPayload,
+    () => performOnboardingSave(flow, requestPayload),
+  )
+  if (request.kind === 'conflict') {
+    return onboardingSaveFailure(
+      'save_in_progress',
+      'OpenSquilla is already saving a different setup request.',
+    )
   }
-  let credential: DesktopConnection
-  const finishWriter = beginDesktopWriterOperation('complete desktop onboarding')
-  try {
-    // Re-read the marker only after reserving the writer. Credential/config,
-    // locale, and marker removal then converge as one lifecycle operation that
-    // update/quit must drain. Imported .env bytes are deliberately untouched.
-    const pendingMigration = await readPendingMigrationProviderSetup()
-    if (pendingMigration?.phase === 'needs-setup' && pendingMigration.provider) {
-      credential = await saveImportedDesktopCredential(
-        pendingMigration,
-        pendingMigration.committedTransactionId,
-        String(payload.apiKey || ''),
-        true,
-      )
-    } else {
-      credential = await saveDesktopCredential(payload, true)
-    }
-    applyDesktopLocaleChoice(payload.locale)
-    await clearPendingMigrationProviderSetup()
-  } finally {
-    finishWriter()
+  if (request.kind === 'inactive') {
+    return onboardingSaveFailure('onboarding_inactive', 'OpenSquilla setup is no longer active.')
   }
-  const resolve = resolveOnboarding
-  resolveOnboarding = null
-  rejectOnboarding = null
-  onboardingWindow?.close()
-  resolve?.(credential)
-  return { ok: true }
+  return await request.promise
 })
-ipcMain.handle('desktop:onboarding:cancel', () => {
-  const reject = rejectOnboarding
-  resolveOnboarding = null
-  rejectOnboarding = null
-  onboardingWindow?.close()
-  reject?.(new Error('OpenSquilla setup was cancelled.'))
+ipcMain.handle('desktop:onboarding:cancel', (event) => {
+  const flow = onboardingFlows.active
+  if (!flow || !trustedOnboardingIpc(event, flow)) {
+    return onboardingSaveFailure('onboarding_inactive', 'No trusted onboarding is in progress.')
+  }
+  // An admitted atomic save cannot be cancelled safely. Mark this flow
+  // abandoned so its late completion cannot resolve a replacement onboarding
+  // window; before-quit drains its writer before Electron exits.
+  abandonOnboardingFlow(flow, new Error('OpenSquilla setup was cancelled.'), true)
   // The onboarding "Quit" button routes here; it is a deliberate exit, so quit
   // the app instead of surfacing the cancellation as a boot failure panel.
   app.quit()

--- a/desktop/electron/src/onboarding-flow-coordinator.ts
+++ b/desktop/electron/src/onboarding-flow-coordinator.ts
@@ -1,0 +1,98 @@
+import { isDeepStrictEqual } from 'node:util'
+
+export type OnboardingFlowState = 'editing' | 'saving' | 'completed' | 'abandoned'
+
+export interface CoordinatedOnboardingFlow<Payload, Result> {
+  state: OnboardingFlowState
+  savePayload: Payload | null
+  savePromise: Promise<Result> | null
+}
+
+export type OnboardingSaveRequest<Result> =
+  | { kind: 'started'; promise: Promise<Result> }
+  | { kind: 'joined'; promise: Promise<Result> }
+  | { kind: 'conflict' }
+  | { kind: 'inactive' }
+
+/**
+ * Owns the identity and per-flow save state for the native onboarding window.
+ * Window lifetime, persistence, and app lifecycle policy remain in the main
+ * process; this coordinator only prevents overlapping or stale flow work.
+ */
+export class OnboardingFlowCoordinator<
+  Payload,
+  Result,
+  Flow extends CoordinatedOnboardingFlow<Payload, Result>,
+> {
+  private activeFlow: Flow | null = null
+
+  get active(): Flow | null {
+    return this.activeFlow
+  }
+
+  activate(flow: Flow): boolean {
+    if (this.activeFlow || flow.state !== 'editing') return false
+    this.activeFlow = flow
+    return true
+  }
+
+  isCurrent(flow: Flow): boolean {
+    return this.activeFlow === flow
+  }
+
+  canComplete(flow: Flow): boolean {
+    return this.activeFlow === flow && flow.state === 'saving'
+  }
+
+  abandon(flow: Flow): boolean {
+    if (flow.state === 'completed' || flow.state === 'abandoned') return false
+    flow.state = 'abandoned'
+    if (!flow.savePromise && this.activeFlow === flow) this.activeFlow = null
+    return true
+  }
+
+  complete(flow: Flow): boolean {
+    if (!this.canComplete(flow)) return false
+    flow.state = 'completed'
+    this.activeFlow = null
+    return true
+  }
+
+  async waitForAbandonedSave(): Promise<void> {
+    const flow = this.activeFlow
+    if (!flow || flow.state !== 'abandoned' || !flow.savePromise) return
+    await flow.savePromise.catch(() => null)
+    if (this.activeFlow === flow && flow.state === 'abandoned') this.activeFlow = null
+  }
+
+  requestSave(
+    flow: Flow,
+    payload: Payload,
+    perform: () => Promise<Result>,
+  ): OnboardingSaveRequest<Result> {
+    if (this.activeFlow !== flow) return { kind: 'inactive' }
+    if (flow.savePromise) {
+      return isDeepStrictEqual(flow.savePayload, payload)
+        ? { kind: 'joined', promise: flow.savePromise }
+        : { kind: 'conflict' }
+    }
+    if (flow.state !== 'editing') return { kind: 'inactive' }
+
+    flow.state = 'saving'
+    flow.savePayload = payload
+    // Defer by one microtask so the single-flight is published before perform
+    // reaches its first await or otherwise yields control.
+    const operation = Promise.resolve().then(perform)
+    let savePromise!: Promise<Result>
+    savePromise = operation.finally(() => {
+      if (flow.savePromise !== savePromise) return
+      flow.savePromise = null
+      flow.savePayload = null
+      if (flow.state === 'abandoned' && this.activeFlow === flow) {
+        this.activeFlow = null
+      }
+    })
+    flow.savePromise = savePromise
+    return { kind: 'started', promise: savePromise }
+  }
+}

--- a/desktop/electron/src/onboarding-save-telemetry.ts
+++ b/desktop/electron/src/onboarding-save-telemetry.ts
@@ -1,0 +1,146 @@
+import { performance } from 'node:perf_hooks'
+
+export type OnboardingSaveTelemetryCode =
+  | 'onboarding_inactive'
+  | 'save_in_progress'
+  | 'recovery_required'
+  | 'lifecycle_deferred'
+
+export type OnboardingSaveTelemetryStage =
+  | 'primary_recovery_inspect'
+  | 'pending_setup_read'
+  | 'settings_persist'
+  | 'local_finalize'
+  | 'flow_handoff'
+
+export type OnboardingSaveTelemetryEvent =
+  | 'onboarding_save_started'
+  | 'onboarding_save_stage_started'
+  | 'onboarding_save_stage_finished'
+  | 'onboarding_save_finished'
+
+export type OnboardingSaveTelemetrySink = (
+  event: OnboardingSaveTelemetryEvent,
+  detail: Record<string, unknown>,
+) => void
+
+type OnboardingSaveReturnedResult =
+  | { ok: true }
+  | { ok: false; code: OnboardingSaveTelemetryCode }
+
+type OnboardingSaveTerminalOutcome = 'ok' | 'returned_error' | 'threw'
+
+function elapsedMilliseconds(startedAt: number, finishedAt: number): number {
+  const elapsed = finishedAt - startedAt
+  return Number.isFinite(elapsed) ? Math.max(0, Math.round(elapsed)) : 0
+}
+
+/**
+ * Emits bounded, content-free timing breadcrumbs for one real onboarding save.
+ * The caller controls save semantics; this observer never logs payloads or errors.
+ */
+export class OnboardingSaveTelemetry {
+  private readonly overallStartedAt: number
+  private lastStage: OnboardingSaveTelemetryStage | null = null
+  private terminalOutcome: OnboardingSaveTerminalOutcome = 'threw'
+  private terminalCode: OnboardingSaveTelemetryCode | undefined
+  private writerAdmitted = false
+  private settingsPersistedConfirmed = false
+  private finished = false
+
+  constructor(
+    private readonly attempt: number,
+    private readonly packaged: boolean,
+    private readonly sink: OnboardingSaveTelemetrySink,
+    private readonly now: () => number = () => performance.now(),
+  ) {
+    this.overallStartedAt = this.now()
+    this.emit('onboarding_save_started', {
+      attempt: this.attempt,
+      packaged: this.packaged,
+    })
+  }
+
+  async stage<T>(
+    stage: OnboardingSaveTelemetryStage,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    this.lastStage = stage
+    this.emit('onboarding_save_stage_started', { attempt: this.attempt, stage })
+    // Exclude the synchronous breadcrumb append itself from the measured work.
+    const startedAt = this.now()
+    let outcome: 'completed' | 'threw' = 'threw'
+    try {
+      const value = await operation()
+      outcome = 'completed'
+      return value
+    } finally {
+      const durationMs = elapsedMilliseconds(startedAt, this.now())
+      this.emit('onboarding_save_stage_finished', {
+        attempt: this.attempt,
+        stage,
+        durationMs,
+        outcome,
+      })
+    }
+  }
+
+  stageSync<T>(stage: OnboardingSaveTelemetryStage, operation: () => T): T {
+    this.lastStage = stage
+    this.emit('onboarding_save_stage_started', { attempt: this.attempt, stage })
+    // Flow handoff is synchronous. Keeping it synchronous prevents observability
+    // from introducing a lifecycle-relevant yield.
+    const startedAt = this.now()
+    let outcome: 'completed' | 'threw' = 'threw'
+    try {
+      const value = operation()
+      outcome = 'completed'
+      return value
+    } finally {
+      const durationMs = elapsedMilliseconds(startedAt, this.now())
+      this.emit('onboarding_save_stage_finished', {
+        attempt: this.attempt,
+        stage,
+        durationMs,
+        outcome,
+      })
+    }
+  }
+
+  markWriterAdmitted(): void {
+    this.writerAdmitted = true
+  }
+
+  markSettingsPersistedConfirmed(): void {
+    this.settingsPersistedConfirmed = true
+  }
+
+  recordReturned<Result extends OnboardingSaveReturnedResult>(result: Result): Result {
+    this.terminalOutcome = result.ok ? 'ok' : 'returned_error'
+    this.terminalCode = result.ok ? undefined : result.code
+    return result
+  }
+
+  finish(): void {
+    if (this.finished) return
+    this.finished = true
+    const detail: Record<string, unknown> = {
+      attempt: this.attempt,
+      totalDurationMs: elapsedMilliseconds(this.overallStartedAt, this.now()),
+      outcome: this.terminalOutcome,
+      writerAdmitted: this.writerAdmitted,
+      settingsPersistedConfirmed: this.settingsPersistedConfirmed,
+      lastStage: this.lastStage,
+    }
+    if (this.terminalCode !== undefined) detail.code = this.terminalCode
+    this.emit('onboarding_save_finished', detail)
+  }
+
+  private emit(event: OnboardingSaveTelemetryEvent, detail: Record<string, unknown>): void {
+    try {
+      this.sink(event, detail)
+    } catch {
+      // Observability must never alter onboarding persistence or lifecycle state.
+    }
+  }
+}

--- a/tests/test_ci/test_windows_test_shards.py
+++ b/tests/test_ci/test_windows_test_shards.py
@@ -91,6 +91,7 @@ RECENTLY_ADDED_ACTIVE_TESTS = {
     "tests/test_ci/test_dockerignore_context.py",
     "tests/test_ci/test_migration_v022.py",
     "tests/test_ci/test_session_storage_connection_contract.py",
+    "tests/test_desktop/test_onboarding_main_process_flow_contract.py",
     "tests/test_channels/test_stream_terminal_routing.py",
     "tests/test_engine/test_agent_canonical_text_contract.py",
     "tests/test_engine/test_agent_transactional_tool_publication.py",

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -585,6 +585,8 @@ def test_desktop_ci_runs_primary_profile_substrate_unit_tests() -> None:
 
     assert "node scripts/test-desktop-profile-substrate.mjs" in unit_step["run"]
     assert "node scripts/test-desktop-profile-consolidation.mjs" in unit_step["run"]
+    assert "node scripts/test-onboarding-flow-coordinator.mjs" in unit_step["run"]
+    assert "node scripts/test-onboarding-save-telemetry.mjs" in unit_step["run"]
 
 
 def test_pr_target_validator_allows_main_pull_requests(tmp_path: Path) -> None:
@@ -1519,6 +1521,8 @@ def test_desktop_recovery_e2e_runs_compiled_flows_on_all_release_platforms() -> 
     assert "test-profile-consolidation-flow.mjs" in run["run"]
     assert "test-primary-repair-accessibility.mjs" in run["run"]
     assert "test-profile-import-flow.mjs" in run["run"]
+    assert run["run"].count("'onboarding-flow:scripts/test-onboarding-flow.mjs'") == 2
+    assert 'if [[ "${RUNNER_OS}" == "macOS" ]]' in run["run"]
     assert "test-desktop-cleanup-flow.mjs" in run["run"]
     assert "test-desktop-gateway-ownership.mjs" in run["run"]
     assert "test-unsafe-legacy-recovery-no-write.mjs" in run["run"]

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -578,6 +578,44 @@ def test_boot_error_and_recovery_states_pause_all_indeterminate_motion() -> None
     assert "document.body.classList.add('recovering', 'errored')" in render_recovery
 
 
+def test_boot_timer_tracks_each_status_identity_without_spamming_live_regions() -> None:
+    boot_html = _read("desktop/electron/src/boot.html")
+    apply_status = _section(
+        boot_html,
+        "function applyStatus(payload)",
+        "function applyError(payload)",
+    )
+    timer = _section(
+        boot_html,
+        "function updateTimer()",
+        "const api = window.opensquillaDesktop",
+    )
+
+    # The phase is announced once, while the visual 100 ms timer stays out of
+    # the live region so assistive technology is not flooded with elapsed time.
+    assert '<section class="status">' in boot_html
+    assert (
+        'id="phase" data-i18n="phaseDefault" role="status" '
+        'aria-live="polite" aria-atomic="true"'
+        in boot_html
+    )
+    assert 'id="timer" aria-hidden="true"' in boot_html
+
+    # Main-process BootStatus.at is the phase anchor. Replaying the same
+    # (phaseId, at) snapshot must not reset it, while a new status identity does.
+    assert "let phaseStartedAt = performance.now()" in boot_html
+    assert "let phaseStatusIdentity = ''" in boot_html
+    assert "const statusAt = payload && payload.at ? String(payload.at) : ''" in apply_status
+    assert "const statusIdentity = phaseId + '\\u0000' + statusAt" in apply_status
+    assert "if (statusIdentity !== phaseStatusIdentity)" in apply_status
+    assert "phaseStatusIdentity = statusIdentity" in apply_status
+    assert "const statusAtMs = Date.parse(statusAt)" in apply_status
+    assert "const wallAgeMs = Number.isFinite(statusAtMs) ? Date.now() - statusAtMs : 0" in apply_status
+    assert "phaseStartedAt = performance.now() - Math.max(0, wallAgeMs)" in apply_status
+    assert "updateTimer()" in apply_status
+    assert "performance.now() - phaseStartedAt" in timer
+
+
 def test_boot_and_native_window_backgrounds_match_control_ui_theme_tokens() -> None:
     boot_html = _read("desktop/electron/src/boot.html")
     main_ts = _read("desktop/electron/src/main.ts")
@@ -1240,7 +1278,7 @@ def test_desktop_onboarding_is_owned_modal_child_of_main_window() -> None:
     assert "const parentWindow = currentMainWindow()" in onboarding
     assert "parent: parentWindow ?? undefined" in onboarding
     assert "modal: Boolean(parentWindow)" in onboarding
-    assert "onboardingWindow?.focus()" in onboarding
+    assert "focusOnboardingWindow()" in onboarding
 
 
 def test_desktop_onboarding_defaults_to_tokenrhythm_with_trusted_registration_cta() -> None:
@@ -1278,6 +1316,46 @@ def test_desktop_onboarding_defaults_to_tokenrhythm_with_trusted_registration_ct
         assert visible_cta in accessible_label
 
 
+def test_desktop_onboarding_exposes_immediate_and_slow_submit_feedback() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    html = _section(main_ts, "function onboardingHtml", "async function runOnboarding")
+    clear_slow_timer = _section(
+        html,
+        "function clearSubmitSlowTimer()",
+        "function setSubmitting(next)",
+    )
+    submitting = _section(
+        html,
+        "function setSubmitting(next)",
+        "onboardingLocale.addEventListener('change'",
+    )
+    submit = _section(
+        html,
+        "let succeeded = false",
+        "function applyMigrationPrefill",
+    )
+
+    assert (
+        '<span class="submit-status" id="submitStatus" role="status" '
+        'aria-live="polite" aria-atomic="true"></span>'
+        in html
+    )
+    assert "const SUBMIT_SLOW_FEEDBACK_MS = 8_000" in html
+    assert main_ts.count("savingSetup:") == 6
+    assert main_ts.count("setupTakingLonger:") == 6
+    assert "t.savingSetup" in submitting
+    assert "desktopMessage(activeLocale, 'boot.profile')" in submitting
+    assert "t.setupTakingLonger" in submitting
+    assert "setTimeout" in submitting
+    assert "clearTimeout" in clear_slow_timer
+    assert "clearSubmitSlowTimer()" in submitting
+    assert "SUBMIT_SLOW_FEEDBACK_MS" in submitting
+    assert "pagehide" in html
+    assert submit.index("succeeded = true") < submit.index("clearSubmitSlowTimer()")
+    assert "if (!succeeded)" in submit
+    assert "setSubmitting(false)" in submit
+
+
 def test_desktop_tokenrhythm_single_page_onboarding_defaults_to_router() -> None:
     main_ts = _read("desktop/electron/src/main.ts")
     tokenrhythm_catalog = _section(main_ts, "id: 'tokenrhythm'", "id: 'openrouter'")
@@ -1296,7 +1374,7 @@ def test_desktop_tokenrhythm_single_page_onboarding_defaults_to_router() -> None
     assert "routerTiers = clone(routerProfiles[profileKeyForMode()]);" in onboarding_html
     assert "return provider.value;" in onboarding_html
     assert "routerDefaultTier: 'c1'," in onboarding_html
-    assert "routerTiers," in onboarding_html
+    assert "routerTiers: clone(routerTiers)," in onboarding_html
     assert "[data-model-routing-mode]" not in onboarding_html
     assert "'selection_mode = \"custom_b5\"'" in main_ts
     assert "'[[llm_ensemble.candidates]]'" in main_ts
@@ -1323,7 +1401,7 @@ def test_desktop_onboarding_opens_only_trusted_registration_url_outside_renderer
     )
     window_open = _section(
         onboarding,
-        "onboardingWindow.webContents.setWindowOpenHandler",
+        "window.webContents.setWindowOpenHandler",
         "const guardOnboardingNavigation",
     )
 
@@ -3186,11 +3264,17 @@ def test_settings_import_reconciles_or_prompts_for_imported_provider() -> None:
         "ipcMain.handle('desktop:onboarding:save'",
         "ipcMain.handle('desktop:onboarding:cancel'",
     )
+    perform_save = _section(
+        main_ts,
+        "async function performOnboardingSave",
+        "async function withRecoveryOperation",
+    )
 
     assert "reconcileImportedDesktopCredential" in run
     assert "loadPendingMigrationProviderSetup" in onboarding
     assert "pendingProviderSetup" in onboarding
-    assert "clearPendingMigrationProviderSetup" in save
+    assert "onboardingFlows.requestSave" in save
+    assert "clearPendingMigrationProviderSetup" in perform_save
     assert "scrubImportedProviderEnvEntry" not in main_ts
     assert "readImportedProviderKey" not in main_ts
     assert "apiKey: ''" in main_ts

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -610,7 +610,10 @@ def test_boot_timer_tracks_each_status_identity_without_spamming_live_regions() 
     assert "if (statusIdentity !== phaseStatusIdentity)" in apply_status
     assert "phaseStatusIdentity = statusIdentity" in apply_status
     assert "const statusAtMs = Date.parse(statusAt)" in apply_status
-    assert "const wallAgeMs = Number.isFinite(statusAtMs) ? Date.now() - statusAtMs : 0" in apply_status
+    assert (
+        "const wallAgeMs = Number.isFinite(statusAtMs) ? Date.now() - statusAtMs : 0"
+        in apply_status
+    )
     assert "phaseStartedAt = performance.now() - Math.max(0, wallAgeMs)" in apply_status
     assert "updateTimer()" in apply_status
     assert "performance.now() - phaseStartedAt" in timer

--- a/tests/test_desktop/test_onboarding_main_process_flow_contract.py
+++ b/tests/test_desktop/test_onboarding_main_process_flow_contract.py
@@ -1,7 +1,6 @@
 import re
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 
 

--- a/tests/test_desktop/test_onboarding_main_process_flow_contract.py
+++ b/tests/test_desktop/test_onboarding_main_process_flow_contract.py
@@ -1,0 +1,162 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _main_source() -> str:
+    return (ROOT / "desktop/electron/src/main.ts").read_text(encoding="utf-8")
+
+
+def _coordinator_source() -> str:
+    return (ROOT / "desktop/electron/src/onboarding-flow-coordinator.ts").read_text(
+        encoding="utf-8"
+    )
+
+
+def _section(source: str, start: str, end: str) -> str:
+    start_index = source.index(start)
+    return source[start_index : source.index(end, start_index)]
+
+
+def test_onboarding_uses_one_flow_scoped_source_of_truth() -> None:
+    source = _main_source()
+    coordinator = _coordinator_source()
+    flow_type = _section(source, "interface OnboardingFlow", "interface DesktopSettingsPayload")
+    run = _section(source, "async function runOnboarding", "async function pathExists")
+
+    assert "extends CoordinatedOnboardingFlow" in flow_type
+    for field in (
+        "window: BrowserWindow | null",
+        "resolve: ((credential: DesktopConnection) => void) | null",
+        "reject: ((error: Error) => void) | null",
+    ):
+        assert field in flow_type
+    for field in (
+        "state: OnboardingFlowState",
+        "savePayload: Payload | null",
+        "savePromise: Promise<Result> | null",
+    ):
+        assert field in coordinator
+
+    assert "private activeFlow: Flow | null = null" in coordinator
+    assert "const onboardingFlows = new OnboardingFlowCoordinator" in source
+    assert "activeOnboardingFlow" not in source
+    assert "let resolveOnboarding" not in source
+    assert "let rejectOnboarding" not in source
+    assert run.index("await onboardingFlows.waitForAbandonedSave()") < run.index(
+        "await loadPendingMigrationProviderSetup()"
+    )
+    assert "const window = new BrowserWindow({" in run
+    assert "const flow: OnboardingFlow = {" in run
+    assert "onboardingFlows.activate(flow)" in run
+    assert "if (onboardingWindow === window) onboardingWindow = null" in run
+    assert "if (flow.window === window) flow.window = null" in run
+
+
+def test_onboarding_save_is_per_flow_single_flight_with_exact_payload_joining() -> None:
+    source = _main_source()
+    coordinator = _coordinator_source()
+    request = coordinator[coordinator.index("  requestSave(") :]
+    handler = _section(
+        source,
+        "ipcMain.handle('desktop:onboarding:save'",
+        "ipcMain.handle('desktop:onboarding:cancel'",
+    )
+
+    assert "isDeepStrictEqual(flow.savePayload, payload)" in request
+    assert "{ kind: 'joined', promise: flow.savePromise }" in request
+    assert "{ kind: 'conflict' }" in request
+    assert "const operation = Promise.resolve().then(perform)" in request
+    assert request.index("flow.savePayload = payload") < request.index(
+        "const operation = Promise.resolve().then(perform)"
+    )
+    assert request.index("const operation = Promise.resolve().then(perform)") < (
+        request.index("flow.savePromise = savePromise")
+    )
+    assert "if (flow.savePromise !== savePromise) return" in request
+
+    trust = "if (!flow || !trustedOnboardingIpc(event, flow))"
+    request_save = "const request = onboardingFlows.requestSave("
+    assert handler.index(trust) < handler.index(request_save)
+    assert "'save_in_progress'" in handler
+    assert "if (request.kind === 'conflict')" in handler
+    assert "if (request.kind === 'inactive')" in handler
+    assert "return await request.promise" in handler
+
+
+def test_onboarding_save_preserves_recovery_and_writer_ordering() -> None:
+    source = _main_source()
+    save = _section(
+        source,
+        "async function performOnboardingSave(",
+        "async function withRecoveryOperation",
+    )
+
+    telemetry_start = save.index("const telemetry = new OnboardingSaveTelemetry(")
+    recovery_stage = save.index("'primary_recovery_inspect'")
+    recovery = save.index("() => refreshPrimaryRecoveryAfterImportAttempt()")
+    admission = save.index("beginDesktopWriterOperation('complete desktop onboarding')")
+    writer_admitted = save.index("telemetry.markWriterAdmitted()")
+    marker_stage = save.index("'pending_setup_read'")
+    marker = save.index("() => readPendingMigrationProviderSetup()")
+    settings_stage = save.index("telemetry.stage('settings_persist'")
+    imported = save.index("await saveImportedDesktopCredential(")
+    ordinary = save.index("await saveDesktopCredential(payload, true)")
+    settings_persisted = save.index("telemetry.markSettingsPersistedConfirmed()")
+    finalize_stage = save.index("telemetry.stage('local_finalize'")
+    locale = save.index("applyDesktopLocaleChoice(payload.locale)")
+    clear_marker = save.index("await clearPendingMigrationProviderSetup()")
+    finish = save.index("finishWriter()")
+    handoff_stage = save.index("telemetry.stageSync('flow_handoff'")
+    lifecycle_guard = save.index(
+        "if (desktopWriters.closed || isQuitting || appExitPhase !== 'running')"
+    )
+    complete = save.index("if (!completeOnboardingFlow(flow, credential))")
+    telemetry_finish = save.index("telemetry.finish()")
+
+    assert telemetry_start < recovery_stage < recovery < admission < writer_admitted
+    assert writer_admitted < marker_stage < marker < settings_stage
+    assert settings_stage < imported < settings_persisted
+    assert settings_stage < ordinary < settings_persisted
+    assert settings_persisted < finalize_stage < locale < clear_marker < finish
+    assert finish < handoff_stage < lifecycle_guard < complete < telemetry_finish
+    assert "app.isPackaged" in save
+    assert "(event, detail) => desktopLog(event, detail)" in save
+    assert "return telemetry.recordReturned(" in save
+    assert "if (flow.state === 'saving') flow.state = 'editing'" in save
+    assert "throw error" in save
+
+
+def test_onboarding_save_and_cancel_have_closed_flow_and_typed_failure_contracts() -> None:
+    source = _main_source()
+    error_codes = _section(
+        source,
+        "type OnboardingSaveErrorCode =",
+        "type OnboardingSaveResult =",
+    )
+    complete = _section(
+        source,
+        "function completeOnboardingFlow(",
+        "async function performOnboardingSave(",
+    )
+    cancel = _section(
+        source,
+        "ipcMain.handle('desktop:onboarding:cancel'",
+        "// Keep the normal app-quit gateway drain single-flight.",
+    )
+
+    assert set(re.findall(r"'([^']+)'", error_codes)) == {
+        "onboarding_inactive",
+        "recovery_required",
+        "save_in_progress",
+        "lifecycle_deferred",
+    }
+    assert "!onboardingFlows.complete(flow)" in complete
+    assert "const window = flow.window" in complete
+    assert "onboardingWindow?.close()" not in complete
+
+    trusted = "if (!flow || !trustedOnboardingIpc(event, flow))"
+    abandon = "abandonOnboardingFlow(flow, new Error('OpenSquilla setup was cancelled.'), true)"
+    assert cancel.index(trusted) < cancel.index(abandon) < cancel.index("app.quit()")


### PR DESCRIPTION
## Scope

- make onboarding saves single-flight and flow-scoped so repeated clicks and abandoned flows cannot race a replacement flow
- show immediate localized saving feedback, add an 8-second first-run reassurance message, and preserve retry/failure behavior
- display boot elapsed time for the current `(phaseId, at)` status instead of total window lifetime
- write bounded, privacy-safe onboarding stage durations to the existing local `desktop.log`
- run onboarding Electron coverage on macOS and Windows CI, with coordinator/telemetry tests on Linux

## Why

A valid Start click could spend several seconds in recovery inspection and atomic settings persistence without visible progress. The renderer also allowed repeated submissions, and the boot timer displayed total page lifetime next to the current phase, making gateway health appear much slower than it was.

## User impact

A valid configuration enters one clearly visible saving state, repeated clicks do not start duplicate writes, failures remain visible and retryable, and the startup timer now reflects the active phase. This change does not promise a shorter write path; the new local timing records provide evidence for a later performance change.

## Target

- Base: `main`
- Head: `fix/onboarding-start-feedback`
- Linked issue: None
- Release note: Yes — improve desktop onboarding feedback and startup timing accuracy.

## Validation

- `npm run test:onboarding-telemetry`
- `npm run test:onboarding-coordinator`
- `npm run test:onboarding-flow`
- `npm run test:profile-substrate`
- `npm run test:profile-import-flow`
- `npm run test:profile-consolidation`
- `.venv/bin/pytest -q tests/test_desktop/test_electron_startup_contract.py tests/test_desktop/test_onboarding_main_process_flow_contract.py tests/test_ci/test_workflows.py` — 222 passed
- `uv run ruff check src tests`
- `git diff --check origin/main...HEAD`

## Safety and compatibility

- no public Gateway/RPC or IPC channel changes
- no config, credential, database, or migration format changes
- no provider probe or additional network request
- recovery, CAS, writer admission, settings persistence, and Gateway startup ordering remain unchanged
- timing logs stay local, use a fixed allowlist, and exclude payloads, keys, provider/model data, paths, errors, process data, and transaction identifiers
- platform-neutral implementation; GUI coverage runs on macOS and Windows, with pure/static coverage on Linux

## Third-party origin

None.