### PR TITLE
Limit Gateway WebSocket shutdown waits

### DIFF
--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -83,6 +83,8 @@ log = structlog.get_logger(__name__)
 GATEWAY_GRACEFUL_TIMEOUT_ENV = "OPENSQUILLA_GATEWAY_GRACEFUL_TIMEOUT"
 _DEFAULT_GRACEFUL_TIMEOUT_S = 30.0
 _MAX_GRACEFUL_TIMEOUT_S = 120.0
+_WS_SHUTDOWN_CLOSE_TIMEOUT_S = 2.0
+_WS_SHUTDOWN_CANCEL_GRACE_S = 0.05
 
 
 def _elapsed_monotonic_ms(started_at: float, ended_at: float | None = None) -> int:
@@ -2213,6 +2215,66 @@ class _GatewayShutdownRelay:
             handler(pending_reason)
 
 
+def _consume_websocket_close_task(task: asyncio.Future[Any]) -> None:
+    try:
+        task.exception()
+    except asyncio.CancelledError:
+        return
+
+
+def _cancel_and_detach_websocket_close_tasks(
+    tasks: set[asyncio.Task[None]],
+) -> None:
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+            task.add_done_callback(_consume_websocket_close_task)
+        else:
+            _consume_websocket_close_task(task)
+
+
+async def _close_gateway_websocket_connections(connections: list[Any]) -> None:
+    tasks: set[asyncio.Task[None]] = set()
+    try:
+        for index, connection in enumerate(connections):
+            tasks.add(
+                asyncio.create_task(
+                    connection.close(),
+                    name=f"gateway-ws-shutdown-close-{index}",
+                )
+            )
+        if not tasks:
+            return
+
+        done, pending = await asyncio.wait(
+            tasks,
+            timeout=_WS_SHUTDOWN_CLOSE_TIMEOUT_S,
+        )
+        for task in done:
+            task.result()
+        if not pending:
+            return
+
+        log.warning(
+            "gateway.ws_shutdown_close_timeout",
+            pending_count=len(pending),
+            timeout_seconds=_WS_SHUTDOWN_CLOSE_TIMEOUT_S,
+        )
+        for task in pending:
+            task.cancel()
+        cancelled, lingering = await asyncio.wait(
+            pending,
+            timeout=_WS_SHUTDOWN_CANCEL_GRACE_S,
+        )
+        for task in cancelled:
+            _consume_websocket_close_task(task)
+        for task in lingering:
+            task.add_done_callback(_consume_websocket_close_task)
+    except BaseException:
+        _cancel_and_detach_websocket_close_tasks(tasks)
+        raise
+
+
 @dataclass
 class GatewayServer:
     """Handle returned after gateway startup. Provides close() method."""
@@ -2337,8 +2399,7 @@ class GatewayServer:
             await registry.broadcast("shutdown", {"reason": reason})
 
             # Close all active WS connections
-            for conn in registry.all():
-                await conn.close()
+            await _close_gateway_websocket_connections(registry.all())
 
             # Close MCP clients
             if runtime_shutdown_clean:

--- a/tests/test_gateway/test_shutdown_order.py
+++ b/tests/test_gateway/test_shutdown_order.py
@@ -12,6 +12,64 @@ from opensquilla.gateway.boot import GatewayServer, ServiceContainer
 from opensquilla.gateway.config import GatewayConfig
 
 
