### PR TITLE
Fix generic custom pricing for auxiliary usage

### DIFF
--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -205,6 +205,21 @@ compatibility. Declare the endpoint's real window under
 `[models.custom_anthropic."<model>"]`; this is important for both remote
 gateways and local servers with larger windows.
 
+`custom` and `custom_anthropic` default to a zero token-cost estimate. This
+does not mean a remote service, GPU, or other infrastructure is free. To
+estimate a paid endpoint, set both input and output prices for its exact
+provider/model override; cache-read and cache-write prices remain optional:
+
+```toml
+[models.custom."vendor-model"]
+input_cost_per_mtok = 0.5
+output_cost_per_mtok = 2.0
+```
+
+If either main price is omitted, the generic custom endpoint remains at the
+zero-price default and does not inherit a same-named marketplace model's
+price.
+
 The current custom-provider boundary is intentionally explicit:
 
 - protocol selection is available through the two fixed provider ids;
@@ -380,7 +395,7 @@ carries a `basis` label:
 | --- | --- |
 | `cache_aware` | All buckets present in the call have a known rate; the four-bucket math ran. |
 | `cache_blind` | The call used cache tokens but a needed cache rate is unknown, so OpenSquilla fell back to pricing every input token (cache or fresh) at the plain input rate. This is a conservative upper bound, not the real charge — expect it to overstate cost on cache-heavy sessions. |
-| `free` | The model or runtime is zero-priced (see local runtimes below). |
+| `free` | The model or runtime is zero-priced, including generic custom endpoints without complete price overrides. |
 
 ### Price Resolution Order
 
@@ -389,15 +404,19 @@ these layers, first match wins:
 
 1. **Local runtime** — `ollama`, `lm_studio`, `ovms`, `vllm`, and `local` are
    always free, regardless of model id.
-2. **User override** — `[models.<provider_id>."<model_id>"]` in your config
+2. **Generic custom endpoint** — `custom` and `custom_anthropic` use a
+   complete explicit input/output price override when present; otherwise they
+   resolve to zero with `priceSource="custom_free"` and stop before catalog,
+   live, static, or default cloud pricing.
+3. **User override** — `[models.<provider_id>."<model_id>"]` in your config
    (see [`configuration.md`](configuration.md) and `opensquilla.toml.example`).
-3. **Model catalog** — the vendored models.dev snapshot, including per-model
+4. **Model catalog** — the vendored models.dev snapshot, including per-model
    cache-read/cache-write rates where upstream publishes them.
-4. **Live OpenRouter endpoint price** — looked up only when the provider is
+5. **Live OpenRouter endpoint price** — looked up only when the provider is
    `openrouter` or unset (first-party provider ids never query the OpenRouter
    marketplace); falls back to the static table if OpenRouter is unreachable.
-5. **Static table** — a built-in pricing table bundled with OpenSquilla.
-6. **Default** — `$3` / `$15` per million input/output tokens when nothing
+6. **Static table** — a built-in pricing table bundled with OpenSquilla.
+7. **Default** — `$3` / `$15` per million input/output tokens when nothing
    else matched.
 
 If OpenSquilla is estimating a model at the wrong price, add an override
@@ -411,8 +430,10 @@ cache_read_cost_per_mtok = 0.05  # USD per million cached-prompt-read tokens
 cache_write_cost_per_mtok = 0.6  # USD per million cached-prompt-write tokens
 ```
 
-Quote model ids that contain dots or slashes. All four fields are optional —
-set only the ones you need to correct. `config.set`/`patch`/`apply` and
+Quote model ids that contain dots or slashes. For ordinary provider overrides,
+all four fields are optional. For `custom` and `custom_anthropic`, set
+`input_cost_per_mtok` and `output_cost_per_mtok` together to enable a nonzero
+estimate; cache rates remain optional. `config.set`/`patch`/`apply` and
 `opensquilla gateway reload` hot-apply these overrides; see
 `opensquilla.toml.example` for more examples including self-hosted `vllm` and
 `custom` endpoints.
@@ -427,15 +448,15 @@ exposed dual-cased as `cost_source`):
 | `provider_billed` | The full cost came from a real provider-reported bill. |
 | `opensquilla_estimate` | No billed cost was available; the figure is a local estimate. |
 | `mixed` | The same model had both billed and unbilled calls in the aggregated row — the total is billed cost plus an estimate for the rest, not a pure bill. |
-| `unavailable` | No pricing table entry and no billed cost, so no dollar figure could be produced. |
+| `unavailable` | No billed cost or positive local estimate is available. |
 
 Rows also carry two additive fields: `estimateBasis` (the `cache_aware` /
 `cache_blind` / `free` label above, present only when part of the row was
 estimated) and `priceSource` (which resolver layer priced it — `user_override`,
-`catalog`, `live_openrouter`, `static_table`, `default`, or `local_free`). The
-Web UI's by-model usage cards show a small source chip for `costSource` and,
-when the underlying basis is `cache_blind`, a hint that the figure is an
-upper bound rather than the real cache-discounted cost.
+`catalog`, `live_openrouter`, `static_table`, `default`, `local_free`, or
+`custom_free`). The Web UI's by-model usage cards show a small source chip for
+`costSource` and, when the underlying basis is `cache_blind`, a hint that the
+figure is an upper bound rather than the real cache-discounted cost.
 
 ### Which Providers Yield Billed vs. Estimated Cost
 
@@ -445,7 +466,7 @@ upper bound rather than the real cache-discounted cost.
 | Cache-aware estimate possible | `anthropic`, `deepseek`, `minimax` (Anthropic-shaped), ensemble members |
 | Cache-read-aware estimate only (no cache-write rate) | `openai`, `openai_responses`, `azure`, `gemini`, `openai_codex` |
 | Cache-blind estimate (falls back to plain input-rate pricing when cache tokens appear) | other OpenAI-compatible provider kinds |
-| Free | local runtimes (`ollama`, `lm_studio`, `ovms`, `vllm`, `local`) |
+| Zero-priced estimate | local runtimes (`ollama`, `lm_studio`, `ovms`, `vllm`, `local`) and `custom` / `custom_anthropic` without complete input/output price overrides |
 | Subscription (no invoice to compare against) | coding-plan/subscription provider kinds — treat any reported figure as an estimate, not a bill |
 
 Use `opensquilla providers status --probe-models` and `opensquilla cost
