### PR TITLE
Recover bounded reasoning-only image turns

### DIFF
--- a/scripts/live_provider_profile_gateway_e2e.py
+++ b/scripts/live_provider_profile_gateway_e2e.py
@@ -726,7 +726,8 @@ def _run_provider(provider: str, *, max_tokens: int, timeout_seconds: float) -> 
     requested_base_url = os.environ.get(BASE_ENV.get(provider, ""), "").strip()
     base_url = registry_endpoint(provider, requested_base_url or None)
     tiers = _profile_tiers(provider)
-    max_tokens = max(max_tokens, 1024) if provider == "tokenrhythm" else max_tokens
+    # This is a live-profile test floor, not a product default or runtime clamp.
+    max_tokens = max(max_tokens, 4096) if provider == "tokenrhythm" else max_tokens
     slot_targets = _profile_slot_targets(tiers)
     if not api_key:
         return {

--- a/scripts/live_provider_profile_smoke.py
+++ b/scripts/live_provider_profile_smoke.py
@@ -165,15 +165,15 @@ _DEFAULT_MODELS = {
     "tokenrhythm": "deepseek-v4-flash",
 }
 
-# Providers whose models spend reasoning tokens out of max_tokens before any
-# text: the CLI default budget of 64 would come back as empty content with
-# finish_reason "length", failing the smoke for provider-independent reasons.
+# Test-only floors for providers whose models spend reasoning tokens out of
+# max_tokens before any text. These keep the CLI's default 64-token live smoke
+# from failing for provider-independent reasons; exact probes can bypass them.
 _MIN_MAX_TOKENS = {
     # MiniMax M2.7 honors the output cap exactly and may spend most of a
     # 32-token smoke on its answer preamble before reaching the marker.
     # Sixty-four remains inside the ordinary-smoke contract.
     "minimax": 64,
-    "tokenrhythm": 1024,
+    "tokenrhythm": 4096,
 }
 
 _DIRECT_TIMEOUT_SECONDS = 60.0

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -4115,7 +4115,36 @@ class Agent:
             **payload,
         )
 
-    def _switch_to_invalid_response_fallback(self, reason: str) -> bool:
+    def _switch_to_invalid_response_fallback(
+        self,
+        reason: str,
+        *,
+        requires_vision: bool = False,
+    ) -> bool:
+        if requires_vision:
+            constrained_fallback = getattr(
+                self.provider,
+                "fallback_after_invalid_response_with_capabilities",
+                None,
+            )
+            if not callable(constrained_fallback):
+                return False
+            try:
+                return bool(
+                    constrained_fallback(
+                        reason,
+                        requires_vision=True,
+                    )
+                )
+            except Exception as exc:  # noqa: BLE001 - fallback support is optional
+                logger.warning(
+                    "provider.invalid_response_fallback_failed",
+                    session_key=self._session_key,
+                    reason=reason,
+                    requires_vision=True,
+                    error=str(exc),
+                )
+                return False
         fallback = getattr(self.provider, "fallback_after_invalid_response", None)
         if not callable(fallback):
             return False
@@ -4129,6 +4158,68 @@ class Agent:
                 error=str(exc),
             )
             return False
+
+    def _new_reasoning_only_act_now_message(
+        self,
+        *,
+        iteration: int,
+        attempt: int,
+        reasoning_content: str | None,
+        provider_default_reasoning: bool,
+    ) -> Message:
+        message = Message(
+            role="user",
+            content=_REASONING_ONLY_ACT_NOW_DIRECTIVE,
+        )
+        append_runtime_event(
+            self.config.runtime_events_path,
+            {
+                "feature": "reasoning_only_act_now",
+                "name": "reasoning_only_act_now.injected",
+                "action": "retry_with_act_now_directive",
+                "reason": "provider_reasoning_only",
+                "provider_default_reasoning": provider_default_reasoning,
+                "iteration": iteration,
+                "attempt": attempt,
+                "reasoning_chars": len(reasoning_content or ""),
+                "session_key": self._session_key,
+                "agent_id": (
+                    self.config.tool_result_store_agent_id
+                    or self.config.metadata.get("agent_id")
+                ),
+            },
+        )
+        return message
+
+    def _provider_log_identity(self, observed_provider: str = "") -> str:
+        return (
+            str(getattr(self.provider, "active_provider_id", "") or "").strip()
+            or str(observed_provider or "").strip()
+            or str(self.config.provider_id or "").strip()
+            or str(getattr(self.provider, "provider_name", "") or "").strip()
+            or type(self.provider).__name__
+        )
+
+    def _log_reasoning_output_budget_exhausted(
+        self,
+        *,
+        model: str,
+        observed_provider: str,
+        configured_max_tokens: int,
+        output_tokens: int,
+        reasoning_tokens: int,
+        reasoning_content: str | None,
+    ) -> None:
+        logger.warning(
+            "provider.reasoning_output_budget_exhausted",
+            session_key=self._session_key,
+            model=model,
+            provider=self._provider_log_identity(observed_provider),
+            configured_max_tokens=configured_max_tokens,
+            iter_output_tokens=output_tokens,
+            iter_reasoning_tokens=reasoning_tokens,
+            reasoning_chars=len(reasoning_content or ""),
+        )
 
     @staticmethod
     def _tool_call_string_arg(
@@ -8019,6 +8110,7 @@ class Agent:
                         active_protected_turn_start_index = current_turn_start_index
 
                     request_suffix_messages: list[Message] = []
+                    reasoning_only_act_now_for_call: Message | None = None
                     if goal_terminal_final_response_pending:
                         # The terminal Goal ToolResult is sufficient context for
                         # one ordinary summary. Do not splice work/recovery
@@ -8043,6 +8135,7 @@ class Agent:
                         # request. Withheld on an assistant tail for the same
                         # reasoning-prefill reason as below.
                         request_suffix_messages = [reasoning_only_act_now_message]
+                        reasoning_only_act_now_for_call = reasoning_only_act_now_message
                     elif deadline_wrapup_message is not None and (
                         not turn_messages or turn_messages[-1].role != "assistant"
                     ):
@@ -10034,6 +10127,17 @@ class Agent:
                                 usage_call,
                                 usage_unknown_reason,
                             )
+                        if (
+                            reasoning_only_act_now_for_call is not None
+                            and not bool(
+                                getattr(
+                                    self.config,
+                                    "reasoning_only_act_now",
+                                    False,
+                                )
+                            )
+                        ):
+                            reasoning_only_act_now_message = None
 
                     call_duration_ms = int((time.monotonic() - call_started_at) * 1000)
                     _notify_call_outcome(
@@ -10204,9 +10308,9 @@ class Agent:
                                 and request_turn_messages[-1] is deadline_wrapup_message
                             )
                             or (
-                                reasoning_only_act_now_message is not None
+                                reasoning_only_act_now_for_call is not None
                                 and request_turn_messages[-1]
-                                is reasoning_only_act_now_message
+                                is reasoning_only_act_now_for_call
                             )
                         )
                     ):
@@ -10304,7 +10408,7 @@ class Agent:
                             "provider.invalid_response",
                             session_key=self._session_key,
                             model=last_actual_model or self.config.model_id or "",
-                            provider=type(self.provider).__name__,
+                            provider=self._provider_log_identity(last_actual_provider),
                             classification=attempt_classification.kind.value,
                             iteration=iterations,
                             call_attempt=_call_attempt,
@@ -10317,7 +10421,6 @@ class Agent:
                             iter_reasoning_tokens=iter_reasoning_tokens,
                             reasoning_chars=len(iter_reasoning_content or ""),
                         )
