### PR TITLE
test(chat): cover consumed steer across session returns

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatDraftPersistence.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatDraftPersistence.test.ts
@@ -58,6 +58,11 @@ describe('useChatDraftPersistence', () => {
     sessionKey.value = 'agent:main:webchat:a'
     await nextTick()
     expect(inputText.value).toBe('draft for A')
+
+    // Repeated navigation restores B's untouched editor draft.
+    sessionKey.value = 'agent:main:webchat:b'
+    await nextTick()
+    expect(inputText.value).toBe('draft for B')
   })
 
   it('clears the persisted draft once the composer is emptied (after send)', async () => {

--- a/opensquilla-webui/src/composables/chat/useChatPendingQueue.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatPendingQueue.test.ts
@@ -1457,6 +1457,120 @@ describe('useChatPendingQueue delivery state', () => {
     queue.cleanup()
   })
 
+  it('never rehydrates or auto-dispatches an accepted steer after repeated session returns', async () => {
+    vi.useFakeTimers()
+    const sessionA = 'agent:main:webchat:A'
+    const sessionB = 'agent:main:webchat:B'
+    const record: PendingInputWalRecord = {
+      schemaVersion: 1,
+      pendingInputId: 'pending-consumed-steer',
+      sessionKey: sessionB,
+      clientRequestId: 'request-consumed-steer',
+      clientMessageId: 'message-consumed-steer',
+      text: 'consume this steer once',
+      attachments: [],
+      intent: null,
+      state: 'staged',
+      mayHaveServerCopy: true,
+      requestFingerprint: 'sha256:consumed-steer',
+      serverRevision: 1,
+      position: 0,
+      walRevision: 1,
+      createdAt: 1,
+      updatedAt: 1,
+    }
+    const { wal, records } = memoryWal([record])
+    let serverRows: Array<Record<string, unknown>> = [{
+      pendingInputId: record.pendingInputId,
+      clientRequestId: record.clientRequestId,
+      clientMessageId: record.clientMessageId,
+      requestFingerprint: record.requestFingerprint,
+      message: record.text,
+      attachments: [],
+      position: record.position,
+      revision: record.serverRevision,
+    }]
+    const listedSessionKeys: string[] = []
+    const rpcCall = vi.fn(async (
+      method: string,
+      params?: Record<string, unknown>,
+    ): Promise<unknown> => {
+      if (method !== 'sessions.pending_inputs.list') {
+        throw new Error(`unexpected method: ${method}`)
+      }
+      const key = String(params?.key || '')
+      listedSessionKeys.push(key)
+      return {
+        items: key === sessionB ? structuredClone(serverRows) : [],
+      }
+    })
+    const rpc: NonNullable<UseChatPendingQueueOptions['rpc']> = {
+      call: <T = unknown>(method: string, params?: Record<string, unknown>) => (
+        rpcCall(method, params) as Promise<T>
+      ),
+    }
+    const sessionKey = ref(sessionB)
+    const dispatchPendingItem = vi.fn(async () => 'accepted' as const)
+    const { queue } = makeQueue(
+      dispatchPendingItem,
+      () => false,
+      undefined,
+      undefined,
+      {
+        sessionKey,
+        pendingInputWal: wal,
+        rpc,
+        supportsMethod: method => method.startsWith('sessions.pending_inputs.'),
+        connectionState: ref('connected'),
+      },
+    )
+
+    const returnToBAndSignalReady = async () => {
+      const previousBLists = listedSessionKeys.filter(key => key === sessionB).length
+      queue.switchPendingQueue(sessionB)
+      sessionKey.value = sessionB
+      await vi.waitFor(() => {
+        expect(listedSessionKeys.filter(key => key === sessionB).length)
+          .toBeGreaterThan(previousBLists)
+      })
+      await vi.waitFor(() => expect(queue.pendingQueue.value).toEqual([]))
+
+      // This is the same drain signal ChatView emits when livePhase becomes ready.
+      queue.schedulePendingDrainAfterTerminal()
+      queue.flushDeferredPendingDrain()
+      await vi.advanceTimersByTimeAsync(50)
+      await nextTick()
+
+      expect(queue.pendingQueue.value).toEqual([])
+      expect(dispatchPendingItem).not.toHaveBeenCalled()
+    }
+
+    try {
+      await vi.waitFor(() => expect(queue.pendingQueue.value).toHaveLength(1))
+      const steering = queue.beginPendingDelivery(pendingUiId(queue, 0))
+      expect(steering).not.toBeNull()
+
+      // The server consumes the durable row atomically with accepting the steer.
+      serverRows = []
+      queue.switchPendingQueue(sessionA)
+      sessionKey.value = sessionA
+      queue.settlePendingDelivery(steering!, 'accepted')
+      await nextTick()
+      await vi.waitFor(() => expect(records.size).toBe(0))
+
+      await returnToBAndSignalReady()
+      queue.switchPendingQueue(sessionA)
+      sessionKey.value = sessionA
+      await nextTick()
+      await returnToBAndSignalReady()
+
+      expect(dispatchPendingItem).not.toHaveBeenCalled()
+    } finally {
+      queue.cleanup()
+      vi.useRealTimers()
+    }
+  })
+
   it('parks an in-flight steer with its source session and exact request snapshot', () => {
     const { queue, sessionKey } = makeQueue()
     const item = queue.enqueuePendingSteerAttempt({

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -4664,6 +4664,26 @@ class TestSessionsSteer:
             assert replay.payload["user_message_id"] == accepted.payload["user_message_id"]
             assert await store.list_pending_chat_inputs(key) == []
 
+            # A stale client may still try to drain the identity it hydrated
+            # before steer acceptance. The receipt is a completion tombstone:
+            # replay it instead of admitting a second session turn.
+            stale_dispatch = await dispatcher.dispatch(
+                "r-pending-steer-stale-dispatch",
+                "sessions.pending_inputs.dispatch",
+                {
+                    "key": key,
+                    "pendingInputId": row.pending_input_id,
+                    "clientRequestId": row.client_request_id,
+                    "requestFingerprint": row.request_fingerprint,
+                    "_source": {"caller_kind": "web", "channel_kind": "web"},
+                },
+                ctx,
+            )
+            assert stale_dispatch.ok is True
+            assert stale_dispatch.payload["accepted"] is True
+            assert stale_dispatch.payload["replayed"] is True
+            assert stale_dispatch.payload["task_id"] == handle.task_id
+
             receipt = await store.get_pending_chat_input_dispatch_receipt(
                 row.pending_input_id
             )


### PR DESCRIPTION
## Scope

Adds regression coverage for the reported A to B to A to B session-switch sequence after a durable pending input is consumed as steering. The WebUI test parks the B queue, settles the accepted steer while B is inactive, returns to B twice, waits for authoritative pending-input hydration, emits the same ready drain signal used by ChatView, and proves the consumed item is never dispatched again. It also verifies per-session editor draft restoration and the Gateway completion tombstone for a stale pending-input dispatch.

This is test-only. It validates the boundary introduced by the current atomic pending-queue steering and streaming lifecycle behavior without changing runtime code, persistence formats, or public APIs.

## Branch target

- Base: main
- Head: fix/consumed-steer-session-rehydration

## Linked issue

- None. Reproduced and verified from the reported local WebUI session-switch sequence.

## Release note

- None; test-only regression coverage.

## Test results

- WebUI related Vitest files: 291 passed
- WebUI typecheck and architecture guards: passed
- Gateway TestSessionsSteer: 8 passed
- Ruff on tests/test_gateway/test_rpc_sessions.py: passed
- git diff --check: passed
- Independent subagent review: no P0, P1, or P2 findings

## Safety

- Synthetic session keys, request IDs, message IDs, fingerprints, and message text only
- No credentials, local paths, real transcripts, migrations, runtime behavior, or external side effects

## Third-party origin

- No third-party code, comments, fixtures, identifiers, wording, or assets were copied.