@@ -461,9 +482,12 @@ Two per-turn agent budgets exist and behave differently:
   do not rely on it alone outside `openrouter`.
 - `max_turn_cost_usd` gates on the same accumulator used everywhere else in
   this section: billed cost when the provider reports it, otherwise the
-  cache-aware/cache-blind estimate. It works on every provider. When it trips,
-  the error (`turn_cost_budget_exceeded`) states whether the total was billed,
-  estimated, or mixed.
+  cache-aware/cache-blind estimate. It can trip only when a call has billed
+  cost or a nonzero local estimate. A generic custom endpoint without complete
+  input/output price overrides resolves to zero, so configure both rates before
+  relying on this gate for a paid custom endpoint. When it trips, the error
+  (`turn_cost_budget_exceeded`) states whether the total was billed, estimated,
+  or mixed.
 
 SquillaRouter's session budget gate (`[squilla_router.budget]`, see
 [`features/squilla-router.md`](features/squilla-router.md)) logs a

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -159,6 +159,8 @@ base_url = "https://tokenrhythm.studio/v1"
 # # api_key is optional: set env CUSTOM_LLM_API_KEY (or api_key here) only if
 # # your endpoint enforces one. Declare the endpoint's real context window via
 # # [models.custom."qwen3-32b-awq"] — see the per-model overrides section below.
+# # Generic custom endpoints default to a zero token-cost estimate; that does
+# # not mean the server, GPU, or remote gateway has no infrastructure cost.
 #
 # Example custom Anthropic Messages endpoint:
 # provider = "custom_anthropic"
@@ -283,11 +285,16 @@ all_failed_policy = "fallback_single"
 # The generic `custom` and `custom_anthropic` providers use the same override
 # table shape, keyed by the served model id. Unknown custom models retain the
 # conservative 8k fallback for upgrade compatibility; both remote gateways
-# and local servers should declare their actual window:
+# and local servers should declare their actual window. Their token estimate
+# defaults to zero; to estimate a paid endpoint, set BOTH main price fields.
+# Cache-read and cache-write prices are optional and the same rule applies to
+# `custom_anthropic`:
 # [models.custom."qwen3-32b-awq"]
 # context_window = 131072
 # max_output_tokens = 8192
 # supports_tools = true
+# input_cost_per_mtok = 0.5
+# output_cost_per_mtok = 2.0
 #
 # [models.custom_anthropic."vendor-model"]
 # context_window = 131072

--- a/src/opensquilla/engine/pricing.py
+++ b/src/opensquilla/engine/pricing.py
@@ -120,7 +120,8 @@ class PriceEntry:
 @dataclass(frozen=True)
 class ResolvedModelPrice:
     """A PriceEntry plus which layer decided it (user_override > catalog >
-    live_openrouter > static_table > default; local_free short-circuits)."""
+    live_openrouter > static_table > default; local_free and custom_free
+    short-circuit)."""
 
     entry: PriceEntry
     source: str
@@ -132,7 +133,8 @@ class CostEstimate:
     cache_aware — four-bucket math with known cache rates;
     cache_blind — cache tokens present but a needed rate is unknown, so the
     legacy input*rate formula was used (conservative upper bound);
-    free — zero-priced (local runtime or known-free model)."""
+    free — zero-priced (local runtime, generic custom endpoint, or known-free
+    model)."""
 
     cost_usd: float
     basis: str
@@ -572,6 +574,8 @@ _DEFAULT_PRICING = PriceEntry(3.0, 15.0)
 # pricing table misses the ``ollama/`` free entry and applies the cloud default.
 _LOCAL_FREE_PROVIDERS = frozenset({"ollama", "lm_studio", "ovms", "vllm", "local"})
 
+_CUSTOM_DEFAULT_ZERO_PROVIDERS = frozenset({"custom", "custom_anthropic"})
+
 
 def _lookup_static_price_ex(model_id: str) -> tuple[PriceEntry, bool]:
     """Static-table price plus whether a row actually matched.