-
                         large_context_invalid = _is_large_context_invalid_response(
                             attempt_classification.kind,
                             input_tokens=iter_input_tokens,
@@ -10537,10 +10640,14 @@ class Agent:
                             if (
                                 not _invalid_response_fallback_done
                                 and self._switch_to_invalid_response_fallback(
-                                    attempt_classification.kind.value
+                                    attempt_classification.kind.value,
+                                    requires_vision=(
+                                        self._count_image_blocks(request_messages) > 0
+                                    ),
                                 )
                             ):
                                 _invalid_response_fallback_done = True
+                                reasoning_only_act_now_message = None
                                 fallback_reason = _provider_activity_reason_for_attempt(
                                     attempt_classification.kind
                                 )
@@ -10565,17 +10672,33 @@ class Agent:
 
                             if (
                                 attempt_classification.kind == _ProviderAttemptKind.REASONING_ONLY
-                                and (
-                                    thinking_enabled
-                                    or (attempt_classification.stop_reason or "").lower()
-                                    == "length"
-                                )
                                 and _retry_policy.can_retry_attempt(
                                     _ProviderAttemptKind.REASONING_ONLY,
                                     _attempt_retries_used,
                                 )
                             ):
                                 _attempt_retries_used[_ProviderAttemptKind.REASONING_ONLY] += 1
+                                if (
+                                    (
+                                        not thinking_enabled
+                                        or bool(
+                                            getattr(
+                                                self.config,
+                                                "reasoning_only_act_now",
+                                                False,
+                                            )
+                                        )
+                                    )
+                                    and reasoning_only_act_now_message is None
+                                ):
+                                    reasoning_only_act_now_message = (
+                                        self._new_reasoning_only_act_now_message(
+                                            iteration=iterations,
+                                            attempt=_call_attempt,
+                                            reasoning_content=iter_reasoning_content,
+                                            provider_default_reasoning=not thinking_enabled,
+                                        )
+                                    )
                                 disable_thinking = (
                                     (attempt_classification.stop_reason or "").lower()
                                     == "length"
@@ -10594,7 +10717,9 @@ class Agent:
                                     "provider.large_context_visible_retry",
                                     session_key=self._session_key,
                                     model=last_actual_model or self.config.model_id or "",
-                                    provider=type(self.provider).__name__,
+                                    provider=self._provider_log_identity(
+                                        last_actual_provider
+                                    ),
                                     classification=attempt_classification.kind.value,
                                     iteration=iterations,
                                     call_attempt=_call_attempt,
@@ -10609,19 +10734,60 @@ class Agent:
                                     iter_reasoning_tokens=iter_reasoning_tokens,
                                     reasoning_chars=len(iter_reasoning_content or ""),
                                     thinking_disabled=disable_thinking,
-                                )
-                                yield WarningEvent(
-                                    code="provider_large_context_visible_retry",
-                                    message=(
-                                        "The provider returned reasoning without visible "
-                                        "content for a large input; "
-                                        + (
-                                            "retrying once with thinking disabled."
-                                            if disable_thinking
-                                            else "retrying once to request visible content."
-                                        )
+                                    configured_max_tokens=max(
+                                        0,
+                                        int(getattr(call_chat_cfg, "max_tokens", 0) or 0),
                                     ),
                                 )
+                                reasoning_output_budget_exhausted = (
+                                    attempt_classification.stop_reason or ""
+                                ).lower() == "length"
+                                if reasoning_output_budget_exhausted:
+                                    self._log_reasoning_output_budget_exhausted(
+                                        model=(
+                                            last_actual_model
+                                            or self.config.model_id
+                                            or ""
+                                        ),
+                                        observed_provider=last_actual_provider,
+                                        configured_max_tokens=max(
+                                            0,
+                                            int(
+                                                getattr(
+                                                    call_chat_cfg,
+                                                    "max_tokens",
+                                                    0,
+                                                )
+                                                or 0
+                                            ),
+                                        ),
+                                        output_tokens=iter_output_tokens,
+                                        reasoning_tokens=iter_reasoning_tokens,
+                                        reasoning_content=iter_reasoning_content,
+                                    )
+                                    yield WarningEvent(
+                                        code="provider_reasoning_only_retry",
+                                        message=(
+                                            "The provider used the configured output budget "
+                                            "for reasoning without returning visible content; "
+                                            "retrying once without changing max_tokens."
+                                        ),
+                                    )
+                                else:
+                                    yield WarningEvent(
+                                        code="provider_large_context_visible_retry",
+                                        message=(
+                                            "The provider returned reasoning without visible "
+                                            "content for a large input; "
+                                            + (
+                                                "retrying once with thinking disabled."
+                                                if disable_thinking
+                                                else (
+                                                    "retrying once to request visible content."
+                                                )
+                                            )
+                                        ),
+                                    )
                                 next_provider_activity_reason = "reasoning_only"
                                 yield ProviderActivityEvent(
                                     activity_id=provider_activity_id,
@@ -10639,21 +10805,38 @@ class Agent:
                                 continue
 
                             yield self._transition(AgentState.ERROR)
-                            if self.config.metadata.get("had_attachments"):
+                            if attempt_classification.kind == _ProviderAttemptKind.REASONING_ONLY:
+                                if (attempt_classification.stop_reason or "").lower() == "length":
+                                    large_context_message = (
+                                        "The provider used the configured output budget for "
+                                        "reasoning without returning a visible answer. Increase "
+                                        "llm.max_tokens or choose another model or provider."
+                                    )
+                                else:
+                                    large_context_message = (
+                                        "The provider returned reasoning without a visible "
+                                        "answer. Try again or choose another model or provider."
+                                    )
+                            elif self.config.metadata.get("had_attachments"):
                                 recovery_guidance = (
                                     "Split, summarize, or shorten the attached material, "
                                     "or use a stronger model."
+                                )
+                                large_context_message = (
+                                    "Provider returned no visible response for a large input. "
+                                    + recovery_guidance
                                 )
                             else:
                                 recovery_guidance = (
                                     "Send the material as an attachment, summarize or "
                                     "shorten the prompt, or use a stronger model."
                                 )
-                            terminal_error = ErrorEvent(
-                                message=(
+                                large_context_message = (
                                     "Provider returned no visible response for a large input. "
                                     + recovery_guidance
-                                ),
+                                )
+                            terminal_error = ErrorEvent(
+                                message=large_context_message,
                                 code="empty_response",
                             )
                             yield terminal_error
@@ -10661,7 +10844,6 @@ class Agent:
 
                         if (
                             attempt_classification.kind == _ProviderAttemptKind.REASONING_ONLY
-                            and thinking_enabled
                             and _retry_policy.can_retry_attempt(
                                 _ProviderAttemptKind.REASONING_ONLY,
                                 _attempt_retries_used,
@@ -10669,44 +10851,51 @@ class Agent:
                         ):
                             _attempt_retries_used[_ProviderAttemptKind.REASONING_ONLY] += 1
                             if (
-                                bool(
-                                    getattr(
-                                        self.config, "reasoning_only_act_now", False
+                                (
+                                    not thinking_enabled
+                                    or bool(
+                                        getattr(
+                                            self.config,
+                                            "reasoning_only_act_now",
+                                            False,
+                                        )
                                     )
                                 )
                                 and reasoning_only_act_now_message is None
                             ):
-                                # Today's bare retry re-sends the identical
-                                # request; the model that just answered it with
-                                # reasoning only usually does so again. Splice
-                                # in an explicit act-now instruction so the
-                                # retry differs where it matters.
-                                reasoning_only_act_now_message = Message(
-                                    role="user",
-                                    content=_REASONING_ONLY_ACT_NOW_DIRECTIVE,
+                                reasoning_only_act_now_message = (
+                                    self._new_reasoning_only_act_now_message(
+                                        iteration=iterations,
+                                        attempt=_call_attempt,
+                                        reasoning_content=iter_reasoning_content,
+                                        provider_default_reasoning=not thinking_enabled,
+                                    )
                                 )
-                                append_runtime_event(
-                                    self.config.runtime_events_path,
-                                    {
-                                        "feature": "reasoning_only_act_now",
-                                        "name": "reasoning_only_act_now.injected",
-                                        "action": "retry_with_act_now_directive",
-                                        "reason": "provider_reasoning_only",
-                                        "iteration": iterations,
-                                        "attempt": _call_attempt,
-                                        "reasoning_chars": len(
-                                            iter_reasoning_content or ""
-                                        ),
-                                        "session_key": self._session_key,
-                                        "agent_id": (
-                                            self.config.tool_result_store_agent_id
-                                            or self.config.metadata.get("agent_id")
-                                        ),
-                                    },
+                            disable_thinking = bool(
+                                thinking_enabled
+                                and getattr(
+                                    self.config,
+                                    "reasoning_only_thinking_fallback",
+                                    False,
                                 )
-                            if getattr(
-                                self.config, "reasoning_only_thinking_fallback", False
-                            ):
+                            )
+                            reasoning_output_budget_exhausted = (
+                                attempt_classification.stop_reason or ""
+                            ).lower() == "length"
+                            if reasoning_output_budget_exhausted:
+                                configured_max_tokens = max(
+                                    0,
+                                    int(getattr(call_chat_cfg, "max_tokens", 0) or 0),
+                                )
+                                self._log_reasoning_output_budget_exhausted(
+                                    model=last_actual_model or self.config.model_id or "",
+                                    observed_provider=last_actual_provider,
+                                    configured_max_tokens=configured_max_tokens,
+                                    output_tokens=iter_output_tokens,
+                                    reasoning_tokens=iter_reasoning_tokens,
+                                    reasoning_content=iter_reasoning_content,
+                                )
+                            if disable_thinking:
                                 _thinking_fallback_done = True
                                 _disable_thinking_for_next_provider_call = True
                                 yield WarningEvent(
@@ -10714,6 +10903,15 @@ class Agent:
                                     message=(
                                         "The provider returned reasoning without visible "
                                         "content; retrying once with thinking disabled."
+                                    ),
+                                )
+                            elif reasoning_output_budget_exhausted:
+                                yield WarningEvent(
+                                    code="provider_reasoning_only_retry",
+                                    message=(
+                                        "The provider used the configured output budget for "
+                                        "reasoning without returning visible content; retrying "
+                                        "once without changing max_tokens."
                                     ),
                                 )
                             else:
@@ -10891,10 +11089,14 @@ class Agent:
                             }
                             and not _invalid_response_fallback_done
                             and self._switch_to_invalid_response_fallback(
-                                attempt_classification.kind.value
+                                attempt_classification.kind.value,
+                                requires_vision=(
+                                    self._count_image_blocks(request_messages) > 0
+                                ),
                             )
                         ):
                             _invalid_response_fallback_done = True
+                            reasoning_only_act_now_message = None
                             fallback_reason = _provider_activity_reason_for_attempt(
                                 attempt_classification.kind
                             )
@@ -10967,7 +11169,7 @@ class Agent:
                             "provider.empty_response",
                             session_key=self._session_key,
                             model=last_actual_model or self.config.model_id or "",
-                            provider=type(self.provider).__name__,
+                            provider=self._provider_log_identity(last_actual_provider),
                             iteration=iterations,
                             retry_attempt=_call_attempt,
                             post_tool_turn=post_tool_turn,
@@ -10977,6 +11179,10 @@ class Agent:
                             iter_output_tokens=iter_output_tokens,
                             iter_reasoning_tokens=iter_reasoning_tokens,
                             reasoning_chars=len(iter_reasoning_content or ""),
+                            configured_max_tokens=max(
+                                0,
+                                int(getattr(call_chat_cfg, "max_tokens", 0) or 0),
+                            ),
                         )
                         self._record_tool_loop_runtime_event(
                             reason="provider_empty_response_terminal",
@@ -10992,8 +11198,22 @@ class Agent:
                             reasoning_tokens=iter_reasoning_tokens,
                             reasoning_chars=len(iter_reasoning_content or ""),
                         )
+                        if attempt_classification.kind == _ProviderAttemptKind.REASONING_ONLY:
+                            if (attempt_classification.stop_reason or "").lower() == "length":
+                                terminal_message = (
+                                    "The provider used the configured output budget for "
+                                    "reasoning without returning a visible answer. Increase "
+                                    "llm.max_tokens or choose another model or provider."
+                                )
+                            else:
+                                terminal_message = (
+                                    "The provider returned reasoning without a visible answer. "
+                                    "Try again or choose another model or provider."
+                                )
+                        else:
+                            terminal_message = "Provider returned an empty response"
                         terminal_error = ErrorEvent(
-                            message="Provider returned an empty response",
+                            message=terminal_message,
                             code="empty_response",
                         )
                         yield terminal_error

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -2789,6 +2789,48 @@ class _SelectorFallbackProvider:
         self._skip_benched_fallbacks()
         return True
 
+    def fallback_after_invalid_response_with_capabilities(
+        self,
+        reason: str,
+        *,
+        requires_vision: bool,
+    ) -> bool:
+        """Select an invalid-response fallback with exact capability evidence.
+
+        Image-bearing retries fail closed unless bootstrap installed
+        deployment-scoped ``supported`` vision evidence. The selector applies
+        plugin, replay, and capacity policy before filtering and atomically
+        installs only the matching chain.
+        """
+
+        if not requires_vision:
+            return self.fallback_after_invalid_response(reason)
+
+        matching_fallback = getattr(
+            self._selector,
+            "next_fallback_after_failure_matching",
+            None,
+        )
+        if not callable(matching_fallback):
+            return False
+        try:
+            self._provider = matching_fallback(
+                RuntimeError(reason),
+                predicate=lambda candidate: (
+                    self._fallback_deployment_vision_support.get(
+                        _fallback_deployment_identity(candidate),
+                        "unknown",
+                    )
+                    == "supported"
+                ),
+            )
+        except Exception:  # noqa: BLE001 - fallback support is optional
+            return False
+
+        self._note_fallback_hop()
+        self._skip_benched_fallbacks()
+        return True
+
     def _reject_unsupported_image_input(
         self,
         messages: list[Any],

--- a/src/opensquilla/provider/selector.py
+++ b/src/opensquilla/provider/selector.py
@@ -485,16 +485,17 @@ class ModelSelector:
         """
         if not self.has_fallback():
             raise IndexError("No more provider fallbacks available")
-        self._index += 1
-        return _build_provider(self._chain[self._index])
+        next_index = self._index + 1
+        provider = _build_provider(self._chain[next_index])
+        self._index = next_index
+        return provider
 
-    def next_fallback_after_failure(self, primary_failure: Exception) -> LLMProvider:
-        """Advance to the next fallback, consulting ``plugin.failover_hook``.
+    def _fallback_chain_after_failure(
+        self,
+        primary_failure: Exception,
+    ) -> tuple[ProviderConfig, list[ProviderConfig]]:
+        """Resolve and constrain a failure-specific chain without mutating state."""
 
-        When a plugin is registered its ``failover_hook`` return value
-        replaces the static fallback chain from ``SelectorConfig``. An
-        empty chain raises ``IndexError`` exactly like ``next_fallback``.
-        """
         current = self._chain[self._index]
         if self._plugin is not None and hasattr(self._plugin, "failover_hook"):
             chain = resolve_failover_chain(primary_failure, self._config, self._plugin)
@@ -508,11 +509,44 @@ class ModelSelector:
                 for cfg in chain
                 if _capacity_config_identity(cfg) in self._capacity_bounded_fallbacks
             ]
+        return current, chain
+
+    def _activate_fallback_chain(
+        self,
+        current: ProviderConfig,
+        chain: list[ProviderConfig],
+    ) -> LLMProvider:
+        """Build the first candidate before atomically installing its chain."""
+
         if not chain:
             raise IndexError("No fallback chain available")
+        provider = _build_provider(chain[0])
         self._chain = [current, *chain]
         self._index = 1
-        return _build_provider(self._chain[self._index])
+        return provider
+
+    def next_fallback_after_failure(self, primary_failure: Exception) -> LLMProvider:
+        """Advance to the next fallback, consulting ``plugin.failover_hook``.
+
+        When a plugin is registered its ``failover_hook`` return value
+        replaces the static fallback chain from ``SelectorConfig``. An
+        empty chain raises ``IndexError`` exactly like ``next_fallback``.
+        """
+
+        current, chain = self._fallback_chain_after_failure(primary_failure)
+        return self._activate_fallback_chain(current, chain)
+
+    def next_fallback_after_failure_matching(
+        self,
+        primary_failure: Exception,
+        *,
+        predicate: Callable[[ProviderConfig], bool],
+    ) -> LLMProvider:
+        """Atomically advance to the first constrained fallback candidate."""
+
+        current, chain = self._fallback_chain_after_failure(primary_failure)
+        matching_chain = [candidate for candidate in chain if predicate(candidate)]
+        return self._activate_fallback_chain(current, matching_chain)
 
     def override_provider_config(self, cfg: ProviderConfig) -> None:
         """Replace the active chain head with a full per-turn provider config.

--- a/src/opensquilla/session/terminal_reply.py
+++ b/src/opensquilla/session/terminal_reply.py
@@ -22,6 +22,22 @@ IMAGE_INPUT_UNSUPPORTED_MESSAGE = (
     "The selected model cannot process image input. Choose an image-capable "
     "model or remove the image and try again."
 )
+_REASONING_ONLY_OUTPUT_BUDGET_ERROR_MESSAGE = (
+    "the provider used the configured output budget for reasoning without returning a visible "
+    "answer. increase llm.max_tokens or choose another model or provider."
+)
+_REASONING_ONLY_OUTPUT_BUDGET_TERMINAL_MESSAGE = (
+    "The model used its output budget for reasoning without returning a visible answer. "
+    "Increase llm.max_tokens or choose another model or provider."
+)
+_REASONING_ONLY_EMPTY_ERROR_MESSAGE = (
+    "the provider returned reasoning without a visible answer. try again or choose another "
+    "model or provider."
+)
+_REASONING_ONLY_EMPTY_TERMINAL_MESSAGE = (
+    "The model returned reasoning without a visible answer. "
+    "Try again or choose another model or provider."
+)
 
 # Non-context budget-exhaustion codes. Context-window exhaustion has its own,
 # more specific message via ``is_context_payload_too_large`` and is intentionally
@@ -163,6 +179,16 @@ def build_terminal_reply(
             "preserved the recoverable state; retry with a narrower request "
             "or a larger-context model."
         )
+    if (
+        error_class == "empty_response"
+        and error_message == _REASONING_ONLY_OUTPUT_BUDGET_ERROR_MESSAGE
+    ):
+        return _REASONING_ONLY_OUTPUT_BUDGET_TERMINAL_MESSAGE
+    if (
+        error_class == "empty_response"
+        and error_message == _REASONING_ONLY_EMPTY_ERROR_MESSAGE
+    ):
+        return _REASONING_ONLY_EMPTY_TERMINAL_MESSAGE
     if reason == "output_truncated" or error_class == "provider_output_truncated":
         return "The provider stopped because the output limit was reached before the task finished."
     if (

--- a/tests/test_engine/test_agent_invalid_provider_response.py
+++ b/tests/test_engine/test_agent_invalid_provider_response.py
@@ -10,6 +10,7 @@ import pytest
 import structlog.testing
 
 from opensquilla.engine import Agent, AgentConfig, ThinkingLevel, ToolResult
+from opensquilla.engine.agent import _REASONING_ONLY_ACT_NOW_DIRECTIVE
 from opensquilla.engine.runtime import TurnRunner
 from opensquilla.engine.usage import UsageTracker
 from opensquilla.provider import (
@@ -20,6 +21,7 @@ from opensquilla.provider import (
     ToolInputSchema,
 )
 from opensquilla.provider import DoneEvent as ProviderDone
+from opensquilla.provider import ErrorEvent as ProviderError
 from opensquilla.provider import TextDeltaEvent as ProviderText
 from opensquilla.provider import ToolUseDeltaEvent as ProviderToolUseDelta
 from opensquilla.provider import ToolUseEndEvent as ProviderToolUseEnd
@@ -74,6 +76,16 @@ def _large_reasoning_only_done() -> ProviderDone:
         output_tokens=2,
         reasoning_tokens=2,
         reasoning_content="internal",
+    )
+
+
+def _length_capped_reasoning_only_done() -> ProviderDone:
+    return ProviderDone(
+        stop_reason="length",
+        input_tokens=12,
+        output_tokens=1024,
+        reasoning_tokens=1023,
+        reasoning_content="internal reasoning",
     )
 
 
@@ -817,7 +829,7 @@ async def test_reasoning_only_retry_restores_thinking_after_retry_call() -> None
 
 
 @pytest.mark.asyncio
-async def test_reasoning_only_with_thinking_disabled_surfaces_empty_response() -> None:
+async def test_reasoning_only_with_thinking_disabled_retries_with_act_now() -> None:
     provider = _SequenceProvider(
         [
             [
@@ -828,22 +840,297 @@ async def test_reasoning_only_with_thinking_disabled_surfaces_empty_response() -
                     reasoning_tokens=2,
                     reasoning_content="internal reasoning",
                 )
-            ]
+            ],
+            [
+                ProviderText(text="visible answer"),
+                ProviderDone(stop_reason="stop", input_tokens=5, output_tokens=1),
+            ],
         ]
     )
     agent = Agent(
         provider=provider,
-        config=AgentConfig(thinking=False, retry_base_backoff_ms=0, retry_max_backoff_ms=0),
+        config=AgentConfig(
+            thinking=False,
+            max_tokens=2048,
+            max_provider_retries=1,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("hello")]
+
+    assert len(provider.calls) == 2
+    assert [call["config"].max_tokens for call in provider.calls] == [2048, 2048]
+    assert [call["config"].thinking for call in provider.calls] == [False, False]
+    assert provider.calls[1]["messages"][-1].content == _REASONING_ONLY_ACT_NOW_DIRECTIVE
+    assert sum(
+        1
+        for event in events
+        if event.kind == "warning" and event.code == "provider_reasoning_only_retry"
+    ) == 1
+    assert not any(event.kind == "error" for event in events)
+    done = next(event for event in events if event.kind == "done")
+    assert done.text == "visible answer"
+    assert done.input_tokens == 9
+    assert done.output_tokens == 3
+    assert done.reasoning_tokens == 2
+
+
+@pytest.mark.asyncio
+async def test_length_capped_reasoning_only_retries_when_thinking_disabled() -> None:
+    provider = _SequenceProvider(
+        [
+            [_length_capped_reasoning_only_done()],
+            [
+                ProviderText(text="visible answer"),
+                ProviderDone(stop_reason="stop", input_tokens=13, output_tokens=2),
+            ],
+        ]
+    )
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            thinking=False,
+            max_tokens=1024,
+            max_provider_retries=1,
+            provider_id="tokenrhythm",
+            model_id="kimi-k2.6",
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+    )
+
+    with structlog.testing.capture_logs() as captured:
+        events = [event async for event in agent.run_turn("hello")]
+
+    assert len(provider.calls) == 2
+    assert [call["config"].max_tokens for call in provider.calls] == [1024, 1024]
+    assert [call["config"].thinking for call in provider.calls] == [False, False]
+    assert provider.calls[1]["messages"][-1].content == _REASONING_ONLY_ACT_NOW_DIRECTIVE
+    warnings = [
+        event
+        for event in events
+        if event.kind == "warning" and event.code == "provider_reasoning_only_retry"
+    ]
+    assert len(warnings) == 1
+    assert "without changing max_tokens" in warnings[0].message
+    budget_log = next(
+        event
+        for event in captured
+        if event.get("event") == "provider.reasoning_output_budget_exhausted"
+    )
+    assert budget_log["provider"] == "tokenrhythm"
+    assert budget_log["model"] == "kimi-k2.6"
+    assert budget_log["configured_max_tokens"] == 1024
+    assert budget_log["iter_output_tokens"] == 1024
+    assert budget_log["iter_reasoning_tokens"] == 1023
+    assert not {"messages", "image", "api_key"}.intersection(budget_log)
+    assert any(event.kind == "done" and event.text == "visible answer" for event in events)
+    assert not any(event.kind == "error" for event in events)
+
+
+@pytest.mark.asyncio
+async def test_implicit_act_now_is_consumed_when_retry_gets_provider_error() -> None:
+    provider = _SequenceProvider(
+        [
+            [_length_capped_reasoning_only_done()],
+            [ProviderError(message="temporary provider failure", code="503")],
+            [
+                ProviderText(text="visible answer"),
+                ProviderDone(stop_reason="stop", input_tokens=13, output_tokens=2),
+            ],
+        ]
+    )
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            thinking=False,
+            max_tokens=1024,
+            max_provider_retries=1,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("hello")]
+
+    assert len(provider.calls) == 3
+    assert provider.calls[1]["messages"][-1].content == _REASONING_ONLY_ACT_NOW_DIRECTIVE
+    assert all(
+        message.content != _REASONING_ONLY_ACT_NOW_DIRECTIVE
+        for message in provider.calls[2]["messages"]
+    )
+    assert any(event.kind == "done" and event.text == "visible answer" for event in events)
+
+
+@pytest.mark.asyncio
+async def test_reasoning_budget_log_uses_active_provider_identity() -> None:
+    provider = _SequenceProvider(
+        [
+            [_length_capped_reasoning_only_done()],
+            [
+                ProviderText(text="visible answer"),
+                ProviderDone(stop_reason="stop", input_tokens=13, output_tokens=2),
+            ],
+        ]
+    )
+    provider.active_provider_id = "fallback-provider"
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            thinking=False,
+            max_tokens=1024,
+            max_provider_retries=1,
+            provider_id="primary-provider",
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+    )
+
+    with structlog.testing.capture_logs() as captured:
+        events = [event async for event in agent.run_turn("hello")]
+
+    budget_log = next(
+        event
+        for event in captured
+        if event.get("event") == "provider.reasoning_output_budget_exhausted"
+    )
+    assert budget_log["provider"] == "fallback-provider"
+    assert any(event.kind == "done" and event.text == "visible answer" for event in events)
+
+
+@pytest.mark.asyncio
+async def test_repeated_length_capped_reasoning_only_is_bounded_and_actionable() -> None:
+    provider = _SequenceProvider(
+        [
+            [_length_capped_reasoning_only_done()],
+            [_length_capped_reasoning_only_done()],
+        ]
+    )
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            thinking=False,
+            max_tokens=1024,
+            max_provider_retries=1,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("hello")]
+
+    assert len(provider.calls) == 2
+    assert sum(
+        1
+        for event in events
+        if event.kind == "warning" and event.code == "provider_reasoning_only_retry"
+    ) == 1
+    error = next(event for event in events if event.kind == "error")
+    assert error.code == "empty_response"
+    assert "llm.max_tokens" in error.message
+    assert "another model or provider" in error.message
+
+
+@pytest.mark.asyncio
+async def test_implicit_act_now_is_not_carried_to_selector_fallback() -> None:
+    provider = _FallbackSequenceProvider(
+        [
+            [_length_capped_reasoning_only_done()],
+            [_length_capped_reasoning_only_done()],
+            [
+                ProviderText(text="fallback answer"),
+                ProviderDone(stop_reason="stop", input_tokens=14, output_tokens=2),
+            ],
+        ]
+    )
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            thinking=False,
+            max_tokens=1024,
+            max_provider_retries=1,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("hello")]
+
+    assert len(provider.calls) == 3
+    assert provider.fallback_reasons == ["reasoning_only"]
+    assert provider.calls[1]["messages"][-1].content == _REASONING_ONLY_ACT_NOW_DIRECTIVE
+    assert all(
+        message.content != _REASONING_ONLY_ACT_NOW_DIRECTIVE
+        for message in provider.calls[2]["messages"]
+    )
+    assert any(event.kind == "done" and event.text == "fallback answer" for event in events)
+
+
+@pytest.mark.asyncio
+async def test_explicit_act_now_retries_do_not_carry_directive_to_fallback() -> None:
+    provider = _FallbackSequenceProvider(
+        [
+            [_length_capped_reasoning_only_done()],
+            [_length_capped_reasoning_only_done()],
+            [_length_capped_reasoning_only_done()],
+            [
+                ProviderText(text="fallback answer"),
+                ProviderDone(stop_reason="stop", input_tokens=15, output_tokens=2),
+            ],
+        ]
+    )
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            thinking=False,
+            max_tokens=1024,
+            max_provider_retries=1,
+            reasoning_only_act_now=True,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("hello")]
+
+    assert len(provider.calls) == 4
+    assert provider.fallback_reasons == ["reasoning_only"]
+    for call in provider.calls[1:3]:
+        assert call["messages"][-1].content == _REASONING_ONLY_ACT_NOW_DIRECTIVE
+    assert all(
+        message.content != _REASONING_ONLY_ACT_NOW_DIRECTIVE
+        for message in provider.calls[3]["messages"]
+    )
+    assert any(event.kind == "done" and event.text == "fallback answer" for event in events)
+
+
+@pytest.mark.asyncio
+async def test_length_capped_reasoning_only_respects_zero_retry_budget() -> None:
+    provider = _SequenceProvider([[_length_capped_reasoning_only_done()]])
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            thinking=False,
+            max_tokens=1024,
+            max_provider_retries=0,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
     )
 
     events = [event async for event in agent.run_turn("hello")]
 
     assert len(provider.calls) == 1
