### PR TITLE
Stabilize session pagination beyond 200 conversations

### DIFF
--- a/opensquilla-webui/src/components/SidebarConversations.pagination.test.ts
+++ b/opensquilla-webui/src/components/SidebarConversations.pagination.test.ts
@@ -96,4 +96,46 @@ describe('SidebarConversations pagination', () => {
     expect(root.textContent).not.toContain('No matches')
     expect(loadMore).toHaveBeenCalled()
   })
+
+  it('loads only when the real scroll position reaches the bottom threshold', async () => {
+    i18n.global.locale.value = 'en'
+    const loadMore = vi.fn()
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    const Root = defineComponent(() => () => h(SidebarConversations, {
+      sections: [{ family: 'chats', label: 'Tasks', rows: [taskRow('agent:main:webchat:one', 'main')] }],
+      error: false,
+      loading: false,
+      loadingMore: false,
+      loadMoreError: false,
+      hasMore: true,
+      currentKey: '',
+      contractDebugEnabled: false,
+      searchHint: 'Ctrl+K',
+      onLoadMore: loadMore,
+    }))
+    const app = createApp(Root)
+    app.use(i18n)
+    app.mount(root)
+    mounted.push(app)
+    await nextTick()
+    await nextTick()
+
+    const list = root.querySelector<HTMLElement>('.sidebar-history-list')!
+    Object.defineProperties(list, {
+      scrollHeight: { configurable: true, value: 1_000 },
+      clientHeight: { configurable: true, value: 200 },
+      scrollTop: { configurable: true, writable: true, value: 0 },
+    })
+    loadMore.mockClear()
+
+    list.dispatchEvent(new Event('scroll'))
+    await nextTick()
+    expect(loadMore).not.toHaveBeenCalled()
+
+    list.scrollTop = 640
+    list.dispatchEvent(new Event('scroll'))
+    await nextTick()
+    expect(loadMore).toHaveBeenCalledTimes(1)
+  })
 })

--- a/opensquilla-webui/src/composables/useFilteredSessionPaging.test.ts
+++ b/opensquilla-webui/src/composables/useFilteredSessionPaging.test.ts
@@ -1,0 +1,106 @@
+import { effectScope, nextTick, ref } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useFilteredSessionPaging } from './useFilteredSessionPaging'
+
+describe('useFilteredSessionPaging', () => {
+  it('continues across unmatched pages after a filter changes', async () => {
+    const active = ref(false)
+    const visibleCount = ref(12)
+    const hasMore = ref(true)
+    const isLoading = ref(false)
+    const isLoadingMore = ref(false)
+    const hasError = ref(false)
+    const loadMore = vi.fn()
+
+    useFilteredSessionPaging({
+      active: () => active.value,
+      visibleCount: () => visibleCount.value,
+      hasMore: () => hasMore.value,
+      isLoading: () => isLoading.value,
+      isLoadingMore: () => isLoadingMore.value,
+      hasError: () => hasError.value,
+      loadMore,
+    })
+
+    active.value = true
+    visibleCount.value = 0
+    await nextTick()
+    expect(loadMore).toHaveBeenCalledTimes(1)
+
+    isLoadingMore.value = true
+    await nextTick()
+    isLoadingMore.value = false
+    await nextTick()
+    expect(loadMore).toHaveBeenCalledTimes(2)
+
+    isLoadingMore.value = true
+    await nextTick()
+    visibleCount.value = 1
+    isLoadingMore.value = false
+    await nextTick()
+    expect(loadMore).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops on an error or terminal page and resumes only with usable state', async () => {
+    const active = ref(true)
+    const visibleCount = ref(0)
+    const hasMore = ref(true)
+    const isLoading = ref(true)
+    const isLoadingMore = ref(false)
+    const hasError = ref(false)
+    const loadMore = vi.fn()
+
+    useFilteredSessionPaging({
+      active: () => active.value,
+      visibleCount: () => visibleCount.value,
+      hasMore: () => hasMore.value,
+      isLoading: () => isLoading.value,
+      isLoadingMore: () => isLoadingMore.value,
+      hasError: () => hasError.value,
+      loadMore,
+    })
+
+    isLoading.value = false
+    hasError.value = true
+    await nextTick()
+    expect(loadMore).not.toHaveBeenCalled()
+
+    hasError.value = false
+    await nextTick()
+    expect(loadMore).toHaveBeenCalledTimes(1)
+
+    hasMore.value = false
+    isLoadingMore.value = true
+    await nextTick()
+    isLoadingMore.value = false
+    await nextTick()
+    expect(loadMore).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops watching after its owning scope is disposed', async () => {
+    const active = ref(true)
+    const visibleCount = ref(1)
+    const hasMore = ref(true)
+    const isLoading = ref(false)
+    const isLoadingMore = ref(false)
+    const hasError = ref(false)
+    const loadMore = vi.fn()
+    const scope = effectScope()
+
+    scope.run(() => useFilteredSessionPaging({
+      active: () => active.value,
+      visibleCount: () => visibleCount.value,
+      hasMore: () => hasMore.value,
+      isLoading: () => isLoading.value,
+      isLoadingMore: () => isLoadingMore.value,
+      hasError: () => hasError.value,
+      loadMore,
+    }))
+    scope.stop()
+
+    visibleCount.value = 0
+    await nextTick()
+    expect(loadMore).not.toHaveBeenCalled()
+  })
+})

