### PR TITLE
Fix cumulative ensemble request accounting

### DIFF
--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -6901,6 +6901,26 @@ class Agent:
         turn_model_usage_breakdown: list[dict[str, Any]] = []
         last_ensemble_trace: dict[str, Any] | None = None
         turn_ensemble_request_count = 0
+        ensemble_continuation_request_count: int | None = None
+        ensemble_continuation_provider: object | None = None
+
+        def _merge_ensemble_request_count(
+            trace: dict[str, Any],
+            continuation_baseline: int | None,
+        ) -> int:
+            nonlocal last_ensemble_trace, turn_ensemble_request_count
+
+            last_ensemble_trace = dict(trace)
+            reported_count = _usage_int(trace.get("llm_request_count") or 0)
+            if continuation_baseline is None:
+                turn_ensemble_request_count += reported_count
+            else:
+                turn_ensemble_request_count += max(
+                    0,
+                    reported_count - continuation_baseline,
+                )
+            return reported_count
+
         terminal_error: ErrorEvent | None = None
         terminal_generation_reset_event: AnswerGenerationResetEvent | None = None
         final_text_parts: list[str] = []
@@ -8440,6 +8460,30 @@ class Agent:
                         call_id=call_id,
                         tools_supported=tools_supported_for_call,
                     )
+                    ensemble_request_count_baseline: int | None = None
+                    if ensemble_continuation_provider is self.provider:
+                        ensemble_request_count_baseline = (
+                            ensemble_continuation_request_count
+                        )
+                    ensemble_continuation_request_count = None
+                    ensemble_continuation_provider = None
+                    if (
+                        ensemble_request_count_baseline is None
+                        and self._execution_context is not None
+                        and getattr(
+                            self.provider, "execution_context_aware", False
+                        )
+                    ):
+                        continuation_snapshot = (
+                            self._execution_context.ensemble_continuation_snapshot
+                        )
+                        if (
+                            continuation_snapshot is not None
+                            and continuation_snapshot.request_started
+                        ):
+                            ensemble_request_count_baseline = (
+                                continuation_snapshot.physical_request_count
+                            )
                     turn_llm_calls += 1
                     cache_prompt_snapshot = None
                     if self._session_key:
@@ -8722,12 +8766,11 @@ class Agent:
                                         last_actual_provider = last_item.provider
                                         last_actual_model = last_item.model
                                     if isinstance(raw_ev.ensemble_trace, dict):
