### PR TITLE
Retry transient Windows Runtime Pack state replacements

### DIFF
--- a/src/opensquilla/runtime_packs/manager.py
+++ b/src/opensquilla/runtime_packs/manager.py
@@ -89,6 +89,8 @@ _INTEGRITY_CACHE_TTL_SECONDS = 30.0
 _SAFE_IDENTITY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$")
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 _MAX_STATE_JSON_BYTES = 64 * 1024**2
+_WINDOWS_ATOMIC_REPLACE_RETRY_DELAYS_SECONDS = (0.02, 0.05, 0.1, 0.2)
+_WINDOWS_TRANSIENT_REPLACE_ERRORS = frozenset({5, 32, 33})
 _configured_state_dir: ContextVar[Path | None] = ContextVar(
     "opensquilla_runtime_pack_state_dir",
     default=None,
@@ -214,9 +216,26 @@ def _atomic_json(path: Path, value: Mapping[str, Any]) -> None:
             temp_path.chmod(0o600)
         except OSError:
             pass
-        os.replace(temp_path, path)
+        _replace_atomic_state(temp_path, path)
     finally:
         temp_path.unlink(missing_ok=True)
+
+
+def _replace_atomic_state(source: Path, destination: Path) -> None:
+    """Publish state after transient Windows readers release the destination."""
+
+    for delay in (*_WINDOWS_ATOMIC_REPLACE_RETRY_DELAYS_SECONDS, None):
+        try:
+            os.replace(source, destination)
+            return
+        except PermissionError as error:
+            if (
+                os.name != "nt"
+                or getattr(error, "winerror", None) not in _WINDOWS_TRANSIENT_REPLACE_ERRORS
+                or delay is None
+            ):
+                raise
+            time.sleep(delay)
 
 
 def _read_json(path: Path) -> dict[str, Any] | None:

--- a/tests/test_runtime_packs/test_runtime_pack_manager.py
+++ b/tests/test_runtime_packs/test_runtime_pack_manager.py
@@ -60,6 +60,68 @@ def _isolate_synthetic_archive_probes(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(runtime_pack_manager, "_run_probe", probe)
 
 
+def test_atomic_state_replace_retries_transient_windows_reader_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "operation.tmp"
+    destination = tmp_path / "operation.json"
+    source.write_text("next", encoding="utf-8")
+    destination.write_text("current", encoding="utf-8")
+    real_replace = os.replace
+    attempts = 0
+    delays: list[float] = []
+
+    class TransientWindowsReplaceError(PermissionError):
+        winerror = 5
+
+    def flaky_replace(source_path: Path, destination_path: Path) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise TransientWindowsReplaceError("reader still has the state file open")
+        real_replace(source_path, destination_path)
+
+    monkeypatch.setattr(runtime_pack_manager.os, "name", "nt")
+    monkeypatch.setattr(runtime_pack_manager.os, "replace", flaky_replace)
+    monkeypatch.setattr(runtime_pack_manager.time, "sleep", delays.append)
+
+    runtime_pack_manager._replace_atomic_state(source, destination)
+
+    assert attempts == 3
+    assert delays == [0.02, 0.05]
+    assert not source.exists()
+    assert destination.read_text(encoding="utf-8") == "next"
+
+
+def test_atomic_state_replace_does_not_retry_permanent_windows_denial(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "operation.tmp"
+    destination = tmp_path / "operation.json"
+    source.write_text("next", encoding="utf-8")
+    attempts = 0
+
+    class PermanentWindowsReplaceError(PermissionError):
+        winerror = 50
+
+    def denied_replace(_source: Path, _destination: Path) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise PermanentWindowsReplaceError("policy denied the replacement")
+
+    monkeypatch.setattr(runtime_pack_manager.os, "name", "nt")
+    monkeypatch.setattr(runtime_pack_manager.os, "replace", denied_replace)
+
+    with pytest.raises(PermanentWindowsReplaceError, match="policy denied"):
+        runtime_pack_manager._replace_atomic_state(source, destination)
+
+    assert attempts == 1
+    assert source.read_text(encoding="utf-8") == "next"
+    assert not destination.exists()
+
+
 class _Response:
     def __init__(self, body: bytes, *, status: int, start: int, total: int) -> None:
         self._body = io.BytesIO(body)


### PR DESCRIPTION
## Scope

Retry atomic Runtime Pack state publication when Windows briefly denies `os.replace` because another reader still has the destination open. Retries are bounded to transient Windows errors 5, 32, and 33; other platforms and permanent permission denials keep their existing fail-fast behavior.

Add regression coverage for both transient recovery and permanent-denial behavior.

## Target

`main`

## Linked issue

Refs #1221 (merge-queue CI failure only)

## Release note

Not required. This is an internal Windows reliability fix with no user-facing API or configuration change.

## Verification

- `PYTHONPATH=src .../pytest tests/test_runtime_packs/test_runtime_pack_manager.py -q` — 33 passed
- Cross-process install-claim regression repeated 20 times — all passed
- `ruff check src/opensquilla/runtime_packs/manager.py tests/test_runtime_packs/test_runtime_pack_manager.py` — passed
- `git diff --check` — passed

## Safety and compatibility

The retry window is bounded to 370 ms and only applies to documented transient Windows sharing/access errors. Permanent denials still propagate immediately after one attempt. No RPC, public type, configuration, persisted schema, or session protocol changes are introduced. Linux and macOS behavior is unchanged, and existing Runtime Pack state remains compatible.

## Third-party origin

None.