### PR TITLE
Optimize Skill catalog refresh on clean turns

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -207,6 +207,7 @@
       "tests/test_skills/test_hub_management_service.py",
       "tests/test_skills/test_hub_scanner.py",
       "tests/test_skills/test_hub_transaction_process_gates.py",
+      "tests/test_skills/test_loader_turn_snapshot.py",
       "tests/test_skills/test_managed_toolchains.py",
       "tests/test_skills/test_meta_clarify_defaults.py",
       "tests/test_skills/test_meta_dsl_extensions.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -1149,6 +1149,7 @@
     "tests/test_skills/test_injector_budget.py": 0.032,
     "tests/test_skills/test_injector_meta_kind.py": 0.01,
     "tests/test_skills/test_loader_list_meta_specs.py": 3.264,
+    "tests/test_skills/test_loader_turn_snapshot.py": 0.01,
     "tests/test_skills/test_managed_toolchains.py": 4.983,
     "tests/test_skills/test_meta_arxiv_daily_digest_deck.py": 3.156,
     "tests/test_skills/test_meta_auto_trigger_enabled.py": 0.01,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "starlette>=0.40",
     "python-multipart>=0.0.20",
     "uvicorn[standard]>=0.30",
+    "watchfiles>=1.1.1",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
     "sqlmodel>=0.0.20",

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -7411,6 +7411,20 @@ class TurnRunner:
         loader = self._skill_loader
         if loader is None:
             return None
+        snapshot_for_turn = getattr(loader, "snapshot_for_turn", None)
+        if callable(snapshot_for_turn):
+            try:
+                return snapshot_for_turn(reason="turn")
+            except Exception as exc:  # noqa: BLE001 - preserve last-known-good catalog
+                log.warning("skills.catalog.turn_snapshot_failed", error=str(exc))
+                try:
+                    return loader.snapshot()
+                except Exception as snapshot_exc:  # noqa: BLE001 - legacy fail-open behavior
+                    log.warning(
+                        "skills.catalog.turn_snapshot_failed",
+                        error=str(snapshot_exc),
+                    )
+                    return None
         refresh = getattr(loader, "refresh_if_changed", None)
         snapshot = getattr(loader, "snapshot", None)
         if not callable(refresh) or not callable(snapshot):

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -675,6 +675,7 @@ class ServiceContainer:
     tool_registry: ToolRegistry | None = None
     session_manager: SessionManager | None = None
     skill_loader: SkillLoader | None = None
+    skill_watcher: Any = None
     skill_management_service: Any = None
     skill_management_state: dict[str, Any] = field(default_factory=dict)
     usage_tracker: UsageTracker | None = None
@@ -745,6 +746,14 @@ class ServiceContainer:
                 pass
             except Exception:
                 log.debug("gateway.deferred_warmup_close_failed", exc_info=True)
+
+        skill_watcher = self.skill_watcher
+        self.skill_watcher = None
+        if skill_watcher is not None:
+            try:
+                await skill_watcher.stop()
+            except Exception:
+                log.debug("gateway.skill_watcher_close_failed", exc_info=True)
 
         model_catalog_refresh_coordinator = self.model_catalog_refresh_coordinator
         self.model_catalog_refresh_coordinator = None
@@ -3794,6 +3803,15 @@ async def build_services(
         deferred_warmups=deferred_warmups,
         sandbox_setup_task=sandbox_setup_task,
     )