@@ -637,6 +641,32 @@ def _catalog_price(model_id: str, provider: str) -> ResolvedModelPrice | None:
     return ResolvedModelPrice(price, source)
 
 
+def _custom_user_override_price(model_id: str, provider: str) -> PriceEntry | None:
+    """Return a complete operator-authored price for a generic custom endpoint.
+
+    ``ModelCatalog.resolve_entry`` merges catalog layers per field, which is
+    correct for metadata but can mix a custom endpoint's user metadata with a
+    same-named OpenRouter model's price. This path intentionally consults only
+    the explicit user price fields.
+    """
+    try:
+        from opensquilla.provider.model_catalog import shared_catalog
+
+        fields = shared_catalog().user_override_price_fields(model_id, provider=provider)
+    except Exception:  # noqa: BLE001 - catalog problems must never break pricing
+        return None
+    input_price = fields.get("input_cost_per_mtok")
+    output_price = fields.get("output_cost_per_mtok")
+    if input_price is None or output_price is None:
+        return None
+    return PriceEntry(
+        input_per_m=input_price,
+        output_per_m=output_price,
+        cache_read_per_m=fields.get("cache_read_cost_per_mtok"),
+        cache_write_per_m=fields.get("cache_write_cost_per_mtok"),
+    )
+
+
 def _cached_or_fetch_live(model_id: str) -> PriceEntry | None:
     """Return a live OpenRouter endpoint price, using the process cache.
 
@@ -670,11 +700,12 @@ def resolve_model_price(model_id: str, provider: str = "") -> ResolvedModelPrice
     """Resolve a model's price and name the layer that decided it.
 
     Authority order: ``local_free`` (short-circuit for local runtimes) >
