### PR TITLE
Harden Windows install telemetry state commits

### DIFF
--- a/src/opensquilla/observability/install_telemetry.py
+++ b/src/opensquilla/observability/install_telemetry.py
@@ -18,6 +18,7 @@ import socket
 import sys
 import tempfile
 import threading
+import time
 import uuid
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
@@ -51,6 +52,8 @@ _MAC_HEX_RE = re.compile(r"^[0-9a-f]{12}$")
 _COLLECT_LOCK = threading.Lock()
 _STATE_LOCK = threading.RLock()
 _STATE_TRANSACTION_TIMEOUT_SECONDS = 1.0
+_WINDOWS_STATE_REPLACE_RETRY_DELAYS_SECONDS = (0.02, 0.05, 0.1, 0.2)
+_WINDOWS_TRANSIENT_STATE_REPLACE_ERRORS = frozenset({5, 32, 33})
 
 
 @contextmanager
@@ -493,7 +496,7 @@ def _write_state(path: Path, state: dict[str, Any]) -> None:
             json.dump(state, fh, ensure_ascii=False, indent=2, sort_keys=True)
             fh.write("\n")
         os.chmod(tmp_name, 0o600)
-        os.replace(tmp_name, path)
+        _replace_state_file(tmp_name, path)
         os.chmod(path, 0o600)
     except Exception:
         try:
@@ -501,6 +504,23 @@ def _write_state(path: Path, state: dict[str, Any]) -> None:
         except OSError:
             pass
         raise
+
+
+def _replace_state_file(source: str | Path, destination: Path) -> None:
+    """Publish telemetry state after transient Windows readers release it."""
+    for delay in (*_WINDOWS_STATE_REPLACE_RETRY_DELAYS_SECONDS, None):
+        try:
+            os.replace(source, destination)
+            return
+        except PermissionError as exc:
+            if (
+                os.name != "nt"
+                or getattr(exc, "winerror", None)
+                not in _WINDOWS_TRANSIENT_STATE_REPLACE_ERRORS
+                or delay is None
+            ):
+                raise
+            time.sleep(delay)
 
 
 def _next_event(state: dict[str, Any], current_version: str) -> str | None:

--- a/src/opensquilla/observability/install_telemetry.py
+++ b/src/opensquilla/observability/install_telemetry.py
@@ -52,12 +52,17 @@ _MAC_HEX_RE = re.compile(r"^[0-9a-f]{12}$")
 _COLLECT_LOCK = threading.Lock()
 _STATE_LOCK = threading.RLock()
 _STATE_TRANSACTION_TIMEOUT_SECONDS = 1.0
+_RESULT_STATE_TRANSACTION_TIMEOUT_SECONDS = 5.0
 _WINDOWS_STATE_REPLACE_RETRY_DELAYS_SECONDS = (0.02, 0.05, 0.1, 0.2)
 _WINDOWS_TRANSIENT_STATE_REPLACE_ERRORS = frozenset({5, 32, 33})
 
 
 @contextmanager
-def _state_transaction(path: Path) -> Iterator[None]:
+def _state_transaction(
+    path: Path,
+    *,
+    timeout: float = _STATE_TRANSACTION_TIMEOUT_SECONDS,
+) -> Iterator[None]:
     """Serialize one short telemetry-state transaction across threads/processes."""
     # Import lazily so merely importing telemetry during boot does not load the
     # platform-specific lock implementation. The exact JSON path is the key, so
@@ -65,7 +70,7 @@ def _state_transaction(path: Path) -> Iterator[None]:
     from opensquilla.profile_operation_lock import ProfileOperationLock
 
     with _STATE_LOCK:
-        with ProfileOperationLock(path, timeout=_STATE_TRANSACTION_TIMEOUT_SECONDS):
+        with ProfileOperationLock(path, timeout=timeout):
             yield
 
 
@@ -168,7 +173,10 @@ def collect_install_telemetry(
                 payload,
                 timeout=DEFAULT_TIMEOUT_SECONDS,
             )
-            with _state_transaction(path):
+            with _state_transaction(
+                path,
+                timeout=_RESULT_STATE_TRANSACTION_TIMEOUT_SECONDS,
+            ):
                 # Merge the result into the latest state rather than overwriting
                 # another telemetry writer's atomic update.
                 state = _load_or_create_state(path)

--- a/tests/test_observability/test_install_telemetry.py
+++ b/tests/test_observability/test_install_telemetry.py
@@ -10,6 +10,8 @@ from threading import Event
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
+
 from opensquilla.observability import install_telemetry as telemetry
 from opensquilla.observability import network_policy
 
