### PR TITLE
Allow empty-tag test package builds

### DIFF
--- a/.github/workflows/wheelhouse-release.yml
+++ b/.github/workflows/wheelhouse-release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Optional existing tag to upload artifacts to
+        description: Existing tag to upload; leave empty for an internal test-package artifact
         required: false
         default: ""
 
@@ -354,7 +354,13 @@ jobs:
         working-directory: desktop/electron
         run: npm ci
 
+      - name: Verify test-package runtime-pack catalog
+        if: ${{ env.RELEASE_TAG == '' }}
+        working-directory: desktop/electron
+        run: node ../../.github/scripts/verify-sandbox-package.mjs --source
+
       - name: Verify finalized runtime-pack catalog
+        if: ${{ env.RELEASE_TAG != '' }}
         working-directory: desktop/electron
         run: node ../../.github/scripts/verify-sandbox-package.mjs --release-source
 
@@ -480,7 +486,13 @@ jobs:
         working-directory: desktop/electron
         run: npm ci
 
+      - name: Verify test-package runtime-pack catalog
+        if: ${{ env.RELEASE_TAG == '' }}
+        working-directory: desktop/electron
+        run: node ../../.github/scripts/verify-sandbox-package.mjs --source
+
       - name: Verify finalized runtime-pack catalog
+        if: ${{ env.RELEASE_TAG != '' }}
         working-directory: desktop/electron
         run: node ../../.github/scripts/verify-sandbox-package.mjs --release-source
 

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -77,6 +77,7 @@ def test_release_workflow_builds_desktop_installers() -> None:
     assert "npx electron-builder --mac --publish never" in workflow
     assert "npx electron-builder --win --publish never" in workflow
     assert "npm run fetch:runtimes" not in workflow
+    assert workflow.count("verify-sandbox-package.mjs --source") == 2
     assert workflow.count("verify-sandbox-package.mjs --release-source") == 2
     assert "verify_desktop_slim_size.py" in workflow
     assert "--platform macos" in workflow
@@ -746,6 +747,22 @@ def test_manual_release_workflow_without_a_tag_only_uploads_aggregate_artifacts(
 
     assert "if" not in aggregate
     assert "github.event.inputs.tag != ''" in github_upload["if"]
+    for job_name in ("build-desktop-macos", "build-desktop-windows"):
+        steps = workflow["jobs"][job_name]["steps"]
+        test_package_catalog = next(
+            step
+            for step in steps
+            if step["name"] == "Verify test-package runtime-pack catalog"
+        )
+        release_catalog = next(
+            step
+            for step in steps
+            if step["name"] == "Verify finalized runtime-pack catalog"
+        )
+        assert test_package_catalog["if"] == "${{ env.RELEASE_TAG == '' }}"
+        assert test_package_catalog["run"].endswith("--source")
+        assert release_catalog["if"] == "${{ env.RELEASE_TAG != '' }}"
+        assert release_catalog["run"].endswith("--release-source")
     for job_name in (
         "prestage-draft-updater-assets",
         "audit-downloaded-macos-release",


### PR DESCRIPTION
## Summary

- allow empty-tag manual Release Assets runs to build internal test packages with the development Runtime Pack catalog contract
- keep finalized Runtime Pack verification mandatory for tag pushes and tagged reruns
- document the empty-tag behavior and add workflow regression assertions

Target branch: `main`

Linked issue: None

## Release note

None; this changes only the internal, untagged Actions test-package path.

## Verification

- `uv run pytest tests/test_release_consistency.py tests/test_public_release_hygiene.py tests/test_sandbox/test_release_contract.py tests/test_scripts/test_build_wheelhouse_zip.py tests/test_ci/test_workflows.py -q` — 187 passed
- Ruff passed
- Actionlint passed
- `git diff --check` passed

## Safety notes

- Tagged and tag-push release jobs still require `--release-source` and a finalized complete Runtime Pack catalog.
- Empty-tag runs upload only the existing aggregate workflow artifact; GitHub Release and OSS publication remain conditional on a tag.
- No persisted data, public protocol, installer metadata, or third-party assets changed.

## Third-party origin

None.