### PR TITLE
Fix sidebar session group expansion

### DIFF
--- a/opensquilla-webui/src/components/SidebarConversations.vue
+++ b/opensquilla-webui/src/components/SidebarConversations.vue
@@ -1032,314 +1032,316 @@ function onSelectRow(row: SidebarConversationItem) {
           <span class="sidebar-group__count">{{ block.rows.length }}</span>
         </button>
 
-        <TransitionGroup
-          v-show="!block.showFamilyHeader || !block.family || !isCollapsed(block.family)"
-          :id="`sidebar-group-${block.key}`"
-          name="sidebar-row"
-          tag="div"
-          class="sidebar-group__body"
-        >
+        <Transition name="sidebar-group">
           <div
-            v-for="row in block.rows"
-            :key="row.key"
-            class="sidebar-history-row"
-            :class="{
-              'is-selected': row.rowKind === 'session' && isRowSelected(row.key),
-              'sidebar-history-row--workspace': row.rowKind === 'workspace',
-              'sidebar-history-row--workspace-empty': row.rowKind === 'workspace-empty',
-              'is-unavailable': row.rowKind === 'workspace' && row.workspaceAvailable === false,
-              'is-reorderable': canDragRow(row),
-              'is-dragging': draggedRowKey === row.key,
-              'is-drop-before': dropTargetKey === row.key && dropPosition === 'before',
-              'is-drop-after': dropTargetKey === row.key && dropPosition === 'after',
-            }"
-            :data-family="row.displayFamily"
-            :data-sidebar-zone="row.displayZone"
-            :data-depth="row.depth"
-            :data-session-key="row.rowKind === 'session' ? row.key : undefined"
-            :style="{ '--row-depth': row.depth }"
-            @pointerdown="onRowPointerDown(row, $event)"
-            @mouseenter="openSessionPreview(row, $event)"
-            @mouseleave="closeSessionPreview"
-            @focusin="openSessionPreview(row, $event)"
-            @focusout="onSessionFocusOut"
+            v-show="!block.showFamilyHeader || !block.family || !isCollapsed(block.family)"
+            :id="`sidebar-group-${block.key}`"
+            class="sidebar-group__body"
           >
-            <div
-              v-if="row.rowKind === 'workspace'"
-              class="sidebar-workspace-header"
-            >
-              <div class="sidebar-project-info-wrap">
-                <button
-                  type="button"
-                  class="sidebar-project-info"
-                  data-testid="project-workspace-info"
-                  :aria-label="t('workspaces.projectInfo', {
-                    path: row.workspaceDisplayPath || row.workspace || row.title,
-                    count: row.workspaceTaskCount ?? 0,
-                  })"
+            <div class="sidebar-group__content">
+              <div
+                v-for="row in block.rows"
+                :key="row.key"
+                class="sidebar-history-row"
+                :class="{
+                  'is-selected': row.rowKind === 'session' && isRowSelected(row.key),
+                  'sidebar-history-row--workspace': row.rowKind === 'workspace',
+                  'sidebar-history-row--workspace-empty': row.rowKind === 'workspace-empty',
+                  'is-unavailable': row.rowKind === 'workspace' && row.workspaceAvailable === false,
+                  'is-reorderable': canDragRow(row),
+                  'is-dragging': draggedRowKey === row.key,
+                  'is-drop-before': dropTargetKey === row.key && dropPosition === 'before',
+                  'is-drop-after': dropTargetKey === row.key && dropPosition === 'after',
+                }"
+                :data-family="row.displayFamily"
+                :data-sidebar-zone="row.displayZone"
+                :data-depth="row.depth"
+                :data-session-key="row.rowKind === 'session' ? row.key : undefined"
+                :style="{ '--row-depth': row.depth }"
+                @pointerdown="onRowPointerDown(row, $event)"
+                @mouseenter="openSessionPreview(row, $event)"
+                @mouseleave="closeSessionPreview"
+                @focusin="openSessionPreview(row, $event)"
+                @focusout="onSessionFocusOut"
+              >
+                <div
+                  v-if="row.rowKind === 'workspace'"
+                  class="sidebar-workspace-header"
                 >
