### PR TITLE
Fix chat scrolling across native input and resize

### DIFF
--- a/opensquilla-webui/e2e/ensemble-router-strip.spec.ts
+++ b/opensquilla-webui/e2e/ensemble-router-strip.spec.ts
@@ -373,6 +373,9 @@ async function mockControlledEnsembleLifecycle(page: Page) {
 const SCROLL_SESSION_KEY = 'agent:main:webchat:e2e-ensemble-scroll-retention'
 const SCROLL_TASK_ID = 'ensemble-scroll-retention-task'
 const LATE_TEXT = 'Issue 549 late text delta'
+const TINY_SCROLL_TEXT_ONE = 'Tiny scroll retention delta one'
+const TINY_SCROLL_TEXT_TWO = 'Tiny scroll retention delta two'
+const TINY_SCROLL_TEXT_THREE = 'Tiny scroll follow resumed delta'
 const LATE_MODEL = 'openai/gpt-5.4-mini'
 
 async function mockEnsembleScrollRetention(page: Page) {
@@ -383,6 +386,16 @@ async function mockEnsembleScrollRetention(page: Page) {
     window.localStorage.setItem('opensquilla-locale', 'en')
     window.localStorage.setItem('opensquilla.routerVisualEffects', '1')
   })
+  await page.route('**/api/system/update', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({}),
+  }))
+  await page.route('**/api/elevated-mode', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ enabled: false }),
+  }))
   await page.route('**/api/approvals', route => route.fulfill({
     status: 200,
     contentType: 'application/json',
@@ -455,6 +468,7 @@ async function mockEnsembleScrollRetention(page: Page) {
   }
 
   return {
+    emitText: (text: string) => emit('session.event.text_delta', { text }),
     emitLateText: () => emit('session.event.text_delta', { text: LATE_TEXT }),
     emitLateProgress: () => emit('session.event.ensemble_progress', {
       event_type: 'proposer_start',
@@ -476,14 +490,22 @@ function threadMetrics(page: Page) {
   })
 }
 
-test('ensemble events do not re-pin a reader who left the live edge', async ({ page }) => {
+async function openEnsembleScrollRetention(page: Page) {
   const stream = await mockEnsembleScrollRetention(page)
   await page.goto(CONTROL_URL + 'chat?session=' + encodeURIComponent(SCROLL_SESSION_KEY))
-  await page.waitForSelector('.conn-pill', { timeout: 10000 })
+  await page.waitForSelector('.conn-pill.connected', { timeout: 15000 })
   await page.locator('.chat-textarea').fill('Keep streaming while I read earlier content.')
   await page.locator('.chat-send-btn[aria-label="Send"]').click()
+  await expect.poll(
+    () => threadMetrics(page).then(metrics => metrics.scrollHeight > 1600),
+    { timeout: 10000 },
+  ).toBe(true)
+  await expect.poll(() => threadMetrics(page).then(metrics => metrics.gap)).toBeLessThanOrEqual(2)
+  return stream
+}
 
-  await expect.poll(() => threadMetrics(page).then(metrics => metrics.scrollHeight > 1600)).toBe(true)
+test('ensemble events do not re-pin a reader who left the live edge', async ({ page }) => {
+  const stream = await openEnsembleScrollRetention(page)
   const beforeLateEvents = await page.locator('.chat-thread').evaluate(el => {
     const thread = el as HTMLElement
     thread.scrollTop = Math.max(0, thread.scrollHeight - thread.clientHeight - 300)
@@ -508,6 +530,48 @@ test('ensemble events do not re-pin a reader who left the live edge', async ({ p
   const afterLateProgress = await threadMetrics(page)
   expect(afterLateProgress.gap).toBeGreaterThan(60)
   await expect(page.locator('.chat-jump-latest')).toBeVisible()
+})
+
+test('a tiny upward wheel pauses an active stream until the reader returns', async ({ page }) => {
+  const stream = await openEnsembleScrollRetention(page)
+  const thread = page.locator('.chat-thread')
+  const latest = page.locator('.chat-jump-latest')
+
+  await thread.hover({ position: { x: 120, y: 120 } })
+  await page.mouse.wheel(0, -8)
+  await expect(latest).toBeVisible()
+  const paused = await threadMetrics(page)
+  expect(paused.gap).toBeGreaterThan(2)
+  expect(paused.gap).toBeLessThan(60)
+
+  // Cross both the 120ms intent window and delayed IntersectionObserver
+  // delivery before proving that later stream deltas preserve the reader.
+  await page.waitForTimeout(150)
+  stream.emitText(TINY_SCROLL_TEXT_ONE)
+  await expect(thread).toContainText(TINY_SCROLL_TEXT_ONE)
+  const afterFirstDelta = await threadMetrics(page)
+  expect(Math.abs(afterFirstDelta.scrollTop - paused.scrollTop)).toBeLessThanOrEqual(1)
+  expect(afterFirstDelta.gap).toBeGreaterThan(2)
+  await expect(latest).toBeVisible()
+
+  stream.emitText(TINY_SCROLL_TEXT_TWO)
+  await expect(thread).toContainText(TINY_SCROLL_TEXT_TWO)
+  const afterSecondDelta = await threadMetrics(page)
+  expect(Math.abs(afterSecondDelta.scrollTop - paused.scrollTop)).toBeLessThanOrEqual(1)
+  expect(afterSecondDelta.gap).toBeGreaterThan(2)
+  await expect(latest).toBeVisible()
+
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    if ((await threadMetrics(page)).gap <= 2) break
+    await page.mouse.wheel(0, 64)
+  }
+  await expect.poll(() => threadMetrics(page).then(metrics => metrics.gap)).toBeLessThanOrEqual(2)
+  await expect(latest).toHaveCount(0)
+
+  stream.emitText(TINY_SCROLL_TEXT_THREE)
+  await expect(thread).toContainText(TINY_SCROLL_TEXT_THREE)
+  await expect.poll(() => threadMetrics(page).then(metrics => metrics.gap)).toBeLessThanOrEqual(2)
+  await expect(latest).toHaveCount(0)
 })
 
 test('ensemble routing reveals members incrementally from ensemble_progress events', async ({ page }) => {

--- a/opensquilla-webui/e2e/floating-composer.spec.ts
+++ b/opensquilla-webui/e2e/floating-composer.spec.ts
@@ -371,15 +371,20 @@ test('treats a native-scrollbar-only event as reader navigation and resumes on f
   await expect.poll(() => scrollGap(page)).toBeGreaterThan(2)
   expect(await scrollGap(page)).toBeLessThan(60)
   await expect(page.locator('.chat-jump-latest')).toBeVisible()
-  await page.locator('.chat-jump-latest').click()
-  await expect.poll(() => scrollGap(page)).toBeLessThan(2)
-  await thread.evaluate(() => new Promise<void>(resolve => {
-    requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
-  }))
-
-  const bareScrollGap = await thread.evaluate(el => {
+  const bareScrollGap = await thread.evaluate(async el => {
     const thread = el as HTMLElement
-    thread.scrollTop = Math.max(0, thread.scrollTop - 5)
+    const latest = document.querySelector<HTMLButtonElement>('.chat-jump-latest')
+    if (!latest) throw new Error('Jump to latest is unavailable')
+    latest.click()
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      await Promise.resolve()
+      const gap = thread.scrollHeight - thread.scrollTop - thread.clientHeight
+      if (gap <= 1) break
+    }
+    const pinnedTop = thread.scrollTop
+    const pinnedGap = thread.scrollHeight - pinnedTop - thread.clientHeight
+    if (pinnedGap > 1) throw new Error('Programmatic live-edge pin did not run')
+    thread.scrollTop = Math.max(0, pinnedTop - 5)
     thread.dispatchEvent(new Event('scroll'))
     return thread.scrollHeight - thread.scrollTop - thread.clientHeight
   })

--- a/opensquilla-webui/e2e/floating-composer.spec.ts
+++ b/opensquilla-webui/e2e/floating-composer.spec.ts
@@ -169,7 +169,7 @@ async function openChat(page: Page, sessionKey = SESSION_A, enabled = true) {
     : sessionKey === SESSION_B
       ? 'Session B message 48.'
       : 'Session A message 48.'
-  await expect(page.getByText(expectedText, { exact: false })).toBeVisible()
+  await expect(page.getByText(expectedText, { exact: false })).toBeVisible({ timeout: 15000 })
   await expect.poll(() => page.locator('.chat-thread').evaluate(el => (
     el.scrollHeight > el.clientHeight
   ))).toBe(true)
@@ -179,6 +179,31 @@ async function scrollGap(page: Page) {
   return page.locator('.chat-thread').evaluate(el => (
     el.scrollHeight - el.scrollTop - el.clientHeight
   ))
+}
+
+async function visibleRowAnchor(page: Page, expectedKey?: string) {
+  return page.locator('.chat-thread').evaluate((el, key) => {
+    const thread = el as HTMLElement
+    const threadRect = thread.getBoundingClientRect()
+    const rows = Array.from(
+      thread.querySelectorAll<HTMLElement>('[data-testid="chat-message-row"]'),
+    )
+    const index = key
+      ? rows.findIndex(row => row.dataset.chatMessageKey === key)
+      : rows.findIndex(row => {
+          const rect = row.getBoundingClientRect()
+          return rect.top >= threadRect.top + 1 && rect.bottom <= threadRect.bottom - 1
+        })
+    if (index < 0) throw new Error(`Unable to resolve visible chat row ${key || ''}`)
+    const row = rows[index]!
+    return {
+      key: row.dataset.chatMessageKey || '',
+      offset: row.getBoundingClientRect().top - threadRect.top,
+      prefixHeight: rows
+        .slice(0, index)
+        .reduce((height, item) => height + item.getBoundingClientRect().height, 0),
+    }
+  }, expectedKey)
 }
 
 async function expectDockClearance(page: Page) {
@@ -275,6 +300,245 @@ test('floating composer reacts only to user scroll and resets across sessions', 
   await expect.poll(() => new URL(page.url()).searchParams.get('session')).toBe(SESSION_B)
   await expect(page.getByText('Session B message 48.', { exact: false })).toBeVisible()
   await expect(chat).not.toHaveClass(/chat--composer-collapsed/)
+})
+
+test('hands keyboard focus to the thread when Jump to latest disappears', async ({ page }) => {
+  await openChat(page)
+  const thread = page.locator('.chat-thread')
+  const latest = page.locator('.chat-jump-latest')
+
+  await thread.evaluate(el => {
+    const thread = el as HTMLElement
+    thread.scrollTop = Math.max(0, thread.scrollHeight - thread.clientHeight - 300)
+    thread.dispatchEvent(new Event('scroll'))
+  })
+  await expect(latest).toBeVisible()
+  await latest.focus()
+  await expect(latest).toBeFocused()
+  await page.keyboard.press('Enter')
+
+  await expect(latest).toHaveCount(0)
+  await expect(thread).toBeFocused()
+  await expect.poll(() => scrollGap(page)).toBeLessThan(2)
+})
+
+test('treats a native-scrollbar-only event as reader navigation and resumes on fine wheel input', async ({ page }) => {
+  await openChat(page)
+  const thread = page.locator('.chat-thread')
+
+  // Native scrollbar thumbs and some middle-button auto-scroll implementations
+  // can change scrollTop without a wheel or pointer event on the thread.
+  await thread.evaluate(el => {
+    const thread = el as HTMLElement
+    thread.scrollTop = thread.scrollHeight
+  })
+  await expect.poll(() => scrollGap(page)).toBeLessThan(2)
+  await thread.evaluate(() => new Promise<void>(resolve => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+  }))
+
+  // Trackpad pinch and Ctrl+wheel are browser zoom gestures, not transcript
+  // navigation, so they must leave live-edge following intact.
+  await thread.evaluate(el => {
+    el.dispatchEvent(new WheelEvent('wheel', {
+      bubbles: true,
+      ctrlKey: true,
+      deltaY: -8,
+    }))
+  })
+  await expect(page.locator('.chat-jump-latest')).toHaveCount(0)
+  await expect(thread).not.toHaveClass(/chat-thread--reading-history/)
+  await expect.poll(() => scrollGap(page)).toBeLessThan(2)
+
+  // A down gesture that is still outside the 60px recovery zone must retain
+  // the reader latch. A later source-less layout correction may cross that
+  // threshold, but must not silently resume live following.
+  await thread.evaluate(el => {
+    const thread = el as HTMLElement
+    thread.scrollTop = Math.max(0, thread.scrollTop - 100)
+    thread.dispatchEvent(new Event('scroll'))
+  })
+  await expect.poll(() => scrollGap(page)).toBeGreaterThan(60)
+  await thread.hover({ position: { x: 120, y: 120 } })
+  await page.mouse.wheel(0, 8)
+  await expect.poll(() => scrollGap(page)).toBeGreaterThan(60)
+  await page.waitForTimeout(150)
+  await thread.evaluate(el => {
+    const thread = el as HTMLElement
+    thread.scrollTop = thread.scrollHeight - thread.clientHeight - 40
+    thread.dispatchEvent(new Event('scroll'))
+  })
+  await expect.poll(() => scrollGap(page)).toBeGreaterThan(2)
+  expect(await scrollGap(page)).toBeLessThan(60)
+  await expect(page.locator('.chat-jump-latest')).toBeVisible()
+  await page.locator('.chat-jump-latest').click()
+  await expect.poll(() => scrollGap(page)).toBeLessThan(2)
+  await thread.evaluate(() => new Promise<void>(resolve => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+  }))
+
+  const bareScrollGap = await thread.evaluate(el => {
+    const thread = el as HTMLElement
+    thread.scrollTop = Math.max(0, thread.scrollTop - 5)
+    thread.dispatchEvent(new Event('scroll'))
+    return thread.scrollHeight - thread.scrollTop - thread.clientHeight
+  })
+  expect(bareScrollGap).toBeGreaterThan(2)
+  expect(bareScrollGap).toBeLessThan(60)
+  await expect(thread).toHaveClass(/chat-thread--reading-history/)
+  await expect(page.locator('.chat-jump-latest')).toBeVisible()
+  await expect.poll(() => scrollGap(page)).toBeGreaterThan(2)
+  expect(await scrollGap(page)).toBeLessThan(60)
+
+  // Native scroll anchoring can move scrollTop downward while text reflows.
+  // A source-less correction inside the 60px recovery zone must not be
+  // mistaken for a deliberate reader gesture back to the live edge.
+  await thread.evaluate(el => {
+    const thread = el as HTMLElement
+    thread.scrollTop = Math.min(
+      thread.scrollHeight - thread.clientHeight,
+      thread.scrollTop + 1,
+    )
+    thread.dispatchEvent(new Event('scroll'))
+  })
+  await expect(thread).toHaveClass(/chat-thread--reading-history/)
+  await expect(page.locator('.chat-jump-latest')).toBeVisible()
+  await expect.poll(() => scrollGap(page)).toBeGreaterThan(2)
+
+  // Browsers expose both a physical mouse wheel and a trackpad gesture as
+  // WheelEvents. Fine deltas model the latter and must be enough to reach the
+  // live edge without needing the Jump to latest button.
+  await thread.hover({ position: { x: 120, y: 120 } })
+  for (const delta of [64, 64, 64, 64, 64, 64]) {
+    await page.mouse.wheel(0, delta)
+  }
+  await expect.poll(() => scrollGap(page)).toBeLessThan(2)
+  await expect(page.locator('.chat-jump-latest')).toHaveCount(0)
+
+  // Upward keyboard navigation pauses before the browser performs its default
+  // scroll; End returns to the live edge through the normal downward path.
+  await thread.focus()
+  await page.keyboard.press('ArrowUp')
+  await expect(page.locator('.chat-jump-latest')).toBeVisible()
+  await expect.poll(() => scrollGap(page)).toBeGreaterThan(2)
+  expect(await scrollGap(page)).toBeLessThan(60)
+  await page.keyboard.press('End')
+  await expect.poll(() => scrollGap(page)).toBeLessThan(2)
+  await expect(page.locator('.chat-jump-latest')).toHaveCount(0)
+})
+
+test('keeps live follow while a nested transcript scroller consumes the wheel', async ({ page }) => {
+  await openChat(page)
+  const thread = page.locator('.chat-thread')
+  const latest = page.locator('.chat-jump-latest')
+
+  await thread.evaluate(el => { el.scrollTop = el.scrollHeight })
+  await expect.poll(() => scrollGap(page)).toBeLessThan(2)
+  await thread.evaluate(el => {
+    const scroller = document.createElement('div')
+    scroller.dataset.testid = 'nested-transcript-scroller'
+    Object.assign(scroller.style, {
+      background: 'white',
+      height: '80px',
+      left: '320px',
+      overflowY: 'auto',
+      position: 'fixed',
+      top: '180px',
+      width: '220px',
+      zIndex: '9999',
+    })
+    const content = document.createElement('div')
+    content.style.height = '320px'
+    scroller.append(content)
+    el.append(scroller)
+    scroller.scrollTop = 120
+  })
+  const nested = page.getByTestId('nested-transcript-scroller')
+  const before = await nested.evaluate(el => el.scrollTop)
+
+  await nested.hover()
+  await page.mouse.wheel(0, -8)
+
+  await expect.poll(() => nested.evaluate(el => el.scrollTop)).toBeLessThan(before)
+  await expect(latest).toHaveCount(0)
+  await expect(thread).not.toHaveClass(/chat-thread--reading-history/)
+  await expect.poll(() => scrollGap(page)).toBeLessThan(2)
+})
+
+test('pins the live edge across viewport changes without moving a historical reader', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 760 })
+  await openChat(page)
+  const thread = page.locator('.chat-thread')
+  const list = page.locator('.chat-message-list')
+
+  await thread.evaluate(el => { el.scrollTop = el.scrollHeight })
+  await expect(list).toHaveAttribute('data-virtualized', 'false')
+  await expect.poll(() => thread.evaluate(el => getComputedStyle(el).overflowAnchor)).toBe('none')
+  await page.setViewportSize({ width: 900, height: 760 })
+  await expect.poll(() => scrollGap(page)).toBeLessThan(2)
+  await expect(page.locator('.chat-jump-latest')).toHaveCount(0)
+  await expect.poll(() => thread.evaluate(el => getComputedStyle(el).overflowAnchor)).toBe('none')
+
+  await page.setViewportSize({ width: 1280, height: 760 })
+  await expect.poll(() => scrollGap(page)).toBeLessThan(2)
+  await page.setViewportSize({ width: 1280, height: 520 })
+  await expect.poll(() => scrollGap(page)).toBeLessThan(2)
+
+  await thread.evaluate(el => {
+    const thread = el as HTMLElement
+    thread.scrollTop = Math.max(0, thread.scrollHeight - thread.clientHeight - 800)
+    thread.dispatchEvent(new Event('scroll'))
+  })
+  await expect(page.locator('.chat-jump-latest')).toBeVisible()
+  const readerTop = await thread.evaluate(el => el.scrollTop)
+
+  await page.setViewportSize({ width: 1280, height: 680 })
+  await expect.poll(() => scrollGap(page)).toBeGreaterThan(60)
+  await expect(page.locator('.chat-jump-latest')).toBeVisible()
+  expect(Math.abs(await thread.evaluate(el => el.scrollTop) - readerTop)).toBeLessThanOrEqual(1)
+})
+
+test('preserves a non-virtualized reader anchor across width reflow', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 760 })
+  await openChat(page)
+  const thread = page.locator('.chat-thread')
+  const list = page.locator('.chat-message-list')
+
+  await expect(list).toHaveAttribute('data-virtualized', 'false')
+  await thread.evaluate(el => {
+    const thread = el as HTMLElement
+    thread.scrollTop = Math.max(0, thread.scrollHeight - thread.clientHeight - 1800)
+    thread.dispatchEvent(new Event('scroll'))
+  })
+  await expect(page.locator('.chat-jump-latest')).toBeVisible()
+  await expect(thread).toHaveClass(/chat-thread--reading-history/)
+  await expect.poll(() => thread.evaluate(el => getComputedStyle(el).overflowAnchor)).toBe('auto')
+  const wideAnchor = await visibleRowAnchor(page)
+
+  await page.setViewportSize({ width: 900, height: 760 })
+  await expect.poll(async () => {
+    const anchor = await visibleRowAnchor(page, wideAnchor.key)
+    return Math.abs(anchor.prefixHeight - wideAnchor.prefixHeight)
+  }).toBeGreaterThan(1)
+  await expect.poll(async () => {
+    const anchor = await visibleRowAnchor(page, wideAnchor.key)
+    return Math.abs(anchor.offset - wideAnchor.offset)
+  }).toBeLessThanOrEqual(2)
+  const narrowAnchor = await visibleRowAnchor(page, wideAnchor.key)
+  expect(Math.abs(narrowAnchor.offset - wideAnchor.offset)).toBeLessThanOrEqual(2)
+  await expect(page.locator('.chat-jump-latest')).toBeVisible()
+  await expect.poll(() => thread.evaluate(el => getComputedStyle(el).overflowAnchor)).toBe('auto')
+
+  await page.setViewportSize({ width: 1280, height: 760 })
+  await expect.poll(async () => {
+    const anchor = await visibleRowAnchor(page, wideAnchor.key)
+    return Math.abs(anchor.prefixHeight - wideAnchor.prefixHeight)
+  }).toBeLessThanOrEqual(1)
+  await expect.poll(async () => {
+    const anchor = await visibleRowAnchor(page, wideAnchor.key)
+    return Math.abs(anchor.offset - wideAnchor.offset)
+  }).toBeLessThanOrEqual(2)
+  await expect(page.locator('.chat-jump-latest')).toBeVisible()
 })
 
 test('disabled preference restores the established docked layout', async ({ page }) => {

--- a/opensquilla-webui/src/components/chat/ChatMessageList.virtualization.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatMessageList.virtualization.test.ts
@@ -155,6 +155,32 @@ describe('ChatMessageList long-history virtualization', () => {
     expect(container.scrollTop).toBe(12_000)
   })
 
+  it('keeps the live edge pinned when the chat viewport changes size', async () => {
+    const { container } = await mountList({ followLiveEdge: true })
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 12_000 })
+    container.scrollTop = 8_400
+
+    const entry = { target: container } as unknown as ResizeObserverEntry
+    for (const callback of resizeObserverCallbacks) callback([entry], {} as ResizeObserver)
+    await nextTick()
+    await nextTick()
+
+    expect(container.scrollTop).toBe(12_000)
+  })
+
+  it('leaves a historical reader in place when the chat viewport changes size', async () => {
+    const { container } = await mountList({ followLiveEdge: false })
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 12_000 })
+    container.scrollTop = 8_400
+
+    const entry = { target: container } as unknown as ResizeObserverEntry
+    for (const callback of resizeObserverCallbacks) callback([entry], {} as ResizeObserver)
+    await nextTick()
+    await nextTick()
+
+    expect(container.scrollTop).toBe(8_400)
+  })
+
   it('compensates an above-viewport resize from physical geometry once', async () => {
     const { container, host } = await mountList()
     const row = host.querySelector<HTMLElement>('[data-testid="chat-message-row"]')

--- a/opensquilla-webui/src/components/chat/ChatMessageList.vue
+++ b/opensquilla-webui/src/components/chat/ChatMessageList.vue
@@ -151,6 +151,7 @@ import {
 } from '@/composables/chat/useChatGoals'
 import type { PlanCardAction, PlanCardActionTarget } from '@/types/plans'
 import { chatMessageKey } from '@/utils/chat/messageIdentity'
+import { applyProgrammaticScroll } from '@/utils/chat/scrollMutation'
 import {
   isUsageAccountingBarrierMessage,
   strictUsageBarrierRetryUserMessageIndex,
@@ -404,7 +405,9 @@ function queueAnchorAdjustment(delta: number) {
     const adjustment = pendingAnchorAdjustment
     pendingAnchorAdjustment = 0
     if (!props.scrollContainer || props.scrollContainer !== container) return
-    container.scrollTop += adjustment
+    applyProgrammaticScroll(container, () => {
+      container.scrollTop += adjustment
+    })
     scheduleViewportMeasure()
   })
 }
@@ -416,7 +419,9 @@ function queueLiveEdgePin() {
   void nextTick(() => {
     liveEdgePinScheduled = false
     if (!props.followLiveEdge || props.scrollContainer !== container) return
-    container.scrollTop = container.scrollHeight
+    applyProgrammaticScroll(container, () => {
+      container.scrollTop = container.scrollHeight
+    })
     scheduleViewportMeasure()
   })
 }
@@ -526,7 +531,15 @@ function attachContainer(container: HTMLElement | null | undefined) {
   container.addEventListener('focusin', onContainerFocusIn)
   container.addEventListener('focusout', onContainerFocusOut)
   if (typeof ResizeObserver !== 'undefined') {
-    viewportResizeObserver = new ResizeObserver(scheduleViewportMeasure)
+    viewportResizeObserver = new ResizeObserver(entries => {
+      scheduleViewportMeasure()
+      // A container-height change has no new stream event to trigger the
+      // ordinary bottom pin. Keep a reader already following the live edge at
+      // the true bottom; historical readers retain their existing anchor.
+      if (props.followLiveEdge && entries.some(entry => entry.target === container)) {
+        queueLiveEdgePin()
+      }
+    })
     viewportResizeObserver.observe(container)
     if (listRootRef.value) viewportResizeObserver.observe(listRootRef.value)
   }

--- a/opensquilla-webui/src/components/chat/ConversationMinimap.test.ts
+++ b/opensquilla-webui/src/components/chat/ConversationMinimap.test.ts
@@ -162,11 +162,11 @@ async function mountMinimap(
     messageOffset: options.messageOffset,
   })
   app.use(i18n)
-  app.mount(host)
+  const instance = app.mount(host) as unknown as { cancelNavigation: () => void }
   mountedApps.push(app)
   await nextTick()
   await vi.waitFor(() => expect(host.querySelector('[data-testid="conversation-minimap"]')).toBeTruthy())
-  return { host, thread }
+  return { host, instance, thread }
 }
 
 function markers(host: HTMLElement): HTMLButtonElement[] {
@@ -346,6 +346,38 @@ describe('ConversationMinimap', () => {
     expect(mounted.thread.scrollTo).toHaveBeenLastCalledWith({ top: 1_184, behavior: 'smooth' })
     mounted.thread.container.dispatchEvent(new Event('scrollend'))
     expect(releaseEnsuredMessage).toHaveBeenCalledWith(6)
+  })
+
+  it('pairs navigation lifecycle when deferred materialization is cancelled', async () => {
+    const deferred: { resolve?: (element: HTMLElement | null) => void } = {}
+    const ensureMessageVisible = vi.fn(() => new Promise<HTMLElement | null>(resolve => {
+      deferred.resolve = resolve
+    }))
+    const releaseEnsuredMessage = vi.fn()
+    const onNavigate = vi.fn()
+    const onNavigateEnd = vi.fn()
+    const mounted = await mountMinimap(8, {
+      ensureMessageVisible,
+      onNavigate,
+      onNavigateEnd,
+      releaseEnsuredMessage,
+    })
+    mounted.thread.container.querySelector('[data-chat-turn-key="user-3"]')?.remove()
+
+    markers(mounted.host)[3].click()
+    await vi.waitFor(() => expect(ensureMessageVisible).toHaveBeenCalledWith(6))
+    expect(onNavigate).toHaveBeenCalledOnce()
+    expect(onNavigateEnd).not.toHaveBeenCalled()
+
+    mounted.instance.cancelNavigation()
+    expect(onNavigateEnd).toHaveBeenCalledOnce()
+
+    const lateAnchor = document.createElement('div')
+    deferred.resolve!(lateAnchor)
+    await nextTick()
+    await vi.waitFor(() => expect(releaseEnsuredMessage).toHaveBeenCalledWith(6))
+    expect(mounted.thread.scrollTo).not.toHaveBeenCalled()
+    expect(onNavigateEnd).toHaveBeenCalledOnce()
   })
 
   it('completes immediately when the selected prompt is already in place', async () => {

--- a/opensquilla-webui/src/components/chat/ConversationMinimap.vue
+++ b/opensquilla-webui/src/components/chat/ConversationMinimap.vue
@@ -563,9 +563,16 @@ function finishNavigation() {
 }
 
 function cancelNavigation() {
+  const container = navigationContainer
+  const shouldCancelSmoothScroll = navigationPending && Boolean(container)
   navigationGeneration += 1
   settleNavigation(false)
+  if (shouldCancelSmoothScroll && container) {
+    container.scrollTo({ top: container.scrollTop, behavior: 'auto' })
+  }
 }
+
+defineExpose({ cancelNavigation })
 
 function armNavigationEnd(container: HTMLElement, smooth: boolean) {
   navigationPending = true
@@ -591,11 +598,21 @@ async function navigateTo(index: number, focusTarget = false) {
     closeHoverPreview()
     focusedIndex.value = null
   }
+  // Open the lifecycle before awaiting a virtualized row. Session changes,
+  // unmounts, or reader input during that await must still emit navigateEnd
+  // and invalidate the eventual continuation.
+  navigationPending = true
   emit('navigate', index)
   activeIndex.value = index
-  const anchor = anchorElements().get(turn.key)
-    || await props.ensureMessageVisible?.(turn.sourceIndex)
-    || null
+  let anchor = anchorElements().get(turn.key) || null
+  if (!anchor) {
+    try {
+      anchor = await props.ensureMessageVisible?.(turn.sourceIndex) || null
+    } catch {
+      if (generation === navigationGeneration) settleNavigation(false)
+      return
+    }
+  }
   if (generation !== navigationGeneration) {
     props.releaseEnsuredMessage?.(turn.sourceIndex)
     return
@@ -606,7 +623,7 @@ async function navigateTo(index: number, focusTarget = false) {
     : props.messageOffset?.(turn.sourceIndex)
   if (anchorTop === null || anchorTop === undefined || !Number.isFinite(anchorTop)) {
     props.releaseEnsuredMessage?.(turn.sourceIndex)
-    emit('navigateEnd')
+    settleNavigation(false)
     return
   }
   const targetTop = Math.min(
@@ -626,7 +643,7 @@ async function navigateTo(index: number, focusTarget = false) {
   if (distance <= ARRIVAL_TOLERANCE_PX) {
     if (anchor) showArrivalHighlight(anchor)
     props.releaseEnsuredMessage?.(turn.sourceIndex)
-    emit('navigateEnd')
+    settleNavigation(false)
     return
   }
   navigationTarget = anchor

--- a/opensquilla-webui/src/composables/chat/useChatHistory.ts
+++ b/opensquilla-webui/src/composables/chat/useChatHistory.ts
@@ -24,6 +24,7 @@ import {
   restoreMessageAnchor,
   stabilizeMessageAnchor,
 } from '@/utils/chat/scrollAnchor'
+import { applyProgrammaticScroll } from '@/utils/chat/scrollMutation'
 import type { InitialHistoryLoadStatus } from '@/utils/chat/sessionLoadState'
 import { planRevisionsFromToolSegments } from '@/utils/chat/plans'
 import {
@@ -1056,10 +1057,12 @@ export function useChatHistory(options: UseChatHistoryOptions) {
               && historyRequestSeq === requestSeq,
           })
         } else if (prependContainer) {
-          prependContainer.scrollTop += Math.max(
-            0,
-            prependContainer.scrollHeight - prependFallbackHeight,
-          )
+          applyProgrammaticScroll(prependContainer, () => {
+            prependContainer.scrollTop += Math.max(
+              0,
+              prependContainer.scrollHeight - prependFallbackHeight,
+            )
+          })
         }
       } else if (options.autoScroll?.value ?? true) {
         await nextTick()

--- a/opensquilla-webui/src/styles/chat-view.css
+++ b/opensquilla-webui/src/styles/chat-view.css
@@ -228,6 +228,13 @@
   scrollbar-gutter: stable;
 }
 
+/* Native anchoring preserves a non-virtualized reader's visible paragraph
+   across width reflow. Live following and virtualized history keep their
+   existing application-owned pin/correction so the two systems never stack. */
+.chat-thread--reading-history:has(.chat-message-list[data-virtualized="false"]) {
+  overflow-anchor: auto;
+}
+
 /* Floating composer (existing conversation, toggle on): reserve the dock's
    measured height in the body itself. This shortens the scroll viewport so no
    visible transcript text can enter the glass panel, including while the

--- a/opensquilla-webui/src/utils/chat/historyNavigationScrollLock.test.ts
+++ b/opensquilla-webui/src/utils/chat/historyNavigationScrollLock.test.ts
@@ -23,4 +23,21 @@ describe('createHistoryNavigationScrollLock', () => {
     lock.updateFromScroll(180)
     expect(autoScroll.value).toBe(false)
   })
+
+  it('reports reader interruption without restoring follow at navigation end', () => {
+    const autoScroll = ref(true)
+    const lock = createHistoryNavigationScrollLock(autoScroll)
+
+    lock.start()
+    expect(lock.interrupt()).toBe(true)
+    expect(lock.interrupt()).toBe(false)
+    lock.updateFromScroll(12)
+
+    expect(autoScroll.value).toBe(false)
+    expect(lock.finish()).toBe(true)
+    expect(lock.locked).toBe(false)
+
+    lock.start()
+    expect(lock.finish()).toBe(false)
+  })
 })

--- a/opensquilla-webui/src/utils/chat/historyNavigationScrollLock.ts
+++ b/opensquilla-webui/src/utils/chat/historyNavigationScrollLock.ts
@@ -7,14 +7,26 @@ import type { Ref } from 'vue'
  */
 export function createHistoryNavigationScrollLock(autoScroll: Ref<boolean>) {
   let locked = false
+  let interrupted = false
 
   return {
     start() {
       locked = true
+      interrupted = false
       autoScroll.value = false
     },
+    interrupt() {
+      if (!locked) return false
+      const firstInterruption = !interrupted
+      interrupted = true
+      autoScroll.value = false
+      return firstInterruption
+    },
     finish() {
+      const wasInterrupted = interrupted
       locked = false
+      interrupted = false
+      return wasInterrupted
     },
     updateFromScroll(bottomGap: number) {
       if (!locked) autoScroll.value = bottomGap < 60

--- a/opensquilla-webui/src/utils/chat/scrollAnchor.ts
+++ b/opensquilla-webui/src/utils/chat/scrollAnchor.ts
@@ -1,3 +1,5 @@
+import { applyProgrammaticScroll } from './scrollMutation'
+
 export interface MessageScrollAnchor {
   container: HTMLElement
   element: HTMLElement
@@ -71,7 +73,11 @@ export function restoreMessageAnchor(anchor: MessageScrollAnchor | null): boolea
   const nextOffset = element.getBoundingClientRect().top
     - anchor.container.getBoundingClientRect().top
   const delta = nextOffset - anchor.offsetTop
-  if (delta) anchor.container.scrollTop += delta
+  if (delta) {
+    applyProgrammaticScroll(anchor.container, () => {
+      anchor.container.scrollTop += delta
+    })
+  }
   anchor.expectedScrollTop = anchor.container.scrollTop
   anchor.element = element
   return true
@@ -108,7 +114,11 @@ export function restoreElementScrollAnchor(
   const nextOffset = replacement.getBoundingClientRect().top
     - anchor.container.getBoundingClientRect().top
   const delta = nextOffset - anchor.offsetTop
-  if (Math.abs(delta) >= 0.5) anchor.container.scrollTop += delta
+  if (Math.abs(delta) >= 0.5) {
+    applyProgrammaticScroll(anchor.container, () => {
+      anchor.container.scrollTop += delta
+    })
+  }
   return true
 }
 
@@ -271,7 +281,11 @@ export function restoreTextScrollAnchor(
   const nextOffset = range.getBoundingClientRect().top
     - anchor.container.getBoundingClientRect().top
   const delta = nextOffset - anchor.offsetTop
-  if (Math.abs(delta) >= 0.5) anchor.container.scrollTop += delta
+  if (Math.abs(delta) >= 0.5) {
+    applyProgrammaticScroll(anchor.container, () => {
+      anchor.container.scrollTop += delta
+    })
+  }
   return true
 }
 

--- a/opensquilla-webui/src/utils/chat/scrollMutation.test.ts
+++ b/opensquilla-webui/src/utils/chat/scrollMutation.test.ts
@@ -22,8 +22,11 @@ describe('chat scroll mutation ownership', () => {
       thread.scrollTop = 180
     })
 
-    expect(consumeProgrammaticScroll(thread)).toBe(true)
-    expect(consumeProgrammaticScroll(thread)).toBe(false)
+    expect(consumeProgrammaticScroll(thread)).toEqual({
+      expectedScrollTop: 180,
+      matched: true,
+    })
+    expect(consumeProgrammaticScroll(thread)).toBeNull()
   })
 
   it('does not swallow a reader move after an application write had no event', () => {
@@ -37,8 +40,11 @@ describe('chat scroll mutation ownership', () => {
     // disable live following rather than consume the stale marker.
     thread.scrollTop = 96
 
-    expect(consumeProgrammaticScroll(thread)).toBe(false)
-    expect(consumeProgrammaticScroll(thread)).toBe(false)
+    expect(consumeProgrammaticScroll(thread)).toEqual({
+      expectedScrollTop: 180,
+      matched: false,
+    })
+    expect(consumeProgrammaticScroll(thread)).toBeNull()
   })
 
   it('keeps only the latest application correction while scroll events coalesce', () => {
@@ -51,6 +57,24 @@ describe('chat scroll mutation ownership', () => {
       thread.scrollTop = 240
     })
 
-    expect(consumeProgrammaticScroll(thread)).toBe(true)
+    expect(consumeProgrammaticScroll(thread)).toEqual({
+      expectedScrollTop: 240,
+      matched: true,
+    })
+  })
+
+  it('retains the pending target when reader movement coalesces with the correction', () => {
+    const thread = container(1_000)
+
+    applyProgrammaticScroll(thread, () => {
+      thread.scrollTop = 1_100
+    })
+    thread.scrollTop = 1_092
+
+    expect(consumeProgrammaticScroll(thread)).toEqual({
+      expectedScrollTop: 1_100,
+      matched: false,
+    })
+    expect(consumeProgrammaticScroll(thread)).toBeNull()
   })
 })

--- a/opensquilla-webui/src/utils/chat/scrollMutation.test.ts
+++ b/opensquilla-webui/src/utils/chat/scrollMutation.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest'
+
+import { applyProgrammaticScroll, consumeProgrammaticScroll } from './scrollMutation'
+
+function container(top = 0): HTMLElement {
+  const element = document.createElement('div')
+  Object.defineProperty(element, 'scrollTop', {
+    configurable: true,
+    writable: true,
+    value: top,
+  })
+  return element
+}
+
+describe('chat scroll mutation ownership', () => {
+  it('consumes the next scroll position written by the application', () => {
+    const thread = container(24)
+
+    applyProgrammaticScroll(thread, () => {
+      thread.scrollTop = 180
+    })
+
+    expect(consumeProgrammaticScroll(thread)).toBe(true)
+    expect(consumeProgrammaticScroll(thread)).toBe(false)
+  })
+
+  it('does not swallow a reader move after an application write had no event', () => {
+    const thread = container(24)
+
+    applyProgrammaticScroll(thread, () => {
+      thread.scrollTop = 180
+    })
+    // A no-op DOM write does not necessarily emit `scroll`. If the next event
+    // instead comes from a native scrollbar drag, its different position must
+    // disable live following rather than consume the stale marker.
+    thread.scrollTop = 96
+
+    expect(consumeProgrammaticScroll(thread)).toBe(false)
+    expect(consumeProgrammaticScroll(thread)).toBe(false)
+  })
+
+  it('keeps only the latest application correction while scroll events coalesce', () => {
+    const thread = container(24)
+
+    applyProgrammaticScroll(thread, () => {
+      thread.scrollTop = 120
+    })
+    applyProgrammaticScroll(thread, () => {
+      thread.scrollTop = 240
+    })
+
+    expect(consumeProgrammaticScroll(thread)).toBe(true)
+  })
+})

--- a/opensquilla-webui/src/utils/chat/scrollMutation.ts
+++ b/opensquilla-webui/src/utils/chat/scrollMutation.ts
@@ -1,5 +1,10 @@
 const expectedProgrammaticScrollTop = new WeakMap<HTMLElement, number>()
 
+export interface ProgrammaticScrollConsumption {
+  expectedScrollTop: number
+  matched: boolean
+}
+
 /**
  * Records a chat-thread scroll position that was produced by the application
  * itself. Browser scroll events carry no reliable source information: native
@@ -18,16 +23,19 @@ export function applyProgrammaticScroll(
 }
 
 /**
- * Returns whether this scroll event belongs to the most recent application
- * correction. A mismatch immediately releases the marker so a real reader
- * gesture is never swallowed by a stale correction.
+ * Returns the consumed application target and whether this event reached it.
+ * A mismatch immediately releases the marker so a real reader gesture is never
+ * swallowed by a stale correction.
  */
 export function consumeProgrammaticScroll(
   container: HTMLElement,
   tolerancePx = 1,
-): boolean {
+): ProgrammaticScrollConsumption | null {
   const expected = expectedProgrammaticScrollTop.get(container)
-  if (expected === undefined) return false
+  if (expected === undefined) return null
   expectedProgrammaticScrollTop.delete(container)
-  return Math.abs(container.scrollTop - expected) <= tolerancePx
+  return {
+    expectedScrollTop: expected,
+    matched: Math.abs(container.scrollTop - expected) <= tolerancePx,
+  }
 }

--- a/opensquilla-webui/src/utils/chat/scrollMutation.ts
+++ b/opensquilla-webui/src/utils/chat/scrollMutation.ts
@@ -1,0 +1,33 @@
+const expectedProgrammaticScrollTop = new WeakMap<HTMLElement, number>()
+
+/**
+ * Records a chat-thread scroll position that was produced by the application
+ * itself. Browser scroll events carry no reliable source information: native
+ * scrollbar drags, middle-button auto-scroll, and a `scrollTop` assignment can
+ * all reach the same listener. The next matching event is therefore consumed
+ * by the view, while any different position remains reader-owned.
+ */
+export function applyProgrammaticScroll(
+  container: HTMLElement,
+  mutate: () => void,
+): void {
+  mutate()
+  // Record the clamped value rather than the requested target. A short thread
+  // or a viewport resize can make the browser choose a smaller legal maximum.
+  expectedProgrammaticScrollTop.set(container, container.scrollTop)
+}
+
+/**
+ * Returns whether this scroll event belongs to the most recent application
+ * correction. A mismatch immediately releases the marker so a real reader
+ * gesture is never swallowed by a stale correction.
+ */
+export function consumeProgrammaticScroll(
+  container: HTMLElement,
+  tolerancePx = 1,
+): boolean {
+  const expected = expectedProgrammaticScrollTop.get(container)
+  if (expected === undefined) return false
+  expectedProgrammaticScrollTop.delete(container)
+  return Math.abs(container.scrollTop - expected) <= tolerancePx
+}

--- a/opensquilla-webui/src/views/ChatView.scroll-follow.test.ts
+++ b/opensquilla-webui/src/views/ChatView.scroll-follow.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import chatViewSource from './ChatView.vue?raw'
+
+function threadScrollHandlerSource(): string {
+  const start = chatViewSource.indexOf('function onThreadScroll()')
+  const end = chatViewSource.indexOf('\nfunction onThreadWheel(', start)
+  if (start < 0 || end < 0) throw new Error('Unable to locate ChatView thread scroll handler')
+  return chatViewSource.slice(start, end)
+}
+
+function historyNavigationEndSource(): string {
+  const start = chatViewSource.indexOf('function onHistoryNavigateEnd()')
+  const end = chatViewSource.indexOf('\n// Show the jump-to-latest', start)
+  if (start < 0 || end < 0) throw new Error('Unable to locate history navigation end handler')
+  return chatViewSource.slice(start, end)
+}
+
+function threadWheelHandlerSource(): string {
+  const start = chatViewSource.indexOf('function onThreadWheel(')
+  const end = chatViewSource.indexOf('\nfunction threadConsumesWheel(', start)
+  if (start < 0 || end < 0) throw new Error('Unable to locate ChatView thread wheel handler')
+  return chatViewSource.slice(start, end)
+}
+
+describe('ChatView scroll ownership wiring', () => {
+  it('removes stale reader intent from application-owned composer samples', () => {
+    const source = threadScrollHandlerSource()
+
+    expect(source).toContain(
+      'const intent = programmatic ? null : currentThreadScrollIntent()',
+    )
+    expect(source).toContain('intent,')
+    expect(source).not.toContain('intent: currentThreadScrollIntent()')
+  })
+
+  it('preserves reader pause when a history navigation is interrupted', () => {
+    const scrollSource = threadScrollHandlerSource()
+    const endSource = historyNavigationEndSource()
+    const wheelSource = threadWheelHandlerSource()
+
+    expect(scrollSource).toContain(
+      'historyNavigationScrollLock.locked && intent !== null',
+    )
+    expect(scrollSource).toContain('interruptHistoryNavigationForReader()')
+    expect(endSource).toContain(
+      'const navigationInterrupted = historyNavigationScrollLock.finish()',
+    )
+    expect(endSource).toContain(
+      'syncComposerRetractionFromThread(!navigationInterrupted)',
+    )
+    expect(wheelSource.indexOf('interruptHistoryNavigationForReader()')).toBeLessThan(
+      wheelSource.indexOf('threadConsumesWheel(event, el)'),
+    )
+    expect(chatViewSource).toContain(
+      'conversationMinimapRef.value?.cancelNavigation()',
+    )
+  })
+})

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -103,13 +103,14 @@
         <div
           ref="threadRef"
           class="chat-thread"
+          :class="{ 'chat-thread--reading-history': !autoScroll }"
           role="region"
           tabindex="0"
           :aria-label="t('chat.conversation')"
           :aria-busy="isStreaming || forkInFlight"
           @scroll="onThreadScroll"
           @wheel.passive="onThreadWheel"
-          @touchmove.passive="markThreadScrollIntent('either')"
+          @touchmove.passive="onThreadTouchMove"
           @pointerdown="markThreadScrollIntent('either')"
           @pointermove="onThreadPointerMove"
           @keydown="onThreadScrollKeydown"
@@ -440,6 +441,7 @@
         </div>
         <ConversationMinimap
           v-if="!isNewChatLanding && !shareMode && !forkTransition"
+          ref="conversationMinimapRef"
           :messages="renderedMessages"
           :scroll-container="threadRef"
           :ensure-message-visible="messageListRef?.ensureMessageVisible"
@@ -506,6 +508,7 @@
     <Transition name="jump-latest">
       <button
         v-if="showJumpToLatest"
+        ref="jumpToLatestButtonRef"
         type="button"
         class="chat-jump-latest"
         :aria-label="t('chat.jumpToLatest')"
@@ -924,6 +927,10 @@ import {
 import { listPendingMetaDiscards } from '@/utils/chat/metaDiscardOutbox'
 import { createHistoryNavigationScrollLock } from '@/utils/chat/historyNavigationScrollLock'
 import {
+  applyProgrammaticScroll,
+  consumeProgrammaticScroll,
+} from '@/utils/chat/scrollMutation'
+import {
   captureElementScrollAnchor,
   captureVisibleTextScrollAnchor,
   createScrollHandoffGuard,
@@ -1068,7 +1075,9 @@ const chatRootRef = ref<HTMLElement | null>(null)
 const threadRef = ref<HTMLElement | null>(null)
 const goalRunDockRef = ref<HTMLElement | null>(null)
 const messageListRef = ref<ChatMessageListVirtualizer | null>(null)
+const conversationMinimapRef = ref<{ cancelNavigation: () => void } | null>(null)
 const bottomSentinelRef = ref<HTMLElement | null>(null)
+const jumpToLatestButtonRef = ref<HTMLButtonElement | null>(null)
 let bottomIntersectionObserver: IntersectionObserver | null = null
 const composerRef = ref<ChatComposerHandle | null>(null)
 /* Floating-composer retract: a pure controller accumulates slow user travel
@@ -1134,6 +1143,20 @@ const composerRevision = ref(0)
 const aborted = ref(false)
 const autoScroll = ref(true)
 const historyNavigationScrollLock = createHistoryNavigationScrollLock(autoScroll)
+const LIVE_EDGE_EPSILON_PX = 2
+const SCROLL_DIRECTION_EPSILON_PX = 0.5
+let lastObservedThreadScrollTop: number | null = null
+let readerMovingAway = false
+
+function resetReaderScrollTracking() {
+  lastObservedThreadScrollTop = null
+  readerMovingAway = false
+}
+
+watch(sessionKey, resetReaderScrollTracking, { flush: 'sync' })
+watch(autoScroll, following => {
+  if (following) readerMovingAway = false
+}, { flush: 'sync' })
 const composing = ref(false)
 const messages = ref<Message[]>([])
 
@@ -4457,7 +4480,9 @@ function scrollToBottom() {
       // below the viewport, so the live answer remains hidden under the dock
       // and the geometric bottom gap equals the composer height. Scroll the
       // container itself to its true maximum instead.
-      threadRef.value.scrollTop = threadRef.value.scrollHeight
+      applyProgrammaticScroll(threadRef.value, () => {
+        threadRef.value!.scrollTop = threadRef.value!.scrollHeight
+      })
     }
   })
 }
@@ -4465,13 +4490,50 @@ function scrollToBottom() {
 function onThreadScroll() {
   const el = threadRef.value
   if (!el) return
+  const previousScrollTop = lastObservedThreadScrollTop
+  const currentScrollTop = el.scrollTop
+  lastObservedThreadScrollTop = currentScrollTop
   const gap = el.scrollHeight - el.scrollTop - el.clientHeight
-  // Virtualized row measurement and other layout corrections can move the
-  // bottom sentinel without any reader gesture. Only release live-edge follow
-  // when the reader expressed scroll intent; arriving back at the bottom may
-  // always re-enable it.
-  const intent = currentThreadScrollIntent()
-  if (gap < 60 || intent !== null) historyNavigationScrollLock.updateFromScroll(gap)
+  // Native scrollbar drags and middle-button auto-scroll can produce only a
+  // scroll event. Application-owned anchor corrections are marked at their
+  // write sites, so every other position change belongs to the reader.
+  const programmatic = consumeProgrammaticScroll(el)
+  const intent = programmatic ? null : currentThreadScrollIntent()
+  if (!programmatic && historyNavigationScrollLock.locked && intent !== null) {
+    interruptHistoryNavigationForReader()
+  } else if (!programmatic && !historyNavigationScrollLock.locked) {
+    const movedUp = previousScrollTop !== null
+      && currentScrollTop < previousScrollTop - SCROLL_DIRECTION_EPSILON_PX
+    const movedDown = previousScrollTop !== null
+      && currentScrollTop > previousScrollTop + SCROLL_DIRECTION_EPSILON_PX
+    const leavingLiveEdge = intent === 'up'
+      || (gap > LIVE_EDGE_EPSILON_PX && movedUp)
+      || (
+        previousScrollTop === null
+        && autoScroll.value
+        && gap > LIVE_EDGE_EPSILON_PX
+      )
+
+    if (leavingLiveEdge) {
+      readerMovingAway = true
+      autoScroll.value = false
+    } else if (gap <= LIVE_EDGE_EPSILON_PX) {
+      readerMovingAway = false
+      historyNavigationScrollLock.updateFromScroll(gap)
+    } else if (readerMovingAway) {
+      // Browser scroll anchoring can adjust scrollTop without an input event.
+      // While the reader is paused, only a definite downward gesture may use
+      // the forgiving 60px return threshold; source-less movement must reach
+      // the real live edge before following resumes.
+      if (intent === 'down' && movedDown) {
+        historyNavigationScrollLock.updateFromScroll(gap)
+      }
+    } else if (movedDown) {
+      historyNavigationScrollLock.updateFromScroll(gap)
+    } else if (!readerMovingAway) {
+      historyNavigationScrollLock.updateFromScroll(gap)
+    }
+  }
   if (isNewChatLanding.value || !composerFxEnabled.value) {
     resetComposerRetraction()
     return
@@ -4480,7 +4542,7 @@ function onThreadScroll() {
   composerCollapsed.value = composerRetraction.observe({
     scrollTop: el.scrollTop,
     bottomGap: gap,
-    intent: currentThreadScrollIntent(),
+    intent,
     canCollapse: !slashOpen.value && (composerRef.value?.canCollapse() ?? true),
     navigationLocked: historyNavigationScrollLock.locked,
   })
@@ -4488,13 +4550,54 @@ function onThreadScroll() {
 }
 
 function onThreadWheel(event: WheelEvent) {
-  if (event.deltaY === 0) return
+  // Browser zoom gestures surface as ctrl+wheel (including trackpad pinch in
+  // Chromium) but do not represent reader movement inside the transcript.
+  if (event.deltaY === 0 || event.ctrlKey) return
+  const el = threadRef.value
+  if (!el) return
+  // Any wheel gesture inside the transcript takes ownership away from an
+  // in-flight minimap animation, including gestures consumed by a nested
+  // reasoning/tool scroller. Outside navigation, only a wheel that reaches the
+  // thread itself may pause live-edge following.
+  if (historyNavigationScrollLock.locked && !event.defaultPrevented) {
+    interruptHistoryNavigationForReader()
+  }
+  if (!threadConsumesWheel(event, el)) return
   markThreadScrollIntent(event.deltaY < 0 ? 'up' : 'down')
+  if (event.deltaY < 0) pauseFollowingForUpwardIntent()
+}
+
+function threadConsumesWheel(event: WheelEvent, thread: HTMLElement): boolean {
+  if (event.defaultPrevented) return false
+  const canScroll = (element: HTMLElement) => event.deltaY < 0
+    ? element.scrollTop > SCROLL_DIRECTION_EPSILON_PX
+    : element.scrollTop + element.clientHeight
+      < element.scrollHeight - SCROLL_DIRECTION_EPSILON_PX
+
+  for (const target of event.composedPath()) {
+    if (target === thread) return canScroll(thread)
+    if (!(target instanceof HTMLElement)) continue
+    const style = getComputedStyle(target)
+    const scrollable = ['auto', 'scroll', 'overlay'].includes(style.overflowY)
+      && target.scrollHeight > target.clientHeight + SCROLL_DIRECTION_EPSILON_PX
+    if (!scrollable) continue
+    if (canScroll(target)) return false
+    if (style.overscrollBehaviorY === 'contain' || style.overscrollBehaviorY === 'none') {
+      return false
+    }
+  }
+  return false
+}
+
+function onThreadTouchMove() {
+  markThreadScrollIntent('either')
+  interruptHistoryNavigationForReader()
 }
 
 function onThreadPointerMove(event: PointerEvent) {
   if (event.buttons !== 0 || event.pointerType === 'touch') {
     markThreadScrollIntent('either')
+    interruptHistoryNavigationForReader()
   }
 }
 
@@ -4509,14 +4612,31 @@ function onThreadScrollKeydown(event: KeyboardEvent) {
     || event.key === 'End'
     || (event.key === ' ' && !event.shiftKey)
   if (up || down) markThreadScrollIntent(up ? 'up' : 'down')
+  if (up) pauseFollowingForUpwardIntent()
 }
 
-function syncComposerRetractionFromThread() {
+function pauseFollowingForUpwardIntent() {
+  const el = threadRef.value
+  if (!el || el.scrollTop <= SCROLL_DIRECTION_EPSILON_PX) return
+  lastObservedThreadScrollTop = el.scrollTop
+  readerMovingAway = true
+  autoScroll.value = false
+}
+
+function interruptHistoryNavigationForReader() {
+  if (!historyNavigationScrollLock.locked) return
+  const firstInterruption = historyNavigationScrollLock.interrupt()
+  readerMovingAway = true
+  autoScroll.value = false
+  if (firstInterruption) conversationMinimapRef.value?.cancelNavigation()
+}
+
+function syncComposerRetractionFromThread(updateFollow = true) {
   const el = threadRef.value
   if (!el) return
   clearPendingComposerScrollIntent()
   const gap = el.scrollHeight - el.scrollTop - el.clientHeight
-  historyNavigationScrollLock.updateFromScroll(gap)
+  if (updateFollow) historyNavigationScrollLock.updateFromScroll(gap)
   composerCollapsed.value = composerRetraction.observe({
     scrollTop: el.scrollTop,
     bottomGap: gap,
@@ -4533,17 +4653,31 @@ function onHistoryNavigate() {
 }
 
 function onHistoryNavigateEnd() {
-  historyNavigationScrollLock.finish()
+  const navigationInterrupted = historyNavigationScrollLock.finish()
   // Smooth-scroll frames and the final arrival are navigation, not transcript
-  // browsing gestures. Establish a baseline without toggling the composer.
-  syncComposerRetractionFromThread()
+  // browsing gestures. If the reader interrupted the motion, establish only a
+  // composer baseline and preserve their pause unless they reached true bottom.
+  syncComposerRetractionFromThread(!navigationInterrupted)
+  if (navigationInterrupted) {
+    const el = threadRef.value
+    const gap = el ? el.scrollHeight - el.scrollTop - el.clientHeight : Infinity
+    if (gap <= LIVE_EDGE_EPSILON_PX) {
+      readerMovingAway = false
+      historyNavigationScrollLock.updateFromScroll(gap)
+    }
+  }
   if (autoScroll.value) expandComposer()
 }
 
 // Show the jump-to-latest affordance whenever the reader has scrolled up off the
-// live edge (autoScroll releases at gap >= 60) and there is content to return to.
-// Re-pinning autoScroll lets the stream resume following the bottom.
+// live edge. Upward reader movement releases the follow immediately; scrolling
+// back within 60px of the bottom resumes it.
 const showJumpToLatest = computed(() => !autoScroll.value && messages.value.length > 0)
+watch(showJumpToLatest, showing => {
+  if (showing || document.activeElement !== jumpToLatestButtonRef.value) return
+  threadRef.value?.focus({ preventScroll: true })
+}, { flush: 'sync' })
+
 function jumpToLatest() {
   cancelAnchorStabilization()
   historyNavigationScrollLock.finish()
@@ -4888,7 +5022,16 @@ onMounted(async () => {
     && bottomSentinelRef.value
   ) {
     bottomIntersectionObserver = new IntersectionObserver((entries) => {
-      if (entries.some(entry => entry.isIntersecting) && !historyNavigationScrollLock.locked) {
+      const thread = threadRef.value
+      const bottomGap = thread
+        ? thread.scrollHeight - thread.scrollTop - thread.clientHeight
+        : Number.POSITIVE_INFINITY
+      if (
+        entries.some(entry => entry.isIntersecting)
+        && bottomGap <= LIVE_EDGE_EPSILON_PX
+        && !readerMovingAway
+        && !historyNavigationScrollLock.locked
+      ) {
         autoScroll.value = true
       }
     }, {
@@ -4995,7 +5138,9 @@ onMounted(async () => {
           composerDockPinFrame = null
           const thread = threadRef.value
           if (thread && autoScroll.value) {
-            thread.scrollTop = thread.scrollHeight
+            applyProgrammaticScroll(thread, () => {
+              thread.scrollTop = thread.scrollHeight
+            })
           }
         })
       }

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -4530,7 +4530,7 @@ function onThreadScroll() {
       }
     } else if (movedDown) {
       historyNavigationScrollLock.updateFromScroll(gap)
-    } else if (!readerMovingAway) {
+    } else {
       historyNavigationScrollLock.updateFromScroll(gap)
     }
   }

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -4490,14 +4490,16 @@ function scrollToBottom() {
 function onThreadScroll() {
   const el = threadRef.value
   if (!el) return
-  const previousScrollTop = lastObservedThreadScrollTop
   const currentScrollTop = el.scrollTop
+  const scrollMutation = consumeProgrammaticScroll(el)
+  const previousScrollTop = scrollMutation?.expectedScrollTop
+    ?? lastObservedThreadScrollTop
   lastObservedThreadScrollTop = currentScrollTop
   const gap = el.scrollHeight - el.scrollTop - el.clientHeight
   // Native scrollbar drags and middle-button auto-scroll can produce only a
   // scroll event. Application-owned anchor corrections are marked at their
   // write sites, so every other position change belongs to the reader.
-  const programmatic = consumeProgrammaticScroll(el)
+  const programmatic = scrollMutation?.matched ?? false
   const intent = programmatic ? null : currentThreadScrollIntent()
   if (!programmatic && historyNavigationScrollLock.locked && intent !== null) {
     interruptHistoryNavigationForReader()


### PR DESCRIPTION
## Scope

Scope boundary:
- Pause live-edge following immediately for upward wheel, trackpad, keyboard, native scrollbar, and middle-button scrolling.
- Mark application-owned scroll corrections so virtualization, history prepend, composer resize, and minimap navigation do not masquerade as reader input.
- Preserve reader anchors across viewport reflow while keeping live-follow pinned to the true bottom.
- Preserve focus and composer behavior when the Jump to latest control disappears.

Non-goals:
- No RPC, public type, configuration, persistence, or session protocol changes.
- No new screen-reader live announcements or unrelated smooth-scroll behavior.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: The defect was discovered during PR review and reproduced independently on main; no issue was filed.

## Release Note

Release note: Fix chat scrolling so native input and window resizing preserve reader position without fighting live updates.

## Tests

Ruff: N/A (frontend-only)

Pytest: N/A (frontend-only)

Build: `npm run typecheck`; `npm run build:artifact`

Regression tests: added

Notes:
- 8 targeted Vitest files, 110 tests passed.
- 7 focused Chromium regression tests passed without retries.
- Verified after fast-forwarding to current `origin/main` at `c57fdf85d`.
- The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: browser | gateway

Maintainer-only note: A real local gateway was started and reached `/ready`; physical trackpad, native scrollbar, middle-button auto-scroll, and browser zoom remain available for maintainer hardware validation.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents were not committed.

The change uses platform-neutral standard browser APIs and does not affect persisted data or public compatibility contracts.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No documentation changes are required for this bug fix.
- [x] Tests and fixtures use synthetic data only.
