### PR TITLE
Explain queued follow-ups when steering is unavailable

### DIFF
--- a/opensquilla-webui/src/components/chat/PendingQueue.test.ts
+++ b/opensquilla-webui/src/components/chat/PendingQueue.test.ts
@@ -70,9 +70,12 @@ describe('PendingQueue', () => {
     _source: { runMode: 'safe' as const },
   }
 
-  it('keeps the original steer affordance visible but disabled when capability is unavailable', async () => {
+  it('keeps the original steer affordance disabled and visibly explains queue-only delivery', async () => {
     const reason = 'Steer unavailable: the active task identity has not synchronized yet.'
-    const { app, el } = await mountQueue({}, undefined, {
+    const { app, el } = await mountQueue({}, [
+      { text: 'Follow the latest instruction' },
+      { text: 'Use the concise version' },
+    ], {
       steerAvailable: false,
       steerUnavailableMessage: reason,
     })
@@ -82,7 +85,11 @@ describe('PendingQueue', () => {
     expect(steer?.disabled).toBe(true)
     expect(steer?.title).toBe(reason)
     expect(steer?.getAttribute('aria-describedby')).toBeNull()
-    expect(el.querySelector('.chat-pending-steer-status')).toBeNull()
+    const status = el.querySelector<HTMLElement>('.chat-pending-steer-status')
+    expect(el.querySelectorAll('.chat-pending-steer-status')).toHaveLength(1)
+    expect(status?.getAttribute('role')).toBe('status')
+    expect(status?.getAttribute('aria-live')).toBe('polite')
+    expect(status?.textContent).toContain(reason)
     expect(el.querySelector('[aria-label="Remove pending message 1"]')).not.toBeNull()
     app.unmount()
   })
@@ -194,14 +201,76 @@ describe('PendingQueue', () => {
     const { app, el } = await mountQueue({}, [{
       text: steerRequest.message,
       steerAttempt: { phase: 'acceptance_unknown', request: steerRequest },
-    }], { steerAvailable: false })
+    }], {
+      steerAvailable: false,
+      steerUnavailableMessage: 'New messages will queue after the current response.',
+    })
 
     const retry = el.querySelector<HTMLButtonElement>('.chat-pending-action--steer')
     expect(el.querySelector('.chat-pending-card')?.getAttribute('data-delivery-state'))
       .toBe('attention')
     expect(retry?.textContent).toContain(action)
     expect(retry?.disabled).toBe(false)
+    expect(el.querySelector('.chat-pending-steer-status')).toBeNull()
     expect(el.querySelector<HTMLButtonElement>(`[aria-label="${remove}"]`)).not.toBeNull()
+    app.unmount()
+  })
+
+  it('keeps a rejected steer retry available without showing queue-only status', async () => {
+    const { app, el } = await mountQueue({}, [{
+      text: steerRequest.message,
+      steerAttempt: { phase: 'retryable_rejected', request: steerRequest },
+    }], {
+      steerAvailable: false,
+      steerUnavailableMessage: 'New messages will queue after the current response.',
+    })
+
+    const retry = el.querySelector<HTMLButtonElement>('.chat-pending-action--steer')
+    expect(retry?.textContent).toContain('Not sent · Retry')
+    expect(retry?.disabled).toBe(false)
+    expect(el.querySelector('.chat-pending-steer-status')).toBeNull()
+    app.unmount()
+  })
+
+  it('does not show queue-only status beside steer confirmation retries', async () => {
+    const { app, el } = await mountQueue({}, [
+      { text: 'Ordinary queued follow-up' },
+      {
+        text: steerRequest.message,
+        steerAttempt: { phase: 'acceptance_unknown', request: steerRequest },
+      },
+    ], {
+      steerAvailable: false,
+      steerUnavailableMessage: 'New messages will queue after the current response.',
+    })
+
+    const steerButtons = [...el.querySelectorAll<HTMLButtonElement>(
+      '.chat-pending-action--steer',
+    )]
+    expect(steerButtons[0]?.disabled).toBe(true)
+    expect(steerButtons[1]?.disabled).toBe(false)
+    expect(el.querySelector('.chat-pending-steer-status')).toBeNull()
+    app.unmount()
+  })
+
+  it('does not show queue-only status beside a rejected steer retry', async () => {
+    const { app, el } = await mountQueue({}, [
+      { text: 'Ordinary queued follow-up' },
+      {
+        text: 'Rejected steer retry',
+        steerAttempt: { phase: 'retryable_rejected', request: steerRequest },
+      },
+    ], {
+      steerAvailable: false,
+      steerUnavailableMessage: 'New messages will queue after the current response.',
+    })
+
+    const steerButtons = [...el.querySelectorAll<HTMLButtonElement>(
+      '.chat-pending-action--steer',
+    )]
+    expect(steerButtons[0]?.disabled).toBe(true)
+    expect(steerButtons[1]?.disabled).toBe(false)
+    expect(el.querySelector('.chat-pending-steer-status')).toBeNull()
     app.unmount()
   })
 
@@ -211,13 +280,17 @@ describe('PendingQueue', () => {
     const { app, el } = await mountQueue({
       onSteer: () => { steered += 1 },
       onEdit: () => { edited += 1 },
-    }, [{ text: 'Retry this steer', deliveryState: 'retryable' }])
+    }, [{ text: 'Retry this steer', deliveryState: 'retryable' }], {
+      steerAvailable: false,
+      steerUnavailableMessage: 'New messages will queue after the current response.',
+    })
 
     expect(el.querySelector('.chat-pending-card')?.hasAttribute('aria-busy')).toBe(false)
     const retry = [...el.querySelectorAll<HTMLButtonElement>('button')]
       .find(button => button.textContent?.includes('Retry'))
     expect(retry?.disabled).toBe(false)
     expect(retry?.title).toBe('Retry')
+    expect(el.querySelector('.chat-pending-steer-status')).toBeNull()
     retry?.click()
     expect(steered).toBe(1)
 

--- a/opensquilla-webui/src/components/chat/PendingQueue.vue
+++ b/opensquilla-webui/src/components/chat/PendingQueue.vue
@@ -119,6 +119,15 @@
         </div>
       </div>
     </article>
+    <p
+      v-if="showSteerUnavailableStatus"
+      key="steer-unavailable"
+      class="chat-pending-steer-status"
+      role="status"
+      aria-live="polite"
+    >
+      {{ steerUnavailableMessage }}
+    </p>
     <span key="reorder-announcement" class="chat-pending-announcement" aria-live="polite">
       {{ reorderAnnouncement }}
     </span>
@@ -204,6 +213,18 @@ const effectiveMaxPending = computed(() => (
       ? 1
       : 0
   )
+))
+const showSteerUnavailableStatus = computed(() => (
+  props.steerAvailable === false
+  && Boolean(props.steerUnavailableMessage?.trim())
+  && !props.items.some(item => (
+    isSteering(item)
+    || item.deliveryState === 'retryable'
+    || isSteerRetry(item)
+  ))
+  && props.items.some(item => (
+    !item.hiddenControl
+  ))
 ))
 
 function displayText(item: PendingQueueItem): string {
@@ -642,6 +663,13 @@ onBeforeUnmount(() => {
   margin-top: 2px;
   line-height: 1.35;
   white-space: normal;
+}
+
+.chat-pending-steer-status {
+  margin: -2px 4px 0;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  line-height: 1.4;
 }
 
 .chat-pending-actions {


### PR DESCRIPTION
## Summary
- Surface the existing queue-only reason directly in the pending queue.
- Preserve the disabled Steer action and all follow-up, idempotency, and retry behavior.
- Hide the queue-only message whenever the queue contains an in-flight or confirmation-retry steer.

## Scope
- Base branch: `main`
- Linked issue: None

## Release note
- User-visible Web UI clarification; suitable for the next patch release notes.

## Tests
- `npm run test:unit -- src/components/chat/PendingQueue.test.ts --reporter=dot`
- `npm run test:unit -- src/composables/chat/useChatSend.attachments.test.ts --reporter=dot`
- `npm run typecheck`

## Safety and compatibility
- No Gateway, RPC, persistence, configuration, or public API changes.
- Existing unknown/rejected steer confirmation behavior remains unchanged.

## Third-party origin
- None.