@@ -340,6 +342,120 @@ def test_upload_failure_does_not_mark_install_uploaded(tmp_path, monkeypatch):
     assert state["last_error"] == "network_down"
 
 
+@pytest.mark.parametrize("winerror", [5, 32, 33])
+def test_state_replace_retries_transient_windows_errors(
+    tmp_path,
+    monkeypatch,
+    winerror,
+):
+    source = tmp_path / "state.tmp"
+    destination = tmp_path / "state.json"
+    source.write_text("next", encoding="utf-8")
+    destination.write_text("current", encoding="utf-8")
+    real_replace = os.replace
+    attempts = 0
+    delays: list[float] = []
+
+    def flaky_replace(source_path, destination_path):
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            error = PermissionError("synthetic transient Windows state reader")
+            error.winerror = winerror
+            raise error
+        real_replace(source_path, destination_path)
+
+    monkeypatch.setattr(telemetry.os, "name", "nt")
+    monkeypatch.setattr(telemetry.os, "replace", flaky_replace)
+    monkeypatch.setattr(telemetry.time, "sleep", delays.append)
+
+    telemetry._replace_state_file(source, destination)
+
+    assert attempts == 3
+    assert delays == [0.02, 0.05]
+    assert not source.exists()
+    assert destination.read_text(encoding="utf-8") == "next"
+
+
+def test_state_replace_does_not_retry_permanent_windows_error(tmp_path, monkeypatch):
+    source = tmp_path / "state.tmp"
+    destination = tmp_path / "state.json"
+    source.write_text("next", encoding="utf-8")
+    destination.write_text("current", encoding="utf-8")
+    attempts = 0
+
+    def denied_replace(_source_path, _destination_path):
+        nonlocal attempts
+        attempts += 1
+        error = PermissionError("synthetic permanent Windows denial")
+        error.winerror = 50
+        raise error
+
+    monkeypatch.setattr(telemetry.os, "name", "nt")
+    monkeypatch.setattr(telemetry.os, "replace", denied_replace)
+
+    with pytest.raises(PermissionError, match="permanent Windows denial"):
+        telemetry._replace_state_file(source, destination)
+
+    assert attempts == 1
+    assert source.read_text(encoding="utf-8") == "next"
+    assert destination.read_text(encoding="utf-8") == "current"
+
+
+def test_state_replace_does_not_retry_transient_code_off_windows(tmp_path, monkeypatch):
+    source = tmp_path / "state.tmp"
+    destination = tmp_path / "state.json"
+    source.write_text("next", encoding="utf-8")
+    destination.write_text("current", encoding="utf-8")
+    attempts = 0
+
+    def denied_replace(_source_path, _destination_path):
+        nonlocal attempts
+        attempts += 1
+        error = PermissionError("synthetic non-Windows denial")
+        error.winerror = 32
+        raise error
+
+    monkeypatch.setattr(telemetry.os, "name", "posix")
+    monkeypatch.setattr(telemetry.os, "replace", denied_replace)
+
+    with pytest.raises(PermissionError, match="non-Windows denial"):
+        telemetry._replace_state_file(source, destination)
+
+    assert attempts == 1
+    assert source.read_text(encoding="utf-8") == "next"
+    assert destination.read_text(encoding="utf-8") == "current"
+
+
+def test_write_state_cleans_temp_after_transient_windows_retries_exhausted(
+    tmp_path,
+    monkeypatch,
+):
+    destination = tmp_path / "state.json"
+    destination.write_text('{"value":"current"}\n', encoding="utf-8")
+    attempts = 0
+    delays: list[float] = []
+
+    def blocked_replace(_source_path, _destination_path):
+        nonlocal attempts
+        attempts += 1
+        error = PermissionError("synthetic persistent Windows sharing violation")
+        error.winerror = 32
+        raise error
+
+    monkeypatch.setattr(telemetry.os, "name", "nt")
+    monkeypatch.setattr(telemetry.os, "replace", blocked_replace)
+    monkeypatch.setattr(telemetry.time, "sleep", delays.append)
+
+    with pytest.raises(PermissionError, match="sharing violation"):
+        telemetry._write_state(destination, {"value": "next"})
+
+    assert attempts == 5
+    assert delays == [0.02, 0.05, 0.1, 0.2]
+    assert destination.read_text(encoding="utf-8") == '{"value":"current"}\n'
+    assert list(tmp_path.glob(".state.json.*.tmp")) == []
+
+
 def test_desktop_env_sets_install_method(monkeypatch):
     _enable_telemetry_for_test(monkeypatch)
     monkeypatch.delenv(telemetry.TELEMETRY_INSTALL_METHOD_ENV, raising=False)
