### PR TITLE
fix(desktop): hand off manual Windows updates through the native drain instead of colliding with the installer

### DIFF
--- a/desktop/electron/package.json
+++ b/desktop/electron/package.json
@@ -28,6 +28,7 @@
     "test:sandbox-default": "npm run build && node scripts/test-desktop-sandbox-default.mjs",
     "test:update-resolver": "npm run build && node scripts/test-update-resolver.mjs",
     "test:update-scheduler": "npm run build && node scripts/test-update-check-scheduler.mjs",
+    "test:manual-update-handoff": "npm run build && node scripts/test-manual-update-handoff.mjs",
     "test:desktop-locale": "npm run build && node scripts/test-desktop-locale.mjs",
     "test:desktop-zoom": "npm run build && node scripts/test-desktop-zoom-shortcuts.mjs",
     "test:project-workspace-picker": "npm run build && node scripts/test-project-workspace-picker.mjs",

--- a/desktop/electron/scripts/test-manual-update-handoff.mjs
+++ b/desktop/electron/scripts/test-manual-update-handoff.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+
+import {
+  manualHandoffBlocker,
+  manualInstallerLaunchPlan,
+} from '../dist/manual-update-handoff.js'
+
+// --- launch plan: detached installer with electron-updater's --updated ---
+
+const plan = manualInstallerLaunchPlan('C:/updater/OpenSquilla-0.5.3-win-x64.exe')
+assert.equal(plan.command, 'C:/updater/OpenSquilla-0.5.3-win-x64.exe')
+assert.deepEqual(plan.args, ['--updated'])
+assert.deepEqual(plan.options, { detached: true, stdio: 'ignore' })
+
+assert.throws(() => manualInstallerLaunchPlan(''), /path is empty/)
+
+// --- eligibility: the ready state and every blocker, in precedence order ---
+
+const ready = {
+  installMode: 'manual',
+  status: 'downloaded',
+  verifiedInstallerPath: 'C:/updater/OpenSquilla-0.5.3-win-x64.exe',
+  updateApplying: false,
+  quitting: false,
+  writersClosed: false,
+}
+
+assert.equal(manualHandoffBlocker(ready), null)
+
+// Lifecycle blockers win over mode/state mismatches so callers can tell
+// "retry later" apart from "wrong flow".
+assert.equal(
+  manualHandoffBlocker({ ...ready, updateApplying: true, installMode: 'native' }),
+  'already-applying',
+)
+assert.equal(manualHandoffBlocker({ ...ready, quitting: true }), 'already-quitting')
+assert.equal(manualHandoffBlocker({ ...ready, writersClosed: true }), 'writers-closed')
+
+// Mode and state mismatches.
+assert.equal(manualHandoffBlocker({ ...ready, installMode: 'native' }), 'not-manual-mode')
+assert.equal(manualHandoffBlocker({ ...ready, installMode: 'none' }), 'not-manual-mode')
+assert.equal(
+  manualHandoffBlocker({ ...ready, verifiedInstallerPath: null }),
+  'no-verified-installer',
+)
+assert.equal(manualHandoffBlocker({ ...ready, status: 'available' }), 'not-downloaded')
+assert.equal(manualHandoffBlocker({ ...ready, status: 'applying' }), 'not-downloaded')
+assert.equal(manualHandoffBlocker({ ...ready, status: 'error' }), 'not-downloaded')
+
+console.log('manual update handoff tests passed')

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -21,6 +21,7 @@ import {
   type DesktopProfilePaths,
 } from './desktop-profile-context.js'
 import { DesktopWriterAdmission } from './desktop-writer-admission.js'
