### PR TITLE
Fix reopened attachment capacity routing across Ensemble legs

### DIFF
--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -9506,15 +9506,43 @@ class TurnRunner:
                     "missing_fixed_fallback: configure a non-empty fixed/direct "
                     "provider and model before enabling multi-model fusion"
                 )
-            turn.metadata["ensemble_fallback_provider"] = fixed_provider
-            turn.metadata["ensemble_fallback_model"] = fixed_model
+
+            # Attachment admission proves the routed logical deployment before
+            # Ensemble replaces it with the configured fixed baseline. If that
+            # baseline cannot carry the same request, keep the proven routed
+            # single-model path and its capacity-filtered selector fallback.
+            if turn.metadata.get("large_context_capacity_required") is True:
+                from opensquilla.engine.selector_override import (
+                    provider_config_has_request_capacity,
+                )
+
+                if not provider_config_has_request_capacity(
+                    initial_provider_config,
+                    turn.metadata,
+                ):
+                    fixed_baseline_ensemble = False
+                    turn.metadata["ensemble_wrap_skipped_reason"] = (
+                        "fixed_fallback_request_capacity"
+                    )
+                    turn.metadata["ensemble_capacity_bypassed"] = True
+                    log.warning(
+                        "llm_ensemble.wrap_skipped",
+                        reason="fixed_fallback_request_capacity",
+                        provider=fixed_provider,
+                        model=fixed_model,
+                    )
+
+            if fixed_baseline_ensemble:
+                turn.metadata["ensemble_fallback_provider"] = fixed_provider
+                turn.metadata["ensemble_fallback_model"] = fixed_model
 
             # Static/custom plans own their members' reasoning policy.  The
             # tier value remains stored as the reversible single-model draft,
             # but must not leak into the shared plan.  Legacy router_dynamic
             # continues to derive per-member thinking from its tier rows.
             if (
-                selection_mode != ROUTER_DYNAMIC_SELECTION_MODE
+                fixed_baseline_ensemble
+                and selection_mode != ROUTER_DYNAMIC_SELECTION_MODE
                 and turn.metadata.get("thinking_source") == "squilla_router_tier"
             ):
                 turn.metadata.pop("thinking_requested", None)
@@ -9702,7 +9730,7 @@ class TurnRunner:
             record_ensemble_unavailable("missing_primary_provider")
         if (
             provider is not None
-            and (ensemble_globally_enabled or tier_ensemble_mode)
+            and fixed_baseline_ensemble
             and artifact_ensemble_bypass is None
         ):
             from opensquilla.engine.selector_override import (

--- a/src/opensquilla/engine/selector_override.py
+++ b/src/opensquilla/engine/selector_override.py
@@ -58,7 +58,7 @@ def _bounded_fallback_chain_required(turn_metadata: dict[str, Any]) -> bool:
     )
 
 