@@ -591,7 +707,12 @@ result = telemetry.collect_install_telemetry(
     state_path=state_path,
     version=version,
 )
-print(json.dumps({"uploaded": result.uploaded, "error": result.error}))
+print(json.dumps({
+    "sent": result.sent,
+    "uploaded": result.uploaded,
+    "skipped_reason": result.skipped_reason,
+    "error": result.error,
+}))
 """
     env = os.environ.copy()
     env[telemetry.TELEMETRY_ENDPOINT_ENV] = TEST_ENDPOINT
@@ -644,7 +765,13 @@ print(json.dumps({"uploaded": result.uploaded, "error": result.error}))
 
     for worker, (stdout, stderr) in zip(workers, outputs, strict=True):
         assert worker.returncode == 0, stderr
-        assert json.loads(stdout)["uploaded"] is True
+        result = json.loads(stdout)
+        assert result["sent"] is True, (
+            f"telemetry worker result={result!r}, stderr={stderr!r}"
+        )
+        assert result["uploaded"] is True, (
+            f"telemetry worker result={result!r}, stderr={stderr!r}"
+        )
     state = _load(state_path)
     assert set(state["uploaded_versions"]) == {"0.9.0", "1.0.0", "2.0.0"}
     assert state["future_field"] == {"preserve": True}

--- a/tests/test_observability/test_install_telemetry.py
+++ b/tests/test_observability/test_install_telemetry.py
@@ -342,6 +342,37 @@ def test_upload_failure_does_not_mark_install_uploaded(tmp_path, monkeypatch):
     assert state["last_error"] == "network_down"
 
 
+def test_successful_upload_uses_longer_timeout_for_result_merge(tmp_path, monkeypatch):
+    _enable_telemetry_for_test(monkeypatch)
+    monkeypatch.setenv(telemetry.TELEMETRY_ENDPOINT_ENV, TEST_ENDPOINT)
+    _set_stable_sources(monkeypatch, macs=["02:00:00:00:00:06"])
+    state_path = tmp_path / "install_telemetry.json"
+    lock_timeouts: list[float] = []
+
+    from opensquilla import profile_operation_lock
+
+    class RecordingLock:
+        def __init__(self, _path, *, timeout):
+            lock_timeouts.append(timeout)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, _exc_type, _exc, _traceback):
+            return None
+
+    monkeypatch.setattr(profile_operation_lock, "ProfileOperationLock", RecordingLock)
+    monkeypatch.setattr(telemetry, "_post_payload", lambda *_args, **_kwargs: (True, None))
+
+    result = telemetry.collect_install_telemetry(state_path=state_path, version="1.0.0")
+
+    assert result.uploaded is True
+    assert lock_timeouts == [
+        telemetry._STATE_TRANSACTION_TIMEOUT_SECONDS,
+        telemetry._RESULT_STATE_TRANSACTION_TIMEOUT_SECONDS,
+    ]
+
+
 @pytest.mark.parametrize("winerror", [5, 32, 33])
 def test_state_replace_retries_transient_windows_errors(
     tmp_path,


### PR DESCRIPTION
## Scope

- Retry only transient Windows state replacement failures with WinError 5, 32, or 33 using bounded backoff.
- Keep the initial telemetry state transaction at one second while allowing the post-upload result merge up to five seconds.
- Include the complete worker result in the concurrent-process regression failure so future CI artifacts retain the real error.

This follows the merge-group failure observed while #1312 was queued. The artifact proves that the mocked upload completed and an immediate result-merge exception was converted to uploaded=false, but the old assertion discarded the exception text. The exact WinError therefore cannot be recovered from that run. The replacement retry matches the remaining Windows failure surface; the longer result-merge wait addresses a separate lock race reproduced during the investigation.

## Target

main

## Linked issue

None

## Release note

No user-facing release note. This is Windows reliability and CI diagnostic hardening.

## Tests

- uv run pytest -q tests/test_observability/test_install_telemetry.py tests/test_observability/test_usage_telemetry.py tests/test_provider_tokenrhythm_correlation.py — 126 passed
- uv run ruff check src/opensquilla/observability/install_telemetry.py tests/test_observability/test_install_telemetry.py
- uv run mypy src/opensquilla/observability/install_telemetry.py --show-error-codes
- git diff --check origin/main...HEAD

## Safety and compatibility

- Offline, deterministic, credential-free tests only; no telemetry request or external provider call is made.
- Retry behavior is Windows-only and limited to documented transient access/sharing errors. Permanent denials and all non-Windows errors still fail immediately.
- The state schema, endpoint contract, privacy controls, and public APIs are unchanged.
- Existing installations and persisted telemetry state require no migration.

## Third-party origins

None.