### PR TITLE
[codex] Speed up desktop recovery startup and Windows ACL migration

### DIFF
--- a/desktop/electron/scripts/gateway-entry.py
+++ b/desktop/electron/scripts/gateway-entry.py
@@ -1,3 +1,4 @@
+import os
 import ssl
 import sys
 
@@ -5,6 +6,29 @@ _DESKTOP_CA_PROBE_ARG = "--_desktop-ca-probe"
 _DESKTOP_CA_PROBE_OK = "opensquilla-desktop-ca-store-ok"
 _SANDBOX_FILESYSTEM_WORKER_ARG = "--_sandbox-filesystem-worker"
 _INTERNAL_CHILD_ARG = "--internal-child"
+
+
+def _top_level_command_index(argv: list[str]) -> int | None:
+    """Find the first positional command without importing the CLI package."""
+
+    index = 1
+    while index < len(argv):
+        value = argv[index]
+        if value == "--":
+            return index + 1 if index + 1 < len(argv) else None
+        if value == "--profile":
+            index += 2
+            continue
+        if value.startswith("--profile=") or value.startswith("-"):
+            index += 1
+            continue
+        return index
+    return None
+
+
+def _is_recovery_invocation(argv: list[str]) -> bool:
+    index = _top_level_command_index(argv)
+    return index is not None and argv[index] == "recovery"
 
 
 def _run_desktop_ca_probe() -> int:
@@ -25,6 +49,15 @@ def _run_desktop_ca_probe() -> int:
     return 0
 
 if __name__ == "__main__":
+    if _is_recovery_invocation(sys.argv):
+        # Set this before importing *any* recovery module.  The lightweight
+        # dispatcher deliberately bypasses opensquilla.cli.main and dotenv.
+        os.environ["OPENSQUILLA_RECOVERY_OFFLINE"] = "1"
+        from opensquilla.cli.recovery_entry import app
+
+        app()
+        raise SystemExit(0)
+
     if sys.argv[1:] == [_DESKTOP_CA_PROBE_ARG]:
         raise SystemExit(_run_desktop_ca_probe())
 

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -475,6 +475,8 @@ let allowGracefulShutdownWhileQuitting = false
 // machine. Synchronous append: lifecycle events are rare, renderer events are
 // rate-limited, and every record must survive an imminent app.exit(). The file
 // sink caps individual records and rotates a bounded backup set.