-                  <Icon name="folder" :size="15" />
-                </button>
-                <div class="sidebar-project-info-popover" role="tooltip">
-                  <span class="sidebar-project-info-path">
-                    {{ row.workspaceDisplayPath || row.workspace || row.title }}
-                  </span>
-                  <span>{{ t('workspaces.taskCount', { count: row.workspaceTaskCount ?? 0 }) }}</span>
-                  <span v-if="row.workspaceAvailable === false" class="sidebar-project-unavailable">
-                    {{ t('workspaces.unavailable') }}
-                  </span>
+                  <div class="sidebar-project-info-wrap">
+                    <button
+                      type="button"
+                      class="sidebar-project-info"
+                      data-testid="project-workspace-info"
+                      :aria-label="t('workspaces.projectInfo', {
+                        path: row.workspaceDisplayPath || row.workspace || row.title,
+                        count: row.workspaceTaskCount ?? 0,
+                      })"
+                    >
+                      <Icon name="folder" :size="15" />
+                    </button>
+                    <div class="sidebar-project-info-popover" role="tooltip">
+                      <span class="sidebar-project-info-path">
+                        {{ row.workspaceDisplayPath || row.workspace || row.title }}
+                      </span>
+                      <span>{{ t('workspaces.taskCount', { count: row.workspaceTaskCount ?? 0 }) }}</span>
+                      <span v-if="row.workspaceAvailable === false" class="sidebar-project-unavailable">
+                        {{ t('workspaces.unavailable') }}
+                      </span>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    class="sidebar-project-disclosure"
+                    data-testid="project-workspace-disclosure"
+                    :aria-expanded="!isProjectCollapsed(row)"
+                    :aria-label="row.title"
+                    @click="toggleProject(row)"
+                  >
+                    <Icon class="sidebar-project-chevron" name="chevronRight" :size="12" />
+                    <span class="sidebar-workspace-label">{{ row.title }}</span>
+                  </button>
+                  <div
+                    v-if="!selectionMode && props.canManageProjects && row.workspaceId"
+                    class="sidebar-project-actions"
+                  >
+                    <button
+                      type="button"
+                      class="sidebar-project-action sidebar-project-action--new-task"
+                      data-testid="project-workspace-new-task"
+                      :aria-label="row.workspaceAvailable === false
+                        ? t('workspaces.unavailableProjectCannotStartTask')
+                        : t('workspaces.newTask')"
+                      :title="row.workspaceAvailable === false
+                        ? t('workspaces.unavailableProjectCannotStartTask')
+                        : t('workspaces.newTask')"
+                      :disabled="row.workspaceAvailable === false"
+                      @click.stop="startProjectTask(row)"
+                    >
+                      <Icon name="plus" :size="13" />
+                    </button>
+                    <button
+                      type="button"
+                      class="sidebar-project-action sidebar-row-menu-btn"
+                      data-testid="project-workspace-more"
+                      aria-haspopup="menu"
+                      :aria-expanded="openMenuKey === row.key"
+                      :aria-label="t('workspaces.moreActions')"
+                      :title="t('workspaces.moreActions')"
+                      @click.stop="toggleMenu(row.key, $event)"
+                    >
+                      <Icon name="moreHorizontal" :size="14" />
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <button
-                type="button"
-                class="sidebar-project-disclosure"
-                data-testid="project-workspace-disclosure"
-                :aria-expanded="!isProjectCollapsed(row)"
-                :aria-label="row.title"
-                @click="toggleProject(row)"
-              >
-                <Icon class="sidebar-project-chevron" name="chevronRight" :size="12" />
-                <span class="sidebar-workspace-label">{{ row.title }}</span>
-              </button>
-              <div
-                v-if="!selectionMode && props.canManageProjects && row.workspaceId"
-                class="sidebar-project-actions"
-              >
-                <button
-                  type="button"
-                  class="sidebar-project-action sidebar-project-action--new-task"
-                  data-testid="project-workspace-new-task"
-                  :aria-label="row.workspaceAvailable === false
-                    ? t('workspaces.unavailableProjectCannotStartTask')
-                    : t('workspaces.newTask')"
-                  :title="row.workspaceAvailable === false
-                    ? t('workspaces.unavailableProjectCannotStartTask')
-                    : t('workspaces.newTask')"
-                  :disabled="row.workspaceAvailable === false"
-                  @click.stop="startProjectTask(row)"
+
+                <span
+                  v-if="row.depth > 0 && row.rowKind !== 'workspace'"
+                  class="sidebar-history-rail"
+                  aria-hidden="true"
+                />
+
+                <div
+                  v-if="row.rowKind === 'workspace-empty'"
+                  class="sidebar-workspace-empty"
                 >
