### PR TITLE
Fix slash command menu navigation

### DIFF
--- a/opensquilla-webui/e2e/chat.spec.ts
+++ b/opensquilla-webui/e2e/chat.spec.ts
@@ -237,6 +237,42 @@ test.describe('Chat Interaction', () => {
     await expect(textarea).toHaveValue('Hello, this is a test message')
   })
 
+  test('keeps slash selection visible and closes the menu on outside pointerdown', async ({ page }) => {
+    const textarea = page.locator('.chat-textarea')
+    const menu = page.locator('.chat-slash')
+
+    await textarea.fill('/')
+    await expect(menu).toBeVisible()
+
+    const items = menu.locator('.chat-slash-item')
+    const itemCount = await items.count()
+    expect(itemCount).toBeGreaterThan(1)
+    await expect.poll(() => menu.evaluate(element => element.scrollHeight > element.clientHeight))
+      .toBe(true)
+
+    for (let index = 1; index < itemCount; index += 1) {
+      await textarea.press('ArrowDown')
+    }
+
+    const activeItem = menu.locator('.chat-slash-item--active')
+    await expect(activeItem).toHaveCount(1)
+    await expect.poll(() => menu.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+    expect(await menu.evaluate(element => {
+      const active = element.querySelector<HTMLElement>('.chat-slash-item--active')
+      if (!active) return false
+      const menuRect = element.getBoundingClientRect()
+      const activeRect = active.getBoundingClientRect()
+      return activeRect.top >= menuRect.top && activeRect.bottom <= menuRect.bottom
+    })).toBe(true)
+
+    await activeItem.dispatchEvent('pointerdown', { pointerType: 'mouse', button: 0 })
+    await expect(menu).toBeVisible()
+
+    await page.locator('.chat-thread').click({ position: { x: 8, y: 8 } })
+    await expect(menu).toHaveCount(0)
+    await expect(textarea).toHaveValue('/')
+  })
+
   test('sidebar toggle works on mobile viewport', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 })
 

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -531,7 +531,7 @@
       </button>
     </Transition>
     <!-- Slash command menu -->
-    <div v-if="slashOpen" class="chat-slash">
+    <div v-if="slashOpen" ref="slashMenuRef" class="chat-slash">
       <div
         v-for="(cmd, i) in filteredSlashCmds"
         :key="cmd.cmd"
@@ -1095,6 +1095,7 @@ const messageListRef = ref<ChatMessageListVirtualizer | null>(null)
 const conversationMinimapRef = ref<{ cancelNavigation: () => void } | null>(null)
 const bottomSentinelRef = ref<HTMLElement | null>(null)
 const jumpToLatestButtonRef = ref<HTMLButtonElement | null>(null)
+const slashMenuRef = ref<HTMLElement | null>(null)
 let bottomIntersectionObserver: IntersectionObserver | null = null
 const composerRef = ref<ChatComposerHandle | null>(null)
 /* Floating-composer retract: a pure controller accumulates slow user travel
@@ -2700,6 +2701,22 @@ const {
   executeSlashCommand,
   restoreDurableMetaDrafts: restoreServerMetaDrafts,
 } = chatSlashCommands
+
+watch([slashIdx, filteredSlashCmds], () => {
+  slashMenuRef.value
+    ?.querySelector<HTMLElement>('.chat-slash-item--active')
+    ?.scrollIntoView?.({ block: 'nearest' })
+}, { flush: 'post' })
+
+useDocumentEvent('pointerdown', event => {
+  if (!slashOpen.value) return
+  const menu = slashMenuRef.value
+  const path = typeof event.composedPath === 'function' ? event.composedPath() : []
+  if (menu && (path.includes(menu) || (event.target instanceof Node && menu.contains(event.target)))) {
+    return
+  }
+  closeSlashMenu()
+}, true)
 
 const chatComposerShortcuts = useChatComposerShortcuts({
   inputText,


### PR DESCRIPTION
## Scope

Scope boundary:
- Keep the keyboard-active Slash command visible while navigating a scrollable menu.
- Dismiss the Slash command panel on pointer interaction outside the panel without clearing the draft.
- Add focused browser regression coverage for both behaviors.

Non-goals:
- No changes to command execution, catalog filtering, menu styling, RPCs, or persisted state.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Directly reported UI behavior defect; no issue number was provided.

## Release Note

Release note: NONE

## Tests

Ruff: N/A (frontend-only)

Pytest: N/A (frontend-only)

Build: cd opensquilla-webui && npm run build:artifact

Regression tests: added

Notes:
- cd opensquilla-webui && npm run typecheck
- OPENSQUILLA_PLAYWRIGHT_MANAGE_WEBUI=gateway OPENSQUILLA_WEBUI_BASE_URL=http://127.0.0.1:18893 npm run test:e2e -- e2e/chat.spec.ts -g "keeps slash selection visible" (1 passed)

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: no credentialed live check is required for this local Web UI behavior change.

## Safety

No secrets, local-only artifacts, private prompts or transcripts, channel identifiers, AI session artifacts, non-public fixtures, or tests/_private/ contents are included.

The change is platform-neutral and does not affect configuration, persistence, public interfaces, or upgrade compatibility.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

Not applicable; no documentation changed.