+    if skill_loader is not None:
+        try:
+            from opensquilla.skills.watcher import SkillCatalogWatcher
+
+            skill_watcher = SkillCatalogWatcher(skill_loader)
+            await skill_watcher.start()
+            svc.skill_watcher = skill_watcher
+        except Exception:
+            log.warning("build_services.skill_watcher_failed", exc_info=True)
     # Attach deferred callback ref so start_gateway_server can wire TurnRunner
     svc._turn_runner_ref = _turn_runner_ref  # type: ignore[attr-defined]
     log.info(

--- a/src/opensquilla/skills/loader.py
+++ b/src/opensquilla/skills/loader.py
@@ -449,6 +449,47 @@ class SkillLoader:
         with self._refresh_lock:
             return self._publication_barrier_snapshot or self._catalog
 
+    def snapshot_for_turn(self, reason: str = "turn") -> SkillCatalogSnapshot:
+        """Return the catalog visible to one turn, probing only when needed.
+
+        A published, clean generation is immutable, so ordinary turns can pin
+        it without touching Skill roots. Initial loads and known invalidations
+        retain the existing full manifest/tree verification path.
+        """
+        started = time.monotonic()
+        with self._refresh_lock:
+            visible = self._publication_barrier_snapshot or self._catalog
+            if self._publication_barrier_depth or self._mutation_depth:
+                self._log_turn_resolution(visible, started, "barrier")
+                return visible
+            if self._initialized and not self._dirty:
+                self._log_turn_resolution(visible, started, "snapshot")
+                return visible
+        result = self.refresh_if_changed(reason=reason)
+        visible = self.snapshot()
+        self._log_turn_resolution(
+            visible,
+            started,
+            "rebuild" if result.changed else "probe",
+        )
+        return visible
+
+    @staticmethod
+    def _log_turn_resolution(
+        snapshot: SkillCatalogSnapshot,
+        started: float,
+        phase: str,
+    ) -> None:
+        if structlog.is_configured():
+            log.debug(
+                "skill_catalog.turn_resolved",
+                catalog_resolve_ms=round((time.monotonic() - started) * 1000, 3),
+                phase=phase,
+                generation=snapshot.generation,
+                skills=len(snapshot.skills),
+                entries=len(snapshot.manifest),
+            )
+
     def freeze_catalog_for_recovery(self, *, reason: str = "recovery-required") -> None:
         """Quarantine managed bytes while retaining their published LKG.
 
@@ -540,6 +581,21 @@ class SkillLoader:
         with self._refresh_lock:
             self._dirty = True
             self._dirty_reason = reason
+        if structlog.is_configured():
+            log.debug("skill_catalog.invalidated", reason=reason)
+
+    def watch_roots(self) -> tuple[Path, ...]:
+        """Return configured Skill roots without probing their contents."""
+        with self._refresh_lock:
+            roots: list[Path] = []
+            seen: set[str] = set()
+            for root, _layer in self._get_layer_dirs():
+                key = os.path.normcase(os.path.abspath(os.fspath(root)))
+                if key in seen:
+                    continue
+                seen.add(key)
+                roots.append(root)
+            return tuple(roots)
 
     @contextmanager
     def mutation_guard(self, reason: str = "mutation") -> Iterator[None]:
@@ -928,7 +984,6 @@ class SkillLoader:
         started = time.monotonic()
         observed_generation = self._catalog.generation
         with self._refresh_lock:
-            self._last_probe_at = time.monotonic()
             old = self._catalog
             if self._initialized and observed_generation != old.generation and not self._dirty:
                 return self._last_refresh_result
@@ -945,6 +1000,7 @@ class SkillLoader:
             dirty = self._dirty
             effective_reason = self._dirty_reason or reason
             if self._initialized and not force and not dirty and manifest == old.manifest:
+                self._last_probe_at = time.monotonic()
                 return self._unchanged_result(old)
 
             if (
@@ -1035,6 +1091,7 @@ class SkillLoader:
             if not catalog_changed:
                 self._dirty = False
                 self._dirty_reason = ""
+                self._last_probe_at = time.monotonic()
                 return self._unchanged_result(old)
 
             candidate = SkillCatalogSnapshot(
@@ -1424,6 +1481,7 @@ class SkillLoader:
         self._initialized = True
         self._dirty = False
         self._dirty_reason = ""
+        self._last_probe_at = time.monotonic()
         try:
             self._write_snapshot(catalog)
         except (OSError, TypeError, ValueError):
@@ -1444,6 +1502,8 @@ class SkillLoader:
                 removed=len(removed),
                 modified=len(modified),
                 errors=len(catalog.errors),
+                skills=len(catalog.skills),
+                entries=len(catalog.manifest),
                 elapsed_ms=elapsed_ms,
                 initial=initial,
             )

--- a/src/opensquilla/skills/watcher.py
+++ b/src/opensquilla/skills/watcher.py
@@ -1,0 +1,209 @@
+"""Filesystem invalidation for the published Skill catalog."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+_Awatch = Callable[..., Any]
+_awatch: _Awatch | None
+try:
+    from watchfiles import awatch as _imported_awatch
+except Exception:
+    _awatch = None
+else:
+    _awatch = _imported_awatch
+
+log = structlog.get_logger(__name__)
+
+_DEBOUNCE_MS = 250
+_WATCH_STEP_MS = 500
+_POLL_INTERVAL_SECONDS = 5.0
+
+
+class SkillCatalogWatcher:
+    """Invalidate a loader when any configured Skill root changes."""
+
+    def __init__(
+        self,
+        loader: Any,
+        *,
+        debounce_ms: int = _DEBOUNCE_MS,
+        poll_interval: float = _POLL_INTERVAL_SECONDS,
+    ) -> None:
+        self._loader = loader
+        self._debounce_ms = max(1, int(debounce_ms))
+        self._poll_interval = max(0.01, float(poll_interval))
+        self._stop_event: asyncio.Event | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._polling = _awatch is None
+        self._poll_signature: tuple[tuple[str, int, int, int], ...] | None = None
+
+    @property
+    def task(self) -> asyncio.Task[None] | None:
+        return self._task
+
+    @property
+    def using_fallback(self) -> bool:
+        return self._polling
+
+    async def start(self) -> None:
+        """Start one watcher task; failures never block gateway startup."""
+        if self._task is not None and not self._task.done():
+            return
+        self._stop_event = asyncio.Event()
+        self._task = asyncio.create_task(self._run(), name="skills:catalog-watcher")
+
+    async def stop(self) -> None:
+        """Stop the watcher and await its task without leaking background work."""
+        task = self._task
+        self._task = None
+        stop_event = self._stop_event
+        self._stop_event = None
+        if stop_event is not None:
+            stop_event.set()
+        if task is None:
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            log.debug("skills.catalog_watcher_stop_failed", exc_info=True)
+
+    async def _run(self) -> None:
+        stop_event = self._stop_event
+        if stop_event is None:
+            return
+        if _awatch is None:
+            await self._poll_loop(stop_event)
+            return
+        try:
+            await self._watch_loop(stop_event)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self._polling = True
+            log.warning("skills.catalog_watcher_failed_using_polling", exc_info=True)
+            await self._poll_loop(stop_event)
+
+    async def _watch_loop(self, stop_event: asyncio.Event) -> None:
+        awatch = _awatch
+        if awatch is None:
+            return
+        while not stop_event.is_set():
+            roots = self._roots()
+            existing_roots = tuple(root for root in roots if root.is_dir())
+            if not existing_roots:
+                self._polling = True
+                await self._poll_once(stop_event)
+                try:
+                    await asyncio.wait_for(stop_event.wait(), timeout=self._poll_interval)
+                except TimeoutError:
+                    pass
+                continue
+            try:
+                async for changes in awatch(
+                    *existing_roots,
+                    debounce=self._debounce_ms,
+                    step=_WATCH_STEP_MS,
+                    stop_event=stop_event,
+                    yield_on_timeout=True,
+                    recursive=True,
+                ):
+                    if stop_event.is_set():
+                        return
+                    current_roots = self._roots()
+                    roots_changed = current_roots != roots
+                    presence_changed = _root_presence(current_roots) != _root_presence(roots)
+                    if roots_changed or presence_changed:
+                        self._loader.mark_dirty("watch.roots")
+                        break
+                    if changes:
+                        self._loader.mark_dirty("watch")
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self._polling = True
+                raise
+
+    async def _poll_loop(self, stop_event: asyncio.Event) -> None:
+        while not stop_event.is_set():
+            await self._poll_once(stop_event)
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=self._poll_interval)
+            except TimeoutError:
+                continue
+
+    async def _poll_once(self, stop_event: asyncio.Event) -> None:
+        roots = self._roots()
+        signature = await asyncio.to_thread(_root_signature, roots)
+        if self._poll_signature is None:
+            self._poll_signature = signature
+        elif signature != self._poll_signature:
+            self._poll_signature = signature
+            self._loader.mark_dirty("poll")
+        if roots != self._roots():
+            self._loader.mark_dirty("poll.roots")
+        await asyncio.sleep(0)
+        if stop_event.is_set():
+            return
+
+    def _roots(self) -> tuple[Path, ...]:
+        roots = getattr(self._loader, "watch_roots", None)
+        if callable(roots):
+            try:
+                return tuple(Path(root) for root in roots())
+            except Exception:
+                log.debug("skills.catalog_watcher_roots_failed", exc_info=True)
+        return ()
+
+
+def _root_signature(roots: Iterable[Path]) -> tuple[tuple[str, int, int, int], ...]:
+    """Build a bounded polling signature without following directory symlinks."""
+    entries: list[tuple[str, int, int, int]] = []
+    for root in roots:
+        root_path = Path(root)
+        try:
+            root_stat = root_path.lstat()
+        except OSError:
+            entries.append((os.fspath(root_path), 0, 0, 0))
+            continue
+        entries.append(
+            (
+                os.fspath(root_path),
+                int(root_stat.st_mtime_ns),
+                int(root_stat.st_size),
+                int(root_stat.st_mode),
+            )
+        )
+        if not root_path.is_dir():
+            continue
+        for current, dirs, files in os.walk(root_path, followlinks=False):
+            dirs[:] = sorted(dirs)
+            files.sort()
+            for name in (*dirs, *files):
+                path = Path(current) / name
+                try:
+                    stat = path.lstat()
+                except OSError:
+                    continue
+                entries.append(
+                    (
+                        os.fspath(path),
+                        int(stat.st_mtime_ns),
+                        int(stat.st_size),
+                        int(stat.st_mode),
+                    )
+                )
+    return tuple(entries)
+
+
+def _root_presence(roots: Iterable[Path]) -> tuple[bool, ...]:
+    return tuple(Path(root).is_dir() for root in roots)