-    static-table overrides > user/catalog cost data > live OpenRouter endpoint
-    price > static table > ``default``. Live lookup runs only for OpenRouter
-    (or an unqualified provider); first-party provider ids never query the
-    OpenRouter marketplace. If OpenRouter is unreachable, the static table is a
-    fail-open fallback so cost estimation keeps working offline.
+    complete generic-custom user price or ``custom_free`` > static-table
+    overrides > user/catalog cost data > live OpenRouter endpoint price >
+    static table > ``default``. Live lookup runs only for OpenRouter (or an
+    unqualified provider); first-party provider ids never query the OpenRouter
+    marketplace. If OpenRouter is unreachable, the static table is a fail-open
+    fallback so cost estimation keeps working offline.
 
     ``provider`` is the configured provider id. Local runtimes (Ollama, …) are
     free regardless of the model id, which is otherwise unqualified (e.g.
@@ -684,6 +715,11 @@ def resolve_model_price(model_id: str, provider: str = "") -> ResolvedModelPrice
     if prov in _LOCAL_FREE_PROVIDERS:
         return ResolvedModelPrice(PriceEntry(0.0, 0.0, 0.0, 0.0), "local_free")
     model_id = str(model_id or "").strip()
+    if prov in _CUSTOM_DEFAULT_ZERO_PROVIDERS:
+        custom_price = _custom_user_override_price(model_id, prov)
+        if custom_price is not None:
+            return ResolvedModelPrice(custom_price, "user_override")
+        return ResolvedModelPrice(PriceEntry(0.0, 0.0, 0.0, 0.0), "custom_free")
     override = _lookup_price_override(model_id)
     if override is not None:
         return ResolvedModelPrice(override, "static_table")

--- a/src/opensquilla/memory/dream/runner.py
+++ b/src/opensquilla/memory/dream/runner.py
@@ -91,7 +91,7 @@ async def _run_complete(
         metadata = provider_metadata(provider)
         stream = account_provider_stream(
             lambda: chat(messages, config=config),
-            provider=metadata.provider_name or metadata.provider_kind,
+            provider=metadata.provider_id or metadata.provider_name or metadata.provider_kind,
             model=metadata.model,
         )
         close_stream = stream

--- a/src/opensquilla/memory/session_flush.py
+++ b/src/opensquilla/memory/session_flush.py
@@ -836,19 +836,38 @@ def _zero_usage(*, model: str = "") -> dict[str, Any]:
     }
 
 
-def _estimate_cost_usd(model: str, input_tokens: int, output_tokens: int) -> float:
+def _estimate_cost_usd(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    *,
+    provider: str = "",
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+) -> float:
     if not model or (input_tokens <= 0 and output_tokens <= 0):
         return 0.0
     try:
-        from opensquilla.engine.pricing import lookup_price
+        from opensquilla.engine.pricing import estimate_cost, lookup_price
 
-        price = lookup_price(model)
-        return (input_tokens * price.input_per_m + output_tokens * price.output_per_m) / 1_000_000
+        price = lookup_price(model, provider=provider)
+        return estimate_cost(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
+            price=price,
+        ).cost_usd
     except Exception:  # noqa: BLE001
         return 0.0
 
 
-def _usage_from_event(event: Any | None, *, request_count: int | None = None) -> dict[str, Any]:
+def _usage_from_event(
+    event: Any | None,
+    *,
+    request_count: int | None = None,
+    provider: str = "",
+) -> dict[str, Any]:
     if event is None:
         return _zero_usage()
     input_tokens = _coerce_int(getattr(event, "input_tokens", 0))
@@ -859,8 +878,16 @@ def _usage_from_event(event: Any | None, *, request_count: int | None = None) ->
     billed_cost = _coerce_float(getattr(event, "billed_cost", 0.0))
     estimated_cost = _coerce_float(getattr(event, "cost_usd", 0.0))
     model = str(getattr(event, "model", "") or "")
+    provider_id = str(provider or getattr(event, "provider", "") or "")
     if estimated_cost <= 0.0:
-        estimated_cost = _estimate_cost_usd(model, input_tokens, output_tokens)
+        estimated_cost = _estimate_cost_usd(
+            model,
+            input_tokens,
+            output_tokens,
+            provider=provider_id,
+            cache_read_tokens=cached_tokens,
+            cache_write_tokens=cache_write_tokens,
+        )
     resolved_request_count = (
         request_count
         if request_count is not None
@@ -902,6 +929,7 @@ def _provider_allows_billed_usage(provider: Any) -> bool:
 
 def _usage_from_complete_response(resp: Any, provider: Any) -> dict[str, Any]:
     allow_billed_cost = _provider_allows_billed_usage(provider)
+    provider_id = _provider_pricing_id(provider)
     usage = getattr(resp, "usage", None)
     if isinstance(usage, dict):
         input_tokens = _coerce_int(usage.get("input_tokens", usage.get("prompt_tokens")))
@@ -931,7 +959,7 @@ def _usage_from_complete_response(resp: Any, provider: Any) -> dict[str, Any]:
             cost_usd=_coerce_float(usage.get("estimated_cost_usd")),
             model=str(usage.get("model") or getattr(resp, "model", "") or ""),
         )
-        return _usage_from_event(event, request_count=1)
+        return _usage_from_event(event, request_count=1, provider=provider_id)
     event_model = getattr(resp, "model", None) or _provider_model_id(provider) or ""
     event = SimpleNamespace(
         input_tokens=getattr(resp, "input_tokens", 0),
@@ -943,7 +971,7 @@ def _usage_from_complete_response(resp: Any, provider: Any) -> dict[str, Any]:
         cost_usd=getattr(resp, "cost_usd", 0.0),
         model=event_model,
     )
-    return _usage_from_event(event, request_count=1)
+    return _usage_from_event(event, request_count=1, provider=provider_id)
 
 
 def _merge_usage(*items: dict[str, Any] | None) -> dict[str, Any]:
@@ -1192,7 +1220,7 @@ async def _provider_complete(
         metadata = provider_metadata(provider)
         stream = account_provider_stream(
             lambda: chat(messages, config=config),
-            provider=metadata.provider_name or metadata.provider_kind,
+            provider=_provider_pricing_id(provider),
             model=metadata.model,
         )
         close_stream = stream
@@ -1217,7 +1245,11 @@ async def _provider_complete(
             await aclose()
     return _CompletionResult(
         text="".join(chunks),
-        usage=_usage_from_event(done_event, request_count=1),
+        usage=_usage_from_event(
+            done_event,
+            request_count=1,
+            provider=_provider_pricing_id(provider),
+        ),
     )
 
 
@@ -1786,6 +1818,12 @@ def _provider_model_id(provider: Any) -> str | None:
         if value:
             return str(value)
     return None
+
+
+def _provider_pricing_id(provider: Any) -> str:
+    """Return the configured provider identity used by the price resolver."""
+    metadata = provider_metadata(provider)
+    return str(metadata.provider_id or metadata.provider_name or metadata.provider_kind or "")
 
 
 def _pure_flush_prompt(messages: list[Message]) -> str:
@@ -3255,6 +3293,7 @@ class SessionFlushService:
     ) -> FlushReceipt:
         t0 = started_at if started_at is not None else time.monotonic()
         plan = resolve_flush_plan()
+        provider_id = _provider_pricing_id(provider)
         slug, slug_usage = await self._generate_slug_with_usage(
             [message for segment in segments for message in segment.messages],
             provider,
@@ -3300,7 +3339,7 @@ class SessionFlushService:
             saved_paths = [result.path for result in save_results]
             flushed = sorted(set(saved_paths)) or [segment_plan.relative_path]
             all_saved_paths.extend(flushed)
-            usage_items.append(_usage_from_event(done_event))
+            usage_items.append(_usage_from_event(done_event, provider=provider_id))
 
             payload = _segment_receipt_payload(
                 index=index,

--- a/src/opensquilla/provider/model_catalog.py
+++ b/src/opensquilla/provider/model_catalog.py
@@ -125,6 +125,13 @@ _SYNTHESIZED_DEFAULTS: dict[str, Any] = {
     "supports_reasoning": False,
 }
 
+_USER_PRICE_FIELDS = (
+    "input_cost_per_mtok",
+    "output_cost_per_mtok",
+    "cache_read_cost_per_mtok",
+    "cache_write_cost_per_mtok",
+)
+
 # Protocol variants that share one service-side model catalog. User and live
 # overrides remain keyed to the exact configured provider; only packaged
 # corrections use this alias.
@@ -620,6 +627,23 @@ class ModelCatalog:
                 for name, value in entry.items():
                     fields.setdefault(name, value)
         return fields
+
+    def user_override_price_fields(self, model: str, *, provider: str = "") -> dict[str, float]:
+        """Return only explicit user price fields for one provider/model pair.
+
+        The provider-qualified override takes precedence over a bare model-id
+        override, matching :meth:`resolve_entry`. Lower catalog layers are
+        deliberately excluded so callers can distinguish operator-authored
+        pricing from a same-named marketplace model.
+        """
+        fields = self._user_override_fields(
+            str(model or ""), (provider or "").strip().lower()
+        )
+        return {
+            name: float(value)
+            for name in _USER_PRICE_FIELDS
+            if (value := fields.get(name)) is not None
+        }
 
     def set_live_provider_entries(
         self, provider_id: str, entries: Mapping[str, Mapping[str, Any]]

--- a/src/opensquilla/tools/builtin/media.py
+++ b/src/opensquilla/tools/builtin/media.py
@@ -458,7 +458,7 @@ async def _complete_from_stream(provider: Any, messages: list, config: Any = Non
         metadata = provider_metadata(provider)
         stream = account_provider_stream(
             lambda: provider.chat(messages=messages, config=config),
-            provider=metadata.provider_name or metadata.provider_kind,
+            provider=metadata.provider_id or metadata.provider_name or metadata.provider_kind,
             model=metadata.model,
         )
         close_stream = stream

--- a/tests/test_engine/test_auxiliary_usage_accounting.py
+++ b/tests/test_engine/test_auxiliary_usage_accounting.py
@@ -18,6 +18,7 @@ from opensquilla.engine.usage_accounting import (
 from opensquilla.memory.dream.runner import _run_complete
 from opensquilla.memory.session_flush import ProviderCompletionError, _provider_complete
 from opensquilla.onboarding.probe import probe_llm_provider
+from opensquilla.provider.protocol import ProviderMetadata
 from opensquilla.provider.types import DoneEvent, ErrorEvent, Message, TextDeltaEvent
 from opensquilla.tools.builtin.media import _complete_from_stream
 
@@ -69,6 +70,21 @@ class _StreamProvider:
     async def _stream(self) -> AsyncIterator[Any]:
         for event in self.events:
             yield event
+
+
+class _ConfiguredGenericCustomStreamProvider(_StreamProvider):
+    def __init__(self, events: list[Any], *, provider_id: str) -> None:
+        super().__init__(events)
+        self._provider_id = provider_id
+
+    def provider_metadata(self) -> ProviderMetadata:
+        is_anthropic = self._provider_id == "custom_anthropic"
+        return ProviderMetadata(
+            provider_id=self._provider_id,
+            provider_name="anthropic" if is_anthropic else "openai",
+            provider_kind="anthropic" if is_anthropic else "openai_compat",
+            model="gpt-4.1",
+        )
 
 
 async def _session_flush_completion(provider: Any) -> str:
@@ -126,6 +142,41 @@ async def test_auxiliary_chat_done_is_accounted_once(
     assert sink.finalized[0][0].event_id == sink.started[0].event_id
     assert sink.finalized[0][1].billed_cost_nanos == 123
     assert sink.unknown == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "runner",
+    [_session_flush_completion, _dream_completion, _media_completion],
+)
+@pytest.mark.parametrize("provider_id", ["custom", "custom_anthropic"])
+async def test_auxiliary_chat_accounts_configured_generic_custom_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    runner: Callable[[Any], Awaitable[str]],
+    provider_id: str,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_OPENROUTER_LIVE_PRICING", "0")
+    sink = _RecordingSink()
+    provider = _ConfiguredGenericCustomStreamProvider(
+        [
+            TextDeltaEvent(text="ok"),
+            DoneEvent(input_tokens=100_000, output_tokens=1_000, model="gpt-4.1"),
+        ],
+        provider_id=provider_id,
+    )
+
+    with bind_usage_accounting_scope(_scope(sink)):
+        assert await runner(provider) == "ok"
+
+    [call] = sink.started
+    [(_finalized_call, result)] = sink.finalized
+    [item] = result.items
+    assert call.provider == provider_id
+    assert item.provider == provider_id
+    assert result.estimated_cost_nanos == 0
+    assert result.cost_source == "free"
+    assert result.estimate_basis == "free"
+    assert result.price_source == "custom_free"
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/test_price_resolver.py
+++ b/tests/test_engine/test_price_resolver.py
@@ -13,6 +13,126 @@ def test_local_provider_resolves_free(monkeypatch: pytest.MonkeyPatch) -> None:
     assert r.entry.input_per_m == 0.0 and r.entry.cache_read_per_m == 0.0
 
 
+@pytest.mark.parametrize("provider", ["custom", "custom_anthropic"])
+@pytest.mark.parametrize("model_id", ["unknown-custom-model", "gpt-4.1"])
+def test_generic_custom_provider_defaults_to_zero_price(
+    monkeypatch: pytest.MonkeyPatch, provider: str, model_id: str
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_OPENROUTER_LIVE_PRICING", "0")
+
+    resolved = resolve_model_price(model_id, provider=provider)
+
+    assert resolved.source == "custom_free"
+    assert resolved.entry == PriceEntry(0.0, 0.0, 0.0, 0.0)
+
+
+@pytest.mark.parametrize("provider", ["custom", "custom_anthropic"])
+def test_generic_custom_provider_ignores_warmed_openrouter_catalog_price(
+    monkeypatch: pytest.MonkeyPatch, provider: str
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_OPENROUTER_LIVE_PRICING", "0")
+    catalog = ModelCatalog()
+    catalog._populate_from_data(
+        [
+            {
+                "id": "vendor/warm-priced-model",
+                "pricing": {"prompt": "0.000003", "completion": "0.000015"},
+            }
+        ]
+    )
+    set_shared_catalog(catalog)
+    try:
+        resolved = resolve_model_price("vendor/warm-priced-model", provider=provider)
+    finally:
+        set_shared_catalog(None)
+
+    assert resolved.source == "custom_free"
+    assert resolved.entry == PriceEntry(0.0, 0.0, 0.0, 0.0)
+
+
+@pytest.mark.parametrize("provider", ["custom", "custom_anthropic"])
+def test_generic_custom_provider_uses_complete_user_price_override(
+    monkeypatch: pytest.MonkeyPatch, provider: str
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_OPENROUTER_LIVE_PRICING", "0")
+    catalog = ModelCatalog()
+    catalog.set_user_overrides(
+        {
+            f"{provider}/vendor/priced-model": {
+                "input_cost_per_mtok": 1.25,
+                "output_cost_per_mtok": 2.5,
+                "cache_read_cost_per_mtok": 0.125,
+                "cache_write_cost_per_mtok": 3.125,
+            }
+        }
+    )
+    set_shared_catalog(catalog)
+    try:
+        resolved = resolve_model_price("vendor/priced-model", provider=provider)
+    finally:
+        set_shared_catalog(None)
+
+    assert resolved.source == "user_override"
+    assert resolved.entry == PriceEntry(1.25, 2.5, 0.125, 3.125)
+
+
+@pytest.mark.parametrize("provider", ["custom", "custom_anthropic"])
+def test_generic_custom_provider_honors_explicit_zero_price_override(
+    monkeypatch: pytest.MonkeyPatch, provider: str
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_OPENROUTER_LIVE_PRICING", "0")
+    catalog = ModelCatalog()
+    catalog.set_user_overrides(
+        {
+            f"{provider}/vendor/zero-priced-model": {
+                "input_cost_per_mtok": 0.0,
+                "output_cost_per_mtok": 0.0,
+            }
+        }
+    )
+    set_shared_catalog(catalog)
+    try:
+        resolved = resolve_model_price("vendor/zero-priced-model", provider=provider)
+    finally:
+        set_shared_catalog(None)
+
+    assert resolved.source == "user_override"
+    assert resolved.entry == PriceEntry(0.0, 0.0)
+
+
+@pytest.mark.parametrize("provider", ["custom", "custom_anthropic"])
+@pytest.mark.parametrize(
+    "fields",
+    [
+        {"context_window": 131_072},
+        {"input_cost_per_mtok": 1.0},
+        {"output_cost_per_mtok": 2.0},
+    ],
+)
+def test_generic_custom_provider_ignores_incomplete_user_price_override(
+    monkeypatch: pytest.MonkeyPatch, provider: str, fields: dict[str, float | int]
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_OPENROUTER_LIVE_PRICING", "0")
+    catalog = ModelCatalog()
+    catalog._populate_from_data(
+        [
+            {
+                "id": "vendor/warm-priced-model",
+                "pricing": {"prompt": "0.000003", "completion": "0.000015"},
+            }
+        ]
+    )
+    catalog.set_user_overrides({f"{provider}/vendor/warm-priced-model": fields})
+    set_shared_catalog(catalog)
+    try:
+        resolved = resolve_model_price("vendor/warm-priced-model", provider=provider)
+    finally:
+        set_shared_catalog(None)
+
+    assert resolved.source == "custom_free"
+    assert resolved.entry == PriceEntry(0.0, 0.0, 0.0, 0.0)
+
+
 def test_user_catalog_override_wins_over_static(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENSQUILLA_OPENROUTER_LIVE_PRICING", "0")
     catalog = ModelCatalog()

--- a/tests/test_engine/test_usage_cache_aware.py
+++ b/tests/test_engine/test_usage_cache_aware.py
@@ -100,6 +100,21 @@ def test_local_free_row_labels_free_basis(monkeypatch: pytest.MonkeyPatch) -> No
     assert row["priceSource"] == "local_free"
 
 
+@pytest.mark.parametrize("provider", ["custom", "custom_anthropic"])
+def test_generic_custom_free_row_preserves_zero_estimate_provenance(
+    monkeypatch: pytest.MonkeyPatch, provider: str
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_OPENROUTER_LIVE_PRICING", "0")
+    su = SessionUsage()
+    su.add(10_000, 500, model_id="gpt-4.1", provider=provider)
+
+    row = su.model_breakdown[0]
+    assert row["costUsd"] == 0.0
+    assert row["costSource"] == "unavailable"
+    assert row["estimateBasis"] == "free"
+    assert row["priceSource"] == "custom_free"
+
+
 def test_unbilled_counters_accumulate_only_when_call_is_unbilled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_gateway/test_boot_model_overrides.py
+++ b/tests/test_gateway/test_boot_model_overrides.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import pytest
 
+from opensquilla.engine.pricing import PriceEntry, resolve_model_price
 from opensquilla.gateway.boot import (
     apply_model_catalog_overrides,
     build_services,
@@ -113,6 +114,27 @@ def test_apply_model_catalog_overrides_installs_onto_catalog() -> None:
     assert entry.input_cost_per_mtok == pytest.approx(0.2)
     assert entry.output_cost_per_mtok == pytest.approx(0.4)
     assert entry.cache_read_cost_per_mtok == pytest.approx(0.002)
+
+
+@pytest.mark.parametrize("provider", ["custom", "custom_anthropic"])
+def test_apply_model_catalog_overrides_enables_custom_price_estimate(provider: str) -> None:
+    config = GatewayConfig()
+    config.models = {
+        provider: {
+            "vendor/priced-model": ModelOverrideConfig(
+                input_cost_per_mtok=0.5,
+                output_cost_per_mtok=2.0,
+            )
+        }
+    }
+    catalog = ModelCatalog()
+    apply_model_catalog_overrides(catalog, config)
+    set_shared_catalog(catalog)
+
+    resolved = resolve_model_price("vendor/priced-model", provider=provider)
+
+    assert resolved.source == "user_override"
+    assert resolved.entry == PriceEntry(0.5, 2.0)
 
 
 def test_apply_model_catalog_overrides_survives_bad_value_and_warns(

--- a/tests/test_memory_flush.py
+++ b/tests/test_memory_flush.py
@@ -18,6 +18,8 @@ from opensquilla.memory.session_flush import (
     FlushReceipt,
     SessionFlushService,
     _make_flush_read_only_handler,
+    _usage_from_complete_response,
+    _usage_from_event,
 )
 from opensquilla.memory.store import LongTermMemoryStore
 from opensquilla.memory.sync_manager import MemorySyncManager
@@ -30,6 +32,8 @@ from opensquilla.provider import (
     ToolUseEndEvent,
     ToolUseStartEvent,
 )
+from opensquilla.provider.model_catalog import ModelCatalog, set_shared_catalog
+from opensquilla.provider.protocol import ProviderMetadata
 from opensquilla.tool_boundary import ToolCall, ToolResult
 
 
@@ -44,6 +48,87 @@ def test_memory_tool_handler_protocol_uses_tool_boundary_types() -> None:
     typed_handler: MemoryToolHandler = handler
 
     assert typed_handler is handler
+
+
+@pytest.mark.parametrize("provider_id", ["custom", "custom_anthropic"])
+def test_session_flush_event_usage_uses_generic_custom_price(
+    monkeypatch: pytest.MonkeyPatch, provider_id: str
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_OPENROUTER_LIVE_PRICING", "0")
+    usage = _usage_from_event(
+        DoneEvent(
+            input_tokens=100_000,
+            output_tokens=1_000,
+            model="gpt-4.1",
+            provider=provider_id,
+        )
+    )
+
+    assert usage["cost_usd"] == 0.0
+    assert usage["estimated_cost_usd"] == 0.0
+    assert usage["cost_source"] == "unavailable"
+
+
+@pytest.mark.parametrize("provider_id", ["custom", "custom_anthropic"])
+def test_session_flush_complete_response_uses_configured_provider_price(
+    monkeypatch: pytest.MonkeyPatch, provider_id: str
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_OPENROUTER_LIVE_PRICING", "0")
+
+    class CustomProvider:
+        def provider_metadata(self) -> ProviderMetadata:
+            return ProviderMetadata(
+                provider_id=provider_id,
+                provider_name="openai",
+                provider_kind="openai_compat",
+                model="gpt-4.1",
+            )
+
+    usage = _usage_from_complete_response(
+        SimpleNamespace(
+            model="gpt-4.1",
+            usage={"prompt_tokens": 100_000, "completion_tokens": 1_000},
+        ),
+        CustomProvider(),
+    )
+
+    assert usage["cost_usd"] == 0.0
+    assert usage["estimated_cost_usd"] == 0.0
+    assert usage["cost_source"] == "unavailable"
+
+
+def test_session_flush_usage_estimate_prices_custom_cache_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_OPENROUTER_LIVE_PRICING", "0")
+    catalog = ModelCatalog()
+    catalog.set_user_overrides(
+        {
+            "custom/vendor/cached-model": {
+                "input_cost_per_mtok": 10.0,
+                "output_cost_per_mtok": 20.0,
+                "cache_read_cost_per_mtok": 1.0,
+                "cache_write_cost_per_mtok": 4.0,
+            }
+        }
+    )
+    set_shared_catalog(catalog)
+    try:
+        usage = _usage_from_event(
+            DoneEvent(
+                input_tokens=1_000_000,
+                output_tokens=100_000,
+                cached_tokens=200_000,
+                cache_write_tokens=100_000,
+                model="vendor/cached-model",
+                provider="custom",
+            )
+        )
+    finally:
+        set_shared_catalog(None)
+
+    assert usage["estimated_cost_usd"] == pytest.approx(9.6)
+    assert usage["cost_usd"] == pytest.approx(9.6)
 
 
 @pytest.mark.asyncio

--- a/tests/test_provider_model_catalog.py
+++ b/tests/test_provider_model_catalog.py
@@ -7,6 +7,33 @@ import pytest
 from opensquilla.provider.model_catalog import ModelCatalog, _corrections_budget_fallback
 
 
+def test_user_override_price_fields_keep_qualified_precedence_and_bare_fallback() -> None:
+    catalog = ModelCatalog()
+    catalog.set_user_overrides(
+        {
+            "vendor/priced-model": {
+                "input_cost_per_mtok": 1.0,
+                "output_cost_per_mtok": 2.0,
+                "cache_write_cost_per_mtok": 4.0,
+                "context_window": 131_072,
+            },
+            "custom/vendor/priced-model": {
+                "input_cost_per_mtok": 0.0,
+                "cache_read_cost_per_mtok": 0.1,
+            },
+        }
+    )
+
+    assert catalog.user_override_price_fields(
+        "VENDOR/PRICED-MODEL", provider="CUSTOM"
+    ) == {
+        "input_cost_per_mtok": 0.0,
+        "output_cost_per_mtok": 2.0,
+        "cache_read_cost_per_mtok": 0.1,
+        "cache_write_cost_per_mtok": 4.0,
+    }
+
+
 def test_deepseek_v4_direct_models_use_models_dev_limits() -> None:
     # The vendored models.dev snapshot supplies the real per-(provider, model)
     # budgets offline (PR #406 roadmap item 4); the packaged corrections


### PR DESCRIPTION
## Summary
- Default `custom` and `custom_anthropic` token estimates to zero unless both primary rates are explicitly configured.
- Preserve configured generic-custom identities through auxiliary usage accounting and use cache-aware flush estimates.
- Document paid custom endpoint pricing and budget-gate behavior.

## Target
- `main`

## Issue
- None

## Release note
- Yes: generic custom endpoints now default to a zero token-cost estimate; paid endpoints should configure both input and output rates.

## Validation
- `.venv/bin/pytest -q tests/test_engine/test_auxiliary_usage_accounting.py tests/test_memory_flush.py tests/test_engine/test_price_resolver.py tests/test_engine/test_usage_cache_aware.py tests/test_provider_model_catalog.py tests/test_gateway/test_boot_model_overrides.py`
- `uv run ruff check src/opensquilla/memory/session_flush.py src/opensquilla/memory/dream/runner.py src/opensquilla/tools/builtin/media.py tests/test_engine/test_auxiliary_usage_accounting.py tests/test_memory_flush.py`
- `uv run mypy src/opensquilla/memory/session_flush.py src/opensquilla/memory/dream/runner.py src/opensquilla/tools/builtin/media.py --show-error-codes`

## Safety
- No provider request, authentication, or infrastructure behavior changes.

## Third-party origin
- None.