-                  <Icon name="plus" :size="13" />
+                  {{ row.title }}
+                </div>
+
+                <!-- Inline rename input replaces the row button while editing -->
+                <input
+                  v-if="row.rowKind === 'session' && renamingKey === row.key"
+                  :ref="setRenameInput"
+                  v-model="renameDraft"
+                  class="sidebar-history-rename"
+                  type="text"
+                  :aria-label="t('shared.sidebar.renameLabel', { title: row.title })"
+                  @keydown.enter.prevent="commitRename"
+                  @keydown.esc.prevent="cancelRename"
+                  @blur="onRenameBlur"
+                />
+
+                <button
+                  v-else-if="row.rowKind === 'session'"
+                  class="sidebar-history-item"
+                  :class="{ 'is-current': row.key === currentKey }"
+                  :aria-pressed="selectionMode && !row.provisional ? isRowSelected(row.key) : undefined"
+                  :aria-describedby="sessionPreview?.row.key === row.key ? 'sidebar-session-preview' : undefined"
+                  @click="onSelectRow(row)"
+                  @contextmenu="openSessionContextMenu(row, $event)"
+                >
+                  <span
+                    v-if="selectionMode && !row.provisional"
+                    class="sidebar-selection-box"
+                    :class="{ 'is-checked': isRowSelected(row.key) }"
+                    aria-hidden="true"
+                  >
+                    <Icon v-if="isRowSelected(row.key)" name="check" :size="11" />
+                  </span>
+                  <span class="sidebar-history-title">{{ row.title }}</span>
+                  <Icon
+                    v-if="row.pinned"
+                    class="sidebar-history-pin"
+                    name="arrowUp"
+                    :size="11"
+                    aria-hidden="true"
+                  />
+                  <span
+                    v-if="contractDebugEnabled && row.hasContractGaps"
+                    class="sidebar-history-gap"
+                    :aria-label="t('shared.sidebar.contractGap')"
+                    :title="t('shared.sidebar.contractGap')"
+                  >{{ t('shared.sidebar.contractGapBadge') }}</span>
+                  <span
+                    v-if="!selectionMode"
+                    class="sidebar-task-attention"
+                    :class="`sidebar-task-attention--${row.taskAttention}`"
+                    :role="row.taskAttention === 'none' ? undefined : 'img'"
+                    :aria-hidden="row.taskAttention === 'none' ? 'true' : undefined"
+                    :aria-label="taskAttentionLabel(row.taskAttention) || undefined"
+                    :title="taskAttentionLabel(row.taskAttention) || undefined"
+                    data-testid="sidebar-task-attention"
+                  />
                 </button>
