### PR TITLE
ci: speed up merge queue fallback and Skill Hub checks

### DIFF
--- a/.github/CI_OPTIMIZATION.md
+++ b/.github/CI_OPTIMIZATION.md
@@ -20,11 +20,12 @@ CI and retain their existing live markers.
 Set the Actions repository variable `CI_OPTIMIZATION_MODE` to one of:
 
 - `shadow`: compute and report whether merge-queue evidence is reusable, but run
-  the normal queue matrix. Change-based PR selection is active so its coverage and duration
-  are observable before queue reuse is enabled.
-- `enforce` (default): reuse an exact trusted PR result in the merge queue; otherwise fail closed to
-  the full queue matrix. Replace the normal `main` push matrix with the installation and
-  offline gateway canary.
+  the classifier-selected merge-group diff matrix. Change-based selection remains observable
+  before queue reuse is enabled.
+- `enforce` (default): reuse an exact trusted PR result in the merge queue; otherwise run the
+  classifier-selected merge-group diff matrix. CI-policy, dependency, unknown, and other
+  high-risk paths still escalate to the full queue matrix. Replace the normal `main` push matrix
+  with the installation and offline gateway canary.
 - `legacy`: emergency rollback mode. It deliberately runs full PR and queue CI and keeps
   the pre-enforcement `main` behavior.
 
@@ -42,8 +43,9 @@ Reusable evidence is accepted only when all of these facts match authoritative G
 4. Every workflow, CI helper, dependency lock/manifest, and `CODEOWNERS` policy input has the
    same digest as `main`.
 
-Missing, expired, malformed, stale, or unverifiable evidence never bypasses tests; it causes
-the queue to run the full matrix. The required branch-protection context remains `CI result`.
+Missing, expired, malformed, stale, or unverifiable evidence never bypasses tests. The exact
+merge-group diff is classified instead; unavailable/empty diffs and high-risk paths run the full
+matrix. The required branch-protection context remains `CI result`.
 
 Before merging this rollout, confirm that the main ruleset requires `CI result` and
 `Validate target branch`, requires conversation resolution, and enforces code-owner review

--- a/.github/scripts/ci_attestation.py
+++ b/.github/scripts/ci_attestation.py
@@ -11,6 +11,8 @@ import os
 import re
 import subprocess
 import sys
+import time
+import urllib.error
 import urllib.parse
 import urllib.request
 import zipfile
@@ -22,6 +24,9 @@ SCHEMA_VERSION: Final = 1
 VALIDATION_PROFILE: Final = "precise-v1"
 WORKFLOW_PATH: Final = ".github/workflows/ci.yml"
 MAX_ATTESTATION_ARCHIVE_BYTES: Final = 64 * 1024