-def _provider_config_has_request_capacity(
+def provider_config_has_request_capacity(
     config: Any,
     turn_metadata: dict[str, Any],
     *,
@@ -121,7 +121,7 @@ def _require_provider_config_capacity(
     provider: str = "",
     model: str = "",
 ) -> None:
-    if _provider_config_has_request_capacity(
+    if provider_config_has_request_capacity(
         config,
         turn_metadata,
         provider=provider,
@@ -231,7 +231,7 @@ def _capacity_approved_fallback_entries(
     return [
         config
         for config in _materialize_fallback_configs(selector, entries)
-        if _provider_config_has_request_capacity(config, turn_metadata)
+        if provider_config_has_request_capacity(config, turn_metadata)
     ]
 
 

--- a/src/opensquilla/provider/ensemble.py
+++ b/src/opensquilla/provider/ensemble.py
@@ -21,7 +21,7 @@ from typing import Any, Literal, cast
 
 import structlog
 
-from opensquilla.context_budget import ContextBudgetGovernor
+from opensquilla.context_budget import CHARS_PER_TOKEN, ContextBudgetGovernor
 from opensquilla.contracts.turn_execution import (
     EnsembleContinuationSnapshot,
     ProviderAdmissionError,
@@ -1402,6 +1402,7 @@ class EnsembleProvider:
         ]
         | None = None,
         _fallback_request_budget_member: EnsembleMemberConfig | None = None,
+        _attachment_request_input_tokens: int = 0,
         _credential_pool_failure_reporter: CredentialPoolFailureReporter | None = None,
         _artifact_tool_executor_capabilities: ModelCapabilities | None = None,
         _artifact_tool_executor_capability_verified: bool = False,
@@ -1459,6 +1460,13 @@ class EnsembleProvider:
             _member_request_budget_bindings or {}
         )
         self._fallback_request_budget_member = _fallback_request_budget_member
+        self._attachment_request_input_tokens = max(
+            0,
+            int(_attachment_request_input_tokens or 0),
+        )
+        self._require_attachment_capacity_proof = (
+            self._attachment_request_input_tokens > 0
+        )
         self._credential_pool_failure_reporter = _credential_pool_failure_reporter
         self.artifact_tool_executor_capabilities = (
             _artifact_tool_executor_capabilities
@@ -1593,6 +1601,68 @@ class EnsembleProvider:
         ):
             return (
                 "proposer has no reliable provider-specific request budget",
+                "provider_request_budget_exhausted",
+            )
+        return None
+
+    def _attachment_request_unavailability(
+        self,
+        *,
+        member: EnsembleMemberConfig | None,
+        chat_config: ChatConfig | None,
+        role: str,
+    ) -> tuple[str, str] | None:
+        """Check the complete routed request against one physical member cap.
+
+        The router freezes a conservative input-token upper bound after prompt,
+        tool, and attachment materialization. Reusing that bound keeps this
+        physical-member preflight cheap and prevents a large attachment from
+        being rescanned once per Ensemble leg.
+        """
+
+        if not self._require_attachment_capacity_proof:
+            return None
+        binding = (
+            self._member_request_budget_binding(member)
+            if member is not None
+            else None
+        )
+        context_window_tokens = (
+            int(binding.context_window_tokens or 0) if binding is not None else 0
+        )
+        if (
+            binding is None
+            or not binding.rederive
+            or context_window_tokens <= 0
+        ):
+            return (
+                f"{role} has no proven attachment request capacity; configure "
+                "context_window_tokens for every Ensemble member and fallback",
+                "provider_request_budget_exhausted",
+            )
+        thinking_budget_tokens = (
+            max(0, int(getattr(chat_config, "thinking_budget_tokens", 0) or 0))
+            if bool(getattr(chat_config, "thinking", False))
+            else 0
+        )
+        budget = ContextBudgetGovernor.from_values(
+            context_window_tokens=context_window_tokens,
+            max_output_tokens=max(
+                0,
+                int(getattr(chat_config, "max_tokens", 0) or 0),
+            ),
+            thinking_budget_tokens=thinking_budget_tokens,
+            context_overflow_threshold=binding.context_overflow_threshold,
+            provider_request_proof_max_chars=max(
+                0,
+                int(binding.top_level_explicit_cap or 0),
+            ),
+        ).snapshot()
+        safe_input_tokens = budget.provider_request_max_chars // CHARS_PER_TOKEN
+        if self._attachment_request_input_tokens > safe_input_tokens:
+            return (
+                f"{role} attachment request exceeds its proven capacity; "
+                "configure a larger-context Ensemble deployment",
                 "provider_request_budget_exhausted",
             )
         return None
@@ -2485,6 +2555,28 @@ class EnsembleProvider:
                 yield event
             return
 
+        aggregator_binding = self._member_request_budget_binding(self.aggregator)
+        if self._require_attachment_capacity_proof and (
+            aggregator_binding is None
+            or not aggregator_binding.rederive
+            or int(aggregator_binding.context_window_tokens or 0) <= 0
+        ):
+            async for event in self._fallback_or_error(
+                messages,
+                tools=tools,
+                config=config,
+                execution_context=execution_context,
+                reason=(
+                    "ensemble aggregator has no proven attachment request "
+                    "capacity; configure context_window_tokens for every "
+                    "Ensemble member"
+                ),
+                code="provider_request_budget_exhausted",
+                candidates=[],
+            ):
+                yield event
+            return
+
         try:
             aggregator_provider = _build_provider(self.aggregator.provider_config)
         except Exception as exc:  # noqa: BLE001 - provider boundary returns ErrorEvent
@@ -2508,7 +2600,6 @@ class EnsembleProvider:
             return
 
         aggregator_cfg = self._aggregator_chat_config(config, messages)
-        aggregator_binding = self._member_request_budget_binding(self.aggregator)
         if (
             aggregator_binding is not None
             and not aggregator_binding.inherit_top_level_cap
@@ -3065,6 +3156,14 @@ class EnsembleProvider:
         # generators. Provider-private continuity state (reasoning_content,
         # thinking blocks, thought signatures) belongs to the model that
         # minted it and must not be replayed into any proposer physical call.
+        capacity_unavailable = self._attachment_request_unavailability(
+            member=member,
+            chat_config=chat_cfg,
+            role="Ensemble proposer",
+        )
+        if capacity_unavailable is not None:
+            result.error, result.error_code = capacity_unavailable
+            return result
         provider = _build_provider(_proposer_provider_config(member))
         text_parts: list[str] = []
         got_done = False
@@ -4546,6 +4645,8 @@ class EnsembleProvider:
         fixed_messages = list(messages)
         fixed_budget_proof: dict[str, Any] | None = None
         fixed_budget_exhausted = False
+        fixed_budget_error_message = ""
+        fixed_budget_error_code = "fallback_aggregator_budget_exhausted"
         if immutable_bundle:
             fitted_fixed = self._fit_fixed_candidate_bundle(
                 self.fallback_provider,
@@ -4558,6 +4659,17 @@ class EnsembleProvider:
                 fixed_bundle, fixed_messages, fixed_budget_proof = fitted_fixed
             else:
                 fixed_budget_exhausted = True
+        else:
+            fixed_capacity_unavailable = self._attachment_request_unavailability(
+                member=fallback_member,
+                chat_config=fallback_config,
+                role="Ensemble fixed fallback",
+            )
+            if fixed_capacity_unavailable is not None:
+                fixed_budget_exhausted = True
+                fixed_budget_error_message, fixed_budget_error_code = (
+                    fixed_capacity_unavailable
+                )
         fallback_timeout_seconds = float(
             getattr(fallback_config, "timeout", ChatConfig().timeout)
             if fallback_config is not None
@@ -4615,7 +4727,7 @@ class EnsembleProvider:
                 fixed_budget_proof
             )
         trace["fallback_code"] = (
-            "fallback_aggregator_budget_exhausted"
+            fixed_budget_error_code
             if fixed_budget_exhausted
             else (
                 "provider_request_budget_exhausted"
@@ -4624,6 +4736,9 @@ class EnsembleProvider:
             )
         )
         if fixed_budget_exhausted:
+            capacity_message = fixed_budget_error_message or (
+                "fixed aggregator request budget cannot retain one candidate draft"
+            )
             if execution_context is not None:
                 await execution_context.begin_failed_fixed_recovery(
                     fixed_execution_role,
@@ -4633,7 +4748,7 @@ class EnsembleProvider:
                         tool_schemas=tuple(tools or ()),
                         conversation=tuple(messages),
                         metadata={
-                            "code": "fallback_aggregator_budget_exhausted",
+                            "code": fixed_budget_error_code,
                             "fixed_role": fixed_role,
                         },
                     ),
@@ -4644,20 +4759,14 @@ class EnsembleProvider:
                     safe_reason="fixed request budget exhausted",
                     terminal=True,
                     terminal_text_snapshot=ENSEMBLE_FIXED_TERMINAL_MESSAGE,
-                    terminal_error_message=(
-                        "fixed aggregator request budget cannot retain one "
-                        "candidate draft"
-                    ),
-                    terminal_error_code="fallback_aggregator_budget_exhausted",
+                    terminal_error_message=capacity_message,
+                    terminal_error_code=fixed_budget_error_code,
                 )
                 return
             yield proposer_error(
                 ErrorEvent(
-                    message=(
-                        "fixed aggregator request budget cannot retain one "
-                        "candidate draft"
-                    ),
-                    code="fallback_aggregator_budget_exhausted",
+                    message=capacity_message,
+                    code=fixed_budget_error_code,
                 )
             )
             return
@@ -7172,6 +7281,19 @@ def build_ensemble_provider_from_config(
         selection_plan=selection_plan,
         _member_request_budget_bindings=request_budget_bindings,
         _fallback_request_budget_member=fallback_request_budget_member,
+        _attachment_request_input_tokens=(
+            int((turn_metadata or {}).get("large_context_request_input_tokens") or 0)
+            if (turn_metadata or {}).get("large_context_capacity_required") is True
+            and isinstance(
+                (turn_metadata or {}).get("large_context_request_input_tokens"),
+                int,
+            )
+            and not isinstance(
+                (turn_metadata or {}).get("large_context_request_input_tokens"),
+                bool,
+            )
+            else 0
+        ),
         _credential_pool_failure_reporter=_credential_pool_failure_reporter,
         _artifact_tool_executor_capabilities=artifact_tool_executor_capabilities,
         _artifact_tool_executor_capability_verified=(

--- a/tests/test_engine/test_attachment_aware_routing.py
+++ b/tests/test_engine/test_attachment_aware_routing.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import io
 import zipfile
+from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
@@ -23,7 +24,11 @@ from opensquilla.engine.turn_runner.attachment_stage import (
     AttachmentStageInput,
     rebind_attachment_prompt,
 )
+from opensquilla.gateway.config import GatewayConfig, SquillaRouterConfig
 from opensquilla.gateway.input_normalization import normalize_incoming_text
+from opensquilla.provider import ChatConfig, EnsembleProvider, Message
+from opensquilla.provider.model_catalog import ModelCatalog
+from opensquilla.provider.selector import ProviderConfig
 from opensquilla.provider.types import ContentBlockText
 from opensquilla.token_estimation import (
     estimate_attachment_text_tokens,
@@ -76,6 +81,66 @@ class _RuntimeAttachmentBuilder:
             workspace_dir=workspace_dir,
             session_id=session_id,
         )
+
+
+class _PipelineProvider:
+    provider_name = "openrouter"
+
+    def chat(
+        self,
+        messages: list[Message],
+        tools: list[Any] | None = None,
+        config: ChatConfig | None = None,
+    ) -> AsyncIterator[Any]:
+        raise AssertionError("routing regression must not start provider chat")
+
+    async def list_models(self) -> list[Any]:
+        return []
+
+
+class _PipelineSelector:
+    def __init__(self) -> None:
+        self._config = ProviderConfig(
+            provider="openrouter",
+            model="small-fixed",
+            api_key="sk-synthetic",
+            base_url="https://example.invalid/v1",
+        )
+
+    @property
+    def current_config(self) -> ProviderConfig:
+        return self._config
+
+    @property
+    def active_provider_id(self) -> str:
+        return self._config.provider
+
+    def remaining_chain(self) -> list[ProviderConfig]:
+        return [self._config]
+
+    def override_model(self, model: str) -> None:
+        self._config = ProviderConfig(
+            provider=self._config.provider,
+            model=model,
+            api_key=self._config.api_key,
+            base_url=self._config.base_url,
+            proxy=self._config.proxy,
+            provider_routing=dict(self._config.provider_routing),
+        )
+
+    def resolve(self) -> _PipelineProvider:
+        return _PipelineProvider()
+
+
+class _C3Strategy:
+    async def classify(
+        self,
+        message: str,
+        valid_tiers: list[str],
+        routing_history: list[dict] | None = None,
+        **kwargs: object,
+    ) -> tuple[str, float, str, dict[str, str]]:
+        return "c3", 0.99, "synthetic", {"route_class": "R3"}
 
 
 def _inline_attachment(payload: bytes, mime: str, name: str) -> dict[str, str]:
@@ -220,6 +285,104 @@ async def test_stats_measure_exact_provider_visible_text_for_rendered_formats(
     assert output.stats.estimated_tokens == sum(
         estimate_attachment_text_tokens(block.text) for block in visible_blocks
     )
+
+
+@pytest.mark.parametrize("attachment_kind", ["txt", "pdf", "docx"])
+@pytest.mark.asyncio
+async def test_capacity_route_does_not_restore_an_unsafe_ensemble_fixed_model(
+    monkeypatch: pytest.MonkeyPatch,
+    attachment_kind: str,
+) -> None:
+    """The physical Ensemble fallback must not undo a proven attachment route."""
+
+    material = (
+        "[]{}!@#$%^&*()_+-=|;:,./?0123456789ABCDEF\n" * 4_200
+    )[:160_000]
+    if attachment_kind == "txt":
+        attachment = _inline_attachment(material.encode(), "text/plain", "sample.txt")
+    elif attachment_kind == "pdf":
+        attachment = _inline_attachment(
+            _pdf_bytes(material),
+            "application/pdf",
+            "sample.pdf",
+        )
+    else:
+        attachment = _inline_attachment(
+            _docx_bytes(material),
+            DOCX_MIME,
+            "sample.docx",
+        )
+    materialized, _builder = await _materialize(attachment)
+
+    catalog = ModelCatalog()
+    catalog.set_user_overrides(
+        {
+            "openrouter/small-fixed": {
+                "context_window": 64_000,
+                "max_output_tokens": 4_000,
+            },
+            "openrouter/large-tier": {
+                "context_window": 256_000,
+                "max_output_tokens": 4_000,
+            },
+        }
+    )
+    monkeypatch.setattr("opensquilla.provider.model_catalog._shared_catalog", catalog)
+    monkeypatch.setattr(
+        "opensquilla.engine.steps.squilla_router._get_strategy",
+        lambda _config: _C3Strategy(),
+    )
+    config = GatewayConfig(
+        llm={
+            "provider": "openrouter",
+            "model": "small-fixed",
+            "api_key": "sk-synthetic",
+            "base_url": "https://example.invalid/v1",
+            "max_tokens": 4_000,
+        },
+        squilla_router=SquillaRouterConfig(
+            enabled=True,
+            auto_thinking=False,
+            tiers={
+                "c3": {
+                    "provider": "openrouter",
+                    "model": "large-tier",
+                    "ensemble_enabled": True,
+                }
+            },
+            default_tier="c3",
+        ),
+        llm_ensemble={
+            "enabled": False,
+            "selection_mode": "static_openrouter_b5",
+        },
+    )
+    selector = _PipelineSelector()
+
+    turn, provider = await TurnRunner(
+        provider_selector=None,
+        config=config,
+        model_catalog=catalog,
+    )._run_pipeline(
+        "inspect attachment",
+        f"agent:main:ensemble-capacity-{attachment_kind}",
+        _PipelineProvider(),
+        selector,
+        [],
+        "system prompt",
+        [attachment],
+        attachment_materialization=materialized.stats,
+        history_capacity_estimate_complete=True,
+    )
+
+    assert 30_000 < materialized.stats.estimated_tokens < 50_000
+    assert turn.metadata["routed_model"] == "large-tier"
+    assert turn.metadata["ensemble_wrap_skipped_reason"] == (
+        "fixed_fallback_request_capacity"
+    )
+    assert turn.model == "large-tier"
+    assert selector.current_config.model == "large-tier"
+    assert not isinstance(provider, EnsembleProvider)
 
 
 @pytest.mark.asyncio

--- a/tests/test_provider_ensemble.py
+++ b/tests/test_provider_ensemble.py
@@ -10,6 +10,7 @@ from typing import Any, Literal
 
 import pytest
 
+from opensquilla.context_budget import CHARS_PER_TOKEN, ContextBudgetGovernor
 from opensquilla.contracts.turn_execution import (
     ProviderAdmissionError,
     StickyExecutionRole,
@@ -8492,3 +8493,229 @@ async def test_step3_configured_minimum_is_the_effective_runtime_floor(
     assert done.ensemble_trace["effective_min_successful_proposers"] == 3
     assert done.ensemble_trace["min_successful_proposers"] == 3
     assert done.ensemble_trace["successful_proposers"] == 4
+
+
+def _attachment_capacity_binding(
+    context_window_tokens: int,
+) -> _MemberRequestBudgetBinding:
+    return _MemberRequestBudgetBinding(
+        context_window_tokens=context_window_tokens,
+        context_window_source="synthetic",
+        context_overflow_threshold=0.85,
+        cap_source="member_context",
+        rederive=True,
+        inherit_top_level_cap=False,
+    )
+
+
+def test_attachment_member_capacity_admits_exact_limit() -> None:
+    member = _member("p1", thinking="off")
+    binding = _attachment_capacity_binding(64_000)
+    chat_config = _member_chat_config(
+        ChatConfig(),
+        member,
+        request_budget_binding=binding,
+    )
+    safe_input_tokens = (
+        ContextBudgetGovernor.from_values(
+            context_window_tokens=64_000,
+            max_output_tokens=chat_config.max_tokens,
+            thinking_budget_tokens=0,
+            context_overflow_threshold=0.85,
+        ).snapshot().provider_request_max_chars
+        // CHARS_PER_TOKEN
+    )
+
+    def provider_for(required_tokens: int) -> EnsembleProvider:
+        return EnsembleProvider(
+            profile_name="attachment-boundary",
+            proposers=[member],
+            aggregator=_member("agg"),
+            _member_request_budget_bindings={
+                ("fake", "p1", ""): binding,
+            },
+            _attachment_request_input_tokens=required_tokens,
+        )
+
+    assert provider_for(safe_input_tokens)._attachment_request_unavailability(
+        member=member,
+        chat_config=chat_config,
+        role="Ensemble proposer",
+    ) is None
+    assert provider_for(safe_input_tokens + 1)._attachment_request_unavailability(
+        member=member,
+        chat_config=chat_config,
+        role="Ensemble proposer",
+    ) == (
+        "Ensemble proposer attachment request exceeds its proven capacity; "
+        "configure a larger-context Ensemble deployment",
+        "provider_request_budget_exhausted",
+    )
+
+
+@pytest.mark.asyncio
+async def test_attachment_capacity_skips_unsafe_cross_provider_proposer_before_chat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    unsafe = EnsembleMemberConfig(
+        provider_config=ProviderConfig(provider="openrouter", model="unsafe-64k"),
+        label="unsafe",
+        thinking="off",
+    )
+    safe = _member("safe-256k", thinking="off")
+    aggregator = _member("agg", thinking="off")
+    registry = _FakeRegistry(
+        {
+            "unsafe-64k": _FakePlan(
+                [TextDeltaEvent(text="must not run"), DoneEvent(model="unsafe-64k")]
+            ),
+            "safe-256k": _FakePlan(
+                [TextDeltaEvent(text="safe draft"), DoneEvent(model="safe-256k")]
+            ),
+            "agg": _FakePlan([TextDeltaEvent(text="final"), DoneEvent(model="agg")]),
+        }
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    provider = EnsembleProvider(
+        profile_name="attachment-cross-provider",
+        proposers=[unsafe, safe],
+        aggregator=aggregator,
+        min_successful_proposers=1,
+        all_failed_policy="error",
+        shuffle_candidates=False,
+        _member_request_budget_bindings={
+            ("openrouter", "unsafe-64k", ""): _attachment_capacity_binding(64_000),
+            ("fake", "safe-256k", ""): _attachment_capacity_binding(256_000),
+            ("fake", "agg", ""): _attachment_capacity_binding(256_000),
+        },
+        _attachment_request_input_tokens=90_000,
+    )
+
+    events = [
+        event
+        async for event in provider.chat(
+            [Message(role="user", content="attachment request")],
+            config=ChatConfig(provider_request_max_chars=300_000),
+        )
+    ]
+
+    assert [call["model"] for call in registry.calls] == ["safe-256k", "agg"]
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.ensemble_trace is not None
+    skipped = next(
+        candidate
+        for candidate in done.ensemble_trace["candidates"]
+        if candidate["model"] == "unsafe-64k"
+    )
+    assert skipped["request_started"] is False
+    assert skipped["error_code"] == "provider_request_budget_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_attachment_unknown_aggregator_stops_before_any_chat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = _FakeRegistry(
+        {
+            "p1": _FakePlan(
+                [TextDeltaEvent(text="must not run"), DoneEvent(model="p1")]
+            ),
+            "unknown-agg": _FakePlan(
+                [TextDeltaEvent(text="must not run"), DoneEvent(model="unknown-agg")]
+            ),
+        }
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    unknown_binding = _MemberRequestBudgetBinding(
+        context_window_tokens=None,
+        context_window_source="default",
+        context_overflow_threshold=0.85,
+        cap_source="inherited",
+        rederive=False,
+        inherit_top_level_cap=True,
+    )
+    provider = EnsembleProvider(
+        profile_name="attachment-unknown-aggregator",
+        proposers=[_member("p1", thinking="off")],
+        aggregator=_member("unknown-agg", thinking="off"),
+        all_failed_policy="error",
+        shuffle_candidates=False,
+        _member_request_budget_bindings={
+            ("fake", "p1", ""): _attachment_capacity_binding(256_000),
+            ("fake", "unknown-agg", ""): unknown_binding,
+        },
+        _attachment_request_input_tokens=90_000,
+    )
+
+    events = [
+        event
+        async for event in provider.chat(
+            [Message(role="user", content="attachment request")],
+            config=ChatConfig(provider_request_max_chars=900_000),
+        )
+    ]
+
+    assert registry.calls == []
+    error = next(event for event in events if isinstance(event, ErrorEvent))
+    assert error.code == "provider_request_budget_exhausted"
+    assert "context_window_tokens" in error.message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("require_attachment_capacity_proof", "expected_models"),
+    [
+        (True, ["p1"]),
+        (False, ["p1", "fixed-64k"]),
+    ],
+)
+async def test_attachment_turn_blocks_unsafe_fixed_direct_before_chat(
+    monkeypatch: pytest.MonkeyPatch,
+    require_attachment_capacity_proof: bool,
+    expected_models: list[str],
+) -> None:
+    registry = _FakeRegistry(
+        {
+            "p1": _FakePlan([ErrorEvent(message="synthetic failure", code="500")]),
+            "fixed-64k": _FakePlan(
+                [TextDeltaEvent(text="fallback"), DoneEvent(model="fixed-64k")]
+            ),
+        }
+    )
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    fallback_member = _member("fixed-64k", thinking="off")
+    provider = EnsembleProvider(
+        profile_name="attachment-fixed-direct",
+        proposers=[_member("p1", thinking="off")],
+        aggregator=_member("agg", thinking="off"),
+        fallback_provider=registry.provider_for(fallback_member.provider_config),
+        fallback_provider_name="fake",
+        fallback_model="fixed-64k",
+        min_successful_proposers=1,
+        all_failed_policy="fallback_single",
+        shuffle_candidates=False,
+        _member_request_budget_bindings={
+            ("fake", "p1", ""): _attachment_capacity_binding(256_000),
+            ("fake", "agg", ""): _attachment_capacity_binding(256_000),
+            ("fake", "fixed-64k", ""): _attachment_capacity_binding(64_000),
+        },
+        _fallback_request_budget_member=fallback_member,
+        _attachment_request_input_tokens=(90_000 if require_attachment_capacity_proof else 0),
+    )
+
+    events = [
+        event
+        async for event in provider.chat(
+            [Message(role="user", content="attachment request")],
+            config=ChatConfig(provider_request_max_chars=300_000),
+        )
+    ]
+
+    assert [call["model"] for call in registry.calls] == expected_models
+    if require_attachment_capacity_proof:
+        error = next(event for event in events if isinstance(event, ErrorEvent))
+        assert error.code == "provider_request_budget_exhausted"
+        assert "larger-context" in error.message
+    else:
+        done = next(event for event in events if isinstance(event, DoneEvent))
+        assert done.model == "fixed-64k"


### PR DESCRIPTION
## Scope

Scope boundary: Reopened follow-up for #1195 after #1304, limited to attachment-capacity admission across the existing Ensemble physical execution legs and focused regression coverage.

Non-goals: No routing architecture redesign, trace-format migration, configuration migration, Bug table update, or merge.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Refs #1195

## Release Note

Release note: Fix large-attachment routing so every physical Ensemble recipient has proven request capacity before execution.

## Summary

#1304 finalized capacity against the routed logical model, but runtime Ensemble activation could restore an unsafe configured fixed baseline. Proposers and the no-candidate fixed-direct fallback also lacked a pre-call capacity check for their actual deployment. A same-provider unknown custom aggregator could inherit the baseline request cap without a trustworthy context window of its own.

## Minimal fix

- Skip Ensemble activation when its fixed baseline/all-failed fallback cannot fit the complete attachment-bearing request, preserving the proven routed deployment and bounded selector fallback chain.
- Before provider.chat, validate each proposer and no-candidate fixed-direct leg against its resolved context window, overflow threshold, output reserve, thinking reserve, and explicit operator cap.
- Require an attachment-mode aggregator to have a rederived trustworthy context window before any proposer starts; known aggregators retain exact projection of their actual aggregated payload.
- Fail closed with actionable capacity errors when no safe physical plan exists.

## Performance and privacy

The preflight reuses the complete request input-token upper bound frozen after attachment materialization and prompt/tool assembly. It does not tokenize the attachment once per Ensemble member, avoiding the Windows long-text regression addressed during #1304. Provider adapters retain their final-envelope admission as a second boundary.

New metadata, logs, and capacity errors contain only deployment identities and reason codes, never attachment content, names, paths, prompts, transcripts, or credentials. The pre-existing successful Ensemble trace input format is unchanged and remains a separate privacy follow-up risk.

## Compatibility

No configuration, persistence, or public API changes. Pure-text Ensemble behavior is unchanged. Unknown custom models retain the #1304 rule: attachment turns need a trustworthy configured or catalog context window, while pure-text turns keep legacy behavior. The implementation is platform-neutral and adds no shared mutable state.

## Tests

Ruff: Passed on all five changed files.

Pytest: 393 passed, 2 skipped in the routing, Ensemble, attachment, token and compatibility matrix; 211 passed in the routing parity, prompt assembler, context overflow, attachment and cross-session matrix.

Build: Not required for this Python-only focused change.

Regression tests: added

Notes: mypy passed on all three changed source files; git diff --check passed. Full-repository and live-provider suites were not run locally. All local fixtures are synthetic, offline, credential-free, and contain no private prompt or transcript data.

## Maintainer Live Check

Maintainer live check: no

Surface: provider

## Safety

No secrets, local paths, private prompts/transcripts, channel identifiers, AI session artifacts, or non-public fixtures were added.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Remaining risk

The existing successful ensemble_trace.final_request.input format may retain clipped request content. This PR neither adds nor expands that behavior; it should be handled separately rather than through a broad trace migration here.