-                                        last_ensemble_trace = dict(raw_ev.ensemble_trace)
-                                        turn_ensemble_request_count += _usage_int(
-                                            raw_ev.ensemble_trace.get(
-                                                "llm_request_count"
+                                        ensemble_request_count_baseline = (
+                                            _merge_ensemble_request_count(
+                                                raw_ev.ensemble_trace,
+                                                ensemble_request_count_baseline,
                                             )
-                                            or 0
                                         )
                                     provider_error_for_log = ProviderErrorEvent(
                                         message=(
@@ -9626,10 +9669,17 @@ class Agent:
                                         )
                                 ensemble_trace = getattr(raw_ev, "ensemble_trace", None)
                                 if isinstance(ensemble_trace, dict):
-                                    last_ensemble_trace = dict(ensemble_trace)
-                                    turn_ensemble_request_count += _usage_int(
-                                        ensemble_trace.get("llm_request_count") or 0
+                                    ensemble_request_count_baseline = (
+                                        _merge_ensemble_request_count(
+                                            ensemble_trace,
+                                            ensemble_request_count_baseline,
+                                        )
                                     )
+                                    if tool_calls:
+                                        ensemble_continuation_request_count = (
+                                            ensemble_request_count_baseline
+                                        )
+                                        ensemble_continuation_provider = self.provider
 
                             elif isinstance(raw_ev, ProviderErrorEvent):
                                 provider_error_for_log = raw_ev

--- a/tests/test_engine/test_agent_transactional_tool_publication.py
+++ b/tests/test_engine/test_agent_transactional_tool_publication.py
@@ -336,6 +336,12 @@ async def test_terminal_generation_reset_carries_usage_without_second_terminal()
     }
     provider = _ScriptedProvider(
         [
+            _tool_stream(
+                terminal=ProviderDone(
+                    stop_reason="tool_use",
+                    ensemble_trace={"llm_request_count": 3},
+                )
+            ),
             [
                 ProviderText(text="partial fixed answer", generation_epoch=0),
                 ProviderGenerationResetEvent(
@@ -347,9 +353,9 @@ async def test_terminal_generation_reset_carries_usage_without_second_terminal()
                     terminal_error_message="unauthorized",
                     terminal_error_code="401",
                     model_usage_breakdown=[usage_row],
-                    ensemble_trace={"llm_request_count": 1},
+                    ensemble_trace={"llm_request_count": 4},
                 ),
-            ]
+            ],
         ]
     )
     context = TurnExecutionContext.create(
@@ -360,13 +366,23 @@ async def test_terminal_generation_reset_carries_usage_without_second_terminal()
         )
     )
     usage = UsageTracker()
+
+    async def tool_handler(call: Any) -> ToolResult:
+        return ToolResult(
+            tool_use_id=call.tool_use_id,
+            tool_name=call.tool_name,
+            content="recorded",
+        )
+
     agent = Agent(
         provider=provider,
         config=AgentConfig(
-            max_iterations=1,
+            max_iterations=2,
             max_provider_retries=0,
             provider_id="openrouter",
         ),
+        tool_definitions=[_record_definition()],
+        tool_handler=tool_handler,
         execution_context=context,
         usage_tracker=usage,
         session_key="agent:main:terminal-reset",
@@ -389,8 +405,10 @@ async def test_terminal_generation_reset_carries_usage_without_second_terminal()
     assert accounting_done.input_tokens == 4
     assert accounting_done.output_tokens == 2
     assert accounting_done.generation_epoch == terminal_reset.new_generation_epoch
+    assert accounting_done.ensemble_trace is not None
+    assert accounting_done.ensemble_trace["llm_request_count"] == 4
     tracked = usage.get("agent:main:terminal-reset")
     assert tracked is not None
     assert tracked.input_tokens == 4
     assert tracked.output_tokens == 2
-    assert len(provider.calls) == 1
+    assert len(provider.calls) == 2

--- a/tests/test_engine/test_agent_usage_tracker_billed_propagation.py
+++ b/tests/test_engine/test_agent_usage_tracker_billed_propagation.py
@@ -26,6 +26,13 @@ from dataclasses import dataclass
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
+from opensquilla.contracts.turn_execution import (
+    EnsembleContinuationSnapshot,
+    TurnExecutionContext,
+    TurnIdentity,
+)
 from opensquilla.engine import Agent, AgentConfig, ToolResult
 from opensquilla.engine.types import DoneEvent as EngineDoneEvent
 from opensquilla.engine.types import ToolCall
@@ -254,21 +261,47 @@ def test_ensemble_breakdown_accumulates_each_underlying_model() -> None:
 
 class _TwoStepEnsembleBreakdownProvider:
     provider_name = "fake"
+    execution_context_aware = True
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        request_counts: tuple[int, ...],
+        *,
+        retry_empty_continuation: bool = False,
+    ) -> None:
         self.calls = 0
+        self.request_counts = request_counts
+        self.retry_empty_continuation = retry_empty_continuation
 
     def chat(
         self,
         messages: list[Message],
         tools: list[Any] | None = None,
         config: ChatConfig | None = None,
+        *,
+        execution_context: TurnExecutionContext | None = None,
     ) -> AsyncIterator[Any]:
         self.calls += 1
-        return self._stream(self.calls)
+        return self._stream(self.calls, execution_context)
 
-    async def _stream(self, call: int) -> AsyncIterator[Any]:
+    async def _stream(
+        self,
+        call: int,
+        execution_context: TurnExecutionContext | None,
+    ) -> AsyncIterator[Any]:
         if call == 1:
+            trace = {
+                "profile": "default",
+                "llm_request_count": self.request_counts[0],
+            }
+            if execution_context is not None:
+                execution_context.record_ensemble_continuation_snapshot(
+                    EnsembleContinuationSnapshot(
+                        ensemble_trace=trace,
+                        physical_request_count=self.request_counts[0],
+                        request_started=True,
+                    )
+                )
             yield ProviderToolUseStartEvent(tool_use_id="lookup-1", tool_name="lookup")
             yield ProviderToolUseEndEvent(
                 tool_use_id="lookup-1",
@@ -281,7 +314,7 @@ class _TwoStepEnsembleBreakdownProvider:
                 output_tokens=3,
                 billed_cost=0.03,
                 model="z-ai/glm-5.2",
-                ensemble_trace={"profile": "default", "llm_request_count": 2},
+                ensemble_trace=trace,
                 model_usage_breakdown=[
                     {
                         "role": "proposer",
@@ -306,6 +339,16 @@ class _TwoStepEnsembleBreakdownProvider:
                 ],
             )
             return
+        if self.retry_empty_continuation and call == 2:
+            yield ProviderDoneEvent(
+                stop_reason="end_turn",
+                model="z-ai/glm-5.2",
+                ensemble_trace={
+                    "profile": "default",
+                    "llm_request_count": self.request_counts[1],
+                },
+            )
+            return
         yield ProviderTextDeltaEvent(text="final answer")
         yield ProviderDoneEvent(
             stop_reason="end_turn",
@@ -313,7 +356,10 @@ class _TwoStepEnsembleBreakdownProvider:
             output_tokens=4,
             billed_cost=0.04,
             model="z-ai/glm-5.2",
-            ensemble_trace={"profile": "default", "llm_request_count": 2},
+            ensemble_trace={
+                "profile": "default",
+                "llm_request_count": self.request_counts[call - 1],
+            },
             model_usage_breakdown=[
                 {
                     "role": "proposer",
@@ -342,7 +388,19 @@ class _TwoStepEnsembleBreakdownProvider:
         return []
 
 
-def test_agent_final_done_summarizes_ensemble_breakdown_across_tool_iterations() -> None:
+@pytest.mark.parametrize("with_execution_context", [True, False])
+def test_agent_final_done_summarizes_ensemble_breakdown_across_tool_iterations(
+    with_execution_context: bool,
+) -> None:
+    request_counts = (3, 4)
+    execution_context = TurnExecutionContext.create(
+        TurnIdentity(
+            "turn-ensemble-usage",
+            "assistant-ensemble-usage",
+            "agent:test:webchat:ensemble-usage",
+        )
+    )
+
     async def tool_handler(call: ToolCall) -> ToolResult:
         return ToolResult(
             tool_use_id=call.tool_use_id,
@@ -352,7 +410,7 @@ def test_agent_final_done_summarizes_ensemble_breakdown_across_tool_iterations()
 
     async def run() -> EngineDoneEvent:
         agent = Agent(
-            provider=_TwoStepEnsembleBreakdownProvider(),
+            provider=_TwoStepEnsembleBreakdownProvider(request_counts),
             config=AgentConfig(max_iterations=3),
             tool_definitions=[
                 ToolDefinition(
@@ -362,6 +420,7 @@ def test_agent_final_done_summarizes_ensemble_breakdown_across_tool_iterations()
                 )
             ],
             tool_handler=tool_handler,
+            execution_context=execution_context if with_execution_context else None,
         )
         events = [event async for event in agent.run_turn("hi")]
         done_events = [event for event in events if isinstance(event, EngineDoneEvent)]
@@ -389,10 +448,65 @@ def test_agent_final_done_summarizes_ensemble_breakdown_across_tool_iterations()
     assert aggregator_row["cost_usd"] == 0.04
     assert aggregator_row["request_count"] == 2
     assert done.ensemble_trace is not None
-    assert done.ensemble_trace["llm_request_count"] == 4
+    assert done.ensemble_trace["llm_request_count"] == request_counts[-1]
     assert done.input_tokens == 70
     assert done.output_tokens == 7
     assert done.billed_cost == 0.07
+
+
+@pytest.mark.parametrize(
+    ("with_execution_context", "request_counts", "expected_request_count"),
+    [
+        (True, (3, 4, 4), 5),
+        (False, (3, 4, 3), 7),
+    ],
+)
+def test_agent_counts_each_retried_ensemble_continuation_request(
+    with_execution_context: bool,
+    request_counts: tuple[int, ...],
+    expected_request_count: int,
+) -> None:
+    execution_context = TurnExecutionContext.create(
+        TurnIdentity(
+            "turn-ensemble-retry",
+            "assistant-ensemble-retry",
+            "agent:test:webchat:ensemble-retry",
+        )
+    )
+    provider = _TwoStepEnsembleBreakdownProvider(
+        request_counts,
+        retry_empty_continuation=True,
+    )
+
+    async def tool_handler(call: ToolCall) -> ToolResult:
+        return ToolResult(
+            tool_use_id=call.tool_use_id,
+            tool_name=call.tool_name,
+            content="lookup result",
+        )
+
+    async def run() -> EngineDoneEvent:
+        agent = Agent(
+            provider=provider,
+            config=AgentConfig(max_iterations=3),
+            tool_definitions=[
+                ToolDefinition(
+                    name="lookup",
+                    description="lookup",
+                    input_schema=ToolInputSchema(properties={}, required=[]),
+                )
+            ],
+            tool_handler=tool_handler,
+            execution_context=execution_context if with_execution_context else None,
+        )
+        events = [event async for event in agent.run_turn("hi")]
+        return next(event for event in events if isinstance(event, EngineDoneEvent))
+
+    done = asyncio.run(run())
+
+    assert provider.calls == 3
+    assert done.ensemble_trace is not None
+    assert done.ensemble_trace["llm_request_count"] == expected_request_count
 
 
 def test_ensemble_breakdown_malformed_usage_values_do_not_raise() -> None:

--- a/tests/test_engine/test_runtime_artifacts.py
+++ b/tests/test_engine/test_runtime_artifacts.py
@@ -3242,7 +3242,7 @@ class _GoalArtifactEnsembleProvider(_GoalPostPublishLoopProvider):
                 ]
                 event.ensemble_trace = {
                     "profile": "test",
-                    "llm_request_count": 2,
+                    "llm_request_count": 2 * call_number,
                 }
             yield event
 


### PR DESCRIPTION
## Scope

Scope boundary: Correct Agent aggregation of cumulative Ensemble physical-request receipts across tool continuations and retries.

Non-goals: No changes to provider calls, token or cost accounting, WebUI behavior, RPCs, schemas, or historical records.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: The source report is tracked outside GitHub and has no public issue number.

## Release Note

Release note: Fix inflated Ensemble request counts shown in conversation metadata after tool continuations.

## Tests

Ruff: Changed Python files passed; `git diff --check` passed.

Pytest: 18 focused Agent/runtime regressions passed; all 165 Ensemble Provider tests passed.

Build: No production build required; the unchanged WebUI rendered-message mapping suite passed 62 tests.

Regression tests: added

Notes: Covers normal completion, terminal reset, context-backed retry, no-context fresh retry, and multi-round cumulative traces. The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: provider

Maintainer-only note: No credentialed or network provider call is required for this accounting-only change.

## Safety

Platform-neutral Python accounting change. No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are included.

No public field, RPC, frontend type, database schema, or migration changes. Single-model and non-Ensemble turns are unchanged. Existing persisted inflated counts are not backfilled.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Not applicable; no documentation surface changed.