-    assert any(event.kind == "error" and event.code == "empty_response" for event in events)
-    done = next(event for event in events if event.kind == "done")
-    assert done.input_tokens == 4
-    assert done.output_tokens == 2
-    assert done.reasoning_tokens == 2
+    assert not any(
+        event.kind == "warning" and event.code == "provider_reasoning_only_retry"
+        for event in events
+    )
+    error = next(event for event in events if event.kind == "error")
+    assert error.code == "empty_response"
+    assert "llm.max_tokens" in error.message
+    assert "another model or provider" in error.message
 
 
 @pytest.mark.asyncio
@@ -1029,6 +1316,39 @@ async def test_large_reasoning_only_without_fallback_keeps_thinking_by_default()
 
 
 @pytest.mark.asyncio
+async def test_large_reasoning_only_with_thinking_disabled_uses_act_now_retry() -> None:
+    provider = _SequenceProvider(
+        [
+            [_large_reasoning_only_done()],
+            [
+                ProviderText(text="visible answer"),
+                ProviderDone(stop_reason="stop", input_tokens=4, output_tokens=1),
+            ],
+        ]
+    )
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            thinking=False,
+            max_provider_retries=1,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("hello")]
+
+    assert len(provider.calls) == 2
+    assert [call["config"].thinking for call in provider.calls] == [False, False]
+    assert provider.calls[1]["messages"][-1].content == _REASONING_ONLY_ACT_NOW_DIRECTIVE
+    assert any(
+        event.kind == "warning" and event.code == "provider_large_context_visible_retry"
+        for event in events
+    )
+    assert any(event.kind == "done" and event.text == "visible answer" for event in events)
+
+
+@pytest.mark.asyncio
 async def test_large_length_capped_reasoning_only_retry_disables_thinking() -> None:
     provider = _SequenceProvider(
         [
@@ -1064,7 +1384,8 @@ async def test_large_length_capped_reasoning_only_retry_disables_thinking() -> N
         ),
     )
 