+class _CancellationResistantConnection:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.cancelled = asyncio.Event()
+        self.release = asyncio.Event()
+        self.finished = asyncio.Event()
+
+    async def close(self) -> None:
+        self.started.set()
+        try:
+            await self.release.wait()
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            await self.release.wait()
+        finally:
+            self.finished.set()
+
+
+class _ImmediateConnection:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _SelfCancellingConnection:
+    async def close(self) -> None:
+        raise asyncio.CancelledError
+
+
+def _gateway_server_for_ws_close_test() -> tuple[
+    GatewayServer,
+    MagicMock,
+    MagicMock,
+    MagicMock,
+]:
+    fake_server = MagicMock()
+    fake_server.should_exit = False
+
+    mock_services = MagicMock()
+    mock_services.goal_service = None
+    mock_services.task_runtime = None
+    mock_services.close = AsyncMock()
+
+    mock_pid_lock = MagicMock()
+    serve_task = asyncio.create_task(asyncio.sleep(0))
+    server = GatewayServer(
+        app=MagicMock(),
+        config=GatewayConfig(),
+        _server=fake_server,
+        _task=serve_task,
+        _services=mock_services,
+        _pid_lock=mock_pid_lock,
+    )
+    return server, fake_server, mock_services, mock_pid_lock
+
+
 @pytest.mark.asyncio
 async def test_runtime_drained_before_channel_stop() -> None:
     """task_runtime.shutdown() must complete before channel_manager.stop_all()."""
@@ -105,6 +163,138 @@ async def test_close_stops_server_even_if_teardown_raises() -> None:
     mock_services.close.assert_awaited_once()
     mock_pid_lock.release.assert_called_once()  # pid lock always released
     assert server._task.done()  # serve task awaited, not leaked
+
+
+@pytest.mark.asyncio
+async def test_close_bounds_cancellation_resistant_websocket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.gateway import boot
+
+    monkeypatch.setattr(boot, "_WS_SHUTDOWN_CLOSE_TIMEOUT_S", 0.02)
+    monkeypatch.setattr(boot, "_WS_SHUTDOWN_CANCEL_GRACE_S", 0.01)
+    connection = _CancellationResistantConnection()
+    server, fake_server, mock_services, mock_pid_lock = _gateway_server_for_ws_close_test()
+    mock_registry = MagicMock()
+    mock_registry.broadcast = AsyncMock()
+    mock_registry.all.return_value = [connection]
+
+    try:
+        with patch("opensquilla.gateway.boot.get_registry", return_value=mock_registry):
+            await asyncio.wait_for(server.close(reason="test"), timeout=0.5)
+
+        assert connection.started.is_set()
+        assert connection.cancelled.is_set()
+        assert fake_server.should_exit is True
+        mock_services.close.assert_awaited_once()
+        mock_pid_lock.release.assert_called_once()
+    finally:
+        connection.release.set()
+        if connection.started.is_set():
+            await asyncio.wait_for(connection.finished.wait(), timeout=0.5)
+            await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_close_uses_one_shared_websocket_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.gateway import boot
+
+    monkeypatch.setattr(boot, "_WS_SHUTDOWN_CLOSE_TIMEOUT_S", 0.25)
+    monkeypatch.setattr(boot, "_WS_SHUTDOWN_CANCEL_GRACE_S", 0.01)
+    blocked_connections = [_CancellationResistantConnection() for _ in range(10)]
+    immediate_connection = _ImmediateConnection()
+    server, fake_server, mock_services, mock_pid_lock = _gateway_server_for_ws_close_test()
+    mock_registry = MagicMock()
+    mock_registry.broadcast = AsyncMock()
+    mock_registry.all.return_value = [*blocked_connections, immediate_connection]
+    close_task: asyncio.Task[None] | None = None
+
+    try:
+        with patch("opensquilla.gateway.boot.get_registry", return_value=mock_registry):
+            close_task = asyncio.create_task(server.close(reason="test"))
+            await asyncio.wait_for(
+                asyncio.gather(*(conn.started.wait() for conn in blocked_connections)),
+                timeout=1.0,
+            )
+            await asyncio.wait_for(close_task, timeout=2.0)
+
+        assert immediate_connection.closed is True
+        assert all(conn.cancelled.is_set() for conn in blocked_connections)
+        assert fake_server.should_exit is True
+        mock_services.close.assert_awaited_once()
+        mock_pid_lock.release.assert_called_once()
+    finally:
+        for connection in blocked_connections:
+            connection.release.set()
+        if close_task is not None and not close_task.done():
+            close_task.cancel()
+            await asyncio.gather(close_task, return_exceptions=True)
+        started_connections = [
+            connection for connection in blocked_connections if connection.started.is_set()
+        ]
+        if started_connections:
+            await asyncio.wait_for(
+                asyncio.gather(
+                    *(connection.finished.wait() for connection in started_connections)
+                ),
+                timeout=1.0,
+            )
+            await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_close_cancellation_detaches_websocket_tasks_and_runs_finally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from opensquilla.gateway import boot
+
+    monkeypatch.setattr(boot, "_WS_SHUTDOWN_CLOSE_TIMEOUT_S", 10.0)
+    connection = _CancellationResistantConnection()
+    server, fake_server, mock_services, mock_pid_lock = _gateway_server_for_ws_close_test()
+    mock_registry = MagicMock()
+    mock_registry.broadcast = AsyncMock()
+    mock_registry.all.return_value = [connection]
+    close_task: asyncio.Task[None] | None = None
+
+    try:
+        with patch("opensquilla.gateway.boot.get_registry", return_value=mock_registry):
+            close_task = asyncio.create_task(server.close(reason="test"))
+            await asyncio.wait_for(connection.started.wait(), timeout=0.5)
+            close_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await close_task
+
+        assert connection.cancelled.is_set()
+        assert fake_server.should_exit is True
+        mock_services.close.assert_awaited_once()
+        mock_pid_lock.release.assert_called_once()
+    finally:
+        connection.release.set()
+        if close_task is not None and not close_task.done():
+            close_task.cancel()
+            await asyncio.gather(close_task, return_exceptions=True)
+        if connection.started.is_set():
+            await asyncio.wait_for(connection.finished.wait(), timeout=0.5)
+            await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_close_preserves_connection_cancellation_semantics() -> None:
+    connection = _SelfCancellingConnection()
+    server, fake_server, mock_services, mock_pid_lock = _gateway_server_for_ws_close_test()
+    mock_registry = MagicMock()
+    mock_registry.broadcast = AsyncMock()
+    mock_registry.all.return_value = [connection]
+
+    with patch("opensquilla.gateway.boot.get_registry", return_value=mock_registry):
+        with pytest.raises(asyncio.CancelledError):
+            await server.close(reason="test")
+
+    assert fake_server.should_exit is True
+    mock_services.close.assert_awaited_once()
+    mock_pid_lock.release.assert_called_once()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Scope