+import { manualHandoffBlocker, manualInstallerLaunchPlan } from './manual-update-handoff.js'
 import {
   createDesktopGatewayInstanceNonce,
   desktopGatewayOwnershipMatchesLaunch,
@@ -10521,9 +10522,13 @@ async function stopAndJoinAllLifecycleOwnedGateways(
 function restoreDownloadedUpdateRetryState(
   pendingVersion: string | null,
   writerAdmissionToken: symbol | null = null,
+  mode: 'native' | 'manual' = 'native',
 ): boolean {
   if (writerAdmissionToken) desktopWriters.reopen(writerAdmissionToken)
-  downloadedUpdateVersion = pendingVersion
+  // The manual flow keys its retry state on verifiedManualInstallerPath
+  // (still set — it is only cleared once the installer has been spawned);
+  // assigning downloadedUpdateVersion would wrongly arm the native path.
+  if (mode === 'native') downloadedUpdateVersion = pendingVersion
   updateApplying = false
   updateInstallHandoffReady = false
   isQuitting = false
@@ -10548,7 +10553,16 @@ function restoreDownloadedUpdateRetryState(
 async function applyDownloadedUpdate(): Promise<void> {
   if (updateApplying) return
   if (isQuitting || desktopWriters.closed) return
-  if (!mockDownloadedUpdate && !downloadedUpdateVersion) return
+  const manualReady = !mockDownloadedUpdate && manualHandoffBlocker({
+    installMode: desktopUpdateInstallMode(),
+    status: desktopUpdateStatus,
+    verifiedInstallerPath: verifiedManualInstallerPath,
+    updateApplying,
+    quitting: isQuitting,
+    writersClosed: desktopWriters.closed,
+  }) === null
+  if (!manualReady && !mockDownloadedUpdate && !downloadedUpdateVersion) return
+  if (manualReady) return applyVerifiedManualInstaller()
 
   if (mockDownloadedUpdate) {
     const version = downloadedUpdateVersion || mockUpdateVersion() || app.getVersion()
@@ -10657,6 +10671,101 @@ async function applyDownloadedUpdate(): Promise<void> {
     // swallowed as intentional (isQuitting was true). restoreDownloadedUpdateRetryState
     // cleared isQuitting, so bring the runtime back up instead of leaving the
     // window stranded on the dead gateway's Control UI.
+    if (!quitResumed) void openOrResumeDesktopApp()
+  }
+}
+
+// Manual-mode (unsigned Windows) counterpart of the native handoff above.
+// Historically the desktop only revealed the verified installer and left it
+// to the user to run against a still-live app: the NSIS process check then
+// force-stopped the app and every process under the install directory — no
+// graceful gateway drain — and an instance it could not stop (elevated,
+// hung, or hidden in the tray) dead-ended the update in a "cannot be
+// closed" retry dialog. Reuse the exact native drain (writers, then owned
+// gateway, joined) and only then start the installer and quit, so the
+// installer finds nothing to close and nothing holding runtime files.
+async function applyVerifiedManualInstaller(): Promise<void> {
+  const installerPath = verifiedManualInstallerPath
+  if (!installerPath) return
+  const pendingVersion = desktopUpdateLatestVersion
+  updateApplying = true
+  setAppExitPhase('deferred', 'preparing downloaded update')
+  const updateWriterAdmission = desktopWriters.close('apply downloaded update')
+  await waitForDesktopWriterOperations()
+  createApplicationMenu()
+  setDesktopUpdateState({
+    status: 'applying',
+    latestVersion: pendingVersion,
+    progress: 100,
+    error: null,
+  })
+  isQuitting = true
+  setAppExitPhase('draining', 'stopping Gateway for downloaded update')
+  const exited = await stopAndJoinAllLifecycleOwnedGateways((child) => {
+    updateGatewayShutdownProcess = child
+    // We stay alive and await the exit below, so let the gateway take its
+    // Windows HTTP graceful drain instead of an immediate TerminateProcess.
+    allowGracefulShutdownWhileQuitting = true
+    try {
+      stopGateway()
+    } finally {
+      allowGracefulShutdownWhileQuitting = false
+    }
+  })
+  // Same re-read as the native path: no await between this check and the
+  // spawn below, so a child already stopping cannot be skipped.
+  if (!exited || liveLifecycleOwnedGatewayProcesses().length > 0) {
+    const quitResumed = restoreDownloadedUpdateRetryState(
+      pendingVersion,
+      updateWriterAdmission,
+      'manual',
+    )
+    if (!quitResumed) {
+      void showUpdateDialog({
+        type: 'error',
+        buttons: ['OK'],
+        title: desktopT('update.errorTitle'),
+        message: desktopT('update.errorTitle'),
+        detail: desktopT('update.gatewayShutdownTimeout'),
+      })
+    }
+    return
+  }
+  updateGatewayShutdownProcess = null
+  try {
+    const plan = manualInstallerLaunchPlan(installerPath)
+    const installer = spawn(plan.command, plan.args, plan.options)
+    // A detached spawn reports failure (missing/blocked installer file)
+    // asynchronously; wait for the definitive spawn/error signal so a
+    // failed launch restores the retry state instead of quitting into
+    // nothing.
+    await new Promise<void>((resolveSpawn, rejectSpawn) => {
+      installer.once('spawn', () => resolveSpawn())
+      installer.once('error', rejectSpawn)
+    })
+    installer.unref()
+    verifiedManualInstallerPath = null
+    updateInstallHandoffReady = true
+    setAppExitPhase('committed', 'handing off to manual installer')
+    app.quit()
+  } catch (err) {
+    console.error('[updater] failed to start verified manual installer', err)
+    const quitResumed = restoreDownloadedUpdateRetryState(
+      pendingVersion,
+      updateWriterAdmission,
+      'manual',
+    )
+    if (!quitResumed) {
+      void showUpdateDialog({
+        type: 'error',
+        buttons: ['OK'],
+        title: desktopT('update.errorTitle'),
+        message: desktopT('update.errorTitle'),
+        detail: desktopT('update.installFailed'),
+      })
+    }
+    // Mirror the native catch: the owned gateway was stopped for the failed
+    // handoff, so bring the runtime back up rather than stranding the window.
     if (!quitResumed) void openOrResumeDesktopApp()
   }
 }

--- a/desktop/electron/src/manual-update-handoff.ts
+++ b/desktop/electron/src/manual-update-handoff.ts
@@ -1,0 +1,73 @@
+/**
+ * Windows manual-update handoff planning.
+ *
+ * The unsigned Windows build cannot use electron-updater's native
+ * quitAndInstall, so the desktop opens the verified NSIS installer itself.
+ * Launching that installer while the app (and its owned gateway) are still
+ * running makes the installer force-close them: NSIS stops every process
+ * under the install directory with no graceful drain, and an instance it
+ * cannot stop (elevated, hung, or hidden in the tray) dead-ends the update
+ * in a "cannot be closed" retry dialog. These helpers describe the handoff
+ * so the main process can drain writers and the gateway first — mirroring
+ * the native quitAndInstall flow — and only then start the installer.
+ *
+ * Pure module by contract: no Electron or Node imports, so the plan and the
+ * eligibility decision stay unit-testable outside an Electron process.
+ */
+
+export interface ManualInstallerLaunchPlan {
+  command: string
+  args: string[]
+  options: { detached: true; stdio: 'ignore' }
+}
+
+/**
+ * Describe how to start the verified installer for an update handoff.
+ *
+ * `--updated` mirrors electron-updater's own launch of an update installer:
+ * NSIS then grace-waits for this process to exit instead of prompting the
+ * user, and keeps existing shortcuts rather than treating the run as a
+ * fresh install. Detached + ignored stdio lets the installer outlive the
+ * quitting app without holding any inherited handle into it.
+ */
+export function manualInstallerLaunchPlan(installerPath: string): ManualInstallerLaunchPlan {
+  if (!installerPath) throw new Error('The manual installer path is empty.')
+  return {
+    command: installerPath,
+    args: ['--updated'],
+    options: { detached: true, stdio: 'ignore' },
+  }
+}
+
+export type ManualHandoffBlocker =
+  | 'already-applying'
+  | 'already-quitting'
+  | 'writers-closed'
+  | 'not-manual-mode'
+  | 'no-verified-installer'
+  | 'not-downloaded'
+
+export interface ManualHandoffContext {
+  installMode: string
+  status: string
+  verifiedInstallerPath: string | null
+  updateApplying: boolean
+  quitting: boolean
+  writersClosed: boolean
+}
+
+/**
+ * Return the first reason the manual handoff must not start, or null when it
+ * may proceed. Order matters: lifecycle blockers are reported before mode or
+ * state mismatches so a caller can distinguish "retry later" from "not this
+ * flow at all".
+ */
+export function manualHandoffBlocker(context: ManualHandoffContext): ManualHandoffBlocker | null {
+  if (context.updateApplying) return 'already-applying'
+  if (context.quitting) return 'already-quitting'
+  if (context.writersClosed) return 'writers-closed'
+  if (context.installMode !== 'manual') return 'not-manual-mode'
+  if (!context.verifiedInstallerPath) return 'no-verified-installer'
+  if (context.status !== 'downloaded') return 'not-downloaded'
+  return null
+}

--- a/opensquilla-webui/src/components/DesktopUpdateIndicator.test.ts
+++ b/opensquilla-webui/src/components/DesktopUpdateIndicator.test.ts
@@ -151,7 +151,7 @@ describe('DesktopUpdateIndicator', () => {
     app.unmount()
   })
 
-  it('reveals a verified Windows installer without offering native relaunch', async () => {
+  it('reveals a verified Windows installer and offers the relaunch handoff', async () => {
     const api = desktopUpdateApi({
       status: 'downloaded',
       canNativeInstall: false,
@@ -165,11 +165,14 @@ describe('DesktopUpdateIndicator', () => {
     ;(el.querySelector('[data-testid="desktop-update-indicator"]') as HTMLButtonElement).click()
     await settle()
     expect(document.body.textContent).toContain('Verified installer ready')
-    expect(document.querySelector('[data-testid="desktop-update-relaunch"]')).toBeNull()
-    ;(document.querySelector('[data-testid="desktop-update-show-installer"]') as HTMLButtonElement).click()
+    expect(document.querySelector('[data-testid="desktop-update-show-installer"]')).not.toBeNull()
+
+    // Manual mode shares the native relaunch handoff: drain, install, exit.
+    // (Click before any mocked action response replaces the state.)
+    ;(document.querySelector('[data-testid="desktop-update-relaunch"]') as HTMLButtonElement).click()
     await settle()
 
-    expect(api.downloadUpdate).toHaveBeenCalledTimes(1)
+    expect(api.relaunchToUpdate).toHaveBeenCalledTimes(1)
     app.unmount()
   })
 

--- a/opensquilla-webui/src/components/DesktopUpdateIndicator.vue
+++ b/opensquilla-webui/src/components/DesktopUpdateIndicator.vue
@@ -130,8 +130,11 @@ useDocumentEvent('keydown', event => {
             <Icon name="download" :size="14" aria-hidden="true" />
             <span>{{ manualInstall ? t('updates.desktop.downloadInstaller') : t('updates.desktop.download') }}</span>
           </button>
+          <!-- Manual installs relaunch through the same handoff: the desktop
+               drains its gateway, starts the verified installer, and exits. -->
           <button
-            v-if="status === 'downloaded' && update.state.value.installMode === 'native'"
+            v-if="status === 'downloaded'
+              && (update.state.value.installMode === 'native' || update.state.value.installMode === 'manual')"
             type="button"
             class="btn btn--primary"
             data-testid="desktop-update-relaunch"

--- a/opensquilla-webui/src/components/settings/SettingsUpdatePanel.test.ts
+++ b/opensquilla-webui/src/components/settings/SettingsUpdatePanel.test.ts
@@ -110,7 +110,7 @@ describe('SettingsUpdatePanel', () => {
     app.unmount()
   })
 
-  it('shows the verified Windows installer again without a relaunch action', async () => {
+  it('offers relaunch handoff alongside the verified Windows installer', async () => {
     const api = desktopUpdateApi({
       status: 'downloaded',
       canNativeInstall: false,
@@ -125,11 +125,16 @@ describe('SettingsUpdatePanel', () => {
     expect(el.textContent).toContain('verified against the canonical GitHub checksum')
     const show = el.querySelector('[data-testid="settings-update-download"]') as HTMLButtonElement
     expect(show.textContent).toContain('Show installer')
-    show.click()
+
+    // The manual flow hands off through the same relaunch action as native:
+    // the desktop drains its gateway, starts the installer, and exits.
+    // (Click before the mocked download response replaces the state.)
+    const relaunch = el.querySelector('[data-testid="settings-update-relaunch"]') as HTMLButtonElement
+    expect(relaunch).not.toBeNull()
+    relaunch.click()
     await settle()
 
-    expect(api.downloadUpdate).toHaveBeenCalledTimes(1)
-    expect(el.querySelector('[data-testid="settings-update-relaunch"]')).toBeNull()
+    expect(api.relaunchToUpdate).toHaveBeenCalledTimes(1)
     app.unmount()
   })
 })

--- a/opensquilla-webui/src/components/settings/SettingsUpdatePanel.vue
+++ b/opensquilla-webui/src/components/settings/SettingsUpdatePanel.vue
@@ -63,7 +63,13 @@ const description = computed(() => {
 const showDownload = computed(() => state.value.canCheck && state.value.installMode !== 'unsupported' && (
   status.value === 'available' || (manualInstall.value && status.value === 'downloaded')
 ))
-const showRelaunch = computed(() => state.value.installMode === 'native' && status.value === 'downloaded')
+// Manual (unsigned Windows) installs hand off through the same relaunch
+// action: the desktop drains its gateway, starts the verified installer,
+// and exits — so the installer never has to force-close a live app.
+const showRelaunch = computed(() => (
+  (state.value.installMode === 'native' || state.value.installMode === 'manual')
+  && status.value === 'downloaded'
+))
 const showLater = computed(() => state.value.canCheck && (status.value === 'available' || status.value === 'downloaded' || status.value === 'error'))
 </script>
 

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -77,7 +77,7 @@
       "availableDesc": "Lade es herunter, wenn du bereit bist. OpenSquilla installiert es erst nach dem Neustart.",
       "manualAvailableDesc": "Lade das versionsgebundene Windows-Installationsprogramm herunter. Windows führt dich durch die Installation.",
       "manualDownloadedTitle": "Geprüfter Installer bereit",
-      "manualDownloadedDesc": "OpenSquilla {version} wurde mit der offiziellen GitHub-Prüfsumme verifiziert und im Ordner angezeigt. Starte das Installationsprogramm, wenn du bereit bist.",
+      "manualDownloadedDesc": "OpenSquilla {version} wurde mit der offiziellen GitHub-Prüfsumme verifiziert. „Neu starten“ beendet OpenSquilla und startet das Installationsprogramm; alternativ kannst du es selbst aus dem Ordner ausführen.",
       "downloadedTitle": "Bereit zur Installation",
       "downloadedDesc": "Starte OpenSquilla neu, um das Update auf {version} abzuschließen.",
       "downloadingTitle": "Update wird heruntergeladen",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -77,7 +77,7 @@
       "availableDesc": "Download it when you're ready. OpenSquilla will install it only after you relaunch.",
       "manualAvailableDesc": "Download the versioned Windows installer. Windows will ask you to complete the installation.",
       "manualDownloadedTitle": "Verified installer ready",
-      "manualDownloadedDesc": "OpenSquilla {version} was verified against the canonical GitHub checksum and shown in its folder. Run the installer when ready.",
+      "manualDownloadedDesc": "OpenSquilla {version} was verified against the canonical GitHub checksum. Relaunch closes OpenSquilla and runs the installer for you, or run it yourself from its folder.",
       "downloadedTitle": "Ready to install",
       "downloadedDesc": "Relaunch OpenSquilla to finish updating to {version}.",
       "downloadingTitle": "Downloading update",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -77,7 +77,7 @@
       "availableDesc": "Descárgala cuando estés listo. OpenSquilla la instalará solo después de reiniciar.",
       "manualAvailableDesc": "Descarga el instalador de Windows correspondiente a esta versión. Windows te guiará para completar la instalación.",
       "manualDownloadedTitle": "Instalador verificado listo",
-      "manualDownloadedDesc": "OpenSquilla {version} se verificó con la suma de comprobación oficial de GitHub y se mostró en su carpeta. Ejecuta el instalador cuando estés listo.",
+      "manualDownloadedDesc": "OpenSquilla {version} se verificó con la suma de comprobación oficial de GitHub. Reiniciar cierra OpenSquilla y ejecuta el instalador; también puedes ejecutarlo tú mismo desde su carpeta.",
       "downloadedTitle": "Lista para instalar",
       "downloadedDesc": "Reinicia OpenSquilla para terminar la actualización a {version}.",
       "downloadingTitle": "Descargando actualización",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -77,7 +77,7 @@
       "availableDesc": "Téléchargez-la quand vous êtes prêt. OpenSquilla ne l'installera qu'après relance.",
       "manualAvailableDesc": "Téléchargez l’installateur Windows correspondant à cette version. Windows vous guidera pour terminer l’installation.",
       "manualDownloadedTitle": "Installateur vérifié prêt",
-      "manualDownloadedDesc": "OpenSquilla {version} a été vérifié avec la somme de contrôle GitHub officielle et affiché dans son dossier. Exécutez l’installateur lorsque vous êtes prêt.",
+      "manualDownloadedDesc": "OpenSquilla {version} a été vérifié avec la somme de contrôle GitHub officielle. Relancer ferme OpenSquilla et exécute l’installateur ; vous pouvez aussi l’exécuter vous-même depuis son dossier.",
       "downloadedTitle": "Prête à installer",
       "downloadedDesc": "Relancez OpenSquilla pour terminer la mise à jour vers {version}.",
       "downloadingTitle": "Téléchargement de la mise à jour",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -77,7 +77,7 @@
       "availableDesc": "準備ができたらダウンロードしてください。OpenSquilla は再起動後にだけインストールします。",
       "manualAvailableDesc": "このバージョン専用の Windows インストーラーをダウンロードします。Windows の案内に従ってインストールを完了してください。",
       "manualDownloadedTitle": "検証済みインストーラの準備完了",
-      "manualDownloadedDesc": "OpenSquilla {version} は GitHub の正規チェックサムで検証され、フォルダに表示されました。準備ができたらインストーラを手動で実行してください。",
+      "manualDownloadedDesc": "OpenSquilla {version} は GitHub の正規チェックサムで検証されました。「再起動」で OpenSquilla を終了してインストーラを自動実行します。フォルダから手動で実行することもできます。",
       "downloadedTitle": "インストール準備完了",
       "downloadedDesc": "OpenSquilla を再起動して {version} への更新を完了します。",
       "downloadingTitle": "更新をダウンロード中",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -77,7 +77,7 @@
       "availableDesc": "你准备好时再下载。OpenSquilla 只会在你重新启动后安装更新。",
       "manualAvailableDesc": "下载此版本对应的 Windows 安装程序。Windows 将提示你完成安装。",
       "manualDownloadedTitle": "已验证的安装包已就绪",
-      "manualDownloadedDesc": "OpenSquilla {version} 已通过 GitHub 官方校验和验证，并已在文件夹中显示。准备好后请手动运行安装程序。",
+      "manualDownloadedDesc": "OpenSquilla {version} 已通过 GitHub 官方校验和验证。点击“重新启动”会自动退出 OpenSquilla 并运行安装程序，也可以自行在文件夹中运行。",
       "downloadedTitle": "可以安装了",
       "downloadedDesc": "重新启动 OpenSquilla 以完成更新到 {version}。",
       "downloadingTitle": "正在下载更新",


### PR DESCRIPTION
## What

On Windows (unsigned → manual install mode) the desktop only revealed the verified NSIS installer and left the user to run it **against the still-running app**. Verified consequences (details and template-level evidence in #1293):

- the installer's process check force-stops every process under the install directory — including `opensquilla-gateway.exe` mid-write, with no drain (a state-database corruption vector, cf. #1159);
- an instance it cannot stop (elevated, hung, or hidden in the tray by close-to-tray) dead-ends the update in the `appCannotBeClosed` retry dialog;
- interrupting the install after the old version has been uninstalled but before extraction finishes leaves no app, no uninstaller, and no Settings-Apps entry, with no rollback — the support case that motivated this.

Fixes #1293.

## How

- **`applyDownloadedUpdate()`** gains a manual branch (`applyVerifiedManualInstaller`): the exact native drain — close desktop writers, wait for operations, stop **and join** the owned gateway with its graceful Windows HTTP drain — and only then start the verified installer **detached with `--updated`** and quit. `--updated` mirrors electron-updater's own installer launch: NSIS grace-waits for our exit instead of prompting (verified in the 26.15.3 templates, `allowOnlyOneInstallerInstance.nsh`). A failed spawn is caught via the definitive `spawn`/`error` child events and restores the retry state instead of quitting into nothing.
- **`restoreDownloadedUpdateRetryState`** takes a `mode` so the manual flow's retry does not assign `downloadedUpdateVersion` (which would wrongly arm the native path); manual retry state is keyed on `verifiedManualInstallerPath`, cleared only after a successful spawn.
- **`manual-update-handoff.ts`** (new, pure — no Electron/Node imports): the launch plan and the eligibility decision (`manualHandoffBlocker`), unit-testable outside an Electron process.
- **webui**: the Relaunch action now shows for `installMode === 'manual'` + `downloaded` in both `SettingsUpdatePanel` and `DesktopUpdateIndicator` (wired to the existing `desktop:update:relaunch` IPC, which reaches the new branch); "Show installer" remains as the secondary action. `manualDownloadedDesc` updated across all six locales to describe the handoff.
- macOS/native and mock flows are untouched; the app menu needed no change (macOS-only, manual mode is Windows-only).

## Verification

- `tsc -p tsconfig.json` clean.
- New `npm run test:manual-update-handoff` — launch plan shape and all blocker precedences.
- Neighboring script tests re-run green: `test-update-resolver`, `test-update-check-scheduler`, `test-desktop-window-lifecycle`.
- webui: `vitest run` on `DesktopUpdateIndicator.test.ts` + `SettingsUpdatePanel.test.ts` — 16/16, including the two updated manual-mode cases now asserting the relaunch handoff.

**Not covered (honest limits):** no end-to-end packaged-installer run on a real Windows update — that needs a built NSIS artifact of two versions. The NSIS-side behavior claims are grounded in reading the exact pinned electron-builder 26.15.3 templates rather than a live trace. Happy to adjust if maintainers have an e2e harness for the packaged updater.

## Follow-ups deliberately out of scope

- Job object so an externally-killed desktop cannot orphan the gateway.
- Boot-time detection of a half-installed directory with a pointed recovery message.