### PR TITLE
Remove usage chart endpoint markers

### DIFF
--- a/opensquilla-webui/src/components/usage/UsageChart.test.ts
+++ b/opensquilla-webui/src/components/usage/UsageChart.test.ts
@@ -31,8 +31,8 @@ function rowByLabel(root: HTMLElement, label: string): HTMLElement {
   return row
 }
 
-describe('UsageChart endpoint cap', () => {
-  it('omits the cap for an exact zero while retaining non-zero endpoints', async () => {
+describe('UsageChart endpoint rendering', () => {
+  it('omits endpoint caps while preserving row values and widths', async () => {
     i18n.global.locale.value = 'en'
     const root = document.createElement('div')
     document.body.appendChild(root)
@@ -56,15 +56,20 @@ describe('UsageChart endpoint cap', () => {
     expect(parseFloat(
       zero.querySelector<HTMLElement>('.usage-bar-row__fill--input')?.style.width || '',
     )).toBe(0)
+    expect(zero.querySelector('.usage-bar-row__value')?.textContent).toBe('0')
 
-    const halfCap = rowByLabel(root, 'half')
-      .querySelector<HTMLElement>('.usage-bar-row__cap')
-    expect(halfCap).not.toBeNull()
-    expect(parseFloat(halfCap?.style.left || '')).toBe(50)
+    const half = rowByLabel(root, 'half')
+    expect(half.querySelector('.usage-bar-row__cap')).toBeNull()
+    expect(parseFloat(
+      half.querySelector<HTMLElement>('.usage-bar-row__fill--input')?.style.width || '',
+    )).toBe(50)
+    expect(half.querySelector('.usage-bar-row__value')?.textContent).toBe('1')
 
-    const tinyCap = rowByLabel(root, 'tiny-positive')
-      .querySelector<HTMLElement>('.usage-bar-row__cap')
-    expect(tinyCap).not.toBeNull()
-    expect(parseFloat(tinyCap?.style.left || '')).toBe(0)
+    const tinyPositive = rowByLabel(root, 'tiny-positive')
+    expect(tinyPositive.querySelector('.usage-bar-row__cap')).toBeNull()
+    expect(parseFloat(
+      tinyPositive.querySelector<HTMLElement>('.usage-bar-row__fill--input')?.style.width || '',
+    )).toBe(0)
+    expect(tinyPositive.querySelector('.usage-bar-row__value')?.textContent).toBe('1')
   })
 })

--- a/opensquilla-webui/src/components/usage/UsageChart.vue
+++ b/opensquilla-webui/src/components/usage/UsageChart.vue
@@ -61,11 +61,6 @@
             class="usage-bar-row__fill usage-bar-row__fill--output"
             :style="`width:${row.outputPct.toFixed(1)}%`"
           />
-          <span
-            v-if="row.totalPct > 0"
-            class="usage-bar-row__cap"
-            :style="`left:${Math.min(100, row.totalPct).toFixed(1)}%`"
-          />
         </span>
         <span class="usage-bar-row__value usage-mono">{{ row.valueLabel }}</span>
       </component>

--- a/opensquilla-webui/src/views/UsageView.vue
+++ b/opensquilla-webui/src/views/UsageView.vue
@@ -327,14 +327,6 @@ async function refresh() {
 .usage-bar-row__fill--output {
   background: var(--chart-2);
 }
-.usage-bar-row__cap {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 2px;
-  background: var(--text);
-  opacity: 0.3;
-}
 .usage-bar-row__value {
   font-size: var(--fs-xs);
   color: var(--text-muted);


### PR DESCRIPTION
## Scope
- Remove standalone endpoint markers from the Usage chart so zero, tiny, and non-zero rows no longer render residual vertical lines.
- Preserve token and cost calculations, bar widths, and usage APIs.

## Branch target
`main`

## Linked issue
None. Supersedes the incomplete visual fix in #1256.

## Release note
Fixed residual vertical lines in the Usage chart.

## Tests
- `npm run test:unit -- src/components/usage/UsageChart.test.ts`
- `npm run typecheck`
- `npm run build:artifact`
- Verified the live local Usage page in Token and Cost modes: no endpoint markers; `177` and `$0.0001` remain displayed.

## Safety and compatibility
Platform-neutral, frontend-only change. No public API, persisted data, configuration, or upgrade path changes.

## Third-party origin
None.