-                <button
-                  type="button"
-                  class="sidebar-project-action sidebar-row-menu-btn"
-                  data-testid="project-workspace-more"
-                  aria-haspopup="menu"
-                  :aria-expanded="openMenuKey === row.key"
-                  :aria-label="t('workspaces.moreActions')"
-                  :title="t('workspaces.moreActions')"
-                  @click.stop="toggleMenu(row.key, $event)"
+
+                <!-- Per-session ⋯ menu: task rows omit pin but keep rename + delete. -->
+                <Teleport to="body">
+                  <div
+                    v-if="
+                      props.canManageProjects
+                      && row.rowKind === 'workspace'
+                      && openMenuKey === row.key
+                    "
+                    :ref="setOpenMenu"
+                    class="sidebar-row-menu sidebar-project-menu"
+                    :style="menuStyle"
+                    role="menu"
+                    :aria-label="t('workspaces.moreActions')"
+                    @keydown="onMenuKeydown"
+                  >
+                    <button
+                      type="button"
+                      class="sidebar-row-menu__item"
+                      data-project-action="pin"
+                      role="menuitem"
+                      @click.stop="emitProjectPin(row)"
+                    >
+                      <Icon name="arrowUp" :size="13" />
+                      <span>{{ row.workspacePinned ? t('workspaces.unpin') : t('workspaces.pin') }}</span>
+                    </button>
+                    <button
+                      type="button"
+                      class="sidebar-row-menu__item"
+                      data-project-action="edit"
+                      role="menuitem"
+                      @click.stop="emitProjectEdit(row)"
+                    >
+                      <Icon name="pencil" :size="13" />
+                      <span>{{ t('workspaces.editProject') }}</span>
+                    </button>
+                    <button
+                      type="button"
+                      class="sidebar-row-menu__item"
+                      data-project-action="delete-history"
+                      role="menuitem"
+                      @click.stop="requestProjectHistoryDelete(row)"
+                    >
+                      <Icon name="trash" :size="13" />
+                      <span>{{ t('workspaces.menuDeleteHistory') }}</span>
+                    </button>
+                    <button
+                      type="button"
+                      class="sidebar-row-menu__item"
+                      data-project-action="remove"
+                      role="menuitem"
+                      @click.stop="emitProjectRemove(row)"
+                    >
+                      <Icon name="x" :size="13" />
+                      <span>{{ t('workspaces.menuRemove') }}</span>
+                    </button>
+                  </div>
+                </Teleport>
+
+                <div
+                  v-if="canOpenSessionMenu(row)"
+                  class="sidebar-row-menu-wrap"
                 >
