### PR TITLE
Prevent transcript reads from blocking turn writes

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -105,6 +105,8 @@
       "tests/test_engine/turn_runner/test_router_control_replay_event.py",
       "tests/test_engine/turn_runner/test_stream_consumer_stage_snapshot.py",
       "tests/test_engine/turn_runner/test_tool_surface_levers_bootstrap_unit.py",
+      "tests/test_engine/turn_runner/test_transcript_snapshot.py",
+      "tests/test_engine/turn_runner/test_transcript_snapshot_runtime.py",
       "tests/test_engine/turn_runner/test_turn_identity_finalizer.py",
       "tests/test_execution_status_contract.py",
       "tests/test_github_issue_link_sync.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -441,6 +441,8 @@
     "tests/test_engine/turn_runner/test_stream_consumer_stage_snapshot.py": 1.134,
     "tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py": 5.648,
     "tests/test_engine/turn_runner/test_tool_surface_levers_bootstrap_unit.py": 0.011,
+    "tests/test_engine/turn_runner/test_transcript_snapshot.py": 0.01,
+    "tests/test_engine/turn_runner/test_transcript_snapshot_runtime.py": 0.01,
     "tests/test_engine/turn_runner/test_turn_finalizer_paused.py": 0.01,
     "tests/test_engine/turn_runner/test_turn_finalizer_paused_im_layout.py": 0.026,
     "tests/test_engine/turn_runner/test_turn_finalizer_stage_snapshot.py": 0.105,

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -135,6 +135,7 @@ from opensquilla.engine.turn_runner import (
     StreamConsumerStageInput,
     TurnFinalizerStage,
     TurnFinalizerStageInput,
+    TurnTranscriptSnapshot,
     rebind_attachment_prompt,
 )
 from opensquilla.engine.turn_runner.context import (
@@ -5138,6 +5139,19 @@ class TurnRunner:
             extra_prompt_context = input_out.extra_prompt_context
             normalization_metadata = input_out.normalization_metadata
 
+            async def _load_turn_transcript() -> Sequence[Any]:
+                if self._session_manager is None:
+                    return ()
+                get_transcript = getattr(self._session_manager, "get_transcript", None)
+                if not callable(get_transcript):
+                    return ()
+                entries = get_transcript(session_key)
+                if inspect.isawaitable(entries):
+                    entries = await entries
+                return entries or ()
+
+            transcript_snapshot = TurnTranscriptSnapshot[Any](_load_turn_transcript)
+
             pt_outcome = await self._provider_and_tools_stage.run(
                 ProviderAndToolsStageInput(
                     session_key=session_key,
@@ -5275,6 +5289,7 @@ class TurnRunner:
                         input_provenance=input_provenance,
                         skill_catalog=skill_catalog,
                         usage_execution_context=pipeline_usage_context,
+                        transcript_snapshot=transcript_snapshot,
                         provider_request_correlation=provider_request_correlation,
                     )
                 )
@@ -5870,6 +5885,7 @@ class TurnRunner:
                             consumer_admission_fingerprint
                         ),
                         skip_compaction=image_input_preflight_blocked,
+                        transcript_snapshot=transcript_snapshot,
                     )
                 )
             ch_out = ch_outcome.require_output()
@@ -5886,6 +5902,14 @@ class TurnRunner:
             )
             if callable(capture_compaction_source):
                 try:
+                    capture_kwargs: dict[str, Any] = {}
+                    if _accepts_keyword_arg(
+                        capture_compaction_source,
+                        "transcript_entries",
+                    ):
+                        capture_kwargs["transcript_entries"] = (
+                            await transcript_snapshot.get_entries()
+                        )
                     source_snapshot = await capture_compaction_source(
                         session_key,
                         boundary_message_id=(
@@ -5893,6 +5917,7 @@ class TurnRunner:
                             if history_has_persisted_user
                             else None
                         ),
+                        **capture_kwargs,
                     )
                 except Exception as exc:  # noqa: BLE001 - inline path fails closed
                     log.warning(
@@ -9524,6 +9549,7 @@ class TurnRunner:
         exclude_last_user: bool = False,
         bound_user_message_id: str | None = None,
         include_capacity: bool = False,
+        transcript_snapshot: TurnTranscriptSnapshot[Any] | None = None,
     ) -> dict[str, Any]:
         """Return transcript context for the V4 router, excluding the current user turn."""
         if self._session_manager is None:
@@ -9544,9 +9570,12 @@ class TurnRunner:
                 else {}
             )
         try:
-            transcript = get_transcript(session_key)
-            if inspect.isawaitable(transcript):
-                transcript = await transcript
+            if transcript_snapshot is not None:
+                transcript = await transcript_snapshot.get_entries()
+            else:
+                transcript = get_transcript(session_key)
+                if inspect.isawaitable(transcript):
+                    transcript = await transcript
         except Exception:  # noqa: BLE001 - router context must never block a turn
             log.debug("turn_runner.router_context_failed", session_key=session_key)
             return (
@@ -10296,6 +10325,7 @@ class TurnRunner:
         provider_request_correlation: ProviderRequestCorrelation | None = None,
         consumer_admission: Any | None = None,
         consumer_admission_fingerprint: str = "",
+        transcript_snapshot: TurnTranscriptSnapshot[Any] | None = None,
     ) -> str:
         """Flush memory and compact transcript when the router upgrades into t3.
 
@@ -10378,7 +10408,11 @@ class TurnRunner:
             return _T3_HANDLED
 
         try:
-            transcript = await self._session_manager.get_transcript(session_key)
+            transcript = (
+                list(await transcript_snapshot.get_entries())
+                if transcript_snapshot is not None
+                else await self._session_manager.get_transcript(session_key)
+            )
         except KeyError:
             return _T3_HANDLED
         (
@@ -10414,6 +10448,7 @@ class TurnRunner:
             CompactionConfig,
             arm_compaction_deadline,
             await_compaction_phase,
+            effective_protected_recent_messages,
             estimate_entries_model_replay_chars,
             estimate_entry_model_replay_chars,
             estimate_entry_model_replay_tokens,
@@ -10511,7 +10546,7 @@ class TurnRunner:
             return _T3_HANDLED
         compaction_config = compaction_config or CompactionConfig()
         compaction_config.protected_recent_messages = max(
-            int(compaction_config.protected_recent_messages or 0),
+            effective_protected_recent_messages(compaction_config),
             protected_suffix_count,
         )
         if self._compaction_circuit_open(session_key):
@@ -10741,6 +10776,17 @@ class TurnRunner:
                     compact_kwargs["consumer_admission_fingerprint"] = (
                         consumer_admission_fingerprint
                     )
+                if (
+                    history_has_persisted_user
+                    and bound_user_message_id is not None
+                    and _accepts_keyword_arg(
+                        compact_method,
+                        "protected_boundary_message_id",
+                    )
+                ):
+                    compact_kwargs["protected_boundary_message_id"] = (
+                        bound_user_message_id
+                    )
                 compaction_result = await await_compaction_phase(
                     self._session_manager.compact_with_result(
                         session_key,
@@ -10791,6 +10837,15 @@ class TurnRunner:
                         **observed_payload,
                     )
             if result:
+                durable_transcript_changed = (
+                    compaction_result is None
+                    or (
+                        int(getattr(compaction_result, "removed_count", 0) or 0) > 0
+                        and bool(getattr(compaction_result, "summary", "") or "")
+                    )
+                )
+                if durable_transcript_changed and transcript_snapshot is not None:
+                    transcript_snapshot.invalidate()
                 self.mark_compacted_this_turn(session_key)
                 self._record_compaction_success(session_key)
                 completed_payload = {"summary_len": len(result)}
@@ -10933,6 +10988,7 @@ class TurnRunner:
         provider_request_correlation: ProviderRequestCorrelation | None = None,
         consumer_admission: Any | None = None,
         consumer_admission_fingerprint: str = "",
+        transcript_snapshot: TurnTranscriptSnapshot[Any] | None = None,
     ) -> None:
         """Compact proactively if session history exceeds token budget.
 
@@ -10982,6 +11038,7 @@ class TurnRunner:
             arm_compaction_deadline,
             await_compaction_phase,
             build_compaction_config_from_provider,
+            effective_protected_recent_messages,
         )
 
         configured_compaction = getattr(getattr(self, "_config", None), "compaction", None)
@@ -11007,7 +11064,11 @@ class TurnRunner:
             )
             return
         try:
-            transcript = await self._session_manager.get_transcript(session_key)
+            transcript = (
+                list(await transcript_snapshot.get_entries())
+                if transcript_snapshot is not None
+                else await self._session_manager.get_transcript(session_key)
+            )
         except KeyError:
             return  # session doesn't exist yet
         (
@@ -11123,7 +11184,7 @@ class TurnRunner:
             )
             return
         compaction_config.protected_recent_messages = max(
-            int(compaction_config.protected_recent_messages or 0),
+            effective_protected_recent_messages(compaction_config),
             protected_suffix_count,
         )
         if self._compaction_circuit_open(session_key):
@@ -11366,6 +11427,17 @@ class TurnRunner:
                     compact_kwargs["consumer_admission_fingerprint"] = (
                         consumer_admission_fingerprint
                     )