Scope boundary: Bound Gateway-owned WebSocket connection closes during shutdown to one shared two-second budget, then continue the existing cleanup sequence.

Non-goals: No global shutdown deadline and no changes to turn drain, residual-runtime ownership fencing, WebSocket close code 1012, configuration, provider behavior, public interfaces, or PID ordering.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Local lifecycle reliability QA reproduced an unbounded shutdown wait; no public issue is linked.

## Release Note

Release note: Prevent Gateway shutdown from hanging indefinitely on a slow WebSocket close.

## Tests

Ruff: `.venv/bin/ruff check src/opensquilla/gateway/boot.py tests/test_gateway/test_shutdown_order.py`

Pytest: `20 passed, 1 skipped` across shutdown order, graceful drain, PID lock, CLI shutdown deadline, and residual-runtime ownership coverage.

Build: Not run; this is a Python-only lifecycle change with no packaging or Web UI impact.

Regression tests: added

Notes: Covers cancellation-resistant closes, one shared multi-connection budget, outer cancellation, connection self-cancellation, and the existing residual-runtime PID/service fence. Mypy passed for `src/opensquilla/gateway/boot.py`. The implementation is platform-neutral and changes no persisted state, configuration, protocol, or upgrade contract.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: gateway

Maintainer-only note: No credentialed live check is needed because the target shutdown path does not invoke a provider.

## Safety

No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are included. Timeout logging contains only the pending connection count and timeout duration.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.

No documentation changes are required because no public configuration, API, protocol, or user workflow changed.
