### PR TITLE
Harden Gemini create_csv schema projection boundaries

### DIFF
--- a/src/opensquilla/provider/compat_policy.py
+++ b/src/opensquilla/provider/compat_policy.py
@@ -198,6 +198,11 @@ class OpenAICompatPolicy:
     # fallback is safe only when the tool's wire semantics are textual.
     tool_schema_string_item_fallback_tools: frozenset[str] = frozenset()
 
+    # Exact API root where the string-item projection is required. A tool
+    # allowlist alone is not sufficient evidence for custom endpoints that
+    # happen to use the same provider kind or hostname.
+    tool_schema_string_item_fallback_api_root: str = ""
+
     # Whether the chat-completions endpoint reliably supports native
     # ``response_format.type=json_schema``.  When false, the OpenAI-compatible
     # adapter keeps the same provider/model and places the authoritative
@@ -347,6 +352,21 @@ class OpenAICompatPolicy:
 
         return self.text_tool_profile.enabled
 
+    def allows_string_item_schema_projection(self, tool_name: str, base_url: str) -> bool:
+        """Return whether a trusted tool may use the lossy wire projection."""
+
+        candidate_base_url = str(base_url or "")
+        if not candidate_base_url or candidate_base_url != candidate_base_url.strip():
+            return False
+        return bool(
+            tool_name in self.tool_schema_string_item_fallback_tools
+            and self.tool_schema_string_item_fallback_api_root
+            and base_url_matches_official_api(
+                self.tool_schema_string_item_fallback_api_root,
+                candidate_base_url,
+            )
+        )
+
 
 def effective_reasoning_format(
     policy: OpenAICompatPolicy,
@@ -455,6 +475,9 @@ _POLICIES_BY_KIND: dict[str, OpenAICompatPolicy] = {
         display_name="Gemini",
         official_host="generativelanguage.googleapis.com",
         tool_schema_string_item_fallback_tools=frozenset({"create_csv"}),
+        tool_schema_string_item_fallback_api_root=(
+            "https://generativelanguage.googleapis.com/v1beta/openai"
+        ),
     ),
     "dashscope": OpenAICompatPolicy(
         display_name="DashScope",

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -3519,19 +3519,16 @@ class OpenAIProvider:
         if cfg.stop_sequences:
             payload["stop"] = cfg.stop_sequences
         if tools:
-            string_item_fallback_tools = (
-                self._compat.tool_schema_string_item_fallback_tools
-                if self._compat.official_host
-                and _base_url_hostname(self._base_url)
-                == self._compat.official_host.lower()
-                else frozenset()
-            )
             payload["tools"] = [
                 _build_openai_tool(
                     tool,
                     unsupported_keywords=self._compat.tool_schema_unsupported_keywords,
                     complete_itemless_arrays_with_string_items=(
-                        tool.name in string_item_fallback_tools
+                        tool.allow_string_item_schema_projection
+                        and self._compat.allows_string_item_schema_projection(
+                            tool.name,
+                            self._base_url,
+                        )
                     ),
                 )
                 for tool in tools

--- a/src/opensquilla/provider/types.py
+++ b/src/opensquilla/provider/types.py
@@ -411,6 +411,7 @@ from pydantic import (  # noqa: E402
     BaseModel,
     ConfigDict,
     Field,
+    PrivateAttr,
     SerializerFunctionWrapHandler,
     model_serializer,
 )
@@ -438,6 +439,10 @@ class ToolInputSchema(BaseModel):
     )
 
 
+class _StringItemSchemaProjectionCapability:
+    """Unserializable identity token for trusted registry construction."""
+
+
 class ToolDefinition(BaseModel):
     """Tool definition passed to the LLM."""
 
@@ -453,6 +458,22 @@ class ToolDefinition(BaseModel):
         default="bounded",
         exclude=True,
     )
+    # Process-local semantic capability. It is deliberately private so an
+    # external ToolDefinition payload cannot opt itself into a lossy provider
+    # projection. Trusted registry construction grants it after validation.
+    _string_item_schema_projection_capability: object | None = PrivateAttr(default=None)
+
+    @property
+    def allow_string_item_schema_projection(self) -> bool:
+        return (
+            self._string_item_schema_projection_capability
+            is _StringItemSchemaProjectionCapability
+        )
+
+    def _enable_string_item_schema_projection(self) -> None:
+        self._string_item_schema_projection_capability = (
+            _StringItemSchemaProjectionCapability
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/opensquilla/tools/builtin/file_authoring.py
+++ b/src/opensquilla/tools/builtin/file_authoring.py
@@ -328,6 +328,7 @@ async def _published_response(
     },
     required=["rows"],
     sandbox=SandboxToolDescriptor.artifact(kind="artifact.create_csv"),
+    allow_string_item_schema_projection=True,
 )
 async def create_csv(rows: list[list[Any]], name: str | None = None) -> str:
     output = io.StringIO(newline="")

--- a/src/opensquilla/tools/registry.py
+++ b/src/opensquilla/tools/registry.py
@@ -387,8 +387,9 @@ class ToolRegistry:
         visible_tools = self._iter_visible_tools(active_ctx, sort=True)
         visible_tool_names = frozenset(rt.spec.name for rt in visible_tools)
         self._record_description_override_event(active_ctx, visible_tools)
-        return [
-            ToolDefinition(
+        definitions: list[ToolDefinition] = []
+        for rt in visible_tools:
+            definition = ToolDefinition(
                 name=rt.spec.name,
                 description=self._description_for(
                     rt,
@@ -412,8 +413,10 @@ class ToolRegistry:
                     )
                 ),
             )
-            for rt in visible_tools
-        ]
+            if rt.spec.allow_string_item_schema_projection:
+                definition._enable_string_item_schema_projection()
+            definitions.append(definition)
+        return definitions
 
     async def list_tools(
         self,
@@ -604,6 +607,7 @@ def tool(
     plan_access: PlanAccess = PlanAccess.DENY,
     terminates_turn: bool = False,
     runtime_only_arguments: frozenset[str] | set[str] | tuple[str, ...] = (),
+    allow_string_item_schema_projection: bool = False,
 ) -> Any:
     """Decorator to register an async function as a tool.
 
@@ -630,6 +634,7 @@ def tool(
             sandbox=sandbox or SandboxToolDescriptor.custom(kind=name),
             plan_access=plan_access,
             terminates_turn=terminates_turn,
+            allow_string_item_schema_projection=allow_string_item_schema_projection,
         )
         target = registry if registry is not None else _default_registry
         target.register(spec, fn)

--- a/src/opensquilla/tools/types.py
+++ b/src/opensquilla/tools/types.py
@@ -357,6 +357,9 @@ class ToolSpec:
     # persisted. The dispatcher owns this behavior; handlers must not emulate
     # it with tool-name branches.
     terminates_turn: bool = False
+    # Trusted declaration that itemless arrays have textual wire semantics.
+    # Provider policy still decides whether a request needs the projection.
+    allow_string_item_schema_projection: bool = False
 
 
 # Registered tool implementation: async fn that accepts keyword args and returns str.

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -1863,8 +1863,20 @@ def test_gemini_projects_only_create_csv_itemless_arrays_to_string_items(
         for tool in get_default_registry().to_tool_definitions()
         if tool.name == "create_csv"
     )
-    original_rows = create_csv.input_schema.properties["rows"]
-    assert original_rows["items"] == {"type": "array"}
+    original_definition = create_csv.model_copy(deep=True)
+    assert create_csv.allow_string_item_schema_projection is True
+    assert "allow_string_item_schema_projection" not in create_csv.model_dump()
+    assert (
+        "allow_string_item_schema_projection"
+        not in ToolDefinition.model_json_schema()["properties"]
+    )
+    assert create_csv.model_copy(deep=True).allow_string_item_schema_projection is True
+    assert (
+        ToolDefinition.model_validate(create_csv.model_dump())
+        .allow_string_item_schema_projection
+        is False
+    )
+    assert create_csv.input_schema.properties["rows"]["items"] == {"type": "array"}
     assert _tool_schema_accepts_arguments(
         create_csv,
         {"rows": [["text", 1, True, None, {"x": 1}, ["nested"]]]},
@@ -1884,13 +1896,14 @@ def test_gemini_projects_only_create_csv_itemless_arrays_to_string_items(
         "properties"
     ]["rows"]
     assert wire_rows["items"] == {"type": "array", "items": {"type": "string"}}
-    assert create_csv.input_schema.properties["rows"] == original_rows
+    assert create_csv == original_definition
 
 
 @pytest.mark.parametrize(
     ("base_url", "tool_name"),
     [
         ("https://relay.example/v1", "create_csv"),
+        ("https://openrouter.ai/api/v1", "create_csv"),
         ("https://generativelanguage.googleapis.com/v1beta/openai", "mcp_csv"),
     ],
 )
@@ -1924,6 +1937,85 @@ def test_gemini_string_item_projection_is_endpoint_and_tool_allowlisted(
     assert rows["items"] == {"type": "array"}
 
 
+def test_gemini_does_not_project_an_untrusted_same_named_tool(monkeypatch: Any) -> None:
+    tool = ToolDefinition.model_validate(
+        {
+            "name": "create_csv",
+            "description": "Third-party tool with unrelated row semantics.",
+            "input_schema": {
+                "properties": {
+                    "rows": {"type": "array", "items": {"type": "array"}}
+                },
+                "required": ["rows"],
+            },
+            "allow_string_item_schema_projection": True,
+            "_string_item_schema_projection_capability": True,
+        }
+    )
+    injected_copy = tool.model_copy(
+        update={
+            "allow_string_item_schema_projection": True,
+            "_string_item_schema_projection_capability": True,
+        }
+    )
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="gemini-2.5-flash",
+        base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+        provider_kind="gemini",
+    )
+
+    _collect_events(provider, ChatConfig(), tools=[tool])
+
+    rows = captured["payload"]["tools"][0]["function"]["parameters"][
+        "properties"
+    ]["rows"]
+    assert tool.allow_string_item_schema_projection is False
+    assert injected_copy.allow_string_item_schema_projection is False
+    assert rows["items"] == {"type": "array"}
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "",
+        " https://generativelanguage.googleapis.com/v1beta/openai",
+        "http://generativelanguage.googleapis.com/v1beta/openai",
+        "https://generativelanguage.googleapis.com:8443/v1beta/openai",
+        "https://generativelanguage.googleapis.com/v1beta/openai/custom",
+        "https://user@generativelanguage.googleapis.com/v1beta/openai",
+        "https://generativelanguage.googleapis.com/v1beta/openai?alt=sse",
+        "https://generativelanguage.googleapis.com/v1beta/openai#custom",
+    ],
+)
+def test_gemini_does_not_project_create_csv_on_nonofficial_api_roots(
+    monkeypatch: Any,
+    base_url: str,
+) -> None:
+    create_csv = next(
+        tool
+        for tool in get_default_registry().to_tool_definitions()
+        if tool.name == "create_csv"
+    )
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="gemini-2.5-flash",
+        base_url=base_url,
+        provider_kind="gemini",
+    )
+
+    _collect_events(provider, ChatConfig(), tools=[create_csv])
+
+    rows = captured["payload"]["tools"][0]["function"]["parameters"][
+        "properties"
+    ]["rows"]
+    assert rows["items"] == {"type": "array"}
+
+
 def test_string_item_projection_preserves_schema_shaped_literals() -> None:
     literal = {"type": "array"}
     tool = ToolDefinition(
@@ -1940,6 +2032,7 @@ def test_string_item_projection_preserves_schema_shaped_literals() -> None:
             }
         ),
     )
+    original_definition = tool.model_copy(deep=True)
 
     payload = _build_openai_tool(
         tool,
@@ -1951,6 +2044,59 @@ def test_string_item_projection_preserves_schema_shaped_literals() -> None:
     assert value["default"] == literal
     assert value["enum"] == [literal]
     assert value["const"] == literal
+    assert tool == original_definition
+
+
+def test_gemini_projection_traverses_composed_schemas_without_mutating_source(
+    monkeypatch: Any,
+) -> None:
+    create_csv = next(
+        tool
+        for tool in get_default_registry().to_tool_definitions()
+        if tool.name == "create_csv"
+    )
+    tool = create_csv.model_copy(
+        deep=True,
+        update={
+            "input_schema": ToolInputSchema(
+                properties={
+                    "all_of": {"allOf": [{"type": "array"}]},
+                    "any_of": {
+                        "anyOf": [
+                            {"type": ["array", "null"]},
+                            {"type": "string"},
+                        ]
+                    },
+                    "one_of": {"oneOf": [{"type": "array"}, {"type": "object"}]},
+                    "tuple": {
+                        "type": "array",
+                        "prefixItems": [{"type": "array"}],
+                    },
+                },
+            )
+        },
+    )
+    original_definition = tool.model_copy(deep=True)
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="gemini-2.5-flash",
+        base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
+        provider_kind="gemini",
+    )
+
+    _collect_events(provider, ChatConfig(), tools=[tool])
+
+    properties = captured["payload"]["tools"][0]["function"]["parameters"][
+        "properties"
+    ]
+    assert properties["all_of"]["allOf"][0]["items"] == {"type": "string"}
+    assert properties["any_of"]["anyOf"][0]["items"] == {"type": "string"}
+    assert properties["one_of"]["oneOf"][0]["items"] == {"type": "string"}
+    assert properties["tuple"]["items"] == {"type": "string"}
+    assert properties["tuple"]["prefixItems"][0]["items"] == {"type": "string"}
+    assert tool == original_definition
 
 
 def test_deepseek_thinking_uses_provider_thinking_field_not_openai_reasoning_effort(

--- a/tests/test_tools/test_file_authoring_tools.py
+++ b/tests/test_tools/test_file_authoring_tools.py
@@ -66,6 +66,8 @@ def test_create_csv_authoritative_schema_keeps_mixed_cell_types() -> None:
 
     rows = definition.input_schema.properties["rows"]
     assert rows["items"] == {"type": "array"}
+    assert definition.allow_string_item_schema_projection is True
+    assert "allow_string_item_schema_projection" not in definition.model_dump()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope

Scope boundary: Tool-schema projection for the trusted built-in create_csv tool on the exact official Gemini OpenAI-compatible API root.

Non-goals: Generic MCP schema repair, relay behavior changes, Vertex support, or broad provider-kind exceptions.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Refs #1264

If None, reason: N/A

## Release Note

Release note: Fix create_csv tool declaration rejection on the official Gemini endpoint.

## Tests

Ruff: passed

Pytest: Independent provider and file-authoring regression selection passed 17 tests. Full affected provider and file-authoring files passed in the combined integration suite.

Build: N/A; no generated asset or packaging contract changed.

Regression tests: added

Notes: The combined four-fix integration suite passed with 1233 passed and 24 skipped. Mypy, diff check, and sensitive-data scan passed. Generic endpoints remain fail closed. Serialization, validation, and model-copy updates cannot forge the private projection capability.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run Live Release E2E for provider, browser, gateway, channel, or release smoke coverage.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.