+MAX_ARTIFACT_PAGES: Final = 3
+ARTIFACTS_PER_PAGE: Final = 100
+ARTIFACT_VISIBILITY_DELAYS: Final = (0, 10, 30)
 SHA_RE: Final = re.compile(r"^[0-9a-f]{40}$")
 POLICY_PREFIXES: Final = (
     ".github/scripts/",
@@ -252,6 +257,70 @@ def _artifact_attestation(archive: bytes) -> Mapping[str, Any]:
     return value
 
 
+def _reason_code(reason: str, *, api_error: bool = False) -> str:
+    lowered = reason.lower()
+    if api_error:
+        return "api_error"
+    if "candidate limit" in lowered:
+        return "candidate_limit"
+    if "no pr ci attestation" in lowered or "expired" in lowered:
+        return "artifact_unavailable"
+    if "associated with the attested pull request" in lowered:
+        return "pr_association_invalid"
+    if "workflow run" in lowered:
+        return "source_run_invalid"
+    if "base_sha" in lowered or "base does not match" in lowered:
+        return "base_mismatch"
+    if "tree" in lowered:
+        return "tree_mismatch"
+    if "policy" in lowered:
+        return "policy_mismatch"
+    if "not in the queue commit" in lowered:
+        return "head_not_ancestor"
+    if "queue" in lowered or "merge_group" in lowered or "checkout" in lowered:
+        return "invalid_context"
+    return "artifact_invalid"
+
+
+def _list_attestation_artifacts(
+    *, api_url: str, repository: str, encoded_name: str, token: str
+) -> list[Mapping[str, Any]]:
+    """List a bounded artifact set, retrying only temporary visibility misses."""
+
+    previous_delay = 0
+    for scheduled_delay in ARTIFACT_VISIBILITY_DELAYS:
+        if scheduled_delay:
+            time.sleep(scheduled_delay - previous_delay)
+        previous_delay = scheduled_delay
+        candidates: list[Mapping[str, Any]] = []
+        try:
+            for page in range(1, MAX_ARTIFACT_PAGES + 1):
+                listing = _request_json(
+                    f"{api_url}/repos/{repository}/actions/artifacts"
+                    f"?name={encoded_name}&per_page={ARTIFACTS_PER_PAGE}&page={page}",
+                    token,
+                )
+                total_count = listing.get("total_count")
+                if isinstance(total_count, int) and total_count > (
+                    MAX_ARTIFACT_PAGES * ARTIFACTS_PER_PAGE
+                ):
+                    raise AttestationError("artifact candidate limit exceeded")
+                page_items = listing.get("artifacts")
+                if not isinstance(page_items, list):
+                    raise AttestationError("artifact listing is invalid")
+                candidates.extend(item for item in page_items if isinstance(item, dict))
+                if len(page_items) < ARTIFACTS_PER_PAGE:
+                    break
+            if len(candidates) > MAX_ARTIFACT_PAGES * ARTIFACTS_PER_PAGE:
+                raise AttestationError("artifact candidate limit exceeded")
+            if candidates:
+                return candidates
+        except urllib.error.HTTPError as exc:
+            if exc.code != 404:
+                raise
+    raise AttestationError("no PR CI attestation exists for the queue tree")
+
+
 def validate_candidate(
     *,
     attestation: Mapping[str, Any],
@@ -288,7 +357,9 @@ def validate_candidate(
     if not isinstance(pr_number, int) or pr_number <= 0:
         raise AttestationError("attestation pull_request_number is invalid")
     head_sha = _require_sha(attestation.get("head_sha"), "attested head SHA")
-    _require_sha(attestation.get("tested_merge_sha"), "attested merge SHA")
+    tested_merge_sha = _require_sha(
+        attestation.get("tested_merge_sha"), "attested merge SHA"
+    )
 
     run_repository = run.get("repository")
     run_repository_name = (
@@ -300,12 +371,13 @@ def validate_candidate(
         "event": "pull_request",
         "status": "completed",
         "conclusion": "success",
-        "head_sha": head_sha,
         "path": WORKFLOW_PATH,
     }
     for key, expected_value in authoritative.items():
         if run.get(key) != expected_value:
             raise AttestationError(f"workflow run {key} is not authoritative")
+    if run.get("head_sha") not in {head_sha, tested_merge_sha}:
+        raise AttestationError("workflow run head_sha is not authoritative")
     if run_repository_name != repository:
         raise AttestationError("workflow run belongs to another repository")
 
@@ -323,7 +395,6 @@ def validate_candidate(
             and isinstance(item_base, dict)
             and item_head.get("sha") == head_sha
             and item_base.get("ref") == "main"
-            and item_base.get("sha") == queue_base_sha
         ):
             matching_pr = True
             break
@@ -341,33 +412,40 @@ def verify_queue(
     token: str,
     api_url: str,
     current_run_id: int,
+    details: dict[str, object] | None = None,
 ) -> tuple[bool, str, int | None]:
+    details = details if details is not None else {}
+    details.update(candidate_count=0, artifact_name="")
     merge_group = event.get("merge_group")
     if not isinstance(merge_group, dict):
+        details["reason_code"] = "invalid_context"
         return False, "not a merge_group event", None
     try:
         queue_head_sha = _require_sha(merge_group.get("head_sha"), "queue head SHA")
         queue_base_sha = _require_sha(merge_group.get("base_sha"), "queue base SHA")
+        details.update(queue_head_sha=queue_head_sha, queue_base_sha=queue_base_sha)
         checked_out_sha = _require_sha(_git("rev-parse", "HEAD", cwd=repo), "checkout SHA")
         if checked_out_sha != queue_head_sha:
             raise AttestationError("checked out commit is not the merge-group head")
         queue_tree_sha = _require_sha(
             _git("rev-parse", "HEAD^{tree}", cwd=repo), "queue tree SHA"
         )
+        details["queue_tree_sha"] = queue_tree_sha
         queue_policy = policy_digest(repo)
         base_policy = policy_digest(repo, queue_base_sha)
         if queue_policy != base_policy:
             raise AttestationError("CI policy changed relative to the queue base")
 
         name = f"ci-attestation-{queue_tree_sha}"
+        details["artifact_name"] = name
         encoded_name = urllib.parse.quote(name, safe="")
-        listing = _request_json(
-            f"{api_url}/repos/{repository}/actions/artifacts?name={encoded_name}&per_page=100",
-            token,
+        artifacts = _list_attestation_artifacts(
+            api_url=api_url,
+            repository=repository,
+            encoded_name=encoded_name,
+            token=token,
         )
-        artifacts = listing.get("artifacts")
-        if not isinstance(artifacts, list) or not artifacts:
-            raise AttestationError("no PR CI attestation exists for the queue tree")
+        details["candidate_count"] = len(artifacts)
 
         reasons: list[str] = []
         for artifact in sorted(
@@ -417,13 +495,16 @@ def verify_queue(
                     queue_policy_digest=queue_policy,
                     pull_request_head_is_ancestor=head_is_ancestor,
                 )
+                details["reason_code"] = "reusable_exact"
                 return True, "matching trusted PR CI attestation", run_id
             except (AttestationError, OSError, ValueError, zipfile.BadZipFile) as exc:
                 reasons.append(str(exc))
         detail = "; ".join(reasons[:3]) or "no usable attestation artifacts"
         raise AttestationError(detail)
     except (AttestationError, OSError, subprocess.CalledProcessError, ValueError) as exc:
-        return False, str(exc), None
+        reason = str(exc)
+        details["reason_code"] = _reason_code(reason, api_error=isinstance(exc, OSError))
+        return False, reason, None
 
 
 def _create_command(args: argparse.Namespace) -> int:
@@ -456,6 +537,7 @@ def _verify_queue_command(args: argparse.Namespace) -> int:
     if not token:
         print("GH_TOKEN is required", file=sys.stderr)
         return 2
+    details: dict[str, object] = {}
     reusable, reason, source_run_id = verify_queue(
         repo=Path(args.repo).resolve(),
         repository=args.repository,
@@ -463,13 +545,20 @@ def _verify_queue_command(args: argparse.Namespace) -> int:
         token=token,
         api_url=args.api_url.rstrip("/"),
         current_run_id=args.run_id,
+        details=details,
     )
     _write_outputs(
         Path(args.github_output) if args.github_output else None,
         {
             "reusable": str(reusable).lower(),
             "reason": reason,
+            "reason_code": details.get("reason_code", "artifact_invalid"),
             "source_run_id": source_run_id or "",
+            "candidate_count": details.get("candidate_count", 0),
+            "artifact_name": details.get("artifact_name", ""),
+            "queue_base_sha": details.get("queue_base_sha", ""),
+            "queue_head_sha": details.get("queue_head_sha", ""),
+            "queue_tree_sha": details.get("queue_tree_sha", ""),
         },
     )
     print(f"reusable={str(reusable).lower()} reason={reason}")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1112,7 +1112,7 @@ jobs:
       UV_PYTHON: "3.12"
       PYTHONPATH: ${{ github.workspace }}
       OPENSQUILLA_TURN_CALL_LOG: "0"
-      PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/ms-playwright
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
 
     steps:
       - name: Prepare Desktop recovery report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,13 @@ jobs:
     outputs:
       reusable: ${{ steps.verify.outputs.reusable || 'false' }}
       reason: ${{ steps.verify.outputs.reason || steps.context.outputs.reason || steps.mode.outputs.reason }}
+      reason_code: ${{ steps.verify.outputs.reason_code || steps.context.outputs.reason_code || steps.mode.outputs.reason_code }}
       source_run_id: ${{ steps.verify.outputs.source_run_id }}
+      candidate_count: ${{ steps.verify.outputs.candidate_count || '0' }}
+      artifact_name: ${{ steps.verify.outputs.artifact_name }}
+      queue_base_sha: ${{ steps.verify.outputs.queue_base_sha }}
+      queue_head_sha: ${{ steps.verify.outputs.queue_head_sha }}
+      queue_tree_sha: ${{ steps.verify.outputs.queue_tree_sha }}
     steps:
       - name: Validate optimization mode
         id: mode
@@ -45,18 +51,22 @@ jobs:
               ;;
           esac
           if [[ "${CI_OPTIMIZATION_MODE}" == "legacy" ]]; then
+            echo "reason_code=legacy_mode" >> "${GITHUB_OUTPUT}"
             echo "reason=legacy mode always runs queue CI" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Record non-queue context
         id: context
         if: ${{ github.event_name != 'merge_group' }}
-        run: echo "reason=not a merge-group event" >> "${GITHUB_OUTPUT}"
+        run: |
+          echo "reason_code=invalid_context" >> "${GITHUB_OUTPUT}"
+          echo "reason=not a merge-group event" >> "${GITHUB_OUTPUT}"
 
       - name: Check out merge-group commit
         if: ${{ github.event_name == 'merge_group' && env.CI_OPTIMIZATION_MODE != 'legacy' }}
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.merge_group.head_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -78,7 +88,13 @@ jobs:
         env:
           REUSABLE: ${{ steps.verify.outputs.reusable || 'false' }}
           REASON: ${{ steps.verify.outputs.reason || steps.mode.outputs.reason }}
+          REASON_CODE: ${{ steps.verify.outputs.reason_code || steps.mode.outputs.reason_code }}
           SOURCE_RUN_ID: ${{ steps.verify.outputs.source_run_id }}
+          CANDIDATE_COUNT: ${{ steps.verify.outputs.candidate_count || '0' }}
+          ARTIFACT_NAME: ${{ steps.verify.outputs.artifact_name }}
+          QUEUE_BASE_SHA: ${{ steps.verify.outputs.queue_base_sha }}
+          QUEUE_HEAD_SHA: ${{ steps.verify.outputs.queue_head_sha }}
+          QUEUE_TREE_SHA: ${{ steps.verify.outputs.queue_tree_sha }}
         shell: bash
         run: |
           {
@@ -86,12 +102,18 @@ jobs:
             echo
             echo "- Mode: \`${CI_OPTIMIZATION_MODE}\`"
             echo "- Reusable: \`${REUSABLE}\`"
-            echo "- Reason: ${REASON}"
+            echo "- Reason: \`${REASON_CODE}\` - ${REASON}"
+            echo "- Candidates: \`${CANDIDATE_COUNT}\`"
+            echo "- Artifact: \`${ARTIFACT_NAME}\`"
+            echo "- Queue base/head/tree: \`${QUEUE_BASE_SHA}\` / \`${QUEUE_HEAD_SHA}\` / \`${QUEUE_TREE_SHA}\`"
             if [[ -n "${SOURCE_RUN_ID}" ]]; then
               echo "- Source run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}"
             fi
+            if [[ "${CI_OPTIMIZATION_MODE}" == "enforce" && "${REUSABLE}" == "true" ]]; then
+              echo "- Decision: \`attestation_reuse\`"
+            fi
             if [[ "${CI_OPTIMIZATION_MODE}" == "shadow" && "${REUSABLE}" == "true" ]]; then
-              echo "- Shadow decision: evidence matched, but the normal queue matrix still runs."
+              echo "- Shadow decision: evidence matched, but the classifier-selected queue matrix still runs."
             fi
           } >> "${GITHUB_STEP_SUMMARY}"
 
@@ -158,17 +180,17 @@ jobs:
             merge_group)
               base="${{ github.event.merge_group.base_sha }}"
               head="${{ github.event.merge_group.head_sha }}"
-              if [[ "${CI_OPTIMIZATION_MODE}" == "legacy" \
-                || "${CI_OPTIMIZATION_MODE}" == "enforce" ]]; then
-                echo "Queue evidence was unavailable; running the full fail-closed matrix." >&2
+              if [[ "${CI_OPTIMIZATION_MODE}" == "legacy" ]]; then
+                echo "Legacy mode runs the full fail-closed matrix." >&2
                 printf '.ci/run-all\n' > "${changed_files}"
               elif [[ -n "${base}" && -n "${head}" ]] \
                 && git cat-file -e "${base}^{commit}" \
                 && git cat-file -e "${head}^{commit}" \
-                && git diff --name-only "${base}" "${head}" > "${changed_files}"; then
-                :
+                && git diff --name-only "${base}" "${head}" > "${changed_files}" \
+                && [[ -s "${changed_files}" ]]; then
+                echo "Queue evidence was unavailable; classifying the exact merge-group diff." >&2
               else
-                echo "Merge-group diff is unavailable; running the full CI matrix." >&2
+                echo "Merge-group diff is unavailable or empty; running the full CI matrix." >&2
                 printf '.ci/run-all\n' > "${changed_files}"
               fi
               ;;
@@ -195,6 +217,22 @@ jobs:
         shell: bash
         run: bash .github/scripts/classify-ci-changes.sh "${CHANGED_FILES}"
 
+      - name: Summarize merge-group fallback decision
+        if: ${{ github.event_name == 'merge_group' }}
+        env:
+          FULL_REQUIRED: ${{ steps.classify.outputs.full_required }}
+        shell: bash
+        run: |
+          decision="queue_diff_targeted"
+          if [[ "${FULL_REQUIRED}" == "true" ]]; then
+            decision="full_fail_closed"
+          fi
+          {
+            echo "## Merge queue fallback"
+            echo
+            echo "- Decision: \`${decision}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
   workflow-lint:
     name: Validate GitHub Actions workflows
     needs: classify-changes
@@ -203,6 +241,14 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Cache actionlint Go build inputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: actionlint-${{ runner.os }}-${{ runner.arch }}-v1.7.12
 
       - name: Run actionlint
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color=false
@@ -1066,6 +1112,7 @@ jobs:
       UV_PYTHON: "3.12"
       PYTHONPATH: ${{ github.workspace }}
       OPENSQUILLA_TURN_CALL_LOG: "0"
+      PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/ms-playwright
 
     steps:
       - name: Prepare Desktop recovery report
@@ -1128,6 +1175,12 @@ jobs:
         working-directory: opensquilla-webui
         shell: bash
         run: npm ci
+
+      - name: Cache Playwright browser
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('opensquilla-webui/package-lock.json') }}
 
       - name: Install WebUI recovery browser
         working-directory: opensquilla-webui

--- a/.github/workflows/managed-toolchain-artifacts.yml
+++ b/.github/workflows/managed-toolchain-artifacts.yml
@@ -62,6 +62,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
 
       - name: Install runtime dependencies
         run: uv sync --frozen

--- a/.github/workflows/skill-hub-contract.yml
+++ b/.github/workflows/skill-hub-contract.yml
@@ -14,8 +14,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect:
+    name: Detect Skill Hub contract changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run_contract: ${{ steps.decision.outputs.run_contract }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: List changed files
+        shell: bash
+        run: |
+          set -euo pipefail
+          changed_files="${RUNNER_TEMP}/changed-files.txt"
+          if [[ "${{ github.event_name }}" == "pull_request" ]] \
+            && git cat-file -e "${{ github.event.pull_request.base.sha }}^{commit}" \
+            && git cat-file -e "${{ github.event.pull_request.head.sha }}^{commit}" \
+            && git diff --name-only \
+              "${{ github.event.pull_request.base.sha }}" \
+              "${{ github.event.pull_request.head.sha }}" > "${changed_files}" \
+            && [[ -s "${changed_files}" ]]; then
+            :
+          else
+            printf '.ci/run-all\n' > "${changed_files}"
+          fi
+          printf 'CHANGED_FILES=%s\n' "${changed_files}" >> "${GITHUB_ENV}"
+
+      - name: Classify changed files
+        id: classify
+        shell: bash
+        run: bash .github/scripts/classify-ci-changes.sh "${CHANGED_FILES}"
+
+      - name: Decide whether to run Skill Hub contracts
+        id: decision
+        env:
+          PYTHON_CHANGED: ${{ steps.classify.outputs.python_changed }}
+        shell: bash
+        run: echo "run_contract=${PYTHON_CHANGED}" >> "${GITHUB_OUTPUT}"
+
   skill-hub-contract:
     name: skill-hub-contract (${{ matrix.os }})
+    needs: detect
+    if: ${{ needs.detect.outputs.run_contract == 'true' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:

--- a/tests/test_ci/test_ci_attestation.py
+++ b/tests/test_ci/test_ci_attestation.py
@@ -396,7 +396,11 @@ def test_artifact_listing_retries_visibility_and_paginates(
         return {"total_count": 1, "artifacts": [{"id": 1}]}
 
     monkeypatch.setitem(list_attestation_artifacts.__globals__, "_request_json", fake_json)
-    monkeypatch.setitem(list_attestation_artifacts.__globals__, "time", type("Clock", (), {"sleep": staticmethod(sleeps.append)}))
+    monkeypatch.setitem(
+        list_attestation_artifacts.__globals__,
+        "time",
+        type("Clock", (), {"sleep": staticmethod(sleeps.append)}),
+    )
 
     result = list_attestation_artifacts(
         api_url="https://api.github.com",

--- a/tests/test_ci/test_ci_attestation.py
+++ b/tests/test_ci/test_ci_attestation.py
@@ -21,6 +21,7 @@ create_attestation = MODULE["create_attestation"]
 policy_digest = MODULE["policy_digest"]
 validate_candidate = MODULE["validate_candidate"]
 verify_queue = MODULE["verify_queue"]
+list_attestation_artifacts = MODULE["_list_attestation_artifacts"]
 
 
 def _artifact_redirect(newurl: str) -> urllib.request.Request:
@@ -260,24 +261,54 @@ def test_validate_candidate_rejects_non_green_or_mismatched_runs(tmp_path: Path)
                 pull_request_head_is_ancestor=True,
             )
 
-    wrong_base = dict(run)
-    wrong_base["pull_requests"] = [
+    stale_base = dict(run)
+    stale_base["pull_requests"] = [
         {
             "number": 42,
             "head": {"sha": attestation["head_sha"]},
             "base": {"ref": "main", "sha": "0" * 40},
         }
     ]
+    validate_candidate(
+        attestation=attestation,
+        run=stale_base,
+        repository="opensquilla/opensquilla",
+        queue_tree_sha=str(attestation["tested_tree_sha"]),
+        queue_base_sha=base_sha,
+        queue_policy_digest=str(attestation["policy_digest"]),
+        pull_request_head_is_ancestor=True,
+    )
+
+    wrong_ref = dict(run)
+    wrong_ref["pull_requests"] = [
+        {
+            "number": 42,
+            "head": {"sha": attestation["head_sha"]},
+            "base": {"ref": "release", "sha": base_sha},
+        }
+    ]
     with pytest.raises(AttestationError):
         validate_candidate(
             attestation=attestation,
-            run=wrong_base,
+            run=wrong_ref,
             repository="opensquilla/opensquilla",
             queue_tree_sha=str(attestation["tested_tree_sha"]),
             queue_base_sha=base_sha,
             queue_policy_digest=str(attestation["policy_digest"]),
             pull_request_head_is_ancestor=True,
         )
+
+    merge_sha_run = dict(run)
+    merge_sha_run["head_sha"] = attestation["tested_merge_sha"]
+    validate_candidate(
+        attestation=attestation,
+        run=merge_sha_run,
+        repository="opensquilla/opensquilla",
+        queue_tree_sha=str(attestation["tested_tree_sha"]),
+        queue_base_sha=base_sha,
+        queue_policy_digest=str(attestation["policy_digest"]),
+        pull_request_head_is_ancestor=True,
+    )
 
 
 def test_verify_queue_reuses_only_exact_trusted_evidence(
@@ -316,6 +347,7 @@ def test_verify_queue_reuses_only_exact_trusted_evidence(
         verify_queue.__globals__, "_request_bytes", lambda _url, _token: _archive(attestation)
     )
 
+    details: dict[str, object] = {}
     reusable, reason, source_run = verify_queue(
         repo=repo,
         repository="opensquilla/opensquilla",
@@ -323,11 +355,15 @@ def test_verify_queue_reuses_only_exact_trusted_evidence(
         token="synthetic-token",
         api_url="https://api.github.com",
         current_run_id=999,
+        details=details,
     )
 
     assert reusable is True
     assert reason == "matching trusted PR CI attestation"
     assert source_run == 123
+    assert details["reason_code"] == "reusable_exact"
+    assert details["candidate_count"] == 1
+    assert details["artifact_name"].startswith("ci-attestation-")
 
     _write(repo, ".github/workflows/ci.yml", "name: Changed CI\n")
     _git(repo, "add", ".github/workflows/ci.yml")
@@ -345,3 +381,46 @@ def test_verify_queue_reuses_only_exact_trusted_evidence(
     assert reusable is False
     assert "CI policy changed" in reason
     assert source_run is None
+
+
+def test_artifact_listing_retries_visibility_and_paginates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    sleeps: list[int] = []
+
+    def fake_json(url: str, _token: str) -> dict[str, Any]:
+        calls.append(url)
+        if len(calls) < 3:
+            return {"artifacts": []}
+        return {"total_count": 1, "artifacts": [{"id": 1}]}
+
+    monkeypatch.setitem(list_attestation_artifacts.__globals__, "_request_json", fake_json)
+    monkeypatch.setitem(list_attestation_artifacts.__globals__, "time", type("Clock", (), {"sleep": staticmethod(sleeps.append)}))
+
+    result = list_attestation_artifacts(
+        api_url="https://api.github.com",
+        repository="opensquilla/opensquilla",
+        encoded_name="ci-attestation-tree",
+        token="synthetic-token",
+    )
+
+    assert result == [{"id": 1}]
+    assert sleeps == [10, 20]
+    assert "page=1" in calls[-1]
+
+
+def test_artifact_listing_fails_closed_at_candidate_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_json(_url: str, _token: str) -> dict[str, Any]:
+        return {"total_count": 301, "artifacts": []}
+
+    monkeypatch.setitem(list_attestation_artifacts.__globals__, "_request_json", fake_json)
+    with pytest.raises(AttestationError, match="candidate limit"):
+        list_attestation_artifacts(
+            api_url="https://api.github.com",
+            repository="opensquilla/opensquilla",
+            encoded_name="ci-attestation-tree",
+            token="synthetic-token",
+        )

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -1546,6 +1546,9 @@ def test_desktop_recovery_e2e_runs_compiled_flows_on_all_release_platforms() -> 
     assert '--grep "terminates stalled"' in session_recovery["run"]
     assert playwright_cache["uses"] == "actions/cache@v4"
     assert playwright_cache["with"]["path"] == "${{ env.PLAYWRIGHT_BROWSERS_PATH }}"
+    assert job["env"]["PLAYWRIGHT_BROWSERS_PATH"] == (
+        "${{ github.workspace }}/.cache/ms-playwright"
+    )
     assert "${{ runner.arch }}" in playwright_cache["with"]["key"]
     assert "opensquilla-webui/package-lock.json" in playwright_cache["with"]["key"]
     assert "restore-keys" not in playwright_cache["with"]

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -215,7 +215,7 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     assert 'merge_group)\n              base="${{ github.event.merge_group.base_sha }}"' in text
     assert 'head="${{ github.event.merge_group.head_sha }}"' in text
     assert 'git diff --name-only "${base}" "${head}" > "${changed_files}"' in text
-    assert "Merge-group diff is unavailable; running the full CI matrix." in text
+    assert "Merge-group diff is unavailable or empty; running the full CI matrix." in text
     assert 'git diff --name-only "${before}" "${after}" > "${changed_files}"' in text
     assert 'printf \'.ci/run-all\\n\' > "${changed_files}"' in text
     assert "runtime_changed" in text
@@ -253,6 +253,13 @@ def test_ci_fast_paths_keep_the_required_check_and_fail_closed() -> None:
     assert "not a merge-group event" in str(jobs["queue-attestation"])
     assert "fetch-depth" in str(jobs["queue-attestation"])
     assert "verify-queue" in str(jobs["queue-attestation"])
+    assert "reason_code" in str(jobs["queue-attestation"])
+    queue_checkout = next(
+        step
+        for step in jobs["queue-attestation"]["steps"]
+        if step.get("name") == "Check out merge-group commit"
+    )
+    assert queue_checkout["with"]["ref"] == "${{ github.event.merge_group.head_sha }}"
     assert "full fail-closed matrix" in str(jobs["classify-changes"])
     assert 'CI_OPTIMIZATION_MODE}" == "legacy"' in str(jobs["classify-changes"])
     assert jobs["main-canary"]["name"] == "Main installation and offline gateway canary"
@@ -261,6 +268,21 @@ def test_ci_fast_paths_keep_the_required_check_and_fail_closed() -> None:
     assert "ci-attestation-${{ steps.attestation.outputs.tree_sha }}" in str(
         jobs["ci-result"]
     )
+
+
+def test_skill_hub_contract_uses_classifier_gate_without_changing_required_names() -> None:
+    workflow = _workflow("skill-hub-contract.yml")
+    jobs = workflow["jobs"]
+    assert jobs["detect"]["name"] == "Detect Skill Hub contract changes"
+    assert jobs["skill-hub-contract"]["needs"] == "detect"
+    assert jobs["skill-hub-contract"]["if"] == (
+        "${{ needs.detect.outputs.run_contract == 'true' }}"
+    )
+    text = (WORKFLOW_DIR / "skill-hub-contract.yml").read_text(encoding="utf-8")
+    assert "classify-ci-changes.sh" in text
+    assert "github.event.pull_request.base.sha" in text
+    assert "github.event.pull_request.head.sha" in text
+    assert "run_contract" in text
 
 
 def test_ci_change_classifier_routes_platform_neutral_gateway_changes(
@@ -476,6 +498,8 @@ def test_managed_toolchain_artifacts_cover_native_macos_architectures_and_musl()
     assert "OPENSQUILLA_GATEWAY_STATE_DIR" not in validate["env"]
     assert "OPENSQUILLA_TOOLCHAIN_VALIDATION_ROOT" not in validate["env"]
     assert validate["env"]["OPENSQUILLA_REQUIRE_MANAGED_TOOLCHAIN_E2E"] == "1"
+    setup_uv = next(step for step in validate["steps"] if step.get("name") == "Set up uv")
+    assert setup_uv["with"]["enable-cache"] is True
 
     configure_state = next(
         step
@@ -1498,6 +1522,9 @@ def test_desktop_recovery_e2e_runs_compiled_flows_on_all_release_platforms() -> 
         if step.get("name")
         == "Run cross-platform production-dist browser session hang contract"
     )
+    playwright_cache = next(
+        step for step in steps if step.get("name") == "Cache Playwright browser"
+    )
     run = next(
         step for step in steps if step.get("name") == "Run compiled Desktop recovery flows"
     )
@@ -1517,6 +1544,11 @@ def test_desktop_recovery_e2e_runs_compiled_flows_on_all_release_platforms() -> 
     assert session_recovery["env"]["OPENSQUILLA_WEBUI_BASE_URL"].endswith(":18791")
     assert "history-hydration.spec.ts" in session_recovery["run"]
     assert '--grep "terminates stalled"' in session_recovery["run"]
+    assert playwright_cache["uses"] == "actions/cache@v4"
+    assert playwright_cache["with"]["path"] == "${{ env.PLAYWRIGHT_BROWSERS_PATH }}"
+    assert "${{ runner.arch }}" in playwright_cache["with"]["key"]
+    assert "opensquilla-webui/package-lock.json" in playwright_cache["with"]["key"]
+    assert "restore-keys" not in playwright_cache["with"]
     assert "xvfb-run -a node" in run["run"]
     assert "test-profile-consolidation-flow.mjs" in run["run"]
     assert "test-primary-repair-accessibility.mjs" in run["run"]


### PR DESCRIPTION
## Summary

- Run the exact merge-group diff through the existing classifier when attestation reuse misses; keep CI, dependency, unknown, empty-diff, and platform-sensitive paths fail-closed.
- Preserve exact attestation validation while adding bounded 0/10/30-second artifact visibility retries, structured reason codes, and queue SHA observability.
- Gate Skill Hub's three-platform matrix on the classifier and add scoped Playwright, uv, and actionlint caches.

## Validation

- 131 CI tests passed.
- classify-ci-changes.sh syntax check passed.
- git diff --check passed.
- actionlint was not run locally because Go/actionlint is not installed; this workflow change will exercise it in CI.

Base: origin/main
Commit: 92f9b658b