--- a/opensquilla-webui/src/composables/useFilteredSessionPaging.ts
+++ b/opensquilla-webui/src/composables/useFilteredSessionPaging.ts
@@ -1,0 +1,40 @@
+import { watch } from 'vue'
+
+interface FilteredSessionPagingOptions {
+  active: () => boolean
+  visibleCount: () => number
+  hasMore: () => boolean
+  isLoading: () => boolean
+  isLoadingMore: () => boolean
+  hasError: () => boolean
+  loadMore: () => void | Promise<void>
+}
+
+/**
+ * Continue an unfiltered session traversal while the active client-side
+ * filter has no match on the pages loaded so far.
+ */
+export function useFilteredSessionPaging(options: FilteredSessionPagingOptions) {
+  watch(
+    [
+      options.active,
+      options.visibleCount,
+      options.hasMore,
+      options.isLoading,
+      options.isLoadingMore,
+      options.hasError,
+    ],
+    ([active, visibleCount, hasMore, isLoading, isLoadingMore, hasError]) => {
+      if (
+        !active
+        || visibleCount > 0
+        || !hasMore
+        || isLoading
+        || isLoadingMore
+        || hasError
+      ) return
+      void options.loadMore()
+    },
+    { flush: 'post' },
+  )
+}

--- a/opensquilla-webui/src/composables/useSessions.pagination.test.ts
+++ b/opensquilla-webui/src/composables/useSessions.pagination.test.ts
@@ -35,16 +35,18 @@ describe('useSessions pagination', () => {
     return { rpc, call, sessions: useSessions() }
   }
 
-  it('appends the 201st session and de-duplicates page boundaries', async () => {
+  it('loads all 401 sessions across three pages and de-duplicates page boundaries', async () => {
     const { call, sessions } = setup([
       { sessions: rows(0, 200), has_more: true, next_cursor: 'cursor-1' },
-      { sessions: rows(199, 401), hasMore: false, nextCursor: null },
+      { sessions: rows(199, 399), hasMore: true, nextCursor: 'cursor-2' },
+      { sessions: rows(398, 401), hasMore: false, nextCursor: null },
     ])
 
     await sessions.loadSessions()
     expect(sessions.sessionsList.value).toHaveLength(200)
     expect(sessions.hasMore.value).toBe(true)
 
+    await sessions.loadMoreSessions()
     await sessions.loadMoreSessions()
 
     expect(sessions.sessionsList.value).toHaveLength(401)
@@ -57,18 +59,153 @@ describe('useSessions pagination', () => {
       view: 'session-list-v1',
       cursor: 'cursor-1',
     })
+    expect(call).toHaveBeenNthCalledWith(3, 'sessions.list', {
+      limit: 200,
+      view: 'session-list-v1',
+      cursor: 'cursor-2',
+    })
     expect(sessionMatches(
       sessions.allSessions.value[sessions.allSessions.value.length - 1]!,
       'task 400',
     )).toBe(true)
   })
 
+  it('replays the loaded page depth when an authoritative refresh resets cursors', async () => {
+    const { call, sessions } = setup([
+      { sessions: rows(0, 200), has_more: true, next_cursor: 'old-cursor-1' },
+      { sessions: rows(200, 400), has_more: true, next_cursor: 'old-cursor-2' },
+      { sessions: rows(400, 401), has_more: false, next_cursor: null },
+      { sessions: rows(0, 200), has_more: true, next_cursor: 'new-cursor-1' },
+      { sessions: rows(200, 400), has_more: true, next_cursor: 'new-cursor-2' },
+      { sessions: rows(400, 401), has_more: false, next_cursor: null },
+    ])
+
+    await sessions.loadSessions()
+    await sessions.loadMoreSessions()
+    await sessions.loadMoreSessions()
+    expect(sessions.sessionsList.value).toHaveLength(401)
+
+    await sessions.loadSessions()
+
+    expect(sessions.sessionsList.value).toHaveLength(401)
+    expect(sessions.hasMore.value).toBe(false)
+    expect(call).toHaveBeenNthCalledWith(5, 'sessions.list', {
+      limit: 200,
+      view: 'session-list-v1',
+      cursor: 'new-cursor-1',
+    })
+    expect(call).toHaveBeenNthCalledWith(6, 'sessions.list', {
+      limit: 200,
+      view: 'session-list-v1',
+      cursor: 'new-cursor-2',
+    })
+  })
+
+  it('keeps the last complete multi-page snapshot when a refresh page fails', async () => {
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { sessions } = setup([
+      { sessions: rows(0, 200), has_more: true, next_cursor: 'old-cursor-1' },
+      { sessions: rows(200, 400), has_more: true, next_cursor: 'old-cursor-2' },
+      { sessions: rows(400, 401), has_more: false, next_cursor: null },
+      { sessions: rows(0, 200), has_more: true, next_cursor: 'new-cursor-1' },
+      Promise.reject(new Error('connection changed during refresh')),
+    ])
+
+    await sessions.loadSessions()
+    await sessions.loadMoreSessions()
+    await sessions.loadMoreSessions()
+    await sessions.loadSessions()
+
+    expect(sessions.sessionsList.value).toHaveLength(401)
+    expect(sessions.sessionListError.value).toBe(false)
+    expect(sessions.hasMore.value).toBe(false)
+    errorLog.mockRestore()
+  })
+
+  it('discards an append from an old traversal when a concurrent refresh wins', async () => {
+    const stalePage = deferred<SessionsListResponse>()
+    const { sessions } = setup([
+      { sessions: rows(0, 200), has_more: true, next_cursor: 'old-cursor-1' },
+      { sessions: rows(200, 400), has_more: true, next_cursor: 'old-cursor-2' },
+      stalePage.promise,
+      { sessions: rows(0, 200), has_more: true, next_cursor: 'new-cursor-1' },
+      { sessions: rows(200, 400), has_more: true, next_cursor: 'new-cursor-2' },
+    ])
+
+    await sessions.loadSessions()
+    await sessions.loadMoreSessions()
+    const append = sessions.loadMoreSessions()
+    await Promise.resolve()
+
+    await sessions.loadSessions()
+    stalePage.resolve({
+      sessions: [{ key: 'agent:stale:webchat:session-400', title: 'Synthetic stale row' }],
+      has_more: false,
+      next_cursor: null,
+    })
+    await append
+
+    expect(sessions.sessionsList.value).toHaveLength(400)
+    expect(sessions.sessionsList.value.some(
+      item => (typeof item === 'string' ? item : item.key)?.includes('stale'),
+    )).toBe(false)
+    expect(sessions.hasMore.value).toBe(true)
+  })
+
+  it('does not dispatch a refresh that became stale while waiting for connection', async () => {
+    const connection = deferred<void>()
+    const { rpc, call, sessions } = setup([
+      { sessions: [{ key: 'agent:main:webchat:current', title: 'Current' }] },
+    ])
+    vi.mocked(rpc.waitForConnection)
+      .mockReset()
+      .mockReturnValueOnce(connection.promise)
+      .mockResolvedValue(undefined)
+
+    const staleRefresh = sessions.loadSessions()
+    const currentRefresh = sessions.loadSessions()
+    await currentRefresh
+    connection.resolve()
+    await staleRefresh
+
+    expect(call).toHaveBeenCalledTimes(1)
+    expect(sessions.sessionsList.value).toEqual([
+      { key: 'agent:main:webchat:current', title: 'Current' },
+    ])
+  })
+
+  it('does not dispatch load-more after a refresh wins during connection wait', async () => {
+    const connection = deferred<void>()
+    const { rpc, call, sessions } = setup([
+      { sessions: rows(0, 200), has_more: true, next_cursor: 'old-cursor' },
+      { sessions: [{ key: 'agent:main:webchat:current', title: 'Current' }] },
+    ])
+    await sessions.loadSessions()
+    vi.mocked(rpc.waitForConnection)
+      .mockReset()
+      .mockReturnValueOnce(connection.promise)
+      .mockResolvedValue(undefined)
+
+    const staleAppend = sessions.loadMoreSessions()
+    const currentRefresh = sessions.loadSessions()
+    await currentRefresh
+    connection.resolve()
+    await staleAppend
+
+    expect(call).toHaveBeenCalledTimes(2)
+    expect(sessions.sessionsList.value).toEqual([
+      { key: 'agent:main:webchat:current', title: 'Current' },
+    ])
+  })
+
   it('treats a legacy response without page metadata as terminal', async () => {
-    const { call, sessions } = setup([{ sessions: rows(0, 200) }])
+    const legacyKeys = rows(0, 200).map(row => row.key)
+    const { call, sessions } = setup([{ keys: legacyKeys }])
 
     await sessions.loadSessions()
     await sessions.loadMoreSessions()
 
+    expect(sessions.sessionsList.value).toEqual(legacyKeys)
     expect(sessions.hasMore.value).toBe(false)
     expect(call).toHaveBeenCalledTimes(1)
   })
@@ -84,6 +221,37 @@ describe('useSessions pagination', () => {
 
     expect(sessions.sessionsList.value).toHaveLength(201)
     expect(sessions.hasMore.value).toBe(false)
+  })
+
+  it('stops when a server cycles back to any cursor from the traversal', async () => {
+    const { sessions } = setup([
+      { sessions: rows(0, 200), has_more: true, next_cursor: 'cursor-1' },
+      { sessions: rows(200, 400), has_more: true, next_cursor: 'cursor-2' },
+      { sessions: rows(400, 401), has_more: true, next_cursor: 'cursor-1' },
+    ])
+
+    await sessions.loadSessions()
+    await sessions.loadMoreSessions()
+    await sessions.loadMoreSessions()
+
+    expect(sessions.sessionsList.value).toHaveLength(401)
+    expect(sessions.hasMore.value).toBe(false)
+  })
+
+  it('stops when a page advances its cursor without adding a unique session', async () => {
+    const firstPage = rows(0, 200)
+    const { call, sessions } = setup([
+      { sessions: firstPage, has_more: true, next_cursor: 'cursor-1' },
+      { sessions: firstPage, has_more: true, next_cursor: 'cursor-2' },
+    ])
+
+    await sessions.loadSessions()
+    await sessions.loadMoreSessions()
+    await sessions.loadMoreSessions()
+
+    expect(sessions.sessionsList.value).toHaveLength(200)
+    expect(sessions.hasMore.value).toBe(false)
+    expect(call).toHaveBeenCalledTimes(2)
   })
 
   it('keeps the cursor available for an explicit retry after a page error', async () => {

--- a/opensquilla-webui/src/composables/useSessions.ts
+++ b/opensquilla-webui/src/composables/useSessions.ts
@@ -11,6 +11,7 @@ import { normalizeTurnOutcome, turnOutcomePresentation } from '@/utils/chat/turn
 import type { SessionTaskAttention } from '@/composables/useSessionTaskAttention'
 
 export const SESSION_LIST_VIEW = 'session-list-v1'
+const SESSION_LIST_PAGE_SIZE = 200
 
 export type { RawSessionItem } from '@/types/rpc'
 
@@ -750,6 +751,8 @@ export function useSessions(readCallOptions?: RpcCallOptions) {
   const hasMore = ref(false)
   const nextCursor = ref<string | null>(null)
   let requestGeneration = 0
+  let loadedPageCount = 0
+  let pageCursors = new Set<string>()
 
   const allSessions = computed((): SessionItem[] =>
     sessionsList.value
@@ -766,7 +769,11 @@ export function useSessions(readCallOptions?: RpcCallOptions) {
       : rpc.call<SessionsListResponse>('sessions.list', params)
   }
 
-  function applyPageState(data: SessionsListResponse | null | undefined, requestedCursor?: string) {
+  function pageState(
+    data: SessionsListResponse | null | undefined,
+    seenCursors: Set<string>,
+    requestedCursor?: string,
+  ) {
     const rawHasMore = data?.hasMore ?? data?.has_more
     const rawNextCursor = data?.nextCursor ?? data?.next_cursor
     const candidate = typeof rawNextCursor === 'string' && rawNextCursor
@@ -777,30 +784,85 @@ export function useSessions(readCallOptions?: RpcCallOptions) {
     const usable = rawHasMore === true
       && candidate !== null
       && candidate !== requestedCursor
-    hasMore.value = usable
-    nextCursor.value = usable ? candidate : null
+      && !seenCursors.has(candidate)
+    if (usable && candidate) seenCursors.add(candidate)
+    return {
+      hasMore: usable,
+      nextCursor: usable ? candidate : null,
+    }
+  }
+
+  function appendUniqueSessions(
+    target: RawSessionListEntry[],
+    page: RawSessionListEntry[],
+  ) {
+    const seen = new Set(target.map(itemKey))
+    let added = 0
+    for (const item of page) {
+      const key = itemKey(item)
+      if (!key || seen.has(key)) continue
+      seen.add(key)
+      target.push(item)
+      added += 1
+    }
+    return added
   }
 
   async function loadSessions() {
     const generation = ++requestGeneration
+    const pagesToReload = Math.max(1, loadedPageCount)
     isLoading.value = true
     isLoadingMore.value = false
     sessionListError.value = false
     loadMoreError.value = false
     try {
       await waitForSessionRpcConnection(rpc, readCallOptions)
-      const params = { limit: 200, view: SESSION_LIST_VIEW }
-      const data = await callSessionsList(params)
       if (generation !== requestGeneration) return
-      const raw = data?.sessions || data?.keys || []
-      sessionsList.value = raw.filter(s => !!itemKey(s))
-      applyPageState(data)
+      const refreshed: RawSessionListEntry[] = []
+      const refreshedCursors = new Set<string>()
+      let requestedCursor: string | undefined
+      let refreshedPageCount = 0
+      let refreshedPageState = { hasMore: false, nextCursor: null as string | null }
+
+      while (refreshedPageCount < pagesToReload) {
+        const params: Record<string, unknown> = {
+          limit: SESSION_LIST_PAGE_SIZE,
+          view: SESSION_LIST_VIEW,
+        }
+        if (requestedCursor) params.cursor = requestedCursor
+        const data = await callSessionsList(params)
+        if (generation !== requestGeneration) return
+        const raw = (data?.sessions || data?.keys || []).filter(s => !!itemKey(s))
+        const added = appendUniqueSessions(refreshed, raw)
+        refreshedPageCount += 1
+        refreshedPageState = pageState(data, refreshedCursors, requestedCursor)
+        if (added === 0) {
+          refreshedPageState = { hasMore: false, nextCursor: null }
+          break
+        }
+        if (!refreshedPageState.hasMore || !refreshedPageState.nextCursor) break
+        requestedCursor = refreshedPageState.nextCursor
+      }
+
+      if (generation !== requestGeneration) return
+      sessionsList.value = refreshed
+      loadedPageCount = refreshedPageCount
+      pageCursors = refreshedCursors
+      hasMore.value = refreshedPageState.hasMore
+      nextCursor.value = refreshedPageState.nextCursor
     } catch (err: unknown) {
       if (generation !== requestGeneration) return
       console.error('[useSessions] sessions.list error:', err instanceof Error ? err.message : err)
-      sessionListError.value = true
-      hasMore.value = false
-      nextCursor.value = null
+      // A reconnect/event refresh must not collapse an already useful ledger.
+      // Keep the last complete traversal and its retry cursor until a whole
+      // replacement snapshot succeeds.
+      if (sessionsList.value.length === 0) {
+        sessionListError.value = true
+        hasMore.value = false
+        nextCursor.value = null
+        loadedPageCount = 0
+        pageCursors = new Set<string>()
+      }
     } finally {
       if (generation === requestGeneration) isLoading.value = false
     }
@@ -814,21 +876,21 @@ export function useSessions(readCallOptions?: RpcCallOptions) {
     loadMoreError.value = false
     try {
       await waitForSessionRpcConnection(rpc, readCallOptions)
+      if (generation !== requestGeneration || nextCursor.value !== cursor) return
       const data = await callSessionsList({
-        limit: 200,
+        limit: SESSION_LIST_PAGE_SIZE,
         view: SESSION_LIST_VIEW,
         cursor,
       })
       if (generation !== requestGeneration || nextCursor.value !== cursor) return
       const raw = (data?.sessions || data?.keys || []).filter(s => !!itemKey(s))
-      const existingKeys = new Set(sessionsList.value.map(itemKey))
-      const additions = raw.filter(item => !existingKeys.has(itemKey(item)))
-      sessionsList.value = [...sessionsList.value, ...additions]
-      applyPageState(data, cursor)
-      if (raw.length === 0) {
-        hasMore.value = false
-        nextCursor.value = null
-      }
+      const appended = [...sessionsList.value]
+      const added = appendUniqueSessions(appended, raw)
+      sessionsList.value = appended
+      loadedPageCount += 1
+      const nextPageState = pageState(data, pageCursors, cursor)
+      hasMore.value = added > 0 && nextPageState.hasMore
+      nextCursor.value = hasMore.value ? nextPageState.nextCursor : null
     } catch (err: unknown) {
       if (generation !== requestGeneration) return
       console.error('[useSessions] sessions.list next page error:', err instanceof Error ? err.message : err)

--- a/opensquilla-webui/src/views/SessionsView.vue
+++ b/opensquilla-webui/src/views/SessionsView.vue
@@ -134,6 +134,7 @@ import Icon from '@/components/Icon.vue'
 import ErrorState from '@/components/ErrorState.vue'
 import LoadingSpinner from '@/components/LoadingSpinner.vue'
 import { useConfirm } from '@/composables/useConfirm'
+import { useFilteredSessionPaging } from '@/composables/useFilteredSessionPaging'
 import { requestUsageSnapshot } from '@/composables/usage/useUsageQuery'
 import type { UsageSnapshot } from '@/types/usage'
 import SessionsTaskInput from '@/components/sessions/SessionsTaskInput.vue'
@@ -201,6 +202,7 @@ const {
 
 const filter = ref<FilterId>('all')
 const search = ref('')
+const filteredPagingActive = ref(false)
 const agentNames = ref<Map<string, string>>(new Map())
 const agentsLoaded = ref(false)
 let agentsRequestGeneration = 0
@@ -240,6 +242,17 @@ const ledgerEntries = computed(() => {
   const visible = allSessions.value.filter(item =>
     matchesFilter(item, byKey) && (!query || sessionMatches(item, query)))
   return arrangeSessionLedger(visible)
+})
+
+useFilteredSessionPaging({
+  active: () => filteredPagingActive.value
+    && (filter.value !== 'all' || search.value.trim().length > 0),
+  visibleCount: () => ledgerEntries.value.length,
+  hasMore: () => hasMore.value,
+  isLoading: () => isLoading.value,
+  isLoadingMore: () => isLoadingMore.value,
+  hasError: () => loadMoreError.value,
+  loadMore: loadMoreSessions,
 })
 
 // The inspected row tracks the live session list by key so status flips keep
@@ -480,6 +493,7 @@ function teardownLive() {
 }
 
 onActivated(() => {
+  filteredPagingActive.value = true
   loadAll()
   window.removeEventListener(LOCAL_SESSIONS_DELETED_EVENT, handleLocalSessionsDeleted)
   window.addEventListener(LOCAL_SESSIONS_DELETED_EVENT, handleLocalSessionsDeleted)
@@ -494,8 +508,13 @@ onActivated(() => {
   pollTimer = setInterval(loadAll, FALLBACK_POLL_MS)
 })
 
-onDeactivated(teardownLive)
-onUnmounted(teardownLive)
+function deactivateView() {
+  filteredPagingActive.value = false
+  teardownLive()
+}
+
+onDeactivated(deactivateView)
+onUnmounted(deactivateView)
 </script>
 
 <style scoped>

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -1216,13 +1216,13 @@ class TestSessionsList:
         assert res.payload["totalCount"] == 201
 
     @pytest.mark.asyncio
-    async def test_session_list_view_pages_beyond_200_without_gaps(
+    async def test_session_list_view_pages_all_401_rows_without_gaps(
         self, dispatcher, tmp_path
     ):
         storage = SessionStorage(str(tmp_path / "sessions-page.db"))
         await storage.connect()
         try:
-            for index in range(201):
+            for index in range(401):
                 await storage.upsert_session(
                     SessionNode(
                         session_key=f"agent:main:webchat:session-{index:03d}",
@@ -1247,26 +1247,38 @@ class TestSessionsList:
             assert first.payload["hasMore"] is True
             assert first.payload["next_cursor"] == first.payload["nextCursor"]
 
-            second = await dispatcher.dispatch(
-                "page-2",
-                "sessions.list",
-                {
-                    "limit": 200,
-                    "view": "session-list-v1",
-                    "cursor": first.payload["next_cursor"],
-                },
-                ctx,
-            )
+            pages = [first]
+            cursor = first.payload["next_cursor"]
+            for page_number in (2, 3):
+                page = await dispatcher.dispatch(
+                    f"page-{page_number}",
+                    "sessions.list",
+                    {
+                        "limit": 200,
+                        "view": "session-list-v1",
+                        "cursor": cursor,
+                    },
+                    ctx,
+                )
+                assert page.ok is True
+                pages.append(page)
+                cursor = page.payload["next_cursor"]
+
+            second, third = pages[1:]
             assert second.ok is True
-            assert second.payload["count"] == 1
-            assert second.payload["has_more"] is False
-            assert second.payload["next_cursor"] is None
+            assert second.payload["count"] == 200
+            assert second.payload["has_more"] is True
+            assert second.payload["next_cursor"] is not None
+            assert third.payload["count"] == 1
+            assert third.payload["has_more"] is False
+            assert third.payload["next_cursor"] is None
 
             keys = [
                 row["key"]
-                for row in [*first.payload["sessions"], *second.payload["sessions"]]
+                for page in pages
+                for row in page.payload["sessions"]
             ]
-            assert len(keys) == len(set(keys)) == 201
+            assert len(keys) == len(set(keys)) == 401
             assert keys == sorted(keys, reverse=True)
         finally:
             await storage.close()

--- a/tests/test_session/test_storage_session_list_pagination.py
+++ b/tests/test_session/test_storage_session_list_pagination.py
@@ -24,11 +24,13 @@ async def _seed(
     updated_at: int = 1000,
 ) -> None:
     for index, key in enumerate(keys):
+        key_parts = key.split(":", 2)
+        agent_id = key_parts[1] if len(key_parts) == 3 and key_parts[0] == "agent" else "main"
         await storage.upsert_session(
             SessionNode(
                 session_key=key,
                 session_id=f"session-{index}-{key[-8:]}",
-                agent_id="main",
+                agent_id=agent_id,
                 status="idle",
                 created_at=updated_at,
                 updated_at=updated_at,
@@ -107,7 +109,11 @@ async def test_keyset_traversal_handles_concurrent_insert_and_delete(
 async def test_keyset_page_preserves_guest_owner_filter(storage: SessionStorage) -> None:
     owner_id = "a" * 64
     other_owner_id = "b" * 64
-    visible = [guest_owned_session_key(owner_id, f"visible-{index}") for index in range(3)]
+    visible = [
+        guest_owned_session_key(owner_id, "visible-main", agent_id="main"),
+        guest_owned_session_key(owner_id, "visible-research", agent_id="research"),
+        guest_owned_session_key(owner_id, "visible-ops", agent_id="ops"),
+    ]
     await _seed(
         storage,
         [


### PR DESCRIPTION
## Scope

Scope boundary: Session list pagination, refresh and load-more concurrency, filtered-page filling, and sidebar scroll behavior.

Non-goals: RPC schema changes, persisted session migrations, or visual redesign.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Refs #1190

If None, reason: N/A

## Release Note

Release note: Fix incomplete and unstable conversation history when more than 200 sessions exist.

## Tests

Ruff: passed

Pytest: Backend session RPC and storage pagination tests passed.

Build: WebUI architecture guards, Vue typecheck, and production build passed in the task worktree.

Regression tests: added

Notes: The WebUI unit suite passed 4108 tests. Pagination-specific integration tests passed 18 tests. The combined four-fix integration suite passed with 1233 passed and 24 skipped. Generation-scoped refresh and load-more paths prevent stale mutations and duplicate-only cursor loops.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run Live Release E2E for provider, browser, gateway, channel, or release smoke coverage.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.