-    events = [event async for event in agent.run_turn("hello")]
+    with structlog.testing.capture_logs() as captured:
+        events = [event async for event in agent.run_turn("hello")]
 
     assert len(provider.calls) == 2
     assert provider.calls[0]["config"].thinking is False
@@ -1074,13 +1395,22 @@ async def test_large_length_capped_reasoning_only_retry_disables_thinking() -> N
     assert provider.calls[1]["config"].thinking_level == ThinkingLevel.OFF
     assert provider.calls[1]["config"].thinking_budget_tokens == 0
     assert provider.calls[1]["config"].max_tokens == 16_384
+    assert provider.calls[1]["messages"][-1].content == _REASONING_ONLY_ACT_NOW_DIRECTIVE
     visible_retry = next(
         event
         for event in events
         if event.kind == "warning"
-        and event.code == "provider_large_context_visible_retry"
+        and event.code == "provider_reasoning_only_retry"
     )
-    assert "thinking disabled" in visible_retry.message
+    assert "without changing max_tokens" in visible_retry.message
+    budget_log = next(
+        event
+        for event in captured
+        if event.get("event") == "provider.reasoning_output_budget_exhausted"
+    )
+    assert budget_log["configured_max_tokens"] == 16_384
+    assert budget_log["iter_output_tokens"] == 16_384
+    assert budget_log["iter_reasoning_tokens"] == 16_384
     assert not any(event.kind == "error" for event in events)
     done = next(event for event in events if event.kind == "done")
     assert done.text == "visible answer"

