### PR TITLE
Make image input admission explicit and localizable

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatFeatureToggles.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatFeatureToggles.test.ts
@@ -295,6 +295,39 @@ describe('useChatFeatureToggles model routing mode', () => {
     expect(api.modelRoutingMode.value).toBe('off')
   })
 
+  it('applies canonical image admission and preserves old-Gateway defaults', async () => {
+    const blocked = createHarness({
+      configGetResults: [{}],
+      routingGetResults: [{
+        mode: 'direct',
+        image_input: {
+          admission: 'blocked',
+          reason: 'model_vision_unsupported',
+        },
+      }],
+    })
+    await blocked.api.loadFeatureToggles()
+    expect(blocked.api.imageInputAdmission.value).toBe('blocked')
+    expect(blocked.api.imageInputAdmissionReason.value).toBe('model_vision_unsupported')
+
+    const legacyDirect = createHarness({
+      configGetResults: [{ llm_ensemble: { enabled: false } }],
+      routingGetResults: [{ mode: 'direct' }],
+    })
+    await legacyDirect.api.loadFeatureToggles()
+    expect(legacyDirect.api.imageInputAdmission.value).toBe('unknown')
+
+    const legacyEnsemble = createHarness({
+      configGetResults: [{ llm_ensemble: { enabled: true } }],
+      routingGetResults: [{ mode: 'ensemble' }],
+    })
+    await legacyEnsemble.api.loadFeatureToggles()
+    expect(legacyEnsemble.api.imageInputAdmission.value).toBe('blocked')
+    expect(legacyEnsemble.api.imageInputAdmissionReason.value).toBe(
+      'ensemble_mode_unsupported',
+    )
+  })
+
   it('applies Gateway routing changes live and unsubscribes on cleanup', async () => {
     vi.stubGlobal('document', {
       visibilityState: 'visible',
@@ -312,10 +345,19 @@ describe('useChatFeatureToggles model routing mode', () => {
     expect(api.modelRoutingMode.value).toBe('llm_ensemble')
     expect(api.llmEnsembleSelectionMode.value).toBe('router_dynamic')
 
+    emit('models.routing.changed', {
+      mode: 'router',
+      image_input: {
+        admission: 'allowed',
+        reason: 'router_image_route_available',
+      },
+    })
+    expect(api.imageInputAdmission.value).toBe('allowed')
+
     cleanup()
     expect(rpc.on).toHaveBeenCalledWith('models.routing.changed', expect.any(Function))
     emit('models.routing.changed', { mode: 'direct' })
-    expect(api.modelRoutingMode.value).toBe('llm_ensemble')
+    expect(api.modelRoutingMode.value).toBe('squilla_router')
   })
 
   it.each([

--- a/opensquilla-webui/src/composables/chat/useChatFeatureToggles.ts
+++ b/opensquilla-webui/src/composables/chat/useChatFeatureToggles.ts
@@ -2,7 +2,7 @@ import { computed, ref } from 'vue'
 import i18n from '@/i18n'
 import { useToasts } from '@/composables/useToasts'
 import type { ChatRouterTierConfig } from '@/types/chat'
-import type { ModelRoutingMode } from '@/types/modelRouting'
+import type { ImageInputAdmission, ModelRoutingMode } from '@/types/modelRouting'
 import { normalizeModelRoutingMode } from '@/types/modelRouting'
 import { normalizeRouterTier, sortRouterTiers } from '@/utils/chat/routerTiers'
 import { encodeRouterShape, decodeRouterShape } from '@/utils/chat/routerShapeCache'
@@ -69,6 +69,10 @@ interface ChatFeatureConfig {
 interface ModelRoutingSnapshot {
   mode?: 'direct' | 'router' | 'ensemble'
   selection_mode?: string
+  image_input?: {
+    admission?: 'allowed' | 'blocked' | 'unknown'
+    reason?: string
+  }
 }
 
 const ROUTER_SHAPE_KEY = 'opensquilla.router.shape'
@@ -87,6 +91,9 @@ export function useChatFeatureToggles(options: UseChatFeatureTogglesOptions) {
   const llmEnsembleSelectionMode = ref('')
   const llmEnsembleSettingsBusy = ref(false)
   const modelRoutingSettingsBusy = ref(false)
+  const imageInputAdmission = ref<ImageInputAdmission>('unknown')
+  const imageInputAdmissionReason = ref('capability_unknown')
+  let hasCanonicalImageAdmission = false
   const routerSlots = ref<string[]>([])
   const routerModels = ref<Record<string, string>>({})
   const routerTierConfigs = ref<Record<string, ChatRouterTierConfig>>({})
@@ -108,6 +115,22 @@ export function useChatFeatureToggles(options: UseChatFeatureTogglesOptions) {
     if (typeof snapshot.selection_mode === 'string') {
       llmEnsembleSelectionMode.value = snapshot.selection_mode
     }
+    const admission = snapshot.image_input?.admission
+    if (admission === 'allowed' || admission === 'blocked' || admission === 'unknown') {
+      hasCanonicalImageAdmission = true
+      imageInputAdmission.value = admission
+      imageInputAdmissionReason.value = String(
+        snapshot.image_input?.reason || 'capability_unknown',
+      )
+    } else if (mode === 'ensemble') {
+      hasCanonicalImageAdmission = false
+      imageInputAdmission.value = 'blocked'
+      imageInputAdmissionReason.value = 'ensemble_mode_unsupported'
+    } else {
+      hasCanonicalImageAdmission = false
+      imageInputAdmission.value = 'unknown'
+      imageInputAdmissionReason.value = 'capability_unknown'
+    }
     return true
   }
 
@@ -123,6 +146,12 @@ export function useChatFeatureToggles(options: UseChatFeatureTogglesOptions) {
     codingModeEnabled.value = cfg?.skills?.coding_mode === true
     llmEnsembleEnabled.value = ensembleEnabled
     llmEnsembleSelectionMode.value = String(cfg?.llm_ensemble?.selection_mode || '')
+    if (!hasCanonicalImageAdmission) {
+      imageInputAdmission.value = ensembleEnabled ? 'blocked' : 'unknown'
+      imageInputAdmissionReason.value = ensembleEnabled
+        ? 'ensemble_mode_unsupported'
+        : 'capability_unknown'
+    }
     routerVisualMode.value = normalizeRouterVisualMode(router.visual_mode)
     const tiers = router.tiers
     const tierKeys: string[] = []
@@ -332,6 +361,8 @@ export function useChatFeatureToggles(options: UseChatFeatureTogglesOptions) {
     routerSettingsBusy,
     modelRoutingMode,
     modelRoutingSettingsBusy,
+    imageInputAdmission,
+    imageInputAdmissionReason,
     codingModeEnabled,
     codingModeSettingsBusy,
     llmEnsembleEnabled,

--- a/opensquilla-webui/src/composables/chat/useChatHistory.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatHistory.test.ts
@@ -2157,6 +2157,61 @@ describe('useChatHistory optimistic local rows', () => {
     })
   })
 
+  it.each([
+    [
+      'image_input_unsupported',
+      'The selected model cannot process image input. Choose an image-capable model or remove the image.',
+    ],
+    [
+      'ensemble_multimodal_unsupported',
+      "Ensemble doesn't support image input yet. Under Model routing, choose AI-powered single-model router with an image-capable tier configured, or turn routing Off and select an image-capable model.",
+    ],
+  ])('restores %s as a localized error card', async (errorClass, expectedText) => {
+    const { api, messages } = makeHistory(true, {
+      response: {
+        messages: [
+          {
+            id: 'user-image',
+            message_id: 'user-image',
+            role: 'user',
+            text: 'inspect this image',
+            timestamp: '2026-07-07T10:00:00Z',
+            turn_context: { turn_id: 'turn-image' },
+          },
+          {
+            id: 'system-image',
+            message_id: 'system-image',
+            role: 'system',
+            text: 'Error: server fallback [synthetic ref]',
+            timestamp: '2026-07-07T10:00:01Z',
+            turn_context: { turn_id: 'turn-image' },
+          },
+        ],
+        turn_outcomes: [{
+          turn_id: 'turn-image',
+          task_id: 'turn-image',
+          status: 'failed',
+          error_class: errorClass,
+          retryable: false,
+          terminal_message: 'server fallback',
+        }],
+        has_more: false,
+        oldest_cursor: null,
+        newest_cursor: null,
+        history_scope: 'session',
+      },
+    })
+
+    await api.loadHistory()
+
+    expect(messages.value.map(message => message.role)).toEqual(['user', 'error'])
+    expect(messages.value[1]).toMatchObject({
+      errorCode: errorClass,
+      terminalNotice: true,
+      text: expectedText,
+    })
+  })
+
   it('restores a usage barrier retry card when the transcript error row is absent', async () => {
     const { api, messages } = makeHistory(true, {
       response: {

--- a/opensquilla-webui/src/composables/chat/useChatHistory.ts
+++ b/opensquilla-webui/src/composables/chat/useChatHistory.ts
@@ -36,7 +36,7 @@ import {
 } from '@/composables/chat/sessionBootstrapContract'
 import type { RpcCallOptions, RpcConnectionWaitOptions } from '@/lib/rpc'
 import { normalizeTurnOutcome } from '@/utils/chat/turnOutcome'
-import { localizedChatErrorMessage } from '@/utils/chat/errors'
+import { isImageInputUnsupported, localizedChatErrorMessage } from '@/utils/chat/errors'
 import { isUsageAccountingBarrier } from '@/utils/chat/usageAccountingFailure'
 import { interleaveHistoryModelCallSegments } from '@/utils/chat/historyModelCallSegments'
 
@@ -371,12 +371,12 @@ function attachHistoryTurnOutcomes(
     const outcome = message.turnId ? byTurnId.get(message.turnId) : undefined
     if (!outcome) return message
     const usageBarrier = isUsageAccountingBarrier(outcome.errorClass)
-    const durableUsageError = usageBarrier
+    const durableLocalizedError = (usageBarrier || isImageInputUnsupported(outcome.errorClass))
       && message.role === 'system'
       && message.text.trimStart().startsWith('Error:')
     return {
       ...message,
-      ...(durableUsageError
+      ...(durableLocalizedError
         ? {
             role: 'error',
             text: localizedChatErrorMessage(
@@ -433,7 +433,10 @@ function attachHistoryTurnOutcomes(
   // compacted or paginated window, so materialize the retry card whenever the
   // outcome has no matching terminal row in this page.
   for (const outcome of outcomes) {
-    if (!isUsageAccountingBarrier(outcome.errorClass)) continue
+    if (
+      !isUsageAccountingBarrier(outcome.errorClass)
+      && !isImageInputUnsupported(outcome.errorClass)
+    ) continue
     if (enriched.some(message =>
       message.turnId === outcome.turnId && message.role === 'error',
     )) continue
@@ -466,7 +469,10 @@ function dedupeSyntheticUsageBarrierErrors(messages: ChatMessage[]): ChatMessage
       .filter(message =>
         message.role === 'error'
         && Boolean(message.turnId)
-        && isUsageAccountingBarrier(message.errorCode)
+        && (
+          isUsageAccountingBarrier(message.errorCode)
+          || isImageInputUnsupported(message.errorCode)
+        )
         && !message.messageId?.startsWith('terminal-error:'),
       )
       .map(message => message.turnId!),
@@ -476,7 +482,10 @@ function dedupeSyntheticUsageBarrierErrors(messages: ChatMessage[]): ChatMessage
     if (
       message.role !== 'error'
       || !message.turnId
-      || !isUsageAccountingBarrier(message.errorCode)
+      || !(
+        isUsageAccountingBarrier(message.errorCode)
+        || isImageInputUnsupported(message.errorCode)
+      )
       || !message.messageId?.startsWith('terminal-error:')
     ) return true
     if (durableErrorTurns.has(message.turnId)) return false

--- a/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
@@ -6723,6 +6723,42 @@ describe('useChatSend Ensemble image guard', () => {
     },
   )
 
+  it('blocks explicitly unsupported image input before upload or draft mutation', async () => {
+    const image = readyAttachment('image/png', { file_uuid: '' })
+    const pendingAttachments = ref<Attachment[]>([image])
+    const prepareAttachmentsForSend = vi.fn(async () => true)
+    const { api, options, rpc } = makeOptions({
+      pendingAttachments,
+      modelRoutingMode: ref<'off'>('off'),
+      imageInputAdmission: ref<'blocked'>('blocked'),
+      prepareAttachmentsForSend,
+    })
+
+    await api.onSend()
+
+    expect(prepareAttachmentsForSend).not.toHaveBeenCalled()
+    expect(rpc.call).not.toHaveBeenCalled()
+    expect(options.messages.value).toEqual([])
+    expect(options.inputText.value).toBe('hello')
+    expect(pendingAttachments.value).toEqual([image])
+  })
+
+  it('allows unknown image admission so the backend remains authoritative', async () => {
+    const image = readyAttachment('image/png')
+    const pendingAttachments = ref<Attachment[]>([image])
+    const { api, rpc } = makeOptions({
+      pendingAttachments,
+      modelRoutingMode: ref<'off'>('off'),
+      imageInputAdmission: ref<'unknown'>('unknown'),
+    })
+
+    await api.onSend()
+
+    expect(rpc.call).toHaveBeenCalledWith('chat.send', expect.objectContaining({
+      attachments: [expect.objectContaining({ mime: 'image/png' })],
+    }))
+  })
+
   it('rechecks routing after attachment preparation without consuming the draft', async () => {
     const image = readyAttachment('image/gif')
     const pendingAttachments = ref<Attachment[]>([image])
@@ -6889,6 +6925,24 @@ describe('useChatSend Ensemble image guard', () => {
       role: 'error',
       errorCode: 'ensemble_multimodal_unsupported',
       text: "Ensemble doesn't support image input yet. Under Model routing, choose AI-powered single-model router with an image-capable tier configured, or turn routing Off and select an image-capable model.",
+    })
+  })
+
+  it('localizes a model image admission rejection while preserving its error code', async () => {
+    const rpc = {
+      call: vi.fn().mockRejectedValue(Object.assign(new Error('server fallback text'), {
+        code: 'image_input_unsupported',
+        retryable: false,
+      })),
+    }
+    const { api, options } = makeOptions({ rpc })
+
+    await api.onSend()
+
+    expect(options.messages.value[options.messages.value.length - 1]).toMatchObject({
+      role: 'error',
+      errorCode: 'image_input_unsupported',
+      text: 'The selected model cannot process image input. Choose an image-capable model or remove the image.',
     })
   })
 

--- a/opensquilla-webui/src/composables/chat/useChatSend.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.ts
@@ -9,7 +9,7 @@ import type {
   ChatPendingItem,
   ChatSteerCapability,
 } from '@/types/chat'
-import type { ModelRoutingMode } from '@/types/modelRouting'
+import type { ImageInputAdmission, ModelRoutingMode } from '@/types/modelRouting'
 import type { CollaborationMode } from '@/types/plans'
 import type { SandboxRunMode } from '@/types/sandbox'
 import { normalizeSandboxRunMode } from '@/types/sandbox'
@@ -33,6 +33,7 @@ import type { SlashCommandClassification } from '@/composables/chat/useChatSlash
 import { recordSessionNavigationDiag } from '@/utils/chat/sessionNavigationDiag'
 import { canonicalSessionKey } from '@/utils/chat/sessionKeys'
 import {
+  hasModelInputImageAttachment,
   hasSendableModelInputImageAttachment,
   isSendableAttachment,
   serializeDisplayAttachment,
@@ -354,6 +355,7 @@ export interface UseChatSendOptions {
   busySendMode: Ref<BusySendMode>
   modelRoutingMode: Readonly<Ref<ModelRoutingMode>>
   modelRoutingSettingsBusy: Readonly<Ref<boolean>>
+  imageInputAdmission?: Readonly<Ref<ImageInputAdmission>>
   elevatedMode: Ref<string>
   runMode: Ref<SandboxRunMode>
   pendingAttachments: Ref<Attachment[]>
@@ -567,9 +569,13 @@ export function useChatSend(options: UseChatSendOptions) {
   }
 
   function modelImageSendBlocked(attachments: readonly Attachment[]): boolean {
-    if (!hasSendableModelInputImageAttachment(attachments)) return false
+    if (!hasModelInputImageAttachment(attachments)) return false
     return options.modelRoutingSettingsBusy.value
-      || options.modelRoutingMode.value === 'llm_ensemble'
+      || options.imageInputAdmission?.value === 'blocked'
+      || (
+        options.imageInputAdmission === undefined
+        && options.modelRoutingMode.value === 'llm_ensemble'
+      )
   }
 
   function activeSteerCapability(): ChatSteerCapability | null {
@@ -2291,7 +2297,13 @@ export function useChatSend(options: UseChatSendOptions) {
       if (options.modelRoutingSettingsBusy.value) {
         return preserveRetryState(delivery === 'followup' ? 'deferred' : 'not_sent')
       }
-      if (options.modelRoutingMode.value === 'llm_ensemble') {
+      if (
+        options.imageInputAdmission?.value === 'blocked'
+        || (
+          options.imageInputAdmission === undefined
+          && options.modelRoutingMode.value === 'llm_ensemble'
+        )
+      ) {
         return preserveRetryState('not_sent')
       }
     }
@@ -2384,7 +2396,7 @@ export function useChatSend(options: UseChatSendOptions) {
     const initialSendableAttachments = sourceAttachments.filter(isSendableAttachment)
     // This is deliberately before optimistic rendering, composer clearing,
     // stream state, and chat.send. A blocked draft remains exactly editable.
-    if (modelImageSendBlocked(initialSendableAttachments)) return 'not_sent'
+    if (modelImageSendBlocked(sourceAttachments)) return 'not_sent'
     const retryCandidate = sendOpts.retryAttempt ?? (preserveComposer ? null : recoveredAttempt)
     const requiresRecoveryReplay = Boolean(
       retryCandidate?.requiresIdempotentReplay

--- a/opensquilla-webui/src/i18n/i18n.test.ts
+++ b/opensquilla-webui/src/i18n/i18n.test.ts
@@ -289,18 +289,19 @@ describe('catalog parity', () => {
 
   it('explains the Ensemble image limit with actionable routing choices', () => {
     const locales = [
-      { messages: en, imagePattern: /image input/i },
-      { messages: zhHans, imagePattern: /图片输入/ },
-      { messages: de, imagePattern: /Bildeingaben/i },
-      { messages: es, imagePattern: /im[aá]gen/i },
-      { messages: fr, imagePattern: /images en entrée/i },
-      { messages: ja, imagePattern: /画像入力/ },
+      { messages: en, imagePattern: /image input/i, unsupportedImagePattern: /image input/i },
+      { messages: zhHans, imagePattern: /图片输入/, unsupportedImagePattern: /图片输入/ },
+      { messages: de, imagePattern: /Bildeingaben/i, unsupportedImagePattern: /Bilder/i },
+      { messages: es, imagePattern: /im[aá]gen/i, unsupportedImagePattern: /imágenes/i },
+      { messages: fr, imagePattern: /images en entrée/i, unsupportedImagePattern: /images/i },
+      { messages: ja, imagePattern: /画像入力/, unsupportedImagePattern: /画像/ },
     ]
 
-    for (const { messages, imagePattern } of locales) {
+    for (const { messages, imagePattern, unsupportedImagePattern } of locales) {
       const composer = messages.chat.composer
       expect(composer.modelRoutingEnsembleDesc).toMatch(imagePattern)
       expect(composer.ensembleImageUnsupported).toMatch(imagePattern)
+      expect(composer.imageInputUnsupported).toMatch(unsupportedImagePattern)
       expect(composer.ensembleImageUnsupported).toContain(composer.modelRouting)
       expect(composer.ensembleImageUnsupported).toContain(composer.modelRoutingSquillaRouter)
       expect(composer.ensembleImageUnsupported).toContain(composer.modelRoutingOff)

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -3806,6 +3806,7 @@
       "routerAnimationOff": "Router-Animation aus",
       "modelRouting": "Modell-Routing",
       "ensembleImageUnsupported": "Ensemble unterstützt derzeit keine Bildeingaben. Wählen Sie unter „Modell-Routing“ „AI-gestützter Einzelmodell-Router“ mit konfiguriertem Bildmodell oder „Aus“ mit einem bildfähigen Modell.",
+      "imageInputUnsupported": "Das ausgewählte Modell kann keine Bilder verarbeiten. Wählen Sie ein bildfähiges Modell oder entfernen Sie das Bild.",
       "routingUpdateImageBlocked": "Das Modell-Routing wird aktualisiert. Warten Sie, bevor Sie Bilder senden.",
       "modelRoutingOff": "Aus",
       "modelRoutingOffDesc": "Jeden Durchlauf an das ausgewählte Modell senden.",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -3888,6 +3888,7 @@
       "routerAnimationOff": "Router animation off",
       "modelRouting": "Model routing",
       "ensembleImageUnsupported": "Ensemble doesn't support image input yet. Under Model routing, choose AI-powered single-model router with an image-capable tier configured, or turn routing Off and select an image-capable model.",
+      "imageInputUnsupported": "The selected model cannot process image input. Choose an image-capable model or remove the image.",
       "routingUpdateImageBlocked": "Model routing is being updated. Wait before sending images.",
       "modelRoutingOff": "Off",
       "modelRoutingOffDesc": "Send every turn to the selected model.",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -3806,6 +3806,7 @@
       "routerAnimationOff": "Animación del enrutador desactivada",
       "modelRouting": "Enrutamiento de modelos",
       "ensembleImageUnsupported": "Ensemble aún no admite entradas de imagen. En «Enrutamiento de modelos», usa «Enrutador monomodelo con IA» configurado para imágenes o «Desactivado» con un modelo compatible con imágenes.",
+      "imageInputUnsupported": "El modelo seleccionado no puede procesar imágenes. Elige un modelo compatible o elimina la imagen.",
       "routingUpdateImageBlocked": "El enrutamiento de modelos se está actualizando. Espera antes de enviar imágenes.",
       "modelRoutingOff": "Desactivado",
       "modelRoutingOffDesc": "Envía cada turno al modelo seleccionado.",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -3806,6 +3806,7 @@
       "routerAnimationOff": "Animation du routeur désactivée",
       "modelRouting": "Routage des modèles",
       "ensembleImageUnsupported": "Ensemble ne prend pas encore en charge les images en entrée. Dans « Routage des modèles », utilisez « Routeur mono-modèle avec IA » configuré pour les images ou « Désactivé » avec un modèle compatible avec les images en entrée.",
+      "imageInputUnsupported": "Le modèle sélectionné ne peut pas traiter les images. Choisissez un modèle compatible ou retirez l’image.",
       "routingUpdateImageBlocked": "Le routage des modèles est en cours de mise à jour. Attendez avant d’envoyer des images.",
       "modelRoutingOff": "Désactivé",
       "modelRoutingOffDesc": "Envoie chaque tour au modèle sélectionné.",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -3806,6 +3806,7 @@
       "routerAnimationOff": "ルーターアニメーション オフ",
       "modelRouting": "モデルルーティング",
       "ensembleImageUnsupported": "Ensemble はまだ画像入力に対応していません。「モデルルーティング」で、画像モデルを設定した「AI搭載シングルモデルルーター」、または「オフ」と画像対応モデルを選択してください。",
+      "imageInputUnsupported": "選択したモデルは画像を処理できません。画像対応モデルを選択するか、画像を削除してください。",
       "routingUpdateImageBlocked": "モデルルーティングを更新しています。画像を送信する前にお待ちください。",
       "modelRoutingOff": "オフ",
       "modelRoutingOffDesc": "各ターンを選択中のモデルへ送信します。",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -3888,6 +3888,7 @@
       "routerAnimationOff": "路由动画已关闭",
       "modelRouting": "模型路由",
       "ensembleImageUnsupported": "多模型融合暂不支持图片输入。请在“模型路由”中选择已配置图片模型的“AI 智能单模型路由”，或选择“关”并使用支持图片的模型。",
+      "imageInputUnsupported": "当前模型不支持图片输入。请选择支持图片的模型，或移除图片后再发送。",
       "routingUpdateImageBlocked": "模型路由正在更新，请稍候再发送图片。",
       "modelRoutingOff": "关",
       "modelRoutingOffDesc": "每轮都发送到当前选定模型。",

--- a/opensquilla-webui/src/types/modelRouting.ts
+++ b/opensquilla-webui/src/types/modelRouting.ts
@@ -1,6 +1,7 @@
 export const MODEL_ROUTING_MODES = ['off', 'squilla_router', 'llm_ensemble'] as const
 
 export type ModelRoutingMode = (typeof MODEL_ROUTING_MODES)[number]
+export type ImageInputAdmission = 'allowed' | 'blocked' | 'unknown'
 
 export function isModelRoutingMode(value: unknown): value is ModelRoutingMode {
   return typeof value === 'string' && MODEL_ROUTING_MODES.includes(value as ModelRoutingMode)

--- a/opensquilla-webui/src/utils/chat/attachments.ts
+++ b/opensquilla-webui/src/utils/chat/attachments.ts
@@ -123,6 +123,10 @@ export function hasSendableModelInputImageAttachment(attachments: readonly Attac
   return attachments.some(isSendableModelInputImageAttachment)
 }
 
+export function hasModelInputImageAttachment(attachments: readonly Attachment[]): boolean {
+  return attachments.some(attachment => isModelInputImageMime(attachment.mime))
+}
+
 export function serializeSendableAttachment(attachment: SendableAttachment): ChatSendAttachmentPayload {
   if (attachment.kind === 'staged') {
     return {

--- a/opensquilla-webui/src/utils/chat/errors.ts
+++ b/opensquilla-webui/src/utils/chat/errors.ts
@@ -2,9 +2,13 @@ import i18n from '@/i18n'
 import { isUsageAccountingBarrier } from '@/utils/chat/usageAccountingFailure'
 
 export const ENSEMBLE_MULTIMODAL_UNSUPPORTED = 'ensemble_multimodal_unsupported'
+export const IMAGE_INPUT_UNSUPPORTED = 'image_input_unsupported'
 
-/** Preserve server-authored text for unknown failures, but give the stable
- * Ensemble image-input error an actionable message in the active UI locale. */
+export function isImageInputUnsupported(code: unknown): boolean {
+  return code === IMAGE_INPUT_UNSUPPORTED || code === ENSEMBLE_MULTIMODAL_UNSUPPORTED
+}
+
+/** Preserve server-authored text for unknown failures, while localizing stable errors. */
 export function localizedChatErrorMessage(
   code: unknown,
   fallback: string,
@@ -17,7 +21,10 @@ export function localizedChatErrorMessage(
         : 'chat.usageAccountingBlockedUnsafeMessage',
     )
   }
-  return code === ENSEMBLE_MULTIMODAL_UNSUPPORTED
-    ? i18n.global.t('chat.composer.ensembleImageUnsupported')
+  if (code === ENSEMBLE_MULTIMODAL_UNSUPPORTED) {
+    return i18n.global.t('chat.composer.ensembleImageUnsupported')
+  }
+  return code === IMAGE_INPUT_UNSUPPORTED
+    ? i18n.global.t('chat.composer.imageInputUnsupported')
     : fallback
 }

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -962,7 +962,7 @@ import {
 } from '@/utils/chat/toolDisplay'
 import {
   collectClipboardFiles,
-  hasSendableModelInputImageAttachment,
+  hasModelInputImageAttachment,
   isSendableAttachment,
   shouldCaptureFilePaste,
 } from '@/utils/chat/attachments'
@@ -1699,6 +1699,8 @@ const {
   routerEnabled,
   modelRoutingMode,
   modelRoutingSettingsBusy,
+  imageInputAdmission,
+  imageInputAdmissionReason,
   routerVisualEffectsEnabled,
   routerVisualMode,
   codingModeEnabled,
@@ -1710,14 +1712,17 @@ const {
   bindFeatureRefresh,
 } = chatFeatureToggles
 isQueuedDeliveryBlocked = () => (
-  modelRoutingSettingsBusy.value
-  && hasSendableModelInputImageAttachment(pendingQueue.value[0]?.attachments || [])
+  hasModelInputImageAttachment(pendingQueue.value[0]?.attachments || [])
+  && (
+    modelRoutingSettingsBusy.value
+    || imageInputAdmission.value === 'blocked'
+  )
 )
 watch(
-  [modelRoutingMode, modelRoutingSettingsBusy],
-  ([mode, busy], [previousMode, wasBusy]) => {
+  [imageInputAdmission, modelRoutingSettingsBusy],
+  ([admission, busy], [previousAdmission, wasBusy]) => {
     const routingUnblocked = (
-      (previousMode === 'llm_ensemble' && mode !== 'llm_ensemble')
+      (previousAdmission === 'blocked' && admission !== 'blocked')
       || (wasBusy && !busy)
     )
     if (!routingUnblocked || pendingQueue.value.length === 0) return
@@ -2633,6 +2638,7 @@ const chatSend = useChatSend({
   busySendMode,
   modelRoutingMode,
   modelRoutingSettingsBusy,
+  imageInputAdmission,
   elevatedMode,
   runMode,
   pendingAttachments,
@@ -3592,13 +3598,14 @@ const queuedImageSendBlockedMessage = computed(() => {
   if (modelRoutingSettingsBusy.value) {
     return t('chat.composer.routingUpdateImageBlocked')
   }
-  return modelRoutingMode.value === 'llm_ensemble'
+  if (imageInputAdmission.value !== 'blocked') return ''
+  return imageInputAdmissionReason.value === 'ensemble_mode_unsupported'
     ? t('chat.composer.ensembleImageUnsupported')
-    : ''
+    : t('chat.composer.imageInputUnsupported')
 })
 
 const modelImageSendBlockedMessage = computed(() => {
-  return hasSendableModelInputImageAttachment(pendingAttachments.value)
+  return hasModelInputImageAttachment(pendingAttachments.value)
     ? queuedImageSendBlockedMessage.value
     : ''
 })

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -202,10 +202,14 @@ from opensquilla.provider.correlation_context import bind_provider_request_corre
 from opensquilla.provider.failures import ProviderFailureKind, classify_provider_error
 from opensquilla.provider.model_identity import is_deepseek_v4_model_id
 from opensquilla.provider.protocol import (
+    IMAGE_INPUT_UNSUPPORTED_CODE,
+    IMAGE_INPUT_UNSUPPORTED_MESSAGE,
+    count_provider_image_blocks,
+    image_input_admission_error,
     project_provider_final_request,
     project_provider_message_count,
     provider_metadata,
-    validate_provider_chat_request,
+    validate_provider_chat_admission,
 )
 from opensquilla.provider.request_proof import (
     ProviderRequestBudgetExceededError,
@@ -372,20 +376,6 @@ _PROVIDER_OUTPUT_CONTINUE_PROMPT = (
     "been written. If a tool call was interrupted or incomplete, regenerate a complete "
     "tool call from scratch."
 )
-UNSUPPORTED_IMAGE_INPUT_REPLY = (
-    "当前选择的模型暂不支持查看图片，因此无法分析你上传的图片。"
-    "请切换到支持图片的模型，或将图片中的文字和关键信息粘贴到消息中后重试。"
-)
-
-
-def model_explicitly_lacks_vision(capabilities: Any) -> bool:
-    """Return true only when capability data explicitly denies vision."""
-
-    return capabilities is not None and not bool(
-        getattr(capabilities, "supports_vision", False)
-    )
-
-
 _TEXT_ONLY_TOOL_RECOVERY_LIMIT = 2
 _TEXT_ONLY_TOOL_RECOVERY_MESSAGE = (
     "[Runtime recovery]\n"
@@ -2658,6 +2648,7 @@ def _chat_config_with_thinking_disabled(chat_cfg: ChatConfig) -> ChatConfig:
         output_json_schema=chat_cfg.output_json_schema,
         output_json_schema_strict=chat_cfg.output_json_schema_strict,
         model_capabilities=chat_cfg.model_capabilities,
+        model_vision_support=chat_cfg.model_vision_support,
         thinking_level=ThinkingLevel.OFF,
         provider_request_max_chars=chat_cfg.provider_request_max_chars,
         context_window_tokens_global_override=(
@@ -3366,6 +3357,7 @@ class Agent:
             model_capabilities=(
                 resolved_capabilities
             ),
+            model_vision_support=self.config.model_vision_support,
             thinking_level=(
                 self.config.thinking
                 if isinstance(self.config.thinking, ThinkingLevel)
@@ -4137,25 +4129,6 @@ class Agent:
                 error=str(exc),
             )
             return False
-
-    def _provider_local_terminal_reply(
-        self,
-        messages: list[Message],
-        config: ChatConfig,
-    ) -> str | None:
-        local_reply = getattr(self.provider, "local_terminal_reply", None)
-        if not callable(local_reply):
-            return None
-        try:
-            reply = local_reply(messages, config)
-        except Exception as exc:  # noqa: BLE001 - optional preflight must be isolated
-            logger.warning(
-                "provider.local_terminal_reply_failed",
-                session_key=self._session_key,
-                error=str(exc),
-            )
-            return None
-        return reply if isinstance(reply, str) and reply else None
 
     @staticmethod
     def _tool_call_string_arg(
@@ -6642,25 +6615,36 @@ class Agent:
             _ = terminates  # always terminates today; reserved for future
             return
 
-        current_turn_image_count = self._count_image_blocks(extra_messages or [])
-        if current_turn_image_count > 0 and model_explicitly_lacks_vision(
-            self.config.model_capabilities
-        ):
+        current_turn_image_count = count_provider_image_blocks(extra_messages or [])
+        forced_image_rejection = str(
+            self.config.metadata.get("image_input_forced_rejection_reason") or ""
+        ).strip()
+        image_admission_error = image_input_admission_error(
+            extra_messages or [],
+            vision_support=(
+                "unsupported"
+                if forced_image_rejection
+                else self.config.model_vision_support
+            ),
+        )
+        if forced_image_rejection or image_admission_error is not None:
+            image_input_reason = forced_image_rejection or "model_vision_unsupported"
             self.config.metadata["image_input_mode"] = "rejected"
-            self.config.metadata["image_input_reason"] = "vision_unsupported"
+            self.config.metadata["image_input_reason"] = image_input_reason
             self.config.metadata["image_input_count"] = current_turn_image_count
+            self.config.metadata["image_input_stage"] = "primary"
             self._write_turn_call_log(
                 "image_input_preflight",
-                action="terminal_reply",
-                reason="vision_unsupported",
+                action="reject",
+                reason=image_input_reason,
                 model=self.config.model_id or "",
                 image_count=current_turn_image_count,
             )
-            async for ev in self._emit_terminal_text(
-                UNSUPPORTED_IMAGE_INPUT_REPLY,
-                iterations=0,
-            ):
-                yield ev
+            yield self._transition(AgentState.ERROR)
+            yield ErrorEvent(
+                message=IMAGE_INPUT_UNSUPPORTED_MESSAGE,
+                code=IMAGE_INPUT_UNSUPPORTED_CODE,
+            )
             return
 
         # Use the system prompt from config (wired by gateway via identity.prompt)
@@ -8121,31 +8105,10 @@ class Agent:
                         self._provider_call_tool_result_retrieval_available = (
                             previous_call_retrieval
                         )
-                    local_terminal_reply = self._provider_local_terminal_reply(
-                        request_messages,
-                        chat_cfg,
-                    )
-                    if local_terminal_reply is not None:
-                        assistant_text_parts = [local_terminal_reply]
-                        attempt_user_visible_emitted = True
-                        _got_done_event = True
-                        provider_done_for_log = ProviderDoneEvent(
-                            stop_reason="end_turn",
-                            input_tokens=0,
-                            output_tokens=0,
-                            model=self.config.model_id or "",
-                        )
-                        self._write_turn_call_log(
-                            "provider_local_terminal_reply",
-                            reason=self.config.metadata.get("image_input_reason", ""),
-                            iteration=iterations,
-                            attempt=_call_attempt,
-                        )
-                        yield TextDeltaEvent(text=local_terminal_reply)
-                        break
-                    validation_error = validate_provider_chat_request(
+                    validation_error = validate_provider_chat_admission(
                         self.provider,
                         request_messages,
+                        chat_cfg,
                     )
                     if validation_error is not None:
                         terminal_error = ErrorEvent(
@@ -8164,6 +8127,39 @@ class Agent:
                             terminal_error = None
                             yield TextDeltaEvent(text=response_text)
                         else:
+                            if terminal_error.code == IMAGE_INPUT_UNSUPPORTED_CODE:
+                                exact_image_count = count_provider_image_blocks(
+                                    request_messages
+                                )
+                                self.config.metadata["image_input_mode"] = "rejected"
+                                self.config.metadata.setdefault(
+                                    "image_input_reason",
+                                    "model_vision_unsupported",
+                                )
+                                self.config.metadata["image_input_count"] = (
+                                    exact_image_count
+                                )
+                                self.config.metadata.setdefault(
+                                    "image_input_stage",
+                                    "primary",
+                                )
+                                self._write_turn_call_log(
+                                    "image_input_preflight",
+                                    action="reject",
+                                    reason=str(
+                                        self.config.metadata.get("image_input_reason")
+                                        or "model_vision_unsupported"
+                                    ),
+                                    stage=str(
+                                        self.config.metadata.get("image_input_stage")
+                                        or "primary"
+                                    ),
+                                    image_count=int(
+                                        self.config.metadata.get("image_input_count") or 0
+                                    ),
+                                    iteration=iterations,
+                                    attempt=_call_attempt,
+                                )
                             self._write_turn_call_log(
                                 "turn_policy_decision",
                                 action="stop",

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -100,12 +100,7 @@ from opensquilla.contracts.attachments import (
     normalize_attachment_mime as _normalize_attachment_mime,
 )
 from opensquilla.contracts.turn_execution import TurnExecutionContext
-from opensquilla.engine.agent import (
-    UNSUPPORTED_IMAGE_INPUT_REPLY,
-    Agent,
-    ToolHandler,
-    model_explicitly_lacks_vision,
-)
+from opensquilla.engine.agent import Agent, ToolHandler
 from opensquilla.engine.agent_injection import PendingInputProvider
 from opensquilla.engine.cache_break_monitor import notify_compaction
 from opensquilla.engine.hooks import (
@@ -228,9 +223,6 @@ from opensquilla.observability.turn_call_log import TurnCallLogger, is_turn_call
 from opensquilla.paths import media_root_from_config
 from opensquilla.process_tree import task_process_scope
 from opensquilla.provider import (
-    DoneEvent as ProviderDoneEvent,
-)
-from opensquilla.provider import (
     ErrorEvent as ProviderErrorEvent,
 )
 from opensquilla.provider import (
@@ -246,9 +238,6 @@ from opensquilla.provider import (
     ReasoningDeltaEvent as ProviderReasoningDeltaEvent,
 )
 from opensquilla.provider import (
-    TextDeltaEvent as ProviderTextDeltaEvent,
-)
-from opensquilla.provider import (
     ToolUseDeltaEvent as ProviderToolUseDeltaEvent,
 )
 from opensquilla.provider import (
@@ -262,19 +251,21 @@ from opensquilla.provider.model_catalog import (
     shared_catalog,
 )
 from opensquilla.provider.protocol import (
+    count_provider_image_blocks,
+    image_input_admission_error,
     project_provider_final_request,
     project_provider_message_count,
     provider_metadata,
-    validate_provider_chat_request,
-)
-from opensquilla.provider.types import (
-    ContentBlockImage,
-    ProviderGenerationResetEvent,
-    ProviderRequestCorrelation,
-    derive_provider_request_correlation,
+    validate_provider_chat_admission,
 )
 from opensquilla.provider.types import (
     EnsembleProgressEvent as ProviderEnsembleProgressEvent,
+)
+from opensquilla.provider.types import (
+    ProviderGenerationResetEvent,
+    ProviderRequestCorrelation,
+    VisionSupport,
+    derive_provider_request_correlation,
 )
 from opensquilla.router_control import (
     RouterControlHoldStore,
@@ -1671,13 +1662,7 @@ def _fallback_deployment_identity(config: Any) -> _FallbackDeploymentIdentity:
 
 
 def _count_image_blocks(messages: Sequence[Any]) -> int:
-    count = 0
-    for message in messages:
-        content = getattr(message, "content", None)
-        if not isinstance(content, list):
-            continue
-        count += sum(1 for block in content if isinstance(block, ContentBlockImage))
-    return count
+    return count_provider_image_blocks(list(messages))
 
 
 _SELECTOR_PRE_TEXT_REASONING_LIMIT_BYTES: Final[int] = 2 * 1024 * 1024
@@ -2200,6 +2185,9 @@ class _SelectorFallbackProvider:
         self._fallback_deployment_capabilities: dict[
             _FallbackDeploymentIdentity, ModelCapabilities
         ] = {}
+        self._fallback_deployment_vision_support: dict[
+            _FallbackDeploymentIdentity, VisionSupport
+        ] = {}
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._provider, name)
@@ -2412,6 +2400,20 @@ class _SelectorFallbackProvider:
         self._fallback_deployment_limits = normalized
         self._fallback_deployment_capabilities = normalized_capabilities
 
+    def configure_fallback_deployment_vision_support(
+        self,
+        entries: Sequence[tuple[Any, Any]],
+    ) -> None:
+        """Install exact deployment-scoped tri-state vision evidence."""
+
+        normalized: dict[_FallbackDeploymentIdentity, VisionSupport] = {}
+        for deployment, value in entries:
+            identity = _fallback_deployment_identity(deployment)
+            if identity is None or value not in {"supported", "unsupported", "unknown"}:
+                continue
+            normalized[identity] = value
+        self._fallback_deployment_vision_support = normalized
+
     def configure_fallback_limits(
         self,
         limits: Mapping[tuple[str, str], tuple[int, int]],
@@ -2536,9 +2538,10 @@ class _SelectorFallbackProvider:
         ).strip()
         model = str(getattr(current_config, "model", "") or "").strip()
         if model:
+            deployment_identity = _fallback_deployment_identity(current_config)
             deployment_capabilities = (
                 self._fallback_deployment_capabilities.get(
-                    _fallback_deployment_identity(current_config)
+                    deployment_identity
                 )
                 if current_config is not None
                 else None
@@ -2583,6 +2586,40 @@ class _SelectorFallbackProvider:
                     error=type(exc).__name__,
                 )
                 updates["model_capabilities"] = ModelCapabilities()
+
+            vision_support = self._fallback_deployment_vision_support.get(
+                deployment_identity,
+                "unknown",
+            )
+            if vision_support == "unknown":
+                try:
+                    vision_resolver = getattr(
+                        shared_catalog(),
+                        "resolve_deployment_vision_support",
+                        None,
+                    )
+                    if callable(vision_resolver):
+                        resolved_vision_support = vision_resolver(
+                            model,
+                            provider=provider_id,
+                            api_key=str(getattr(current_config, "api_key", "") or ""),
+                            base_url=str(getattr(current_config, "base_url", "") or ""),
+                            proxy=str(getattr(current_config, "proxy", "") or ""),
+                        )
+                        if resolved_vision_support in {
+                            "supported",
+                            "unsupported",
+                            "unknown",
+                        }:
+                            vision_support = resolved_vision_support
+                except Exception as exc:  # noqa: BLE001 - optional capability refinement
+                    log.warning(
+                        "selector_fallback_vision_support_rebind_failed",
+                        provider=provider_id,
+                        model=model,
+                        error=type(exc).__name__,
+                    )
+            updates["model_vision_support"] = vision_support
 
         try:
             inherited_proof_cap = max(
@@ -2757,46 +2794,57 @@ class _SelectorFallbackProvider:
         messages: list[Any],
         config: Any,
         *,
-        reason: str,
         reject_unknown_capability: bool,
-    ) -> int:
-        """Record a local image rejection for the active physical leg."""
+    ) -> ProviderErrorEvent | None:
+        """Return and record an image admission error for the active physical leg."""
 
+        raw_vision_support = getattr(config, "model_vision_support", "unknown")
+        vision_support: VisionSupport = (
+            cast(VisionSupport, raw_vision_support)
+            if raw_vision_support in {"supported", "unsupported", "unknown"}
+            else "unknown"
+        )
+        error = image_input_admission_error(
+            messages,
+            vision_support=vision_support,
+            reject_unknown=reject_unknown_capability,
+        )
+        if error is None:
+            return None
         image_count = _count_image_blocks(messages)
-        capabilities = getattr(config, "model_capabilities", None)
-        if image_count <= 0:
-            return 0
-        if capabilities is None and not reject_unknown_capability:
-            return 0
-        if capabilities is not None and bool(
-            getattr(capabilities, "supports_vision", False)
-        ):
-            return 0
         if self._turn_metadata is not None:
             self._turn_metadata["image_input_mode"] = "rejected"
-            self._turn_metadata["image_input_reason"] = reason
+            self._turn_metadata["image_input_reason"] = (
+                "capability_unknown"
+                if vision_support == "unknown"
+                else "model_vision_unsupported"
+            )
             self._turn_metadata["image_input_count"] = image_count
-        return image_count
+            self._turn_metadata["image_input_stage"] = (
+                "fallback" if self._used_fallback else "primary"
+            )
+        return error
 
-    def local_terminal_reply(
+    def validate_chat_admission(
         self,
         messages: list[Any],
         config: Any,
-    ) -> str | None:
-        """Return a capability rejection before Agent reserves another call."""
+    ) -> ProviderErrorEvent | None:
+        """Validate the exact request against the active physical deployment."""
 
         active_config = self._config_for_active_leg(config)
-        reason = (
-            "fallback_vision_unsupported" if self._used_fallback else "vision_unsupported"
-        )
-        if self._reject_unsupported_image_input(
+        capability_error = self._reject_unsupported_image_input(
             messages,
             active_config,
-            reason=reason,
             reject_unknown_capability=self._used_fallback,
-        ):
-            return UNSUPPORTED_IMAGE_INPUT_REPLY
-        return None
+        )
+        if capability_error is not None:
+            return capability_error
+        return validate_provider_chat_admission(
+            self._provider,
+            messages,
+            active_config,
+        )
 
     def project_final_request(
         self,
@@ -2864,18 +2912,7 @@ class _SelectorFallbackProvider:
         active_provider = self._provider
         active_provider_id, active_model = self._active_deployment()
         active_config = self._config_for_active_leg(config)
-        local_terminal_reply = self.local_terminal_reply(messages, config)
-        if local_terminal_reply is not None:
-            yield ProviderTextDeltaEvent(text=UNSUPPORTED_IMAGE_INPUT_REPLY)
-            yield ProviderDoneEvent(
-                stop_reason="end_turn",
-                input_tokens=0,
-                output_tokens=0,
-                model=self._last_executed_model or active_model,
-            )
-            return
-
-        validation_error = validate_provider_chat_request(active_provider, messages)
+        validation_error = self.validate_chat_admission(messages, config)
         if validation_error is not None:
             yield validation_error
             return
@@ -3068,19 +3105,21 @@ class _SelectorFallbackProvider:
                     fallback_provider = self._provider
                     fallback_provider_id, fallback_model = self._active_deployment()
                     fallback_config = self._config_for_active_leg(config)
-                    if self._reject_unsupported_image_input(
+                    fallback_admission_error = self._reject_unsupported_image_input(
                         messages,
                         fallback_config,
-                        reason="fallback_vision_unsupported",
                         reject_unknown_capability=True,
-                    ):
-                        yield ProviderTextDeltaEvent(text=UNSUPPORTED_IMAGE_INPUT_REPLY)
-                        yield ProviderDoneEvent(
-                            stop_reason="end_turn",
-                            input_tokens=0,
-                            output_tokens=0,
-                            model=self._last_executed_model or active_model,
-                        )
+                    )
+                    if fallback_admission_error is not None:
+                        yield fallback_admission_error
+                        return
+                    fallback_validation_error = validate_provider_chat_admission(
+                        fallback_provider,
+                        messages,
+                        fallback_config,
+                    )
+                    if fallback_validation_error is not None:
+                        yield fallback_validation_error
                         return
                     fallback_authority_config = getattr(
                         self._selector,
@@ -5378,14 +5417,23 @@ class TurnRunner:
                 )
 
             current_turn_image_count = _count_image_blocks(extra_msgs or [])
+            forced_image_rejection_reason = str(
+                turn.metadata.get("image_input_forced_rejection_reason", "") or ""
+            ).strip()
             image_input_preflight_blocked = bool(
-                current_turn_image_count > 0
-                and model_explicitly_lacks_vision(model_caps)
+                forced_image_rejection_reason
+                or (
+                    current_turn_image_count > 0
+                    and agent_config.model_vision_support == "unsupported"
+                )
             )
             if image_input_preflight_blocked:
                 turn.metadata["image_input_mode"] = "rejected"
-                turn.metadata["image_input_reason"] = "vision_unsupported"
+                turn.metadata["image_input_reason"] = (
+                    forced_image_rejection_reason or "model_vision_unsupported"
+                )
                 turn.metadata["image_input_count"] = current_turn_image_count
+                turn.metadata["image_input_stage"] = "primary"
             # 6. Compaction (t3 + preflight) + history load + request-context
             # prepend. CompactionAndHistoryStage owns the four-call sequence
             # (t3_upgrade → preflight → load_history → prepend_request_context_prompt).

--- a/src/opensquilla/engine/steps/squilla_router.py
+++ b/src/opensquilla/engine/steps/squilla_router.py
@@ -1747,18 +1747,12 @@ async def apply_squilla_router(ctx: TurnContext) -> TurnContext:
                 c3_fusion_active=c3_fusion_active,
                 empty_model_tiers=sorted(image_capable_tiers),
             )
-            if c3_fusion_active:
-                raise RuntimeError(
-                    "No image-capable SquillaRouter tier is available for this image "
-                    "request while C3 multi-model fusion is selected. Configure "
-                    "squilla_router.tiers.image_model with supports_image=true and a "
-                    "non-empty model, or enable image support on another non-C3 tier."
-                )
-            raise RuntimeError(
-                "No image-capable SquillaRouter tier is configured with a non-empty model "
-                "for this image request. Configure squilla_router.tiers.image_model with "
-                "supports_image=true and a model."
+            ctx.metadata["image_input_forced_rejection_reason"] = (
+                "router_image_route_unavailable"
             )
+            ctx.metadata["image_input_mode"] = "rejected"
+            ctx.metadata["image_input_reason"] = "router_image_route_unavailable"
+            return ctx
         ordered_image_tiers = sorted(
             image_tiers,
             key=lambda name: (

--- a/src/opensquilla/engine/turn_runner/agent_bootstrap_stage.py
+++ b/src/opensquilla/engine/turn_runner/agent_bootstrap_stage.py
@@ -396,6 +396,7 @@ class _ResolvedCatalog:
     max_tokens: int
     context_window: int
     capabilities: ModelCapabilities | None
+    vision_support: Literal["supported", "unsupported", "unknown"] = "unknown"
     # Raw positive global ``llm.context_window_tokens`` value, or zero when
     # unset. This is deliberately distinct from ``context_window`` because a
     # per-model override may win for the current deployment while the global
@@ -840,6 +841,9 @@ class AgentBootstrapStage:
         private_fallback_limits: list[
             tuple[Any, int, int, ModelCapabilities | None]
         ] = []
+        private_fallback_vision_support: list[
+            tuple[Any, Literal["supported", "unsupported", "unknown"]]
+        ] = []
         fallback_deployment_configs = getattr(
             inp.provider,
             "fallback_deployment_configs",
@@ -878,6 +882,9 @@ class AgentBootstrapStage:
                         effective_max_tokens,
                         fallback_catalog.capabilities,
                     )
+                )
+                private_fallback_vision_support.append(
+                    (deployment, fallback_catalog.vision_support)
                 )
                 fallback_capabilities.setdefault(
                     (fallback_provider, fallback_model),
@@ -930,6 +937,15 @@ class AgentBootstrapStage:
         )
         if callable(configure_private_fallback_limits):
             configure_private_fallback_limits(private_fallback_limits)
+        configure_private_fallback_vision_support = getattr(
+            inp.provider,
+            "configure_fallback_deployment_vision_support",
+            None,
+        )
+        if callable(configure_private_fallback_vision_support):
+            configure_private_fallback_vision_support(
+                private_fallback_vision_support
+            )
         configure_fallback_limits = getattr(
             inp.provider,
             "configure_fallback_limits",
@@ -1028,6 +1044,7 @@ class AgentBootstrapStage:
             compaction_heartbeat_interval_seconds=aux.compaction_heartbeat_interval_seconds,
             flush_workspace_dir=aux.flush_workspace_dir,
             model_capabilities=catalog.capabilities,
+            model_vision_support=catalog.vision_support,
             thinking=aux.thinking,
             tool_result_projection_max_inline_chars=(aux.tool_result_projection_max_inline_chars),
             tool_result_fresh_diagnostic_policy_enabled=(

--- a/src/opensquilla/engine/turn_runner/harness.py
+++ b/src/opensquilla/engine/turn_runner/harness.py
@@ -582,16 +582,48 @@ class _TurnRunnerModelCatalogAdapter(ModelCatalogPort):
             capabilities = runner._model_catalog.get_capabilities(
                 model_id, provider_name=provider_name, base_url=base_url
             )
+            deployment_vision_resolver = getattr(
+                runner._model_catalog,
+                "resolve_deployment_vision_support",
+                None,
+            )
+            if callable(deployment_vision_resolver):
+                vision_support = deployment_vision_resolver(
+                    model_id,
+                    provider=provider_name,
+                    api_key=str(getattr(llm_cfg, "api_key", "") or ""),
+                    base_url=base_url,
+                    proxy=str(getattr(llm_cfg, "proxy", "") or ""),
+                )
+            else:
+                vision_resolver = getattr(
+                    runner._model_catalog,
+                    "resolve_vision_support",
+                    None,
+                )
+                vision_support = (
+                    vision_resolver(
+                        model_id,
+                        provider_name=provider_name,
+                        base_url=base_url,
+                    )
+                    if callable(vision_resolver)
+                    else "unknown"
+                )
         else:
             max_tokens = user_max_tokens if user_max_tokens > 0 else 16384
             auto_max_tokens = 0
             auto_max_tokens_source = "default"
             context_window = user_context_window if user_context_window > 0 else 200_000
             capabilities = None
+            vision_support = "unknown"
+        if vision_support not in {"supported", "unsupported", "unknown"}:
+            vision_support = "unknown"
         return _ResolvedCatalog(
             max_tokens=max_tokens,
             context_window=context_window,
             capabilities=capabilities,
+            vision_support=cast(Any, vision_support),
             context_window_tokens_global_override=user_context_window,
             auto_max_tokens=auto_max_tokens,
             auto_max_tokens_known=auto_max_tokens_source in {"catalog", "override"},
@@ -658,6 +690,24 @@ class _TurnRunnerModelCatalogAdapter(ModelCatalogPort):
                 base_url=base_url,
             )
         )
+        deployment_vision_resolver = getattr(
+            catalog,
+            "resolve_deployment_vision_support",
+            None,
+        )
+        vision_support = (
+            deployment_vision_resolver(
+                model_id,
+                provider=provider_name,
+                api_key=str(getattr(deployment, "api_key", "") or ""),
+                base_url=base_url,
+                proxy=str(getattr(deployment, "proxy", "") or ""),
+            )
+            if callable(deployment_vision_resolver)
+            else "unknown"
+        )
+        if vision_support not in {"supported", "unsupported", "unknown"}:
+            vision_support = "unknown"
         context_window = limits.context_window
         if include_global_overrides:
             per_model_context = catalog.user_context_window_override(
@@ -676,6 +726,7 @@ class _TurnRunnerModelCatalogAdapter(ModelCatalogPort):
             max_tokens=max_tokens,
             context_window=context_window,
             capabilities=capabilities,
+            vision_support=cast(Any, vision_support),
             auto_max_tokens=limits.max_output_tokens,
             auto_max_tokens_known=limits.max_output_tokens_known,
             temperature=getattr(llm_cfg, "temperature", None),

--- a/src/opensquilla/engine/types.py
+++ b/src/opensquilla/engine/types.py
@@ -749,6 +749,9 @@ class AgentConfig:
     repair_max_items_per_tick: int = 5
     flush_workspace_dir: str | None = None
     model_capabilities: Any | None = None  # ModelCapabilities from provider.types
+    # Runtime-only tri-state evidence; synthesized capability defaults remain
+    # ``unknown`` instead of becoming an authoritative vision denial.
+    model_vision_support: Literal["supported", "unsupported", "unknown"] = "unknown"
     # Tokenjuice projection: project eligible fresh tool results before the
     # next LLM turn. This is not user-selectable behavior.
     # Legacy compression knobs remain as compatibility shims for meta_invoke

--- a/src/opensquilla/gateway/model_routing.py
+++ b/src/opensquilla/gateway/model_routing.py
@@ -13,14 +13,149 @@ from typing import Any, Literal
 
 from opensquilla.router_tiers import (
     CUSTOM_B5_SELECTION_MODE,
+    HIGHEST_TEXT_TIER,
+    IMAGE_TIER,
     INDEPENDENT_ENSEMBLE_SELECTION_MODES,
     STATIC_B5_PROFILES,
     effective_ensemble_selection_mode,
     ensemble_selection_configured,
+    normalize_tier_mapping,
     static_b5_profile,
+    tier_ensemble_active,
+    tier_index,
 )
 
 ModelRoutingMode = Literal["direct", "router", "ensemble"]
+
+
+def _router_image_route(config: Any) -> tuple[str, dict[str, Any]] | None:
+    router = getattr(config, "squilla_router", None)
+    tiers = normalize_tier_mapping(getattr(router, "tiers", {}) or {})
+    c3_fusion_active = bool(
+        getattr(getattr(config, "llm_ensemble", None), "enabled", False)
+    ) or tier_ensemble_active(tiers, HIGHEST_TEXT_TIER)
+    image_tiers = {
+        name: tier
+        for name, tier in tiers.items()
+        if isinstance(tier, dict)
+        and bool(tier.get("supports_image", False))
+        and bool(str(tier.get("model") or "").strip())
+        and not (c3_fusion_active and name == HIGHEST_TEXT_TIER)
+    }
+    if not image_tiers:
+        return None
+    ordered = sorted(
+        image_tiers,
+        key=lambda name: (tier_index(name) < 0, tier_index(name)),
+    )
+    if IMAGE_TIER in image_tiers:
+        ordered = [IMAGE_TIER, *(name for name in ordered if name != IMAGE_TIER)]
+    selected = ordered[0]
+    return selected, image_tiers[selected]
+
+
+def _deployment_vision_support(
+    *,
+    model: str,
+    provider: str,
+    api_key: str = "",
+    base_url: str = "",
+    proxy: str = "",
+) -> str:
+    if not model:
+        return "unknown"
+    try:
+        from opensquilla.provider.model_catalog import shared_catalog
+
+        resolver = getattr(shared_catalog(), "resolve_deployment_vision_support", None)
+        if callable(resolver):
+            resolved = resolver(
+                model,
+                provider=provider,
+                api_key=api_key,
+                base_url=base_url,
+                proxy=proxy,
+            )
+            if isinstance(resolved, str) and resolved in {
+                "supported",
+                "unsupported",
+                "unknown",
+            }:
+                return resolved
+    except Exception:  # noqa: BLE001 - public snapshot must remain available
+        pass
+    return "unknown"
+
+
+def _image_input_routing_snapshot(
+    config: Any,
+    *,
+    router_enabled: bool,
+    ensemble_enabled: bool,
+    selection_mode: str,
+) -> dict[str, str]:
+    independent_ensemble = bool(
+        ensemble_enabled and selection_mode in INDEPENDENT_ENSEMBLE_SELECTION_MODES
+    )
+    if independent_ensemble or (ensemble_enabled and not router_enabled):
+        return {
+            "admission": "blocked",
+            "reason": "ensemble_mode_unsupported",
+        }
+    if router_enabled:
+        image_route = _router_image_route(config)
+        if image_route is None:
+            return {
+                "admission": "blocked",
+                "reason": "router_image_route_unavailable",
+            }
+        _, image_tier = image_route
+        llm = getattr(config, "llm", None)
+        active_provider = _clean(getattr(llm, "provider", ""))
+        tier_provider = _clean(image_tier.get("provider"))
+        cross_provider = bool(
+            getattr(getattr(config, "squilla_router", None), "cross_provider_tiers", False)
+        )
+        provider = tier_provider if cross_provider and tier_provider else active_provider
+        provider = provider or tier_provider
+        use_active_authority = not provider or provider == active_provider
+        vision_support = _deployment_vision_support(
+            model=_clean(image_tier.get("model")),
+            provider=provider,
+            api_key=str(getattr(llm, "api_key", "") or "") if use_active_authority else "",
+            base_url=str(getattr(llm, "base_url", "") or "") if use_active_authority else "",
+            proxy=str(getattr(llm, "proxy", "") or "") if use_active_authority else "",
+        )
+        if vision_support == "supported":
+            return {
+                "admission": "allowed",
+                "reason": "router_image_route_available",
+            }
+        if vision_support == "unsupported":
+            return {
+                "admission": "blocked",
+                "reason": "model_vision_unsupported",
+            }
+        return {"admission": "unknown", "reason": "capability_unknown"}
+
+    llm = getattr(config, "llm", None)
+    model = _clean(getattr(llm, "model", ""))
+    provider = _clean(getattr(llm, "provider", ""))
+    vision_support = _deployment_vision_support(
+        model=model,
+        provider=provider,
+        api_key=str(getattr(llm, "api_key", "") or ""),
+        base_url=str(getattr(llm, "base_url", "") or ""),
+        proxy=str(getattr(llm, "proxy", "") or ""),
+    )
+    if vision_support == "supported":
+        return {"admission": "allowed", "reason": "model_vision_supported"}
+    if vision_support == "unsupported":
+        return {
+            "admission": "blocked",
+            "reason": "model_vision_unsupported",
+        }
+    return {"admission": "unknown", "reason": "capability_unknown"}
 
 @dataclass(frozen=True, slots=True)
 class _ModelRoutingConfigSnapshot:
@@ -266,6 +401,12 @@ def model_routing_snapshot(config: Any) -> dict[str, Any]:
         "selection_configured": ensemble_selection_configured(config),
         "activation_preview": ensemble_activation_preview(config),
         "router_required_by_ensemble": router_required,
+        "image_input": _image_input_routing_snapshot(
+            config,
+            router_enabled=router_enabled,
+            ensemble_enabled=ensemble_enabled,
+            selection_mode=selection_mode,
+        ),
         "applies_to": "next_accepted_turn",
     }
 

--- a/src/opensquilla/provider/ensemble.py
+++ b/src/opensquilla/provider/ensemble.py
@@ -62,13 +62,13 @@ from .model_catalog import resolve_effective_context_window, shared_catalog
 from .protocol import (
     LLMProvider,
     ProviderMetadata,
+    count_provider_image_blocks,
     project_provider_final_request,
     project_provider_message_count,
 )
 from .selector import ModelSelector, ProviderConfig, SelectorConfig
 from .types import (
     ChatConfig,
-    ContentBlockImage,
     ContentBlockToolResult,
     DoneEvent,
     EnsembleProgressEvent,
@@ -2114,25 +2114,12 @@ class EnsembleProvider:
     def validate_chat_request(self, messages: list[Message]) -> ErrorEvent | None:
         """Reject typed image input before any ensemble leg can start."""
 
-        for message in messages:
-            if not isinstance(message.content, list):
-                continue
-            for block in message.content:
-                if isinstance(block, ContentBlockImage):
-                    return ErrorEvent(
-                        message=ENSEMBLE_MULTIMODAL_UNSUPPORTED_MESSAGE,
-                        code=ENSEMBLE_MULTIMODAL_UNSUPPORTED_CODE,
-                    )
-                if not isinstance(block, ContentBlockToolResult):
-                    continue
-                if isinstance(block.content, list) and any(
-                    isinstance(item, ContentBlockImage) for item in block.content
-                ):
-                    return ErrorEvent(
-                        message=ENSEMBLE_MULTIMODAL_UNSUPPORTED_MESSAGE,
-                        code=ENSEMBLE_MULTIMODAL_UNSUPPORTED_CODE,
-                    )
-        return None
+        if count_provider_image_blocks(messages) <= 0:
+            return None
+        return ErrorEvent(
+            message=ENSEMBLE_MULTIMODAL_UNSUPPORTED_MESSAGE,
+            code=ENSEMBLE_MULTIMODAL_UNSUPPORTED_CODE,
+        )
 
     async def list_models(self) -> list[ModelInfo]:
         models: list[ModelInfo] = []

--- a/src/opensquilla/provider/failures.py
+++ b/src/opensquilla/provider/failures.py
@@ -202,7 +202,9 @@ _SHARED_PRE_MATCHERS: tuple[FailureMatcher, ...] = (
     # which would bypass Ensemble's text-only contract.
     FailureMatcher(
         ProviderFailureKind.BAD_REQUEST,
-        raw_codes=frozenset({"ensemble_multimodal_unsupported"}),
+        raw_codes=frozenset(
+            {"ensemble_multimodal_unsupported", "image_input_unsupported"}
+        ),
     ),
     FailureMatcher(
         ProviderFailureKind.CONTEXT_OVERFLOW,

--- a/src/opensquilla/provider/model_catalog.py
+++ b/src/opensquilla/provider/model_catalog.py
@@ -32,7 +32,7 @@ from .tokenrhythm_catalog import (
     is_official_tokenrhythm_endpoint,
     tokenrhythm_authority_identity,
 )
-from .types import ModelCapabilities, ModelInfo
+from .types import ModelCapabilities, ModelInfo, VisionSupport
 
 log = structlog.get_logger(__name__)
 
@@ -991,6 +991,97 @@ class ModelCatalog:
             max_output_tokens=effective_max,
             max_output_tokens_known=max_known,
         )
+
+    def resolve_vision_support(
+        self,
+        model_id: str,
+        *,
+        provider_name: str = "",
+        base_url: str = "",
+    ) -> VisionSupport:
+        """Resolve per-field vision evidence without treating defaults as facts."""
+
+        provider_id = str(provider_name or "").strip().lower()
+        model_id = str(model_id or "").strip()
+        openrouter_live_fields = (
+            _live_layer_fields(self._models.get(model_id))
+            if provider_id in {"", "openrouter"}
+            else {}
+        )
+        layers = (
+            self._user_override_fields(model_id, provider_id),
+            self._live_provider_fields(model_id, provider_id),
+            openrouter_live_fields,
+            _corrections_layer_fields(provider_id, model_id),
+            _snapshot_layer_fields(provider_id, model_id),
+        )
+        for fields in layers:
+            value = fields.get("supports_vision")
+            if isinstance(value, bool):
+                return "supported" if value else "unsupported"
+        return "unknown"
+
+    def resolve_deployment_vision_support(
+        self,
+        model_id: str,
+        *,
+        provider: str,
+        api_key: str = "",
+        base_url: str = "",
+        proxy: str = "",
+    ) -> VisionSupport:
+        """Resolve exact deployment vision evidence for selector legs."""
+
+        del proxy  # Identity is represented by the provider's catalog authority.
+        provider_id = str(provider or "").strip().lower()
+        if provider_id != "tokenrhythm":
+            return self.resolve_vision_support(
+                model_id,
+                provider_name=provider_id,
+                base_url=base_url,
+            )
+
+        effective_base = str(base_url or "").strip() or TOKENRHYTHM_API_BASE_URL
+        canonical_base = canonical_tokenrhythm_base_url(effective_base)
+        official_endpoint = bool(
+            canonical_base and is_official_tokenrhythm_endpoint(canonical_base)
+        )
+        authority = tokenrhythm_authority_identity(
+            provider=provider_id,
+            base_url=canonical_base,
+            api_key=api_key,
+        )
+        model_l = str(model_id or "").strip().lower()
+        snapshot = self._tokenrhythm_snapshot_sidecars
+        declared = (
+            snapshot.declared_by_authority.get(authority, {}).get(model_l)
+            if authority is not None
+            else None
+        )
+        published = snapshot.published.get(model_l) if official_endpoint else None
+        deployment_value = None
+        if declared is not None:
+            deployment_value = declared.capabilities.vision
+        if deployment_value is None and published is not None:
+            deployment_value = published.capabilities.vision
+
+        layers = (
+            self._user_override_fields(str(model_id or "").strip(), provider_id),
+            {"supports_vision": deployment_value}
+            if isinstance(deployment_value, bool)
+            else {},
+            _corrections_layer_fields(provider_id, model_id)
+            if official_endpoint
+            else {},
+            _snapshot_layer_fields(provider_id, model_id)
+            if official_endpoint
+            else {},
+        )
+        for fields in layers:
+            value = fields.get("supports_vision")
+            if isinstance(value, bool):
+                return "supported" if value else "unsupported"
+        return "unknown"
 
     def resolve_deployment_capabilities(
         self,

--- a/src/opensquilla/provider/protocol.py
+++ b/src/opensquilla/provider/protocol.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from .types import (
     ChatConfig,
+    ContentBlockImage,
+    ContentBlockToolResult,
     ErrorEvent,
     Message,
     ModelInfo,
@@ -16,6 +18,13 @@ from .types import (
     QuotaStatus,
     StreamEvent,
     ToolDefinition,
+    VisionSupport,
+)
+
+IMAGE_INPUT_UNSUPPORTED_CODE = "image_input_unsupported"
+IMAGE_INPUT_UNSUPPORTED_MESSAGE = (
+    "The selected model cannot process image input. Choose an image-capable "
+    "model or remove the image and try again."
 )
 
 if TYPE_CHECKING:
@@ -254,6 +263,75 @@ def validate_provider_chat_request(
     except Exception:  # noqa: BLE001 - optional preflight must stay best-effort
         return None
     return validation_error if isinstance(validation_error, ErrorEvent) else None
+
+
+def count_provider_image_blocks(messages: Sequence[object]) -> int:
+    """Count typed images in the exact provider request, including tool results."""
+
+    count = 0
+    for message in messages:
+        content = getattr(message, "content", None)
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if isinstance(block, ContentBlockImage):
+                count += 1
+                continue
+            if not isinstance(block, ContentBlockToolResult):
+                continue
+            if isinstance(block.content, list):
+                count += sum(
+                    1 for item in block.content if isinstance(item, ContentBlockImage)
+                )
+    return count
+
+
+def image_input_admission_error(
+    messages: Sequence[object],
+    *,
+    vision_support: VisionSupport,
+    reject_unknown: bool = False,
+) -> ErrorEvent | None:
+    """Return the stable image admission error when capability evidence rejects."""
+
+    if count_provider_image_blocks(messages) <= 0:
+        return None
+    if vision_support == "supported":
+        return None
+    if vision_support == "unknown" and not reject_unknown:
+        return None
+    return ErrorEvent(
+        message=IMAGE_INPUT_UNSUPPORTED_MESSAGE,
+        code=IMAGE_INPUT_UNSUPPORTED_CODE,
+    )
+
+
+def validate_provider_chat_admission(
+    provider: object | None,
+    messages: list[Message],
+    config: ChatConfig,
+) -> ErrorEvent | None:
+    """Run typed admission, then the legacy request validator as a fallback."""
+
+    capability_error = image_input_admission_error(
+        messages,
+        vision_support=config.model_vision_support,
+    )
+    if capability_error is not None:
+        return capability_error
+    if provider is not None:
+        admission_fn = getattr(provider, "validate_chat_admission", None)
+        if callable(admission_fn):
+            try:
+                result = admission_fn(messages, config)
+            except Exception:  # noqa: BLE001 - optional capability must be isolated
+                pass
+            else:
+                if isinstance(result, ErrorEvent):
+                    return result
+                if result is None:
+                    return None
+    return validate_provider_chat_request(provider, messages)
 
 
 @runtime_checkable

--- a/src/opensquilla/provider/protocol.py
+++ b/src/opensquilla/provider/protocol.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
 
 from .types import (
     ChatConfig,
@@ -309,13 +309,19 @@ def image_input_admission_error(
 def validate_provider_chat_admission(
     provider: object | None,
     messages: list[Message],
-    config: ChatConfig,
+    config: ChatConfig | None,
 ) -> ErrorEvent | None:
     """Run typed admission, then the legacy request validator as a fallback."""
 
+    raw_vision_support = getattr(config, "model_vision_support", "unknown")
+    vision_support: VisionSupport = (
+        cast(VisionSupport, raw_vision_support)
+        if raw_vision_support in {"supported", "unsupported", "unknown"}
+        else "unknown"
+    )
     capability_error = image_input_admission_error(
         messages,
-        vision_support=config.model_vision_support,
+        vision_support=vision_support,
     )
     if capability_error is not None:
         return capability_error

--- a/src/opensquilla/provider/types.py
+++ b/src/opensquilla/provider/types.py
@@ -376,6 +376,9 @@ class QuotaStatus:
     abort_reason: str | None = None
 
 
+VisionSupport = Literal["supported", "unsupported", "unknown"]
+
+
 @dataclass(frozen=True)
 class ModelCapabilities:
     """Per-model capability flags resolved from ModelCatalog."""
@@ -563,6 +566,14 @@ class ChatConfig(BaseModel):
     output_json_schema: dict[str, Any] | None = None
     output_json_schema_strict: bool = True
     model_capabilities: ModelCapabilities | None = None
+    # Runtime-only evidence for the vision field.  ``ModelCapabilities`` keeps
+    # its long-standing boolean contract, while this sidecar distinguishes an
+    # authoritative false value from a synthesized catalog default.
+    model_vision_support: VisionSupport = Field(
+        default="unknown",
+        exclude=True,
+        repr=False,
+    )
     thinking_level: Any | None = None
     provider_request_max_chars: int = 0
     # Runtime-only provenance for an explicit global

--- a/src/opensquilla/session/terminal_reply.py
+++ b/src/opensquilla/session/terminal_reply.py
@@ -17,6 +17,11 @@ ENSEMBLE_MULTIMODAL_UNSUPPORTED_MESSAGE = (
     "Ensemble does not support image input yet. "
     "Switch to a single-model routing mode and try again."
 )
+IMAGE_INPUT_UNSUPPORTED_CODE = "image_input_unsupported"
+IMAGE_INPUT_UNSUPPORTED_MESSAGE = (
+    "The selected model cannot process image input. Choose an image-capable "
+    "model or remove the image and try again."
+)
 
 # Non-context budget-exhaustion codes. Context-window exhaustion has its own,
 # more specific message via ``is_context_payload_too_large`` and is intentionally
@@ -57,6 +62,7 @@ _SAFE_PROVIDER_TERMINAL_CODES = frozenset(
         "context_overflow",
         "empty_response",
         "ensemble_multimodal_unsupported",
+        "image_input_unsupported",
         "incomplete_stream",
         "incomplete_tool_call",
         "incomplete_tool_stream",
@@ -176,6 +182,8 @@ def build_terminal_reply(
         or reason == ENSEMBLE_MULTIMODAL_UNSUPPORTED_CODE
     ):
         return ENSEMBLE_MULTIMODAL_UNSUPPORTED_MESSAGE
+    if error_class == IMAGE_INPUT_UNSUPPORTED_CODE or reason == IMAGE_INPUT_UNSUPPORTED_CODE:
+        return IMAGE_INPUT_UNSUPPORTED_MESSAGE
     if error_class == "sandbox_threshold_exceeded" or reason == "sandbox_threshold_exceeded":
         return (
             "Automatic execution paused after repeated sandbox denials. Approve the "

--- a/tests/functional/test_gateway_attachment_history_e2e.py
+++ b/tests/functional/test_gateway_attachment_history_e2e.py
@@ -21,7 +21,6 @@ import pytest
 import opensquilla.engine.steps.squilla_router as squilla_router_step
 from opensquilla.attachment_refs import transcript_material_path
 from opensquilla.engine import Agent, AgentConfig
-from opensquilla.engine.agent import UNSUPPORTED_IMAGE_INPUT_REPLY
 from opensquilla.engine.runtime import TurnRunner
 from opensquilla.gateway import rpc_sessions as _rpc_sessions  # noqa: F401
 from opensquilla.gateway.agent_tasks import get_agent_task_registry
@@ -36,6 +35,10 @@ from opensquilla.gateway.uploads import (
 )
 from opensquilla.gateway.websocket import SubscriptionManager, get_registry
 from opensquilla.provider import ChatConfig, DoneEvent, Message, ModelCapabilities
+from opensquilla.provider.protocol import (
+    IMAGE_INPUT_UNSUPPORTED_CODE,
+    IMAGE_INPUT_UNSUPPORTED_MESSAGE,
+)
 from opensquilla.provider.types import (
     ContentBlockImage,
     ContentBlockText,
@@ -136,6 +139,15 @@ class _FakeModelCatalog:
         base_url: str = "",  # noqa: ARG002
     ) -> ModelCapabilities:
         return ModelCapabilities(supports_vision=model_id == _VISION_MODEL)
+
+    def resolve_vision_support(
+        self,
+        model_id: str,
+        *,
+        provider_name: str = "openrouter",  # noqa: ARG002
+        base_url: str = "",  # noqa: ARG002
+    ) -> str:
+        return "supported" if model_id == _VISION_MODEL else "unsupported"
 
 
 class _EventSink:
@@ -254,6 +266,7 @@ async def _send_session_turn(
     sink: _EventSink,
     message: str,
     attachments: list[dict[str, Any]] | None = None,
+    expected_error_code: str | None = None,
 ) -> None:
     done_before = sum(1 for event, _payload in sink.events if event == "session.event.done")
     event_count_before = len(sink.events)
@@ -291,6 +304,16 @@ async def _send_session_turn(
             if event == "session.event.error"
         ]
         if new_errors:
+            if (
+                expected_error_code
+                and new_errors[-1].get("code") == expected_error_code
+            ):
+                if task is not None:
+                    await asyncio.wait_for(
+                        asyncio.shield(task),
+                        timeout=_TURN_TASK_DRAIN_TIMEOUT_SECONDS,
+                    )
+                return
             raise AssertionError(f"turn emitted error events: {sink.events!r}")
         if task is not None and task.done():
             if task.cancelled():
@@ -416,7 +439,7 @@ async def _e2e_stack(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.mark.asyncio
-async def test_gateway_single_text_model_returns_friendly_reply_without_provider_call(
+async def test_gateway_single_text_model_returns_structured_error_without_provider_call(
     _e2e_stack: dict[str, Any],
 ) -> None:
     config: GatewayConfig = _e2e_stack["config"]
@@ -448,6 +471,7 @@ async def test_gateway_single_text_model_returns_friendly_reply_without_provider
         sink=sink,
         message="请分析这张图片。",
         attachments=[_file_uuid_attachment(file_uuid)],
+        expected_error_code=IMAGE_INPUT_UNSUPPORTED_CODE,
     )
 
     assert len(gate_provider.calls) == gate_calls_before
@@ -456,16 +480,14 @@ async def test_gateway_single_text_model_returns_friendly_reply_without_provider
     assert len(usage_sink.started) == usage_started_before
     assert len(usage_sink.finalized) == usage_finalized_before
     assert len(usage_sink.unknown) == usage_unknown_before
-    deltas = _event_payloads(sink, "session.event.text_delta")
-    assert deltas[-1]["text"] == UNSUPPORTED_IMAGE_INPUT_REPLY
-    assert _event_payloads(sink, "session.event.error") == []
-    done = _event_payloads(sink, "session.event.done")[-1]
-    assert done["text"] == UNSUPPORTED_IMAGE_INPUT_REPLY
-    assert done["input_tokens"] == 0
-    assert done["output_tokens"] == 0
+    assert _event_payloads(sink, "session.event.text_delta") == []
+    errors = _event_payloads(sink, "session.event.error")
+    assert errors[-1]["code"] == IMAGE_INPUT_UNSUPPORTED_CODE
+    assert errors[-1]["message"] == IMAGE_INPUT_UNSUPPORTED_MESSAGE
+    assert _event_payloads(sink, "session.event.done") == []
     transcript = await manager.get_transcript(key)
-    assert transcript[-1].role == "assistant"
-    assert transcript[-1].content == UNSUPPORTED_IMAGE_INPUT_REPLY
+    assert transcript[-1].role == "system"
+    assert IMAGE_INPUT_UNSUPPORTED_MESSAGE in str(transcript[-1].content or "")
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/goldens/routing_policy_parity_golden.json
+++ b/tests/test_engine/goldens/routing_policy_parity_golden.json
@@ -3583,10 +3583,13 @@
   "model": "dummy-vision-1"
  },
  "image_without_image_tier_errors": {
-  "error": "RuntimeError: No image-capable SquillaRouter tier is configured with a non-empty model for this image request. Configure squilla_router.tiers.image_model with supports_image=true and a model.",
+  "error": null,
   "message_len": 32,
   "message_tail": "please summarize this short note",
   "metadata": {
+   "image_input_forced_rejection_reason": "router_image_route_unavailable",
+   "image_input_mode": "rejected",
+   "image_input_reason": "router_image_route_unavailable",
    "large_context_capacity_required": true,
    "large_context_material_tokens": 8
   },

--- a/tests/test_engine/test_agent_image_capability_guard.py
+++ b/tests/test_engine/test_agent_image_capability_guard.py
@@ -7,15 +7,20 @@ from typing import Any
 import pytest
 
 from opensquilla.engine import Agent, AgentConfig
-from opensquilla.engine.agent import UNSUPPORTED_IMAGE_INPUT_REPLY
 from opensquilla.engine.types import DoneEvent, ErrorEvent, TextDeltaEvent
 from opensquilla.provider import ChatConfig, Message, ModelCapabilities
-from opensquilla.provider.types import ContentBlockImage
+from opensquilla.provider.protocol import IMAGE_INPUT_UNSUPPORTED_CODE
+from opensquilla.provider.types import ContentBlockImage, ContentBlockToolResult
 
 
 class _RecordingProvider:
+    provider_name = "recording"
+
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
+
+    async def list_models(self) -> list[Any]:
+        return []
 
     def chat(
         self,
@@ -47,11 +52,12 @@ def _image_message() -> Message:
 
 
 @pytest.mark.asyncio
-async def test_non_vision_model_returns_friendly_reply_without_provider_call() -> None:
+async def test_non_vision_model_returns_structured_error_without_provider_call() -> None:
     provider = _RecordingProvider()
     config = AgentConfig(
         model_id="text-only-model",
         model_capabilities=ModelCapabilities(supports_vision=False),
+        model_vision_support="unsupported",
     )
     agent = Agent(provider=provider, config=config)
 
@@ -64,18 +70,14 @@ async def test_non_vision_model_returns_friendly_reply_without_provider_call() -
     ]
 
     assert provider.calls == []
-    assert [event.text for event in events if isinstance(event, TextDeltaEvent)] == [
-        UNSUPPORTED_IMAGE_INPUT_REPLY
-    ]
-    assert not any(isinstance(event, ErrorEvent) for event in events)
-    done = next(event for event in events if isinstance(event, DoneEvent))
-    assert done.text == UNSUPPORTED_IMAGE_INPUT_REPLY
-    assert done.input_tokens == 0
-    assert done.output_tokens == 0
-    assert done.cost_usd == 0.0
+    assert not any(isinstance(event, TextDeltaEvent) for event in events)
+    assert not any(isinstance(event, DoneEvent) for event in events)
+    error = next(event for event in events if isinstance(event, ErrorEvent))
+    assert error.code == IMAGE_INPUT_UNSUPPORTED_CODE
     assert config.metadata["image_input_mode"] == "rejected"
-    assert config.metadata["image_input_reason"] == "vision_unsupported"
+    assert config.metadata["image_input_reason"] == "model_vision_unsupported"
     assert config.metadata["image_input_count"] == 1
+    assert config.metadata["image_input_stage"] == "primary"
 
 
 @pytest.mark.asyncio
@@ -87,6 +89,7 @@ async def test_vision_model_still_receives_current_turn_image() -> None:
             max_iterations=1,
             model_id="vision-model",
             model_capabilities=ModelCapabilities(supports_vision=True),
+            model_vision_support="supported",
         ),
     )
 
@@ -117,6 +120,7 @@ async def test_unknown_model_capability_defers_to_provider() -> None:
             max_iterations=1,
             model_id="custom-model",
             model_capabilities=None,
+            model_vision_support="unknown",
         ),
     )
 
@@ -130,3 +134,61 @@ async def test_unknown_model_capability_defers_to_provider() -> None:
 
     assert any(isinstance(event, DoneEvent) for event in events)
     assert len(provider.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_tool_result_image_uses_the_same_admission_guard() -> None:
+    provider = _RecordingProvider()
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            model_id="text-only-model",
+            model_vision_support="unsupported",
+        ),
+    )
+    tool_result_message = Message(
+        role="user",
+        content=[
+            ContentBlockToolResult(
+                tool_use_id="synthetic-tool",
+                content=[ContentBlockImage(media_type="image/png", data="c3ludGhldGlj")],
+            )
+        ],
+    )
+
+    events = [
+        event
+        async for event in agent.run_turn(
+            "Inspect the tool result.",
+            extra_messages=[tool_result_message],
+        )
+    ]
+
+    assert provider.calls == []
+    assert [event.code for event in events if isinstance(event, ErrorEvent)] == [
+        IMAGE_INPUT_UNSUPPORTED_CODE
+    ]
+
+
+@pytest.mark.asyncio
+async def test_forced_router_rejection_does_not_require_a_current_turn_image() -> None:
+    provider = _RecordingProvider()
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            model_id="text-only-model",
+            model_vision_support="unknown",
+            metadata={
+                "image_input_forced_rejection_reason": "router_image_route_unavailable",
+            },
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("Inspect the previous image.")]
+
+    assert provider.calls == []
+    assert [event.code for event in events if isinstance(event, ErrorEvent)] == [
+        IMAGE_INPUT_UNSUPPORTED_CODE
+    ]
+    assert agent.config.metadata["image_input_reason"] == "router_image_route_unavailable"
+    assert agent.config.metadata["image_input_count"] == 0

--- a/tests/test_engine/test_agent_image_capability_guard.py
+++ b/tests/test_engine/test_agent_image_capability_guard.py
@@ -9,7 +9,10 @@ import pytest
 from opensquilla.engine import Agent, AgentConfig
 from opensquilla.engine.types import DoneEvent, ErrorEvent, TextDeltaEvent
 from opensquilla.provider import ChatConfig, Message, ModelCapabilities
-from opensquilla.provider.protocol import IMAGE_INPUT_UNSUPPORTED_CODE
+from opensquilla.provider.protocol import (
+    IMAGE_INPUT_UNSUPPORTED_CODE,
+    validate_provider_chat_admission,
+)
 from opensquilla.provider.types import ContentBlockImage, ContentBlockToolResult
 
 
@@ -49,6 +52,14 @@ def _image_message() -> Message:
             )
         ],
     )
+
+
+def test_provider_admission_without_config_preserves_unknown_capability() -> None:
+    assert (
+        validate_provider_chat_admission(None, [Message(role="user", content="hi")], None)
+        is None
+    )
+    assert validate_provider_chat_admission(None, [_image_message()], None) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/test_routing_policy_parity.py
+++ b/tests/test_engine/test_routing_policy_parity.py
@@ -30,6 +30,11 @@ entries include the capacity-required marker, material estimate, thinking
 reserve, and capacity-filtered fallback chain. Non-attachment cases retain
 their prior byte-identical behavior.
 
+The missing image-tier case was intentionally recaptured after Router image
+admission began returning a structured rejection instead of raising a runtime
+configuration exception. Its golden pins the stable rejection metadata while
+the later provider admission layer owns the user-facing error event.
+
 Classifier outputs are injected through a fake strategy: the corpus never
 loads the LightGBM/ONNX bundle, touches the network, or needs credentials.
 All tier/model/provider names and messages are synthetic dummy data; tier

--- a/tests/test_engine/test_runtime_artifacts.py
+++ b/tests/test_engine/test_runtime_artifacts.py
@@ -1591,19 +1591,23 @@ async def test_goal_terminal_summary_preflight_failure_degrades_without_system_e
             fail_terminal_summary_assembly,
         )
     elif preflight_failure == "request_validation":
-        original_validate = agent_module.validate_provider_chat_request
+        original_validate = agent_module.validate_provider_chat_admission
 
-        def fail_terminal_summary_validation(provider: Any, messages: list[Message]) -> Any:
+        def fail_terminal_summary_validation(
+            provider: Any,
+            messages: list[Message],
+            config: Any,
+        ) -> Any:
             if getattr(provider, "calls", 0) == 3:
                 return ProviderError(
                     message="Synthetic terminal summary validation failure.",
                     code="synthetic_terminal_summary_validation_failure",
                 )
-            return original_validate(provider, messages)
+            return original_validate(provider, messages, config)
 
         monkeypatch.setattr(
             agent_module,
-            "validate_provider_chat_request",
+            "validate_provider_chat_admission",
             fail_terminal_summary_validation,
         )
     else:

--- a/tests/test_engine/test_selector_fallback_routed_model.py
+++ b/tests/test_engine/test_selector_fallback_routed_model.py
@@ -14,9 +14,11 @@ from collections.abc import AsyncIterator
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
+
 from opensquilla.context_budget import ContextBudgetGovernor
 from opensquilla.engine import ToolResult
-from opensquilla.engine.agent import UNSUPPORTED_IMAGE_INPUT_REPLY, Agent
+from opensquilla.engine.agent import Agent
 from opensquilla.engine.agent_injection import ListPendingInputProvider
 from opensquilla.engine.pipeline import TurnContext
 from opensquilla.engine.runtime import TurnRunner, _SelectorFallbackProvider
@@ -41,6 +43,7 @@ from opensquilla.provider import (
     ToolUseStartEvent,
 )
 from opensquilla.provider.openai import OpenAIProvider
+from opensquilla.provider.protocol import IMAGE_INPUT_UNSUPPORTED_CODE
 from opensquilla.provider.types import ContentBlockImage
 from opensquilla.tools.types import CallerKind, ToolContext
 
@@ -1029,6 +1032,9 @@ async def test_unknown_primary_uses_known_vision_fallback_for_image() -> None:
     wrapper.configure_fallback_deployment_limits(
         [(fallback_config, 0, 0, ModelCapabilities(supports_vision=True))]
     )
+    wrapper.configure_fallback_deployment_vision_support(
+        [(fallback_config, "supported")]
+    )
     messages = [
         Message(
             role="user",
@@ -1045,7 +1051,11 @@ async def test_unknown_primary_uses_known_vision_fallback_for_image() -> None:
     ]
 
 
-async def test_image_request_does_not_call_text_only_fallback(monkeypatch: Any) -> None:
+@pytest.mark.parametrize("fallback_vision_support", ["unsupported", "unknown"])
+async def test_image_request_does_not_call_text_only_fallback(
+    monkeypatch: Any,
+    fallback_vision_support: str,
+) -> None:
     class _Catalog:
         def get_capabilities(
             self,
@@ -1055,6 +1065,10 @@ async def test_image_request_does_not_call_text_only_fallback(monkeypatch: Any) 
         ) -> ModelCapabilities:
             del model_id, provider_name, base_url
             return ModelCapabilities(supports_vision=False)
+
+        def resolve_deployment_vision_support(self, *args, **kwargs):
+            del args, kwargs
+            return fallback_vision_support
 
     class _Provider:
         provider_name = "openrouter"
@@ -1141,16 +1155,18 @@ async def test_image_request_does_not_call_text_only_fallback(monkeypatch: Any) 
         and event.phase in {"retry_wait", "fallback"}
         for event in events
     )
-    assert not any(isinstance(event, ErrorEvent) for event in events)
-    assert [event.text for event in events if isinstance(event, TextDeltaEvent)] == [
-        UNSUPPORTED_IMAGE_INPUT_REPLY
+    assert [event.code for event in events if isinstance(event, ErrorEvent)] == [
+        IMAGE_INPUT_UNSUPPORTED_CODE
     ]
-    done = next(event for event in events if isinstance(event, DoneEvent))
-    assert done.model == "vision-primary"
-    assert done.input_tokens == 0
-    assert done.output_tokens == 0
+    assert not any(isinstance(event, TextDeltaEvent) for event in events)
+    assert not any(isinstance(event, DoneEvent) for event in events)
     assert metadata["image_input_mode"] == "rejected"
-    assert metadata["image_input_reason"] == "fallback_vision_unsupported"
+    assert metadata["image_input_reason"] == (
+        "capability_unknown"
+        if fallback_vision_support == "unknown"
+        else "model_vision_unsupported"
+    )
+    assert metadata["image_input_stage"] == "fallback"
     assert metadata["routed_model"] == "vision-primary"
     assert metadata["executed_model"] == "vision-primary"
     assert "router_fallback_hops" not in metadata
@@ -1173,6 +1189,10 @@ async def test_invalid_response_fallback_rejects_image_before_text_only_call(
         ) -> ModelCapabilities:
             del model_id, provider_name, base_url
             return ModelCapabilities(supports_vision=False)
+
+        def resolve_deployment_vision_support(self, *args, **kwargs):
+            del args, kwargs
+            return "unsupported"
 
     class _Provider:
         provider_name = "openrouter"
@@ -1248,6 +1268,7 @@ async def test_invalid_response_fallback_rejects_image_before_text_only_call(
             max_turn_llm_calls=1,
             model_id="vision-primary",
             model_capabilities=ModelCapabilities(supports_vision=True),
+            model_vision_support="supported",
         ),
     )
     image_message = Message(
@@ -1267,17 +1288,23 @@ async def test_invalid_response_fallback_rejects_image_before_text_only_call(
     assert selector.fallback.calls == 0
     assert selector.primary.validation_calls == 2
     assert selector.fallback.validation_calls == 0
-    assert not any(event.kind == "error" for event in events)
     assert any(
-        event.kind == "warning" and event.code == "provider_empty_retry"
+        getattr(event, "kind", "") == "error"
+        and getattr(event, "code", "") == IMAGE_INPUT_UNSUPPORTED_CODE
         for event in events
     )
-    done = next(event for event in events if isinstance(event, EngineDoneEvent))
-    assert done.text == UNSUPPORTED_IMAGE_INPUT_REPLY
-    assert done.input_tokens == 3
-    assert done.output_tokens == 0
+    assert any(
+        getattr(event, "kind", "") == "warning"
+        and getattr(event, "code", "") == "provider_empty_retry"
+        for event in events
+    )
+    done_events = [event for event in events if isinstance(event, EngineDoneEvent)]
+    if done_events:
+        assert done_events[-1].input_tokens == 3
+        assert done_events[-1].output_tokens == 0
     assert metadata["image_input_mode"] == "rejected"
-    assert metadata["image_input_reason"] == "fallback_vision_unsupported"
+    assert metadata["image_input_reason"] == "model_vision_unsupported"
+    assert metadata["image_input_stage"] == "fallback"
     assert metadata["routed_model"] == "vision-primary"
     assert metadata["executed_model"] == "vision-primary"
     assert "router_fallback_hops" not in metadata

--- a/tests/test_gateway/test_rpc_model_routing.py
+++ b/tests/test_gateway/test_rpc_model_routing.py
@@ -353,6 +353,101 @@ def test_model_routing_snapshot_maps_config_to_one_public_mode(
     assert model_routing_snapshot(config)["mode"] == expected
 
 
+def test_model_routing_snapshot_exposes_direct_image_admission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Catalog:
+        def resolve_deployment_vision_support(self, *args: Any, **kwargs: Any) -> str:
+            del args, kwargs
+            return "unsupported"
+
+    monkeypatch.setattr(
+        "opensquilla.provider.model_catalog.shared_catalog",
+        lambda: _Catalog(),
+    )
+    config = GatewayConfig(
+        llm={"provider": "openrouter", "model": "text-only"},
+        squilla_router={"enabled": False, "rollout_phase": "observe"},
+        llm_ensemble={"enabled": False},
+    )
+
+    snapshot = model_routing_snapshot(config)
+
+    assert snapshot["image_input"] == {
+        "admission": "blocked",
+        "reason": "model_vision_unsupported",
+    }
+    assert "api_key" not in str(snapshot)
+    assert "proxy" not in str(snapshot)
+
+
+@pytest.mark.parametrize(
+    ("tiers", "vision_support", "expected"),
+    [
+        (
+            {"image_model": {"model": "vision-model", "supports_image": True}},
+            "supported",
+            {
+                "admission": "allowed",
+                "reason": "router_image_route_available",
+            },
+        ),
+        (
+            {"image_model": {"model": "text-only-model", "supports_image": True}},
+            "unsupported",
+            {
+                "admission": "blocked",
+                "reason": "model_vision_unsupported",
+            },
+        ),
+        (
+            {"image_model": {"model": "unlisted-model", "supports_image": True}},
+            "unknown",
+            {
+                "admission": "unknown",
+                "reason": "capability_unknown",
+            },
+        ),
+        (
+            {"image_model": {"model": "", "supports_image": True}},
+            "supported",
+            {
+                "admission": "blocked",
+                "reason": "router_image_route_unavailable",
+            },
+        ),
+    ],
+)
+def test_model_routing_snapshot_applies_image_route_in_observe(
+    tiers: dict[str, Any],
+    vision_support: str,
+    expected: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Catalog:
+        def resolve_deployment_vision_support(self, *args: Any, **kwargs: Any) -> str:
+            del args, kwargs
+            return vision_support
+
+    monkeypatch.setattr(
+        "opensquilla.provider.model_catalog.shared_catalog",
+        lambda: _Catalog(),
+    )
+    config = GatewayConfig(
+        squilla_router={
+            "enabled": True,
+            "rollout_phase": "observe",
+            "tiers": tiers,
+        },
+        llm_ensemble={"enabled": False},
+    )
+
+    snapshot = model_routing_snapshot(config)
+
+    assert snapshot["mode"] == "direct"
+    assert snapshot["image_input"] == expected
+
+
 @pytest.mark.parametrize(
     ("selection_mode", "router_enabled"),
     [

--- a/tests/test_gateway/test_terminal_reply.py
+++ b/tests/test_gateway/test_terminal_reply.py
@@ -192,6 +192,22 @@ def test_ensemble_multimodal_reply_is_actionable_and_stable() -> None:
     )
 
 
+def test_image_input_unsupported_reply_is_actionable_and_stable() -> None:
+    reply = build_terminal_reply(
+        {
+            "status": "failed",
+            "terminal_reason": "error",
+            "error_class": "image_input_unsupported",
+            "error_message": "provider-specific detail must not win",
+        }
+    )
+
+    assert reply == (
+        "The selected model cannot process image input. Choose an image-capable "
+        "model or remove the image and try again."
+    )
+
+
 def test_human_silent_reply_failure_has_actionable_terminal_message() -> None:
     reply = build_terminal_reply(
         {

--- a/tests/test_model_router_behavior.py
+++ b/tests/test_model_router_behavior.py
@@ -1396,8 +1396,11 @@ async def test_c3_fusion_rejects_image_input_when_no_independent_image_tier_is_a
         },
     }
 
-    with pytest.raises(RuntimeError, match="while C3 multi-model fusion is selected"):
-        await apply_squilla_router(ctx)
+    result = await apply_squilla_router(ctx)
+
+    assert result.metadata["image_input_forced_rejection_reason"] == (
+        "router_image_route_unavailable"
+    )
 
 
 @pytest.mark.asyncio
@@ -1423,8 +1426,11 @@ async def test_global_fusion_rejects_c3_as_the_only_image_fallback(
         },
     }
 
-    with pytest.raises(RuntimeError, match="while C3 multi-model fusion is selected"):
-        await apply_squilla_router(ctx)
+    result = await apply_squilla_router(ctx)
+
+    assert result.metadata["image_input_forced_rejection_reason"] == (
+        "router_image_route_unavailable"
+    )
 
 
 @pytest.mark.asyncio
@@ -1538,8 +1544,11 @@ async def test_image_route_rejects_when_every_image_tier_has_blank_model(
         },
     }
 
-    with pytest.raises(RuntimeError, match="non-empty model"):
-        await apply_squilla_router(ctx)
+    result = await apply_squilla_router(ctx)
+
+    assert result.metadata["image_input_forced_rejection_reason"] == (
+        "router_image_route_unavailable"
+    )
 
 
 @pytest.mark.asyncio
@@ -1904,11 +1913,11 @@ async def test_image_attachment_without_image_tier_fails_locally(
     )
     ctx.config.squilla_router.tiers["image_model"]["supports_image"] = False
 
-    with pytest.raises(
-        RuntimeError,
-        match="No image-capable SquillaRouter tier is configured",
-    ):
-        await apply_squilla_router(ctx)
+    result = await apply_squilla_router(ctx)
+
+    assert result.metadata["image_input_forced_rejection_reason"] == (
+        "router_image_route_unavailable"
+    )
 
 
 @pytest.mark.asyncio
@@ -1949,11 +1958,11 @@ async def test_caption_less_image_attachment_without_image_tier_fails_locally(
     )
     ctx.config.squilla_router.tiers["image_model"]["supports_image"] = False
 
-    with pytest.raises(
-        RuntimeError,
-        match="No image-capable SquillaRouter tier is configured",
-    ):
-        await apply_squilla_router(ctx)
+    result = await apply_squilla_router(ctx)
+
+    assert result.metadata["image_input_forced_rejection_reason"] == (
+        "router_image_route_unavailable"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_provider/test_tokenrhythm_catalog.py
+++ b/tests/test_provider/test_tokenrhythm_catalog.py
@@ -146,6 +146,7 @@ def test_deployment_limits_and_capabilities_are_isolated_by_authority() -> None:
                     "max_completion_tokens": 131_072,
                     "supports_tools": True,
                     "supports_streaming": True,
+                    "supports_vision": True,
                 }
             ]
         }
@@ -159,6 +160,7 @@ def test_deployment_limits_and_capabilities_are_isolated_by_authority() -> None:
                     "max_completion_tokens": 8_192,
                     "supports_tools": False,
                     "supports_streaming": False,
+                    "supports_vision": False,
                 }
             ]
         }
@@ -216,6 +218,18 @@ def test_deployment_limits_and_capabilities_are_isolated_by_authority() -> None:
     assert caps_a.supports_streaming is True
     assert caps_b.supports_tools is False
     assert caps_b.supports_streaming is False
+    assert catalog.resolve_deployment_vision_support(
+        "qwen3.8-max",
+        provider="tokenrhythm",
+        api_key="synthetic-authority-key-a",
+        base_url="https://tokenrhythm.studio/v1",
+    ) == "supported"
+    assert catalog.resolve_deployment_vision_support(
+        "qwen3.8-max",
+        provider="tokenrhythm",
+        api_key="synthetic-authority-key-b",
+        base_url="https://tokenrhythm.studio/v1",
+    ) == "unsupported"
 
 
 def test_custom_tokenrhythm_deployment_never_uses_website_projection() -> None:

--- a/tests/test_provider_failures.py
+++ b/tests/test_provider_failures.py
@@ -57,6 +57,19 @@ def test_ensemble_multimodal_rejection_is_surfaced_without_fallback(
     assert FallbackPolicy().should_retry(kind, attempt=0) is False
 
 
+def test_image_input_rejection_is_surfaced_without_fallback() -> None:
+    kind = classify_provider_error(
+        provider_name="openrouter",
+        status_code=None,
+        raw_code="image_input_unsupported",
+        message="The selected model cannot process image input.",
+    )
+
+    assert kind is ProviderFailureKind.BAD_REQUEST
+    assert decide_recovery_action(kind) is ProviderRecoveryAction.SURFACE
+    assert FallbackPolicy().should_retry(kind, attempt=0) is False
+
+
 @pytest.mark.parametrize(
     ("provider_name", "raw_code", "message"),
     [

--- a/tests/test_provider_model_catalog.py
+++ b/tests/test_provider_model_catalog.py
@@ -311,6 +311,27 @@ def test_get_capabilities_honors_user_vision_override_on_live_reasoning_model() 
 
     assert caps.supports_reasoning is True
     assert caps.supports_vision is False
+    assert catalog.resolve_vision_support(
+        "vendor/reasoning-model",
+        provider_name="openrouter",
+    ) == "unsupported"
+
+
+def test_vision_support_distinguishes_live_evidence_from_synthesized_default() -> None:
+    catalog = _catalog_with_live_reasoning_model()
+
+    assert catalog.resolve_vision_support(
+        "vendor/reasoning-model",
+        provider_name="openrouter",
+    ) == "supported"
+    assert catalog.resolve_vision_support(
+        "vendor/unknown-model",
+        provider_name="openrouter",
+    ) == "unknown"
+    assert catalog.resolve_vision_support(
+        "vendor/reasoning-model",
+        provider_name="synthetic-provider",
+    ) == "unknown"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Scope

- add tri-state deployment-level image admission and a stable `image_input_unsupported` error contract
- reject unsupported primary, fallback, ensemble, and router image requests before provider usage
- expose additive routing snapshot admission fields for WebUI send-time blocking
- localize blocked-send and structured-error UX, including history reload parity
- preserve unknown-primary compatibility, fail-closed automatic fallback behavior, compaction skipping, and executed-leg attribution

## Branch target

- Base: `main`
- Head: `fix/image-input-admission`

## Linked issue

None.

## Release note status

User-facing behavior change documented here: unsupported image input is now a localized blocked send in current WebUI clients and a structured non-retryable request error for stale or non-WebUI clients, rather than a successful fixed-language assistant reply.

## Tests

- `uv run pytest -q tests/test_provider_model_catalog.py tests/test_provider/test_tokenrhythm_catalog.py tests/test_engine/test_agent_image_capability_guard.py tests/test_engine/test_selector_fallback_routed_model.py tests/test_gateway/test_rpc_model_routing.py tests/test_gateway/test_terminal_reply.py tests/test_provider_failures.py tests/test_model_router_behavior.py tests/functional/test_gateway_attachment_history_e2e.py` — 278 passed, 2 skipped
- `npm run test:unit -- src/composables/chat/useChatFeatureToggles.test.ts src/composables/chat/useChatHistory.test.ts src/composables/chat/useChatSend.attachments.test.ts src/i18n/i18n.test.ts` — 349 passed
- `npm run build` — passed, including typecheck, architecture, security, theme, i18n, and artifact guards
- Ruff on all changed Python files — passed
- `git diff --check origin/main...HEAD` — passed

## Safety and compatibility

- platform-neutral; no filesystem, process, or OS-specific behavior changed
- no database migration or persisted-config migration required
- RPC fields are additive; older clients continue without the new snapshot fields
- existing fixed-language assistant transcript rows are not migrated and remain readable
- blocked candidates do not consume provider, retry, activity, hop, execution-leg, or usage accounting state

## Third-party origin

None. Implementation and tests are original to this repository.