### PR TITLE
Offer save before closing Settings

### DIFF
--- a/opensquilla-webui/e2e/settings-modal.spec.ts
+++ b/opensquilla-webui/e2e/settings-modal.spec.ts
@@ -358,11 +358,11 @@ test.describe('Settings modal', () => {
     await expect(dirtybar).toBeVisible()
     await expect(dirtybar).toContainText('Unsaved changes in Capabilities')
 
-    // Closing with unsaved edits raises the themed confirm; declining keeps the modal.
+    // Closing with unsaved edits offers save or discard; Escape keeps the modal open.
     await page.keyboard.press('Escape')
-    const confirm = page.getByRole('dialog', { name: 'Discard unsaved changes?' })
+    const confirm = page.getByRole('dialog', { name: 'Unsaved changes' })
     await expect(confirm).toBeVisible()
-    await confirm.getByRole('button', { name: 'Cancel' }).click()
+    await page.keyboard.press('Escape')
     await expect(confirm).toBeHidden()
     await expect(dialog(page)).toBeVisible()
 
@@ -387,9 +387,9 @@ test.describe('Settings modal', () => {
     // router-level guard must raise the same confirm. Declining cancels the
     // navigation and restores the /settings URL.
     await page.goBack()
-    const confirm = page.getByRole('dialog', { name: 'Discard unsaved changes?' })
+    const confirm = page.getByRole('dialog', { name: 'Unsaved changes' })
     await expect(confirm).toBeVisible()
-    await confirm.getByRole('button', { name: 'Cancel' }).click()
+    await page.keyboard.press('Escape')
     await expect(confirm).toBeHidden()
     await expect(dialog(page)).toBeVisible()
     await expect(page).toHaveURL(/\/settings\/capabilities$/)
@@ -398,7 +398,7 @@ test.describe('Settings modal', () => {
     // Accepting the discard lets the same Back proceed and close the overlay.
     await page.goBack()
     await expect(confirm).toBeVisible()
-    await confirm.getByRole('button', { name: 'Confirm' }).click()
+    await confirm.getByRole('button', { name: 'Discard changes' }).click()
     await expect(dialog(page)).toBeHidden()
     await expect(page).not.toHaveURL(/\/settings/)
     await expect(settingsRow(page)).toBeFocused()

--- a/opensquilla-webui/src/components/ConfirmModal.a11y.test.ts
+++ b/opensquilla-webui/src/components/ConfirmModal.a11y.test.ts
@@ -66,6 +66,34 @@ describe('ConfirmModal accessibility', () => {
     await expect(confirmed).resolves.toBe(true)
   })
 
+  it('can present save and discard as the only visible actions', async () => {
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    app = createApp(ConfirmModal)
+    app.use(i18n)
+    app.mount(root)
+
+    const choice = useConfirm().confirmChoice({
+      title: 'Save changes before closing?',
+      body: 'Choose how to handle the current edits.',
+      primaryLabel: 'Save and close',
+      secondaryLabel: 'Discard changes',
+      showCancel: false,
+    })
+    await nextTick()
+    await nextTick()
+
+    const labels = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('.modal__footer button'),
+      button => button.textContent?.trim(),
+    )
+    expect(labels).toEqual(['Discard changes', 'Save and close'])
+    expect(document.activeElement?.textContent?.trim()).toBe('Save and close')
+
+    document.querySelector<HTMLButtonElement>('.modal__secondary')?.click()
+    await expect(choice).resolves.toBe('secondary')
+  })
+
   it('places Cancel before Trust and open in the project trust prompt', async () => {
     const root = document.createElement('div')
     document.body.appendChild(root)

--- a/opensquilla-webui/src/components/ConfirmModal.vue
+++ b/opensquilla-webui/src/components/ConfirmModal.vue
@@ -16,8 +16,23 @@
             <p id="confirm-modal-description">{{ confirmState.body }}</p>
           </div>
           <div class="modal__footer">
-            <button ref="cancelBtn" type="button" class="btn btn--ghost" @click.stop="onCancel">{{ t('common.cancel') }}</button>
             <button
+              v-if="confirmState.showCancel !== false"
+              ref="cancelBtn"
+              type="button"
+              class="btn btn--ghost"
+              @click.stop="onCancel"
+            >{{ t('common.cancel') }}</button>
+            <button
+              v-if="confirmState.secondaryLabel"
+              type="button"
+              :class="['btn', 'modal__secondary', confirmState.secondaryClass]"
+              @click.stop="onSecondary"
+            >
+              {{ confirmState.secondaryLabel }}
+            </button>
+            <button
+              ref="primaryBtn"
               type="button"
               :class="['btn', 'modal__primary', confirmState.primaryClass]"
               @click.stop="onConfirm"
@@ -38,11 +53,15 @@ import { useConfirm } from '@/composables/useConfirm'
 import { useDialogA11y } from '@/composables/useDialogA11y'
 
 const { t } = useI18n()
-const { confirmState, resolveConfirm } = useConfirm()
+const { confirmState, resolveConfirm, resolveConfirmChoice } = useConfirm()
 
 const modalRef = ref<HTMLElement | null>(null)
 const cancelBtn = ref<HTMLElement | null>(null)
+const primaryBtn = ref<HTMLElement | null>(null)
 const isOpen = computed(() => confirmState.value !== null)
+const initialFocus = computed(() => (
+  confirmState.value?.showCancel === false ? primaryBtn.value : cancelBtn.value
+))
 
 function onConfirm() {
   resolveConfirm(true)
@@ -52,11 +71,15 @@ function onCancel() {
   resolveConfirm(false)
 }
 
-// Cancel sits first (leading edge) and is the initial focus target so a
-// destructive primary is never auto-focused; the confirming action stays on the
-// trailing edge, matching the app's other dialog footers. Escape and
-// Tab-trapping come from the shared a11y helper.
-useDialogA11y(modalRef, isOpen, onCancel, { initialFocus: cancelBtn })
+function onSecondary() {
+  resolveConfirmChoice('secondary')
+}
+
+// Cancel sits first (leading edge) and is the initial focus target when shown.
+// A two-action save/discard prompt instead focuses its non-destructive save
+// action, never the destructive discard button. Escape and Tab-trapping come
+// from the shared a11y helper.
+useDialogA11y(modalRef, isOpen, onCancel, { initialFocus })
 </script>
 
 <style scoped>

--- a/opensquilla-webui/src/components/settings/SettingsDialog.save-pending.test.ts
+++ b/opensquilla-webui/src/components/settings/SettingsDialog.save-pending.test.ts
@@ -11,6 +11,7 @@ let routerMock: Record<string, any>
 let confirmState: ReturnType<typeof ref<boolean>>
 let leaveGuard: ((to: { path: string }) => boolean | Promise<boolean>) | null
 const confirmAction = vi.fn()
+const confirmChoiceAction = vi.fn()
 
 vi.mock('@/composables/setup/useSetupCatalog', () => ({
   SETTINGS_SECTIONS: [
@@ -26,7 +27,7 @@ vi.mock('vue-router', () => ({
 }))
 
 vi.mock('@/composables/useConfirm', () => ({
-  useConfirm: () => ({ confirm: confirmAction, confirmState }),
+  useConfirm: () => ({ confirm: confirmAction, confirmChoice: confirmChoiceAction, confirmState }),
 }))
 
 vi.mock('@/platform', () => ({
@@ -44,6 +45,7 @@ function mockCatalog() {
   const providerDraftDirty = ref(false)
   const hasUnsavedChanges = ref(true)
   const saveDirtySections = vi.fn()
+  const saveProvider = vi.fn(async () => true)
   const discardChanges = vi.fn()
   const setAutoSessionTitles = vi.fn()
   const noop = vi.fn()
@@ -79,6 +81,7 @@ function mockCatalog() {
     saveAllPending,
     providerSavePending,
     saveDirtySections,
+    saveProvider,
     discardChanges,
     setAutoSessionTitles,
     copyCommand: noop,
@@ -96,6 +99,7 @@ function mockCatalog() {
     providerDraftDirty,
     hasUnsavedChanges,
     saveDirtySections,
+    saveProvider,
     discardChanges,
     setAutoSessionTitles,
   }
@@ -118,6 +122,8 @@ beforeEach(() => {
   confirmState = ref(false)
   confirmAction.mockReset()
   confirmAction.mockResolvedValue(true)
+  confirmChoiceAction.mockReset()
+  confirmChoiceAction.mockResolvedValue('primary')
   leaveGuard = null
   routeState = reactive({
     params: { section: 'general' },
@@ -200,6 +206,7 @@ describe('SettingsDialog save-all pending state', () => {
     expect(controls.saveDirtySections).not.toHaveBeenCalled()
     expect(controls.discardChanges).not.toHaveBeenCalled()
     expect(confirmAction).not.toHaveBeenCalled()
+    expect(confirmChoiceAction).not.toHaveBeenCalled()
 
     controls.saveAllPending.value = false
     await nextTick()
@@ -273,7 +280,7 @@ describe('SettingsDialog exit protection', () => {
     controls.hasUnsavedChanges.value = false
     controls.providerDraftDirty.value = true
     catalogApi.dirtySections.value = []
-    confirmAction.mockResolvedValue(false)
+    confirmChoiceAction.mockResolvedValue('cancel')
 
     const el = await mountDialog()
 
@@ -282,20 +289,66 @@ describe('SettingsDialog exit protection', () => {
 
     const internalResult = await leaveGuard!({ path: '/settings/modelStrategy' })
     expect(internalResult).toBe(true)
-    expect(confirmAction).not.toHaveBeenCalled()
+    expect(confirmChoiceAction).not.toHaveBeenCalled()
 
     const externalResult = await leaveGuard!({ path: '/sessions' })
     expect(externalResult).toBe(false)
-    expect(confirmAction).toHaveBeenCalledOnce()
+    expect(confirmChoiceAction).toHaveBeenCalledOnce()
 
-    confirmAction.mockClear()
+    confirmChoiceAction.mockClear()
     el.querySelector<HTMLButtonElement>('.settings-modal__head button')?.click()
     await nextTick()
     await Promise.resolve()
 
-    expect(confirmAction).toHaveBeenCalledOnce()
+    expect(confirmChoiceAction).toHaveBeenCalledOnce()
     expect(el.querySelector('.settings-modal')).toBeTruthy()
     expect(routerMock.push).not.toHaveBeenCalled()
+  })
+
+  it('saves unsaved settings before closing when Save and close is chosen', async () => {
+    const controls = mockCatalog()
+    controls.saveAllPending.value = false
+    controls.saveDirtySections.mockImplementation(() => {
+      controls.hasUnsavedChanges.value = false
+    })
+    catalogApi.dirtySections.value = []
+    confirmChoiceAction.mockResolvedValue('primary')
+
+    const el = await mountDialog()
+    el.querySelector<HTMLButtonElement>('.settings-modal__head button')?.click()
+    await nextTick()
+    await Promise.resolve()
+    await nextTick()
+
+    expect(confirmChoiceAction).toHaveBeenCalledWith(expect.objectContaining({
+      primaryLabel: 'Save and close',
+      secondaryLabel: 'Discard changes',
+      showCancel: false,
+    }))
+    expect(controls.saveDirtySections).toHaveBeenCalledOnce()
+    expect(el.querySelector('.settings-modal')).toBeTruthy()
+  })
+
+  it('uses the provider save path before closing a provider-only draft', async () => {
+    const controls = mockCatalog()
+    controls.saveAllPending.value = false
+    controls.hasUnsavedChanges.value = false
+    controls.providerDraftDirty.value = true
+    controls.saveProvider.mockImplementation(async () => {
+      controls.providerDraftDirty.value = false
+      return true
+    })
+    catalogApi.dirtySections.value = []
+    confirmChoiceAction.mockResolvedValue('primary')
+
+    const el = await mountDialog()
+    el.querySelector<HTMLButtonElement>('.settings-modal__head button')?.click()
+    await nextTick()
+    await Promise.resolve()
+    await nextTick()
+
+    expect(controls.saveProvider).toHaveBeenCalledOnce()
+    expect(controls.saveDirtySections).not.toHaveBeenCalled()
   })
 
   it('blocks external exit while a provider save is pending', async () => {
@@ -311,6 +364,7 @@ describe('SettingsDialog exit protection', () => {
     expect(close?.disabled).toBe(true)
     expect(await leaveGuard!({ path: '/sessions' })).toBe(false)
     expect(confirmAction).not.toHaveBeenCalled()
+    expect(confirmChoiceAction).not.toHaveBeenCalled()
     expect(await leaveGuard!({ path: '/settings/provider' })).toBe(true)
 
     const unloadEvent = new Event('beforeunload', { cancelable: true })

--- a/opensquilla-webui/src/components/settings/SettingsDialog.vue
+++ b/opensquilla-webui/src/components/settings/SettingsDialog.vue
@@ -12,8 +12,8 @@
       >
       <div
         class="settings-body"
-        :inert="saveAllPending ? true : undefined"
-        :aria-busy="saveAllPending ? 'true' : undefined"
+        :inert="settingsInteractionLocked ? true : undefined"
+        :aria-busy="settingsInteractionLocked ? 'true' : undefined"
       >
         <nav ref="railRef" class="settings-rail" role="tablist" :aria-label="t('settings.dialog.sections')" :aria-orientation="railOrientation">
           <template v-for="(s, i) in visibleSections" :key="s.id">
@@ -71,8 +71,8 @@
         >
           <fieldset
             class="settings-panel__interactions"
-            :disabled="saveAllPending"
-            :aria-busy="saveAllPending ? 'true' : undefined"
+            :disabled="settingsInteractionLocked"
+            :aria-busy="settingsInteractionLocked ? 'true' : undefined"
           >
           <!-- Gateway remains available even when config readiness cannot load,
                because this is where users recover the connection/runtime. -->
@@ -192,23 +192,23 @@
       <div
         v-if="loaded && hasUnsavedChanges"
         class="settings-dirtybar"
-        :aria-busy="saveAllPending ? 'true' : undefined"
+        :aria-busy="settingsInteractionLocked ? 'true' : undefined"
       >
         <span class="settings-dirtybar__pulse" aria-hidden="true"></span>
         <span class="settings-dirtybar__text" role="status" aria-live="polite" aria-atomic="true">
-          {{ saveAllPending ? t('settings.dialog.savingChanges') : dirtyBarText }}
+          {{ settingsInteractionLocked ? t('settings.dialog.savingChanges') : dirtyBarText }}
         </span>
         <span class="settings-dirtybar__spacer"></span>
-        <button type="button" class="btn" :disabled="saveAllPending" @click="discardChanges">
+        <button type="button" class="btn" :disabled="settingsInteractionLocked" @click="discardChanges">
           {{ dirtyDiscardLabel }}
         </button>
         <button
           type="button"
           class="btn btn--primary"
-          :disabled="saveAllPending"
-          :aria-busy="saveAllPending ? 'true' : undefined"
+          :disabled="settingsInteractionLocked"
+          :aria-busy="settingsInteractionLocked ? 'true' : undefined"
           @click="saveDirtySections"
-        >{{ saveAllPending ? t('settings.dialog.savingChanges') : dirtySaveLabel }}</button>
+        >{{ settingsInteractionLocked ? t('settings.dialog.savingChanges') : dirtySaveLabel }}</button>
       </div>
 
       <footer class="settings-foot">
@@ -263,7 +263,7 @@ import '@/styles/settings-forms.css'
 const route = useRoute()
 const router = useRouter()
 const { t } = useI18n()
-const { confirm, confirmState } = useConfirm()
+const { confirmChoice, confirmState } = useConfirm()
 
 // The catalog retains the desktopOnly capability for future destinations. The
 // consolidated rail currently shares all ten destinations across surfaces.
@@ -350,6 +350,7 @@ const modalRef = ref<HTMLElement | null>(null)
 const railRef = ref<HTMLElement | null>(null)
 const panelRef = ref<HTMLElement | null>(null)
 const closeBtn = ref<HTMLButtonElement | null>(null)
+const closeSavePending = ref(false)
 
 // Keep the active section's rail tab in view — on mobile the rail scrolls
 // horizontally, so a deep-linked or later section would otherwise sit off-screen.
@@ -426,7 +427,10 @@ const hasSettingsExitDraft = computed(() => (
   hasUnsavedChanges.value || providerDraftDirty.value
 ))
 const hasPendingSettingsWrite = computed(() => (
-  saveAllPending.value || providerSavePending.value
+  saveAllPending.value || providerSavePending.value || closeSavePending.value
+))
+const settingsInteractionLocked = computed(() => (
+  saveAllPending.value || closeSavePending.value
 ))
 const shouldGuardBrowserUnload = computed(() => (
   hasSettingsExitDraft.value || hasPendingSettingsWrite.value
@@ -652,21 +656,47 @@ async function openProfileImport() {
   panelRef.value?.querySelector<HTMLElement>('[data-testid="memory-import-heading"]')?.focus()
 }
 
-// One discard prompt shared by every exit path: requestClose (Escape, the
-// close button, backdrop click) and the history-back leave guard below.
-function confirmDiscard(): Promise<boolean> {
-  return confirm({
+// One exit prompt shared by every exit path: requestClose (Escape, the close
+// button, backdrop click) and the history-back leave guard below. Saving is
+// the primary action; discarding remains explicit and destructive.
+function confirmExitChanges() {
+  return confirmChoice({
     title: t('settings.dialog.discardTitle'),
     body: t('settings.dialog.discardBody'),
-    primaryLabel: t('settings.dialog.discardConfirmPrimary'),
-    primaryClass: 'btn--danger',
+    primaryLabel: t('settings.dialog.saveAndClose'),
+    primaryClass: 'btn--primary',
+    secondaryLabel: t('settings.dialog.discardConfirmPrimary'),
+    secondaryClass: 'btn--danger',
+    showCancel: false,
   })
 }
 
-// Closes unless a section carries unsaved edits and the user keeps them.
+// Save every kind of Settings draft before allowing an exit. Provider drafts
+// have their own save path, while the remaining sections share the dirty bar.
+// If validation or a request fails, their dirty state remains and the dialog
+// stays open for correction.
+async function saveExitChanges(): Promise<boolean> {
+  if (closeSavePending.value || hasPendingSettingsWrite.value) return false
+  closeSavePending.value = true
+  try {
+    if (providerDraftDirty.value && !(await saveProvider())) return false
+    if (hasUnsavedChanges.value) await saveDirtySections()
+    await nextTick()
+    return !hasSettingsExitDraft.value
+  } finally {
+    closeSavePending.value = false
+  }
+}
+
+// Closes unless a section carries unsaved edits and the user chooses to keep
+// them, save them, or discard them.
 async function requestClose(event?: MouseEvent): Promise<boolean> {
   if (hasPendingSettingsWrite.value) return false
-  if (hasSettingsExitDraft.value && !(await confirmDiscard())) return false
+  if (hasSettingsExitDraft.value) {
+    const choice = await confirmExitChanges()
+    if (choice === 'cancel') return false
+    if (choice === 'primary' && !(await saveExitChanges())) return false
+  }
   // Keyboard-generated click events have detail 0; real pointer clicks have a
   // positive click count. Preserve focus restoration for keyboard activation.
   closeOverlay(!event || event.detail === 0)
@@ -676,8 +706,8 @@ async function requestClose(event?: MouseEvent): Promise<boolean> {
 // History traversal (browser Back, a trackpad back-swipe) pops the /settings
 // route and unmounts the overlay without passing through requestClose, which
 // would silently drop unsaved edits. This router-level guard runs the same
-// discard prompt for any navigation that leaves /settings while the dialog is
-// mounted; cancelling restores the URL. Registered on the router rather than
+// save/discard prompt for any navigation that leaves /settings while the dialog
+// is mounted; cancelling restores the URL. Registered on the router rather than
 // via onBeforeRouteLeave because selectSection's replace swaps the matched
 // record between `settings` and `settings-section` while the viewKey-keyed
 // component instance survives — a component guard would stay bound to the
@@ -690,7 +720,10 @@ const removeLeaveGuard = router.beforeEach(async (to) => {
   // requestClose already has the prompt up — hold this navigation instead of
   // stacking a second prompt (useConfirm cancels a pending request).
   if (confirmState.value) return false
-  return confirmDiscard()
+  const choice = await confirmExitChanges()
+  if (choice === 'cancel') return false
+  if (choice === 'primary') return saveExitChanges()
+  return true
 })
 
 function onDocumentKeydown(event: KeyboardEvent) {

--- a/opensquilla-webui/src/composables/useConfirm.ts
+++ b/opensquilla-webui/src/composables/useConfirm.ts
@@ -8,10 +8,23 @@ export interface ConfirmOptions {
   primaryClass?: string
 }
 
+export interface ConfirmChoiceOptions extends ConfirmOptions {
+  secondaryLabel: string
+  secondaryClass?: string
+  showCancel?: boolean
+}
+
+export type ConfirmChoice = 'cancel' | 'secondary' | 'primary'
+
+type ConfirmResult = boolean | 'secondary'
+
 interface ConfirmRequest extends ConfirmOptions {
   primaryLabel: string
   primaryClass: string
-  resolve: (value: boolean) => void
+  secondaryLabel?: string
+  secondaryClass?: string
+  showCancel?: boolean
+  resolve: (value: ConfirmResult) => void
 }
 
 // Module-level singleton so any composable or component can raise a confirm
@@ -31,7 +44,32 @@ function confirm(options: ConfirmOptions): Promise<boolean> {
       body: options.body,
       primaryLabel: options.primaryLabel ?? i18n.global.t('shared.confirm.defaultPrimary'),
       primaryClass: options.primaryClass ?? 'btn--danger',
-      resolve,
+      resolve: value => resolve(value === true),
+    }
+  })
+}
+
+// A small extension of the standard confirmation model for exits that need a
+// third, non-destructive action (for example, save before closing). Keep the
+// boolean `confirm` API above intact for existing destructive confirmations.
+function confirmChoice(options: ConfirmChoiceOptions): Promise<ConfirmChoice> {
+  if (confirmState.value) {
+    confirmState.value.resolve(false)
+  }
+  return new Promise<ConfirmChoice>(resolve => {
+    confirmState.value = {
+      title: options.title,
+      body: options.body,
+      primaryLabel: options.primaryLabel ?? i18n.global.t('shared.confirm.defaultPrimary'),
+      primaryClass: options.primaryClass ?? 'btn--primary',
+      secondaryLabel: options.secondaryLabel,
+      secondaryClass: options.secondaryClass ?? 'btn--danger',
+      showCancel: options.showCancel,
+      resolve: value => {
+        if (value === true) resolve('primary')
+        else if (value === 'secondary') resolve('secondary')
+        else resolve('cancel')
+      },
     }
   })
 }
@@ -43,6 +81,13 @@ function resolveConfirm(ok: boolean) {
   request.resolve(ok)
 }
 
+function resolveConfirmChoice(choice: Exclude<ConfirmChoice, 'cancel'>) {
+  const request = confirmState.value
+  if (!request) return
+  confirmState.value = null
+  request.resolve(choice === 'primary' ? true : 'secondary')
+}
+
 export function useConfirm() {
-  return { confirm, confirmState, resolveConfirm }
+  return { confirm, confirmChoice, confirmState, resolveConfirm, resolveConfirmChoice }
 }

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -540,8 +540,9 @@
       "moreOptionsIn": "Weitere Optionen finden sich in",
       "copyConfigPath": "Konfigurationspfad kopieren",
       "applyLiveNote": "Die meisten Änderungen werden sofort übernommen; einige erfordern einen Neustart des Gateways",
-      "discardTitle": "Ungespeicherte Änderungen verwerfen?",
-      "discardBody": "Es gibt ungespeicherte Änderungen. Beim Schließen gehen sie verloren.",
+      "discardTitle": "Nicht gespeicherte Änderungen",
+      "discardBody": "Speichern Sie die Änderungen vor dem Schließen oder verwerfen Sie sie.",
+      "saveAndClose": "Speichern und schließen",
       "discardConfirmPrimary": "Änderungen verwerfen"
     },
     "gateway": {

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -620,8 +620,9 @@
       "moreOptionsIn": "More options live in",
       "copyConfigPath": "Copy config path",
       "applyLiveNote": "Most changes apply live; some need a gateway restart",
-      "discardTitle": "Discard unsaved changes?",
-      "discardBody": "You have unsaved edits. Closing now will lose them.",
+      "discardTitle": "Unsaved changes",
+      "discardBody": "Save your edits before closing, or discard them.",
+      "saveAndClose": "Save and close",
       "discardConfirmPrimary": "Discard changes"
     },
     "gateway": {

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -540,8 +540,9 @@
       "moreOptionsIn": "Hay más opciones en",
       "copyConfigPath": "Copiar ruta de configuración",
       "applyLiveNote": "La mayoría de los cambios se aplican en vivo; algunos requieren reiniciar la puerta de enlace",
-      "discardTitle": "¿Descartar los cambios sin guardar?",
-      "discardBody": "Tienes ediciones sin guardar. Si cierras ahora se perderán.",
+      "discardTitle": "Cambios sin guardar",
+      "discardBody": "Guarda las ediciones antes de cerrar o descártalas.",
+      "saveAndClose": "Guardar y cerrar",
       "discardConfirmPrimary": "Descartar cambios"
     },
     "gateway": {

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -540,8 +540,9 @@
       "moreOptionsIn": "Plus d'options se trouvent dans",
       "copyConfigPath": "Copier le chemin de configuration",
       "applyLiveNote": "La plupart des changements s'appliquent à chaud ; certains nécessitent un redémarrage de la passerelle",
-      "discardTitle": "Abandonner les modifications non enregistrées ?",
-      "discardBody": "Vous avez des modifications non enregistrées. Fermer maintenant les perdra.",
+      "discardTitle": "Modifications non enregistrées",
+      "discardBody": "Enregistrez les modifications avant de fermer ou abandonnez-les.",
+      "saveAndClose": "Enregistrer et fermer",
       "discardConfirmPrimary": "Abandonner les modifications"
     },
     "gateway": {

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -540,8 +540,9 @@
       "moreOptionsIn": "その他のオプションは次の場所にあります",
       "copyConfigPath": "設定パスをコピー",
       "applyLiveNote": "ほとんどの変更は即時に反映されます。一部はゲートウェイの再起動が必要です",
-      "discardTitle": "未保存の変更を破棄しますか？",
-      "discardBody": "未保存の編集があります。今閉じると失われます。",
+      "discardTitle": "未保存の変更があります",
+      "discardBody": "閉じる前に保存するか、変更を破棄してください。",
+      "saveAndClose": "保存して閉じる",
       "discardConfirmPrimary": "変更を破棄"
     },
     "gateway": {

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -620,8 +620,9 @@
       "moreOptionsIn": "更多选项位于",
       "copyConfigPath": "复制配置路径",
       "applyLiveNote": "大多数更改即时生效；部分需要重启网关",
-      "discardTitle": "放弃未保存的修改？",
-      "discardBody": "有尚未保存的编辑，现在关闭将丢失它们。",
+      "discardTitle": "有未保存的修改",
+      "discardBody": "关闭前可选择保存这些编辑，或放弃修改。",
+      "saveAndClose": "保存并关闭",
       "discardConfirmPrimary": "放弃修改"
     },
     "gateway": {


### PR DESCRIPTION
## Summary
- Offer **Save and close** or **Discard changes** when leaving Settings with unsaved edits.
- Keep Escape and backdrop dismissal as non-destructive ways to remain in Settings.
- Apply the same exit behavior to the close button, Escape, backdrop, and browser navigation.

## Root cause
The Settings exit confirmation only exposed discarding changes, even though the dialog could save the outstanding drafts.

## Compatibility
No persisted schema, RPC, or public API changes. Existing two-action confirmations retain their current behavior.

## Validation
- `npm run test:unit -- src/components/ConfirmModal.a11y.test.ts src/components/settings/SettingsDialog.save-pending.test.ts`
- `npm run typecheck`
- Manual browser verification with isolated temporary Gateway state.

## Release notes
None.

## Safety
No secrets, user data, or production configuration are included.

## Third-party origin
None.

Refs: None