-                  <Icon name="moreHorizontal" :size="14" />
+                  <button
+                    type="button"
+                    class="sidebar-row-menu-btn"
+                    aria-haspopup="menu"
+                    :aria-expanded="openMenuKey === row.key"
+                    :aria-label="t('shared.sidebar.rowActions', { title: row.title })"
+                    :title="t('shared.sidebar.rowActions', { title: row.title })"
+                    @click.stop="toggleMenu(row.key, $event)"
+                  >
+                    <span aria-hidden="true">&#8943;</span>
+                  </button>
+                  <Teleport to="body">
+                  <div
+                    v-if="openMenuKey === row.key"
+                    :ref="setOpenMenu"
+                    class="sidebar-row-menu"
+                    :style="menuStyle"
+                    role="menu"
+                    :aria-label="t('shared.sidebar.rowActions', { title: row.title })"
+                    @keydown="onMenuKeydown"
+                  >
+                    <button
+                      v-if="row.sessionKind !== 'task'"
+                      type="button"
+                      class="sidebar-row-menu__item"
+                      role="menuitem"
+                      @click.stop="emitSessionPin(row)"
+                    >
+                      <Icon name="arrowUp" :size="14" />
+                      <span>{{ row.pinned ? t('shared.sidebar.unpinTask') : t('shared.sidebar.pinTask') }}</span>
+                    </button>
+                    <button
+                      type="button"
+                      class="sidebar-row-menu__item"
+                      role="menuitem"
+                      @click.stop="startRename(row)"
+                    >
+                      <Icon name="pencil" :size="14" />
+                      <span>{{ t('shared.sidebar.rename') }}</span>
+                    </button>
+                    <button
+                      type="button"
+                      class="sidebar-row-menu__item sidebar-row-menu__item--danger"
+                      role="menuitem"
+                      @click.stop="requestDelete(row)"
+                    >
+                      <Icon name="trash" :size="14" />
+                      <span>{{ t('shared.sidebar.delete') }}</span>
+                    </button>
+                  </div>
+                  </Teleport>
+                </div>
+
+                <!-- Agent-initial badge: indicator + click-to-filter (Chats only) -->
+                <button
+                  v-else-if="
+                    row.rowKind === 'session'
+                    && !row.provisional
+                    && shouldShowAgentFilterBadge(row.displayFamily, row)
+                    && renamingKey !== row.key
+                    && !selectionMode
+                  "
+                  type="button"
+                  class="sidebar-agent-badge"
+                  :class="{ 'is-active': agentFilter === row.effectiveAgentId }"
+                  :aria-pressed="agentFilter === row.effectiveAgentId"
+                  :aria-label="t('shared.sidebar.filterByAgent', { name: row.agentName })"
+                  :title="t('shared.sidebar.filterByAgent', { name: row.agentName })"
+                  @click.stop="toggleAgentFilter(row.effectiveAgentId)"
+                >
+                  {{ agentInitial(row.agentName) }}
                 </button>
               </div>
             </div>
