### PR TITLE
Enable explicit prompt cache for verified Qwen models

### DIFF
--- a/src/opensquilla/provider/compat_policy.py
+++ b/src/opensquilla/provider/compat_policy.py
@@ -568,6 +568,7 @@ _POLICIES_BY_KIND: dict[str, OpenAICompatPolicy] = {
     "tokenrhythm": OpenAICompatPolicy(
         display_name="TokenRhythm",
         official_host="tokenrhythm.studio",
+        supports_explicit_prompt_cache=True,
         supports_native_json_schema_output=False,
         text_tool_profile=TextToolCompatProfile(
             model_rules=(

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -2242,6 +2242,7 @@ def _dashscope_model_likely_supports_explicit_prompt_cache(model: str) -> bool:
         return True
     return model_name.startswith(
         (
+            "qwen3.8-max",
             "qwen3.7-max",
             "qwen3.6-max-preview",
             "qwen3.7-plus",
@@ -2257,6 +2258,13 @@ def _dashscope_model_likely_supports_explicit_prompt_cache(model: str) -> bool:
     )
 
 
+def _tokenrhythm_model_supports_explicit_prompt_cache(model: str) -> bool:
+    """Return True only for TokenRhythm models with live cache-control proof."""
+
+    model_name = model.rsplit("/", 1)[-1].strip().lower()
+    return model_name in {"qwen3.7-max", "qwen3.8-max"}
+
+
 def _supports_explicit_prompt_cache(
     provider_kind: str,
     model: str,
@@ -2268,6 +2276,8 @@ def _supports_explicit_prompt_cache(
         return cache_mode == "on" or _openrouter_model_likely_supports_explicit_prompt_cache(model)
     if provider_kind == "dashscope":
         return cache_mode == "on" or _dashscope_model_likely_supports_explicit_prompt_cache(model)
+    if provider_kind == "tokenrhythm":
+        return _tokenrhythm_model_supports_explicit_prompt_cache(model)
     return False
 
 
@@ -2383,7 +2393,7 @@ def _log_provider_cache_usage(
     cache_write_tokens: int,
     cache_shape: Mapping[str, Any],
 ) -> None:
-    if provider_kind != "dashscope":
+    if provider_kind not in {"dashscope", "tokenrhythm"}:
         return
     log.info(
         f"{provider_kind}.prompt_cache_usage",
@@ -3133,7 +3143,9 @@ def _build_openai_wire_messages(
             content_blocks = _build_cache_breakpoint_blocks(
                 cfg.cache_breakpoints,
                 max_cache_markers=(
-                    _DASHSCOPE_MAX_CACHE_MARKERS if provider_kind == "dashscope" else None
+                    _DASHSCOPE_MAX_CACHE_MARKERS
+                    if provider_kind in {"dashscope", "tokenrhythm"}
+                    else None
                 ),
             )
             openai_messages.append({"role": "system", "content": content_blocks})
@@ -3213,7 +3225,11 @@ def _build_openai_wire_messages(
                         (_reasoning_replay_signature(built_message), suppressed_units)
                     )
         openai_messages.extend(built_messages)
-    if provider_kind == "dashscope" and cfg.cache_mode == "on":
+    if (
+        provider_kind in {"dashscope", "tokenrhythm"}
+        and cfg.cache_mode == "on"
+        and explicit_cache_supported
+    ):
         _attach_cache_control_to_latest_text_messages(
             openai_messages,
             max_cache_markers=_DASHSCOPE_MAX_CACHE_MARKERS,

--- a/tests/test_provider_openai_prompt_cache.py
+++ b/tests/test_provider_openai_prompt_cache.py
@@ -5,6 +5,7 @@ import json
 from typing import Any
 
 import httpx
+import pytest
 
 from opensquilla.provider import openai as openai_module
 from opensquilla.provider.openai import OpenAIProvider
@@ -129,12 +130,25 @@ def test_openrouter_deepseek_auto_cache_does_not_add_top_level_cache_control(mon
     assert payload["messages"][0]["content"][0]["cache_control"] == {"type": "ephemeral"}
 
 
-def test_dashscope_qwen36_flash_auto_cache_adds_message_cache_control(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    "model",
+    (
+        "qwen3.8-max",
+        "qwen3.7-max",
+        "qwen3.7-plus",
+        "qwen3.6-flash",
+        "qwen-plus",
+    ),
+)
+def test_dashscope_verified_qwen_auto_cache_adds_message_cache_control(
+    monkeypatch,
+    model: str,
+) -> None:
     captured: dict[str, Any] = {}
     _patch_openai_transport(monkeypatch, captured)
     provider = OpenAIProvider(
         api_key="test",
-        model="qwen3.6-flash",
+        model=model,
         base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
         provider_kind="dashscope",
     )
@@ -155,6 +169,113 @@ def test_dashscope_qwen36_flash_auto_cache_adds_message_cache_control(monkeypatc
     assert system_message["content"][0]["cache_control"] == {"type": "ephemeral"}
     assert system_message["content"][0]["text"] == "stable base"
     assert payload["messages"][1] == {"role": "user", "content": "hi"}
+
+
+@pytest.mark.parametrize("model", ("qwen3.7-max", "qwen3.8-max"))
+def test_tokenrhythm_verified_qwen_on_adds_message_cache_control(
+    monkeypatch,
+    model: str,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_openai_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model=model,
+        base_url="https://tokenrhythm.studio/v1",
+        provider_kind="tokenrhythm",
+    )
+    cfg = ChatConfig(
+        system="stable base",
+        cache_breakpoints=[{"text": "stable base", "cache": "true"}],
+        cache_mode="on",
+    )
+
+    done = _collect_done(provider, cfg)
+
+    assert done.cached_tokens == 5
+    payload = captured["payload"]
+    assert "cache_control" not in payload
+    assert payload["messages"] == [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "stable base",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "hi",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
+    ]
+
+
+@pytest.mark.parametrize("model", ("qwen3.7-max", "qwen3.8-max"))
+def test_tokenrhythm_verified_qwen_auto_enables_system_cache_control(
+    monkeypatch,
+    model: str,
+) -> None:
+    captured: dict[str, Any] = {}
+    _patch_openai_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model=model,
+        base_url="https://tokenrhythm.studio/v1",
+        provider_kind="tokenrhythm",
+    )
+    cfg = ChatConfig(
+        system="stable base",
+        cache_breakpoints=[{"text": "stable base", "cache": "true"}],
+        cache_mode="auto",
+    )
+
+    _collect_done(provider, cfg)
+
+    assert captured["payload"]["messages"] == [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "stable base",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
+        {"role": "user", "content": "hi"},
+    ]
+
+
+def test_tokenrhythm_non_qwen_cache_on_does_not_add_cache_control(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+    _patch_openai_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="glm-5.2",
+        base_url="https://tokenrhythm.studio/v1",
+        provider_kind="tokenrhythm",
+    )
+    cfg = ChatConfig(
+        system="stable base",
+        cache_breakpoints=[{"text": "stable base", "cache": "true"}],
+        cache_mode="on",
+    )
+
+    _collect_done(provider, cfg)
+
+    assert captured["payload"]["messages"] == [
+        {"role": "system", "content": "stable base"},
+        {"role": "user", "content": "hi"},
+    ]
 
 
 def test_openrouter_qwen36_flash_auto_cache_adds_alibaba_message_cache_control(


### PR DESCRIPTION
## Scope

Enable explicit prompt-cache markers for models with live cache-control evidence:

- TokenRhythm: `qwen3.7-max`, `qwen3.8-max`
- DashScope auto mode: add `qwen3.8-max`
- Preserve the existing verified DashScope Qwen families and cover the live-verified set with credential-free payload tests.

The TokenRhythm predicate remains exact and fail-closed. `cache_mode="on"` does not force markers onto unverified TokenRhythm models.

## Non-goals

- No API keys, credentials, private endpoints, or live-test data are stored in source or tests.
- No change to OpenRouter cache behavior.
- No broad `qwen*` wildcard for TokenRhythm.
- No ensemble or proposer changes.

## Release Note

TokenRhythm `qwen3.7-max` and `qwen3.8-max`, plus DashScope `qwen3.8-max`, now emit explicit prompt-cache markers in supported cache modes so repeated stable prefixes can reuse provider cache.

## Context

TokenRhythm was absent from the explicit prompt-cache path. Live checks confirmed cache creation followed by cache reads for TokenRhythm `qwen3.8-max` and DashScope `qwen3.8-max`. The implementation admits only the verified TokenRhythm models and adds `qwen3.8-max` to DashScope auto detection.

## Tests

- `ruff check src/opensquilla/provider/compat_policy.py src/opensquilla/provider/openai.py tests/test_provider_openai_prompt_cache.py` — pass
- `pytest tests/test_provider_openai_prompt_cache.py tests/test_provider_compat_policy.py tests/test_provider_ensemble.py` — 197 passed
- Regression tests use only the placeholder key `test` and assert the emitted wire payload offline.

## Maintainer Live Check

Maintainer live check: yes

- TokenRhythm `qwen3.8-max`: first request wrote 2,591 cache tokens; the repeated request read 2,591 cached tokens.
- DashScope `qwen3.8-max`: first request wrote 2,393 cache tokens; the repeated request read 2,393 cached tokens.

No credentials or private endpoint identifiers are included in this PR.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
