### PR TITLE
Preserve live steer boundaries across reconnects

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
@@ -45,6 +45,8 @@ function createHarness(options: {
     streamHasVisibleOutput: ref(false),
     startStreaming: vi.fn(),
     endStreaming: vi.fn(() => options.endStreaming?.(messages.value)),
+    checkpointForUserMessage: vi.fn(),
+    acknowledgeSteerBoundary: vi.fn(),
     appendDelta: vi.fn(),
     scheduleRender: vi.fn(),
     appendToolCall: vi.fn(),
@@ -469,6 +471,208 @@ describe('useChatRpcEventHandlers live snapshot restoration', () => {
       expect(stream.appendDelta).toHaveBeenCalledWith('Recovered answer', 'answer')
       expect(activeStreamTaskId.value).toBe('task-live')
       expect(lastStreamSeq.value).toBe(2400)
+    } finally {
+      stop()
+    }
+  })
+
+  it('rebuilds an applied steer boundary in snapshot stream order', () => {
+    const { api, stream, stop } = createHarness({
+      messages: [{
+        role: 'user',
+        text: 'Use English',
+        ts: 2,
+        messageId: 'steer-message-1',
+        turnId: 'turn-live',
+        inputDisposition: 'steering',
+      }],
+    })
+    try {
+      api.restoreLiveTurnSnapshot({
+        key: 'agent:main:test',
+        task_id: 'task-live',
+        current_stream_seq: 12,
+        events: [
+          {
+            event: 'session.event.text_delta',
+            payload: {
+              session_key: 'agent:main:test',
+              task_id: 'task-live',
+              text: 'Second answer',
+              stream_seq: 12,
+            },
+          },
+          {
+            event: 'session.event.input_disposition',
+            payload: {
+              session_key: 'agent:main:test',
+              task_id: 'task-live',
+              turn_id: 'task-live',
+              user_message_id: 'steer-message-1',
+              intent: 'steer',
+              disposition: 'applied',
+              stream_seq: 11,
+            },
+          },
+          {
+            event: 'session.event.text_delta',
+            payload: {
+              session_key: 'agent:main:test',
+              task_id: 'task-live',
+              text: 'First answer',
+              stream_seq: 10,
+            },
+          },
+        ],
+      })
+
+      expect(stream.checkpointForUserMessage).toHaveBeenCalledWith(
+        'task-live',
+        'steer-message-1',
+      )
+      expect(stream.acknowledgeSteerBoundary).toHaveBeenCalledWith(
+        'steer-message-1',
+        '',
+        0,
+      )
+      expect(vi.mocked(stream.checkpointForUserMessage!).mock.invocationCallOrder[0])
+        .toBeLessThan(
+          vi.mocked(stream.acknowledgeSteerBoundary!).mock.invocationCallOrder[0]!,
+        )
+      expect(vi.mocked(stream.appendDelta).mock.calls.map(call => call[0])).toEqual([
+        'First answer',
+        'Second answer',
+      ])
+    } finally {
+      stop()
+    }
+  })
+
+  it('checkpoints an applied snapshot boundary before its history row exists', () => {
+    const { api, messages, stream, stop } = createHarness()
+    try {
+      api.restoreLiveTurnSnapshot({
+        key: 'agent:main:test',
+        task_id: 'task-live',
+        current_stream_seq: 12,
+        events: [
+          {
+            event: 'session.event.text_delta',
+            payload: {
+              session_key: 'agent:main:test',
+              task_id: 'task-live',
+              text: 'First answer',
+              stream_seq: 10,
+            },
+          },
+          {
+            event: 'session.event.input_disposition',
+            payload: {
+              session_key: 'agent:main:test',
+              task_id: 'task-live',
+              turn_id: 'task-live',
+              user_message_id: 'steer-message-orphan',
+              intent: 'steer',
+              disposition: 'applied',
+              stream_seq: 11,
+            },
+          },
+          {
+            event: 'session.event.text_delta',
+            payload: {
+              session_key: 'agent:main:test',
+              task_id: 'task-live',
+              text: 'Second answer',
+              stream_seq: 12,
+            },
+          },
+        ],
+      })
+
+      expect(messages.value).toEqual([])
+      expect(stream.checkpointForUserMessage).toHaveBeenCalledWith(
+        'task-live',
+        'steer-message-orphan',
+      )
+      expect(stream.acknowledgeSteerBoundary).toHaveBeenCalledWith(
+        'steer-message-orphan',
+        '',
+        0,
+      )
+      const textOrders = vi.mocked(stream.appendDelta).mock.invocationCallOrder
+      const checkpointOrders = vi.mocked(stream.checkpointForUserMessage!).mock.invocationCallOrder
+      const acknowledgeOrders = vi.mocked(stream.acknowledgeSteerBoundary!).mock.invocationCallOrder
+      expect(textOrders[0]).toBeLessThan(checkpointOrders[0]!)
+      expect(checkpointOrders[0]).toBeLessThan(acknowledgeOrders[0]!)
+      expect(acknowledgeOrders[0]).toBeLessThan(textOrders[1]!)
+
+      messages.value = [{
+        role: 'user',
+        text: 'Use English',
+        ts: 2,
+        messageId: 'steer-message-orphan',
+        turnId: 'task-live',
+        inputDisposition: 'applied',
+      }]
+      expect(stream.checkpointForUserMessage).toHaveBeenCalledTimes(2)
+      expect(stream.acknowledgeSteerBoundary).toHaveBeenCalledTimes(2)
+    } finally {
+      stop()
+    }
+  })
+
+  it('rebuilds the boundary when a legacy applied snapshot omits revision and call id', () => {
+    const { api, messages, stream, stop } = createHarness({
+      messages: [{
+        role: 'user',
+        text: 'Use English',
+        ts: 2,
+        messageId: 'steer-message-1',
+        turnId: 'turn-live',
+        inputDisposition: 'applied',
+        inputDispositionRevision: 3,
+      }],
+    })
+    try {
+      api.restoreLiveTurnSnapshot({
+        key: 'agent:main:test',
+        task_id: 'task-live',
+        current_stream_seq: 2,
+        events: [
+          {
+            event: 'session.event.text_delta',
+            payload: {
+              session_key: 'agent:main:test',
+              task_id: 'task-live',
+              text: 'First answer',
+              stream_seq: 1,
+            },
+          },
+          {
+            event: 'session.event.input_disposition',
+            payload: {
+              session_key: 'agent:main:test',
+              task_id: 'task-live',
+              turn_id: 'turn-live',
+              user_message_id: 'steer-message-1',
+              intent: 'steer',
+              disposition: 'applied',
+              stream_seq: 2,
+            },
+          },
+        ],
+      })
+
+      expect(stream.checkpointForUserMessage).toHaveBeenCalledWith(
+        'turn-live',
+        'steer-message-1',
+      )
+      expect(stream.acknowledgeSteerBoundary).toHaveBeenCalledWith(
+        'steer-message-1',
+        '',
+        0,
+      )
+      expect(messages.value[0]?.inputDispositionRevision).toBe(3)
     } finally {
       stop()
     }
@@ -1472,6 +1676,20 @@ describe('useChatRpcEventHandlers done usage attachment', () => {
         usage: { text: '' },
       })
       expect(stream.reconcileFinalText).toHaveBeenLastCalledWith('outer legacy canonical')
+
+      const segments = [{
+        model_call_id: '2.0',
+        iteration: 2,
+        start_codepoint: 3,
+        end_codepoint: 6,
+      }]
+      api.handlers.onAny('session.event.done', {
+        session_key: 'agent:main:test',
+        stream_seq: 7,
+        text_snapshot: '前半段后半段',
+        model_call_segments: segments,
+      })
+      expect(stream.reconcileFinalText).toHaveBeenLastCalledWith('前半段后半段', segments)
     } finally {
       stop()
     }

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
@@ -1,6 +1,7 @@
 import { computed, onScopeDispose, ref, watch, type Ref } from 'vue'
 import type {
   ChatMessage,
+  ChatModelCallSegment,
   ChatPendingItem,
   ChatRunStatus,
   ChatRunStatusSource,
@@ -78,7 +79,12 @@ export interface ChatRpcStreamApi {
   streamHasVisibleOutput: Ref<boolean>
   startStreaming: () => void
   endStreaming: (opts?: { reason?: string, suppressed?: boolean }) => void
-  checkpointForUserMessage?: (turnId: string) => void
+  checkpointForUserMessage?: (turnId: string, boundaryKey?: string) => void
+  acknowledgeSteerBoundary?: (
+    boundaryKey: string,
+    modelCallId?: string,
+    iteration?: number,
+  ) => void
   appendDelta: (text: string, presentation?: 'intermediate' | 'answer') => void
   scheduleRender: () => void
   appendToolCall: (payload: ToolUsePayload) => void
@@ -86,7 +92,10 @@ export interface ChatRpcStreamApi {
   appendToolEnd?: (payload: ToolEndPayload) => void
   appendToolResult: (payload: ToolResultPayload) => void
   appendArtifact: (payload: ArtifactPayload) => void
-  reconcileFinalText: (finalText: string | null | undefined) => void
+  reconcileFinalText: (
+    finalText: string | null | undefined,
+    modelCallSegments?: ChatModelCallSegment[] | null,
+  ) => void
   resetLiveTurnState?: () => void
   resetAnswerGeneration?: (options?: {
     textSnapshot?: string
@@ -181,6 +190,8 @@ type ChatDoneUsageFields = {
   usageUnknown?: boolean
   unknown_usage_events?: number
   unknownUsageEvents?: number
+  model_call_segments?: ChatModelCallSegment[]
+  modelCallSegments?: ChatModelCallSegment[]
   decision_id?: string
 }
 
@@ -384,9 +395,12 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
     stream,
   } = options
   const steerDelivery = options.steerDelivery || useChatSteerDelivery({
+    sessionKey,
+    activeTurnId: activeStreamTaskId,
     messages,
     pendingQueue,
     checkpointForUserMessage: stream.checkpointForUserMessage,
+    acknowledgeSteerBoundary: stream.acknowledgeSteerBoundary,
     scheduleHistorySync: options.scheduleHistorySync,
     restoreSteerIntoComposer: options.restoreSteerIntoComposer,
   })
@@ -735,6 +749,8 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
       handleRpcEnsembleProgress(payload as EnsembleProgressPayload)
     } else if (event === 'session.event.router_control_replay') {
       handleRpcRouterControlReplay(payload)
+    } else if (event === 'session.event.input_disposition') {
+      handleRpcInputDisposition(payload as InputDispositionPayload)
     } else if (event === 'session.event.compaction') {
       // A live snapshot is the authoritative base for the active stream, not
       // historical replay. Compaction deliberately ignores replayed
@@ -756,6 +772,7 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
   function restoreLiveTurnSnapshot(snapshot: SessionMessagesSnapshotResponse) {
     if (!snapshot || snapshot.key !== sessionKey.value) return
 
+    steerDelivery.resetTransientBoundaries()
     stream.resetLiveTurnState?.()
     clearLiveThinking()
     clearGenerationTracking()
@@ -768,9 +785,20 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
       ? snapshot.task_id
       : ''
 
-    for (const entry of snapshot.events || []) {
-      if (!entry || typeof entry.event !== 'string') continue
-      const payload = { ...(entry.payload || {}) }
+    const replayEntries: BufferedPendingReplayEntry[] = (snapshot.events || [])
+      .flatMap((entry, order): BufferedPendingReplayEntry[] => {
+        if (!entry || typeof entry.event !== 'string') return []
+        return [{
+          kind: 'stream',
+          event: entry.event,
+          payload: { ...(entry.payload || {}) },
+          order,
+        }]
+      })
+      .sort(comparePendingReplayEntries)
+    for (const entry of replayEntries) {
+      if (entry.kind !== 'stream') continue
+      const payload = { ...entry.payload }
       // Snapshot events retain their original sequence for diagnostics, but
       // they form an authoritative base rather than fresh deltas. Replaying
       // them through the normal render handlers without the old sequence
@@ -2064,7 +2092,19 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
       if (u.model) usageModel.value = u.model
       options.saveWidgetState()
 
-      stream.reconcileFinalText(doneSuppressed ? '' : doneTextSnapshot(donePayload, u))
+      const rawModelCallSegments = u.model_call_segments
+        ?? u.modelCallSegments
+        ?? donePayload.model_call_segments
+        ?? donePayload.modelCallSegments
+      const terminalText = doneSuppressed ? '' : doneTextSnapshot(donePayload, u)
+      if (Array.isArray(rawModelCallSegments)) {
+        stream.reconcileFinalText(
+          terminalText,
+          rawModelCallSegments as ChatModelCallSegment[],
+        )
+      } else {
+        stream.reconcileFinalText(terminalText)
+      }
 
       if (payload?.reason === 'aborted') {
         options.clearPendingRouterDecision()

--- a/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
@@ -1811,7 +1811,10 @@ describe('useChatSend attachment payloads', () => {
     })
     expect(rpc.call).not.toHaveBeenCalledWith('chat.send', expect.anything())
     expect(rpc.call).not.toHaveBeenCalledWith('chat.abort', expect.anything())
-    expect(stream.checkpointForUserMessage).toHaveBeenCalledWith('turn-current')
+    expect(stream.checkpointForUserMessage).toHaveBeenCalledWith(
+      'turn-current',
+      expect.any(String),
+    )
     expect(options.messages.value).toContainEqual(expect.objectContaining({
       role: 'user',
       text: 'hello',

--- a/opensquilla-webui/src/composables/chat/useChatSteerDelivery.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSteerDelivery.test.ts
@@ -16,17 +16,23 @@ const REQUEST: SessionSteerV2Params = {
 }
 
 function createHarness() {
+  const sessionKey = ref('agent:main:webchat:test')
+  const activeTurnId = ref('')
   const messages = ref<ChatMessage[]>([])
   const pendingQueue = ref<ChatPendingItem[]>([])
   const checkpointForUserMessage = vi.fn()
+  const acknowledgeSteerBoundary = vi.fn()
   const scheduleHistorySync = vi.fn()
   const restoreSteerIntoComposer = vi.fn()
   const onProjected = vi.fn()
   const scope = effectScope()
   const api = scope.run(() => useChatSteerDelivery({
+    sessionKey,
+    activeTurnId,
     messages,
     pendingQueue,
     checkpointForUserMessage,
+    acknowledgeSteerBoundary,
     scheduleHistorySync,
     restoreSteerIntoComposer,
     onProjected,
@@ -47,9 +53,12 @@ function createHarness() {
 
   return {
     api,
+    sessionKey,
+    activeTurnId,
     messages,
     pendingQueue,
     checkpointForUserMessage,
+    acknowledgeSteerBoundary,
     scheduleHistorySync,
     restoreSteerIntoComposer,
     onProjected,
@@ -101,7 +110,10 @@ describe('useChatSteerDelivery', () => {
 
       expect(projection.created).toBe(true)
       expect(harness.checkpointForUserMessage).toHaveBeenCalledOnce()
-      expect(harness.checkpointForUserMessage).toHaveBeenCalledWith('turn-current')
+      expect(harness.checkpointForUserMessage).toHaveBeenCalledWith(
+        'turn-current',
+        'client-steer',
+      )
       expect(harness.pendingQueue.value).toEqual([])
       expect(harness.messages.value).toMatchObject([{
         role: 'user',
@@ -189,6 +201,11 @@ describe('useChatSteerDelivery', () => {
         steerAppliedIteration: 1,
       })
       expect(harness.checkpointForUserMessage).toHaveBeenCalledOnce()
+      expect(harness.acknowledgeSteerBoundary).toHaveBeenCalledWith(
+        'client-steer',
+        '',
+        1,
+      )
     } finally {
       harness.stop()
     }
@@ -224,7 +241,7 @@ describe('useChatSteerDelivery', () => {
     }
   })
 
-  it('reconciles a history-restored durable row and checkpoints the attempt only once', () => {
+  it('reconciles a history-restored durable row and checkpoints the attempt', () => {
     const harness = createHarness()
     try {
       harness.addPending()
@@ -244,7 +261,15 @@ describe('useChatSteerDelivery', () => {
 
       expect(harness.pendingQueue.value).toEqual([])
       expect(harness.checkpointForUserMessage).toHaveBeenCalledOnce()
-      expect(harness.checkpointForUserMessage).toHaveBeenCalledWith('turn-current')
+      expect(harness.checkpointForUserMessage).toHaveBeenCalledWith(
+        'turn-current',
+        'client-steer',
+      )
+      expect(harness.acknowledgeSteerBoundary).toHaveBeenCalledWith(
+        'client-steer',
+        '',
+        0,
+      )
     } finally {
       harness.stop()
     }
@@ -269,7 +294,10 @@ describe('useChatSteerDelivery', () => {
       expect(harness.pendingQueue.value).toEqual([])
       expect(harness.messages.value).toHaveLength(1)
       expect(harness.checkpointForUserMessage).toHaveBeenCalledOnce()
-      expect(harness.checkpointForUserMessage).toHaveBeenCalledWith('turn-current')
+      expect(harness.checkpointForUserMessage).toHaveBeenCalledWith(
+        'turn-current',
+        'client-steer',
+      )
     } finally {
       harness.stop()
     }
@@ -288,6 +316,134 @@ describe('useChatSteerDelivery', () => {
 
       expect(harness.messages.value).toEqual([])
       expect(harness.scheduleHistorySync).toHaveBeenCalledOnce()
+    } finally {
+      harness.stop()
+    }
+  })
+
+  it('checkpoints an orphan applied boundary before history hydration and repositions it later', () => {
+    const harness = createHarness()
+    try {
+      harness.api.disposition({
+        userMessageId: 'user-orphan',
+        disposition: 'applied',
+        turnId: 'turn-orphan',
+      })
+
+      expect(harness.messages.value).toEqual([])
+      expect(harness.checkpointForUserMessage).toHaveBeenCalledWith(
+        'turn-orphan',
+        'user-orphan',
+      )
+      expect(harness.acknowledgeSteerBoundary).toHaveBeenCalledWith(
+        'user-orphan',
+        '',
+        0,
+      )
+
+      harness.messages.value = [{
+        role: 'user',
+        text: 'Use English',
+        ts: 'durable',
+        messageId: 'user-orphan',
+        turnId: 'turn-orphan',
+        inputDisposition: 'applied',
+      }]
+
+      expect(harness.checkpointForUserMessage).toHaveBeenCalledTimes(2)
+      expect(harness.acknowledgeSteerBoundary).toHaveBeenCalledTimes(2)
+      expect(harness.messages.value).toHaveLength(1)
+    } finally {
+      harness.stop()
+    }
+  })
+
+  it('discards orphan boundary evidence on an authoritative reset', () => {
+    const harness = createHarness()
+    try {
+      harness.api.disposition({
+        userMessageId: 'user-stale-orphan',
+        disposition: 'applied',
+        turnId: 'turn-stale',
+      })
+      harness.api.resetTransientBoundaries()
+      harness.messages.value = [{
+        role: 'user',
+        text: 'stale',
+        ts: 'durable',
+        messageId: 'user-stale-orphan',
+        turnId: 'turn-stale',
+        inputDisposition: 'applied',
+      }]
+
+      expect(harness.checkpointForUserMessage).toHaveBeenCalledOnce()
+      expect(harness.acknowledgeSteerBoundary).toHaveBeenCalledOnce()
+    } finally {
+      harness.stop()
+    }
+  })
+
+  it('does not replay a delayed orphan boundary into a successor turn', () => {
+    const harness = createHarness()
+    try {
+      harness.activeTurnId.value = 'turn-old'
+      harness.api.disposition({
+        userMessageId: 'user-old-orphan',
+        disposition: 'applied',
+        turnId: 'turn-old',
+      })
+      expect(harness.checkpointForUserMessage).toHaveBeenCalledOnce()
+
+      harness.activeTurnId.value = 'turn-new'
+      harness.messages.value = [{
+        role: 'user',
+        text: 'old steer',
+        ts: 'delayed-history',
+        messageId: 'user-old-orphan',
+        turnId: 'turn-old',
+        inputDisposition: 'applied',
+      }]
+
+      expect(harness.checkpointForUserMessage).toHaveBeenCalledOnce()
+      expect(harness.acknowledgeSteerBoundary).toHaveBeenCalledOnce()
+    } finally {
+      harness.stop()
+    }
+  })
+
+  it('accepts a legacy applied event without revision and keeps the newer revision', () => {
+    const harness = createHarness()
+    try {
+      harness.messages.value = [{
+        role: 'user',
+        text: REQUEST.message,
+        ts: 'durable',
+        turnId: REQUEST.expected_turn_id,
+        messageId: 'user-steer',
+        inputDisposition: 'applied',
+        inputDispositionRevision: 3,
+        steerClientRequestId: REQUEST.client_request_id,
+        steerClientMessageId: REQUEST.client_message_id,
+      }]
+
+      const projection = harness.api.disposition({
+        clientRequestId: REQUEST.client_request_id,
+        clientMessageId: REQUEST.client_message_id,
+        expectedTurnId: REQUEST.expected_turn_id,
+        disposition: 'applied',
+      })
+
+      expect(projection.stale).toBe(false)
+      expect(harness.messages.value[0]?.inputDispositionRevision).toBe(3)
+      expect(harness.checkpointForUserMessage).toHaveBeenCalledWith(
+        'turn-current',
+        'client-steer',
+      )
+      expect(harness.acknowledgeSteerBoundary).toHaveBeenCalledWith(
+        'client-steer',
+        '',
+        0,
+      )
     } finally {
       harness.stop()
     }

--- a/opensquilla-webui/src/composables/chat/useChatSteerDelivery.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSteerDelivery.ts
@@ -36,9 +36,16 @@ export interface SteerDeliveryProjection {
 }
 
 export interface UseChatSteerDeliveryOptions {
+  sessionKey?: Ref<string>
+  activeTurnId?: Ref<string>
   messages: Ref<ChatMessage[]>
   pendingQueue: Ref<ChatPendingItem[]>
-  checkpointForUserMessage?: (turnId: string) => void
+  checkpointForUserMessage?: (turnId: string, boundaryKey?: string) => void
+  acknowledgeSteerBoundary?: (
+    boundaryKey: string,
+    modelCallId?: string,
+    iteration?: number,
+  ) => void
   scheduleHistorySync: () => void
   removePendingItem?: (item: ChatPendingItem) => void
   restoreSteerIntoComposer?: (text: string) => void
@@ -66,6 +73,7 @@ export interface ChatSteerDeliveryApi {
   acknowledgeAcceptedOffscreen: (item: ChatPendingItem) => void
   markStopRequested: (turnId: string) => void
   reconcileDurableMessages: () => void
+  resetTransientBoundaries: () => void
 }
 
 const TERMINAL_DISPOSITIONS = new Set<ChatSteerDisposition>([
@@ -137,14 +145,77 @@ export function useChatSteerDelivery(
   options: UseChatSteerDeliveryOptions,
 ): ChatSteerDeliveryApi {
   const restoredAttemptIds = new Set<string>()
-  const checkpointedAttemptIds = new Set<string>()
+  const orphanBoundaries = new Map<string, SteerDeliveryEvidence>()
 
-  function checkpointOnce(attempt: PendingSteerAttempt) {
-    const request = attempt.request
-    const key = request.client_request_id || request.client_message_id
-    if (!key || checkpointedAttemptIds.has(key)) return
-    options.checkpointForUserMessage?.(request.expected_turn_id)
-    checkpointedAttemptIds.add(key)
+  function boundaryKey(
+    identity: Partial<SteerDeliveryIdentity>,
+    userMessageId = '',
+  ): string {
+    return identity.clientMessageId || identity.clientRequestId || userMessageId
+  }
+
+  function checkpointBoundary(
+    identity: Partial<SteerDeliveryIdentity>,
+    turnId: string,
+    userMessageId = '',
+  ) {
+    const key = boundaryKey(identity, userMessageId)
+    if (!key || !turnId) return
+    // The stream owns lifecycle-local idempotence. Reissuing this projection is
+    // intentional: reset/reconnect clears the in-memory checkpoint while the
+    // durable steer identity remains available for rebuilding it.
+    options.checkpointForUserMessage?.(turnId, key)
+  }
+
+  function projectAdmittedBoundary(
+    evidence: SteerDeliveryEvidence,
+    identity: Partial<SteerDeliveryIdentity>,
+    turnId: string,
+  ) {
+    const disposition = evidence.disposition || 'steering'
+    if (disposition !== 'steering' && disposition !== 'applied') return
+    checkpointBoundary(identity, turnId, evidence.userMessageId)
+    if (disposition === 'applied') {
+      options.acknowledgeSteerBoundary?.(
+        boundaryKey(identity, evidence.userMessageId),
+        evidence.modelCallId || '',
+        evidence.appliedIteration || 0,
+      )
+    }
+  }
+
+  function rememberOrphanBoundary(evidence: SteerDeliveryEvidence) {
+    const identity = {
+      clientRequestId: evidence.clientRequestId || '',
+      clientMessageId: evidence.clientMessageId || '',
+    }
+    const key = boundaryKey(identity, evidence.userMessageId)
+    if (!key) return
+    const evidenceTurnId = evidence.expectedTurnId || evidence.turnId || ''
+    const activeTurnId = options.activeTurnId?.value || ''
+    if (activeTurnId && evidenceTurnId && activeTurnId !== evidenceTurnId) return
+    const current = orphanBoundaries.get(key)
+    const currentRevision = Number(current?.revision)
+    const incomingRevision = Number(evidence.revision)
+    if (
+      current
+      && current.disposition === 'applied'
+      && evidence.disposition !== 'applied'
+    ) return
+    if (
+      Number.isInteger(currentRevision)
+      && Number.isInteger(incomingRevision)
+      && incomingRevision < currentRevision
+    ) return
+    if (!orphanBoundaries.has(key) && orphanBoundaries.size >= 32) {
+      const oldestKey = orphanBoundaries.keys().next().value
+      if (typeof oldestKey === 'string') orphanBoundaries.delete(oldestKey)
+    }
+    orphanBoundaries.set(key, { ...evidence })
+  }
+
+  function resetTransientBoundaries() {
+    orphanBoundaries.clear()
   }
 
   function attemptForItem(item: ChatPendingItem): PendingSteerAttempt | null {
@@ -226,20 +297,29 @@ export function useChatSteerDelivery(
       clientMessageId: evidence.clientMessageId || pendingIdentity?.clientMessageId || '',
       expectedTurnId: evidence.expectedTurnId || pendingIdentity?.expectedTurnId || '',
     }
+    const disposition = evidence.disposition || 'steering'
     let message = options.messages.value.find(candidate => matchesIdentity(candidate, {
       ...identity,
       userMessageId: evidence.userMessageId,
     }))
     let created = false
+    let pendingRemoved = false
     if (!message && pending && (identity.clientRequestId || identity.clientMessageId)) {
-      if (attempt) checkpointOnce(attempt)
+      if (disposition === 'steering' || disposition === 'applied') {
+        checkpointBoundary(identity, identity.expectedTurnId, evidence.userMessageId)
+      }
+      // Settle the transport projection before publishing the durable row.
+      // The synchronous reconciliation watcher would otherwise observe both
+      // at once and checkpoint the same boundary a second time.
+      removePending(pending)
+      pendingRemoved = true
       message = {
         role: 'user',
         text: pending.text,
         ts: new Date().toISOString(),
         clientId: identity.clientMessageId || undefined,
         turnId: identity.expectedTurnId || undefined,
-        inputDisposition: evidence.disposition || 'steering',
+        inputDisposition: disposition,
         steerClientRequestId: identity.clientRequestId || undefined,
         steerClientMessageId: identity.clientMessageId || undefined,
         ...(attempt?.stopRequested ? { steerStopRequested: true } : {}),
@@ -256,11 +336,15 @@ export function useChatSteerDelivery(
     const currentTerminal = message?.inputDisposition
       ? TERMINAL_DISPOSITIONS.has(message.inputDisposition)
       : false
-    const disposition = evidence.disposition || 'steering'
+    const staleMetadata = currentRevision !== undefined
+      && incomingRevision !== undefined
+      && incomingRevision < currentRevision
     const stale = Boolean(message) && (
       (
         currentRevision !== undefined
-        && (incomingRevision === undefined || incomingRevision < currentRevision)
+        && disposition !== message?.inputDisposition
+        && incomingRevision !== undefined
+        && incomingRevision < currentRevision
       )
       || (
         currentTerminal
@@ -274,7 +358,12 @@ export function useChatSteerDelivery(
 
     if (message && !stale) {
       message.inputDisposition = disposition
-      if (incomingRevision !== undefined) message.inputDispositionRevision = incomingRevision
+      if (
+        incomingRevision !== undefined
+        && (currentRevision === undefined || incomingRevision >= currentRevision)
+      ) {
+        message.inputDispositionRevision = incomingRevision
+      }
       if (evidence.userMessageId) message.messageId = evidence.userMessageId
       if (identity.clientRequestId) message.steerClientRequestId = identity.clientRequestId
       if (identity.clientMessageId) message.steerClientMessageId = identity.clientMessageId
@@ -282,10 +371,26 @@ export function useChatSteerDelivery(
         || evidence.turnId
         || identity.expectedTurnId
       if (targetTurnId) message.turnId = targetTurnId
-      if (evidence.appliedIteration !== undefined) {
+      if (!created && (disposition === 'steering' || disposition === 'applied')) {
+        checkpointBoundary(
+          identity,
+          identity.expectedTurnId || targetTurnId || '',
+          evidence.userMessageId || message.messageId,
+        )
+      }
+      if (!staleMetadata && evidence.appliedIteration !== undefined) {
         message.steerAppliedIteration = evidence.appliedIteration
       }
-      if (evidence.modelCallId) message.steerModelCallId = evidence.modelCallId
+      if (!staleMetadata && evidence.modelCallId) {
+        message.steerModelCallId = evidence.modelCallId
+      }
+      if (disposition === 'applied') {
+        options.acknowledgeSteerBoundary?.(
+          boundaryKey(identity, evidence.userMessageId || message.messageId),
+          message.steerModelCallId || evidence.modelCallId || '',
+          message.steerAppliedIteration || evidence.appliedIteration || 0,
+        )
+      }
       if (disposition === 'promoted') {
         message.promotedFromTurnId = evidence.promotedFromTurnId
           || identity.expectedTurnId
@@ -297,7 +402,7 @@ export function useChatSteerDelivery(
 
     // The exact durable row/event/accepted response supersedes pending UI even
     // when its revision is older than a row already on screen.
-    if (pending) removePending(pending)
+    if (pending && !pendingRemoved) removePending(pending)
     if (pending && (disposition === 'cancelled')) restoreOnce(pending, message)
     if ((message || pending) && (!stale || pending)) {
       options.scheduleHistorySync()
@@ -325,6 +430,18 @@ export function useChatSteerDelivery(
     const state = evidence.disposition
     const projection = accept(evidence, pending)
     if (!projection.message && !projection.pending) {
+      if (state === 'steering' || state === 'applied') {
+        const identity = {
+          clientRequestId: evidence.clientRequestId || '',
+          clientMessageId: evidence.clientMessageId || '',
+        }
+        projectAdmittedBoundary(
+          evidence,
+          identity,
+          evidence.expectedTurnId || evidence.turnId || '',
+        )
+        rememberOrphanBoundary(evidence)
+      }
       // The event can beat both local pending hydration and canonical history.
       // Pull history so the durable row is still rendered after reconnect.
       options.scheduleHistorySync()
@@ -382,8 +499,36 @@ export function useChatSteerDelivery(
         matchesIdentity(candidate, attemptIdentity(attempt))
       ))
       if (!message) continue
-      checkpointOnce(attempt)
+      const identity = attemptIdentity(attempt)
+      if (message.inputDisposition === 'steering' || message.inputDisposition === 'applied') {
+        checkpointBoundary(identity, identity.expectedTurnId || message.turnId || '')
+      }
+      if (message.inputDisposition === 'applied') {
+        options.acknowledgeSteerBoundary?.(
+          boundaryKey(identity),
+          message.steerModelCallId || '',
+          message.steerAppliedIteration || 0,
+        )
+      }
       removePending(item)
+    }
+    for (const [key, evidence] of [...orphanBoundaries]) {
+      const evidenceTurnId = evidence.expectedTurnId || evidence.turnId || ''
+      const activeTurnId = options.activeTurnId?.value || ''
+      if (activeTurnId && evidenceTurnId && activeTurnId !== evidenceTurnId) {
+        orphanBoundaries.delete(key)
+        continue
+      }
+      const message = options.messages.value.find(candidate => matchesIdentity(candidate, {
+        clientRequestId: evidence.clientRequestId,
+        clientMessageId: evidence.clientMessageId,
+        userMessageId: evidence.userMessageId,
+      }))
+      if (!message) continue
+      // Remove before accept(): its synchronous message mutations re-enter
+      // this watcher, and the lifecycle projection itself is idempotent.
+      orphanBoundaries.delete(key)
+      accept(evidence)
     }
   }
 
@@ -394,6 +539,12 @@ export function useChatSteerDelivery(
     reconcileDurableMessages,
     { deep: true, flush: 'sync' },
   )
+  if (options.sessionKey) {
+    watch(options.sessionKey, resetTransientBoundaries, { flush: 'sync' })
+  }
+  if (options.activeTurnId) {
+    watch(options.activeTurnId, resetTransientBoundaries, { flush: 'sync' })
+  }
 
   return {
     attemptForItem,
@@ -406,5 +557,6 @@ export function useChatSteerDelivery(
     acknowledgeAcceptedOffscreen,
     markStopRequested,
     reconcileDurableMessages,
+    resetTransientBoundaries,
   }
 }

--- a/opensquilla-webui/src/composables/chat/useChatStream.render.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatStream.render.test.ts
@@ -839,14 +839,16 @@ describe('useChatStream render coalescing', () => {
     const { api, messages } = makeStream()
 
     api.appendDelta('before')
-    api.checkpointForUserMessage('turn-steered')
+    api.checkpointForUserMessage('turn-steered', 'steer-1')
     messages.value.push({
       role: 'user',
       text: 'adjust',
       ts: new Date().toISOString(),
+      clientId: 'steer-1',
       turnId: 'turn-steered',
       inputDisposition: 'steering',
     })
+    api.acknowledgeSteerBoundary('steer-1', '', 0)
     api.appendDelta('after')
     api.reconcileFinalText('beforeafter')
     api.endStreaming()
@@ -857,6 +859,130 @@ describe('useChatStream render coalescing', () => {
       ['assistant', 'after'],
     ])
     expect(messages.value.every(message => message.turnId === 'turn-steered')).toBe(true)
+    api.cleanup()
+  })
+
+  it('keeps late old-call tokens above the steer until it is applied', () => {
+    const { api, messages } = makeStream()
+
+    api.appendDelta('第一段')
+    api.checkpointForUserMessage('turn-steered', 'steer-1')
+    messages.value.push({
+      role: 'user',
+      text: 'Use English',
+      ts: 2,
+      clientId: 'steer-1',
+      turnId: 'turn-steered',
+      inputDisposition: 'steering',
+    })
+    messages.value = messages.value.map(message => ({ ...message }))
+
+    api.appendDelta('仍属于第一段')
+    expect(messages.value.map(message => [message.role, message.text])).toEqual([
+      ['assistant', '第一段仍属于第一段'],
+      ['user', 'Use English'],
+    ])
+    expect(api.foldedTurn.value.rawText).toBe('')
+
+    api.acknowledgeSteerBoundary('steer-1', '2.0', 2)
+    api.appendDelta('Second section.')
+    const prefix = '第一段仍属于第一段'
+    const finalText = `${prefix}Second section.`
+    api.reconcileFinalText(finalText, [{
+      model_call_id: '2.0',
+      iteration: 2,
+      start_codepoint: Array.from(prefix).length,
+      end_codepoint: Array.from(finalText).length,
+    }])
+    api.endStreaming()
+
+    expect(messages.value.map(message => [message.role, message.text])).toEqual([
+      ['assistant', prefix],
+      ['user', 'Use English'],
+      ['assistant', 'Second section.'],
+    ])
+    api.cleanup()
+  })
+
+  it('closes an applied steer boundary when an old gateway omits model-call identity', () => {
+    const { api, messages } = makeStream()
+
+    api.appendDelta('第一段')
+    api.checkpointForUserMessage('turn-steered', 'steer-legacy')
+    messages.value.push({
+      role: 'user',
+      text: 'Use English',
+      ts: 2,
+      clientId: 'steer-legacy',
+      turnId: 'turn-steered',
+      inputDisposition: 'steering',
+    })
+    api.acknowledgeSteerBoundary('steer-legacy')
+    api.appendDelta('Second section.')
+    api.reconcileFinalText('第一段Second section.')
+    api.endStreaming()
+
+    expect(messages.value.map(message => [message.role, message.text])).toEqual([
+      ['assistant', '第一段'],
+      ['user', 'Use English'],
+      ['assistant', 'Second section.'],
+    ])
+    api.cleanup()
+  })
+
+  it('rebuilds a checkpoint before an existing steer after live-state reset', () => {
+    const { api, messages } = makeStream()
+    messages.value.push({
+      role: 'user',
+      text: 'Use English',
+      ts: 2,
+      messageId: 'steer-message-1',
+      turnId: 'turn-steered',
+      inputDisposition: 'applied',
+    })
+
+    api.appendDelta('第一段')
+    api.checkpointForUserMessage('turn-steered', 'steer-message-1')
+    api.acknowledgeSteerBoundary('steer-message-1')
+    api.appendDelta('Second section.')
+    api.endStreaming()
+
+    expect(messages.value.map(message => [message.role, message.text])).toEqual([
+      ['assistant', '第一段'],
+      ['user', 'Use English'],
+      ['assistant', 'Second section.'],
+    ])
+    api.cleanup()
+  })
+
+  it('reuses an orphan checkpoint when history hydrates the steer row later', () => {
+    const { api, messages } = makeStream()
+
+    api.appendDelta('First answer')
+    api.checkpointForUserMessage('turn-steered', 'steer-orphan')
+    api.acknowledgeSteerBoundary('steer-orphan')
+    api.appendDelta('Second answer')
+
+    // History replacement can arrive after the live snapshot and omit the
+    // optimistic assistant prefix. Replaying the same boundary must restore
+    // that stable row before the now-durable user message.
+    messages.value = [{
+      role: 'user',
+      text: 'Use English',
+      ts: 2,
+      messageId: 'steer-orphan',
+      turnId: 'turn-steered',
+      inputDisposition: 'applied',
+    }]
+    api.checkpointForUserMessage('turn-steered', 'steer-orphan')
+    api.acknowledgeSteerBoundary('steer-orphan')
+    api.endStreaming()
+
+    expect(messages.value.map(message => [message.role, message.text])).toEqual([
+      ['assistant', 'First answer'],
+      ['user', 'Use English'],
+      ['assistant', 'Second answer'],
+    ])
     api.cleanup()
   })
 
@@ -871,7 +997,7 @@ describe('useChatStream render coalescing', () => {
     })
     const phaseBeforeSteer = api.streamPhaseLabel.value
 
-    api.checkpointForUserMessage('turn-steered')
+    api.checkpointForUserMessage('turn-steered', 'steer-activity')
 
     expect(messages.value).toHaveLength(1)
     expect(messages.value[0]).toMatchObject({
@@ -902,6 +1028,7 @@ describe('useChatStream render coalescing', () => {
       tool_name: 'web_search',
       result: 'ok',
     })
+    api.acknowledgeSteerBoundary('steer-activity')
     api.appendDelta('after')
     api.reconcileFinalText('beforeafter')
     api.endStreaming()
@@ -1030,10 +1157,11 @@ describe('useChatStream render coalescing', () => {
     api.appendDelta('before')
     expect(api.streamTimelineItems.value).toEqual([])
     expect(api.foldedTurn.value.rawText).toBe('before')
-    api.checkpointForUserMessage('turn-production-steer')
+    api.checkpointForUserMessage('turn-production-steer', 'steer-production')
     expect(messages.value[0]).toMatchObject({ role: 'assistant', text: 'before' })
     expect(api.foldedTurn.value.rawText).toBe('')
 
+    api.acknowledgeSteerBoundary('steer-production')
     api.appendDelta('stale')
     api.reconcileFinalText('canonical')
     expect(api.streamTimelineItems.value).toEqual([])

--- a/opensquilla-webui/src/composables/chat/useChatStream.ts
+++ b/opensquilla-webui/src/composables/chat/useChatStream.ts
@@ -2,6 +2,7 @@ import { computed, ref, type Ref } from 'vue'
 import i18n from '@/i18n'
 import type {
   ChatMessage,
+  ChatModelCallSegment,
   ChatRunStatus,
   ChatRunStatusSource,
   ChatStreamSegment,
@@ -37,6 +38,10 @@ import {
 } from '@/utils/chat/toolDisplay'
 import { segmentsToTimelineItems } from '@/utils/chat/segmentsToTimelineItems'
 import { reconcileTextSnapshot } from '@/utils/chat/foldTurn'
+import {
+  normalizeModelCallSegments,
+  splitTextByModelCallSegments,
+} from '@/utils/chat/modelCallSegments'
 import { useChatTurnLog } from '@/composables/chat/useChatTurnLog'
 import type { ReasoningBlock } from '@/types/turnlog'
 import { isLegacySilentSentinelOnly } from '@/utils/chat/silentSentinels'
@@ -149,6 +154,18 @@ export function useChatStream(options: UseChatStreamOptions) {
   let checkpointedAcrossToolBoundary = false
   let activeStreamTurnId = ''
   let activeAssistantMessageId = ''
+  let streamCheckpointSeq = 0
+  const streamCheckpoints: Array<{
+    message: ChatMessage | null
+    insertIndex: number
+    turnId: string
+    boundaryKey: string
+    messageClientId: string
+    rawText: string
+    applied: boolean
+    modelCallId: string
+    iteration: number
+  }> = []
   const streamBubble = ref(false)
   const streamShowHeader = ref(false)
 
@@ -336,6 +353,8 @@ export function useChatStream(options: UseChatStreamOptions) {
     toolTimes.value = new Map()
     reasoningCharsSinceFlush = 0
     reasoningPresentationPending.value = false
+    streamCheckpointSeq = 0
+    streamCheckpoints.length = 0
     // Clear the live-turn log alongside the legacy refs so the next turn's fold
     // starts empty. A steer checkpoint deliberately resets only the current
     // visible segment; checkpointedRaw remains available to de-duplicate an
@@ -654,23 +673,37 @@ export function useChatStream(options: UseChatStreamOptions) {
     publishTurnLog()
   }
 
-  function checkpointForUserMessage(turnId: string) {
+  function checkpointForUserMessage(turnId: string, boundaryKey = '') {
     if (!isStreaming.value || !streamBubble.value) return
+    const existing = boundaryKey
+      ? streamCheckpoints.find(checkpoint => checkpoint.boundaryKey === boundaryKey)
+      : undefined
+    if (existing) {
+      existing.turnId = turnId || existing.turnId
+      existing.insertIndex = boundaryMessageIndex(boundaryKey)
+      setCheckpointText(existing, existing.rawText)
+      return
+    }
     activeStreamTurnId = turnId || activeStreamTurnId
 
     clearRenderTimer()
-    const cleanedText = options.stripDirectiveTags(
-      options.stripGeneratedArtifactMarkers(currentStreamRaw()),
-    ).trim()
-    if (cleanedText) {
-      options.messages.value.push({
-        role: 'assistant',
-        text: cleanedText,
-        ts: new Date().toISOString(),
-        turnId,
-        timeline: [{ type: 'text', raw: cleanedText }],
-      })
+    const rawText = currentStreamRaw()
+    const checkpoint: typeof streamCheckpoints[number] = {
+      message: null,
+      insertIndex: boundaryMessageIndex(boundaryKey),
+      turnId,
+      boundaryKey,
+      messageClientId: `live-steer-checkpoint:${boundaryKey || streamCheckpointSeq++}`,
+      rawText,
+      applied: false,
+      modelCallId: '',
+      iteration: 0,
     }
+    streamCheckpoints.push(checkpoint)
+    // Reconnect/session restoration may retain the optimistic checkpoint row
+    // while resetLiveTurnState clears only its in-memory lifecycle record.
+    // Adopt that stable row instead of inserting a duplicate.
+    setCheckpointText(checkpoint, rawText)
 
     checkpointedAcrossToolBoundary = checkpointedAcrossToolBoundary || Boolean(
       streamToolCalls.value.length
@@ -687,6 +720,109 @@ export function useChatStream(options: UseChatStreamOptions) {
     )
     checkpointText()
     resetStreamIdleTimer()
+  }
+
+  function acknowledgeSteerBoundary(
+    boundaryKey: string,
+    modelCallId = '',
+    iteration = 0,
+  ) {
+    const checkpoint = streamCheckpoints.find(candidate =>
+      !candidate.applied
+      && (!boundaryKey || candidate.boundaryKey === boundaryKey),
+    ) || streamCheckpoints.find(candidate => !candidate.applied)
+    if (!checkpoint) return
+    checkpoint.applied = true
+    if (modelCallId) checkpoint.modelCallId = modelCallId
+    checkpoint.iteration = iteration
+  }
+
+  function boundaryMessageIndex(boundaryKey: string): number {
+    if (!boundaryKey) return options.messages.value.length
+    const userIndex = options.messages.value.findIndex(message =>
+      message.role === 'user'
+      && (
+        message.clientId === boundaryKey
+        || message.messageId === boundaryKey
+        || message.steerClientMessageId === boundaryKey
+        || message.steerClientRequestId === boundaryKey
+      ),
+    )
+    return userIndex >= 0 ? userIndex : options.messages.value.length
+  }
+
+  function checkpointMessageInsertIndex(checkpoint: typeof streamCheckpoints[number]): number {
+    const userIndex = boundaryMessageIndex(checkpoint.boundaryKey)
+    if (userIndex < options.messages.value.length) return userIndex
+    return Math.min(checkpoint.insertIndex, options.messages.value.length)
+  }
+
+  function setCheckpointText(
+    checkpoint: typeof streamCheckpoints[number],
+    rawText: string,
+  ) {
+    const cleanedText = options.stripDirectiveTags(
+      options.stripGeneratedArtifactMarkers(rawText),
+    ).trim()
+    let currentIndex = checkpoint.message
+      ? options.messages.value.indexOf(checkpoint.message)
+      : -1
+    if (currentIndex < 0) {
+      currentIndex = options.messages.value.findIndex(message =>
+        message.role === 'assistant'
+        && message.clientId === checkpoint.messageClientId,
+      )
+    }
+    if (!cleanedText) {
+      if (currentIndex >= 0) options.messages.value.splice(currentIndex, 1)
+      checkpoint.message = null
+      return
+    }
+    const timeline: ChatTimelineSegment[] = [{ type: 'text', raw: cleanedText }]
+    if (currentIndex >= 0) {
+      const current = options.messages.value[currentIndex]!
+      current.text = cleanedText
+      current.timeline = timeline
+      const desiredIndex = checkpointMessageInsertIndex(checkpoint)
+      const moveTo = desiredIndex > currentIndex ? desiredIndex - 1 : desiredIndex
+      if (moveTo !== currentIndex) {
+        options.messages.value.splice(currentIndex, 1)
+        options.messages.value.splice(moveTo, 0, current)
+      }
+      checkpoint.message = current
+      return
+    }
+    const insertIndex = checkpointMessageInsertIndex(checkpoint)
+    options.messages.value.splice(insertIndex, 0, {
+      role: 'assistant',
+      text: cleanedText,
+      ts: new Date().toISOString(),
+      clientId: checkpoint.messageClientId,
+      turnId: checkpoint.turnId,
+      timeline,
+    })
+    checkpoint.message = options.messages.value[insertIndex]!
+  }
+
+  function appendDeltaBeforeAppliedSteer(text: string): boolean {
+    const checkpoint = streamCheckpoints.find(candidate => !candidate.applied)
+    if (!checkpoint) return false
+
+    let deltaText = typeof text === 'string' ? text : ''
+    if (checkpoint.rawText && deltaText === checkpoint.rawText) return true
+    if (checkpoint.rawText && deltaText.startsWith(checkpoint.rawText)) {
+      deltaText = deltaText.slice(checkpoint.rawText.length)
+    } else if (checkpointedRaw && deltaText.startsWith(checkpointedRaw)) {
+      deltaText = deltaText.slice(checkpointedRaw.length)
+    }
+    if (!deltaText) return true
+
+    checkpoint.rawText += deltaText
+    checkpointedRaw += deltaText
+    setCheckpointText(checkpoint, checkpoint.rawText)
+    noteStreamSignal()
+    scheduleRender()
+    return true
   }
 
   function resetStreamForRouterReplay() {
@@ -810,6 +946,7 @@ export function useChatStream(options: UseChatStreamOptions) {
     presentation: 'intermediate' | 'answer' = 'answer',
   ) {
     if (options.aborted.value) return
+    if (appendDeltaBeforeAppliedSteer(text)) return
     const deltaText = normalizeIncomingTextDelta(text)
     if (!deltaText) return
     if (!isStreaming.value) startStreaming()
@@ -1334,15 +1471,66 @@ export function useChatStream(options: UseChatStreamOptions) {
     isStreaming.value = true
   }
 
-  function reconcileFinalText(finalText: string | null | undefined) {
+  function reconcileCheckpointedText(
+    finalText: string,
+    modelCallSegments: ChatModelCallSegment[] | null | undefined,
+  ): string | null {
+    if (streamCheckpoints.length === 0) return null
+    const chunks = splitTextByModelCallSegments(finalText, modelCallSegments)
+    if (!chunks) return null
+    const normalized = normalizeModelCallSegments(
+      modelCallSegments,
+      Array.from(finalText).length,
+    )
+    const checkpointTexts = streamCheckpoints.map(() => '')
+    const hasAppliedIdentities = streamCheckpoints.every(checkpoint => checkpoint.modelCallId)
+    if (hasAppliedIdentities) {
+      let checkpointIndex = 0
+      for (let segmentIndex = 0; segmentIndex < normalized.length; segmentIndex++) {
+        const segment = normalized[segmentIndex]!
+        const groupStart = checkpointIndex
+        while (
+          checkpointIndex < streamCheckpoints.length
+          && streamCheckpoints[checkpointIndex]!.modelCallId === segment.modelCallId
+        ) {
+          checkpointIndex++
+        }
+        if (checkpointIndex === groupStart) return null
+        checkpointTexts[groupStart] = chunks[segmentIndex] || ''
+      }
+      if (checkpointIndex !== streamCheckpoints.length) return null
+    } else {
+      // Compatibility with gateways that predate applied model-call identity.
+      if (
+        streamCheckpoints.some(checkpoint => checkpoint.modelCallId)
+        || chunks.length !== streamCheckpoints.length + 1
+      ) return null
+      streamCheckpoints.forEach((_checkpoint, index) => {
+        checkpointTexts[index] = chunks[index] || ''
+      })
+    }
+    streamCheckpoints.forEach((checkpoint, index) => {
+      checkpoint.rawText = checkpointTexts[index] || ''
+      setCheckpointText(checkpoint, checkpoint.rawText)
+    })
+    return chunks[chunks.length - 1]!
+  }
+
+  function reconcileFinalText(
+    finalText: string | null | undefined,
+    modelCallSegments?: ChatModelCallSegment[] | null,
+  ) {
     // null/undefined means the terminal event carried no authoritative text
     // snapshot, so streamed deltas remain canonical. Empty string is distinct:
     // it intentionally clears stale text while preserving tool history.
     if (finalText == null) return
 
-    const segmentFinalText = checkpointedRaw && finalText.startsWith(checkpointedRaw)
-      ? finalText.slice(checkpointedRaw.length)
-      : finalText
+    const boundaryTail = reconcileCheckpointedText(finalText, modelCallSegments)
+    const segmentFinalText = boundaryTail != null
+      ? boundaryTail
+      : checkpointedRaw && finalText.startsWith(checkpointedRaw)
+        ? finalText.slice(checkpointedRaw.length)
+        : finalText
     if (useReducer.value === true) {
       const changed = currentStreamRaw() !== segmentFinalText
       appendFrame({ kind: 'final-text', text: segmentFinalText })
@@ -1424,6 +1612,7 @@ export function useChatStream(options: UseChatStreamOptions) {
     reconcileStreamTaskClock,
     endStreaming,
     checkpointForUserMessage,
+    acknowledgeSteerBoundary,
     resetStreamForRouterReplay,
     resetLiveTurnState,
     resetAnswerGeneration,

--- a/opensquilla-webui/src/utils/chat/historyModelCallSegments.ts
+++ b/opensquilla-webui/src/utils/chat/historyModelCallSegments.ts
@@ -3,73 +3,14 @@ import type {
   ChatModelCallSegment,
   ChatUsagePayload,
 } from '@/types/chat'
-
-interface NormalizedModelCallSegment {
-  modelCallId: string
-  iteration: number
-  startCodepoint: number
-  endCodepoint: number
-}
-
-function nonNegativeInteger(value: unknown): number | undefined {
-  const number = Number(value)
-  return Number.isInteger(number) && number >= 0 ? number : undefined
-}
-
-function positiveInteger(value: unknown): number | undefined {
-  const number = nonNegativeInteger(value)
-  return number !== undefined && number > 0 ? number : undefined
-}
+import {
+  normalizeModelCallSegments,
+  type NormalizedModelCallSegment,
+} from '@/utils/chat/modelCallSegments'
 
 function usageSegments(usage: ChatUsagePayload | undefined): ChatModelCallSegment[] {
   const value = usage?.model_call_segments ?? usage?.modelCallSegments
   return Array.isArray(value) ? value : []
-}
-
-function normalizedSegments(
-  message: ChatMessage,
-  codepointLength: number,
-): NormalizedModelCallSegment[] {
-  const seenCallIds = new Set<string>()
-  const normalized: NormalizedModelCallSegment[] = []
-  for (const raw of usageSegments(message.usage || message.turn_usage)) {
-    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return []
-    const modelCallId = String(raw.model_call_id || raw.modelCallId || '').trim()
-    const iteration = positiveInteger(raw.iteration)
-    const startCodepoint = nonNegativeInteger(
-      raw.start_codepoint ?? raw.startCodepoint,
-    )
-    const endCodepoint = nonNegativeInteger(raw.end_codepoint ?? raw.endCodepoint)
-    if (
-      !modelCallId
-      || seenCallIds.has(modelCallId)
-      || iteration === undefined
-      || startCodepoint === undefined
-      || endCodepoint === undefined
-      || endCodepoint < startCodepoint
-      || endCodepoint > codepointLength
-      || (
-        normalized.length > 0
-        && startCodepoint !== normalized[normalized.length - 1]!.endCodepoint
-      )
-    ) {
-      return []
-    }
-    seenCallIds.add(modelCallId)
-    normalized.push({
-      modelCallId,
-      iteration,
-      startCodepoint,
-      endCodepoint,
-    })
-  }
-  if (
-    normalized.length === 0
-    || normalized[normalized.length - 1]!.endCodepoint !== codepointLength
-  ) {
-    return []
-  }
-  return normalized
 }
 
 function matchesSegment(message: ChatMessage, segment: NormalizedModelCallSegment): boolean {
@@ -113,7 +54,10 @@ function interleaveAssistantAt(
     return null
   }
   const codepoints = Array.from(assistant.text)
-  const segments = normalizedSegments(assistant, codepoints.length)
+  const segments = normalizeModelCallSegments(
+    usageSegments(assistant.usage || assistant.turn_usage),
+    codepoints.length,
+  )
   if (segments.length === 0) return null
 
   const matchedByCall = new Map<string, Array<{ index: number; message: ChatMessage }>>()

--- a/opensquilla-webui/src/utils/chat/modelCallSegments.ts
+++ b/opensquilla-webui/src/utils/chat/modelCallSegments.ts
@@ -1,0 +1,81 @@
+import type { ChatModelCallSegment } from '@/types/chat'
+
+export interface NormalizedModelCallSegment {
+  modelCallId: string
+  iteration: number
+  startCodepoint: number
+  endCodepoint: number
+}
+
+function nonNegativeInteger(value: unknown): number | undefined {
+  const number = Number(value)
+  return Number.isInteger(number) && number >= 0 ? number : undefined
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  const number = nonNegativeInteger(value)
+  return number !== undefined && number > 0 ? number : undefined
+}
+
+/**
+ * Validate the backend's model-call ranges before they are allowed to move or
+ * split visible messages. Invalid or partial metadata deliberately fails
+ * closed so an older gateway cannot corrupt the local chronology.
+ */
+export function normalizeModelCallSegments(
+  rawSegments: ChatModelCallSegment[] | null | undefined,
+  codepointLength: number,
+): NormalizedModelCallSegment[] {
+  if (!Array.isArray(rawSegments) || rawSegments.length === 0) return []
+
+  const seenCallIds = new Set<string>()
+  const normalized: NormalizedModelCallSegment[] = []
+  for (const raw of rawSegments) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return []
+    const modelCallId = String(raw.model_call_id || raw.modelCallId || '').trim()
+    const iteration = positiveInteger(raw.iteration)
+    const startCodepoint = nonNegativeInteger(
+      raw.start_codepoint ?? raw.startCodepoint,
+    )
+    const endCodepoint = nonNegativeInteger(raw.end_codepoint ?? raw.endCodepoint)
+    if (
+      !modelCallId
+      || seenCallIds.has(modelCallId)
+      || iteration === undefined
+      || startCodepoint === undefined
+      || endCodepoint === undefined
+      || endCodepoint < startCodepoint
+      || endCodepoint > codepointLength
+      || (
+        normalized.length > 0
+        && startCodepoint !== normalized[normalized.length - 1]!.endCodepoint
+      )
+    ) {
+      return []
+    }
+    seenCallIds.add(modelCallId)
+    normalized.push({ modelCallId, iteration, startCodepoint, endCodepoint })
+  }
+
+  if (normalized[normalized.length - 1]!.endCodepoint !== codepointLength) {
+    return []
+  }
+  return normalized
+}
+
+/** Return the pre-steer prefix followed by one text chunk per model call. */
+export function splitTextByModelCallSegments(
+  text: string,
+  rawSegments: ChatModelCallSegment[] | null | undefined,
+): string[] | null {
+  const codepoints = Array.from(text)
+  const segments = normalizeModelCallSegments(rawSegments, codepoints.length)
+  if (segments.length === 0) return null
+
+  return [
+    codepoints.slice(0, segments[0]!.startCodepoint).join(''),
+    ...segments.map(segment =>
+      codepoints.slice(segment.startCodepoint, segment.endCodepoint).join(''),
+    ),
+  ]
+}

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -1875,9 +1875,14 @@ const {
 planMutationAccepted = () => scheduleHistorySync()
 
 const steerDelivery = useChatSteerDelivery({
+  sessionKey,
+  activeTurnId: activeStreamTaskId,
   messages,
   pendingQueue,
-  checkpointForUserMessage: turnId => chatStream.checkpointForUserMessage?.(turnId),
+  checkpointForUserMessage: (turnId, boundaryKey) =>
+    chatStream.checkpointForUserMessage?.(turnId, boundaryKey),
+  acknowledgeSteerBoundary: (boundaryKey, modelCallId, iteration) =>
+    chatStream.acknowledgeSteerBoundary?.(boundaryKey, modelCallId, iteration),
   scheduleHistorySync,
   removePendingItem: item => settlePendingDelivery(item, 'accepted'),
   restoreSteerIntoComposer: text => appendComposerText(text),

--- a/tests/test_gateway/test_session_streams.py
+++ b/tests/test_gateway/test_session_streams.py
@@ -239,6 +239,47 @@ def test_live_turn_snapshot_compacts_high_frequency_deltas_without_losing_state(
     assert snapshot.events[5].payload["text"] == "Hello world"
 
 
+def test_live_turn_snapshot_preserves_text_steer_text_boundary_order() -> None:
+    registry = SessionStreamRegistry(max_events_per_session=5)
+    session_key = "agent:main:steered-turn"
+    task_id = "task-steered"
+
+    first = registry.record(
+        session_key,
+        "session.event.text_delta",
+        {"task_id": task_id, "text": "First answer"},
+    )
+    applied = registry.record(
+        session_key,
+        "session.event.input_disposition",
+        {
+            "task_id": task_id,
+            "turn_id": task_id,
+            "intent": "steer",
+            "disposition": "applied",
+            "user_message_id": "steer-message-1",
+        },
+    )
+    second = registry.record(
+        session_key,
+        "session.event.text_delta",
+        {"task_id": task_id, "text": "Second answer"},
+    )
+
+    snapshot = registry.live_snapshot(session_key)
+
+    assert [event.event_name for event in snapshot.events] == [
+        "session.event.text_delta",
+        "session.event.input_disposition",
+        "session.event.text_delta",
+    ]
+    assert [event.stream_seq for event in snapshot.events] == [
+        first["stream_seq"],
+        applied["stream_seq"],
+        second["stream_seq"],
+    ]
+
+
 def test_live_turn_snapshot_compacts_thinking_per_block_and_preserves_boundaries() -> None:
     registry = SessionStreamRegistry(max_events_per_session=5)
     session_key = "agent:main:reasoning-blocks"


### PR DESCRIPTION
## Scope

- keep late pre-application model output above same-turn steer messages
- rebuild steer boundaries from ordered live snapshots, including snapshot-before-history hydration
- reconcile terminal model-call ranges with Unicode-safe shared validation
- prevent orphan boundary evidence from leaking across sessions or turns
- cover legacy gateways that omit optional model-call identity or disposition revision

## Target

- Base branch: `main`

## Linked issue

- None

## Release note

- Not required; this is a WebUI stream ordering and recovery bug fix.

## Tests

- `opensquilla-webui`: 339 test files and 4109 tests passed
- `tests/test_gateway/test_session_streams.py`: 21 passed
- WebUI architecture, security, theme, i18n, channel catalog, and README locale checks passed
- Vite production build passed
- Clean-branch UI smoke test confirmed retry activity, route cards, and completed output remain stable
- Deterministic lifecycle tests cover same-turn steer behavior because the connected gateway queued busy input during the UI smoke test
- Independent subagent review completed with no findings

## Safety and compatibility

- Presentation and state reconciliation only; no permission, secret, or security-boundary changes
- Platform-neutral TypeScript and Python
- Compatible with older gateways that omit optional `model_call_id` or `revision`
- No database migration or destructive data change

## Third-party origin

- None