-
-            <span
-              v-if="row.depth > 0 && row.rowKind !== 'workspace'"
-              class="sidebar-history-rail"
-              aria-hidden="true"
-            />
-
-            <div
-              v-if="row.rowKind === 'workspace-empty'"
-              class="sidebar-workspace-empty"
-            >
-              {{ row.title }}
-            </div>
-
-            <!-- Inline rename input replaces the row button while editing -->
-            <input
-              v-if="row.rowKind === 'session' && renamingKey === row.key"
-              :ref="setRenameInput"
-              v-model="renameDraft"
-              class="sidebar-history-rename"
-              type="text"
-              :aria-label="t('shared.sidebar.renameLabel', { title: row.title })"
-              @keydown.enter.prevent="commitRename"
-              @keydown.esc.prevent="cancelRename"
-              @blur="onRenameBlur"
-            />
-
-            <button
-              v-else-if="row.rowKind === 'session'"
-              class="sidebar-history-item"
-              :class="{ 'is-current': row.key === currentKey }"
-              :aria-pressed="selectionMode && !row.provisional ? isRowSelected(row.key) : undefined"
-              :aria-describedby="sessionPreview?.row.key === row.key ? 'sidebar-session-preview' : undefined"
-              @click="onSelectRow(row)"
-              @contextmenu="openSessionContextMenu(row, $event)"
-            >
-              <span
-                v-if="selectionMode && !row.provisional"
-                class="sidebar-selection-box"
-                :class="{ 'is-checked': isRowSelected(row.key) }"
-                aria-hidden="true"
-              >
-                <Icon v-if="isRowSelected(row.key)" name="check" :size="11" />
-              </span>
-              <span class="sidebar-history-title">{{ row.title }}</span>
-              <Icon
-                v-if="row.pinned"
-                class="sidebar-history-pin"
-                name="arrowUp"
-                :size="11"
-                aria-hidden="true"
-              />
-              <span
-                v-if="contractDebugEnabled && row.hasContractGaps"
-                class="sidebar-history-gap"
-                :aria-label="t('shared.sidebar.contractGap')"
-                :title="t('shared.sidebar.contractGap')"
-              >{{ t('shared.sidebar.contractGapBadge') }}</span>
-              <span
-                v-if="!selectionMode"
-                class="sidebar-task-attention"
-                :class="`sidebar-task-attention--${row.taskAttention}`"
-                :role="row.taskAttention === 'none' ? undefined : 'img'"
-                :aria-hidden="row.taskAttention === 'none' ? 'true' : undefined"
-                :aria-label="taskAttentionLabel(row.taskAttention) || undefined"
-                :title="taskAttentionLabel(row.taskAttention) || undefined"
-                data-testid="sidebar-task-attention"
-              />
-            </button>
-
-            <!-- Per-session ⋯ menu: task rows omit pin but keep rename + delete. -->
-            <Teleport to="body">
-              <div
-                v-if="
-                  props.canManageProjects
-                  && row.rowKind === 'workspace'
-                  && openMenuKey === row.key
-                "
-                :ref="setOpenMenu"
-                class="sidebar-row-menu sidebar-project-menu"
-                :style="menuStyle"
-                role="menu"
-                :aria-label="t('workspaces.moreActions')"
-                @keydown="onMenuKeydown"
-              >
-                <button
-                  type="button"
-                  class="sidebar-row-menu__item"
-                  data-project-action="pin"
-                  role="menuitem"
-                  @click.stop="emitProjectPin(row)"
-                >
-                  <Icon name="arrowUp" :size="13" />
-                  <span>{{ row.workspacePinned ? t('workspaces.unpin') : t('workspaces.pin') }}</span>
-                </button>
-                <button
-                  type="button"
-                  class="sidebar-row-menu__item"
-                  data-project-action="edit"
-                  role="menuitem"
-                  @click.stop="emitProjectEdit(row)"
-                >
-                  <Icon name="pencil" :size="13" />
-                  <span>{{ t('workspaces.editProject') }}</span>
-                </button>
-                <button
-                  type="button"
-                  class="sidebar-row-menu__item"
-                  data-project-action="delete-history"
-                  role="menuitem"
-                  @click.stop="requestProjectHistoryDelete(row)"
-                >
-                  <Icon name="trash" :size="13" />
-                  <span>{{ t('workspaces.menuDeleteHistory') }}</span>
-                </button>
-                <button
-                  type="button"
-                  class="sidebar-row-menu__item"
-                  data-project-action="remove"
-                  role="menuitem"
-                  @click.stop="emitProjectRemove(row)"
-                >
-                  <Icon name="x" :size="13" />
-                  <span>{{ t('workspaces.menuRemove') }}</span>
-                </button>
-              </div>
-            </Teleport>
-
-            <div
-              v-if="canOpenSessionMenu(row)"
-              class="sidebar-row-menu-wrap"
-            >
-              <button
-                type="button"
-                class="sidebar-row-menu-btn"
-                aria-haspopup="menu"
-                :aria-expanded="openMenuKey === row.key"
-                :aria-label="t('shared.sidebar.rowActions', { title: row.title })"
-                :title="t('shared.sidebar.rowActions', { title: row.title })"
-                @click.stop="toggleMenu(row.key, $event)"
-              >
-                <span aria-hidden="true">&#8943;</span>
-              </button>
-              <Teleport to="body">
-              <div
-                v-if="openMenuKey === row.key"
-                :ref="setOpenMenu"
-                class="sidebar-row-menu"
-                :style="menuStyle"
-                role="menu"
-                :aria-label="t('shared.sidebar.rowActions', { title: row.title })"
-                @keydown="onMenuKeydown"
-              >
-                <button
-                  v-if="row.sessionKind !== 'task'"
-                  type="button"
-                  class="sidebar-row-menu__item"
-                  role="menuitem"
-                  @click.stop="emitSessionPin(row)"
-                >
-                  <Icon name="arrowUp" :size="14" />
-                  <span>{{ row.pinned ? t('shared.sidebar.unpinTask') : t('shared.sidebar.pinTask') }}</span>
-                </button>
-                <button
-                  type="button"
-                  class="sidebar-row-menu__item"
-                  role="menuitem"
-                  @click.stop="startRename(row)"
-                >
-                  <Icon name="pencil" :size="14" />
-                  <span>{{ t('shared.sidebar.rename') }}</span>
-                </button>
-                <button
-                  type="button"
-                  class="sidebar-row-menu__item sidebar-row-menu__item--danger"
-                  role="menuitem"
-                  @click.stop="requestDelete(row)"
-                >
-                  <Icon name="trash" :size="14" />
-                  <span>{{ t('shared.sidebar.delete') }}</span>
-                </button>
-              </div>
-              </Teleport>
-            </div>
-
-            <!-- Agent-initial badge: indicator + click-to-filter (Chats only) -->
-            <button
-              v-else-if="
-                row.rowKind === 'session'
-                && !row.provisional
-                && shouldShowAgentFilterBadge(row.displayFamily, row)
-                && renamingKey !== row.key
-                && !selectionMode
-              "
-              type="button"
-              class="sidebar-agent-badge"
-              :class="{ 'is-active': agentFilter === row.effectiveAgentId }"
-              :aria-pressed="agentFilter === row.effectiveAgentId"
-              :aria-label="t('shared.sidebar.filterByAgent', { name: row.agentName })"
-              :title="t('shared.sidebar.filterByAgent', { name: row.agentName })"
-              @click.stop="toggleAgentFilter(row.effectiveAgentId)"
-            >
-              {{ agentInitial(row.agentName) }}
-            </button>
           </div>
