### PR TITLE
fix(chat): preserve router cards across steered turns

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatRenderedMessages.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRenderedMessages.test.ts
@@ -656,6 +656,84 @@ describe('useChatRenderedMessages silent sentinel compatibility', () => {
 })
 
 describe('useChatRenderedMessages immutable route history', () => {
+  it('keeps a restored steered route card on its physical answer segment', () => {
+    const routerUsage = {
+      routed_tier: 'c1',
+      routed_model: 'provider/initial',
+      routing_source: 'squilla_router',
+      router_model_call_id: '1.0',
+      router_iteration: 1,
+      input_tokens: 12,
+      output_tokens: 3,
+      cost_usd: 0.004,
+    }
+    const api = useChatRenderedMessages({
+      messages: ref<ChatMessage[]>([
+        { role: 'user', text: 'question', ts: 1, turnId: 'turn-steer' },
+        {
+          role: 'assistant',
+          text: 'first segment',
+          ts: 2,
+          turnId: 'turn-steer',
+          clientId: 'history-prefix',
+          routerUsage,
+          routerModelCallId: '1.0',
+          restoredFromHistory: true,
+        },
+        {
+          role: 'user',
+          text: 'guide it',
+          ts: 3,
+          turnId: 'turn-steer',
+          inputDisposition: 'applied',
+        },
+        {
+          role: 'assistant',
+          text: 'continued segment',
+          ts: 4,
+          turnId: 'turn-steer',
+          messageId: 'assistant-final',
+          usage: routerUsage,
+          restoredFromHistory: true,
+        },
+      ]),
+      sessionKey: ref('agent:main:webchat:steer-router'),
+      routerSlots: ref(['c0', 'c1']),
+      routerModels: ref({ c0: 'provider/fast', c1: 'provider/initial' }),
+      routerTierConfigs: ref({
+        c0: { model: 'provider/fast', supportsImage: false, imageOnly: false },
+        c1: { model: 'provider/initial', supportsImage: false, imageOnly: false },
+      }),
+      routerVisualEffectsEnabled: ref(true),
+      routerVisualMode: ref('real_candidates'),
+      renderMarkdown: text => text,
+      stripGeneratedArtifactMarkers: text => text,
+      stripTimePrefix: text => text,
+      isSubagentCompletionMessage: () => false,
+    })
+
+    const rendered = api.renderedMessages.value
+    expect(rendered.map(message => message.displayRole)).toEqual([
+      'user',
+      'router',
+      'assistant',
+      'user',
+      'assistant',
+    ])
+    expect(rendered.filter(message => message.isRouterStrip)).toHaveLength(1)
+    expect(rendered[1]).toMatchObject({
+      routerModelCallId: '1.0',
+      routerIteration: 1,
+      routerTurnKey: 'router-call:turn-steer:1.0',
+    })
+    expect(rendered[2]?.meta).toBeUndefined()
+    expect(rendered[4]?.meta).toMatchObject({
+      input: 12,
+      output: 3,
+      costUsd: 0.004,
+    })
+  })
+
   it('keeps the logical RoutePlan model after a provider fallback leg', () => {
     const api = useChatRenderedMessages({
       messages: ref<ChatMessage[]>([
@@ -1262,6 +1340,7 @@ describe('useChatRenderedMessages router visual mode', () => {
         role: 'user',
         text: 'compare candidates',
         ts: 1,
+        turnId: 'turn-live',
         clientId: 'local-user-turn',
         messageId: 'server-user-turn',
       },
@@ -1269,6 +1348,7 @@ describe('useChatRenderedMessages router visual mode', () => {
         role: 'router',
         text: '',
         ts: 2,
+        turnId: 'turn-live',
         messageId: 'router-live-event',
         provenanceKind: 'router_decision',
         routerDecision: {
@@ -1297,12 +1377,21 @@ describe('useChatRenderedMessages router visual mode', () => {
 
     const liveKey = api.renderedMessages.value.find(message => message.isRouterStrip)?.routerTurnKey
 
+    Object.assign(messages.value[1]!, {
+      routerModelCallId: '1.0',
+      routerIteration: 1,
+    })
+    const boundKey = api.renderedMessages.value.find(message => message.isRouterStrip)?.routerTurnKey
+
     messages.value.push({
       role: 'assistant',
       text: 'Settled answer.',
       ts: 3,
+      turnId: 'turn-live',
       messageId: 'assistant-settled',
       usage: {
+        router_model_call_id: '1.0',
+        router_iteration: 1,
         model_usage_breakdown: [
           { role: 'proposer', provider: 'openrouter', model: 'qwen/qwen3.7-plus' },
           { role: 'aggregator', provider: 'openrouter', model: 'z-ai/glm-5.2' },
@@ -1317,8 +1406,250 @@ describe('useChatRenderedMessages router visual mode', () => {
     isStreaming.value = false
 
     const settledKey = api.renderedMessages.value.find(message => message.isRouterStrip)?.routerTurnKey
-    expect(liveKey).toBe('router-turn:local-user-turn')
+    expect(liveKey).toBe('router-event:turn-live:router-live-event')
+    expect(boundKey).toBe(liveKey)
     expect(settledKey).toBe(liveKey)
+
+    messages.value = [
+      {
+        role: 'user',
+        text: 'compare candidates',
+        ts: 1,
+        turnId: 'turn-live',
+        messageId: 'server-user-turn',
+      },
+      {
+        role: 'assistant',
+        text: 'Partial answer.',
+        ts: 2,
+        turnId: 'turn-live',
+        clientId: 'history-prefix',
+        routerUsage: messages.value[2]!.usage,
+        routerModelCallId: '1.0',
+        restoredFromHistory: true,
+      },
+      {
+        role: 'user',
+        text: 'guide it',
+        ts: 2.5,
+        turnId: 'turn-live',
+        inputDisposition: 'applied',
+      },
+      {
+        role: 'assistant',
+        text: 'Settled answer.',
+        ts: 3,
+        turnId: 'turn-live',
+        messageId: 'assistant-settled',
+        usage: messages.value[2]!.usage,
+        restoredFromHistory: true,
+      },
+    ]
+    const restoredKey = api.renderedMessages.value.find(message => message.isRouterStrip)?.routerTurnKey
+    expect(restoredKey).toBe(liveKey)
+  })
+
+  it('settles the exact physical route card without replacing another card in the turn', () => {
+    const api = useChatRenderedMessages({
+      messages: ref<ChatMessage[]>([
+        { role: 'user', text: 'question', ts: 1, turnId: 'turn-multi' },
+        {
+          role: 'router',
+          text: '',
+          ts: 2,
+          turnId: 'turn-multi',
+          messageId: 'router-first',
+          provenanceKind: 'router_decision',
+          routerModelCallId: '1.0',
+          routerDecision: { tier: 'c1', model: 'provider/first', source: 'squilla_router' },
+        },
+        { role: 'assistant', text: 'first segment', ts: 3, turnId: 'turn-multi' },
+        {
+          role: 'user',
+          text: 'guide it',
+          ts: 4,
+          turnId: 'turn-multi',
+          inputDisposition: 'applied',
+        },
+        {
+          role: 'router',
+          text: '',
+          ts: 5,
+          turnId: 'turn-multi',
+          messageId: 'router-second',
+          provenanceKind: 'router_decision',
+          routerModelCallId: '2.0',
+          routerDecision: { tier: 'c2', model: 'provider/second', source: 'squilla_router' },
+        },
+        {
+          role: 'assistant',
+          text: 'settled first call',
+          ts: 6,
+          turnId: 'turn-multi',
+          messageId: 'assistant-terminal',
+          usage: {
+            routed_tier: 'c1',
+            routed_model: 'provider/first',
+            routing_source: 'squilla_router',
+            router_model_call_id: '1.0',
+          },
+        },
+      ]),
+      sessionKey: ref('router-exact-settlement-test'),
+      routerSlots: ref(['c1', 'c2']),
+      routerModels: ref({ c1: 'provider/first', c2: 'provider/second' }),
+      routerTierConfigs: ref({
+        c1: { model: 'provider/first', supportsImage: false, imageOnly: false },
+        c2: { model: 'provider/second', supportsImage: false, imageOnly: false },
+      }),
+      routerVisualEffectsEnabled: ref(true),
+      routerVisualMode: ref('real_candidates'),
+      renderMarkdown: text => text,
+      stripGeneratedArtifactMarkers: text => text,
+      stripTimePrefix: text => text,
+      isSubagentCompletionMessage: () => false,
+    })
+
+    const strips = api.renderedMessages.value.filter(message => message.isRouterStrip)
+    expect(strips).toHaveLength(2)
+    expect(strips.map(strip => strip.routerModelCallId)).toEqual(['1.0', '2.0'])
+    expect(strips.map(strip => strip.routerTurnKey)).toEqual([
+      'router-call:turn-multi:1.0',
+      'router-call:turn-multi:2.0',
+    ])
+    expect(strips.map(strip => strip.gridCells?.[strip.winnerIdx ?? -1]?.model)).toEqual([
+      'provider/first',
+      'provider/second',
+    ])
+    expect(strips.map(strip => strip.routerSettled)).toEqual([true, false])
+  })
+
+  it('does not reuse an incompatible card key for an anchored ensemble settlement', () => {
+    const api = useChatRenderedMessages({
+      messages: ref<ChatMessage[]>([
+        { role: 'user', text: 'question', ts: 1, turnId: 'turn-ensemble-anchor' },
+        {
+          role: 'router',
+          text: '',
+          ts: 2,
+          turnId: 'turn-ensemble-anchor',
+          messageId: 'router-second-call',
+          provenanceKind: 'router_decision',
+          routerModelCallId: '2.0',
+          routerDecision: { tier: 'c2', model: 'provider/second', source: 'squilla_router' },
+        },
+        {
+          role: 'assistant',
+          text: 'settled ensemble call',
+          ts: 3,
+          turnId: 'turn-ensemble-anchor',
+          messageId: 'assistant-terminal',
+          usage: {
+            routed_tier: 'c1',
+            routed_model: 'provider/first',
+            routing_source: 'squilla_router',
+            router_model_call_id: '1.0',
+            model_usage_breakdown: [
+              { role: 'proposer', provider: 'provider', model: 'member/one' },
+              { role: 'aggregator', provider: 'provider', model: 'member/final' },
+            ],
+            ensemble_trace: {
+              profile: 'default',
+              total_candidates: 1,
+              llm_request_count: 2,
+            },
+          },
+        },
+      ]),
+      sessionKey: ref('router-ensemble-anchor-test'),
+      routerSlots: ref(['c1', 'c2']),
+      routerModels: ref({ c1: 'provider/first', c2: 'provider/second' }),
+      routerTierConfigs: ref({
+        c1: { model: 'provider/first', supportsImage: false, imageOnly: false },
+        c2: { model: 'provider/second', supportsImage: false, imageOnly: false },
+      }),
+      routerVisualEffectsEnabled: ref(true),
+      routerVisualMode: ref('real_candidates'),
+      renderMarkdown: text => text,
+      stripGeneratedArtifactMarkers: text => text,
+      stripTimePrefix: text => text,
+      isSubagentCompletionMessage: () => false,
+      modelRoutingMode: ref('squilla_router'),
+    })
+
+    const strips = api.renderedMessages.value.filter(message => message.isRouterStrip)
+    expect(strips).toHaveLength(2)
+    expect(strips.map(strip => strip.routerModelCallId)).toEqual(['2.0', '1.0'])
+    expect(strips.map(strip => strip.routerTurnKey)).toEqual([
+      'router-call:turn-ensemble-anchor:2.0',
+      'router-call:turn-ensemble-anchor:1.0',
+    ])
+    expect(new Set(strips.map(strip => strip.routerTurnKey)).size).toBe(2)
+    expect(strips[1]?.routerPanel).toBe('router-ensemble-sequence')
+  })
+
+  it('uses latest-unresolved fallback settlement for gateway events without call anchors', () => {
+    const api = useChatRenderedMessages({
+      messages: ref<ChatMessage[]>([
+        { role: 'user', text: 'question', ts: 1, turnId: 'turn-legacy' },
+        {
+          role: 'router',
+          text: '',
+          ts: 2,
+          turnId: 'turn-legacy',
+          messageId: 'router-first',
+          provenanceKind: 'router_decision',
+          routerDecision: { tier: 'c1', model: 'provider/first', source: 'squilla_router' },
+        },
+        { role: 'assistant', text: 'first segment', ts: 3, turnId: 'turn-legacy' },
+        {
+          role: 'router',
+          text: '',
+          ts: 4,
+          turnId: 'turn-legacy',
+          messageId: 'router-second',
+          provenanceKind: 'router_decision',
+          routerDecision: { tier: 'c2', model: 'provider/second', source: 'squilla_router' },
+        },
+        {
+          role: 'assistant',
+          text: 'legacy terminal',
+          ts: 5,
+          turnId: 'turn-legacy',
+          messageId: 'assistant-terminal',
+          usage: {
+            routed_tier: 'c2',
+            routed_model: 'provider/second',
+            routing_source: 'squilla_router',
+          },
+        },
+      ]),
+      sessionKey: ref('router-fallback-settlement-test'),
+      routerSlots: ref(['c1', 'c2']),
+      routerModels: ref({ c1: 'provider/first', c2: 'provider/second' }),
+      routerTierConfigs: ref({
+        c1: { model: 'provider/first', supportsImage: false, imageOnly: false },
+        c2: { model: 'provider/second', supportsImage: false, imageOnly: false },
+      }),
+      routerVisualEffectsEnabled: ref(true),
+      routerVisualMode: ref('real_candidates'),
+      renderMarkdown: text => text,
+      stripGeneratedArtifactMarkers: text => text,
+      stripTimePrefix: text => text,
+      isSubagentCompletionMessage: () => false,
+    })
+
+    const strips = api.renderedMessages.value.filter(message => message.isRouterStrip)
+    expect(strips).toHaveLength(2)
+    expect(strips.map(strip => strip.routerTurnKey)).toEqual([
+      'router-event:turn-legacy:router-first',
+      'router-event:turn-legacy:router-second',
+    ])
+    expect(strips.map(strip => strip.gridCells?.[strip.winnerIdx ?? -1]?.model)).toEqual([
+      'provider/first',
+      'provider/second',
+    ])
+    expect(strips.map(strip => strip.routerSettled)).toEqual([false, true])
   })
 
   it('keeps same-turn steer rows under one explicit turn and one Router strip', () => {
@@ -1336,6 +1667,8 @@ describe('useChatRenderedMessages router visual mode', () => {
         messageId: 'router-turn-1',
         turnId: 'turn-1',
         provenanceKind: 'router_decision',
+        routerModelCallId: '1.0',
+        routerIteration: 1,
         routerDecision: {
           tier: 'c1',
           model: 'qwen/qwen3.7-plus',
@@ -1384,7 +1717,19 @@ describe('useChatRenderedMessages router visual mode', () => {
     })
 
     const rendered = api.renderedMessages.value
+    expect(rendered.map(message => message.displayRole)).toEqual([
+      'user',
+      'router',
+      'assistant',
+      'user',
+      'assistant',
+    ])
     expect(rendered.filter(message => message.isRouterStrip)).toHaveLength(1)
+    expect(rendered[1]).toMatchObject({
+      routerModelCallId: '1.0',
+      routerIteration: 1,
+      routerTurnKey: 'router-call:turn-1:1.0',
+    })
     expect(rendered.filter(message => !message.isRouterStrip).map(message => message.turnKey))
       .toEqual([
         'turn:turn-1',
@@ -1507,7 +1852,9 @@ describe('useChatRenderedMessages router visual mode', () => {
       'turn:turn-server',
       'turn:turn-server',
     ])
-    expect(api.renderedMessages.value[1]?.routerTurnKey).toBe('router-turn:turn-server')
+    expect(api.renderedMessages.value[1]?.routerTurnKey).toBe(
+      'router-event:turn-server:router-server',
+    )
   })
 })
 

--- a/opensquilla-webui/src/composables/chat/useChatRenderedMessages.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRenderedMessages.ts
@@ -254,11 +254,38 @@ function rehomeCompletedSessionCards(
 }
 
 export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions) {
+  // A live route card exists before the first provider delta reveals its
+  // physical call id. Preserve the event key while teaching that call (and a
+  // later history projection) to reuse it, so Vue never remounts the card.
+  const stableRouterKeys = new Map<string, string>()
+
+  function stableRouterStripRenderKey(
+    turnIdentity: string,
+    message: Pick<ChatMessage, 'routerModelCallId' | 'messageId'>
+      | Pick<ChatRenderedMessage, 'routerModelCallId' | 'messageId' | 'sourceIndex' | 'id'>,
+    messageId?: string,
+    index = 0,
+  ): string {
+    const sessionIdentity = options.sessionKey.value || 'session'
+    const identityPrefix = `${sessionIdentity}\u0000${turnIdentity}\u0000`
+    const callId = String(message.routerModelCallId || '').trim()
+    const eventId = routerStripEventId(message, messageId, index)
+    const eventIdentity = `${identityPrefix}event:${eventId}`
+    const callIdentity = callId ? `${identityPrefix}call:${callId}` : ''
+    const key = (callIdentity ? stableRouterKeys.get(callIdentity) : undefined)
+      || stableRouterKeys.get(eventIdentity)
+      || routerStripRenderKey(turnIdentity, message, messageId, index)
+    stableRouterKeys.set(eventIdentity, key)
+    if (callIdentity) stableRouterKeys.set(callIdentity, key)
+    return key
+  }
+
   const renderedMessages = computed((): ChatRenderedMessage[] => {
     const result: ChatRenderedMessage[] = []
     let prevDay = ''
     let prevRole = ''
-    let turnRouterIdx = -1
+    let turnRouterIndexes = new Map<string, number>()
+    let turnRouterOrder: number[] = []
     let turnIdx = 0
     let turnIdentity = 'turn-0'
     let explicitTurnId = ''
@@ -300,15 +327,18 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
       if (adoptsLegacyTurnId) {
         turnIdentity = messageTurnId
         const adoptedTurnKey = `turn:${messageTurnId}`
-        const adoptedRouterKey = `router-turn:${messageTurnId}`
         for (let index = turnResultStartIndex; index < result.length; index++) {
           result[index]!.turnKey = adoptedTurnKey
           if (result[index]!.isRouterStrip) {
-            result[index]!.routerTurnKey = adoptedRouterKey
+            result[index]!.routerTurnKey = stableRouterStripRenderKey(
+              messageTurnId,
+              result[index]!,
+            )
           }
         }
       } else if (explicitTurnChanged || legacyUserStartsTurn) {
-        turnRouterIdx = -1
+        turnRouterIndexes = new Map()
+        turnRouterOrder = []
         turnRouterDecision = null
         lastAssistantResultIndex = -1
         turnRequestKind = msg.role === 'user'
@@ -372,7 +402,9 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
           turnRequestKind,
           turnIdentity,
         )
-        if (stripItem) turnRouterIdx = upsertRouterStrip(result, stripItem, turnRouterIdx)
+        if (stripItem) {
+          upsertRouterStrip(result, stripItem, turnRouterIndexes, turnRouterOrder)
+        }
         prevRole = ''
         continue
       }
@@ -386,7 +418,14 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
           ...msg,
           routerSettled: msg.routerSettled === true || !inLiveTurn,
         }
-        const priorStrip = turnRouterIdx >= 0 ? result[turnRouterIdx] : undefined
+        const callIdentity = routerModelCallIdFromMessage(msg)
+        const priorIndex = routerSettlementCandidateIndex(
+          result,
+          turnRouterIndexes,
+          turnRouterOrder,
+          callIdentity,
+        )
+        const priorStrip = priorIndex === undefined ? undefined : result[priorIndex]
         const stripItem = turnRouterDecision
           && shouldCombineRouterAndEnsemble(turnRouterDecision, true, msg.restoredFromHistory === true)
           ? renderedCombinedRouterStrip(
@@ -408,7 +447,8 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
               turnIdentity,
             )
         if (stripItem) {
-          turnRouterIdx = upsertRouterStrip(result, stripItem, turnRouterIdx, {
+          upsertRouterStrip(result, stripItem, turnRouterIndexes, turnRouterOrder, {
+            settlement: true,
             settleReplacement: false,
           })
         }
@@ -426,7 +466,11 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
             turnRequestKind,
             turnIdentity,
           )
-          if (stripItem) turnRouterIdx = upsertRouterStrip(result, stripItem, turnRouterIdx)
+          if (stripItem) {
+            upsertRouterStrip(result, stripItem, turnRouterIndexes, turnRouterOrder, {
+              settlement: true,
+            })
+          }
           prevRole = ''
         }
       }
@@ -624,8 +668,15 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
       showHeader: false,
       sourceIndex: index,
       isRouterStrip: true,
-      routerTurnKey: `router-turn:${turnIdentity}`,
+      routerTurnKey: stableRouterStripRenderKey(
+        turnIdentity,
+        { routerModelCallId: routerModelCallIdFromMessage(msg), messageId },
+        messageId,
+        index,
+      ),
       turnKey: `turn:${turnIdentity}`,
+      routerModelCallId: routerModelCallIdFromMessage(msg) || undefined,
+      routerIteration: routerIterationFromMessage(msg) || undefined,
       routerState: routerDecisionState(decision),
       routerSource: decision.source || 'none',
       routerObserve: decision.routing_applied === false,
@@ -731,8 +782,15 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
       showHeader: false,
       sourceIndex: index,
       isRouterStrip: true,
-      routerTurnKey: `router-turn:${turnIdentity}`,
+      routerTurnKey: stableRouterStripRenderKey(
+        turnIdentity,
+        { routerModelCallId: routerModelCallIdFromMessage(msg), messageId },
+        messageId,
+        index,
+      ),
       turnKey: `turn:${turnIdentity}`,
+      routerModelCallId: routerModelCallIdFromMessage(msg) || undefined,
+      routerIteration: routerIterationFromMessage(msg) || undefined,
       routerState: msg.routerSettled === true ? 'settled' : 'pending',
       routerSource: 'llm_ensemble',
       routerObserve: false,
@@ -873,7 +931,7 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
   }
 
   function ensembleMetaFromMessage(msg: ChatMessage): ChatEnsembleMeta | undefined {
-    const usage = msg.usage || msg.turn_usage
+    const usage = msg.routerUsage || msg.usage || msg.turn_usage
     return usage ? ensembleMeta(usage) : undefined
   }
 
@@ -1367,19 +1425,116 @@ function sameMultiset(a: Map<string, number>, b: Map<string, number>): boolean {
   return true
 }
 
+function routerUsageFromMessage(msg: ChatMessage): ChatMessage['usage'] {
+  return msg.routerUsage || msg.usage || msg.turn_usage
+}
+
+function routerModelCallIdFromMessage(msg: ChatMessage): string {
+  const usage = routerUsageFromMessage(msg)
+  return String(
+    msg.routerModelCallId
+    || usage?.router_model_call_id
+    || usage?.routerModelCallId
+    || '',
+  ).trim()
+}
+
+function routerIterationFromMessage(msg: ChatMessage): number {
+  const usage = routerUsageFromMessage(msg)
+  return Number(
+    msg.routerIteration
+    || usage?.router_iteration
+    || usage?.routerIteration
+    || 0,
+  ) || 0
+}
+
+function routerStripIdentity(strip: ChatRenderedMessage): string {
+  if (strip.routerModelCallId) return `call:${strip.routerModelCallId}`
+  return `event:${strip.messageId || strip.sourceIndex || strip.id || 'router'}`
+}
+
+function routerStripRenderKey(
+  turnIdentity: string,
+  message: Pick<ChatMessage, 'routerModelCallId' | 'messageId'>
+    | Pick<ChatRenderedMessage, 'routerModelCallId' | 'messageId' | 'sourceIndex' | 'id'>,
+  messageId?: string,
+  index = 0,
+): string {
+  const callId = String(message.routerModelCallId || '').trim()
+  const eventId = routerStripEventId(message, messageId, index)
+  return callId
+    ? `router-call:${turnIdentity}:${callId}`
+    : `router-event:${turnIdentity}:${eventId}`
+}
+
+function routerStripEventId(
+  message: Pick<ChatMessage, 'messageId'>
+    | Pick<ChatRenderedMessage, 'messageId' | 'sourceIndex' | 'id'>,
+  messageId?: string,
+  index = 0,
+): string | number {
+  return messageId
+    || message.messageId
+    || ('sourceIndex' in message ? message.sourceIndex : undefined)
+    || ('id' in message ? message.id : undefined)
+    || index
+}
+
+function routerSettlementCandidateIndex(
+  result: ChatRenderedMessage[],
+  indexes: Map<string, number>,
+  order: number[],
+  modelCallId: string | undefined,
+): number | undefined {
+  const normalizedCallId = String(modelCallId || '').trim()
+  if (normalizedCallId) {
+    const exactIndex = indexes.get(`call:${normalizedCallId}`)
+    if (exactIndex !== undefined) return exactIndex
+  }
+  for (let cursor = order.length - 1; cursor >= 0; cursor--) {
+    const candidateIndex = order[cursor]!
+    const candidate = result[candidateIndex]
+    if (!candidate?.isRouterStrip) continue
+    if (
+      !normalizedCallId
+      || !candidate.routerModelCallId
+      || candidate.routerModelCallId === normalizedCallId
+    ) {
+      return candidateIndex
+    }
+  }
+  return undefined
+}
+
 function upsertRouterStrip(
   result: ChatRenderedMessage[],
   stripItem: ChatRenderedMessage,
-  previousIndex: number,
-  options: { settleReplacement?: boolean } = {},
-): number {
+  indexes: Map<string, number>,
+  order: number[],
+  options: { settlement?: boolean; settleReplacement?: boolean } = {},
+): void {
+  const identity = routerStripIdentity(stripItem)
+  let previousIndex = indexes.get(identity) ?? -1
+  if (previousIndex < 0 && options.settlement === true) {
+    previousIndex = routerSettlementCandidateIndex(
+      result,
+      indexes,
+      order,
+      stripItem.routerModelCallId,
+    ) ?? -1
+  }
   if (previousIndex >= 0) {
     if (options.settleReplacement !== false) stripItem.routerSettled = true
+    stripItem.routerTurnKey = result[previousIndex]?.routerTurnKey || stripItem.routerTurnKey
     result[previousIndex] = stripItem
-    return previousIndex
+    indexes.set(identity, previousIndex)
+    return
   }
   result.push(stripItem)
-  return result.length - 1
+  const index = result.length - 1
+  indexes.set(identity, index)
+  order.push(index)
 }
 
 function routerRequestKindFromAttachments(attachments: ChatMessage['attachments']): ChatRouterRequestKind {
@@ -1425,7 +1580,7 @@ function routerDecisionFromUsage(
   msg: ChatMessage,
   inheritedRoute: NormalizedRouterDecision | null = null,
 ): NormalizedRouterDecision | null {
-  const usage = msg.usage || msg.turn_usage
+  const usage = msg.routerUsage || msg.usage || msg.turn_usage
   if (!usage) return inheritedRoute
   if (usage.routing_source === 'none') return inheritedRoute
   const routePlan = usage.route_plan

--- a/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.test.ts
@@ -29,6 +29,47 @@ function makeRuntime(
   return { runtime, messagesRef, scrollToBottom }
 }
 
+describe('router decision identity', () => {
+  it('keeps emitted same-turn cards immutable and binds each physical call', () => {
+    const { runtime, messagesRef } = makeRuntime([{
+      role: 'user',
+      text: 'q',
+      ts: 0,
+      turnId: 'turn-1',
+    }], true, 'squilla_router')
+
+    runtime.queueRouterDecision({
+      stream_seq: 10,
+      turn_id: 'turn-1',
+      tier: 'c1',
+      model: 'provider/first',
+      source: 'squilla_router',
+    })
+    runtime.bindRouterDecisionToModelCall('1.0', 1, 'turn-1')
+    runtime.queueRouterDecision({
+      stream_seq: 20,
+      turn_id: 'turn-1',
+      tier: 'c2',
+      model: 'provider/replay',
+      source: 'squilla_router',
+    })
+    runtime.bindRouterDecisionToModelCall('2.0', 2, 'turn-1')
+    runtime.flushPendingRouterDecision()
+
+    const routers = messagesRef.value.filter(message => message.role === 'router')
+    expect(routers).toHaveLength(2)
+    expect(routers.map(message => [
+      message.messageId,
+      message.routerDecision?.model,
+      message.routerModelCallId,
+      message.routerIteration,
+    ])).toEqual([
+      ['router-sess-10', 'provider/first', '1.0', 1],
+      ['router-sess-20', 'provider/replay', '2.0', 2],
+    ])
+  })
+})
+
 describe('appendEnsembleProgress', () => {
   it('normalizes every internal candidate label to the public Proposer role', () => {
     const { runtime, messagesRef } = makeRuntime([{ role: 'user', text: 'q', ts: 0 }])

--- a/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.ts
@@ -75,28 +75,42 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
     return undefined
   }
 
+  function bindRouterDecisionToModelCall(
+    modelCallId: string,
+    iteration = 0,
+    targetTurnId = latestExplicitTurnId(),
+  ) {
+    const normalizedCallId = String(modelCallId || '').trim()
+    if (!normalizedCallId) return
+    for (let i = options.messages.value.length - 1; i >= 0; i--) {
+      const message = options.messages.value[i]
+      if (
+        message.role === 'router'
+        && message.provenanceKind === 'router_decision'
+        && (!targetTurnId || message.turnId === targetTurnId)
+      ) {
+        if (message.routerModelCallId === normalizedCallId) return
+        if (!message.routerModelCallId) {
+          message.routerModelCallId = normalizedCallId
+          if (iteration > 0) message.routerIteration = iteration
+          return
+        }
+      }
+      if (
+        message.role === 'user'
+        && (!targetTurnId || !message.turnId || message.turnId !== targetTurnId)
+      ) break
+    }
+  }
+
   function appendRouterDecision(payload: RouterDecisionPayload, decision = normalizeRouterDecision(payload)) {
     if (!decision) return
     const messageId = payload?.stream_seq
       ? `router-${options.sessionKey.value}-${payload.stream_seq}`
       : `router-${options.sessionKey.value}-${Date.now()}`
-    const last = options.messages.value[options.messages.value.length - 1]
-    if (last?.messageId === messageId) return
+    if (options.messages.value.some(message => message.messageId === messageId)) return
 
     const turnId = payloadTurnId(payload)
-    if (options.isStreaming.value) {
-      const message = findRouterMessageForTurn(turnId)
-      if (message) {
-        message.routerDecision = decision
-        message.messageId = messageId
-        message.ts = new Date().toISOString()
-        message.routerSettled = true
-        if (turnId) message.turnId = turnId
-        scrollToBottomIfFollowing()
-        return
-      }
-    }
-
     options.messages.value.push({
       role: 'router',
       text: '',
@@ -276,5 +290,6 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
     clearPendingRouterDecision,
     appendEnsembleProgress,
     markEnsembleHandoff,
+    bindRouterDecisionToModelCall,
   }
 }

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
@@ -66,6 +66,7 @@ function createHarness(options: {
     useReducer: ref(false),
   }
   const markEnsembleHandoff = vi.fn()
+  const bindRouterDecisionToModelCall = vi.fn()
   const schedulePendingDrainAfterTerminal = vi.fn()
   const scheduleHistorySync = vi.fn()
   const showCompactionToast = vi.fn()
@@ -104,6 +105,7 @@ function createHarness(options: {
     sessionRunStatus: options.sessionRunStatus || (() => ({ status: 'idle', label: 'Idle', task: null })),
     applySessionRunState,
     queueRouterDecision: vi.fn(),
+    bindRouterDecisionToModelCall,
     appendEnsembleProgress: vi.fn(),
     markEnsembleHandoff,
     flushPendingRouterDecision: vi.fn(),
@@ -135,6 +137,7 @@ function createHarness(options: {
     pendingQueue,
     applySessionRunState,
     markEnsembleHandoff,
+    bindRouterDecisionToModelCall,
     schedulePendingDrainAfterTerminal,
     scheduleHistorySync,
     showCompactionToast,
@@ -148,6 +151,55 @@ function createHarness(options: {
     stop: () => scope.stop(),
   }
 }
+
+describe('useChatRpcEventHandlers route-card ownership', () => {
+  it('binds text and thinking events to their physical provider calls', () => {
+    const { api, bindRouterDecisionToModelCall, stop } = createHarness()
+    try {
+      api.handlers.onTextDelta({
+        session_key: 'agent:main:test',
+        turn_id: 'turn-1',
+        stream_seq: 1,
+        generation_epoch: 0,
+        text: 'answer',
+        model_call_id: '1.0',
+        iteration: 1,
+      })
+      api.handlers.onAnswerGenerationReset({
+        session_key: 'agent:main:test',
+        turn_id: 'turn-1',
+        stream_seq: 2,
+        old_generation_epoch: 0,
+        new_generation_epoch: 1,
+      })
+      api.handlers.onTextDelta({
+        session_key: 'agent:main:test',
+        turn_id: 'turn-1',
+        stream_seq: 3,
+        generation_epoch: 0,
+        text: 'stale answer',
+        model_call_id: 'stale-call',
+        iteration: 99,
+      })
+      api.handlers.onAny('session.event.thinking', {
+        session_key: 'agent:main:test',
+        turn_id: 'turn-1',
+        stream_seq: 4,
+        generation_epoch: 1,
+        text: 'reasoning',
+        model_call_id: '2.0',
+        iteration: 2,
+      })
+
+      expect(bindRouterDecisionToModelCall.mock.calls).toEqual([
+        ['1.0', 1, 'turn-1'],
+        ['2.0', 2, 'turn-1'],
+      ])
+    } finally {
+      stop()
+    }
+  })
+})
 
 describe('useChatRpcEventHandlers live snapshot restoration', () => {
   it('replays a committed tool timeline including its authoritative end', () => {

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
@@ -132,6 +132,11 @@ export interface UseChatRpcEventHandlersOptions {
   sessionRunStatus: (source: ChatRunStatusSource | null | undefined) => ChatRunStatus
   applySessionRunState: (source: ChatRunStatusSource | null | undefined) => void
   queueRouterDecision: (payload: RouterDecisionPayload) => void
+  bindRouterDecisionToModelCall?: (
+    modelCallId: string,
+    iteration?: number,
+    turnId?: string,
+  ) => void
   appendEnsembleProgress: (payload: EnsembleProgressPayload) => void
   markEnsembleHandoff: () => void
   flushPendingRouterDecision: () => void
@@ -1384,6 +1389,11 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
     stream.resetStreamIdleTimer()
     const taskId = payloadTaskId(payload) || activeStreamTaskId.value
     if (taskId && options.taskOwnership?.stopRequestedTaskId.value === taskId) return
+    options.bindRouterDecisionToModelCall?.(
+      String(payload.model_call_id || payload.modelCallId || ''),
+      Number(payload.iteration || 0),
+      String(payload.turn_id || payload.turnId || ''),
+    )
     options.markEnsembleHandoff()
     const presentation = payload.presentation
     if (presentation === 'intermediate' || presentation === 'answer') {
@@ -2034,9 +2044,15 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
 
     if (event === 'session.event.thinking') {
       if (aborted.value) return
-      const thinkingText = (payload as SessionEventPayload).text
+      const thinkingPayload = payload as SessionEventPayload
+      const thinkingText = thinkingPayload.text
       if (typeof thinkingText !== 'string' || !thinkingText) return
       stream.resetStreamIdleTimer()
+      options.bindRouterDecisionToModelCall?.(
+        String(thinkingPayload.model_call_id || thinkingPayload.modelCallId || ''),
+        Number(thinkingPayload.iteration || 0),
+        String(thinkingPayload.turn_id || thinkingPayload.turnId || ''),
+      )
       appendThinkingDelta(thinkingText, payload)
       return
     }

--- a/opensquilla-webui/src/types/chat.ts
+++ b/opensquilla-webui/src/types/chat.ts
@@ -385,6 +385,11 @@ export interface ChatUsagePayload {
   routePlan?: Record<string, unknown>
   model_call_segments?: ChatModelCallSegment[]
   modelCallSegments?: ChatModelCallSegment[]
+  /** Physical provider call whose visible output owns the route card. */
+  router_model_call_id?: string
+  routerModelCallId?: string
+  router_iteration?: number
+  routerIteration?: number
   /** Per-turn ledger coverage. Older gateways omit these additive fields. */
   coverage_status?: string
   coverageStatus?: string
@@ -508,6 +513,10 @@ export interface ChatMessage {
   /** Ephemeral handoff when a coarse live burst still needs visual reveal. */
   reasoningPresentationPending?: boolean
   routerDecision?: import('./rpc').RouterDecisionPayload | null
+  /** Routing-only usage projection for a split historical answer segment. */
+  routerUsage?: ChatUsagePayload
+  routerModelCallId?: string
+  routerIteration?: number
   artifacts?: ArtifactPayload[]
   tool_calls?: RawToolCallPayload[]
   planRevisions?: import('./plans').PlanRevisionSnapshot[]
@@ -645,9 +654,10 @@ export interface ChatRenderedMessage {
   daySeparator?: boolean
   dayLabel?: string
   isRouterStrip?: boolean
-  /** Stable per-turn render identity. Unlike the router event message id, this
-   *  does not change when a live strip is replaced by its settled trace. */
+  /** Stable per-card render identity; preserved during terminal reconciliation. */
   routerTurnKey?: string
+  routerModelCallId?: string
+  routerIteration?: number
   routerState?: string
   routerSource?: string
   routerObserve?: boolean

--- a/opensquilla-webui/src/types/rpc.ts
+++ b/opensquilla-webui/src/types/rpc.ts
@@ -378,6 +378,9 @@ export interface TextDeltaPayload extends SessionEventPayload {
   text?: string
   /** Gateway-owned semantic role for this text span. */
   presentation?: 'intermediate' | 'answer'
+  model_call_id?: string
+  modelCallId?: string
+  iteration?: number
 }
 
 export type AssistantDelivery = 'visible' | 'suppressed'

--- a/opensquilla-webui/src/utils/chat/historyModelCallSegments.test.ts
+++ b/opensquilla-webui/src/utils/chat/historyModelCallSegments.test.ts
@@ -46,6 +46,11 @@ describe('interleaveHistoryModelCallSegments', () => {
         turnId: 'turn-1',
         restoredFromHistory: true,
         usage: {
+          routed_tier: 'c1',
+          routed_model: 'provider/initial',
+          routing_source: 'squilla_router',
+          router_model_call_id: '1.0',
+          router_iteration: 1,
           model_call_segments: [{
             model_call_id: '2.0',
             iteration: 2,
@@ -66,6 +71,13 @@ describe('interleaveHistoryModelCallSegments', () => {
     ])
     expect(result[1]?.messageId).toBeUndefined()
     expect(result[1]?.clientId).toContain('history-model-call-segment:')
+    expect(result[1]?.usage).toBeUndefined()
+    expect(result[1]?.routerUsage).toMatchObject({
+      routed_tier: 'c1',
+      router_model_call_id: '1.0',
+    })
+    expect(result[1]?.routerModelCallId).toBe('1.0')
+    expect(result[1]?.routerIteration).toBe(1)
     expect(result[3]?.messageId).toBe('assistant-1')
     expect(result[3]?.usage?.model_call_segments).toHaveLength(1)
   })

--- a/opensquilla-webui/src/utils/chat/historyModelCallSegments.ts
+++ b/opensquilla-webui/src/utils/chat/historyModelCallSegments.ts
@@ -88,7 +88,15 @@ function syntheticAssistantSegment(
   source: ChatMessage,
   text: string,
   segmentKey: string,
+  projectRouter = false,
 ): ChatMessage {
+  const routerUsage = projectRouter ? source.usage || source.turn_usage : undefined
+  const routerModelCallId = String(
+    routerUsage?.router_model_call_id || routerUsage?.routerModelCallId || '',
+  ).trim()
+  const routerIteration = Number(
+    routerUsage?.router_iteration || routerUsage?.routerIteration || 0,
+  ) || 0
   return {
     role: 'assistant',
     text,
@@ -96,6 +104,9 @@ function syntheticAssistantSegment(
     clientId: `history-model-call-segment:${source.messageId || source.clientId || 'assistant'}:${segmentKey}`,
     turnId: source.turnId,
     restoredFromHistory: true,
+    ...(routerUsage ? { routerUsage } : {}),
+    ...(routerModelCallId ? { routerModelCallId } : {}),
+    ...(routerIteration ? { routerIteration } : {}),
   }
 }
 
@@ -153,6 +164,7 @@ function interleaveAssistantAt(
         assistant,
         codepoints.slice(0, firstStart).join(''),
         `prefix-${firstStart}`,
+        true,
       ),
     )
   }

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -1748,6 +1748,7 @@ const {
   markEnsembleHandoff,
   flushPendingRouterDecision,
   clearPendingRouterDecision,
+  bindRouterDecisionToModelCall,
 } = chatRouterDecisionRuntime
 
 // Gate the live answer's reveal to a [MIN,MAX] window so the model-router panel
@@ -3052,6 +3053,7 @@ const rpcEventHandlers = useChatRpcEventHandlers({
   sessionRunStatus,
   applySessionRunState,
   queueRouterDecision,
+  bindRouterDecisionToModelCall,
   appendEnsembleProgress,
   markEnsembleHandoff,
   flushPendingRouterDecision,

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -6921,6 +6921,8 @@ class Agent:
         terminal_generation_reset_event: AnswerGenerationResetEvent | None = None
         final_text_parts: list[str] = []
         applied_model_call_boundaries: list[dict[str, Any]] = []
+        router_model_call_id = ""
+        router_iteration = 0
         final_reasoning_parts: list[str] = []
         artifact_delivery_final_response_pending = False
         artifact_delivery_degraded_final_response = False
@@ -8860,6 +8862,9 @@ class Agent:
                                 )
 
                             elif isinstance(raw_ev, ProviderTextDelta):
+                                if raw_ev.text and not router_model_call_id:
+                                    router_model_call_id = call_id
+                                    router_iteration = iterations
                                 if raw_ev.text:
                                     reasoning_end = _finish_reasoning_block("completed")
                                     if reasoning_end is not None:
@@ -8875,6 +8880,8 @@ class Agent:
                                         text=raw_ev.text,
                                         presentation="intermediate",
                                         generation_epoch=generation_epoch,
+                                        model_call_id=call_id,
+                                        iteration=iterations,
                                     )
                                 else:
                                     # No tool has appeared yet. Stream the text live,
@@ -8891,6 +8898,8 @@ class Agent:
                                         text=raw_ev.text,
                                         presentation="answer",
                                         generation_epoch=generation_epoch,
+                                        model_call_id=call_id,
+                                        iteration=iterations,
                                     )
 
                             elif isinstance(raw_ev, ProviderReasoningDelta):
@@ -8900,6 +8909,9 @@ class Agent:
                                 # still arrives via DoneEvent.reasoning_content.
                                 if not raw_ev.text:
                                     continue
+                                if not router_model_call_id:
+                                    router_model_call_id = call_id
+                                    router_iteration = iterations
                                 if not reasoning_block_id:
                                     reasoning_started_at_ms = time.time_ns() // 1_000_000
                                     active_reasoning_block_index = reasoning_block_index
@@ -8947,6 +8959,8 @@ class Agent:
                                     block_id=reasoning_block_id,
                                     block_index=active_reasoning_block_index,
                                     generation_epoch=generation_epoch,
+                                    model_call_id=call_id,
+                                    iteration=iterations,
                                 )
                                 if (
                                     wrapup_margin_seconds > 0
@@ -15483,6 +15497,8 @@ class Agent:
                 missing_cost_entries=missing_cost_entries,
                 model_call_segments=model_call_segments,
                 generation_epoch=generation_epoch,
+                router_model_call_id=router_model_call_id,
+                router_iteration=router_iteration,
             )
             yield done_event
         # Reset for next turn

--- a/src/opensquilla/engine/turn_runner/turn_finalizer_stage.py
+++ b/src/opensquilla/engine/turn_runner/turn_finalizer_stage.py
@@ -281,6 +281,10 @@ def _turn_usage_payload(
             done_event,
             persisted_text=persisted_text,
         ),
+        "router_model_call_id": str(
+            getattr(done_event, "router_model_call_id", "") or ""
+        ),
+        "router_iteration": int(getattr(done_event, "router_iteration", 0) or 0),
     }
     optional_fields = {
         "provider": getattr(done_event, "provider", None),

--- a/src/opensquilla/engine/types.py
+++ b/src/opensquilla/engine/types.py
@@ -87,6 +87,10 @@ class ThinkingEvent:
     block_id: str = ""
     block_index: int = -1
     generation_epoch: int = 0
+    # Physical provider-call identity for stable presentation ownership.
+    # Additive defaults preserve legacy producers and positional construction.
+    model_call_id: str = ""
+    iteration: int = 0
 
 
 @dataclass
@@ -110,6 +114,10 @@ class TextDeltaEvent:
     # producer that does not set it keeps the pre-existing card behavior.
     presentation: Literal["intermediate", "answer"] = "answer"
     generation_epoch: int = 0
+    # Physical provider-call identity for stable presentation ownership.
+    # Additive defaults preserve legacy producers and positional construction.
+    model_call_id: str = ""
+    iteration: int = 0
 
 
 @dataclass
@@ -366,6 +374,10 @@ class DoneEvent:
     delivery: Literal["visible", "suppressed"] = "visible"
     suppression_reason: Literal["no_reply", "heartbeat_ack"] | None = None
     generation_epoch: int = 0
+    # First physical provider call that emitted visible output for the route
+    # plan. Clients use this to keep its route card on the same answer segment.
+    router_model_call_id: str = ""
+    router_iteration: int = 0
 
     @property
     def upstream_cost_usd(self) -> float:

--- a/src/opensquilla/gateway/channel_dispatch.py
+++ b/src/opensquilla/gateway/channel_dispatch.py
@@ -21,7 +21,7 @@ import re
 import time
 import uuid
 from collections.abc import AsyncIterator, Callable
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -2622,6 +2622,14 @@ def _text_delta_from_event(event: Any) -> str:
     return ""
 
 
+def _text_delta_event_payload(event: TextDeltaEvent) -> dict[str, Any]:
+    """Serialize a channel-origin text delta through the full public contract."""
+
+    payload = asdict(event)
+    payload.pop("kind", None)
+    return payload
+
+
 def _generation_reset_snapshot(event: Any) -> tuple[bool, str] | None:
     """Return the public reset terminal flag and authoritative replacement."""
 
@@ -4122,10 +4130,7 @@ async def _run_turn_batch_path(
                     await event_bridge.emit(
                         session_key,
                         "session.event.text_delta",
-                        {
-                            "text": event.text,
-                            "presentation": getattr(event, "presentation", "answer"),
-                        },
+                        _text_delta_event_payload(event),
                     )
             elif isinstance(event, DoneEvent):
                 snapshot_present, snapshot_text = done_text_snapshot(event)
@@ -4360,10 +4365,7 @@ async def _run_turn_streaming_path(
                     await event_bridge.emit(
                         session_key,
                         "session.event.text_delta",
-                        {
-                            "text": event.text,
-                            "presentation": getattr(event, "presentation", "answer"),
-                        },
+                        _text_delta_event_payload(event),
                     )
             elif isinstance(event, DoneEvent):
                 snapshot_present, snapshot_text = done_text_snapshot(event)

--- a/tests/test_engine/test_agent_invalid_provider_response.py
+++ b/tests/test_engine/test_agent_invalid_provider_response.py
@@ -196,6 +196,11 @@ async def test_reasoning_only_first_turn_retries_without_disabling_thinking() ->
     assert "thinking disabled" not in warning.message
     done = next(event for event in events if event.kind == "done")
     assert done.text == "ok"
+    # Terminal-only reasoning is classified before it crosses the public
+    # presentation boundary, so the discarded attempt must not own the route
+    # card. The first retained visible output comes from the retry.
+    assert done.router_model_call_id == "1.1"
+    assert done.router_iteration == 1
     assert done.input_tokens == 21
     assert done.output_tokens == 6
     assert done.reasoning_tokens == 5
@@ -1740,6 +1745,8 @@ async def test_discarded_empty_attempt_counts_usage_but_skips_cache_check(
     done = next(event for event in events if event.kind == "done")
     assert done.input_tokens == 7
     assert done.output_tokens == 1
+    assert done.router_model_call_id == "1.1"
+    assert done.router_iteration == 1
     tracked = usage.get("agent:test:empty-retry")
     assert tracked is not None
     assert tracked.input_tokens == 7

--- a/tests/test_engine/test_agent_mid_turn_injection.py
+++ b/tests/test_engine/test_agent_mid_turn_injection.py
@@ -513,8 +513,14 @@ async def test_done_event_records_unicode_model_call_segment_for_applied_steer()
         event async for event in agent.run_turn("原始问题", pending_input_provider=pending)
     ]
     done = next(event for event in events if event.kind == "done")
+    text_events = [event for event in events if event.kind == "text_delta"]
 
     assert done.text == "前😀后续"
+    assert done.router_model_call_id == "1.0"
+    assert done.router_iteration == 1
+    assert [
+        (event.text, event.model_call_id, event.iteration) for event in text_events
+    ] == [("前😀", "1.0", 1), ("后续", "2.0", 2)]
     assert done.model_call_segments == [
         {
             "model_call_id": "2.0",

--- a/tests/test_engine/turn_runner/test_turn_finalizer_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_turn_finalizer_stage_unit.py
@@ -368,6 +368,8 @@ async def test_simple_text_with_done_event_fires_rollup() -> None:
         routed_tier="c2",
         routing_applied=False,
         rollout_phase="observe",
+        router_model_call_id="1.0",
+        router_iteration=1,
         model_call_segments=[
             {
                 "model_call_id": "2.0",
@@ -392,6 +394,8 @@ async def test_simple_text_with_done_event_fires_rollup() -> None:
     assert recs["transcript_append"].calls[0]["turn_usage"]["routed_tier"] == "c2"
     assert recs["transcript_append"].calls[0]["turn_usage"]["routing_applied"] is False
     assert recs["transcript_append"].calls[0]["turn_usage"]["rollout_phase"] == "observe"
+    assert recs["transcript_append"].calls[0]["turn_usage"]["router_model_call_id"] == "1.0"
+    assert recs["transcript_append"].calls[0]["turn_usage"]["router_iteration"] == 1
     assert recs["transcript_append"].calls[0]["turn_usage"]["model_call_segments"] == [
         {
             "model_call_id": "2.0",

--- a/tests/test_gateway/test_channel_dispatch_realtime.py
+++ b/tests/test_gateway/test_channel_dispatch_realtime.py
@@ -1004,7 +1004,12 @@ def test_direct_channel_batch_turn_emits_tool_events_to_webui() -> None:
                 result="outline done",
                 arguments={"kind": "llm_chat", "output_chars": 12},
             )
-            yield TextDeltaEvent(text="ok")
+            yield TextDeltaEvent(
+                text="ok",
+                generation_epoch=4,
+                model_call_id="3.0",
+                iteration=3,
+            )
             yield DoneEvent()
 
     channel = _FakeChannel()
@@ -1044,6 +1049,17 @@ def test_direct_channel_batch_turn_emits_tool_events_to_webui() -> None:
         and payload["arguments"]["kind"] == "llm_chat"
         for _, event_name, payload in bridge.events
     )
+    assert (
+        "agent:main:channel-test",
+        "session.event.text_delta",
+        {
+            "text": "ok",
+            "presentation": "answer",
+            "generation_epoch": 4,
+            "model_call_id": "3.0",
+            "iteration": 3,
+        },
+    ) in bridge.events
     assert channel.sent[-1].content == "ok"
 
 
@@ -2209,7 +2225,12 @@ def test_direct_streaming_path_emits_tool_events_to_webui() -> None:
                 tool_name="meta-step:section_introduction",
                 result="section done",
             )
-            yield TextDeltaEvent(text="finished")
+            yield TextDeltaEvent(
+                text="finished",
+                generation_epoch=3,
+                model_call_id="2.1",
+                iteration=2,
+            )
             yield DoneEvent()
 
     channel = StreamingChannel()
@@ -2245,6 +2266,17 @@ def test_direct_streaming_path_emits_tool_events_to_webui() -> None:
         and payload["result"] == "section done"
         for _, event_name, payload in bridge.events
     )
+    assert (
+        "agent:main:stream-tool-events",
+        "session.event.text_delta",
+        {
+            "text": "finished",
+            "presentation": "answer",
+            "generation_epoch": 3,
+            "model_call_id": "2.1",
+            "iteration": 2,
+        },
+    ) in bridge.events
     assert channel.sent[-1].content == "finished"
 
 

--- a/tests/test_gateway/test_emit_stream_task_id.py
+++ b/tests/test_gateway/test_emit_stream_task_id.py
@@ -73,7 +73,11 @@ async def test_emit_stamps_task_id_on_every_stream_event() -> None:
 
     async def _stream():
         yield ToolUseStartEvent(tool_use_id="t1", tool_name="create_pdf.py")
-        yield TextDeltaEvent(text="partial output")
+        yield TextDeltaEvent(
+            text="partial output",
+            model_call_id="1.2",
+            iteration=1,
+        )
 
     async def _emitter(session_key: str, event_name: str, payload: dict[str, Any]) -> None:
         emitted.append((session_key, event_name, payload))
@@ -92,6 +96,8 @@ async def test_emit_stamps_task_id_on_every_stream_event() -> None:
         "session.event.text_delta",
     ]
     assert all(payload.get("task_id") == "task-A" for _, _, payload in emitted)
+    assert emitted[-1][2]["model_call_id"] == "1.2"
+    assert emitted[-1][2]["iteration"] == 1
 
 
 @pytest.mark.asyncio
@@ -99,7 +105,12 @@ async def test_emit_preserves_thinking_start_time() -> None:
     emitted: list[tuple[str, str, dict[str, Any]]] = []
 
     async def _stream():
-        yield ThinkingEvent(text="checking", started_at=1_234_567)
+        yield ThinkingEvent(
+            text="checking",
+            started_at=1_234_567,
+            model_call_id="2.0",
+            iteration=2,
+        )
 
     async def _emitter(session_key: str, event_name: str, payload: dict[str, Any]) -> None:
         emitted.append((session_key, event_name, payload))
@@ -116,7 +127,13 @@ async def test_emit_preserves_thinking_start_time() -> None:
         (
             SESSION,
             "session.event.thinking",
-            {"text": "checking", "started_at": 1_234_567, "generation_epoch": 0},
+            {
+                "text": "checking",
+                "started_at": 1_234_567,
+                "generation_epoch": 0,
+                "model_call_id": "2.0",
+                "iteration": 2,
+            },
         )
     ]
 
@@ -131,6 +148,8 @@ async def test_emit_preserves_typed_silent_reply_done_contract() -> None:
             text_snapshot="",
             delivery="suppressed",
             suppression_reason="no_reply",
+            router_model_call_id="3.0",
+            router_iteration=3,
         )
 
     async def _emitter(session_key: str, event_name: str, payload: dict[str, Any]) -> None:
@@ -151,6 +170,8 @@ async def test_emit_preserves_typed_silent_reply_done_contract() -> None:
     assert payload["text_snapshot"] == ""
     assert payload["delivery"] == "suppressed"
     assert payload["suppression_reason"] == "no_reply"
+    assert payload["router_model_call_id"] == "3.0"
+    assert payload["router_iteration"] == 3
     assert payload["input_mode"] == "system_event"
     assert payload["run_kind"] == "goal"
 

--- a/tests/test_gateway/test_rpc_chat_history.py
+++ b/tests/test_gateway/test_rpc_chat_history.py
@@ -1986,6 +1986,8 @@ async def test_chat_history_exposes_persisted_turn_usage() -> None:
             "routed_tier": "economy",
             "routing_source": "squilla_router",
             "total_savings_pct": 42.0,
+            "router_model_call_id": "1.0",
+            "router_iteration": 1,
         },
     )
 
@@ -2002,6 +2004,8 @@ async def test_chat_history_exposes_persisted_turn_usage() -> None:
     assert msg["usage"]["input_tokens"] == 11
     assert msg["usage"]["output_tokens"] == 5
     assert msg["usage"]["cost_usd"] == 0.0123
+    assert msg["usage"]["router_model_call_id"] == "1.0"
+    assert msg["usage"]["router_iteration"] == 1
     assert msg["model"] == "openai/gpt-test"
     assert msg["input"] == 11
     assert msg["output"] == 5

--- a/tests/test_gateway/test_session_streams.py
+++ b/tests/test_gateway/test_session_streams.py
@@ -175,12 +175,22 @@ def test_live_turn_snapshot_compacts_high_frequency_deltas_without_losing_state(
     registry.record(
         session_key,
         "session.event.thinking",
-        {"task_id": task_id, "text": "Plan"},
+        {
+            "task_id": task_id,
+            "text": "Plan",
+            "model_call_id": "1.0",
+            "iteration": 1,
+        },
     )
     registry.record(
         session_key,
         "session.event.thinking",
-        {"task_id": task_id, "text": "ning"},
+        {
+            "task_id": task_id,
+            "text": "ning",
+            "model_call_id": "1.0",
+            "iteration": 1,
+        },
     )
     registry.record(
         session_key,
@@ -210,12 +220,22 @@ def test_live_turn_snapshot_compacts_high_frequency_deltas_without_losing_state(
     registry.record(
         session_key,
         "session.event.text_delta",
-        {"task_id": task_id, "text": "Hello"},
+        {
+            "task_id": task_id,
+            "text": "Hello",
+            "model_call_id": "2.0",
+            "iteration": 2,
+        },
     )
     registry.record(
         session_key,
         "session.event.text_delta",
-        {"task_id": task_id, "text": " world"},
+        {
+            "task_id": task_id,
+            "text": " world",
+            "model_call_id": "2.0",
+            "iteration": 2,
+        },
     )
 
     replay = registry.replay(session_key, 0)
@@ -235,8 +255,12 @@ def test_live_turn_snapshot_compacts_high_frequency_deltas_without_losing_state(
         "session.event.text_delta",
     ]
     assert snapshot.events[1].payload["text"] == "Planning"
+    assert snapshot.events[1].payload["model_call_id"] == "1.0"
+    assert snapshot.events[1].payload["iteration"] == 1
     assert snapshot.events[3].payload["json_fragment"] == '{"cmd":"pwd"}'
     assert snapshot.events[5].payload["text"] == "Hello world"
+    assert snapshot.events[5].payload["model_call_id"] == "2.0"
+    assert snapshot.events[5].payload["iteration"] == 2
 
 
 def test_live_turn_snapshot_compacts_thinking_per_block_and_preserves_boundaries() -> None:


### PR DESCRIPTION
## Scope

Scope boundary: Preserve every emitted model-router card across same-turn steering, streaming, retries, terminal reconciliation, history refresh, snapshots, and session re-entry by binding it to the physical provider call that owns the visible answer segment.

Non-goals: No router policy, model selection, activity timeline, skills, environment, or image capability changes.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Reported directly with a precise reproduction: submit guidance while the first answer segment is streaming.

## Release Note

Release note: Fixed model routing cards disappearing or moving when steering an in-progress response.

## Tests

Ruff: Passed on all changed Python files.

Pytest: 259 relevant engine and gateway tests passed.

Build: WebUI production build, vue-tsc, and all architecture/security/theme/i18n guards passed.

Regression tests: added

Notes: All 4,104 WebUI unit tests passed. Independent backend, frontend, and final-scope subagent reviews approved the final diff. In-app browser E2E was attempted, but the existing error tab was blocked from local navigation by the browser URL policy; no browser result is claimed.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: browser

Maintainer-only note: The deterministic regression suite covers live-to-bound-to-settled-to-history identity, same-turn multi-card retention, generation retry, snapshot compaction, and persisted history.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents are not committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.