--- a/tests/test_engine/test_agent_reasoning_reemit.py
+++ b/tests/test_engine/test_agent_reasoning_reemit.py
@@ -95,7 +95,10 @@ def test_reasoning_timer_starts_on_first_nonempty_delta() -> None:
     import asyncio
 
     async def run() -> list[Any]:
-        agent = Agent(provider=_EmptyThenReasoningProvider(), config=AgentConfig(max_iterations=1))
+        agent = Agent(
+            provider=_EmptyThenReasoningProvider(),
+            config=AgentConfig(max_iterations=1, max_provider_retries=0),
+        )
         return [event async for event in agent.run_turn("hi")]
 
     thinking = [

--- a/tests/test_engine/test_selector_fallback_routed_model.py
+++ b/tests/test_engine/test_selector_fallback_routed_model.py
@@ -491,6 +491,164 @@ def test_each_hop_uses_the_active_physical_models_own_output_limit() -> None:
     assert last.provider_request_max_chars < middle.provider_request_max_chars
 
 
+async def test_capability_constrained_fallback_skips_non_vision_candidates() -> None:
+    primary_config = SimpleNamespace(provider="openrouter", model="vision-primary")
+    text_config = SimpleNamespace(provider="openrouter", model="text-fallback")
+    unknown_config = SimpleNamespace(provider="openrouter", model="unknown-fallback")
+    vision_config = SimpleNamespace(provider="openrouter", model="vision-fallback")
+
+    class _Provider:
+        provider_name = "openrouter"
+
+        def __init__(self, model: str) -> None:
+            self.model = model
+            self.calls = 0
+
+        async def chat(self, messages, tools=None, config=None):
+            del messages, tools, config
+            self.calls += 1
+            yield TextDeltaEvent(text=f"reply from {self.model}")
+            yield DoneEvent(model=self.model)
+
+    providers = {
+        config.model: _Provider(config.model)
+        for config in (
+            primary_config,
+            text_config,
+            unknown_config,
+            vision_config,
+        )
+    }
+
+    class _Selector:
+        active_provider_id = "openrouter"
+
+        def __init__(self) -> None:
+            self._chain = [
+                primary_config,
+                text_config,
+                unknown_config,
+                vision_config,
+            ]
+            self._index = 0
+
+        @property
+        def current_config(self):
+            return self._chain[self._index]
+
+        def remaining_chain(self):
+            return list(self._chain[self._index :])
+
+        def next_fallback_after_failure_matching(self, _exc, *, predicate):
+            matching = [cfg for cfg in self._chain[self._index + 1 :] if predicate(cfg)]
+            if not matching:
+                raise IndexError("No fallback chain available")
+            provider = providers[matching[0].model]
+            self._chain = [self.current_config, *matching]
+            self._index = 1
+            return provider
+
+    selector = _Selector()
+    wrapper = _SelectorFallbackProvider(providers[primary_config.model], selector)
+    wrapper.configure_fallback_deployment_limits(
+        [
+            (text_config, 0, 0, ModelCapabilities(supports_vision=False)),
+            (unknown_config, 0, 0, ModelCapabilities(supports_vision=False)),
+            (vision_config, 0, 0, ModelCapabilities(supports_vision=True)),
+        ]
+    )
+    wrapper.configure_fallback_deployment_vision_support(
+        [
+            (text_config, "unsupported"),
+            (unknown_config, "unknown"),
+            (vision_config, "supported"),
+        ]
+    )
+
+    selected = wrapper.fallback_after_invalid_response_with_capabilities(
+        "reasoning_only",
+        requires_vision=True,
+    )
+    events = [
+        event
+        async for event in wrapper.chat(
+            [
+                Message(
+                    role="user",
+                    content=[
+                        ContentBlockImage(
+                            media_type="image/png",
+                            data="c3ludGhldGlj",
+                        )
+                    ],
+                )
+            ],
+            config=ChatConfig(),
+        )
+    ]
+
+    assert selected is True
+    assert selector.current_config is vision_config
+    assert providers[primary_config.model].calls == 0
+    assert providers[text_config.model].calls == 0
+    assert providers[unknown_config.model].calls == 0
+    assert providers[vision_config.model].calls == 1
+    assert [event.text for event in events if isinstance(event, TextDeltaEvent)] == [
+        "reply from vision-fallback"
+    ]
+
+
+def test_capability_constrained_fallback_keeps_primary_without_vision_candidate() -> None:
+    primary_config = SimpleNamespace(provider="openrouter", model="vision-primary")
+    text_config = SimpleNamespace(provider="openrouter", model="text-fallback")
+    unknown_config = SimpleNamespace(provider="openrouter", model="unknown-fallback")
+
+    class _Selector:
+        active_provider_id = "openrouter"
+
+        def __init__(self) -> None:
+            self._chain = [primary_config, text_config, unknown_config]
+            self._index = 0
+            self.fallback_builds = 0
+
+        @property
+        def current_config(self):
+            return self._chain[self._index]
+
+        def remaining_chain(self):
+            return list(self._chain[self._index :])
+
+        def next_fallback_after_failure_matching(self, _exc, *, predicate):
+            matching = [cfg for cfg in self._chain[self._index + 1 :] if predicate(cfg)]
+            if not matching:
+                raise IndexError("No fallback chain available")
+            self.fallback_builds += 1
+            self._chain = [self.current_config, *matching]
+            self._index = 1
+            return object()
+
+    primary_provider = object()
+    selector = _Selector()
+    wrapper = _SelectorFallbackProvider(primary_provider, selector)
+    wrapper.configure_fallback_deployment_vision_support(
+        [
+            (text_config, "unsupported"),
+            (unknown_config, "unknown"),
+        ]
+    )
+
+    selected = wrapper.fallback_after_invalid_response_with_capabilities(
+        "reasoning_only",
+        requires_vision=True,
+    )
+
+    assert selected is False
+    assert selector.current_config is primary_config
+    assert selector.fallback_builds == 0
+    assert wrapper._provider is primary_provider
+    assert wrapper._used_fallback is False
+
+
 def test_tokenrhythm_same_model_fallback_uses_exact_private_config_identity() -> None:
     primary = SimpleNamespace(
         provider="tokenrhythm",
@@ -1177,7 +1335,7 @@ async def test_image_request_does_not_call_text_only_fallback(
     ]
 
 
-async def test_invalid_response_fallback_rejects_image_before_text_only_call(
+async def test_invalid_response_fallback_preserves_empty_response_without_vision_candidate(
     monkeypatch: Any,
 ) -> None:
     class _Catalog:
@@ -1217,9 +1375,11 @@ async def test_invalid_response_fallback_rejects_image_before_text_only_call(
             self.calls += 1
             if self.empty:
                 yield DoneEvent(
-                    stop_reason="stop",
+                    stop_reason="length",
                     input_tokens=3,
-                    output_tokens=0,
+                    output_tokens=1024,
+                    reasoning_tokens=1023,
+                    reasoning_content="internal reasoning",
                     model="vision-primary",
                 )
                 return
@@ -1230,22 +1390,41 @@ async def test_invalid_response_fallback_rejects_image_before_text_only_call(
         def __init__(self) -> None:
             self.primary = _Provider(empty=True)
             self.fallback = _Provider(empty=False)
-            self.current_config = SimpleNamespace(
+            self.primary_config = SimpleNamespace(
                 provider="openrouter",
                 model="vision-primary",
                 base_url="",
             )
+            self.fallback_config = SimpleNamespace(
+                provider="openrouter",
+                model="text-fallback",
+                base_url="",
+            )
+            self.current_config = self.primary_config
+            self.fallback_builds = 0
 
         @property
         def active_provider_id(self) -> str:
             return "openrouter"
 
+        def remaining_chain(self):
+            return [self.primary_config, self.fallback_config]
+
+        def next_fallback_after_failure_matching(
+            self,
+            _exc: Exception,
+            *,
+            predicate,
+        ) -> _Provider:
+            matching = [cfg for cfg in [self.fallback_config] if predicate(cfg)]
+            if not matching:
+                raise IndexError("No fallback chain available")
+            self.fallback_builds += 1
+            self.current_config = self.fallback_config
+            return self.fallback
+
         def next_fallback_after_failure(self, _exc: Exception) -> _Provider:
-            self.current_config = SimpleNamespace(
-                provider="openrouter",
-                model="text-fallback",
-                base_url="",
-            )
+            self.current_config = self.fallback_config
             return self.fallback
 
     monkeypatch.setattr("opensquilla.engine.runtime.shared_catalog", lambda: _Catalog())
@@ -1260,6 +1439,9 @@ async def test_invalid_response_fallback_rejects_image_before_text_only_call(
         selector.primary,
         selector,
         turn_metadata=metadata,
+    )
+    wrapper.configure_fallback_deployment_vision_support(
+        [(selector.fallback_config, "unsupported")]
     )
     agent = Agent(
         provider=wrapper,
@@ -1286,25 +1468,25 @@ async def test_invalid_response_fallback_rejects_image_before_text_only_call(
 
     assert selector.primary.calls == 1
     assert selector.fallback.calls == 0
+    assert selector.fallback_builds == 0
     assert selector.primary.validation_calls == 2
     assert selector.fallback.validation_calls == 0
-    assert any(
+    error = next(event for event in events if getattr(event, "kind", "") == "error")
+    assert getattr(error, "code", "") == "empty_response"
+    assert "llm.max_tokens" in getattr(error, "message", "")
+    assert not any(
         getattr(event, "kind", "") == "error"
         and getattr(event, "code", "") == IMAGE_INPUT_UNSUPPORTED_CODE
-        for event in events
-    )
-    assert any(
-        getattr(event, "kind", "") == "warning"
-        and getattr(event, "code", "") == "provider_empty_retry"
         for event in events
     )
     done_events = [event for event in events if isinstance(event, EngineDoneEvent)]
     if done_events:
         assert done_events[-1].input_tokens == 3
-        assert done_events[-1].output_tokens == 0
-    assert metadata["image_input_mode"] == "rejected"
-    assert metadata["image_input_reason"] == "model_vision_unsupported"
-    assert metadata["image_input_stage"] == "fallback"
+        assert done_events[-1].output_tokens == 1024
+        assert done_events[-1].reasoning_tokens == 1023
+    assert "image_input_mode" not in metadata
+    assert "image_input_reason" not in metadata
+    assert "image_input_stage" not in metadata
     assert metadata["routed_model"] == "vision-primary"
     assert metadata["executed_model"] == "vision-primary"
     assert "router_fallback_hops" not in metadata
@@ -1312,6 +1494,131 @@ async def test_invalid_response_fallback_rejects_image_before_text_only_call(
     assert metadata["savings_pct"] == 17.0
     assert [leg["model"] for leg in metadata["execution_legs"]] == [
         "vision-primary"
+    ]
+
+
+async def test_invalid_response_fallback_skips_text_leg_for_vision_fallback() -> None:
+    primary_config = SimpleNamespace(provider="openrouter", model="vision-primary")
+    text_config = SimpleNamespace(provider="openrouter", model="text-fallback")
+    vision_config = SimpleNamespace(provider="openrouter", model="vision-fallback")
+
+    class _Provider:
+        provider_name = "openrouter"
+
+        def __init__(self, model: str, *, empty: bool = False) -> None:
+            self.model = model
+            self.empty = empty
+            self.calls = 0
+
+        async def chat(self, messages, tools=None, config=None):
+            del messages, tools, config
+            self.calls += 1
+            if self.empty:
+                yield DoneEvent(
+                    stop_reason="length",
+                    input_tokens=3,
+                    output_tokens=1024,
+                    reasoning_tokens=1023,
+                    reasoning_content="internal reasoning",
+                    model=self.model,
+                )
+                return
+            yield TextDeltaEvent(text=f"reply from {self.model}")
+            yield DoneEvent(model=self.model)
+
+    providers = {
+        primary_config.model: _Provider(primary_config.model, empty=True),
+        text_config.model: _Provider(text_config.model),
+        vision_config.model: _Provider(vision_config.model),
+    }
+
+    class _Selector:
+        active_provider_id = "openrouter"
+
+        def __init__(self) -> None:
+            self._chain = [primary_config, text_config, vision_config]
+            self._index = 0
+
+        @property
+        def current_config(self):
+            return self._chain[self._index]
+
+        def remaining_chain(self):
+            return list(self._chain[self._index :])
+
+        def next_fallback_after_failure_matching(self, _exc, *, predicate):
+            matching = [cfg for cfg in self._chain[self._index + 1 :] if predicate(cfg)]
+            if not matching:
+                raise IndexError("No fallback chain available")
+            provider = providers[matching[0].model]
+            self._chain = [self.current_config, *matching]
+            self._index = 1
+            return provider
+
+    selector = _Selector()
+    metadata: dict[str, Any] = {
+        "routed_model": "vision-primary",
+        "executed_provider": "openrouter",
+        "executed_model": "vision-primary",
+    }
+    wrapper = _SelectorFallbackProvider(
+        providers[primary_config.model],
+        selector,
+        turn_metadata=metadata,
+    )
+    wrapper.configure_fallback_deployment_limits(
+        [
+            (text_config, 0, 0, ModelCapabilities(supports_vision=False)),
+            (vision_config, 0, 0, ModelCapabilities(supports_vision=True)),
+        ]
+    )
+    wrapper.configure_fallback_deployment_vision_support(
+        [
+            (text_config, "unsupported"),
+            (vision_config, "supported"),
+        ]
+    )
+    agent = Agent(
+        provider=wrapper,
+        config=AgentConfig(
+            max_provider_retries=0,
+            max_turn_llm_calls=2,
+            model_id="vision-primary",
+            model_capabilities=ModelCapabilities(supports_vision=True),
+            model_vision_support="supported",
+        ),
+    )
+    image_message = Message(
+        role="user",
+        content=[ContentBlockImage(media_type="image/png", data="c3ludGhldGlj")],
+    )
+
+    events = [
+        event
+        async for event in agent.run_turn(
+            "Describe the image.",
+            extra_messages=[image_message],
+        )
+    ]
+
+    assert providers[primary_config.model].calls == 1
+    assert providers[text_config.model].calls == 0
+    assert providers[vision_config.model].calls == 1
+    assert selector.current_config is vision_config
+    assert any(
+        getattr(event, "kind", "") == "text_delta"
+        and getattr(event, "text", "") == "reply from vision-fallback"
+        for event in events
+    )
+    assert not any(
+        getattr(event, "kind", "") == "error"
+        and getattr(event, "code", "") == IMAGE_INPUT_UNSUPPORTED_CODE
+        for event in events
+    )
+    assert metadata["router_fallback_hops"] == 1
+    assert [leg["model"] for leg in metadata["execution_legs"]] == [
+        "vision-primary",
+        "vision-fallback",
     ]
 
 

--- a/tests/test_gateway/test_task_runtime_terminal_message.py
+++ b/tests/test_gateway/test_task_runtime_terminal_message.py
@@ -723,6 +723,42 @@ async def test_task_runtime_stream_error_emits_sanitized_terminal_message() -> N
 
 
 @pytest.mark.asyncio
+async def test_task_runtime_stream_reasoning_budget_error_emits_actionable_terminal_message(
+) -> None:
+    emitted: list[tuple[str, str, dict[str, Any]]] = []
+    engine_message = (
+        "The provider used the configured output budget for reasoning without returning a "
+        "visible answer. Increase llm.max_tokens or choose another model or provider."
+    )
+
+    async def _stream():
+        yield ErrorEvent(message=engine_message, code="empty_response")
+
+    async def _emitter(session_key: str, event_name: str, payload: dict[str, Any]) -> None:
+        emitted.append((session_key, event_name, payload))
+
+    with pytest.raises(TaskRuntimeStreamError) as exc_info:
+        await _emit_task_runtime_stream_events(
+            _stream(),
+            "agent:main:test",
+            _emitter,
+            stream_event_sink=None,
+            idle_timeout=1.0,
+            heartbeat_interval=0.0,
+        )
+
+    assert exc_info.value.code == "empty_response"
+    payload = emitted[-1][2]
+    assert payload["code"] == "empty_response"
+    assert payload["message"] == (
+        "The model used its output budget for reasoning without returning a visible answer. "
+        "Increase llm.max_tokens or choose another model or provider."
+    )
+    assert payload["terminal_message"] == payload["message"]
+    assert payload["error_message"] == engine_message
+
+
+@pytest.mark.asyncio
 async def test_task_runtime_stream_error_terminal_message_carries_error_ref() -> None:
     # Additive: when the turn loop stamped an error_id, the stream emitter
     # suffixes the user-facing text with the durable turn_errors reference.

--- a/tests/test_gateway/test_terminal_reply.py
+++ b/tests/test_gateway/test_terminal_reply.py
@@ -208,6 +208,80 @@ def test_image_input_unsupported_reply_is_actionable_and_stable() -> None:
     )
 
 
+def test_reasoning_only_output_budget_empty_response_reply_is_actionable_and_stable() -> None:
+    reply = build_terminal_reply(
+        {
+            "status": "failed",
+            "terminal_reason": "error",
+            "error_class": "empty_response",
+            "error_message": (
+                "The provider used the configured output budget for reasoning without "
+                "returning a visible answer. Increase llm.max_tokens or choose another "
+                "model or provider."
+            ),
+        }
+    )
+
+    assert reply == (
+        "The model used its output budget for reasoning without returning a visible answer. "
+        "Increase llm.max_tokens or choose another model or provider."
+    )
+
+
+def test_reasoning_only_empty_response_reply_is_actionable_and_stable() -> None:
+    reply = build_terminal_reply(
+        {
+            "status": "failed",
+            "terminal_reason": "error",
+            "error_class": "empty_response",
+            "error_message": (
+                "The provider returned reasoning without a visible answer. "
+                "Try again or choose another model or provider."
+            ),
+        }
+    )
+
+    assert reply == (
+        "The model returned reasoning without a visible answer. "
+        "Try again or choose another model or provider."
+    )
+
+
+@pytest.mark.parametrize(
+    ("error_class", "error_message"),
+    [
+        ("empty_response", "Provider returned an empty response"),
+        (
+            "empty_response",
+            "private provider detail: increase llm.max_tokens or choose another model",
+        ),
+        (
+            "RuntimeError",
+            (
+                "The provider used the configured output budget for reasoning without "
+                "returning a visible answer. Increase llm.max_tokens or choose another "
+                "model or provider."
+            ),
+        ),
+    ],
+)
+def test_other_empty_or_provider_errors_keep_generic_terminal_reply(
+    error_class: str,
+    error_message: str,
+) -> None:
+    reply = build_terminal_reply(
+        {
+            "status": "failed",
+            "terminal_reason": "error",
+            "error_class": error_class,
+            "error_message": error_message,
+        }
+    )
+
+    assert reply == "The task failed before it could finish."
+    assert error_message not in reply
+
+
 def test_human_silent_reply_failure_has_actionable_terminal_message() -> None:
     reply = build_terminal_reply(
         {

--- a/tests/test_live_provider_profile_gateway_e2e.py
+++ b/tests/test_live_provider_profile_gateway_e2e.py
@@ -137,11 +137,12 @@ def test_tokenrhythm_uses_curated_inline_tiers_and_never_persists_profile(
     )
 
     data = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert data["llm"]["max_tokens"] == 1024
     assert "tier_profile" not in data["squilla_router"]
     assert data["squilla_router"]["tiers"] == tiers
 
 
-def test_tokenrhythm_run_uses_inline_preset_and_1024_output_floor(
+def test_tokenrhythm_run_uses_inline_preset_and_4096_output_floor(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -174,7 +175,7 @@ def test_tokenrhythm_run_uses_inline_preset_and_1024_output_floor(
     result = e2e._run_provider("tokenrhythm", max_tokens=64, timeout_seconds=1.0)
 
     tiers = e2e._profile_tiers("tokenrhythm")
-    assert captured["max_tokens"] == 1024
+    assert captured["max_tokens"] == 4096
     assert captured["tier_overrides"] == tiers
     assert result["tier_profile"] is None
     assert result["tier_mode"] == "inline_preset"

--- a/tests/test_live_provider_profile_smoke.py
+++ b/tests/test_live_provider_profile_smoke.py
@@ -143,7 +143,7 @@ def test_live_smoke_env_maps_cover_openai_zhipu_kimi_and_minimax() -> None:
     assert smoke._DEFAULT_MODELS["tokenrhythm"] == "deepseek-v4-flash"
     # Reasoning tokens bill against max_tokens: the default 64 budget would
     # return empty content with finish_reason "length".
-    assert smoke._MIN_MAX_TOKENS["tokenrhythm"] == 1024
+    assert smoke._MIN_MAX_TOKENS["tokenrhythm"] == 4096
     assert smoke._MIN_MAX_TOKENS["minimax"] == 64
 
 
@@ -182,6 +182,39 @@ async def test_exact_probe_budget_bypasses_provider_stream_floor(monkeypatch: An
     )
 
     assert observed == [1]
+    assert result.direct_status == "passed"
+
+
+async def test_tokenrhythm_exact_probe_budget_bypasses_live_smoke_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: list[int] = []
+
+    async def fake_direct(
+        provider: str,
+        model: str,
+        api_key: str,
+        base_url: str,
+        expected: str,
+        max_tokens: int,
+    ) -> tuple[str, str, str, dict[str, int], int]:
+        del api_key, base_url
+        assert provider == "tokenrhythm"
+        observed.append(max_tokens)
+        return "passed", model, expected, {"output_tokens": 1}, 1
+
+    monkeypatch.setenv("TOKENRHYTHM_API_KEY", "synthetic-tokenrhythm-key")
+    monkeypatch.setattr(smoke, "_direct_openai", fake_direct)
+
+    result = await smoke.smoke_provider(
+        "tokenrhythm",
+        include_stream=False,
+        model_override="deepseek-v4-flash",
+        max_tokens=1024,
+        apply_token_floor=False,
+    )
+
+    assert observed == [1024]
     assert result.direct_status == "passed"
 
 

--- a/tests/test_provider_selector.py
+++ b/tests/test_provider_selector.py
@@ -85,6 +85,288 @@ def test_turn_clone_disables_replay_for_plugin_fallback_without_mutating_shared_
     assert shared.current_config.replay_provider_state is True
 
 
+def test_matching_fallback_filters_plugin_chain_before_build(monkeypatch) -> None:
+    text_fallback = ProviderConfig(
+        "openrouter",
+        "text-fallback",
+        api_key="plugin-test-key",
+    )
+    unknown_fallback = ProviderConfig(
+        "openrouter",
+        "unknown-fallback",
+        api_key="plugin-test-key",
+    )
+    vision_fallback = ProviderConfig(
+        "openrouter",
+        "vision-fallback",
+        api_key="plugin-test-key",
+    )
+    second_vision_fallback = ProviderConfig(
+        "openrouter",
+        "second-vision-fallback",
+        api_key="plugin-test-key",
+    )
+    observed_failures: list[Exception] = []
+
+    class _Plugin:
+        def failover_hook(self, primary_failure: Exception) -> list[ProviderConfig]:
+            observed_failures.append(primary_failure)
+            return [
+                text_fallback,
+                unknown_fallback,
+                vision_fallback,
+                second_vision_fallback,
+            ]
+
+    built: list[ProviderConfig] = []
+
+    def fake_build_provider(cfg: ProviderConfig) -> ProviderConfig:
+        built.append(cfg)
+        return cfg
+
+    monkeypatch.setattr("opensquilla.provider.selector._build_provider", fake_build_provider)
+    selector = ModelSelector(
+        SelectorConfig(
+            primary=ProviderConfig(
+                "openrouter",
+                "primary",
+                api_key="primary-test-key",
+            ),
+            fallbacks=[
+                ProviderConfig(
+                    "openrouter",
+                    "static-fallback-must-not-run",
+                    api_key="static-test-key",
+                )
+            ],
+        ),
+        plugin=_Plugin(),
+    )
+    failure = RuntimeError("classified failure")
+
+    fallback = selector.next_fallback_after_failure_matching(
+        failure,
+        predicate=lambda cfg: cfg.model in {
+            "vision-fallback",
+            "second-vision-fallback",
+        },
+    )
+
+    assert observed_failures == [failure]
+    assert fallback is vision_fallback
+    assert built == [vision_fallback]
+    assert [cfg.model for cfg in selector.remaining_chain()] == [
+        "vision-fallback",
+        "second-vision-fallback",
+    ]
+
+
+def test_matching_fallback_honors_empty_plugin_veto_atomically(monkeypatch) -> None:
+    static_fallback = ProviderConfig(
+        "openrouter",
+        "static-vision-fallback",
+        api_key="static-test-key",
+    )
+    plugin_calls = 0
+
+    class _Plugin:
+        def failover_hook(self, primary_failure: Exception) -> list[ProviderConfig]:
+            nonlocal plugin_calls
+            del primary_failure
+            plugin_calls += 1
+            return []
+
+    built: list[ProviderConfig] = []
+
+    def fake_build_provider(cfg: ProviderConfig) -> ProviderConfig:
+        built.append(cfg)
+        return cfg
+
+    monkeypatch.setattr("opensquilla.provider.selector._build_provider", fake_build_provider)
+    selector = ModelSelector(
+        SelectorConfig(
+            primary=ProviderConfig(
+                "openrouter",
+                "primary",
+                api_key="primary-test-key",
+            ),
+            fallbacks=[static_fallback],
+        ),
+        plugin=_Plugin(),
+    )
+    original_chain = selector.remaining_chain()
+
+    with pytest.raises(IndexError, match="No fallback chain available"):
+        selector.next_fallback_after_failure_matching(
+            RuntimeError("classified failure"),
+            predicate=lambda cfg: cfg.model == "static-vision-fallback",
+        )
+
+    assert plugin_calls == 1
+    assert built == []
+    assert selector.current_config is original_chain[0]
+    assert selector.remaining_chain() == original_chain
+
+
+def test_matching_fallback_applies_replay_and_capacity_before_predicate(
+    monkeypatch,
+) -> None:
+    approved = ProviderConfig(
+        "tokenrhythm",
+        "vision-model",
+        api_key="approved-key",
+        base_url="https://approved.example/v1",
+        replay_provider_state=True,
+    )
+    unapproved_endpoint = ProviderConfig(
+        "tokenrhythm",
+        "vision-model",
+        api_key="other-key",
+        base_url="https://unapproved.example/v1",
+        replay_provider_state=True,
+    )
+
+    class _Plugin:
+        def failover_hook(self, primary_failure: Exception) -> list[ProviderConfig]:
+            del primary_failure
+            return [unapproved_endpoint, approved]
+
+    predicate_inputs: list[ProviderConfig] = []
+    built: list[ProviderConfig] = []
+
+    def predicate(cfg: ProviderConfig) -> bool:
+        predicate_inputs.append(cfg)
+        return True
+
+    def fake_build_provider(cfg: ProviderConfig) -> ProviderConfig:
+        built.append(cfg)
+        return cfg
+
+    monkeypatch.setattr("opensquilla.provider.selector._build_provider", fake_build_provider)
+    selector = ModelSelector(
+        SelectorConfig(
+            primary=ProviderConfig(
+                "openrouter",
+                "baseline",
+                api_key="primary-test-key",
+            ),
+            fallbacks=[approved],
+        ),
+        plugin=_Plugin(),
+    )
+    selector.override_model_with_bounded_fallback_chain(
+        HIGH_TIER_MODEL,
+        [approved],
+    )
+    selector.disable_provider_state_replay()
+
+    fallback = selector.next_fallback_after_failure_matching(
+        RuntimeError("classified failure"),
+        predicate=predicate,
+    )
+
+    assert [cfg.base_url for cfg in predicate_inputs] == [
+        "https://approved.example/v1"
+    ]
+    assert all(cfg.replay_provider_state is False for cfg in predicate_inputs)
+    assert fallback.base_url == "https://approved.example/v1"
+    assert fallback.replay_provider_state is False
+    assert built == [fallback]
+    assert approved.replay_provider_state is True
+    assert unapproved_endpoint.replay_provider_state is True
+
+
+def test_matching_fallback_build_failure_does_not_advance_selector(monkeypatch) -> None:
+    primary = ProviderConfig(
+        "openrouter",
+        "primary",
+        api_key="primary-test-key",
+    )
+    text_fallback = ProviderConfig(
+        "openrouter",
+        "text-fallback",
+        api_key="text-test-key",
+    )
+    vision_fallback = ProviderConfig(
+        "openrouter",
+        "vision-fallback",
+        api_key="vision-test-key",
+    )
+    built: list[ProviderConfig] = []
+
+    def failing_build_provider(cfg: ProviderConfig):
+        built.append(cfg)
+        raise ProviderBuildError("synthetic build failure")
+
+    monkeypatch.setattr(
+        "opensquilla.provider.selector._build_provider",
+        failing_build_provider,
+    )
+    selector = ModelSelector(
+        SelectorConfig(
+            primary=primary,
+            fallbacks=[text_fallback, vision_fallback],
+        )
+    )
+    original_chain = selector.remaining_chain()
+
+    with pytest.raises(ProviderBuildError, match="synthetic build failure"):
+        selector.next_fallback_after_failure_matching(
+            RuntimeError("classified failure"),
+            predicate=lambda cfg: cfg.model == "vision-fallback",
+        )
+
+    assert built == [vision_fallback]
+    assert selector.current_config is primary
+    assert selector.remaining_chain() == original_chain
+
+
+def test_next_fallback_build_failure_keeps_active_matching_candidate(monkeypatch) -> None:
+    primary = ProviderConfig("openrouter", "primary", api_key="primary-test-key")
+    first_vision = ProviderConfig(
+        "openrouter",
+        "first-vision",
+        api_key="first-vision-test-key",
+    )
+    second_vision = ProviderConfig(
+        "openrouter",
+        "second-vision",
+        api_key="second-vision-test-key",
+    )
+    built: list[ProviderConfig] = []
+
+    def build_provider(cfg: ProviderConfig) -> ProviderConfig:
+        built.append(cfg)
+        if cfg is second_vision:
+            raise ProviderBuildError("synthetic second-candidate build failure")
+        return cfg
+
+    monkeypatch.setattr("opensquilla.provider.selector._build_provider", build_provider)
+    selector = ModelSelector(
+        SelectorConfig(
+            primary=primary,
+            fallbacks=[first_vision, second_vision],
+        )
+    )
+
+    active_provider = selector.next_fallback_after_failure_matching(
+        RuntimeError("classified failure"),
+        predicate=lambda cfg: cfg.model in {"first-vision", "second-vision"},
+    )
+
+    assert active_provider is first_vision
+    assert selector.current_config is first_vision
+    with pytest.raises(
+        ProviderBuildError,
+        match="synthetic second-candidate build failure",
+    ):
+        selector.next_fallback()
+
+    assert built == [first_vision, second_vision]
+    assert selector.current_config is first_vision
+    assert selector.remaining_chain() == [first_vision, second_vision]
+
+
 def test_override_model_keeps_original_primary_as_first_fallback(monkeypatch) -> None:
     built: list[ProviderConfig] = []
 


### PR DESCRIPTION
## Scope

- Recover terminal reasoning-only responses independently of local thinking state with a bounded, non-identical retry while preserving the configured output cap.
- Keep image invalid-response fallback exact, vision-compatible, plugin-aware, and atomic.
- Surface fixed, actionable empty-response terminal messages.
- Raise the TokenRhythm live-profile test floor to 4096 without changing product auto resolution or explicit user caps.

Scope boundary: This is a containment fix for terminal reasoning-only responses. It does not add a first-visible-output watchdog or a universal provider reasoning-control protocol.

Non-goals: Automatic output-cap escalation, provider-specific unverified reasoning fields, and long-running hidden-reasoning watchdog behavior.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Refs #1321

## Release Note

Release note: Prevent silent image-turn completion when provider-default reasoning consumes the output budget; retry once with an execution directive and return an actionable error when recovery is exhausted.

## Tests

Ruff: passed on all 14 touched files

Pytest: 297 passed in the focused engine, gateway, provider, catalog, and live-harness offline suite

Build: not needed; Python-only runtime and test changes

Regression tests: added

Notes: A prior full engine run completed with 3098 passed and 1 deselected. The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: yes

Surface: provider

Maintainer-only note: Synthetic image qualification confirmed visible answers for ordinary cases and bounded explicit `empty_response` for repeated output-budget exhaustion. The 4096 hidden-reasoning timeout remains tracked by #1321. No credential, prompt, image, or transcript is included.

## Safety

- Platform-neutral.
- No database, persisted config, RPC, or public error-code migration.
- Existing user `max_tokens` remains authoritative.
- At most one additional provider call occurs when retries are enabled.
- Image fallbacks require exact supported vision evidence and never call unsupported or unknown candidates.
- No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are committed.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