-        </TransitionGroup>
+        </Transition>
         <div
           v-if="block.zone === 'recents' && block.rows.length === 0"
           class="sidebar-zone-empty"

--- a/opensquilla-webui/src/styles/apple-modern.css
+++ b/opensquilla-webui/src/styles/apple-modern.css
@@ -459,19 +459,17 @@ body > .settings-overlay .settings-modal .settings-rail__item:not(:disabled):act
   position: relative;
 }
 
-.sidebar-row-enter-from,
-.sidebar-row-leave-to {
+.sidebar-group-enter-active,
+.sidebar-group-leave-active {
+  transition:
+    grid-template-rows var(--dur-base) var(--ease-out),
+    opacity var(--dur-base) var(--ease-out);
+}
+
+.sidebar-group-enter-from,
+.sidebar-group-leave-to {
+  grid-template-rows: 0fr;
   opacity: 0;
-  transform: translateY(-4px);
-}
-
-.sidebar-row-leave-active {
-  position: absolute;
-  width: 100%;
-}
-
-.sidebar-row-move {
-  transition: transform var(--dur-base) var(--ease-out);
 }
 
 .sidebar-foot {

--- a/opensquilla-webui/src/styles/control-visual-system.css
+++ b/opensquilla-webui/src/styles/control-visual-system.css
@@ -772,8 +772,15 @@ summary.control-row--divider:focus-visible {
 }
 
 .sidebar-group__body {
+  display: grid;
+  grid-template-rows: 1fr;
+  overflow: hidden;
+}
+
+.sidebar-group__content {
   display: flex;
   flex-direction: column;
+  min-height: 0;
 }
 
 /* Subagent indent: a left rail mirrors the console list's nested look. The


### PR DESCRIPTION
## Summary

- Replace the row-level transition group with a local group transition for collapsible session families.
- Animate the family container height and opacity beneath its own header.
- Retain existing collapse state and row rendering behavior.

## Testing

- `npm run test:unit -- src/components/SidebarConversations.workspaces.test.ts`
- `npm run typecheck`
- `npm run build`
- Manual verification with seeded multi-workspace, multi-session, multi-entry WebUI data.

## Compatibility

No persisted schema, RPC, config, or public API changes. Existing collapsed-section preferences remain unchanged.

## Release note

Fix sidebar session histories expanding from the top of the sidebar instead of beneath their section header.

## Safety

UI-only change; no user data or sensitive runtime artifacts included.

## Third-party origin

None.
