### PR TITLE
Stop replaying provider-private state into ensemble proposers

### DIFF
--- a/src/opensquilla/provider/ensemble.py
+++ b/src/opensquilla/provider/ensemble.py
@@ -868,6 +868,15 @@ def _member_budget_key(member: EnsembleMemberConfig) -> tuple[str, str, str]:
     )
 
 
+def _proposer_provider_config(member: EnsembleMemberConfig) -> ProviderConfig:
+    """Return the provider boundary used by every proposer-side operation."""
+
+    return replace(
+        member.provider_config,
+        replay_provider_state=False,
+    )
+
+
 _ENSEMBLE_CORRELATION_PHASES = frozenset(
     {
         "proposer",
@@ -2199,7 +2208,7 @@ class EnsembleProvider:
                 role="proposer",
             ).model_copy(update=proposer_updates)
             _require_projection(
-                _build_provider(member.provider_config),
+                _build_provider(_proposer_provider_config(member)),
                 member_config,
                 synthetic_messages=additional_messages,
             )
@@ -2944,7 +2953,11 @@ class EnsembleProvider:
                     ),
                 )
             return result
-        provider = _build_provider(member.provider_config)
+        # Proposers consume the visible conversation as independent candidate
+        # generators. Provider-private continuity state (reasoning_content,
+        # thinking blocks, thought signatures) belongs to the model that
+        # minted it and must not be replayed into any proposer physical call.
+        provider = _build_provider(_proposer_provider_config(member))
         text_parts: list[str] = []
         got_done = False
 

--- a/tests/test_provider_ensemble.py
+++ b/tests/test_provider_ensemble.py
@@ -1911,6 +1911,47 @@ async def test_control_wins_if_it_arrives_with_primary_failure(
 
 
 @pytest.mark.asyncio
+async def test_proposer_physical_calls_disable_provider_private_state_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = _FakeRegistry(
+        {
+            "p1": _FakePlan(
+                [
+                    TextDeltaEvent(text="draft"),
+                    DoneEvent(input_tokens=1, output_tokens=1, model="p1"),
+                ]
+            ),
+            "agg": _FakePlan(
+                [
+                    TextDeltaEvent(text="final"),
+                    DoneEvent(input_tokens=1, output_tokens=1, model="agg"),
+                ]
+            ),
+        }
+    )
+    built_configs: list[ProviderConfig] = []
+
+    def build_provider(cfg: ProviderConfig) -> _FakeProvider:
+        built_configs.append(cfg)
+        return registry.provider_for(cfg)
+
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", build_provider)
+    provider = EnsembleProvider(
+        profile_name="private-state-boundary",
+        proposers=[_member("p1")],
+        aggregator=_member("agg"),
+        min_successful_proposers=1,
+        shuffle_candidates=False,
+    )
+
+    await _collect(provider)
+
+    replay_by_model = {cfg.model: cfg.replay_provider_state for cfg in built_configs}
+    assert replay_by_model == {"p1": False, "agg": True}
+
+
+@pytest.mark.asyncio
 async def test_ensemble_proposer_tool_events_violate_inert_candidate_contract(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Scope

Scope boundary: Provider construction for ensemble **proposer** calls only.

Non-goals:
- Aggregator behaviour is untouched — an aggregator continues its own turn and legitimately inherits its own provider-private state.
- No prompt-cache / provider-capability changes (split into a separate PR).
- No change to candidate selection, quorum, timeout, or fallback logic.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Found while auditing cross-model ensemble runs; no tracking issue was filed.

## Release Note

Release note: Ensemble proposers no longer receive provider-private continuity state (reasoning content, thinking blocks, thought signatures) minted by a different model.

## Context

Proposers are independent candidate generators: they consume the *visible* conversation. Provider-private continuity state is minted by, and cryptographically bound to, the model that produced it. Replaying it into a proposer physical call sends one vendor's signed state to a model that never produced it — which at best confuses the model and at worst trips vendor-side signature validation.

Both proposer-side provider constructions now route through a single `_proposer_provider_config()` boundary that clears `replay_provider_state`. Centralising it in one helper means a future proposer call site cannot silently reacquire the old behaviour.

## Tests

Ruff: `ruff check src/opensquilla/provider/ensemble.py tests/test_provider_ensemble.py` — pass

Pytest: `pytest tests/test_provider_ensemble.py tests/test_provider_openai_prompt_cache.py` — 174 passed

Build: not applicable — no packaging, dependency, or generated-artifact surface touched.

Regression tests: added

Notes: `test_proposer_physical_calls_disable_provider_private_state_replay` asserts the boundary by observed effect rather than by construction — it captures every `ProviderConfig` actually built during a run and asserts `{"p1": False, "agg": True}`, so it fails if a proposer regains replay *or* if the aggregator loses it. The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