+                if (
+                    history_has_persisted_user
+                    and bound_user_message_id is not None
+                    and _accepts_keyword_arg(
+                        compact_method,
+                        "protected_boundary_message_id",
+                    )
+                ):
+                    compact_kwargs["protected_boundary_message_id"] = (
+                        bound_user_message_id
+                    )
                 compaction_result = await await_compaction_phase(
                     self._session_manager.compact_with_result(
                         session_key,
@@ -11530,6 +11602,15 @@ class TurnRunner:
             if emergency_applied:
                 return
         if result:
+            durable_transcript_changed = (
+                compaction_result is None
+                or (
+                    int(getattr(compaction_result, "removed_count", 0) or 0) > 0
+                    and bool(getattr(compaction_result, "summary", "") or "")
+                )
+            )
+            if durable_transcript_changed and transcript_snapshot is not None:
+                transcript_snapshot.invalidate()
             self.mark_compacted_this_turn(session_key)
             self._record_compaction_success(session_key)
             completed_payload = {"tokens_before": total_tokens}
@@ -12144,6 +12225,7 @@ class TurnRunner:
         *,
         trim_last_user: bool = True,
         bound_user_message_id: str | None = None,
+        transcript_snapshot: TurnTranscriptSnapshot[Any] | None = None,
     ) -> str | None:
         """Load existing transcript as agent history.
 
@@ -12161,7 +12243,11 @@ class TurnRunner:
         if self._session_manager is None:
             return None
 
-        transcript = await self._session_manager.get_transcript(session_key)
+        transcript = (
+            list(await transcript_snapshot.get_entries())
+            if transcript_snapshot is not None
+            else await self._session_manager.get_transcript(session_key)
+        )
 
         from opensquilla.engine.history import reconstruct_messages_from_entry
         from opensquilla.provider import Message

--- a/src/opensquilla/engine/turn_runner/__init__.py
+++ b/src/opensquilla/engine/turn_runner/__init__.py
@@ -77,6 +77,7 @@ from opensquilla.engine.turn_runner.stream_consumer_stage import (
     SystemPromptRefreshPort,
     WarningTransformer,
 )
+from opensquilla.engine.turn_runner.transcript_snapshot import TurnTranscriptSnapshot
 from opensquilla.engine.turn_runner.turn_finalizer_stage import (
     CostRollupResult,
     SessionTotalsPort,
@@ -145,6 +146,7 @@ __all__ = [
     "ToolBuilderPort",
     "TranscriptAppendPort",
     "TranscriptAppendResult",
+    "TurnTranscriptSnapshot",
     "TurnContext",
     "TurnExecutionContext",
     "TurnErrorPersistPort",

--- a/src/opensquilla/engine/turn_runner/compaction_and_history_stage.py
+++ b/src/opensquilla/engine/turn_runner/compaction_and_history_stage.py
@@ -50,6 +50,9 @@ if TYPE_CHECKING:
     from opensquilla.engine.agent import Agent
     from opensquilla.engine.hooks.types import CompactionHook
     from opensquilla.engine.turn_runner.outcome import StageOutcome
+    from opensquilla.engine.turn_runner.transcript_snapshot import (
+        TurnTranscriptSnapshot,
+    )
     from opensquilla.provider.types import ProviderRequestCorrelation
     from opensquilla.session.compaction_deployment import CompactionExecutionPlan
 
@@ -102,6 +105,7 @@ class T3UpgradeCompactionPort(Protocol):
         provider_request_correlation: ProviderRequestCorrelation | None = None,
         consumer_admission: Any | None = None,
         consumer_admission_fingerprint: str = "",
+        transcript_snapshot: TurnTranscriptSnapshot[Any] | None = None,
     ) -> str: ...
 
 @runtime_checkable
@@ -134,6 +138,7 @@ class PreflightCompactionPort(Protocol):
         provider_request_correlation: ProviderRequestCorrelation | None = None,
         consumer_admission: Any | None = None,
         consumer_admission_fingerprint: str = "",
+        transcript_snapshot: TurnTranscriptSnapshot[Any] | None = None,
     ) -> None: ...
 
 @runtime_checkable
@@ -160,6 +165,7 @@ class HistoryLoaderPort(Protocol):
         session_key: str,
         trim_last_user: bool,
         bound_user_message_id: str | None = None,
+        transcript_snapshot: TurnTranscriptSnapshot[Any] | None = None,
     ) -> str | None: ...
 
 @runtime_checkable
@@ -228,6 +234,10 @@ class CompactionAndHistoryStageInput:
     consumer_admission: Any | None = field(default=None, repr=False)
     consumer_admission_fingerprint: str = ""
     skip_compaction: bool = False
+    transcript_snapshot: TurnTranscriptSnapshot[Any] | None = field(
+        default=None,
+        repr=False,
+    )
 
 @dataclass(frozen=True)
 class CompactionAndHistoryStageOutput:
@@ -333,6 +343,9 @@ class CompactionAndHistoryStage:
                 extra={"phase": "t3_upgrade"},
             )
             await self._fire_before_compact(t3_state)
+            t3_kwargs: dict[str, Any] = {}
+            if inp.transcript_snapshot is not None:
+                t3_kwargs["transcript_snapshot"] = inp.transcript_snapshot
             t3_status = await self._t3_upgrade.maybe_compact(
                 session_key=inp.session_key,
                 turn=inp.turn,
@@ -347,6 +360,7 @@ class CompactionAndHistoryStage:
                 provider_request_correlation=inp.provider_request_correlation,
                 consumer_admission=inp.consumer_admission,
                 consumer_admission_fingerprint=inp.consumer_admission_fingerprint,
+                **t3_kwargs,
             )
             await self._fire_after_compact(t3_state, {"status": t3_status})
 
@@ -361,6 +375,9 @@ class CompactionAndHistoryStage:
                     extra={"phase": "preflight"},
                 )
                 await self._fire_before_compact(preflight_state)
+                preflight_kwargs: dict[str, Any] = {}
+                if inp.transcript_snapshot is not None:
+                    preflight_kwargs["transcript_snapshot"] = inp.transcript_snapshot
                 await self._preflight.maybe_compact(
                     session_key=inp.session_key,
                     context_window_tokens=compaction_context_window_tokens,
@@ -374,15 +391,20 @@ class CompactionAndHistoryStage:
                     provider_request_correlation=inp.provider_request_correlation,
                     consumer_admission=inp.consumer_admission,
                     consumer_admission_fingerprint=inp.consumer_admission_fingerprint,
+                    **preflight_kwargs,
                 )
                 await self._fire_after_compact(preflight_state, {"status": "ran"})
 
         # 3. Load history (transcript + reconstructed messages + durable summary).
+        history_kwargs: dict[str, Any] = {}
+        if inp.transcript_snapshot is not None:
+            history_kwargs["transcript_snapshot"] = inp.transcript_snapshot
         compaction_summary_context = await self._history_loader.load(
             agent=inp.agent,
             session_key=inp.session_key,
             trim_last_user=inp.history_has_persisted_user,
             bound_user_message_id=inp.bound_user_message_id,
+            **history_kwargs,
         )
 
         # 4. Prepend compaction summary context to request_context_prompt (pure).

--- a/src/opensquilla/engine/turn_runner/harness.py
+++ b/src/opensquilla/engine/turn_runner/harness.py
@@ -340,6 +340,7 @@ class _TurnRunnerRouterContextAdapter(RouterContextPort):
         exclude_last_user: bool,
         bound_user_message_id: str | None = None,
         include_capacity: bool = False,
+        transcript_snapshot: Any | None = None,
     ) -> dict[str, Any]:
         from opensquilla.engine.runtime import _accepts_keyword_arg
 
@@ -352,6 +353,11 @@ class _TurnRunnerRouterContextAdapter(RouterContextPort):
             "include_capacity",
         ):
             kwargs["include_capacity"] = include_capacity
+        if transcript_snapshot is not None and _accepts_keyword_arg(
+            self._runner._router_previous_assistant_context,
+            "transcript_snapshot",
+        ):
+            kwargs["transcript_snapshot"] = transcript_snapshot
         return await self._runner._router_previous_assistant_context(
             session_key,
             **kwargs,
@@ -1071,6 +1077,7 @@ class _TurnRunnerT3UpgradeCompactionAdapter(T3UpgradeCompactionPort):
         provider_request_correlation: Any | None = None,
         consumer_admission: Any | None = None,
         consumer_admission_fingerprint: str = "",
+        transcript_snapshot: Any | None = None,
     ) -> str:
         from opensquilla.engine.runtime import _accepts_keyword_arg
 
@@ -1121,6 +1128,11 @@ class _TurnRunnerT3UpgradeCompactionAdapter(T3UpgradeCompactionPort):
             correlation_kwargs["consumer_admission_fingerprint"] = (
                 consumer_admission_fingerprint
             )
+        if transcript_snapshot is not None and _accepts_keyword_arg(
+            self._runner._maybe_compact_on_t3_upgrade,
+            "transcript_snapshot",
+        ):
+            correlation_kwargs["transcript_snapshot"] = transcript_snapshot
         return await self._runner._maybe_compact_on_t3_upgrade(
             session_key,
             turn,
@@ -1155,6 +1167,7 @@ class _TurnRunnerPreflightCompactionAdapter(PreflightCompactionPort):
         provider_request_correlation: Any | None = None,
         consumer_admission: Any | None = None,
         consumer_admission_fingerprint: str = "",
+        transcript_snapshot: Any | None = None,
     ) -> None:
         from opensquilla.engine.runtime import _accepts_keyword_arg
 
@@ -1205,6 +1218,11 @@ class _TurnRunnerPreflightCompactionAdapter(PreflightCompactionPort):
             correlation_kwargs["consumer_admission_fingerprint"] = (
                 consumer_admission_fingerprint
             )
+        if transcript_snapshot is not None and _accepts_keyword_arg(
+            self._runner._maybe_preflight_compact,
+            "transcript_snapshot",
+        ):
+            correlation_kwargs["transcript_snapshot"] = transcript_snapshot
         await self._runner._maybe_preflight_compact(
             session_key,
             context_window_tokens,
@@ -1232,12 +1250,23 @@ class _TurnRunnerHistoryLoaderAdapter(HistoryLoaderPort):
         session_key: str,
         trim_last_user: bool,
         bound_user_message_id: str | None = None,
+        transcript_snapshot: Any | None = None,
     ) -> str | None:
+        from opensquilla.engine.runtime import _accepts_keyword_arg
+
+        kwargs: dict[str, Any] = {
+            "trim_last_user": trim_last_user,
+            "bound_user_message_id": bound_user_message_id,
+        }
+        if transcript_snapshot is not None and _accepts_keyword_arg(
+            self._runner._load_history,
+            "transcript_snapshot",
+        ):
+            kwargs["transcript_snapshot"] = transcript_snapshot
         return await self._runner._load_history(
             agent,
             session_key,
-            trim_last_user=trim_last_user,
-            bound_user_message_id=bound_user_message_id,
+            **kwargs,
         )
 
 class _RequestContextPrependAdapter(RequestContextPrependPort):

--- a/src/opensquilla/engine/turn_runner/prompt_assembler_stage.py
+++ b/src/opensquilla/engine/turn_runner/prompt_assembler_stage.py
@@ -33,6 +33,9 @@ if TYPE_CHECKING:
         AttachmentMaterializationStats,
     )
     from opensquilla.engine.turn_runner.outcome import StageOutcome
+    from opensquilla.engine.turn_runner.transcript_snapshot import (
+        TurnTranscriptSnapshot,
+    )
     from opensquilla.observability.decision_log import PipelineStepRecord
     from opensquilla.observability.prompt_report import PromptReport
     from opensquilla.provider.types import ProviderRequestCorrelation
@@ -159,6 +162,7 @@ class RouterContextPort(Protocol):
         exclude_last_user: bool,
         bound_user_message_id: str | None = None,
         include_capacity: bool = False,
+        transcript_snapshot: TurnTranscriptSnapshot[Any] | None = None,
     ) -> dict[str, Any]: ...
 
 @runtime_checkable
@@ -266,6 +270,10 @@ class PromptAssemblerStageInput:
     skill_catalog: Any | None = None
     usage_execution_context: Any | None = None
     provider_request_correlation: ProviderRequestCorrelation | None = field(
+        default=None,
+        repr=False,
+    )
+    transcript_snapshot: TurnTranscriptSnapshot[Any] | None = field(
         default=None,
         repr=False,
     )
@@ -396,13 +404,18 @@ class PromptAssemblerStage:
         )
 
         # 2. Fetch router context (transcript-driven)
-        router_context = await self._router_context.fetch_router_context(
-            inp.session_key,
-            exclude_last_user=(
+        router_context_kwargs: dict[str, Any] = {
+            "exclude_last_user": (
                 inp.history_has_persisted_user or inp.persist_input
             ),
-            bound_user_message_id=inp.bound_user_message_id,
-            include_capacity=bool(inp.attachments),
+            "bound_user_message_id": inp.bound_user_message_id,
+            "include_capacity": bool(inp.attachments),
+        }
+        if inp.transcript_snapshot is not None:
+            router_context_kwargs["transcript_snapshot"] = inp.transcript_snapshot
+        router_context = await self._router_context.fetch_router_context(
+            inp.session_key,
+            **router_context_kwargs,
         )
 
         raw_history_image_turn_count = router_context.get("history_image_turn_count")

--- a/src/opensquilla/engine/turn_runner/transcript_snapshot.py
+++ b/src/opensquilla/engine/turn_runner/transcript_snapshot.py
@@ -1,0 +1,57 @@
+"""Turn-local lazy transcript snapshot."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Iterable
+
+
+class TurnTranscriptSnapshot[T]:
+    """Cache one successful transcript load until explicitly invalidated."""
+
+    def __init__(self, loader: Callable[[], Awaitable[Iterable[T]]]) -> None:
+        self._loader = loader
+        self._entries: tuple[T, ...] | None = None
+        self._lock = asyncio.Lock()
+        self._load_count = 0
+        self._generation = 0
+
+    @property
+    def load_count(self) -> int:
+        """Return the number of loader invocations, including failed attempts."""
+
+        return self._load_count
+
+    @property
+    def generation(self) -> int:
+        """Return the invalidation generation for this turn-local snapshot."""
+
+        return self._generation
+
+    async def get_entries(self) -> tuple[T, ...]:
+        """Return cached entries, loading once per successful generation."""
+
+        while True:
+            entries = self._entries
+            if entries is not None:
+                return entries
+
+            async with self._lock:
+                entries = self._entries
+                if entries is not None:
+                    return entries
+
+                generation = self._generation
+                self._load_count += 1
+                loaded_entries = tuple(await self._loader())
+                if generation != self._generation:
+                    continue
+
+                self._entries = loaded_entries
+                return loaded_entries
+
+    def invalidate(self) -> None:
+        """Discard cached entries and advance the snapshot generation."""
+
+        self._entries = None
+        self._generation += 1

--- a/src/opensquilla/session/compaction.py
+++ b/src/opensquilla/session/compaction.py
@@ -576,7 +576,7 @@ def _entry_tokens(entry: dict[str, Any]) -> int:
     return estimate_entry_model_replay_tokens(entry)
 
 
-def _profile_protected_recent_messages(cfg: CompactionConfig) -> int:
+def effective_protected_recent_messages(cfg: CompactionConfig) -> int:
     configured = max(0, int(getattr(cfg, "protected_recent_messages", 0) or 0))
     if configured:
         return configured
@@ -591,7 +591,7 @@ def _apply_protected_tail(
     cut: int,
     cfg: CompactionConfig,
 ) -> int:
-    protected_recent = _profile_protected_recent_messages(cfg)
+    protected_recent = effective_protected_recent_messages(cfg)
     protected_start = (
         max(0, len(entries) - protected_recent)
         if protected_recent > 0
@@ -807,7 +807,7 @@ def _compaction_quality_report(
     trigger: CompactionTrigger = "token_budget",
     replaces_previous_summary: bool = False,
 ) -> dict[str, Any]:
-    protected_recent = _profile_protected_recent_messages(cfg)
+    protected_recent = effective_protected_recent_messages(cfg)
     protected_tail_preserved = True
     if protected_recent > 0:
         protected_tail = entries[-protected_recent:]
@@ -2022,7 +2022,7 @@ async def compact_context_new(request: CompactionRequest) -> CompactionResult:
             kept = entries
         else:
             skip_reason = "no_safe_turn_boundary"
-            if _profile_protected_recent_messages(cfg) > 0:
+            if effective_protected_recent_messages(cfg) > 0:
                 skip_reason = "protected_tail_exhausts_compaction_window"
             return CompactionResult(
                 summary="",

--- a/src/opensquilla/session/manager.py
+++ b/src/opensquilla/session/manager.py
@@ -30,6 +30,7 @@ from opensquilla.session.compaction import (
     await_compaction_phase,
     compact_context,
     compaction_remaining_seconds,
+    effective_protected_recent_messages,
     require_compaction_time,
 )
 from opensquilla.session.compaction_deployment import compaction_deployment_fingerprint
@@ -2238,6 +2239,7 @@ class SessionManager:
         session_key: str,
         *,
         boundary_message_id: str | None = None,
+        transcript_entries: Sequence[TranscriptEntry] | None = None,
     ) -> CompactionSourceSnapshot:
         """Freeze the exact durable prefix visible to the active turn.
 
@@ -2246,7 +2248,11 @@ class SessionManager:
         boundary cannot be found.
         """
 
-        transcript = await self.get_transcript(session_key)
+        transcript = (
+            list(transcript_entries)
+            if transcript_entries is not None
+            else await self.get_transcript(session_key)
+        )
         source_entries = transcript
         if boundary_message_id is not None:
             boundary_index = next(
@@ -2646,6 +2652,7 @@ class SessionManager:
         provider_request_correlation: ProviderRequestCorrelation | None = None,
         consumer_admission: Callable[[str, list[dict[str, Any]]], Any] | None = None,
         consumer_admission_fingerprint: str = "",
+        protected_boundary_message_id: str | None = None,
     ) -> CompactionResult:
         """Compact the session transcript and return full compaction metadata."""
 
@@ -2674,6 +2681,28 @@ class SessionManager:
                 effective_config,
                 phase="snapshotting",
             )
+            if protected_boundary_message_id is not None:
+                protected_boundary_index = next(
+                    (
+                        index
+                        for index, entry in enumerate(entries)
+                        if entry.message_id == protected_boundary_message_id
+                    ),
+                    None,
+                )
+                if protected_boundary_index is None:
+                    return CompactionResult(
+                        summary="",
+                        kept_entries=_compaction_entry_payloads(entries),
+                        removed_count=0,
+                        chunks_processed=0,
+                        summary_source="skipped",
+                        skip_reason="protected_boundary_missing",
+                    )
+                effective_config.protected_recent_messages = max(
+                    effective_protected_recent_messages(effective_config),
+                    len(entries) - protected_boundary_index,
+                )
             summaries = await await_compaction_phase(
                 self._storage.get_all_summaries(node.session_id),
                 effective_config,

--- a/src/opensquilla/session/storage.py
+++ b/src/opensquilla/session/storage.py
@@ -1554,6 +1554,10 @@ def _deserialize_row(row: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def _decode_transcript_rows(rows: Sequence[Any]) -> list[TranscriptEntry]:
+    return [TranscriptEntry(**_deserialize_row(dict(row))) for row in rows]
+
+
 def _py_lower(value: Any) -> Any:
     """Unicode-aware lowercase for the ``py_lower`` SQL function.
 
@@ -1715,8 +1719,11 @@ class SessionStorage:
     ) -> None:
         self._db_path = db_path
         self._conn: Any | None = None
+        self._transcript_reader: Any | None = None
         self._meta_run_writer = meta_run_writer
         self._operation_lock = asyncio.Lock()
+        self._transcript_reader_lock = asyncio.Lock()
+        self._transcript_reader_fallback_warned = False
         self._usage_backfill_index_lock = asyncio.Lock()
         self._usage_backfill_indexes_ready = False
         self._legacy_project_adoption_lock = asyncio.Lock()
@@ -1774,6 +1781,13 @@ class SessionStorage:
         *,
         goal_pause_reason: str = "process_restart",
     ) -> None:
+        if (
+            self._conn is not None
+            or self._transcript_reader is not None
+            or self._meta_launch_draft_gc_task is not None
+        ):
+            await self.close()
+        self._poisoned = False
         self._conn = await aiosqlite.connect(self._db_path, isolation_level=None)
         self._conn.row_factory = aiosqlite.Row
         # Unicode-aware case folding for non-ASCII LIKE search (see _py_lower).
@@ -1792,10 +1806,17 @@ class SessionStorage:
             await self._conn.create_function(  # type: ignore[attr-defined]
                 name, arity, function, deterministic=True
             )
-        await self._conn.execute("PRAGMA journal_mode=WAL")
+        async with self._conn.execute("PRAGMA journal_mode=WAL") as cur:
+            journal_mode_row = await cur.fetchone()
+        journal_mode = (
+            str(journal_mode_row[0]).strip().lower()
+            if journal_mode_row is not None
+            else ""
+        )
         await self._conn.execute("PRAGMA foreign_keys=ON")
         await self._conn.execute(f"PRAGMA busy_timeout={_SQLITE_BUSY_TIMEOUT_MS}")
         await self._initialize_schema(goal_pause_reason=goal_pause_reason)
+        await self._open_transcript_reader(journal_mode)
         self._meta_launch_draft_gc_task = asyncio.create_task(
             self._run_meta_launch_draft_gc(),
             name="session-storage-meta-launch-draft-gc",
@@ -1814,9 +1835,96 @@ class SessionStorage:
             with contextlib.suppress(asyncio.CancelledError):
                 await gc_task
         async with self._operation_lock:
-            if self._conn:
-                await self._conn.close()
-                self._conn = None
+            async with self._transcript_reader_lock:
+                reader, self._transcript_reader = self._transcript_reader, None
+                conn, self._conn = self._conn, None
+                try:
+                    if reader is not None:
+                        await reader.close()
+                finally:
+                    if conn is not None:
+                        await conn.close()
+
+    def _warn_transcript_reader_fallback_once(
+        self,
+        reason: str,
+        journal_mode: str,
+    ) -> None:
+        if self._transcript_reader_fallback_warned:
+            return
+        self._transcript_reader_fallback_warned = True
+        safe_reason = (
+            reason
+            if reason in {"journal_mode_not_wal", "memory_database", "open_failed"}
+            else "unknown"
+        )
+        safe_journal_mode = (
+            journal_mode
+            if journal_mode in {"delete", "memory", "off", "persist", "truncate", "wal"}
+            else "unknown"
+        )
+        log.warning(
+            "session_storage.transcript_reader_fallback reason=%s journal_mode=%s",
+            safe_reason,
+            safe_journal_mode,
+            extra={
+                "event": "session_storage.transcript_reader_fallback",
+                "reason": safe_reason,
+                "journal_mode": safe_journal_mode,
+            },
+        )
+
+    async def _open_transcript_reader(self, journal_mode: str) -> None:
+        if self._db_path == ":memory:":
+            self._warn_transcript_reader_fallback_once("memory_database", journal_mode)
+            return
+        if journal_mode != "wal":
+            self._warn_transcript_reader_fallback_once(
+                "journal_mode_not_wal",
+                journal_mode,
+            )
+            return
+
+        reader: Any | None = None
+        try:
+            reader = await aiosqlite.connect(self._db_path, isolation_level=None)
+            reader.row_factory = aiosqlite.Row
+            async with reader.execute("PRAGMA query_only=ON"):
+                pass
+            async with reader.execute(
+                f"PRAGMA busy_timeout={_SQLITE_BUSY_TIMEOUT_MS}"
+            ):
+                pass
+            async with reader.execute("PRAGMA journal_mode") as cur:
+                reader_journal_mode_row = await cur.fetchone()
+            reader_journal_mode = (
+                str(reader_journal_mode_row[0]).strip().lower()
+                if reader_journal_mode_row is not None
+                else ""
+            )
+            if reader_journal_mode != "wal":
+                await reader.close()
+                self._warn_transcript_reader_fallback_once(
+                    "journal_mode_not_wal",
+                    reader_journal_mode,
+                )
+                return
+            async with reader.execute("PRAGMA query_only") as cur:
+                query_only_row = await cur.fetchone()
+            if query_only_row is None or int(query_only_row[0]) != 1:
+                raise RuntimeError("transcript reader query-only mode unavailable")
+        except asyncio.CancelledError:
+            if reader is not None:
+                with contextlib.suppress(BaseException):
+                    await reader.close()
+            raise
+        except Exception:
+            if reader is not None:
+                with contextlib.suppress(BaseException):
+                    await reader.close()
+            self._warn_transcript_reader_fallback_once("open_failed", journal_mode)
+            return
+        self._transcript_reader = reader
 
     async def _run_meta_launch_draft_gc(self) -> None:
         """Physically enforce raw-draft retention while the Gateway stays up."""
@@ -1843,10 +1951,15 @@ class SessionStorage:
 
     async def _retire_poisoned_connection(self) -> None:
         self._poisoned = True
-        conn, self._conn = self._conn, None
-        if conn is not None:
-            with contextlib.suppress(BaseException):
-                await conn.close()
+        async with self._transcript_reader_lock:
+            reader, self._transcript_reader = self._transcript_reader, None
+            conn, self._conn = self._conn, None
+            if reader is not None:
+                with contextlib.suppress(BaseException):
+                    await reader.close()
+            if conn is not None:
+                with contextlib.suppress(BaseException):
+                    await conn.close()
 
     async def _finish_sqlite_call(self, awaitable: Awaitable[Any]) -> Any:
         """Do not release the operation gate while a cancelled DB call is still queued."""
@@ -13252,19 +13365,129 @@ class SessionStorage:
             )
         return acceptance_result
 
-    @_serialized_read
-    async def get_transcript(
-        self, session_id: str, limit: int | None = None, offset: int = 0
-    ) -> list[TranscriptEntry]:
+    async def _fetchall_transcript_rows(self, cursor: Any) -> list[Any]:
+        return cast(
+            list[Any],
+            await self._finish_sqlite_call(cursor.fetchall()),
+        )
+
+    async def _fetch_transcript_rows(
+        self,
+        conn: Any,
+        session_id: str,
+        limit: int | None,
+        offset: int,
+    ) -> list[Any]:
         # SQLite requires LIMIT before OFFSET; use -1 for unlimited
         limit_val = limit if limit is not None else -1
         sql = (
             "SELECT * FROM transcript_entries WHERE session_id = ? "
             "ORDER BY created_at ASC, id ASC LIMIT ? OFFSET ?"
         )
-        async with self.conn.execute(sql, (session_id, limit_val, offset)) as cur:
-            rows = await cur.fetchall()
-        return [TranscriptEntry(**_deserialize_row(dict(r))) for r in rows]
+        async with conn.execute(sql, (session_id, limit_val, offset)) as cur:
+            return await self._fetchall_transcript_rows(cur)
+
+    async def _fetch_transcript_rows_on_writer(
+        self,
+        session_id: str,
+        limit: int | None,
+        offset: int,
+    ) -> list[Any]:
+        if not _BOUNDED_INTERACTIVE_READS.get():
+            async with self._operation_lock:
+                self._raise_if_poisoned()
+                return cast(
+                    list[Any],
+                    await self._finish_sqlite_call(
+                        self._fetch_transcript_rows(
+                            self.conn,
+                            session_id,
+                            limit,
+                            offset,
+                        )
+                    )
+                )
+
+        started = self._monotonic()
+        acquired = False
+        try:
+            try:
+                async with asyncio.timeout(self._busy_budget_seconds):
+                    await self._operation_lock.acquire()
+            except TimeoutError as exc:
+                raise StorageBusyError(
+                    "get_transcript",
+                    waited_ms=max(0, int((self._monotonic() - started) * 1000)),
+                    retry_after_ms=_SQLITE_BUSY_TIMEOUT_MS,
+                    stage="lock_acquire",
+                    resource="session_storage_operation_lock",
+                ) from exc
+            acquired = True
+            self._raise_if_poisoned()
+            return cast(
+                list[Any],
+                await self._finish_sqlite_call(
+                    self._fetch_transcript_rows(
+                        self.conn,
+                        session_id,
+                        limit,
+                        offset,
+                    )
+                )
+            )
+        finally:
+            if acquired:
+                self._operation_lock.release()
+
+    @asynccontextmanager
+    async def _transcript_reader_access(self) -> AsyncIterator[Any | None]:
+        acquired = False
+        if not _BOUNDED_INTERACTIVE_READS.get():
+            await self._transcript_reader_lock.acquire()
+            acquired = True
+        else:
+            started = self._monotonic()
+            try:
+                async with asyncio.timeout(self._busy_budget_seconds):
+                    await self._transcript_reader_lock.acquire()
+            except TimeoutError as exc:
+                raise StorageBusyError(
+                    "get_transcript",
+                    waited_ms=max(0, int((self._monotonic() - started) * 1000)),
+                    retry_after_ms=_SQLITE_BUSY_TIMEOUT_MS,
+                    stage="lock_acquire",
+                    resource="session_storage_transcript_reader_lock",
+                ) from exc
+            acquired = True
+        try:
+            self._raise_if_poisoned()
+            yield self._transcript_reader
+        finally:
+            if acquired:
+                self._transcript_reader_lock.release()
+
+    async def get_transcript(
+        self, session_id: str, limit: int | None = None, offset: int = 0
+    ) -> list[TranscriptEntry]:
+        async with self._transcript_reader_access() as reader:
+            if reader is not None:
+                rows = await self._finish_sqlite_call(
+                    self._fetch_transcript_rows(
+                        reader,
+                        session_id,
+                        limit,
+                        offset,
+                    )
+                )
+            else:
+                rows = None
+        if rows is None:
+            rows = await self._fetch_transcript_rows_on_writer(
+                session_id,
+                limit,
+                offset,
+            )
+        return await asyncio.to_thread(_decode_transcript_rows, rows)
 
     @_serialized_read
     async def get_canonical_transcript(

--- a/tests/test_engine/turn_runner/test_compaction_and_history_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_compaction_and_history_stage_unit.py
@@ -130,6 +130,7 @@ def _make_input(
     bound_user_message_id: str | None = None,
     context_window_tokens: int = 200_000,
     skip_compaction: bool = False,
+    transcript_snapshot: Any | None = None,
 ) -> CompactionAndHistoryStageInput:
     if agent is None:
         agent = _make_agent_stub(request_context_prompt=request_context_prompt)
@@ -144,6 +145,7 @@ def _make_input(
         history_has_persisted_user=history_has_persisted_user,
         bound_user_message_id=bound_user_message_id,
         skip_compaction=skip_compaction,
+        transcript_snapshot=transcript_snapshot,
     )
 
 
@@ -302,6 +304,20 @@ async def test_active_prompt_binding_is_forwarded_to_both_compaction_ports() -> 
     for call in (t3.calls[0], preflight.calls[0]):
         assert call["history_has_persisted_user"] is True
         assert call["bound_user_message_id"] == "active-user-message"
+
+
+@pytest.mark.asyncio
+async def test_turn_transcript_snapshot_is_shared_across_all_reading_ports() -> None:
+    stage, t3, preflight, history, _ = _make_stage(
+        t3=_RecordingT3(return_value="not_applicable"),
+    )
+    transcript_snapshot = SimpleNamespace()
+
+    await stage.run(_make_input(transcript_snapshot=transcript_snapshot))
+
+    assert t3.calls[0]["transcript_snapshot"] is transcript_snapshot
+    assert preflight.calls[0]["transcript_snapshot"] is transcript_snapshot
+    assert history.calls[0]["transcript_snapshot"] is transcript_snapshot
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/turn_runner/test_prompt_assembler_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_prompt_assembler_stage_unit.py
@@ -76,6 +76,7 @@ class _RecordingRouterContext:
     context: dict[str, Any] = field(default_factory=dict)
     calls: list[tuple[str, bool]] = field(default_factory=list)
     bound_user_message_ids: list[str | None] = field(default_factory=list)
+    transcript_snapshots: list[Any | None] = field(default_factory=list)
 
     async def fetch_router_context(
         self,
@@ -84,9 +85,11 @@ class _RecordingRouterContext:
         exclude_last_user,
         bound_user_message_id=None,
         include_capacity=False,
+        transcript_snapshot=None,
     ):
         self.calls.append((session_key, exclude_last_user))
         self.bound_user_message_ids.append(bound_user_message_id)
+        self.transcript_snapshots.append(transcript_snapshot)
         return dict(self.context)
 
 
@@ -232,6 +235,7 @@ def _make_input(
     ingress_pipeline_steps=None,
     input_provenance=None,
     skill_catalog=None,
+    transcript_snapshot=None,
 ):
     return PromptAssemblerStageInput(
         runtime_message=runtime_message,
@@ -255,6 +259,7 @@ def _make_input(
         ingress_pipeline_steps=ingress_pipeline_steps,
         input_provenance=input_provenance,
         skill_catalog=skill_catalog,
+        transcript_snapshot=transcript_snapshot,
     )
 
 
@@ -370,6 +375,17 @@ async def test_prompt_assembler_forwards_bound_user_message_id_to_router_context
 
     assert router_context.calls == [("agent:main:s1", True)]
     assert router_context.bound_user_message_ids == ["msg-bound"]
+
+
+@pytest.mark.asyncio
+async def test_prompt_assembler_forwards_turn_transcript_snapshot() -> None:
+    router_context = _RecordingRouterContext()
+    stage = _make_stage(router=router_context)
+    transcript_snapshot = SimpleNamespace()
+
+    await stage.run(_make_input(transcript_snapshot=transcript_snapshot))
+
+    assert router_context.transcript_snapshots == [transcript_snapshot]
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/turn_runner/test_transcript_snapshot.py
+++ b/tests/test_engine/turn_runner/test_transcript_snapshot.py
@@ -1,0 +1,152 @@
+"""Tests for the turn-local lazy transcript snapshot."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from opensquilla.engine.turn_runner import TurnTranscriptSnapshot
+
+
+@pytest.mark.asyncio
+async def test_get_entries_caches_one_successful_load() -> None:
+    calls = 0
+
+    async def loader() -> list[str]:
+        nonlocal calls
+        calls += 1
+        return ["user", "assistant"]
+
+    snapshot = TurnTranscriptSnapshot(loader)
+
+    first = await snapshot.get_entries()
+    second = await snapshot.get_entries()
+
+    assert first == ("user", "assistant")
+    assert second is first
+    assert calls == 1
+    assert snapshot.load_count == 1
+    assert snapshot.generation == 0
+
+
+@pytest.mark.asyncio
+async def test_get_entries_caches_empty_tuple() -> None:
+    calls = 0
+
+    async def loader() -> list[str]:
+        nonlocal calls
+        calls += 1
+        return []
+
+    snapshot = TurnTranscriptSnapshot(loader)
+
+    assert await snapshot.get_entries() == ()
+    assert await snapshot.get_entries() == ()
+    assert calls == 1
+    assert snapshot.load_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_entries_does_not_cache_loader_exception() -> None:
+    calls = 0
+
+    async def loader() -> list[str]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("transient read failure")
+        return ["recovered"]
+
+    snapshot = TurnTranscriptSnapshot(loader)
+
+    with pytest.raises(RuntimeError, match="transient read failure"):
+        await snapshot.get_entries()
+
+    assert await snapshot.get_entries() == ("recovered",)
+    assert calls == 2
+    assert snapshot.load_count == 2
+    assert snapshot.generation == 0
+
+
+@pytest.mark.asyncio
+async def test_invalidate_reloads_in_next_generation() -> None:
+    calls = 0
+
+    async def loader() -> list[int]:
+        nonlocal calls
+        calls += 1
+        return [calls]
+
+    snapshot = TurnTranscriptSnapshot(loader)
+
+    assert await snapshot.get_entries() == (1,)
+    snapshot.invalidate()
+
+    assert snapshot.generation == 1
+    assert snapshot.load_count == 1
+    assert await snapshot.get_entries() == (2,)
+    assert snapshot.load_count == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_get_entries_uses_one_loader_call() -> None:
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def loader() -> list[str]:
+        nonlocal calls
+        calls += 1
+        entered.set()
+        await release.wait()
+        return ["shared"]
+
+    snapshot = TurnTranscriptSnapshot(loader)
+    tasks = [asyncio.create_task(snapshot.get_entries()) for _ in range(8)]
+
+    await entered.wait()
+    release.set()
+    results = await asyncio.gather(*tasks)
+
+    assert results == [("shared",)] * 8
+    assert calls == 1
+    assert snapshot.load_count == 1
+
+
+@pytest.mark.asyncio
+async def test_invalidation_during_load_discards_stale_result() -> None:
+    first_load_entered = asyncio.Event()
+    release_first_load = asyncio.Event()
+    calls = 0
+
+    async def loader() -> list[int]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            first_load_entered.set()
+            await release_first_load.wait()
+        return [calls]
+
+    snapshot = TurnTranscriptSnapshot(loader)
+    task = asyncio.create_task(snapshot.get_entries())
+
+    await first_load_entered.wait()
+    snapshot.invalidate()
+    release_first_load.set()
+
+    assert await task == (2,)
+    assert snapshot.load_count == 2
+    assert snapshot.generation == 1
+
+
+def test_counters_are_read_only() -> None:
+    async def loader() -> list[str]:
+        return []
+
+    snapshot = TurnTranscriptSnapshot(loader)
+
+    with pytest.raises(AttributeError):
+        setattr(snapshot, "load_count", 3)
+    with pytest.raises(AttributeError):
+        setattr(snapshot, "generation", 4)

--- a/tests/test_engine/turn_runner/test_transcript_snapshot_runtime.py
+++ b/tests/test_engine/turn_runner/test_transcript_snapshot_runtime.py
@@ -1,0 +1,507 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from opensquilla.engine.runtime import TurnRunner
+from opensquilla.engine.steps import squilla_router as squilla_router_step
+from opensquilla.engine.types import ErrorEvent, RouterControlReplayEvent
+from opensquilla.gateway.config import (
+    GatewayConfig,
+    SquillaRouterConfig,
+    _router_tier_profile_defaults,
+)
+from opensquilla.provider import (
+    DoneEvent as ProviderDone,
+)
+from opensquilla.provider import (
+    Message,
+    ModelInfo,
+)
+from opensquilla.provider import (
+    TextDeltaEvent as ProviderText,
+)
+from opensquilla.provider import (
+    ToolUseEndEvent as ProviderToolEnd,
+)
+from opensquilla.provider import (
+    ToolUseStartEvent as ProviderToolStart,
+)
+from opensquilla.session.compaction import CompactionResult
+from opensquilla.session.manager import SessionManager
+from opensquilla.session.models import TranscriptEntry
+from opensquilla.session.storage import SessionStorage
+from opensquilla.tools import get_default_registry
+from opensquilla.tools.types import CallerKind, ToolContext
+
+_MODEL = "deepseek/deepseek-v4-pro"
+
+
+class _CountingProvider:
+    provider_name = "openrouter"
+
+    def __init__(self, transcript_read_count: Callable[[], int]) -> None:
+        self._transcript_read_count = transcript_read_count
+        self._model = _MODEL
+        self._api_key = "test-key"
+        self._base_url = "https://example.invalid/v1"
+        self.read_counts_at_dispatch: list[int] = []
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    def chat(
+        self,
+        messages: list[Message],
+        tools: Any = None,
+        config: Any = None,
+    ) -> AsyncIterator[Any]:
+        self.read_counts_at_dispatch.append(self._transcript_read_count())
+        return self._stream()
+
+    async def _stream(self) -> AsyncIterator[Any]:
+        yield ProviderText(text="ok")
+        yield ProviderDone(model=self.model)
+
+    async def list_models(self) -> list[ModelInfo]:
+        return []
+
+
+class _ReplayProvider(_CountingProvider):
+    def chat(
+        self,
+        messages: list[Message],
+        tools: Any = None,
+        config: Any = None,
+    ) -> AsyncIterator[Any]:
+        self.read_counts_at_dispatch.append(self._transcript_read_count())
+        return self._replay_stream(len(self.read_counts_at_dispatch))
+
+    async def _replay_stream(self, call_number: int) -> AsyncIterator[Any]:
+        if call_number == 1:
+            yield ProviderText(text="discarded partial")
+            yield ProviderToolStart(tool_use_id="tool-1", tool_name="router_control")
+            yield ProviderToolEnd(
+                tool_use_id="tool-1",
+                tool_name="router_control",
+                arguments={
+                    "action": "set_hold",
+                    "target_id": "tier:c3",
+                    "evidence": "use c3",
+                },
+            )
+            yield ProviderDone(model=self.model)
+            return
+        yield ProviderText(text="replayed final")
+        yield ProviderDone(model=self.model)
+
+
+class _RetryProvider(_CountingProvider):
+    def chat(
+        self,
+        messages: list[Message],
+        tools: Any = None,
+        config: Any = None,
+    ) -> AsyncIterator[Any]:
+        self.read_counts_at_dispatch.append(self._transcript_read_count())
+        return self._retry_stream(len(self.read_counts_at_dispatch))
+
+    async def _retry_stream(self, call_number: int) -> AsyncIterator[Any]:
+        if call_number == 1:
+            yield ProviderDone(
+                model=self.model,
+                stop_reason="stop",
+                input_tokens=1,
+                output_tokens=0,
+            )
+            return
+        yield ProviderText(text="retry ok")
+        yield ProviderDone(
+            model=self.model,
+            stop_reason="stop",
+            input_tokens=1,
+            output_tokens=1,
+        )
+
+
+class _SelectorClone:
+    def __init__(self, provider: _CountingProvider) -> None:
+        self.provider = provider
+        self.current_config = SimpleNamespace(
+            provider=provider.provider_name,
+            model=provider.model,
+        )
+
+    def override_model(self, model: str) -> None:
+        self.provider._model = model
+        self.current_config = SimpleNamespace(
+            provider=self.provider.provider_name,
+            model=model,
+        )
+
+    def resolve(self) -> _CountingProvider:
+        return self.provider
+
+
+class _Selector:
+    def __init__(self, provider: _CountingProvider) -> None:
+        self.provider = provider
+
+    def clone(self) -> _SelectorClone:
+        return _SelectorClone(self.provider)
+
+
+class _Strategy:
+    async def classify(
+        self,
+        message: str,
+        valid_tiers: list[str],
+        routing_history: list[dict[str, Any]] | None = None,
+        **kwargs: object,
+    ) -> tuple[str, float, str, dict[str, Any]]:
+        return "c1", 0.9, "snapshot-runtime", {"route_class": "R1"}
+
+
+def _config() -> GatewayConfig:
+    return GatewayConfig(llm={"provider": "openrouter", "model": _MODEL})
+
+
+def _tool_context() -> ToolContext:
+    return ToolContext(is_owner=True, caller_kind=CallerKind.CLI)
+
+
+async def _run(runner: TurnRunner, session_key: str) -> list[Any]:
+    return [
+        event
+        async for event in runner.run(
+            "current request",
+            session_key,
+            tool_context=_tool_context(),
+            history_has_persisted_user=False,
+            no_memory_capture=True,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "session_key",
+    [
+        "agent:main:snapshot-normal",
+        "cron:snapshot-normal",
+        "subagent:snapshot-normal",
+    ],
+)
+async def test_normal_turn_reads_transcript_once_before_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    session_key: str,
+) -> None:
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    manager = SessionManager(storage)
+    await manager.create(session_key)
+    original_get_transcript = manager.get_transcript
+    read_count = 0
+
+    async def _counted_get_transcript(
+        key: str,
+        limit: int | None = None,
+    ) -> list[TranscriptEntry]:
+        nonlocal read_count
+        read_count += 1
+        return await original_get_transcript(key, limit=limit)
+
+    monkeypatch.setattr(manager, "get_transcript", _counted_get_transcript)
+    provider = _CountingProvider(lambda: read_count)
+    runner = TurnRunner(
+        provider_selector=_Selector(provider),
+        session_manager=manager,
+        config=_config(),
+    )
+
+    try:
+        events = await _run(runner, session_key)
+    finally:
+        await storage.close()
+
+    assert not any(isinstance(event, ErrorEvent) for event in events)
+    assert provider.read_counts_at_dispatch == [1]
+    assert read_count == 1
+
+
+@pytest.mark.asyncio
+async def test_provider_retry_reuses_loaded_transcript_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    manager = SessionManager(storage)
+    session_key = "agent:main:snapshot-provider-retry"
+    await manager.create(session_key)
+    original_get_transcript = manager.get_transcript
+    read_count = 0
+
+    async def _counted_get_transcript(
+        key: str,
+        limit: int | None = None,
+    ) -> list[TranscriptEntry]:
+        nonlocal read_count
+        read_count += 1
+        return await original_get_transcript(key, limit=limit)
+
+    monkeypatch.setattr(manager, "get_transcript", _counted_get_transcript)
+    provider = _RetryProvider(lambda: read_count)
+    runner = TurnRunner(
+        provider_selector=_Selector(provider),
+        session_manager=manager,
+        config=GatewayConfig(
+            llm={"provider": "openrouter", "model": _MODEL},
+            agent_max_provider_retries=1,
+        ),
+    )
+
+    try:
+        events = await _run(runner, session_key)
+    finally:
+        await storage.close()
+
+    assert not any(isinstance(event, ErrorEvent) for event in events)
+    assert provider.read_counts_at_dispatch == [1, 1]
+    assert read_count == 1
+
+
+@pytest.mark.asyncio
+async def test_router_read_failure_is_retried_by_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    manager = SessionManager(storage)
+    session_key = "cron:snapshot-router-retry"
+    await manager.create(session_key)
+    await manager.append_message(session_key, "assistant", "prior answer")
+    original_get_transcript = manager.get_transcript
+    read_count = 0
+
+    async def _fail_once_then_read(
+        key: str,
+        limit: int | None = None,
+    ) -> list[TranscriptEntry]:
+        nonlocal read_count
+        read_count += 1
+        if read_count == 1:
+            raise RuntimeError("router read failed")
+        return await original_get_transcript(key, limit=limit)
+
+    monkeypatch.setattr(manager, "get_transcript", _fail_once_then_read)
+    provider = _CountingProvider(lambda: read_count)
+    runner = TurnRunner(
+        provider_selector=_Selector(provider),
+        session_manager=manager,
+        config=_config(),
+    )
+
+    try:
+        events = await _run(runner, session_key)
+    finally:
+        await storage.close()
+
+    assert not any(isinstance(event, ErrorEvent) for event in events)
+    assert provider.read_counts_at_dispatch == [2]
+    assert read_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("compaction_result", "expected_read_count"),
+    [
+        pytest.param(
+            CompactionResult(
+                summary="compacted durable history",
+                kept_entries=[],
+                removed_count=1,
+                chunks_processed=1,
+                summary_source="fallback",
+                tokens_before=10_000,
+                tokens_after=8,
+                remaining_budget_tokens=56,
+            ),
+            2,
+            id="durable-rows-changed",
+        ),
+        pytest.param(
+            CompactionResult(
+                summary="rolled checkpoint",
+                kept_entries=[],
+                removed_count=0,
+                chunks_processed=1,
+                summary_source="fallback",
+                tokens_before=10_000,
+                tokens_after=8,
+                remaining_budget_tokens=56,
+                replaced_previous_summary=True,
+            ),
+            1,
+            id="checkpoint-only",
+        ),
+        pytest.param(
+            CompactionResult(
+                summary="",
+                kept_entries=[],
+                removed_count=0,
+                chunks_processed=0,
+                summary_source="skipped",
+                tokens_before=10_000,
+                tokens_after=10_000,
+                remaining_budget_tokens=0,
+                skip_reason="stale_preimage",
+            ),
+            1,
+            id="stale-preimage",
+        ),
+    ],
+)
+async def test_preflight_invalidates_snapshot_only_when_transcript_rows_change(
+    monkeypatch: pytest.MonkeyPatch,
+    compaction_result: CompactionResult,
+    expected_read_count: int,
+) -> None:
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    manager = SessionManager(storage)
+    session_key = "agent:main:snapshot-compacted"
+    node = await manager.create(session_key)
+    compacted = False
+    compaction_called = False
+    read_count = 0
+    before = TranscriptEntry(
+        session_id=node.session_id,
+        session_key=session_key,
+        message_id="before-compaction",
+        role="assistant",
+        content="old durable history",
+        token_count=10_000,
+    )
+    after = TranscriptEntry(
+        session_id=node.session_id,
+        session_key=session_key,
+        message_id="after-compaction",
+        role="system",
+        content="[Context Summary] compacted durable history",
+        token_count=8,
+    )
+
+    async def _versioned_get_transcript(
+        key: str,
+        limit: int | None = None,
+    ) -> list[TranscriptEntry]:
+        nonlocal read_count
+        assert key == session_key
+        assert limit is None
+        read_count += 1
+        return [after] if compacted else [before]
+
+    async def _compact_with_result(
+        key: str,
+        context_window_tokens: int,
+        config: Any = None,
+        **kwargs: Any,
+    ) -> CompactionResult:
+        nonlocal compacted, compaction_called
+        assert key == session_key
+        assert context_window_tokens == 64
+        compaction_called = True
+        compacted = bool(
+            compaction_result.summary and compaction_result.removed_count > 0
+        )
+        return compaction_result
+
+    monkeypatch.setattr(manager, "get_transcript", _versioned_get_transcript)
+    monkeypatch.setattr(manager, "compact_with_result", _compact_with_result)
+    provider = _CountingProvider(lambda: read_count)
+    runner = TurnRunner(
+        provider_selector=_Selector(provider),
+        session_manager=manager,
+        config=_config(),
+    )
+    original_preflight = runner._maybe_preflight_compact
+
+    async def _force_small_preflight_window(
+        key: str,
+        context_window_tokens: int,
+        **kwargs: Any,
+    ) -> None:
+        kwargs["history_capacity_tokens"] = 64
+        kwargs["history_capacity_chars"] = 256
+        await original_preflight(key, 64, **kwargs)
+
+    async def _checkpoint_succeeds(*args: Any, **kwargs: Any) -> bool:
+        return True
+
+    monkeypatch.setattr(runner, "_maybe_preflight_compact", _force_small_preflight_window)
+    monkeypatch.setattr(runner, "_record_checkpoint_before_compaction", _checkpoint_succeeds)
+    monkeypatch.setattr(runner, "_pre_compaction_flush_enabled", lambda: False)
+
+    try:
+        events = await _run(runner, session_key)
+    finally:
+        await storage.close()
+
+    assert not any(isinstance(event, ErrorEvent) for event in events)
+    assert compaction_called is True
+    assert provider.read_counts_at_dispatch == [expected_read_count]
+    assert read_count == expected_read_count
+
+
+@pytest.mark.asyncio
+async def test_router_control_replay_uses_fresh_turn_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(squilla_router_step, "_get_strategy", lambda _cfg: _Strategy())
+    storage = SessionStorage(":memory:")
+    await storage.connect()
+    manager = SessionManager(storage)
+    session_key = "agent:main:snapshot-router-control-replay"
+    await manager.create(session_key)
+    original_get_transcript = manager.get_transcript
+    read_count = 0
+
+    async def _counted_get_transcript(
+        key: str,
+        limit: int | None = None,
+    ) -> list[TranscriptEntry]:
+        nonlocal read_count
+        read_count += 1
+        return await original_get_transcript(key, limit=limit)
+
+    monkeypatch.setattr(manager, "get_transcript", _counted_get_transcript)
+    provider = _ReplayProvider(lambda: read_count)
+    config = GatewayConfig(
+        llm={"provider": "openrouter", "model": _MODEL},
+        squilla_router=SquillaRouterConfig(
+            enabled=True,
+            rollout_phase="full",
+            require_router_runtime=False,
+            tiers=_router_tier_profile_defaults("openrouter"),
+        ),
+    )
+    runner = TurnRunner(
+        provider_selector=_Selector(provider),
+        session_manager=manager,
+        tool_registry=get_default_registry(),
+        config=config,
+    )
+
+    try:
+        events = await _run(runner, session_key)
+    finally:
+        await storage.close()
+
+    assert not any(isinstance(event, ErrorEvent) for event in events)
+    assert len([event for event in events if isinstance(event, RouterControlReplayEvent)]) == 1
+    assert provider.read_counts_at_dispatch == [1, 2]
+    assert read_count == 2

--- a/tests/test_session/test_manager.py
+++ b/tests/test_session/test_manager.py
@@ -2615,6 +2615,91 @@ async def test_compact_with_result_returns_source_and_persists(manager):
     assert [entry.content for entry in transcript] == original_contents[-len(transcript) :]
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("config", "expected_protected_recent_messages"),
+    [
+        pytest.param(
+            CompactionConfig(protected_recent_messages=1),
+            2,
+            id="explicit-protection",
+        ),
+        pytest.param(
+            CompactionConfig(compaction_profile="coding"),
+            12,
+            id="profile-protection",
+        ),
+    ],
+)
+async def test_compact_with_result_recomputes_bound_to_tail_protection(
+    manager,
+    monkeypatch,
+    config,
+    expected_protected_recent_messages,
+):
+    node = await manager.create("agent:main:protected-boundary")
+    await manager.append_message(node.session_key, "user", "old question")
+    await manager.append_message(node.session_key, "assistant", "old answer")
+    active_user = await manager.append_message(node.session_key, "user", "active request")
+    await manager.append_message(node.session_key, "user", "queued request")
+    observed: dict[str, Any] = {}
+
+    async def compact_context_spy(request):
+        observed["protected_recent_messages"] = request.config.protected_recent_messages
+        return CompactionResult(
+            summary="",
+            kept_entries=request.entries,
+            removed_count=0,
+            chunks_processed=0,
+            summary_source="skipped",
+        )
+
+    monkeypatch.setattr(session_manager_module, "compact_context", compact_context_spy)
+
+    result = await manager.compact_with_result(
+        node.session_key,
+        context_window_tokens=1_000,
+        config=config,
+        protected_boundary_message_id=active_user.message_id,
+    )
+
+    assert result.removed_count == 0
+    assert observed["protected_recent_messages"] == expected_protected_recent_messages
+
+
+@pytest.mark.asyncio
+async def test_compact_with_result_missing_protected_boundary_fails_closed(
+    manager,
+    monkeypatch,
+):
+    node = await manager.create("agent:main:missing-protected-boundary")
+    entry = await manager.append_message(node.session_key, "user", "active request")
+
+    async def unexpected_compact_context(request):  # noqa: ARG001
+        raise AssertionError("compaction must not run without the protected boundary")
+
+    monkeypatch.setattr(
+        session_manager_module,
+        "compact_context",
+        unexpected_compact_context,
+    )
+
+    result = await manager.compact_with_result(
+        node.session_key,
+        context_window_tokens=1_000,
+        protected_boundary_message_id="missing-message-id",
+    )
+
+    assert result.summary == ""
+    assert result.removed_count == 0
+    assert result.skip_reason == "protected_boundary_missing"
+    transcript = await manager.get_transcript(node.session_key)
+    assert [candidate.message_id for candidate in transcript] == [entry.message_id]
+    current = await manager.get_session(node.session_key)
+    assert current is not None
+    assert current.compaction_count == 0
+
+
 def test_compaction_singleflight_target_fingerprint_is_credential_aware():
     first = CompactionConfig(provider="provider-a", model="model-a", api_key="secret-a")
     same_deployment_and_credentials = CompactionConfig(
@@ -3577,6 +3662,29 @@ async def test_persist_compaction_result_preserves_structured_tail_metadata(mana
     assert transcript[0].reasoning_content == "signed reasoning"
     assert transcript[1].tool_call_id == "tool-live"
     assert transcript[1].content == "result"
+
+
+@pytest.mark.asyncio
+async def test_capture_compaction_source_uses_supplied_transcript_entries(
+    manager,
+    monkeypatch,
+):
+    node = await manager.create("agent:main:capture-snapshot")
+    await manager.append_message(node.session_key, "user", "old question")
+    active_user = await manager.append_message(node.session_key, "user", "active request")
+    transcript = await manager.get_transcript(node.session_key)
+    get_transcript = AsyncMock(side_effect=AssertionError("unexpected transcript reread"))
+    monkeypatch.setattr(manager, "get_transcript", get_transcript)
+
+    source = await manager.capture_compaction_source(
+        node.session_key,
+        boundary_message_id=active_user.message_id,
+        transcript_entries=transcript,
+    )
+
+    get_transcript.assert_not_awaited()
+    assert source.entries == tuple(transcript)
+    assert source.boundary_message_id == active_user.message_id
 
 
 @pytest.mark.asyncio

--- a/tests/test_session/test_storage_transactions.py
+++ b/tests/test_session/test_storage_transactions.py
@@ -462,7 +462,7 @@ async def test_cancelled_transcript_fetch_settles_before_releasing_connection() 
 
     cursor.release.set()
     with pytest.raises(asyncio.CancelledError):
-        await fetch
+        await asyncio.gather(fetch)
 
 
 @pytest.mark.asyncio
@@ -505,7 +505,7 @@ async def test_cancelled_reader_query_settles_before_lock_release(tmp_path) -> N
 
         release.set()
         with pytest.raises(asyncio.CancelledError):
-            await read
+            await asyncio.gather(read)
         assert storage._transcript_reader_lock.locked() is False
         await set_progress_handler(None, 0)
     finally:

--- a/tests/test_session/test_storage_transactions.py
+++ b/tests/test_session/test_storage_transactions.py
@@ -9,18 +9,29 @@ clock timing or external services.
 from __future__ import annotations
 
 import asyncio
+import logging
 import sqlite3
+import threading
 from collections.abc import Coroutine
 from typing import Any
 
 import pytest
 
-from opensquilla.session.models import AgentTaskRecord, AgentTaskStatus
+from opensquilla.session import storage as storage_module
+from opensquilla.session.models import (
+    AgentTaskRecord,
+    AgentTaskStatus,
+    SessionNode,
+    TranscriptEntry,
+)
 from opensquilla.session.storage import (
     SessionStorage,
     StorageBusyError,
     bounded_interactive_storage_reads,
 )
+
+_TRANSCRIPT_SESSION_KEY = "agent:main:webchat:transcript-reader"
+_TRANSCRIPT_SESSION_ID = "session-transcript-reader"
 
 
 def _agent_task(task_id: str) -> AgentTaskRecord:
@@ -33,6 +44,63 @@ def _agent_task(task_id: str) -> AgentTaskRecord:
         status=AgentTaskStatus.QUEUED,
         created_at=100,
         updated_at=100,
+    )
+
+
+def _transcript_session(
+    *,
+    session_key: str = _TRANSCRIPT_SESSION_KEY,
+    session_id: str = _TRANSCRIPT_SESSION_ID,
+) -> SessionNode:
+    return SessionNode(
+        session_key=session_key,
+        session_id=session_id,
+        agent_id="main",
+        created_at=100,
+        updated_at=100,
+        epoch=0,
+    )
+
+
+def _transcript_entry(
+    message_id: str,
+    *,
+    created_at: int,
+    session_key: str = _TRANSCRIPT_SESSION_KEY,
+    session_id: str = _TRANSCRIPT_SESSION_ID,
+) -> TranscriptEntry:
+    return TranscriptEntry(
+        session_id=session_id,
+        session_key=session_key,
+        message_id=message_id,
+        role="user",
+        content=f"content-{message_id}",
+        created_at=created_at,
+    )
+
+
+async def _accept_transcript_turn(
+    storage: SessionStorage,
+    message_id: str,
+    *,
+    updated_at: int,
+    session_key: str = _TRANSCRIPT_SESSION_KEY,
+    session_id: str = _TRANSCRIPT_SESSION_ID,
+) -> Any:
+    return await storage.accept_turn(
+        _transcript_entry(
+            message_id,
+            created_at=updated_at,
+            session_key=session_key,
+            session_id=session_id,
+        ),
+        expected_epoch=0,
+        updated_at=updated_at,
+        task_record=None,
+        source_scope="webui",
+        request_session_key=session_key,
+        client_request_id=f"request-{message_id}",
+        request_fingerprint=f"sha256:{message_id}",
     )
 
 
@@ -121,6 +189,17 @@ class _RollbackGateConnection:
 
     def release_rollback(self) -> None:
         self._release.set()
+
+
+class _FetchallGateCursor:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def fetchall(self) -> list[Any]:
+        self.started.set()
+        await self.release.wait()
+        return []
 
 
 @pytest.mark.asyncio
@@ -336,3 +415,479 @@ async def test_repeated_cancellation_during_rollback_does_not_poison_connection(
         gate.release_rollback()
         await asyncio.gather(write, return_exceptions=True)
         await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_file_wal_opens_persistent_query_only_transcript_reader(tmp_path) -> None:
+    storage = await SessionStorage.open(str(tmp_path / "sessions.db"))
+    try:
+        reader = storage._transcript_reader
+        assert reader is not None
+        assert reader is not storage.conn
+        async with reader.execute("PRAGMA query_only") as cursor:
+            row = await cursor.fetchone()
+        assert row is not None
+        assert int(row[0]) == 1
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_bounded_transcript_reader_lock_wait_reports_storage_busy(tmp_path) -> None:
+    storage = await SessionStorage.open(str(tmp_path / "sessions.db"))
+    storage._busy_budget_seconds = 0.0
+    await storage._transcript_reader_lock.acquire()
+    try:
+        with bounded_interactive_storage_reads():
+            with pytest.raises(StorageBusyError) as caught:
+                await storage.get_transcript(_TRANSCRIPT_SESSION_ID)
+        assert caught.value.operation == "get_transcript"
+        assert caught.value.stage == "lock_acquire"
+        assert caught.value.resource == "session_storage_transcript_reader_lock"
+    finally:
+        storage._transcript_reader_lock.release()
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_transcript_fetch_settles_before_releasing_connection() -> None:
+    storage = SessionStorage(":memory:")
+    cursor = _FetchallGateCursor()
+    fetch = asyncio.create_task(storage._fetchall_transcript_rows(cursor))
+    await asyncio.wait_for(cursor.started.wait(), timeout=1.0)
+
+    fetch.cancel()
+    await asyncio.sleep(0)
+    assert fetch.done() is False
+
+    cursor.release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await fetch
+
+
+@pytest.mark.asyncio
+async def test_cancelled_reader_query_settles_before_lock_release(tmp_path) -> None:
+    storage = await SessionStorage.open(str(tmp_path / "sessions.db"))
+    read: asyncio.Task[list[TranscriptEntry]] | None = None
+    release = threading.Event()
+    try:
+        await storage.upsert_session(_transcript_session())
+        await storage.append_transcript_entry(
+            _transcript_entry("cancelled-reader", created_at=150),
+            expected_epoch=0,
+        )
+        reader = storage._transcript_reader
+        assert reader is not None
+        set_progress_handler = getattr(reader, "set_progress_handler", None)
+        if not callable(set_progress_handler):
+            pytest.skip("active aiosqlite backend does not expose a progress handler")
+
+        entered = threading.Event()
+        calls = 0
+
+        def block_reader_worker() -> int:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                entered.set()
+                release.wait(5)
+            return 0
+
+        await set_progress_handler(block_reader_worker, 1)
+        read = asyncio.create_task(storage.get_transcript(_TRANSCRIPT_SESSION_ID))
+        assert await asyncio.wait_for(asyncio.to_thread(entered.wait), timeout=1.0)
+
+        read.cancel()
+        await asyncio.sleep(0)
+
+        assert read.done() is False
+        assert storage._transcript_reader_lock.locked() is True
+
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await read
+        assert storage._transcript_reader_lock.locked() is False
+        await set_progress_handler(None, 0)
+    finally:
+        release.set()
+        if read is not None:
+            await asyncio.gather(read, return_exceptions=True)
+        await storage.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cross_session", [False, True])
+async def test_slow_transcript_reader_does_not_block_accept_turn(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    cross_session: bool,
+) -> None:
+    storage = await SessionStorage.open(str(tmp_path / "sessions.db"))
+    read: asyncio.Task[list[TranscriptEntry]] | None = None
+    try:
+        assert storage._transcript_reader is not None
+        await storage.upsert_session(_transcript_session())
+        write_session_key = (
+            "agent:main:webchat:transcript-writer"
+            if cross_session
+            else _TRANSCRIPT_SESSION_KEY
+        )
+        write_session_id = (
+            "session-transcript-writer" if cross_session else _TRANSCRIPT_SESSION_ID
+        )
+        if cross_session:
+            await storage.upsert_session(
+                _transcript_session(
+                    session_key=write_session_key,
+                    session_id=write_session_id,
+                )
+            )
+        await storage.append_transcript_entry(
+            _transcript_entry("existing", created_at=150),
+            expected_epoch=0,
+        )
+        fetch_started = asyncio.Event()
+        original_fetchall = storage._fetchall_transcript_rows
+
+        async def slow_fetchall(cursor: Any) -> list[Any]:
+            fetch_started.set()
+            await asyncio.sleep(2.35)
+            return await original_fetchall(cursor)
+
+        monkeypatch.setattr(storage, "_fetchall_transcript_rows", slow_fetchall)
+        read = asyncio.create_task(storage.get_transcript(_TRANSCRIPT_SESSION_ID))
+        await asyncio.wait_for(fetch_started.wait(), timeout=1.0)
+
+        await asyncio.wait_for(
+            _accept_transcript_turn(
+                storage,
+                "accepted-during-read",
+                updated_at=200,
+                session_key=write_session_key,
+                session_id=write_session_id,
+            ),
+            timeout=1.5,
+        )
+        assert read.done() is False
+
+        await asyncio.wait_for(read, timeout=3.0)
+        monkeypatch.setattr(storage, "_fetchall_transcript_rows", original_fetchall)
+        persisted = await storage.get_transcript(write_session_id)
+        expected = ["accepted-during-read"] if cross_session else [
+            "existing",
+            "accepted-during-read",
+        ]
+        assert [entry.message_id for entry in persisted] == expected
+    finally:
+        if read is not None:
+            await asyncio.gather(read, return_exceptions=True)
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_transcript_reader_observes_only_committed_writer_state(tmp_path) -> None:
+    storage = await SessionStorage.open(str(tmp_path / "sessions.db"))
+    gate: _CommitGateConnection | None = None
+    write: asyncio.Task[Any] | None = None
+    try:
+        assert storage._transcript_reader is not None
+        await storage.upsert_session(_transcript_session())
+        gate = _CommitGateConnection(storage.conn, commit_count=1)
+        storage._conn = gate
+        write = asyncio.create_task(
+            _accept_transcript_turn(storage, "pending-commit", updated_at=200)
+        )
+        await gate.wait_until_commit(0)
+
+        assert await asyncio.wait_for(
+            storage.get_transcript(_TRANSCRIPT_SESSION_ID),
+            timeout=0.5,
+        ) == []
+
+        gate.release_commit(0)
+        await asyncio.wait_for(write, timeout=1.0)
+        committed = await storage.get_transcript(_TRANSCRIPT_SESSION_ID)
+        assert [entry.message_id for entry in committed] == ["pending-commit"]
+    finally:
+        if gate is not None:
+            gate.release_all()
+        if write is not None:
+            await asyncio.gather(write, return_exceptions=True)
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_transcript_decode_runs_after_fetch_on_worker_thread(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = await SessionStorage.open(str(tmp_path / "sessions.db"))
+    try:
+        await storage.upsert_session(_transcript_session())
+        await storage.append_transcript_entry(
+            _transcript_entry("decode", created_at=150),
+            expected_epoch=0,
+        )
+        event_loop_thread = threading.get_ident()
+        decode_threads: list[int] = []
+        original_decode = storage_module._decode_transcript_rows
+
+        def observe_decode(rows: list[Any]) -> list[TranscriptEntry]:
+            decode_threads.append(threading.get_ident())
+            assert rows
+            assert not isinstance(rows[0], dict)
+            return original_decode(rows)
+
+        monkeypatch.setattr(storage_module, "_decode_transcript_rows", observe_decode)
+
+        transcript = await storage.get_transcript(_TRANSCRIPT_SESSION_ID)
+
+        assert [entry.message_id for entry in transcript] == ["decode"]
+        assert decode_threads
+        assert decode_threads[0] != event_loop_thread
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_memory_transcript_reader_warns_once_and_falls_back(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING, logger=storage_module.__name__)
+    storage = await SessionStorage.open(":memory:")
+    try:
+        assert storage._transcript_reader is None
+        await storage.upsert_session(_transcript_session())
+        await storage.append_transcript_entry(
+            _transcript_entry("memory", created_at=150),
+            expected_epoch=0,
+        )
+        assert [
+            entry.message_id
+            for entry in await storage.get_transcript(_TRANSCRIPT_SESSION_ID)
+        ] == ["memory"]
+        storage._busy_budget_seconds = 0.0
+        await storage._operation_lock.acquire()
+        try:
+            with bounded_interactive_storage_reads():
+                with pytest.raises(StorageBusyError) as caught:
+                    await storage.get_transcript(_TRANSCRIPT_SESSION_ID)
+            assert caught.value.operation == "get_transcript"
+            assert caught.value.resource == "session_storage_operation_lock"
+        finally:
+            storage._operation_lock.release()
+    finally:
+        await storage.close()
+
+    warnings = [
+        record
+        for record in caplog.records
+        if "session_storage.transcript_reader_fallback" in record.getMessage()
+    ]
+    assert len(warnings) == 1
+    assert warnings[0].getMessage() == (
+        "session_storage.transcript_reader_fallback "
+        "reason=memory_database journal_mode=memory"
+    )
+    assert warnings[0].reason == "memory_database"
+    assert warnings[0].journal_mode == "memory"
+
+
+@pytest.mark.asyncio
+async def test_non_wal_transcript_reader_warns_once_without_database_path(
+    tmp_path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    private_path = tmp_path / "private-customer-session.db"
+    storage = SessionStorage(str(private_path))
+    caplog.set_level(logging.WARNING, logger=storage_module.__name__)
+
+    await storage._open_transcript_reader("delete")
+    await storage._open_transcript_reader("truncate")
+
+    assert storage._transcript_reader is None
+    warnings = [
+        record
+        for record in caplog.records
+        if "session_storage.transcript_reader_fallback" in record.getMessage()
+    ]
+    assert len(warnings) == 1
+    assert warnings[0].reason == "journal_mode_not_wal"
+    assert warnings[0].journal_mode == "delete"
+    assert str(private_path) not in warnings[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_transcript_reader_open_failure_warns_once_and_uses_writer_fallback(
+    tmp_path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    private_path = tmp_path / "private-open-failure.db"
+    real_connect = storage_module.aiosqlite.connect
+    connect_calls = 0
+
+    def fail_reader_connect(*args: Any, **kwargs: Any) -> Any:
+        nonlocal connect_calls
+        connect_calls += 1
+        if connect_calls == 2:
+            raise OSError("sensitive reader failure body")
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(storage_module.aiosqlite, "connect", fail_reader_connect)
+    caplog.set_level(logging.WARNING, logger=storage_module.__name__)
+    storage = await SessionStorage.open(str(private_path))
+    try:
+        assert storage._transcript_reader is None
+        await storage.upsert_session(_transcript_session())
+        await storage.append_transcript_entry(
+            _transcript_entry("fallback", created_at=150),
+            expected_epoch=0,
+        )
+        transcript = await storage.get_transcript(_TRANSCRIPT_SESSION_ID)
+        assert [entry.message_id for entry in transcript] == ["fallback"]
+    finally:
+        await storage.close()
+
+    warnings = [
+        record
+        for record in caplog.records
+        if "session_storage.transcript_reader_fallback" in record.getMessage()
+    ]
+    assert len(warnings) == 1
+    assert warnings[0].reason == "open_failed"
+    assert warnings[0].journal_mode == "wal"
+    assert str(private_path) not in warnings[0].getMessage()
+    assert "sensitive reader failure body" not in warnings[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_non_ascii_database_path_releases_reader_handle_on_close(tmp_path) -> None:
+    db_path = tmp_path / "会话 数据.db"
+    moved_path = tmp_path / "已关闭 数据.db"
+    storage = await SessionStorage.open(str(db_path))
+    assert storage._transcript_reader is not None
+
+    await storage.close()
+    db_path.replace(moved_path)
+    moved_path.unlink()
+
+    assert not moved_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_retires_existing_connections_before_reopening(tmp_path) -> None:
+    db_path = tmp_path / "reconnect 会话.db"
+    moved_path = tmp_path / "reconnect 已关闭.db"
+    storage = await SessionStorage.open(str(db_path))
+    first_writer = storage.conn
+    first_reader = storage._transcript_reader
+    assert first_reader is not None
+
+    await storage.connect()
+
+    assert storage.conn is not first_writer
+    assert storage._transcript_reader is not None
+    assert storage._transcript_reader is not first_reader
+    with pytest.raises((ValueError, sqlite3.ProgrammingError)):
+        await first_writer.execute("SELECT 1")
+    with pytest.raises((ValueError, sqlite3.ProgrammingError)):
+        await first_reader.execute("SELECT 1")
+
+    await storage.close()
+    db_path.replace(moved_path)
+    moved_path.unlink()
+    assert not moved_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_after_poison_restores_reader_and_writer(tmp_path) -> None:
+    storage = await SessionStorage.open(str(tmp_path / "poison-reconnect.db"))
+    await storage._retire_poisoned_connection()
+    assert storage._poisoned is True
+
+    await storage.connect()
+    try:
+        assert storage._poisoned is False
+        assert storage._transcript_reader is not None
+        await storage.upsert_session(_transcript_session())
+        await storage.append_transcript_entry(
+            _transcript_entry("after-reconnect", created_at=150),
+            expected_epoch=0,
+        )
+        transcript = await storage.get_transcript(_TRANSCRIPT_SESSION_ID)
+        assert [entry.message_id for entry in transcript] == ["after-reconnect"]
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_existing_database_reopens_with_reader_and_passes_quick_check(
+    tmp_path,
+) -> None:
+    db_path = tmp_path / "existing-v21.db"
+    storage = await SessionStorage.open(str(db_path))
+    await storage.upsert_session(_transcript_session())
+    await storage.append_transcript_entry(
+        _transcript_entry("existing-v21", created_at=150),
+        expected_epoch=0,
+    )
+    await storage.close()
+
+    reopened = await SessionStorage.open(str(db_path))
+    try:
+        assert reopened._transcript_reader is not None
+        transcript = await reopened.get_transcript(_TRANSCRIPT_SESSION_ID)
+        assert [entry.message_id for entry in transcript] == ["existing-v21"]
+        async with reopened.conn.execute("PRAGMA quick_check") as cursor:
+            row = await cursor.fetchone()
+        assert row is not None
+        assert str(row[0]).lower() == "ok"
+    finally:
+        await reopened.close()
+
+
+@pytest.mark.asyncio
+async def test_close_takes_writer_lock_before_transcript_reader_lock(tmp_path) -> None:
+    storage = await SessionStorage.open(str(tmp_path / "sessions.db"))
+    close: asyncio.Task[None] | None = None
+    await storage._transcript_reader_lock.acquire()
+    try:
+        close = asyncio.create_task(storage.close())
+        for _ in range(100):
+            if storage._operation_lock.locked():
+                break
+            await asyncio.sleep(0)
+        assert storage._operation_lock.locked()
+        assert close.done() is False
+    finally:
+        storage._transcript_reader_lock.release()
+    assert close is not None
+    await asyncio.wait_for(close, timeout=1.0)
+    assert storage._transcript_reader is None
+    assert storage._conn is None
+
+
+@pytest.mark.asyncio
+async def test_poison_retirement_closes_transcript_reader_without_lock_inversion(
+    tmp_path,
+) -> None:
+    storage = await SessionStorage.open(str(tmp_path / "sessions.db"))
+    retirement: asyncio.Task[None] | None = None
+    await storage._operation_lock.acquire()
+    await storage._transcript_reader_lock.acquire()
+    try:
+        retirement = asyncio.create_task(storage._retire_poisoned_connection())
+        await asyncio.sleep(0)
+        assert storage._poisoned is True
+        assert retirement.done() is False
+    finally:
+        storage._transcript_reader_lock.release()
+    assert retirement is not None
+    try:
+        await asyncio.wait_for(retirement, timeout=1.0)
+    finally:
+        storage._operation_lock.release()
+    assert storage._transcript_reader is None
+    assert storage._conn is None
+    await storage.close()


### PR DESCRIPTION
## Scope

Scope boundary:

- Reuse one lazy transcript snapshot across router, compaction preflight, history assembly, and compaction capture within each turn.
- Reload the turn snapshot only after a durable transcript rewrite.
- Protect the active bound-user suffix when compacting against the latest persisted transcript.
- Read transcripts through a persistent query-only connection for file-backed WAL databases, with decoding outside the reader lock.
- Fall back to the existing serialized read path with one sanitized operator warning when a dedicated reader is unavailable.

Non-goals:

- No database schema, migration, configuration, RPC, CLI, provider payload, or client protocol changes.
- No general rewrite of session storage locking or connection pooling.
- No unrelated prompt-assembly performance changes.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: The contention was reproduced and fixed during a focused runtime/storage audit; no public issue currently tracks it.

## Release Note

Release note: Reduce temporary session storage busy failures when turns with large persisted histories overlap new message writes.

## Tests

Ruff: affected runtime, session, and regression-test files pass.

Mypy: `src/opensquilla` passes (`949` source files).

Pytest: post-rebase focused suite: `216 passed, 1 skipped`; broader pre-rebase affected suite: `792 passed, 1 skipped`.

Build: not run; packaging and generated assets are unchanged.

Regression tests: added

Notes:

- Covers one-query normal turns, retry-after-read-failure, router-control replay, durable compaction invalidation, bound-user protection, reader fallback, reconnect/poison lifecycle, query-only enforcement, lock deadlines, and concurrent writes during a blocked reader.
- A real Gateway + Web UI health check used one TokenRhythm provider request against a synthetic 2,000-entry session: one transcript query, concurrent write accepted, no `STORAGE_BUSY`, and SQLite `quick_check=ok`.
- The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: yes

Surface: provider, browser, gateway

Maintainer-only note: one minimal billable provider turn was run through isolated temporary state; no request headers, credentials, or real transcripts were recorded.

## Safety

- No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are committed.
- The fallback warning contains only an enumerated reason and journal mode. It is visible to operators through Gateway logs, not in ordinary chat responses or notifications.
- Platform-neutral Python/SQLite behavior; no POSIX-only path or process assumptions were introduced. The reader uses a normal SQLite connection rather than file URIs, preserving Windows path compatibility.
- Existing databases remain directly compatible; no migration or persisted contract changes are required.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A; no external code, comments, fixtures, identifiers, or wording were copied or adapted.

## Documentation Changes

- [x] No documentation changes are required; public interfaces and configuration are unchanged.
- [x] No new links, code fences, or Markdown tables are introduced.
- [x] Tests and PR notes use synthetic data and contain no real secrets, local paths, or private transcripts.