+const desktopProcessStartedAt = Date.now()
+
 function desktopLog(event: string, detail?: Record<string, unknown>): void {
   try {
     appendDesktopLogRecord(
@@ -1124,6 +1126,7 @@ function assertSupportedMacInstallLocation(): void {
 function sendBootStatus(phaseId: BootPhaseId): void {
   bootStatus = { phaseId, label: desktopT('boot.' + phaseId), at: new Date().toISOString() }
   bootError = null
+  desktopStartupLog('boot_phase', { phaseId })
   mainWindow?.webContents.send('desktop:boot:status', bootStatus)
 }
 
@@ -6757,6 +6760,11 @@ async function probeOnboardingProvider(
 const RECOVERY_PROTOCOL_SCHEMA_VERSION = 1
 const RECOVERY_STDOUT_LIMIT = 2 * 1024 * 1024
 const RECOVERY_COMMAND_TIMEOUT_MS = 60_000
+// Mutating recovery can legitimately scan several profiles, but it must never
+// leave Electron waiting forever (especially while Defender is inspecting a
+// packaged child). Keep this bound separate from the read-only probe budget so
+// a slow repair fails closed without weakening the ordinary inspect timeout.
+const RECOVERY_MUTATING_COMMAND_TIMEOUT_MS = 120_000
 // Mutating recovery commands fail closed with profile_lock_busy the moment
 // another writer holds the profile locks. A short in-CLI wait lets a transient
 // writer (an exiting gateway, a cron tick) finish instead of stranding startup
@@ -7104,6 +7112,8 @@ async function runDesktopProfileConsolidationCli(
   const runtime = await resolveGatewayRuntime()
   const prefix = runtime.args.slice(0, -2)
   return await new Promise((resolveResult, rejectResult) => {
+    const command = commandArgs[0] || 'unknown'
+    const startedAt = Date.now()
     const child = spawn(runtime.command, [
       ...prefix,
       'recovery',
@@ -7119,30 +7129,64 @@ async function runDesktopProfileConsolidationCli(
         PYTHONIOENCODING: 'utf-8:replace',
       }),
     })
+    desktopStartupLog('recovery_child_spawned', {
+      command,
+      pid: child.pid,
+      mutating: true,
+    })
     let stdout = ''
     let oversized = false
     let settled = false
+    let timeout: NodeJS.Timeout | null = null
     const finish = (
       error?: Error,
       result?: DesktopProfileConsolidationResult,
     ) => {
       if (settled) return
       settled = true
+      if (timeout) clearTimeout(timeout)
       if (error) rejectResult(error)
       else resolveResult(result as DesktopProfileConsolidationResult)
     }
+    timeout = setTimeout(() => {
+      desktopStartupLog('recovery_child_timeout', {
+        command,
+        pid: child.pid,
+        durationMs: Math.max(0, Date.now() - startedAt),
+        timeoutMs: RECOVERY_MUTATING_COMMAND_TIMEOUT_MS,
+      })
+      // On Windows ChildProcess.kill() terminates the exact process handle;
+      // do not launch or reuse a Gateway after this fail-closed timeout.
+      child.kill()
+      finish(new Error('Desktop profile consolidation timed out.'))
+    }, RECOVERY_MUTATING_COMMAND_TIMEOUT_MS)
+    timeout.unref()
     child.stdout.on('data', (chunk) => {
       if (oversized) return
       stdout += String(chunk)
       if (stdout.length > RECOVERY_STDOUT_LIMIT) oversized = true
+      if (oversized) child.kill()
     })
     // The protocol result is the only trusted diagnostic surface. stderr can
     // contain local profile paths and is deliberately drained without exposure.
     child.stderr.resume()
-    child.once('error', (error) => finish(
-      error instanceof Error ? error : new Error(String(error)),
-    ))
-    child.once('close', (code) => {
+    child.once('error', (error) => {
+      desktopStartupLog('recovery_child_error', {
+        command,
+        pid: child.pid,
+        durationMs: Math.max(0, Date.now() - startedAt),
+        error: error instanceof Error ? error.message : String(error),
+      })
+      finish(error instanceof Error ? error : new Error(String(error)))
+    })
+    child.once('close', (code, signal) => {
+      desktopStartupLog('recovery_child_exit', {
+        command,
+        pid: child.pid,
+        code,
+        signal,
+        durationMs: Math.max(0, Date.now() - startedAt),
+      })
       if (oversized) {
         return finish(new Error('Desktop profile consolidation output exceeded its limit.'))
       }
@@ -7266,6 +7310,8 @@ async function runRecoveryCli(
     const runtime = await resolveGatewayRuntime()
     const prefix = runtime.args.slice(0, -2)
     return await new Promise((resolveResult, rejectResult) => {
+      const command = commandArgs[0] || 'unknown'
+      const startedAt = Date.now()
       const child = spawn(runtime.command, [...prefix, 'recovery', ...effectiveArgs], {
         cwd: runtime.cwd,
         windowsHide: true,
@@ -7276,6 +7322,11 @@ async function runRecoveryCli(
           PYTHONUTF8: '1',
           PYTHONIOENCODING: 'utf-8:replace',
         }),
+      })
+      desktopStartupLog('recovery_child_spawned', {
+        command,
+        pid: child.pid,
+        mutating,
       })
       let stdout = ''
       let oversized = false
@@ -7288,13 +7339,20 @@ async function runRecoveryCli(
         if (error) rejectResult(error)
         else resolveResult(result as RecoveryProtocolResult)
       }
-      if (!mutating) {
-        timeout = setTimeout(() => {
-          child.kill()
-          finish(new Error('Recovery command timed out.'))
-        }, RECOVERY_COMMAND_TIMEOUT_MS)
-        timeout.unref()
-      }
+      const timeoutMs = mutating
+        ? RECOVERY_MUTATING_COMMAND_TIMEOUT_MS
+        : RECOVERY_COMMAND_TIMEOUT_MS
+      timeout = setTimeout(() => {
+        desktopStartupLog('recovery_child_timeout', {
+          command,
+          pid: child.pid,
+          durationMs: Math.max(0, Date.now() - startedAt),
+          timeoutMs,
+        })
+        child.kill()
+        finish(new Error('Recovery command timed out.'))
+      }, timeoutMs)
+      timeout.unref()
       child.stdin.once('error', () => {})
       child.stdin.end(stdinPayload ?? '')
       child.stdout.on('data', (chunk) => {
@@ -7302,16 +7360,29 @@ async function runRecoveryCli(
         stdout += String(chunk)
         if (stdout.length > RECOVERY_STDOUT_LIMIT) {
           oversized = true
-          if (!mutating) child.kill()
+          child.kill()
         }
       })
       // The renderer receives only parsed protocol JSON. stderr is drained but
       // never copied into diagnostics because it may contain local details.
       child.stderr.resume()
-      child.once('error', (error) => finish(
-        error instanceof Error ? error : new Error(String(error)),
-      ))
-      child.once('close', (code) => {
+      child.once('error', (error) => {
+        desktopStartupLog('recovery_child_error', {
+          command,
+          pid: child.pid,
+          durationMs: Math.max(0, Date.now() - startedAt),
+          error: error instanceof Error ? error.message : String(error),
+        })
+        finish(error instanceof Error ? error : new Error(String(error)))
+      })
+      child.once('close', (code, signal) => {
+        desktopStartupLog('recovery_child_exit', {
+          command,
+          pid: child.pid,
+          code,
+          signal,
+          durationMs: Math.max(0, Date.now() - startedAt),
+        })
         if (oversized) return finish(new Error('Recovery command output exceeded its limit.'))
         try {
           return finish(undefined, parseRecoveryProtocol(JSON.parse(stdout)))
@@ -7917,7 +7988,11 @@ function classifyGatewayExitMessage(message: string, outputTail: string): string
   )
 }
 
-async function waitForGateway(url: string, earlyExitMessage?: () => string | null): Promise<void> {
+async function waitForGateway(
+  url: string,
+  earlyExitMessage?: () => string | null,
+): Promise<void> {
+  const startedAt = Date.now()
   const result = await waitForGatewayReadiness({
     probe: (remainingMs) => healthCheck(url, remainingMs),
     exitMessage: earlyExitMessage,
@@ -7926,6 +8001,11 @@ async function waitForGateway(url: string, earlyExitMessage?: () => string | nul
     pollIntervalMs: 500,
   })
   if (result.status === 'ready') {
+    desktopStartupLog('gateway_health_ready', {
+      port: gatewayState.port,
+      late: result.late,
+      durationMs: Math.max(0, Date.now() - startedAt),
+    })
     if (result.late) {
       desktopLog('gateway_health_ready_after_primary_deadline', { port: gatewayState.port })
     }
@@ -8364,6 +8444,7 @@ async function startGateway(): Promise<GatewayState> {
   })
   gatewayProfileKey = desktopProfileKey(activeProfile)
   desktopLog('gateway_spawned', {
+    elapsedMs: Math.max(0, Date.now() - desktopProcessStartedAt),
     profileKind: activeProfile.kind,
     pid: child.pid,
     port,
@@ -8490,6 +8571,10 @@ async function loadControlUi(window: BrowserWindow, gatewayUrl: string): Promise
   for (let attempt = 1; attempt <= 10; attempt += 1) {
     try {
       await window.loadURL(url)
+      desktopStartupLog('control_ui_ready', {
+        url: gatewayUrl,
+        attempt,
+      })
       return
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error))
@@ -8624,6 +8709,16 @@ async function createMainWindow(): Promise<BrowserWindow> {
     rendererUnresponsiveAt = null
     const entry = buildRendererStateLogEntry('responsive', durationMs)
     desktopLog(entry.event, entry.detail)
+  })
+
+  window.webContents.once('did-finish-load', () => {
+    desktopStartupLog('splash_ready', { url: window.webContents.getURL() })
+  })
+  window.webContents.on('dom-ready', () => {
+    const url = window.webContents.getURL()
+    if (!url.startsWith('file:')) {
+      desktopStartupLog('renderer_interactive', { url })
+    }
   })
 
   window.webContents.setWindowOpenHandler(({ url }) => {
@@ -8894,8 +8989,10 @@ async function inspectActiveProfileBeforeStartup(): Promise<boolean> {
       // A whole-profile transaction may have committed immediately before the
       // Electron process stopped. The narrow layout receipt is the authority
       // for finishing provider credential reconciliation.
-      await recoverPendingMigrationReconciliation()
-      inspection = await inspectDesktopProfile(active)
+      const reconciliation = await recoverPendingMigrationReconciliation()
+      if (reconciliation.requiresInspection) {
+        inspection = await inspectDesktopProfile(active)
+      }
     } catch (error) {
       desktopLog('migration_reconciliation_startup_failed', {
         error: error instanceof Error ? error.message : 'unknown error',
@@ -11616,6 +11713,12 @@ interface PendingMigrationProviderSetup extends MigrationProviderPrefill {
   credentialBackupPath: string
 }
 
+interface PendingMigrationReconciliationResult {
+  observedApplyingMarker: boolean
+  stateModified: boolean
+  requiresInspection: boolean
+}
+
 let transientPendingMigrationProviderSetup: PendingMigrationProviderSetup | null = null
 
 function pendingMigrationProviderSetupPath(): string {
@@ -12078,26 +12181,52 @@ async function reconcileImportedDesktopCredential(
   return { requiresSetup: true }
 }
 
-async function recoverPendingMigrationReconciliation(): Promise<void> {
-  const initial = await readPendingMigrationProviderSetup()
-  if (!initial || initial.phase !== 'applying') return
+async function recoverPendingMigrationReconciliation(): Promise<PendingMigrationReconciliationResult> {
   const finishWriter = beginDesktopWriterOperation('recover imported provider settings')
   try {
+    const initial = await readPendingMigrationProviderSetup()
+    if (!initial || initial.phase !== 'applying') {
+      return {
+        observedApplyingMarker: false,
+        stateModified: false,
+        requiresInspection: false,
+      }
+    }
+    // Once an applying marker is observed, retain the post-recovery inspection
+    // even when the marker turns out to have no matching receipt. The marker is
+    // the durable evidence that the previous startup may have changed profile
+    // state; skipping the refresh would let stale revision/action data continue.
+    const result: PendingMigrationReconciliationResult = {
+      observedApplyingMarker: true,
+      stateModified: false,
+      requiresInspection: true,
+    }
     let pending = await readPendingMigrationProviderSetup()
-    if (!pending || pending.phase !== 'applying') return
+    if (!pending || pending.phase !== 'applying') return result
     const receipt = await findAppliedReceiptForIntent(pending)
     if (!receipt) {
       // Profile inspection has already recovered any unfinished replacement
       // transaction. With no new layout receipt, this attempt never committed.
       await clearPendingMigrationProviderSetup()
-      return
+      result.stateModified = true
+      return result
     }
     pending = await bindMigrationIntentToReceipt(pending, receipt)
+    result.stateModified = true
     pending = await prepareImportedCredentialBackup(pending)
     await reconcileImportedDesktopCredential(pending, true)
+    result.stateModified = true
+    return result
   } finally {
     finishWriter()
   }
+}
+
+function desktopStartupLog(event: string, detail?: Record<string, unknown>): void {
+  desktopLog(event, {
+    elapsedMs: Math.max(0, Date.now() - desktopProcessStartedAt),
+    ...detail,
+  })
 }
 
 async function refreshPrimaryRecoveryAfterImportAttempt(): Promise<boolean> {
@@ -13512,7 +13641,10 @@ function acquireSingleInstanceLockWithRetry(): boolean {
   for (;;) {
     attempt += 1
     if (app.requestSingleInstanceLock()) {
-      desktopLog('single_instance_lock_acquired', { attempt })
+      desktopLog('single_instance_lock_acquired', {
+        elapsedMs: Math.max(0, Date.now() - desktopProcessStartedAt),
+        attempt,
+      })
       return true
     }
     // A Windows protocol launch targets the current instance and does not need
@@ -13537,7 +13669,11 @@ app.on('open-url', (event, rawUrl) => {
   handleDeepLink(rawUrl, 'open-url')
 })
 
-desktopLog('launch', { platform: process.platform, argv: process.argv.length })
+desktopLog('launch', {
+  elapsedMs: Math.max(0, Date.now() - desktopProcessStartedAt),
+  platform: process.platform,
+  argv: process.argv.length,
+})
 const gotSingleInstanceLock = acquireSingleInstanceLockWithRetry()
 
 if (!gotSingleInstanceLock) {

--- a/src/opensquilla/cli/recovery_cmd.py
+++ b/src/opensquilla/cli/recovery_cmd.py
@@ -35,7 +35,6 @@ from opensquilla.recovery.settings_transaction import (
     apply_desktop_settings,
     recover_desktop_settings,
 )
-from opensquilla.sandbox.upgrade_migration import inspect_sandbox_upgrade
 
 recovery_app = typer.Typer(
     help="Inspect and repair Desktop profiles without starting the runtime.",
@@ -63,6 +62,11 @@ def sandbox_upgrade_status(
     json_output: bool = typer.Option(False, "--json"),
 ) -> None:
     """Inspect the retained sandbox-upgrade journal without changing it."""
+    # Keep the ordinary recovery process below the runtime import boundary.
+    # ``opensquilla.sandbox`` exposes a broad public surface at package import
+    # time; only this diagnostic command needs the migration implementation.
+    from opensquilla.sandbox.upgrade_migration import inspect_sandbox_upgrade
+
     report = inspect_sandbox_upgrade(home)
     if json_output:
         typer.echo(json.dumps(report.to_dict(), ensure_ascii=False, sort_keys=True))

--- a/src/opensquilla/cli/recovery_entry.py
+++ b/src/opensquilla/cli/recovery_entry.py
@@ -1,0 +1,124 @@
+"""Lightweight entry point for the offline Desktop recovery CLI.
+
+This module is intentionally kept below the ordinary CLI bootstrap.  Desktop
+starts recovery commands before the Gateway, so importing the full command
+tree here would also import the runtime and its optional numerical stack.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import typer
+
+# Set this before importing *any* recovery implementation.  Recovery code must
+# never read cwd/profile dotenv files, even when called directly (rather than
+# through Electron, which also sets the variable in its child environment).
+os.environ["OPENSQUILLA_RECOVERY_OFFLINE"] = "1"
+
+from opensquilla.cli.stdio import configure_stdio_for_unicode  # noqa: E402
+from opensquilla.paths import is_valid_profile_name  # noqa: E402
+
+configure_stdio_for_unicode()
+
+
+def _top_level_command_index(argv: list[str]) -> int | None:
+    """Return the first positional command in a CLI argv vector."""
+
+    index = 1
+    while index < len(argv):
+        value = argv[index]
+        if value == "--":
+            return index + 1 if index + 1 < len(argv) else None
+        if value == "--profile":
+            index += 2
+            continue
+        if value.startswith("--profile=") or value.startswith("-"):
+            index += 1
+            continue
+        return index
+    return None
+
+
+def _profile_from_top_level_argv(argv: list[str]) -> str | None:
+    """Read a root ``--profile`` option without consuming subcommand flags."""
+
+    index = 1
+    while index < len(argv):
+        arg = argv[index]
+        if arg == "--":
+            return None
+        if arg.startswith("--profile="):
+            return arg.partition("=")[2].strip() or None
+        if arg == "--profile":
+            if index + 1 < len(argv):
+                return argv[index + 1].strip() or None
+            return None
+        if not arg.startswith("-"):
+            return None
+        index += 1
+    return None
+
+
+def _activate_profile(profile: str | None) -> None:
+    """Match the public CLI's profile validation before command dispatch."""
+
+    if profile is None:
+        return
+    name = profile.strip()
+    if not name:
+        return
+    if not is_valid_profile_name(name):
+        raise typer.BadParameter(
+            "use lowercase letters, digits, hyphens, or underscores; "
+            "start with a letter or digit; max length 64"
+        )
+    os.environ["OPENSQUILLA_PROFILE"] = name
+
+
+# Preserve explicit profile selection before the recovery package resolves any
+# paths, while still avoiding all dotenv loading.  Invalid values are left for
+# the Typer callback below so import-time behavior matches the public CLI.
+_initial_profile = _profile_from_top_level_argv(sys.argv)
+if _initial_profile and is_valid_profile_name(_initial_profile):
+    os.environ["OPENSQUILLA_PROFILE"] = _initial_profile
+
+from opensquilla.cli.recovery_cmd import recovery_app  # noqa: E402
+
+app = typer.Typer(
+    name="opensquilla",
+    help="OpenSquilla - Python agent runtime with multi-channel support.",
+    no_args_is_help=True,
+    pretty_exceptions_enable=False,
+)
+
+
+@app.callback()
+def _main_callback(
+    profile: str | None = typer.Option(
+        None,
+        "--profile",
+        envvar="OPENSQUILLA_PROFILE",
+        help="Use a named OpenSquilla profile home.",
+    ),
+) -> None:
+    # Typer invokes the callback after parsing.  Keep this validation in place
+    # for CliRunner callers that pass argv directly instead of process argv.
+    _activate_profile(profile)
+    # Import the observability package only after Typer has selected the
+    # recovery command.  Its broad package initializer is outside the shared
+    # offline recovery dependency budget, but command diagnostics still need
+    # the normal stderr-only structlog contract.
+    from opensquilla.observability.cli_logging import configure_cli_structlog
+
+    configure_cli_structlog()
+
+
+app.add_typer(recovery_app, name="recovery")
+
+__all__ = ["app", "recovery_app"]
+
+
+if __name__ == "__main__":
+    app()

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -3006,7 +3006,23 @@ async def build_services(
             ensure_sandbox_upgrade_migrated,
         )
 
-        upgrade_report = ensure_sandbox_upgrade_migrated(config_path.parent)
+        sandbox_upgrade_started_at = time.monotonic()
+        log.info("build_services.sandbox_upgrade_started")
+        try:
+            upgrade_report = ensure_sandbox_upgrade_migrated(config_path.parent)
+        except Exception as exc:
+            log.exception(
+                "build_services.sandbox_upgrade_failed",
+                duration_ms=_elapsed_monotonic_ms(sandbox_upgrade_started_at),
+                error_type=type(exc).__name__,
+            )
+            raise
+        log.info(
+            "build_services.sandbox_upgrade_finished",
+            ok=upgrade_report.ok,
+            status=upgrade_report.status,
+            duration_ms=_elapsed_monotonic_ms(sandbox_upgrade_started_at),
+        )
         if not upgrade_report.ok:
             raise RuntimeError(
                 "migration_failed_manual_recovery_required: "

--- a/src/opensquilla/sandbox/upgrade_migration.py
+++ b/src/opensquilla/sandbox/upgrade_migration.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import base64
-import csv
+import binascii
 import hashlib
 import json
 import os
+import re
 import shutil
 import stat
 import subprocess
@@ -31,89 +32,142 @@ from opensquilla.sandbox.legacy_codec import (
 MIGRATION_VERSION = 2
 JOURNAL_NAME = ".sandbox-upgrade-v2.json"
 SNAPSHOT_NAME = ".sandbox-upgrade-snapshot"
+WINDOWS_ACL_STAGE_TIMEOUT_SECONDS = 30.0
+_WINDOWS_IDENTITY_FALLBACK_TIMEOUT_SECONDS = 10.0
+_FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+_ERROR_INSUFFICIENT_BUFFER = 122
+_TOKEN_QUERY = 0x0008
+_TOKEN_USER = 1
+
 
 _WINDOWS_PRIVATE_ACL_SCRIPT = r"""
 $ErrorActionPreference = "Stop"
-$target = $env:OPENSQUILLA_UPGRADE_ACL_TARGET
+$utf8WithoutBom = [System.Text.UTF8Encoding]::new($false)
+[Console]::OutputEncoding = $utf8WithoutBom
+$OutputEncoding = $utf8WithoutBom
 $userSid = $env:OPENSQUILLA_UPGRADE_ACL_USER_SID
-$isDirectory = $env:OPENSQUILLA_UPGRADE_ACL_IS_DIRECTORY -eq "1"
-$acl = if ($isDirectory) {
-    [System.Security.AccessControl.DirectorySecurity]::new()
-} else {
-    [System.Security.AccessControl.FileSecurity]::new()
-}
-$acl.SetAccessRuleProtection($true, $false)
-$inheritance = [System.Security.AccessControl.InheritanceFlags]::None
-if ($isDirectory) {
-    $inheritance = [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
-        [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
-}
-$propagation = [System.Security.AccessControl.PropagationFlags]::None
-$fullControl = [System.Security.AccessControl.FileSystemRights]::FullControl
 $allowed = @($userSid)
 foreach ($trustedSid in @("S-1-5-18", "S-1-5-32-544")) {
     if ($allowed -notcontains $trustedSid) {
         $allowed += $trustedSid
     }
 }
-foreach ($sidText in $allowed) {
-    $sid = [System.Security.Principal.SecurityIdentifier]::new($sidText)
-    $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
-        $sid,
-        $fullControl,
-        $inheritance,
-        $propagation,
-        [System.Security.AccessControl.AccessControlType]::Allow
-    )
-    [void]$acl.AddAccessRule($rule)
-}
-if ($isDirectory) {
-    [System.IO.Directory]::SetAccessControl($target, $acl)
-    $verified = [System.IO.Directory]::GetAccessControl($target)
-} else {
-    [System.IO.File]::SetAccessControl($target, $acl)
-    $verified = [System.IO.File]::GetAccessControl($target)
-}
-if (-not $verified.AreAccessRulesProtected) {
-    throw "DACL inheritance remains enabled"
-}
-$rules = @($verified.Access)
-if ($rules.Count -ne $allowed.Count) {
-    throw "DACL contains an unexpected rule count"
-}
-foreach ($rule in $rules) {
-    $identity = $rule.IdentityReference.Translate(
-        [System.Security.Principal.SecurityIdentifier]
-    ).Value
-    if ($allowed -notcontains $identity -or
-        $rule.AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow -or
-        $rule.IsInherited -or
-        ($rule.FileSystemRights -band $fullControl) -ne $fullControl -or
-        $rule.InheritanceFlags -ne $inheritance -or
-        $rule.PropagationFlags -ne $propagation) {
-        throw "DACL verification failed"
+$raw = [Console]::In.ReadToEnd()
+$parsed = $raw | ConvertFrom-Json
+if ($null -eq $parsed) { throw "ACL batch is empty" }
+$items = if ($parsed -is [System.Array]) { $parsed } else { @($parsed) }
+$itemCount = if ($items -is [System.Array]) { $items.Length } else { 1 }
+if ($itemCount -eq 0) { throw "ACL batch is empty" }
+$verifiedIds = New-Object 'System.Collections.Generic.List[string]'
+$verifiedPathUtf8Base64 = New-Object 'System.Collections.Generic.List[string]'
+$verifiedPathHashes = New-Object 'System.Collections.Generic.List[string]'
+$seenPaths = New-Object 'System.Collections.Generic.HashSet[string]'
+$fullControl = [System.Security.AccessControl.FileSystemRights]::FullControl
+foreach ($item in $items) {
+    $target = [string]$item.path
+    $itemId = [string]$item.id
+    if ($null -eq $item.directory -or $item.directory.GetType().Name -ne "Boolean") {
+        throw "ACL batch item directory flag is invalid"
     }
-}
-foreach ($sidText in $allowed) {
-    $matchCount = 0
+    $isDirectory = $item.directory
+    if ([string]::IsNullOrWhiteSpace($target) -or [string]::IsNullOrWhiteSpace($itemId)) {
+        throw "ACL batch item is invalid"
+    }
+    if (-not $seenPaths.Add($target)) { throw "ACL batch contains duplicate paths" }
+    $attributes = [System.IO.File]::GetAttributes($target)
+    if (($attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "snapshot path is a reparse point: $target"
+    }
+    $actualDirectory = ($attributes -band [System.IO.FileAttributes]::Directory) -ne 0
+    if ($actualDirectory -ne $isDirectory) { throw "snapshot path type changed: $target" }
+    $acl = if ($isDirectory) {
+        [System.Security.AccessControl.DirectorySecurity]::new()
+    } else {
+        [System.Security.AccessControl.FileSecurity]::new()
+    }
+    $acl.SetAccessRuleProtection($true, $false)
+    $inheritance = [System.Security.AccessControl.InheritanceFlags]::None
+    if ($isDirectory) {
+        $inheritance = [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
+            [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
+    }
+    $propagation = [System.Security.AccessControl.PropagationFlags]::None
+    foreach ($sidText in $allowed) {
+        $sid = [System.Security.Principal.SecurityIdentifier]::new($sidText)
+        $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+            $sid,
+            $fullControl,
+            $inheritance,
+            $propagation,
+            [System.Security.AccessControl.AccessControlType]::Allow
+        )
+        [void]$acl.AddAccessRule($rule)
+    }
+    if ($isDirectory) {
+        [System.IO.Directory]::SetAccessControl($target, $acl)
+        $verified = [System.IO.Directory]::GetAccessControl($target)
+    } else {
+        [System.IO.File]::SetAccessControl($target, $acl)
+        $verified = [System.IO.File]::GetAccessControl($target)
+    }
+    $postAttributes = [System.IO.File]::GetAttributes($target)
+    if (($postAttributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "snapshot path became a reparse point: $target"
+    }
+    if ((($postAttributes -band [System.IO.FileAttributes]::Directory) -ne 0) -ne $isDirectory) {
+        throw "snapshot path type changed after ACL update: $target"
+    }
+    if (-not $verified.AreAccessRulesProtected) { throw "DACL inheritance remains enabled" }
+    $rules = @($verified.Access)
+    if ($rules.Count -ne $allowed.Count) { throw "DACL contains an unexpected rule count" }
     foreach ($rule in $rules) {
         $identity = $rule.IdentityReference.Translate(
             [System.Security.Principal.SecurityIdentifier]
         ).Value
-        if ($identity -eq $sidText) {
-            $matchCount += 1
+        if ($allowed -notcontains $identity -or
+            $rule.AccessControlType -ne
+                [System.Security.AccessControl.AccessControlType]::Allow -or
+            $rule.IsInherited -or
+            $rule.FileSystemRights -ne $fullControl -or
+            $rule.InheritanceFlags -ne $inheritance -or
+            $rule.PropagationFlags -ne $propagation) {
+            throw "DACL verification failed"
         }
     }
-    if ($matchCount -ne 1) {
-        throw "DACL principal verification failed"
+    foreach ($sidText in $allowed) {
+        $matchCount = 0
+        foreach ($rule in $rules) {
+            $identity = $rule.IdentityReference.Translate(
+                [System.Security.Principal.SecurityIdentifier]
+            ).Value
+            if ($identity -eq $sidText) { $matchCount += 1 }
+        }
+        if ($matchCount -ne 1) { throw "DACL principal verification failed" }
     }
+    [void]$verifiedIds.Add($itemId)
+    $pathBytes = [System.Text.Encoding]::UTF8.GetBytes($target)
+    [void]$verifiedPathUtf8Base64.Add(
+        [System.Convert]::ToBase64String($pathBytes)
+    )
+    $hash = [System.Security.Cryptography.SHA256]::Create().ComputeHash(
+        $pathBytes
+    )
+    $pathHash = (
+        [System.BitConverter]::ToString($hash) -replace "-", ""
+    ).ToLowerInvariant()
+    [void]$verifiedPathHashes.Add($pathHash)
 }
+$resultJson = [ordered]@{
+    count = $verifiedIds.Count
+    ids = $verifiedIds.ToArray()
+    pathUtf8Base64 = $verifiedPathUtf8Base64.ToArray()
+    pathHashes = $verifiedPathHashes.ToArray()
+} | ConvertTo-Json -Compress
+[Console]::Out.WriteLine($resultJson)
 """
 _WINDOWS_PRIVATE_ACL_ENCODED = base64.b64encode(
     _WINDOWS_PRIVATE_ACL_SCRIPT.encode("utf-16-le")
 ).decode("ascii")
-_WINDOWS_IDENTITY_TIMEOUT_SECONDS = 10.0
-_WINDOWS_ACL_TIMEOUT_SECONDS = 15.0
 _WINDOWS_DLL_DIRECTORY_LOCK = threading.Lock()
 
 
@@ -148,30 +202,295 @@ def _system_windows_process_context() -> Iterator[None]:
             _set_windows_dll_directory(str(bundle_root))
 
 
-def _current_windows_user_sid() -> str:
+def _native_windows_user_sid() -> str:
+    import ctypes
+
+    class SidAndAttributes(ctypes.Structure):
+        _fields_ = [("sid", ctypes.c_void_p), ("attributes", ctypes.c_uint32)]
+
+    class TokenUser(ctypes.Structure):
+        _fields_ = [("user", SidAndAttributes)]
+
+    loader = getattr(ctypes, "WinDLL")
+    advapi32 = loader("advapi32", use_last_error=True)
+    kernel32 = loader("kernel32", use_last_error=True)
+    open_token = advapi32.OpenProcessToken
+    get_token = advapi32.GetTokenInformation
+    convert_sid = advapi32.ConvertSidToStringSidW
+    get_process = kernel32.GetCurrentProcess
+    close_handle = kernel32.CloseHandle
+    local_free = kernel32.LocalFree
+    open_token.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.POINTER(ctypes.c_void_p),
+    ]
+    open_token.restype = ctypes.c_int
+    get_token.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.POINTER(ctypes.c_uint32),
+    ]
+    get_token.restype = ctypes.c_int
+    convert_sid.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+    convert_sid.restype = ctypes.c_int
+    get_process.argtypes = []
+    get_process.restype = ctypes.c_void_p
+    close_handle.argtypes = [ctypes.c_void_p]
+    close_handle.restype = ctypes.c_int
+    local_free.argtypes = [ctypes.c_void_p]
+    local_free.restype = ctypes.c_void_p
+
+    token = ctypes.c_void_p()
+    if not open_token(get_process(), _TOKEN_QUERY, ctypes.byref(token)):
+        error_number = int(getattr(ctypes, "get_last_error")())
+        raise OSError(error_number, "cannot open the current Windows process token")
     try:
-        with _system_windows_process_context():
-            completed = subprocess.run(
-                ["whoami", "/user", "/fo", "csv", "/nh"],
-                capture_output=True,
-                creationflags=int(getattr(subprocess, "CREATE_NO_WINDOW", 0)),
-                stdin=subprocess.DEVNULL,
-                text=True,
-                check=False,
-                timeout=_WINDOWS_IDENTITY_TIMEOUT_SECONDS,
-            )
-    except subprocess.TimeoutExpired as exc:
-        raise OSError("Windows user SID lookup timed out") from exc
-    if completed.returncode != 0:
-        raise OSError("cannot resolve the current Windows user SID")
-    try:
-        row = next(csv.reader(completed.stdout.splitlines()))
-        sid = row[1].strip()
-    except (IndexError, StopIteration) as exc:
-        raise OSError("cannot resolve the current Windows user SID") from exc
+        required = ctypes.c_uint32()
+        get_token(token, _TOKEN_USER, None, 0, ctypes.byref(required))
+        error_number = int(getattr(ctypes, "get_last_error")())
+        if required.value == 0 or error_number != _ERROR_INSUFFICIENT_BUFFER:
+            raise OSError(error_number, "cannot size the current Windows token user")
+        buffer = ctypes.create_string_buffer(required.value)
+        if not get_token(
+            token,
+            _TOKEN_USER,
+            buffer,
+            required.value,
+            ctypes.byref(required),
+        ):
+            error_number = int(getattr(ctypes, "get_last_error")())
+            raise OSError(error_number, "cannot read the current Windows token user")
+        token_user = ctypes.cast(buffer, ctypes.POINTER(TokenUser)).contents
+        string_sid = ctypes.c_void_p()
+        if not convert_sid(token_user.user.sid, ctypes.byref(string_sid)):
+            error_number = int(getattr(ctypes, "get_last_error")())
+            raise OSError(error_number, "cannot format the current Windows user SID")
+        try:
+            sid = ctypes.wstring_at(string_sid)
+        finally:
+            local_free(string_sid)
+    finally:
+        close_handle(token)
     if not sid.startswith("S-"):
         raise OSError("cannot resolve the current Windows user SID")
     return sid
+
+
+def _current_windows_user_sid(*, deadline: float | None = None) -> str:
+    try:
+        with _system_windows_process_context():
+            return _native_windows_user_sid()
+    except (AttributeError, ImportError, OSError):
+        remaining = (
+            WINDOWS_ACL_STAGE_TIMEOUT_SECONDS
+            if deadline is None
+            else deadline - time.monotonic()
+        )
+        if remaining <= 0:
+            raise TimeoutError("Windows ACL migration timed out resolving the current user SID")
+        try:
+            with _system_windows_process_context():
+                completed = subprocess.run(
+                    ["whoami", "/user", "/fo", "csv", "/nh"],
+                    capture_output=True,
+                    check=False,
+                    timeout=min(_WINDOWS_IDENTITY_FALLBACK_TIMEOUT_SECONDS, remaining),
+                    stdin=subprocess.DEVNULL,
+                    creationflags=int(getattr(subprocess, "CREATE_NO_WINDOW", 0)),
+                )
+        except subprocess.TimeoutExpired as exc:
+            raise TimeoutError(
+                "Windows ACL migration timed out resolving the current user SID"
+            ) from exc
+        if completed.returncode != 0:
+            raise OSError("cannot resolve the current Windows user SID")
+        stdout = completed.stdout
+        if not isinstance(stdout, bytes):
+            raise OSError("cannot resolve the current Windows user SID")
+        sid_matches: list[bytes] = re.findall(
+            rb"(?<![A-Za-z0-9-])S-\d+(?:-\d+){2,}(?![A-Za-z0-9-])",
+            stdout,
+        )
+        if len(sid_matches) != 1:
+            raise OSError("cannot resolve the current Windows user SID")
+        return sid_matches[0].decode("ascii")
+
+
+def _remaining_windows_acl_time(deadline: float | None) -> float:
+    if deadline is None:
+        return WINDOWS_ACL_STAGE_TIMEOUT_SECONDS
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise TimeoutError("Windows ACL migration stage timed out")
+    return remaining
+
+
+def _path_is_directory(path: Path) -> bool:
+    value = path.lstat()
+    attributes = int(getattr(value, "st_file_attributes", 0))
+    if stat.S_ISLNK(value.st_mode) or attributes & _FILE_ATTRIBUTE_REPARSE_POINT:
+        raise OSError(f"snapshot path has an unsafe type: {path}")
+    if stat.S_ISDIR(value.st_mode):
+        return True
+    if stat.S_ISREG(value.st_mode):
+        return False
+    raise OSError(f"snapshot path has an unsafe type: {path}")
+
+def _path_exists_no_follow(path: Path) -> bool:
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def _private_tree_entries(
+    root: Path,
+    *,
+    deadline: float | None = None,
+) -> tuple[tuple[Path, bool], ...]:
+    entries: list[tuple[Path, bool]] = []
+
+    def visit(path: Path, *, expected_directory: bool | None = None) -> None:
+        if deadline is not None and time.monotonic() >= deadline:
+            raise TimeoutError("Windows ACL migration stage timed out")
+        is_directory = _path_is_directory(path)
+        if expected_directory is not None and is_directory != expected_directory:
+            raise OSError(f"snapshot path type changed: {path}")
+        entries.append((path, is_directory))
+        if not is_directory:
+            return
+        with os.scandir(path) as iterator:
+            children = sorted(iterator, key=lambda item: item.name.casefold())
+        for child in children:
+            if deadline is not None and time.monotonic() >= deadline:
+                raise TimeoutError("Windows ACL migration stage timed out")
+            child_path = Path(child.path)
+            child_attributes = int(
+                getattr(child.stat(follow_symlinks=False), "st_file_attributes", 0)
+            )
+            if child_attributes & _FILE_ATTRIBUTE_REPARSE_POINT:
+                raise OSError(f"snapshot path has an unsafe type: {child_path}")
+            visit(child_path)
+
+    if not _path_is_directory(root):
+        raise OSError(f"snapshot root is not a directory: {root}")
+    visit(root)
+    return tuple(sorted(entries, key=lambda item: item[0].as_posix().casefold()))
+
+
+def _acl_batch_payload(entries: tuple[tuple[Path, bool], ...]) -> str:
+    return json.dumps(
+        [
+            {"id": str(index), "path": str(path), "directory": directory}
+            for index, (path, directory) in enumerate(entries)
+        ],
+        ensure_ascii=True,
+        separators=(",", ":"),
+    )
+
+
+def _acl_path_hash(path: Path) -> str:
+    return hashlib.sha256(str(path).encode("utf-8")).hexdigest()
+
+
+def _protect_windows_acl_batch(
+    entries: tuple[tuple[Path, bool], ...],
+    *,
+    windows_user_sid: str,
+    deadline: float | None = None,
+) -> None:
+    if not entries:
+        raise OSError("ACL batch is empty")
+    normalized_paths = [os.path.normcase(os.path.abspath(str(path))) for path, _ in entries]
+    if len(set(normalized_paths)) != len(normalized_paths):
+        raise OSError("ACL batch contains duplicate paths")
+    for path, directory in entries:
+        _remaining_windows_acl_time(deadline)
+        if _path_is_directory(path) != directory:
+            raise OSError(f"snapshot path type changed: {path}")
+    environment = {
+        **os.environ,
+        "OPENSQUILLA_UPGRADE_ACL_USER_SID": windows_user_sid,
+    }
+    try:
+        with _system_windows_process_context():
+            completed = subprocess.run(
+                [
+                    "powershell",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-NoLogo",
+                    "-EncodedCommand",
+                    _WINDOWS_PRIVATE_ACL_ENCODED,
+                ],
+                env=environment,
+                input=_acl_batch_payload(entries).encode("ascii"),
+                capture_output=True,
+                check=False,
+                timeout=_remaining_windows_acl_time(deadline),
+                creationflags=int(getattr(subprocess, "CREATE_NO_WINDOW", 0)),
+            )
+    except subprocess.TimeoutExpired as exc:
+        raise TimeoutError("Windows ACL migration stage timed out") from exc
+    if completed.returncode != 0:
+        detail = " ".join(
+            (completed.stderr or completed.stdout or b"")
+            .decode("utf-8", errors="replace")
+            .strip()
+            .split()
+        )
+        suffix = f" ({detail[-500:]})" if detail else ""
+        raise OSError(f"cannot protect upgrade snapshot path ACL batch{suffix}")
+    try:
+        result = json.loads(completed.stdout.decode("ascii"))
+        if not isinstance(result, dict):
+            raise TypeError("ACL helper result is not an object")
+        ids = result["ids"]
+        encoded_paths = result["pathUtf8Base64"]
+        path_hashes = result["pathHashes"]
+        count = result["count"]
+        if (
+            isinstance(count, bool)
+            or not isinstance(count, int)
+            or not isinstance(ids, list)
+            or not all(isinstance(item, str) for item in ids)
+            or not isinstance(encoded_paths, list)
+            or not all(isinstance(item, str) for item in encoded_paths)
+            or not isinstance(path_hashes, list)
+            or not all(isinstance(item, str) for item in path_hashes)
+        ):
+            raise TypeError("ACL helper result has invalid field types")
+        paths = [
+            base64.b64decode(item, validate=True).decode("utf-8")
+            for item in encoded_paths
+        ]
+    except (
+        AttributeError,
+        binascii.Error,
+        KeyError,
+        TypeError,
+        UnicodeDecodeError,
+        ValueError,
+    ) as exc:
+        raise OSError("Windows ACL helper returned an invalid verification result") from exc
+    expected_ids = [str(index) for index in range(len(entries))]
+    expected_paths = [str(path) for path, _ in entries]
+    expected_hashes = [_acl_path_hash(path) for path, _ in entries]
+    if (
+        count != len(expected_ids)
+        or ids != expected_ids
+        or paths != expected_paths
+        or path_hashes != expected_hashes
+    ):
+        raise OSError("Windows ACL helper did not verify the requested paths exactly")
+    for path, directory in entries:
+        _remaining_windows_acl_time(deadline)
+        if _path_is_directory(path) != directory:
+            raise OSError(f"snapshot path changed after ACL verification: {path}")
 
 
 def _protect_private_path(
@@ -179,49 +498,22 @@ def _protect_private_path(
     *,
     directory: bool,
     windows_user_sid: str | None,
+    deadline: float | None = None,
 ) -> None:
-    value = path.lstat()
-    attributes = int(getattr(value, "st_file_attributes", 0))
-    expected_type = stat.S_ISDIR if directory else stat.S_ISREG
-    if stat.S_ISLNK(value.st_mode) or attributes & 0x400 or not expected_type(value.st_mode):
+    if _path_is_directory(path) != directory:
         raise OSError(f"snapshot path has an unsafe type: {path}")
 
     if _running_on_windows():
         if windows_user_sid is None:
             raise OSError("current Windows user SID is unavailable")
-        environment = {
-            **os.environ,
-            "OPENSQUILLA_UPGRADE_ACL_TARGET": str(path),
-            "OPENSQUILLA_UPGRADE_ACL_USER_SID": windows_user_sid,
-            "OPENSQUILLA_UPGRADE_ACL_IS_DIRECTORY": "1" if directory else "0",
-        }
         try:
-            with _system_windows_process_context():
-                completed = subprocess.run(
-                    [
-                        "powershell",
-                        "-NoProfile",
-                        "-NonInteractive",
-                        "-NoLogo",
-                        "-EncodedCommand",
-                        _WINDOWS_PRIVATE_ACL_ENCODED,
-                    ],
-                    env=environment,
-                    capture_output=True,
-                    creationflags=int(getattr(subprocess, "CREATE_NO_WINDOW", 0)),
-                    stdin=subprocess.DEVNULL,
-                    text=True,
-                    check=False,
-                    timeout=_WINDOWS_ACL_TIMEOUT_SECONDS,
-                )
-        except subprocess.TimeoutExpired as exc:
-            detail = " ".join(str(exc.stderr or exc.stdout or "").strip().split())
-            suffix = f" ({detail[-500:]})" if detail else ""
-            raise OSError(f"Windows ACL hardening timed out: {path}{suffix}") from exc
-        if completed.returncode != 0:
-            detail = " ".join((completed.stderr or completed.stdout).strip().split())
-            suffix = f" ({detail[-500:]})" if detail else ""
-            raise OSError(f"cannot protect upgrade snapshot path: {path}{suffix}")
+            _protect_windows_acl_batch(
+                ((path, directory),),
+                windows_user_sid=windows_user_sid,
+                deadline=deadline,
+            )
+        except TimeoutError as exc:
+            raise OSError(f"Windows ACL hardening timed out: {path}") from exc
         return
 
     mode = 0o700 if directory else 0o600
@@ -230,13 +522,21 @@ def _protect_private_path(
         raise OSError(f"cannot protect upgrade snapshot path: {path}")
 
 
-def _create_private_directory(path: Path, *, windows_user_sid: str | None) -> None:
+def _create_private_directory(
+    path: Path,
+    *,
+    windows_user_sid: str | None,
+    protect: bool = True,
+    deadline: float | None = None,
+) -> None:
     path.mkdir(mode=0o700)
-    _protect_private_path(
-        path,
-        directory=True,
-        windows_user_sid=windows_user_sid,
-    )
+    if protect:
+        _protect_private_path(
+            path,
+            directory=True,
+            windows_user_sid=windows_user_sid,
+            deadline=deadline,
+        )
 
 
 def _copy_private_file(
@@ -244,6 +544,8 @@ def _copy_private_file(
     destination: Path,
     *,
     windows_user_sid: str | None,
+    protect: bool = True,
+    deadline: float | None = None,
 ) -> None:
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0)
     descriptor = os.open(destination, flags, 0o600)
@@ -258,22 +560,43 @@ def _copy_private_file(
     finally:
         if descriptor >= 0:
             os.close(descriptor)
-    _protect_private_path(
-        destination,
-        directory=False,
-        windows_user_sid=windows_user_sid,
-    )
-
-
-def _protect_private_tree(root: Path, *, windows_user_sid: str | None) -> None:
-    _protect_private_path(root, directory=True, windows_user_sid=windows_user_sid)
-    entries = sorted(root.rglob("*"), key=lambda item: item.as_posix())
-    for entry in entries:
+    if protect:
         _protect_private_path(
-            entry,
-            directory=entry.is_dir(),
+            destination,
+            directory=False,
             windows_user_sid=windows_user_sid,
+            deadline=deadline,
         )
+
+
+def _protect_private_tree(
+    root: Path,
+    *,
+    windows_user_sid: str | None,
+    deadline: float | None = None,
+) -> None:
+    entries = _private_tree_entries(root, deadline=deadline)
+    if _running_on_windows():
+        if windows_user_sid is None:
+            raise OSError("current Windows user SID is unavailable")
+        _protect_windows_acl_batch(
+            entries,
+            windows_user_sid=windows_user_sid,
+            deadline=deadline,
+        )
+    else:
+        for path, directory in entries:
+            _protect_private_path(
+                path,
+                directory=directory,
+                windows_user_sid=windows_user_sid,
+                deadline=deadline,
+            )
+    after = _private_tree_entries(root, deadline=deadline)
+    before_keys = tuple((str(path), directory) for path, directory in entries)
+    after_keys = tuple((str(path), directory) for path, directory in after)
+    if before_keys != after_keys:
+        raise OSError("snapshot tree changed during ACL migration")
 
 
 def _remove_failed_snapshot(path: Path, *, original_error: Exception) -> None:
@@ -443,17 +766,27 @@ class SandboxUpgradeCoordinator:
             status="manual_recovery_required",
             canonical_mode=None,
             journal_path=self.journal_path,
-            snapshot_path=self.snapshot_path if self.snapshot_path.exists() else None,
+            snapshot_path=(
+                self.snapshot_path if _path_exists_no_follow(self.snapshot_path) else None
+            ),
             stores=store_names,
             error=str(failed["error"]),
         )
 
     def _snapshot(self, stores: tuple[Path, ...]) -> None:
-        windows_user_sid = _current_windows_user_sid() if _running_on_windows() else None
-        if self.snapshot_path.exists():
+        deadline = (
+            time.monotonic() + WINDOWS_ACL_STAGE_TIMEOUT_SECONDS
+            if _running_on_windows()
+            else None
+        )
+        windows_user_sid = (
+            _current_windows_user_sid(deadline=deadline) if _running_on_windows() else None
+        )
+        if _path_exists_no_follow(self.snapshot_path):
             _protect_private_tree(
                 self.snapshot_path,
                 windows_user_sid=windows_user_sid,
+                deadline=deadline,
             )
             return
         staging = Path(
@@ -469,46 +802,59 @@ class SandboxUpgradeCoordinator:
                 staging,
                 directory=True,
                 windows_user_sid=windows_user_sid,
+                deadline=deadline,
             )
             if next(staging.iterdir(), None) is not None:
                 raise OSError("upgrade snapshot staging is not empty after hardening")
-            manifest: list[dict[str, object]] = []
-            for source in stores:
-                relative = source.relative_to(self.home)
-                destination = staging / relative
-                current = staging
-                for part in relative.parts[:-1]:
-                    current = current / part
-                    if not current.exists():
-                        _create_private_directory(
-                            current,
-                            windows_user_sid=windows_user_sid,
-                        )
-                _copy_private_file(
-                    source,
-                    destination,
-                    windows_user_sid=windows_user_sid,
-                )
-                manifest.append(
-                    {
-                        "path": relative.as_posix(),
-                        "sha256": _digest(destination),
-                        "size": destination.stat().st_size,
-                    }
-                )
-            manifest_path = staging / "manifest.json"
-            _write_json(manifest_path, {"stores": manifest})
-            _protect_private_path(
-                manifest_path,
-                directory=False,
+            materialization_started: float | None = None
+            if deadline is not None:
+                _remaining_windows_acl_time(deadline)
+                materialization_started = time.monotonic()
+            try:
+                manifest: list[dict[str, object]] = []
+                for source in stores:
+                    relative = source.relative_to(self.home)
+                    destination = staging / relative
+                    current = staging
+                    for part in relative.parts[:-1]:
+                        current = current / part
+                        if not current.exists():
+                            _create_private_directory(
+                                current,
+                                windows_user_sid=windows_user_sid,
+                                protect=False,
+                                deadline=deadline,
+                            )
+                    _copy_private_file(
+                        source,
+                        destination,
+                        windows_user_sid=windows_user_sid,
+                        protect=False,
+                        deadline=deadline,
+                    )
+                    manifest.append(
+                        {
+                            "path": relative.as_posix(),
+                            "sha256": _digest(destination),
+                            "size": destination.stat().st_size,
+                        }
+                    )
+                manifest_path = staging / "manifest.json"
+                _write_json(manifest_path, {"stores": manifest})
+            finally:
+                if deadline is not None and materialization_started is not None:
+                    deadline += time.monotonic() - materialization_started
+            _protect_private_tree(
+                staging,
                 windows_user_sid=windows_user_sid,
+                deadline=deadline,
             )
-            _protect_private_tree(staging, windows_user_sid=windows_user_sid)
             os.replace(staging, self.snapshot_path)
             promoted = True
             _protect_private_tree(
                 self.snapshot_path,
                 windows_user_sid=windows_user_sid,
+                deadline=deadline,
             )
         except Exception as exc:
             cleanup = self.snapshot_path if promoted else staging
@@ -529,8 +875,9 @@ class SandboxUpgradeCoordinator:
         journal = self._load_journal()
         if journal is not None and journal.get("status") == "committed":
             try:
-                if self.snapshot_path.exists():
-                    self._snapshot(())
+                if not _path_exists_no_follow(self.snapshot_path):
+                    raise OSError("committed sandbox upgrade snapshot is missing")
+                self._snapshot(())
             except Exception as exc:
                 return self._manual_recovery_report(
                     store_names=store_names,
@@ -541,7 +888,7 @@ class SandboxUpgradeCoordinator:
                 status="committed",
                 canonical_mode=journal.get("canonicalMode"),
                 journal_path=self.journal_path,
-                snapshot_path=self.snapshot_path if self.snapshot_path.exists() else None,
+                snapshot_path=self.snapshot_path,
                 stores=store_names,
             )
         try:
@@ -607,7 +954,9 @@ def inspect_sandbox_upgrade(home: str | Path) -> UpgradeMigrationReport:
             canonical_mode=None,
             journal_path=coordinator.journal_path,
             snapshot_path=(
-                coordinator.snapshot_path if coordinator.snapshot_path.exists() else None
+                coordinator.snapshot_path
+                if _path_exists_no_follow(coordinator.snapshot_path)
+                else None
             ),
             stores=(),
             error=f"{type(exc).__name__}: {exc}",
@@ -627,7 +976,9 @@ def inspect_sandbox_upgrade(home: str | Path) -> UpgradeMigrationReport:
         canonical_mode=journal.get("canonicalMode"),
         journal_path=coordinator.journal_path,
         snapshot_path=(
-            coordinator.snapshot_path if coordinator.snapshot_path.exists() else None
+            coordinator.snapshot_path
+            if _path_exists_no_follow(coordinator.snapshot_path)
+            else None
         ),
         stores=tuple(str(item) for item in journal.get("stores", ())),
         error=journal.get("error"),

--- a/src/opensquilla/sandbox/upgrade_migration.py
+++ b/src/opensquilla/sandbox/upgrade_migration.py
@@ -16,6 +16,7 @@ import tempfile
 import threading
 import time
 import tomllib
+import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -103,7 +104,37 @@ foreach ($item in $items) {
         )
         [void]$acl.AddAccessRule($rule)
     }
-    if ($isDirectory) {
+    if ($PSVersionTable.PSVersion.Major -ge 6) {
+        $verified = Get-Acl -LiteralPath $target
+        $needsSet = -not $verified.AreAccessRulesProtected
+        $initialRules = @($verified.Access)
+        if ($initialRules.Count -ne $allowed.Count) { $needsSet = $true }
+        foreach ($rule in $initialRules) {
+            $identity = $rule.IdentityReference.Translate(
+                [System.Security.Principal.SecurityIdentifier]
+            ).Value
+            if ($allowed -notcontains $identity -or
+                $rule.AccessControlType -ne
+                    [System.Security.AccessControl.AccessControlType]::Allow -or
+                $rule.IsInherited -or
+                $rule.FileSystemRights -ne $fullControl -or
+                $rule.InheritanceFlags -ne $inheritance -or
+                $rule.PropagationFlags -ne $propagation) {
+                $needsSet = $true
+                break
+            }
+        }
+        if ($needsSet) {
+            $inheritanceSddl = if ($isDirectory) { "OICI" } else { "" }
+            $sddl = "D:P" + (($allowed | ForEach-Object {
+                "(A;$inheritanceSddl;FA;;;$_)"
+            }) -join "")
+            $acl = $verified
+            $acl.SetSecurityDescriptorSddlForm($sddl)
+            Set-Acl -LiteralPath $target -AclObject $acl
+            $verified = Get-Acl -LiteralPath $target
+        }
+    } elseif ($isDirectory) {
         [System.IO.Directory]::SetAccessControl($target, $acl)
         $verified = [System.IO.Directory]::GetAccessControl($target)
     } else {
@@ -397,6 +428,13 @@ def _acl_path_hash(path: Path) -> str:
     return hashlib.sha256(str(path).encode("utf-8")).hexdigest()
 
 
+def _windows_acl_shells() -> tuple[str, ...]:
+    preferred = shutil.which("pwsh")
+    fallback = shutil.which("powershell")
+    shells = tuple(item for item in (preferred, fallback) if item is not None)
+    return shells or ("powershell",)
+
+
 def _protect_windows_acl_batch(
     entries: tuple[tuple[Path, bool], ...],
     *,
@@ -416,26 +454,46 @@ def _protect_windows_acl_batch(
         **os.environ,
         "OPENSQUILLA_UPGRADE_ACL_USER_SID": windows_user_sid,
     }
-    try:
-        with _system_windows_process_context():
-            completed = subprocess.run(
-                [
-                    "powershell",
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-NoLogo",
-                    "-EncodedCommand",
-                    _WINDOWS_PRIVATE_ACL_ENCODED,
-                ],
-                env=environment,
-                input=_acl_batch_payload(entries).encode("ascii"),
-                capture_output=True,
-                check=False,
-                timeout=_remaining_windows_acl_time(deadline),
-                creationflags=int(getattr(subprocess, "CREATE_NO_WINDOW", 0)),
-            )
-    except subprocess.TimeoutExpired as exc:
-        raise TimeoutError("Windows ACL migration stage timed out") from exc
+    completed: subprocess.CompletedProcess[bytes] | None = None
+    shells = _windows_acl_shells()
+    for shell_index, shell in enumerate(shells):
+        try:
+            with _system_windows_process_context():
+                completed = subprocess.run(
+                    [
+                        shell,
+                        "-NoProfile",
+                        "-NonInteractive",
+                        "-NoLogo",
+                        "-EncodedCommand",
+                        _WINDOWS_PRIVATE_ACL_ENCODED,
+                    ],
+                    env=environment,
+                    input=_acl_batch_payload(entries).encode("ascii"),
+                    capture_output=True,
+                    check=False,
+                    timeout=_remaining_windows_acl_time(deadline),
+                    creationflags=int(getattr(subprocess, "CREATE_NO_WINDOW", 0)),
+                )
+        except subprocess.TimeoutExpired as exc:
+            raise TimeoutError("Windows ACL migration stage timed out") from exc
+        if completed is None:
+            raise OSError("cannot start Windows ACL helper")
+        if completed.returncode == 0:
+            break
+        detail = " ".join(
+            (completed.stderr or completed.stdout or b"")
+            .decode("utf-8", errors="replace")
+            .strip()
+            .split()
+        )
+        if (
+            shell_index + 1 >= len(shells)
+            or "securityprivilege" not in detail.casefold()
+        ):
+            break
+    if completed is None:
+        raise OSError("cannot start Windows ACL helper")
     if completed.returncode != 0:
         detail = " ".join(
             (completed.stderr or completed.stdout or b"")
@@ -529,7 +587,7 @@ def _create_private_directory(
     protect: bool = True,
     deadline: float | None = None,
 ) -> None:
-    path.mkdir(mode=0o700)
+    path.mkdir(mode=0o777 if _running_on_windows() else 0o700)
     if protect:
         _protect_private_path(
             path,
@@ -607,6 +665,28 @@ def _remove_failed_snapshot(path: Path, *, original_error: Exception) -> None:
             raise OSError("path still exists after cleanup")
     except Exception:
         raise OSError(f"upgrade snapshot failed and cleanup failed: {path}") from original_error
+
+
+def _make_snapshot_staging_directory(home: Path) -> Path:
+    if not _running_on_windows():
+        return Path(
+            tempfile.mkdtemp(
+                prefix=f".{SNAPSHOT_NAME}.",
+                suffix=".tmp",
+                dir=home,
+            )
+        )
+    for _ in range(100):
+        candidate = home / f".{SNAPSHOT_NAME}.{uuid.uuid4().hex}.tmp"
+        try:
+            # Let the profile parent provide the initial Windows DACL.  The
+            # helper hardens this empty directory before any snapshot bytes
+            # are written and rejects any injected entry after hardening.
+            candidate.mkdir(mode=0o777)
+        except FileExistsError:
+            continue
+        return candidate
+    raise FileExistsError("cannot create a unique upgrade snapshot staging directory")
 
 
 @dataclass(frozen=True)
@@ -789,13 +869,7 @@ class SandboxUpgradeCoordinator:
                 deadline=deadline,
             )
             return
-        staging = Path(
-            tempfile.mkdtemp(
-                prefix=f".{SNAPSHOT_NAME}.",
-                suffix=".tmp",
-                dir=self.home,
-            )
-        )
+        staging = _make_snapshot_staging_directory(self.home)
         promoted = False
         try:
             _protect_private_path(

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -3382,6 +3382,15 @@ def test_settings_import_reconciles_or_prompts_for_imported_provider() -> None:
     save_index = reconcile.index("await saveImportedDesktopCredential(")
     assert save_index < reconcile.index("await clearPendingMigrationProviderSetup()", save_index)
 
+    pending_reconciliation = _section(
+        main_ts,
+        "async function recoverPendingMigrationReconciliation",
+        "function desktopStartupLog",
+    )
+    assert pending_reconciliation.index(
+        "beginDesktopWriterOperation('recover imported provider settings')"
+    ) < pending_reconciliation.index("readPendingMigrationProviderSetup()")
+
     encryption = _section(main_ts, "function encryptSecret", "function decryptSecret")
     assert "desktopSecretStoragePolicyBackend()" in encryption
     assert "if (availableBackend !== 'safeStorage')" in encryption

--- a/tests/test_migration/test_sandbox_direct_update.py
+++ b/tests/test_migration/test_sandbox_direct_update.py
@@ -204,8 +204,8 @@ def _mock_windows_acl(
             getattr(subprocess, "CREATE_NO_WINDOW", 0)
         )
         assert "text" not in kwargs
-        assert tuple(command[:5]) == (
-            "powershell",
+        assert Path(command[0]).name.casefold() in {"powershell.exe", "pwsh.exe"}
+        assert tuple(command[1:5]) == (
             "-NoProfile",
             "-NonInteractive",
             "-NoLogo",
@@ -220,10 +220,11 @@ def _mock_windows_acl(
     monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
 
 
-def test_windows_acl_script_does_not_require_powershell_module_autoload() -> None:
+def test_windows_acl_script_keeps_host_specific_acl_apis_bounded() -> None:
     script = upgrade_migration._WINDOWS_PRIVATE_ACL_SCRIPT
 
-    assert "Get-Acl" not in script
+    assert "Get-Acl -LiteralPath $target" in script
+    assert "Set-Acl -LiteralPath $target -AclObject $acl" in script
     assert "Select-Object" not in script
     assert "Where-Object" not in script
     assert "[System.IO.Directory]::GetAccessControl($target)" in script
@@ -265,6 +266,56 @@ def test_windows_acl_batch_round_trips_non_ascii_path_over_ascii_protocol(
         ((target, True),),
         windows_user_sid="S-1-5-21-1234",
     )
+
+
+def test_windows_acl_batch_falls_back_to_windows_powershell_on_privilege_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "snapshot"
+    target.mkdir()
+    calls: list[str] = []
+    timeouts: list[float] = []
+
+    monkeypatch.setattr(
+        upgrade_migration,
+        "_windows_acl_shells",
+        lambda: ("pwsh", "powershell"),
+    )
+
+    def run(command: list[str], **kwargs: object) -> SimpleNamespace:
+        calls.append(command[0])
+        timeout = kwargs["timeout"]
+        assert isinstance(timeout, (int, float))
+        timeouts.append(timeout)
+        if command[0] == "pwsh":
+            return SimpleNamespace(
+                returncode=1,
+                stdout=b"",
+                stderr=b"SeSecurityPrivilege",
+            )
+        result = {
+            "count": 1,
+            "ids": ["0"],
+            "pathUtf8Base64": [base64.b64encode(str(target).encode()).decode("ascii")],
+            "pathHashes": [upgrade_migration._acl_path_hash(target)],
+        }
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(result).encode("ascii"),
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
+
+    upgrade_migration._protect_windows_acl_batch(
+        ((target, True),),
+        windows_user_sid="S-1-5-21-1234",
+        deadline=upgrade_migration.time.monotonic() + 30,
+    )
+
+    assert calls == ["pwsh", "powershell"]
+    assert 0 < timeouts[1] <= timeouts[0]
 
 
 @pytest.mark.parametrize(
@@ -638,8 +689,8 @@ def test_windows_snapshot_acl_is_applied_in_copy_and_promotion_order(
     )
     assert tmp_path / upgrade_migration.SNAPSHOT_NAME / "manifest.json" in protected_paths
     for _kind, _path, command in (event for event in events if event[0] == "acl"):
-        assert command[:5] == (
-            "powershell",
+        assert Path(command[0]).name.casefold() in {"powershell.exe", "pwsh.exe"}
+        assert tuple(command[1:5]) == (
             "-NoProfile",
             "-NonInteractive",
             "-NoLogo",

--- a/tests/test_migration/test_sandbox_direct_update.py
+++ b/tests/test_migration/test_sandbox_direct_update.py
@@ -160,31 +160,61 @@ def _mock_windows_acl(
     fail_when: Any | None = None,
 ) -> None:
     monkeypatch.setattr(upgrade_migration, "_running_on_windows", lambda: True)
+    monkeypatch.setattr(
+        upgrade_migration,
+        "_current_windows_user_sid",
+        lambda **_kwargs: "S-1-5-21-1234",
+    )
 
     def run(command: list[str], **kwargs: object) -> SimpleNamespace:
         if command[0] == "whoami":
             return SimpleNamespace(
                 returncode=0,
-                stdout='"DESKTOP\\owner","S-1-5-21-1234"\n',
-                stderr="",
+                stdout=b'"DESKTOP\\owner","S-1-5-21-1234"\n',
+                stderr=b"",
             )
         environment = kwargs["env"]
         assert isinstance(environment, dict)
-        path = Path(environment["OPENSQUILLA_UPGRADE_ACL_TARGET"])
         assert environment["OPENSQUILLA_UPGRADE_ACL_USER_SID"] == "S-1-5-21-1234"
-        assert environment["OPENSQUILLA_UPGRADE_ACL_IS_DIRECTORY"] in {"0", "1"}
-        assert kwargs["stdin"] == subprocess.DEVNULL
-        assert kwargs["timeout"] == upgrade_migration._WINDOWS_ACL_TIMEOUT_SECONDS
+        payload = kwargs["input"]
+        assert isinstance(payload, bytes)
+        items = json.loads(payload.decode("ascii"))
+        assert isinstance(items, list) and items
+        paths = [Path(item["path"]) for item in items]
+        for path in paths:
+            events.append(("acl", path, tuple(command)))
+        failed = any(
+            fail_when is not None and fail_when(path, events)
+            for path in paths
+        )
+        result = {
+            "count": len(items),
+            "ids": [str(index) for index in range(len(items))],
+            "pathUtf8Base64": [
+                base64.b64encode(item["path"].encode("utf-8")).decode("ascii")
+                for item in items
+            ],
+            "pathHashes": [
+                upgrade_migration._acl_path_hash(Path(item["path"]))
+                for item in items
+            ],
+        }
+        assert kwargs["timeout"] > 0
         assert kwargs["creationflags"] == int(
             getattr(subprocess, "CREATE_NO_WINDOW", 0)
         )
-        event = ("acl", path, tuple(command))
-        events.append(event)
-        failed = fail_when is not None and fail_when(path, events)
+        assert "text" not in kwargs
+        assert tuple(command[:5]) == (
+            "powershell",
+            "-NoProfile",
+            "-NonInteractive",
+            "-NoLogo",
+            "-EncodedCommand",
+        )
         return SimpleNamespace(
             returncode=5 if failed else 0,
-            stdout="",
-            stderr="access denied" if failed else "",
+            stdout=json.dumps(result).encode("ascii"),
+            stderr=b"access denied" if failed else b"",
         )
 
     monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
@@ -198,6 +228,238 @@ def test_windows_acl_script_does_not_require_powershell_module_autoload() -> Non
     assert "Where-Object" not in script
     assert "[System.IO.Directory]::GetAccessControl($target)" in script
     assert "[System.IO.File]::GetAccessControl($target)" in script
+    assert "pathHashes" in script
+    assert "pathUtf8Base64 = $verifiedPathUtf8Base64.ToArray()" in script
+    assert "[Console]::OutputEncoding = $utf8WithoutBom" in script
+    assert "paths = $verifiedPaths.ToArray()" not in script
+    assert "-ne $fullControl" in script
+
+
+def test_windows_acl_batch_round_trips_non_ascii_path_over_ascii_protocol(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "中文快照"
+    target.mkdir()
+
+    def run(_command: list[str], **kwargs: object) -> SimpleNamespace:
+        payload = kwargs["input"]
+        assert isinstance(payload, bytes)
+        assert payload.isascii()
+        items = json.loads(payload.decode("ascii"))
+        result = {
+            "count": 1,
+            "ids": ["0"],
+            "pathUtf8Base64": [
+                base64.b64encode(items[0]["path"].encode("utf-8")).decode("ascii")
+            ],
+            "pathHashes": [upgrade_migration._acl_path_hash(target)],
+        }
+        stdout = json.dumps(result, separators=(",", ":")).encode("ascii")
+        assert stdout.isascii()
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr=b"")
+
+    monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
+
+    upgrade_migration._protect_windows_acl_batch(
+        ((target, True),),
+        windows_user_sid="S-1-5-21-1234",
+    )
+
+
+@pytest.mark.parametrize(
+    "case",
+    ["malformed_base64", "invalid_utf8", "count", "path", "hash"],
+)
+def test_windows_acl_batch_rejects_malformed_or_mismatched_verification(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    case: str,
+) -> None:
+    target = tmp_path / "中文快照"
+    target.mkdir()
+    encoded_path = base64.b64encode(str(target).encode("utf-8")).decode("ascii")
+    result: dict[str, object] = {
+        "count": 1,
+        "ids": ["0"],
+        "pathUtf8Base64": [encoded_path],
+        "pathHashes": [upgrade_migration._acl_path_hash(target)],
+    }
+    if case == "malformed_base64":
+        result["pathUtf8Base64"] = ["not base64!"]
+    elif case == "invalid_utf8":
+        result["pathUtf8Base64"] = [
+            base64.b64encode(b"\xff").decode("ascii")
+        ]
+    elif case == "count":
+        result["count"] = 2
+    elif case == "path":
+        result["pathUtf8Base64"] = [
+            base64.b64encode(b"C:\\wrong").decode("ascii")
+        ]
+    else:
+        result["pathHashes"] = ["0" * 64]
+
+    def run(_command: list[str], **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(result).encode("ascii"),
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
+
+    with pytest.raises(OSError, match="Windows ACL helper"):
+        upgrade_migration._protect_windows_acl_batch(
+            ((target, True),),
+            windows_user_sid="S-1-5-21-1234",
+        )
+
+
+def test_whoami_fallback_parses_sid_from_non_utf8_bytes_and_caps_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_native_sid() -> str:
+        raise OSError("synthetic native SID failure")
+
+    observed: dict[str, object] = {}
+
+    def run(command: list[str], **kwargs: object) -> SimpleNamespace:
+        observed.update(kwargs)
+        assert command == ["whoami", "/user", "/fo", "csv", "/nh"]
+        return SimpleNamespace(
+            returncode=0,
+            stdout=(
+                b'"'
+                + "中文用户".encode("cp936")
+                + b'","S-1-5-21-1234-5678-9012-1001"\r\n'
+            ),
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(upgrade_migration, "_native_windows_user_sid", fail_native_sid)
+    monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
+
+    sid = upgrade_migration._current_windows_user_sid(
+        deadline=upgrade_migration.time.monotonic() + 30
+    )
+
+    assert sid == "S-1-5-21-1234-5678-9012-1001"
+    timeout = observed["timeout"]
+    assert isinstance(timeout, (int, float))
+    assert 0 < timeout <= upgrade_migration._WINDOWS_IDENTITY_FALLBACK_TIMEOUT_SECONDS
+    assert observed["stdin"] == subprocess.DEVNULL
+    assert "text" not in observed
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    [
+        b'"DESKTOP\\owner","missing"\r\n',
+        (
+            b'"DESKTOP\\owner","S-1-5-21-1234-5678-9012-1001" '
+            b'"S-1-5-21-1234-5678-9012-1002"\r\n'
+        ),
+    ],
+)
+def test_whoami_fallback_rejects_missing_or_multiple_sids(
+    monkeypatch: pytest.MonkeyPatch,
+    stdout: bytes,
+) -> None:
+    def fail_native_sid() -> str:
+        raise OSError("synthetic native SID failure")
+
+    def run(_command: list[str], **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr=b"")
+
+    monkeypatch.setattr(upgrade_migration, "_native_windows_user_sid", fail_native_sid)
+    monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
+
+    with pytest.raises(OSError, match="cannot resolve"):
+        upgrade_migration._current_windows_user_sid()
+
+
+def test_windows_acl_batch_rejects_incomplete_helper_verification(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(upgrade_migration, "_running_on_windows", lambda: True)
+    monkeypatch.setattr(
+        upgrade_migration,
+        "_current_windows_user_sid",
+        lambda **_kwargs: "S-1-5-21-1234",
+    )
+    target = tmp_path / "snapshot"
+    target.mkdir()
+
+    def run(_command: list[str], **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "count": 1,
+                    "ids": ["0"],
+                    "pathUtf8Base64": [],
+                    "pathHashes": [],
+                }
+            ).encode("ascii"),
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
+
+    with pytest.raises(OSError, match="requested paths exactly"):
+        upgrade_migration._protect_windows_acl_batch(
+            ((target, True),),
+            windows_user_sid="S-1-5-21-1234",
+        )
+
+
+def test_windows_acl_batch_timeout_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(upgrade_migration, "_running_on_windows", lambda: True)
+    target = tmp_path / "snapshot"
+    target.mkdir()
+
+    def run(_command: list[str], **_kwargs: object) -> SimpleNamespace:
+        raise subprocess.TimeoutExpired("powershell", 0.01)
+
+    monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
+
+    with pytest.raises(TimeoutError, match="ACL migration stage timed out"):
+        upgrade_migration._protect_windows_acl_batch(
+            ((target, True),),
+            windows_user_sid="S-1-5-21-1234",
+            deadline=upgrade_migration.time.monotonic() + 1,
+        )
+
+
+def test_private_tree_rejects_reparse_points_without_following_them(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "snapshot"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("secret", encoding="utf-8")
+    link = root / "redirect"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink unavailable: {exc}")
+
+    with pytest.raises(OSError, match="unsafe type"):
+        upgrade_migration._private_tree_entries(root)
+
+
+def test_private_tree_rejects_file_root(tmp_path: Path) -> None:
+    root = tmp_path / "snapshot"
+    root.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(OSError, match="snapshot root is not a directory"):
+        upgrade_migration._private_tree_entries(root)
 
 
 def test_windows_acl_process_timeout_is_actionable(
@@ -211,7 +473,7 @@ def test_windows_acl_process_timeout_is_actionable(
     def run(command: list[str], **_kwargs: object) -> SimpleNamespace:
         raise subprocess.TimeoutExpired(
             command,
-            upgrade_migration._WINDOWS_ACL_TIMEOUT_SECONDS,
+            upgrade_migration.WINDOWS_ACL_STAGE_TIMEOUT_SECONDS,
         )
 
     monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
@@ -245,9 +507,28 @@ def test_frozen_windows_acl_process_restores_packaged_dll_directory(
         lambda path: events.append(("dll", path)),
     )
 
-    def run(_command: list[str], **_kwargs: object) -> SimpleNamespace:
+    def run(_command: list[str], **kwargs: object) -> SimpleNamespace:
         events.append(("run", None))
-        return SimpleNamespace(returncode=0, stdout="", stderr="")
+        payload = kwargs.get("input")
+        if isinstance(payload, bytes):
+            items = json.loads(payload.decode("ascii"))
+            stdout = json.dumps(
+                {
+                    "count": len(items),
+                    "ids": [str(index) for index in range(len(items))],
+                    "pathUtf8Base64": [
+                        base64.b64encode(item["path"].encode("utf-8")).decode("ascii")
+                        for item in items
+                    ],
+                    "pathHashes": [
+                        upgrade_migration._acl_path_hash(Path(item["path"]))
+                        for item in items
+                    ],
+                }
+            ).encode("ascii")
+        else:
+            stdout = b'"DESKTOP\\owner","S-1-5-21-1234"\n'
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr=b"")
 
     monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
 
@@ -366,6 +647,123 @@ def test_windows_snapshot_acl_is_applied_in_copy_and_promotion_order(
         )
 
 
+@pytest.mark.parametrize("slow_phase", ["copy", "digest"])
+def test_windows_snapshot_materialization_does_not_consume_acl_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    slow_phase: str,
+) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text('[sandbox]\nrun_mode = "trusted"\n', encoding="utf-8")
+    monkeypatch.setattr(upgrade_migration, "_running_on_windows", lambda: True)
+    monkeypatch.setattr(
+        upgrade_migration,
+        "_current_windows_user_sid",
+        lambda **_kwargs: "S-1-5-21-1234",
+    )
+    clock = [100.0]
+    monkeypatch.setattr(upgrade_migration.time, "monotonic", lambda: clock[0])
+    remaining_before_acl: list[float] = []
+
+    def protect_acl(
+        _entries: tuple[tuple[Path, bool], ...],
+        *,
+        windows_user_sid: str,
+        deadline: float | None = None,
+    ) -> None:
+        assert windows_user_sid == "S-1-5-21-1234"
+        remaining_before_acl.append(
+            upgrade_migration._remaining_windows_acl_time(deadline)
+        )
+        if len(remaining_before_acl) == 1:
+            clock[0] += 5.0
+
+    monkeypatch.setattr(
+        upgrade_migration,
+        "_protect_windows_acl_batch",
+        protect_acl,
+    )
+
+    real_copyfileobj = upgrade_migration.shutil.copyfileobj
+    real_digest = upgrade_migration._digest
+
+    def slow_copyfileobj(source: Any, destination: Any, length: int = 0) -> None:
+        clock[0] += upgrade_migration.WINDOWS_ACL_STAGE_TIMEOUT_SECONDS + 1
+        real_copyfileobj(source, destination, length)
+
+    def slow_digest(path: Path) -> str:
+        clock[0] += upgrade_migration.WINDOWS_ACL_STAGE_TIMEOUT_SECONDS + 1
+        return real_digest(path)
+
+    if slow_phase == "copy":
+        monkeypatch.setattr(
+            upgrade_migration.shutil,
+            "copyfileobj",
+            slow_copyfileobj,
+        )
+    else:
+        monkeypatch.setattr(upgrade_migration, "_digest", slow_digest)
+
+    report = SandboxUpgradeCoordinator(tmp_path).run()
+
+    assert report.ok is True
+    assert report.status == "committed"
+    assert clock[0] == 136.0
+    assert remaining_before_acl == pytest.approx([30.0, 25.0, 25.0])
+
+
+def test_windows_acl_budget_exhaustion_requires_manual_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "config.toml").write_text(
+        '[sandbox]\nrun_mode = "trusted"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(upgrade_migration, "_running_on_windows", lambda: True)
+    monkeypatch.setattr(
+        upgrade_migration,
+        "_current_windows_user_sid",
+        lambda **_kwargs: "S-1-5-21-1234",
+    )
+    clock = [100.0]
+    monkeypatch.setattr(upgrade_migration.time, "monotonic", lambda: clock[0])
+    copied = False
+
+    def exhaust_acl_budget(
+        _entries: tuple[tuple[Path, bool], ...],
+        *,
+        windows_user_sid: str,
+        deadline: float | None = None,
+    ) -> None:
+        assert windows_user_sid == "S-1-5-21-1234"
+        clock[0] += upgrade_migration.WINDOWS_ACL_STAGE_TIMEOUT_SECONDS + 1
+        upgrade_migration._remaining_windows_acl_time(deadline)
+
+    def copyfileobj(_source: Any, _destination: Any, _length: int = 0) -> None:
+        nonlocal copied
+        copied = True
+
+    monkeypatch.setattr(
+        upgrade_migration,
+        "_protect_windows_acl_batch",
+        exhaust_acl_budget,
+    )
+    monkeypatch.setattr(upgrade_migration.shutil, "copyfileobj", copyfileobj)
+
+    report = SandboxUpgradeCoordinator(tmp_path).run()
+
+    assert report.ok is False
+    assert report.status == "manual_recovery_required"
+    assert report.snapshot_path is None
+    assert copied is False
+    assert "Windows ACL hardening timed out" in str(report.error)
+    journal = json.loads(
+        (tmp_path / upgrade_migration.JOURNAL_NAME).read_text(encoding="utf-8")
+    )
+    assert journal["status"] == "prepared"
+
+
 def test_committed_legacy_snapshot_is_hardened_before_success(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -429,9 +827,33 @@ def test_committed_legacy_snapshot_acl_failure_requires_manual_recovery(
     assert "cannot protect upgrade snapshot path" in journal["error"]
 
 
+def test_committed_journal_without_snapshot_fails_closed(tmp_path: Path) -> None:
+    (tmp_path / upgrade_migration.JOURNAL_NAME).write_text(
+        json.dumps(
+            {
+                "migrationVersion": upgrade_migration.MIGRATION_VERSION,
+                "status": "committed",
+                "stores": ["config.toml"],
+                "snapshot": str(tmp_path / upgrade_migration.SNAPSHOT_NAME),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = SandboxUpgradeCoordinator(tmp_path).run()
+
+    assert report.ok is False
+    assert report.status == "manual_recovery_required"
+    assert "committed sandbox upgrade snapshot is missing" in str(report.error)
+    journal = json.loads(
+        (tmp_path / upgrade_migration.JOURNAL_NAME).read_text(encoding="utf-8")
+    )
+    assert journal["status"] == "prepared"
+
+
 @pytest.mark.skipif(os.name != "nt", reason="Windows DACL smoke")
 def test_windows_private_acl_replaces_explicit_everyone_grants(tmp_path: Path) -> None:
-    directory = tmp_path / "snapshot"
+    directory = tmp_path / "\u4e2d\u6587\u5feb\u7167"
     directory.mkdir()
     file_path = directory / "config.toml"
     file_path.write_text("sensitive", encoding="utf-8")
@@ -439,13 +861,11 @@ def test_windows_private_acl_replaces_explicit_everyone_grants(tmp_path: Path) -
         ["icacls", str(directory), "/grant:r", "*S-1-1-0:(OI)(CI)F", "/L"],
         check=True,
         capture_output=True,
-        text=True,
     )
     subprocess.run(
         ["icacls", str(file_path), "/grant:r", "*S-1-1-0:F", "/L"],
         check=True,
         capture_output=True,
-        text=True,
     )
     user_sid = upgrade_migration._current_windows_user_sid()
 
@@ -462,7 +882,14 @@ def test_windows_private_acl_replaces_explicit_everyone_grants(tmp_path: Path) -
 
     verifier = r"""
 $ErrorActionPreference = "Stop"
-$acl = Get-Acl -LiteralPath $env:OPENSQUILLA_TEST_ACL_TARGET
+$target = $env:OPENSQUILLA_TEST_ACL_TARGET
+$attributes = [System.IO.File]::GetAttributes($target)
+$isDirectory = ($attributes -band [System.IO.FileAttributes]::Directory) -ne 0
+$acl = if ($isDirectory) {
+    [System.IO.Directory]::GetAccessControl($target)
+} else {
+    [System.IO.File]::GetAccessControl($target)
+}
 $sids = @($acl.Access | ForEach-Object {
     $_.IdentityReference.Translate(
         [System.Security.Principal.SecurityIdentifier]
@@ -558,12 +985,14 @@ def test_windows_staging_is_rechecked_empty_before_copy(
         *,
         directory: bool,
         windows_user_sid: str | None,
+        deadline: float | None = None,
     ) -> None:
         nonlocal injected
         real_protect(
             path,
             directory=directory,
             windows_user_sid=windows_user_sid,
+            deadline=deadline,
         )
         if directory and path.name.endswith(".tmp") and not injected:
             (path / "unexpected").write_text("injected", encoding="utf-8")

--- a/tests/test_migration/test_sandbox_direct_update.py
+++ b/tests/test_migration/test_sandbox_direct_update.py
@@ -204,7 +204,7 @@ def _mock_windows_acl(
             getattr(subprocess, "CREATE_NO_WINDOW", 0)
         )
         assert "text" not in kwargs
-        assert Path(command[0]).name.casefold() in {"powershell.exe", "pwsh.exe"}
+        assert Path(command[0]).stem.casefold() in {"powershell", "pwsh"}
         assert tuple(command[1:5]) == (
             "-NoProfile",
             "-NonInteractive",
@@ -689,7 +689,7 @@ def test_windows_snapshot_acl_is_applied_in_copy_and_promotion_order(
     )
     assert tmp_path / upgrade_migration.SNAPSHOT_NAME / "manifest.json" in protected_paths
     for _kind, _path, command in (event for event in events if event[0] == "acl"):
-        assert Path(command[0]).name.casefold() in {"powershell.exe", "pwsh.exe"}
+        assert Path(command[0]).stem.casefold() in {"powershell", "pwsh"}
         assert tuple(command[1:5]) == (
             "-NoProfile",
             "-NonInteractive",

--- a/tests/test_recovery/test_recovery_cmd.py
+++ b/tests/test_recovery/test_recovery_cmd.py
@@ -113,6 +113,63 @@ def test_recovery_subprocess_routes_before_cwd_or_profile_dotenv(
     assert payload["effective_workspace"] == str(workspace)
 
 
+def test_packaged_recovery_entry_avoids_runtime_imports(tmp_path: Path) -> None:
+    home = tmp_path / "opensquilla"
+    workspace = _workspace(home / "workspace", "lightweight recovery")
+    (home / "state").mkdir(parents=True)
+    (home / "config.toml").write_text(
+        'state_dir = "state"\nworkspace_dir = "workspace"\n',
+        encoding="utf-8",
+    )
+    repository = Path(__file__).resolve().parents[2]
+    entry = repository / "desktop" / "electron" / "scripts" / "gateway-entry.py"
+    environment = os.environ.copy()
+    environment["OPENSQUILLA_RECOVERY_OFFLINE"] = "1"
+    environment["OPENSQUILLA_USER_STATE_DIR"] = str(tmp_path / "user-state")
+    environment["PYTHONPATH"] = os.pathsep.join(
+        value for value in (str(repository / "src"), environment.get("PYTHONPATH", "")) if value
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, runpy, sys\n"
+                "entry, home = sys.argv[1:]\n"
+                "sys.argv = ['gateway-entry.py', 'recovery', 'inspect', "
+                "'--home', home, '--json']\n"
+                "try:\n"
+                "    runpy.run_path(entry, run_name='__main__')\n"
+                "except SystemExit as exc:\n"
+                "    if exc.code not in (None, 0):\n"
+                "        raise\n"
+                "modules = sorted(sys.modules)\n"
+                "print('MODULES=' + json.dumps(modules), file=sys.stderr)\n"
+            ),
+            str(entry),
+            str(home),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=repository,
+        env=environment,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    assert payload["effective_workspace"] == str(workspace)
+    modules_line = next(
+        line for line in completed.stderr.splitlines() if line.startswith("MODULES=")
+    )
+    modules = json.loads(modules_line.removeprefix("MODULES="))
+    assert not any(
+        name == prefix or name.startswith(prefix + ".")
+        for prefix in ("opensquilla.gateway", "opensquilla.engine", "sqlalchemy", "numpy")
+        for name in modules
+    )
+
+
 def test_inspect_command_emits_fixed_json_protocol(tmp_path: Path) -> None:
     home = tmp_path / "opensquilla"
     workspace = _workspace(home / "workspace", "current identity")


### PR DESCRIPTION
## What changed
- Add a platform-neutral lightweight Desktop recovery entry that bypasses the full CLI runtime import path while preserving offline dotenv behavior, JSON stdout, stderr logging, Typer semantics, and recovery ordering.
- Make pending reconciliation report whether startup state was observed or modified, skipping the second inspect only when safe; credential adoption keeps the follow-up inspect.
- Batch Windows snapshot ACL set-and-verify in one PowerShell process, reject reparse points, verify exact paths and ACEs, resolve the current SID natively first, and fail closed on a bounded 30-second ACL stage timeout.
- Add startup timeline logging for Electron recovery children, Gateway, health, Control UI, and renderer readiness.

## Root cause
Normal Desktop startup serialized multiple heavyweight recovery/import steps before Gateway startup. On Windows, committed snapshots also launched PowerShell once per path and could wait without a bound under Defender/EDR.

## Validation
- 153 focused Python tests passed, 2 skipped.
- Electron startup contract passed.
- npm run build and npm run verify:package passed.
- compileall passed.
- Windows Defender remained Running; no WSL and no real user profile were used.
- Packaged Windows matrix passed: 5 cold starts, 10 hot starts, Gateway forced-kill recovery, and profile-consolidation scenarios including interrupted receipt, credential adoption, multiple recovery profiles, legacy and invalid credentials.
- Packaged artifact used cached Electron 42.3.3 because exact 42.4.0 download was unavailable locally; one renderer sandbox diagnostic appeared during first-send smoke, but Gateway, health, Control UI, renderer interactive, and real interaction completed.

CI should be the final gate before merge. This PR is intentionally draft.