### PR TITLE
Fix coordinated onboarding package verification

### DIFF
--- a/desktop/electron/scripts/verify-package.mjs
+++ b/desktop/electron/scripts/verify-package.mjs
@@ -307,17 +307,38 @@ function verifyMainProcess(source, label) {
   }
 
   const onboardingIndex = source.indexOf('async function runOnboarding')
-  const onboardingWindowIndex = source.indexOf('onboardingWindow = new BrowserWindow', onboardingIndex)
-  const parentIndex = source.indexOf('const parentWindow = currentMainWindow()', onboardingIndex)
-  const parentOptionIndex = source.indexOf('parent: parentWindow ?? undefined', onboardingWindowIndex)
-  const modalOptionIndex = source.indexOf('modal: Boolean(parentWindow)', onboardingWindowIndex)
+  const onboardingEndIndex = source.indexOf('async function pathExists', onboardingIndex)
+  const onboardingSource =
+    onboardingIndex === -1 || onboardingEndIndex === -1
+      ? ''
+      : source.slice(onboardingIndex, onboardingEndIndex)
+  const parentIndex = onboardingSource.search(
+    /const\s+parentWindow\s*=\s*currentMainWindow\(\)/,
+  )
+  const onboardingWindowIndex = onboardingSource.search(
+    /const\s+window\s*=\s*new\s+(?:[A-Za-z_$][\w$]*\.)*BrowserWindow\s*\(\s*\{/,
+  )
+  const parentOptionIndex = onboardingSource.search(
+    /parent\s*:\s*parentWindow\s*\?\?\s*undefined/,
+  )
+  const modalOptionIndex = onboardingSource.search(
+    /modal\s*:\s*Boolean\(parentWindow\)/,
+  )
+  const onboardingWindowAssignmentIndex = onboardingSource.search(
+    /onboardingWindow\s*=\s*window\b/,
+  )
   if (
     onboardingIndex === -1
+    || onboardingEndIndex === -1
     || onboardingWindowIndex === -1
     || parentIndex === -1
     || parentOptionIndex === -1
     || modalOptionIndex === -1
+    || onboardingWindowAssignmentIndex === -1
     || parentIndex > onboardingWindowIndex
+    || parentOptionIndex < onboardingWindowIndex
+    || modalOptionIndex < parentOptionIndex
+    || onboardingWindowAssignmentIndex < modalOptionIndex
   ) {
     fail(`${label} main process does not make first-run onboarding an owned modal child window`)
   }

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -1298,6 +1298,7 @@ def test_desktop_local_packaging_builds_slim_package_without_runtime_fetch() -> 
 
 def test_desktop_onboarding_is_owned_modal_child_of_main_window() -> None:
     main_ts = _read("desktop/electron/src/main.ts")
+    verifier = _read("desktop/electron/scripts/verify-package.mjs")
     onboarding = _section(
         main_ts,
         "async function runOnboarding",
@@ -1305,9 +1306,14 @@ def test_desktop_onboarding_is_owned_modal_child_of_main_window() -> None:
     )
 
     assert "const parentWindow = currentMainWindow()" in onboarding
+    assert "const window = new BrowserWindow" in onboarding
     assert "parent: parentWindow ?? undefined" in onboarding
     assert "modal: Boolean(parentWindow)" in onboarding
+    assert "onboardingWindow = window" in onboarding
     assert "focusOnboardingWindow()" in onboarding
+    assert r"const\s+window\s*=\s*new\s+" in verifier
+    assert r"onboardingWindow\s*=\s*window\b" in verifier
+    assert "onboardingWindowAssignmentIndex < modalOptionIndex" in verifier
 
 
 def test_desktop_onboarding_defaults_to_tokenrhythm_with_trusted_registration_cta() -> None:


### PR DESCRIPTION
## Scope

Update the Electron package verifier to recognize the coordinated onboarding window lifecycle introduced on main. The verifier now scopes checks to runOnboarding and validates window construction, parent ownership, modal behavior, and the later onboardingWindow assignment in order. Add regression assertions for the coordinated lifecycle.

## Branch target

main

## Linked issue

None

## Release notes

None. Internal release verification fix only; no user-facing runtime behavior changes.

## Verification

- uv run pytest tests/test_desktop/test_electron_startup_contract.py tests/test_release_consistency.py tests/test_sandbox/test_release_contract.py -q: 165 passed
- npm run test:window-lifecycle: passed
- npm run build: passed
- npm run verify:package: onboarding checks pass for source and compiled main; local run stops only on the expected absent PyInstaller gateway runtime
- uv run ruff check tests/test_desktop/test_electron_startup_contract.py: passed
- node --check desktop/electron/scripts/verify-package.mjs: passed
- git diff --check: passed

## Safety and compatibility

Platform-neutral verifier correction used by Windows and macOS packaging. It does not change desktop runtime behavior, persisted state, public interfaces, installer contents, or upgrade behavior. The stricter ordering checks retain the owned-modal safety contract.

## Third-party origin

None.