--- a/src/opensquilla/skills/watcher.py
+++ b/src/opensquilla/skills/watcher.py
@@ -73,6 +73,7 @@ class SkillCatalogWatcher:
         try:
             await task
         except asyncio.CancelledError:
+            # Cancellation is expected after task.cancel() during normal shutdown.
             pass
         except Exception:
             log.debug("skills.catalog_watcher_stop_failed", exc_info=True)
@@ -106,6 +107,7 @@ class SkillCatalogWatcher:
                 try:
                     await asyncio.wait_for(stop_event.wait(), timeout=self._poll_interval)
                 except TimeoutError:
+                    # The timeout lets polling re-check roots while waiting to stop.
                     pass
                 continue
             try:

--- a/tests/test_ci/test_windows_test_shards.py
+++ b/tests/test_ci/test_windows_test_shards.py
@@ -61,6 +61,7 @@ OFFLINE_MARKER_EXCLUSIONS = {
 RECENTLY_ADDED_ACTIVE_TESTS = {
     "tests/test_scripts/test_bench_skill_integrity.py",
     "tests/test_skills_hash_consumers.py",
+    "tests/test_skills/test_loader_turn_snapshot.py",
     "tests/test_skills_tree.py",
     "tests/test_recovery/test_config_recovery.py",
     "tests/unit/cli/tui/test_keys_cheatsheet.py",

--- a/tests/test_skills/test_loader_turn_snapshot.py
+++ b/tests/test_skills/test_loader_turn_snapshot.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+import opensquilla.skills.loader as loader_module
+from opensquilla.engine.runtime import TurnRunner
+from opensquilla.skills.loader import SkillLoader
+from opensquilla.skills.watcher import SkillCatalogWatcher
+
+
+def _write_skill(root: Path, name: str = "demo", body: str = "body") -> Path:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: test skill\n---\n{body}\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _loader(tmp_path: Path) -> tuple[SkillLoader, Path]:
+    root = tmp_path / "skills"
+    root.mkdir()
+    loader = SkillLoader(
+        bundled_dir=root,
+        snapshot_path=tmp_path / "snapshot.json",
+        lockfile_path=tmp_path / "skills-lock.json",
+    )
+    return loader, root
+
+
+def test_clean_turn_snapshot_does_not_probe_filesystem(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    loader, root = _loader(tmp_path)
+    _write_skill(root)
+    loader.snapshot_for_turn()
+
+    calls = 0
+
+    def fail_probe(_skill_dir: Path) -> dict[str, int | str]:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("clean turn probed the Skill tree")
+
+    monkeypatch.setattr("opensquilla.skills.loader.compute_tree_state", fail_probe)
+    snapshot = loader.snapshot_for_turn()
+
+    assert snapshot.generation == 1
+    assert calls == 0
+
+
+def test_dirty_turn_refreshes_and_publishes_new_generation(tmp_path: Path) -> None:
+    loader, root = _loader(tmp_path)
+    skill_dir = _write_skill(root)
+    first = loader.snapshot_for_turn()
+
+    (skill_dir / "nested").mkdir()
+    (skill_dir / "nested" / ".hidden").write_text("changed", encoding="utf-8")
+    loader.mark_dirty("watch")
+    second = loader.snapshot_for_turn()
+
+    assert second.generation == first.generation + 1
+    assert second.manifest != first.manifest
+
+
+def test_explicit_reload_keeps_full_scan_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    loader, root = _loader(tmp_path)
+    _write_skill(root)
+    loader.snapshot_for_turn()
+    calls = 0
+    real_tree_state = loader_module.compute_tree_state
+
+    def counted(path: Path) -> dict[str, int | str]:
+        nonlocal calls
+        calls += 1
+        return real_tree_state(path)
+
+    monkeypatch.setattr(loader_module, "compute_tree_state", counted)
+    loader.reload(force=True, reason="test.reload")
+
+    assert calls > 0
+
+
+def test_publication_barrier_returns_visible_lkg_without_scanning(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    loader, root = _loader(tmp_path)
+    _write_skill(root)
+    baseline = loader.snapshot_for_turn()
+    monkeypatch.setattr(
+        loader_module,
+        "compute_tree_state",
+        lambda _path: (_ for _ in ()).throw(AssertionError("unexpected scan")),
+    )
+
+    with loader.catalog_publication_barrier():
+        loader.mark_dirty("management")
+        assert loader.snapshot_for_turn() is baseline
+
+
+def test_slow_probe_records_completion_time(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loader, root = _loader(tmp_path)
+    _write_skill(root)
+    real_manifest = loader._build_manifest
+
+    def slow_manifest() -> dict[str, dict[str, int | str]]:
+        import time
+
+        time.sleep(0.03)
+        return real_manifest()
+
+    monkeypatch.setattr(loader, "_build_manifest", slow_manifest)
+    started = time.monotonic()
+    loader.load_all()
+    finished = time.monotonic()
+
+    assert started <= loader._last_probe_at <= finished
+
+
+def test_turn_runner_prefers_snapshot_for_turn() -> None:
+    snapshot = object()
+    loader = SimpleNamespace(snapshot_for_turn=Mock(return_value=snapshot))
+    runner = TurnRunner(provider_selector=None, skill_loader=loader)
+
+    assert runner._resolve_skill_catalog() is snapshot
+    loader.snapshot_for_turn.assert_called_once_with(reason="turn")
+
+
+def test_turn_runner_keeps_legacy_loader_fallback() -> None:
+    snapshot = object()
+    loader = SimpleNamespace(
+        refresh_if_changed=Mock(),
+        snapshot=Mock(return_value=snapshot),
+    )
+    runner = TurnRunner(provider_selector=None, skill_loader=loader)
+
+    assert runner._resolve_skill_catalog() is snapshot
+    loader.refresh_if_changed.assert_called_once_with(reason="turn")
+
+
+@pytest.mark.asyncio
+async def test_polling_fallback_invalidates_nested_changes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import opensquilla.skills.watcher as watcher_module
+
+    monkeypatch.setattr(watcher_module, "_awatch", None)
+    loader, root = _loader(tmp_path)
+    skill_dir = _write_skill(root)
+    loader.snapshot_for_turn()
+    changes: list[str] = []
+    original_mark_dirty = loader.mark_dirty
+    monkeypatch.setattr(
+        loader,
+        "mark_dirty",
+        lambda reason="mutation": (changes.append(reason), original_mark_dirty(reason))[1],
+    )
+    watcher = SkillCatalogWatcher(loader, poll_interval=0.01)
+    await watcher.start()
+    await asyncio.sleep(0.03)
+    (skill_dir / "nested").mkdir()
+    (skill_dir / "nested" / ".hidden").write_text("changed", encoding="utf-8")
+    for _ in range(20):
+        if changes:
+            break
+        await asyncio.sleep(0.01)
+    await watcher.stop()
+
+    assert watcher.task is None
+    assert "poll" in changes
+
+
+@pytest.mark.asyncio
+async def test_native_watcher_debounces_to_one_invalidation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import opensquilla.skills.watcher as watcher_module
+
+    loader, root = _loader(tmp_path)
+    _write_skill(root)
+    invalidations: list[str] = []
+    monkeypatch.setattr(loader, "mark_dirty", invalidations.append)
+
+    async def fake_awatch(*_paths: Path, **kwargs: object):
+        yield {("modified", str(root / "demo" / "SKILL.md"))}
+        await asyncio.sleep(3600)
+
+    monkeypatch.setattr(watcher_module, "_awatch", fake_awatch)
+    watcher = SkillCatalogWatcher(loader, debounce_ms=1)
+    await watcher.start()
+    for _ in range(20):
+        if invalidations:
+            break
+        await asyncio.sleep(0.01)
+    await watcher.stop()
+
+    assert invalidations == ["watch"]
+
+
+@pytest.mark.asyncio
+async def test_watcher_shutdown_is_idempotent(tmp_path: Path) -> None:
+    loader, root = _loader(tmp_path)
+    _write_skill(root)
+    watcher = SkillCatalogWatcher(loader, poll_interval=0.01)
+    await watcher.start()
+    await watcher.stop()
+    await watcher.stop()
+
+    assert watcher.task is None

--- a/tests/test_skills/test_loader_turn_snapshot.py
+++ b/tests/test_skills/test_loader_turn_snapshot.py
@@ -9,9 +9,8 @@ from unittest.mock import Mock
 import pytest
 
 import opensquilla.skills.loader as loader_module
+import opensquilla.skills.watcher as watcher_module
 from opensquilla.engine.runtime import TurnRunner
-from opensquilla.skills.loader import SkillLoader
-from opensquilla.skills.watcher import SkillCatalogWatcher
 
 
 def _write_skill(root: Path, name: str = "demo", body: str = "body") -> Path:
@@ -24,10 +23,10 @@ def _write_skill(root: Path, name: str = "demo", body: str = "body") -> Path:
     return skill_dir
 
 
-def _loader(tmp_path: Path) -> tuple[SkillLoader, Path]:
+def _loader(tmp_path: Path) -> tuple[loader_module.SkillLoader, Path]:
     root = tmp_path / "skills"
     root.mkdir()
-    loader = SkillLoader(
+    loader = loader_module.SkillLoader(
         bundled_dir=root,
         snapshot_path=tmp_path / "snapshot.json",
         lockfile_path=tmp_path / "skills-lock.json",
@@ -158,8 +157,6 @@ async def test_polling_fallback_invalidates_nested_changes(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    import opensquilla.skills.watcher as watcher_module
-
     monkeypatch.setattr(watcher_module, "_awatch", None)
     loader, root = _loader(tmp_path)
     skill_dir = _write_skill(root)
@@ -171,7 +168,7 @@ async def test_polling_fallback_invalidates_nested_changes(
         "mark_dirty",
         lambda reason="mutation": (changes.append(reason), original_mark_dirty(reason))[1],
     )
-    watcher = SkillCatalogWatcher(loader, poll_interval=0.01)
+    watcher = watcher_module.SkillCatalogWatcher(loader, poll_interval=0.01)
     await watcher.start()
     await asyncio.sleep(0.03)
     (skill_dir / "nested").mkdir()
@@ -191,8 +188,6 @@ async def test_native_watcher_debounces_to_one_invalidation(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    import opensquilla.skills.watcher as watcher_module
-
     loader, root = _loader(tmp_path)
     _write_skill(root)
     invalidations: list[str] = []
@@ -203,7 +198,7 @@ async def test_native_watcher_debounces_to_one_invalidation(
         await asyncio.sleep(3600)
 
     monkeypatch.setattr(watcher_module, "_awatch", fake_awatch)
-    watcher = SkillCatalogWatcher(loader, debounce_ms=1)
+    watcher = watcher_module.SkillCatalogWatcher(loader, debounce_ms=1)
     await watcher.start()
     for _ in range(20):
         if invalidations:
@@ -218,7 +213,7 @@ async def test_native_watcher_debounces_to_one_invalidation(
 async def test_watcher_shutdown_is_idempotent(tmp_path: Path) -> None:
     loader, root = _loader(tmp_path)
     _write_skill(root)
-    watcher = SkillCatalogWatcher(loader, poll_interval=0.01)
+    watcher = watcher_module.SkillCatalogWatcher(loader, poll_interval=0.01)
     await watcher.start()
     await watcher.stop()
     await watcher.stop()

--- a/uv.lock
+++ b/uv.lock
@@ -1807,6 +1807,7 @@ dependencies = [
     { name = "tomli-w" },
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "watchfiles" },
     { name = "websockets" },
     { name = "yoyo-migrations" },
 ]
@@ -1917,6 +1918,7 @@ requires-dist = [
     { name = "tomli-w", specifier = ">=1.0" },
     { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
+    { name = "watchfiles", specifier = ">=1.1.1" },
     { name = "weasyprint", marker = "extra == 'document-extras'", specifier = ">=60.0" },
     { name = "websockets", specifier = ">=13.0" },
     { name = "yoyo-migrations", specifier = ">=8.2,<10" },


### PR DESCRIPTION
## Scope
- Add immutable Skill catalog turn fast path: clean turns reuse the published snapshot without filesystem scans.
- Add watchfiles invalidation with polling fallback and lifecycle cleanup.
- Preserve legacy custom-loader behavior, snapshot schema, RPC, database, and client protocols.

## Link
None.

## Release note
Internal performance and reliability improvement; no user-facing protocol or configuration change.

## Verification
- 71 targeted compatibility tests passed.
- New loader/watcher tests passed.
- Ruff, compileall, and targeted mypy passed.
- Loopback Gateway deterministic E2E: 3/3 turns succeeded; one initial refresh, clean snapshot lookups thereafter.
- Temporary 10/100/500 Skill benchmark: clean tree scan count zero.

## Safety
Watcher failures fall back to low-frequency polling; shutdown cancels the watcher task. Full manifest/tree/digest validation remains on cold, dirty, and explicit reload paths.