### PR TITLE
Avoid background Git prompts when Git is unavailable

### DIFF
--- a/src/opensquilla/cli/tui/opentui/completion.py
+++ b/src/opensquilla/cli/tui/opentui/completion.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import fnmatch
 import os
-import shutil
-import subprocess
 import sys
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any, Protocol
 
 from opensquilla.engine.commands import CommandPresentation, Surface
+from opensquilla.git_runtime import run_git
 from opensquilla.tools.builtin.filesystem import _is_sensitive_access_path
 
 from .messages import (
@@ -214,25 +213,18 @@ def _is_segment_start(text: str, position: int) -> bool:
 
 
 def _git_files(root: Path) -> list[str] | None:
-    if not (root / ".git").exists() or shutil.which("git") is None:
-        return None
-
-    try:
-        # -z: NUL-separated verbatim paths, so core.quotePath never C-quotes a
-        # non-ASCII name into an octal-escape string that matches nothing on
-        # disk. Keep the platform's normal filesystem decoding first, then fall
-        # back to surrogateescape because Windows' surrogatepass handler can
-        # raise for malformed UTF-8 bytes. Completion must remain available for
-        # every Git path without changing valid Windows path decoding.
-        result = subprocess.run(
-            ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
-            cwd=root,
-            capture_output=True,
-            check=False,
-        )
-    except (OSError, ValueError):
-        return None
-    if result.returncode != 0:
+    # -z: NUL-separated verbatim paths, so core.quotePath never C-quotes a
+    # non-ASCII name into an octal-escape string that matches nothing on disk.
+    # Keep the platform's normal filesystem decoding first, then fall back to
+    # surrogateescape because Windows' surrogatepass handler can raise for
+    # malformed UTF-8 bytes. Completion must remain available for every Git
+    # path without changing valid Windows path decoding.
+    result = run_git(
+        ("ls-files", "-z", "--cached", "--others", "--exclude-standard"),
+        cwd=root,
+        timeout=2.0,
+    )
+    if not result.ok:
         return None
     return [
         Path(_decode_git_path(entry)).as_posix() for entry in result.stdout.split(b"\0") if entry

--- a/src/opensquilla/contrib/codetask/verification.py
+++ b/src/opensquilla/contrib/codetask/verification.py
@@ -44,6 +44,7 @@ from opensquilla.contrib.codetask.types import (
     RegressionResult,
     TaskState,
 )
+from opensquilla.git_runtime import GitRunState, run_git
 
 logger = logging.getLogger(__name__)
 
@@ -791,33 +792,32 @@ class _BaseWorktree:
         import shutil
 
         tmp = Path(tempfile.mkdtemp(prefix="codetask-base-"))
-        try:
-            r = subprocess.run(
-                ["git", "worktree", "add", "--detach", str(tmp), self.base_commit],
-                cwd=str(self.repo),
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=120,
-            )
-        except (OSError, subprocess.TimeoutExpired) as exc:
+        result = run_git(
+            ["worktree", "add", "--detach", str(tmp), self.base_commit],
+            cwd=self.repo,
+            timeout=120,
+        )
+        if result.state is GitRunState.UNAVAILABLE:
             shutil.rmtree(tmp, ignore_errors=True)
-            raise _WorktreeError(str(exc)) from exc
-        if r.returncode != 0:
+            reason = result.capability.reason or result.stderr_text.strip()
+            raise _WorktreeError(f"Git is unavailable ({reason or 'git_unavailable'})")
+        if result.state is GitRunState.TIMED_OUT:
+            shutil.rmtree(tmp, ignore_errors=True)
+            raise _WorktreeError("git worktree add timed out after 120s")
+        if not result.ok:
             # Do not leak the mkdtemp dir when the worktree was never added
             # (codex review #9).
             shutil.rmtree(tmp, ignore_errors=True)
-            raise _WorktreeError((r.stderr or "").strip()[-200:])
+            detail = result.stderr_text.strip() or result.state.value
+            raise _WorktreeError(detail[-200:])
         self._dir = tmp
         return tmp
 
     def __exit__(self, *exc) -> None:
         if self._dir is not None:
-            subprocess.run(
-                ["git", "worktree", "remove", "--force", str(self._dir)],
-                cwd=str(self.repo),
-                capture_output=True,
+            run_git(
+                ["worktree", "remove", "--force", str(self._dir)],
+                cwd=self.repo,
                 timeout=60,
             )
 

--- a/src/opensquilla/contrib/codetask/workspace.py
+++ b/src/opensquilla/contrib/codetask/workspace.py
@@ -28,6 +28,7 @@ from opensquilla.contrib.codetask.config import (
     repo_dir,
     run_dir,
 )
+from opensquilla.git_runtime import GitRunResult, GitRunState, run_git
 
 logger = logging.getLogger(__name__)
 
@@ -46,16 +47,48 @@ class PreparedRepo:
     branch: str
 
 
-def _git(args: list[str], cwd: Path, timeout: int = 120) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        ["git", *args],
-        cwd=str(cwd),
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        timeout=timeout,
+def _git_unavailable_error(result: GitRunResult) -> WorkspaceError:
+    reason = result.capability.reason or result.stderr_text.strip() or "git_unavailable"
+    return WorkspaceError(
+        "code-task requires Git, but no safe Git runtime is available "
+        f"({reason}). Install or enable Git before running code-task."
     )
+
+
+def _completed_git_process(
+    args: list[str],
+    result: GitRunResult,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["git", *args],
+        returncode=result.returncode if result.returncode is not None else 1,
+        stdout=result.stdout_text,
+        stderr=result.stderr_text,
+    )
+
+
+def _git(
+    args: list[str],
+    cwd: Path,
+    timeout: int = 120,
+    *,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    result = run_git(
+        args,
+        cwd=cwd,
+        timeout=timeout,
+        input_bytes=input_text.encode("utf-8") if input_text is not None else None,
+        allow_user_interaction=True,
+    )
+    if result.state is GitRunState.UNAVAILABLE:
+        raise _git_unavailable_error(result)
+    if result.state is GitRunState.TIMED_OUT:
+        raise WorkspaceError(f"git {' '.join(args)} timed out after {timeout}s")
+    if result.returncode is None:
+        detail = result.stderr_text.strip() or result.state.value
+        raise WorkspaceError(f"git {' '.join(args)} could not be launched: {detail}")
+    return _completed_git_process(args, result)
 
 
 def is_dirty(path: Path) -> bool:
@@ -131,23 +164,20 @@ def prepare_repo(
     if dest.exists():
         shutil.rmtree(dest)
 
-    clone_cmd = ["git", "clone"]
+    clone_args = ["clone"]
     if shallow:
-        clone_cmd += ["--depth", "1"]
-    clone_cmd += [_normalize_source(repo), str(dest)]
-    try:
-        result = subprocess.run(
-            clone_cmd,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=CLONE_TIMEOUT,
-        )
-    except FileNotFoundError as exc:
-        raise WorkspaceError("git is not installed.") from exc
-    except subprocess.TimeoutExpired as exc:
-        raise WorkspaceError(f"git clone timed out after {CLONE_TIMEOUT}s.") from exc
+        clone_args += ["--depth", "1"]
+    clone_args += [_normalize_source(repo), str(dest)]
+    clone_result = run_git(
+        clone_args,
+        timeout=CLONE_TIMEOUT,
+        allow_user_interaction=True,
+    )
+    if clone_result.state is GitRunState.UNAVAILABLE:
+        raise _git_unavailable_error(clone_result)
+    if clone_result.state is GitRunState.TIMED_OUT:
+        raise WorkspaceError(f"git clone timed out after {CLONE_TIMEOUT}s.")
+    result = _completed_git_process(clone_args, clone_result)
     if result.returncode != 0:
         raise WorkspaceError(f"git clone failed: {(result.stderr or '').strip()[-400:]}")
 
@@ -248,15 +278,11 @@ def _empty_tree(repo: Path) -> str:
     SHA-1 and SHA-256 repositories. Uses ``--stdin`` with empty input so it
     works on Windows too (``/dev/null`` does not exist there).
     """
-    r = subprocess.run(
-        ["git", "hash-object", "-t", "tree", "--stdin"],
-        cwd=str(repo),
-        input="",
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
+    r = _git(
+        ["hash-object", "-t", "tree", "--stdin"],
+        repo,
         timeout=30,
+        input_text="",
     )
     if r.returncode != 0:
         raise WorkspaceError(f"could not compute empty tree: {(r.stderr or '').strip()}")
@@ -335,16 +361,15 @@ def persist_to_source(
         return False, f"source HEAD moved ({head[:12]} != base {base_commit[:12]})"
     if not patch.strip():
         return False, "no change to persist"
-    proc = subprocess.run(
-        ["git", "apply", "--whitespace=nowarn"],
-        cwd=str(source_repo),
-        input=patch,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        timeout=120,
-    )
+    try:
+        proc = _git(
+            ["apply", "--whitespace=nowarn"],
+            source_repo,
+            timeout=120,
+            input_text=patch,
+        )
+    except WorkspaceError as exc:
+        return False, str(exc)
     if proc.returncode != 0:
         return False, f"git apply failed: {(proc.stderr or '').strip()[-300:]}"
     _git(["config", "user.email", GIT_USER_EMAIL], source_repo)

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -16,7 +16,6 @@ import math
 import os
 import re
 import stat
-import subprocess
 import time
 import uuid
 from collections.abc import AsyncIterator, Callable, Mapping
@@ -163,6 +162,7 @@ from opensquilla.execution_status import (
     normalize_execution_status,
     runtime_execution_status,
 )
+from opensquilla.git_runtime import GitRunState, run_git
 from opensquilla.observability.turn_call_log import TurnCallLogger
 from opensquilla.persistence.meta_run_writer import replay_inputs_are_modified
 from opensquilla.provider import (
@@ -3021,6 +3021,9 @@ class Agent:
             tuple[str, str, str, str, str, str], ToolResultRecord
         ] = {}
         self._patch_evidence_ledger: PatchEvidenceLedger | None = None
+        self._runtime_git_state = GitRunState.OK
+        self._runtime_git_skip_states_recorded: set[GitRunState] = set()
+        self._submit_review_git_state = GitRunState.OK
         if self.config.patch_evidence_ledger_path:
             self._patch_evidence_ledger = PatchEvidenceLedger(
                 path=self.config.patch_evidence_ledger_path,
@@ -14172,10 +14175,14 @@ class Agent:
                         and not post_write_convergence_finalization_pending
                     ):
                         gate_status = await self._workspace_git_status_porcelain()
-                        gate_observation = finalize_evidence_tracker.build_observation(
-                            has_workspace_diff=bool(gate_status and gate_status.strip()),
+                        gate_observation = (
+                            finalize_evidence_tracker.build_observation(
+                                has_workspace_diff=bool(gate_status.strip()),
+                            )
+                            if gate_status is not None
+                            else None
                         )
-                        if gate_observation.should_challenge:
+                        if gate_observation is not None and gate_observation.should_challenge:
                             submit_review_red_detected = True
                             gate_key = finalize_evidence_gate_key(gate_observation)
                             # Never spend the run's last LLM call or deadline
@@ -14509,14 +14516,23 @@ class Agent:
                         ) is None and (
                             _total_deadline is None or _loop.time() < _total_deadline
                         )
-                        (
-                            implicit_file_index,
-                            implicit_diff_text,
-                        ) = await self._workspace_submit_review_capture()
-                        implicit_diff_empty = not (
-                            implicit_file_index.strip() or implicit_diff_text.strip()
-                        )
-                        if submit_review_should_fire_implicit(
+                        implicit_capture = await self._workspace_submit_review_capture()
+                        if implicit_capture is None:
+                            self._record_runtime_event(
+                                "submit_review.skipped",
+                                feature="submit_review",
+                                reason="git_observation_unavailable",
+                                iteration=iterations,
+                                provider_call_count=turn_llm_calls,
+                                injected_to_model=False,
+                                git_state=self._submit_review_git_state.value,
+                            )
+                        else:
+                            implicit_file_index, implicit_diff_text = implicit_capture
+                            implicit_diff_empty = not (
+                                implicit_file_index.strip() or implicit_diff_text.strip()
+                            )
+                        if implicit_capture is not None and submit_review_should_fire_implicit(
                             submit_review_state,
                             enabled=submit_review_enabled,
                             diff_empty=implicit_diff_empty,
@@ -15232,10 +15248,37 @@ class Agent:
                         async for event in _flush_parallel_batch(parallel_batch):
                             yield event
                         parallel_batch = []
-                        (
-                            submit_file_index,
-                            submit_diff_text,
-                        ) = await self._workspace_submit_review_capture()
+                        submit_capture = await self._workspace_submit_review_capture()
+                        if submit_capture is None:
+                            unavailable_payload = self._submit_review_git_unavailable_payload(
+                                self._submit_review_git_state
+                            )
+                            submit_result = ToolResult(
+                                tool_use_id=tc.tool_use_id,
+                                tool_name="submit",
+                                content=json.dumps(unavailable_payload, ensure_ascii=False),
+                                is_error=True,
+                                execution_status=runtime_execution_status(
+                                    "error",
+                                    reason=str(unavailable_payload["code"]).lower(),
+                                ),
+                                terminates_turn=True,
+                            )
+                            results_by_id[tc.tool_use_id] = submit_result
+                            dispatch_boundary = submit_result
+                            self._record_runtime_event(
+                                "submit_review.explicit_unavailable",
+                                feature="submit_review",
+                                reason="git_observation_unavailable",
+                                iteration=iterations,
+                                provider_call_count=turn_llm_calls,
+                                injected_to_model=False,
+                                git_state=self._submit_review_git_state.value,
+                                code=unavailable_payload["code"],
+                                terminates_turn=True,
+                            )
+                            continue
+                        submit_file_index, submit_diff_text = submit_capture
                         submit_diff_empty = not (
                             submit_file_index.strip() or submit_diff_text.strip()
                         )
@@ -15849,12 +15892,38 @@ class Agent:
                 ):
                     recent_failure_anchor_summaries.append(failure_anchor_summary)
                     recent_failure_anchor_summaries[:] = recent_failure_anchor_summaries[-3:]
-                runtime_diff_paths = self._workspace_diff_paths_for_runtime_event()
-                runtime_diff_fingerprint = (
-                    self._workspace_diff_fingerprint_for_runtime_event()
+                runtime_diff_paths: list[str] | None = None
+                runtime_diff_fingerprint: str | None = None
+                if (
+                    runtime_diagnostics is not None
+                    or post_write_convergence_tracker is not None
+                ):
+                    self._runtime_git_state = GitRunState.OK
+                    runtime_diff_paths = self._workspace_diff_paths_for_runtime_event()
+                    if runtime_diff_paths is not None:
+                        runtime_diff_fingerprint = (
+                            self._workspace_diff_fingerprint_for_runtime_event()
+                        )
+                runtime_git_observed = bool(
+                    runtime_diff_paths is not None
+                    and self._runtime_git_state is GitRunState.OK
                 )
+                if (
+                    (runtime_diagnostics is not None or post_write_convergence_tracker is not None)
+                    and not runtime_git_observed
+                ):
+                    self._record_runtime_git_observation_skip(
+                        consumers=(
+                            "runtime_diagnostics",
+                            "post_write_convergence",
+                        )
+                    )
                 runtime_diagnostic_events: list[dict[str, Any]] = []
-                if runtime_diagnostics is not None:
+                if (
+                    runtime_diagnostics is not None
+                    and runtime_git_observed
+                    and runtime_diff_paths is not None
+                ):
                     for runtime_event in runtime_diagnostics.observe_tool_results(
                         iteration=iterations,
                         provider_call_count=turn_llm_calls,
@@ -15873,6 +15942,8 @@ class Agent:
                 if (
                     accepted_goal_terminal_status is None
                     and post_write_convergence_tracker is not None
+                    and runtime_git_observed
+                    and runtime_diff_paths is not None
                 ):
                     continued_activity_after_verification = bool(
                         (
@@ -16815,16 +16886,32 @@ class Agent:
             provider_call_count=turn_llm_calls,
         )
         if runtime_diagnostics is not None and terminal_error is not None:
+            self._runtime_git_state = GitRunState.OK
             runtime_diff_paths = self._workspace_diff_paths_for_runtime_event()
-            for runtime_event in runtime_diagnostics.observe_finish_error(
-                iteration=iterations,
-                provider_call_count=turn_llm_calls,
-                error_code=terminal_error.code,
-                changed_files=self._relative_paths_from_records(self._workspace_write_records()),
-                diff_paths=runtime_diff_paths,
-                diff_fingerprint=self._workspace_diff_fingerprint_for_runtime_event(),
+            runtime_diff_fingerprint = (
+                self._workspace_diff_fingerprint_for_runtime_event()
+                if runtime_diff_paths is not None
+                else None
+            )
+            if (
+                runtime_diff_paths is not None
+                and self._runtime_git_state is GitRunState.OK
             ):
-                append_runtime_event(self.config.runtime_events_path, runtime_event)
+                for runtime_event in runtime_diagnostics.observe_finish_error(
+                    iteration=iterations,
+                    provider_call_count=turn_llm_calls,
+                    error_code=terminal_error.code,
+                    changed_files=self._relative_paths_from_records(
+                        self._workspace_write_records()
+                    ),
+                    diff_paths=runtime_diff_paths,
+                    diff_fingerprint=runtime_diff_fingerprint,
+                ):
+                    append_runtime_event(self.config.runtime_events_path, runtime_event)
+            else:
+                self._record_runtime_git_observation_skip(
+                    consumers=("runtime_diagnostics_finish",)
+                )
         if bool(getattr(self.config, "final_diff_salvage", False)):
             # Last engine-controlled moment before the runner collects the
             # patch from the worktree: if prior source writes ended in an
@@ -17084,7 +17171,11 @@ class Agent:
                 return True
             if getattr(ctx, "source_diff_candidates", []) or []:
                 return True
-        return bool(self._workspace_tracked_diff_paths_for_nudge())
+        paths = self._workspace_tracked_diff_paths_for_nudge()
+        # Unknown Git state must not manufacture a "no progress" nudge. Treat
+        # it conservatively as possible source evidence and let the turn keep
+        # its normal course without spending another model call.
+        return True if paths is None else bool(paths)
 
     def _workspace_source_fix_beyond_instrumentation(self) -> bool:
         """Whether the tracked diff contains more than diagnostic output.
@@ -17097,6 +17188,8 @@ class Agent:
         """
 
         paths = self._workspace_tracked_diff_paths_for_nudge()
+        if paths is None:
+            return True
         if not paths:
             return False
         ctx = self._tool_context
@@ -17106,26 +17199,19 @@ class Agent:
         if not raw_workspace:
             return True
         workspace_dir = Path(raw_workspace).expanduser().resolve(strict=False)
-        try:
-            result = subprocess.run(
-                ["git", "-C", str(workspace_dir), "diff", "HEAD", "--", *paths],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=5.0,
-                check=False,
-            )
-        except (OSError, subprocess.SubprocessError):
+        result = run_git(
+            ["diff", "HEAD", "--", *paths],
+            cwd=workspace_dir,
+            timeout=5.0,
+        )
+        if not result.ok:
             return True
-        if result.returncode != 0:
-            return True
-        patch = result.stdout or ""
+        patch = result.stdout_text
         if not patch.strip():
             return False
         return not is_instrumentation_only_patch(patch)
 
-    def _workspace_tracked_diff_paths_for_nudge(self) -> list[str]:
+    def _workspace_tracked_diff_paths_for_nudge(self) -> list[str] | None:
         ctx = self._tool_context
         raw_workspace = getattr(ctx, "workspace_dir", None) if ctx is not None else None
         if not raw_workspace:
@@ -17135,24 +17221,21 @@ class Agent:
         workspace_dir = Path(raw_workspace).expanduser().resolve(strict=False)
         if not workspace_dir.exists():
             return []
-        ignored_paths = self._workspace_gitlink_paths(workspace_dir) | (
-            self._workspace_internal_diagnostic_paths(workspace_dir)
+        self._runtime_git_state = GitRunState.OK
+        ignored_state, ignored_paths = self._workspace_ignored_diff_paths_observed(
+            workspace_dir
         )
+        if ignored_state is not GitRunState.OK:
+            self._runtime_git_state = ignored_state
+            return None
+        ignored_paths |= self._workspace_internal_diagnostic_paths(workspace_dir)
         paths: set[str] = set()
         for args in (("diff", "--name-only"), ("diff", "--cached", "--name-only")):
-            try:
-                result = subprocess.run(
-                    ["git", "-C", str(workspace_dir), *args],
-                    capture_output=True,
-                    text=True,
-                    encoding="utf-8",
-                    errors="replace",
-                    timeout=2.0,
-                    check=False,
-                )
-            except (OSError, subprocess.SubprocessError):
-                continue
-            for line in (result.stdout or "").splitlines():
+            result = run_git(args, cwd=workspace_dir, timeout=2.0)
+            if not result.ok:
+                self._runtime_git_state = result.state
+                return None
+            for line in result.stdout_text.splitlines():
                 text = line.strip()
                 if text:
                     normalized = _normalize_workspace_relative_path(text)
@@ -17286,6 +17369,8 @@ class Agent:
 
     def _final_diff_contract_observation(self) -> FinalDiffContractObservation | None:
         diff_paths = self._workspace_diff_paths_for_final_diff_contract()
+        if diff_paths is None:
+            return None
         known_scratch_paths = [
             path for path in diff_paths if self._workspace_relative_path_targets_scratch(path)
         ]
@@ -17386,13 +17471,21 @@ class Agent:
         workspace = self._workspace_dir_for_status()
         if workspace is None:
             return []
-        if self._workspace_diff_paths_for_final_diff_contract(include_untracked=False):
+        tracked_diff_paths = self._workspace_diff_paths_for_final_diff_contract(
+            include_untracked=False
+        )
+        if tracked_diff_paths is None:
+            return []
+        if tracked_diff_paths:
             # A tracked path still carries a live diff: the run ends with a
             # non-empty scored patch the agent chose to keep, and candidates
             # for clean paths are exactly the edits it deliberately reverted.
             # Resurrecting those here would corrupt a healthy final diff.
             return []
-        live_diff_paths = set(self._workspace_diff_paths_for_final_diff_contract())
+        current_diff_paths = self._workspace_diff_paths_for_final_diff_contract()
+        if current_diff_paths is None:
+            return []
+        live_diff_paths = set(current_diff_paths)
         deadline = time.monotonic() + self._FINAL_DIFF_SALVAGE_TIME_BUDGET_SECONDS
         applied: list[dict[str, Any]] = []
         handled_paths: set[str] = set()
@@ -17482,24 +17575,17 @@ class Agent:
         *,
         check_only: bool,
     ) -> bool:
-        args = ["git", "-C", str(workspace), "apply"]
+        args = ["apply"]
         if check_only:
             args.append("--check")
         args.append("-")
-        try:
-            result = subprocess.run(
-                args,
-                input=patch,
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=10.0,
-                check=False,
-            )
-        except (OSError, subprocess.SubprocessError):
-            return False
-        return result.returncode == 0
+        result = run_git(
+            args,
+            cwd=workspace,
+            timeout=10.0,
+            input_bytes=patch.encode("utf-8"),
+        )
+        return result.ok
 
     def _record_final_diff_salvage_event(
         self,
@@ -17603,19 +17689,21 @@ class Agent:
         return mirror_root.as_posix() in command
 
     @staticmethod
-    def _git_head_blob(workspace: Path, relative_path: str) -> bytes | None:
-        try:
-            result = subprocess.run(
-                ["git", "-C", str(workspace), "show", f"HEAD:{relative_path}"],
-                capture_output=True,
-                timeout=2.0,
-                check=False,
-            )
-        except (OSError, subprocess.TimeoutExpired):
-            return None
-        if result.returncode != 0:
-            return None
-        return result.stdout
+    def _git_head_blob(workspace: Path, relative_path: str) -> tuple[bool, bytes | None]:
+        result = run_git(
+            ["show", "--end-of-options", f"HEAD:{relative_path}"],
+            cwd=workspace,
+            timeout=2.0,
+        )
+        if result.ok:
+            return True, result.stdout
+        error_text = result.stderr_text.casefold()
+        if result.state is GitRunState.FAILED and (
+            "does not exist in 'head'" in error_text
+            or "exists on disk, but not in 'head'" in error_text
+        ):
+            return True, None
+        return False, None
 
     def _scratch_verify_mirror_evidence_credit(self, command: str) -> bool:
         """Anti-weakening hash guard for scratch verify-mirror runs.
@@ -17639,6 +17727,7 @@ class Agent:
         workspace = self._workspace_dir_for_status()
         if workspace is None:
             return False
+        repository_verified = False
         checked = 0
         for mirror_file in sorted(mirror_root.rglob("*")):
             if not mirror_file.is_file():
@@ -17663,7 +17752,21 @@ class Agent:
                 if mirror_digest != original_digest:
                     return False
                 continue
-            head_blob = self._git_head_blob(workspace, relative.as_posix())
+            if not repository_verified:
+                repository_check = run_git(
+                    ["rev-parse", "--is-inside-work-tree"],
+                    cwd=workspace,
+                    timeout=2.0,
+                )
+                if not repository_check.ok:
+                    return False
+                repository_verified = True
+            head_observed, head_blob = self._git_head_blob(
+                workspace,
+                relative.as_posix(),
+            )
+            if not head_observed:
+                return False
             if head_blob is None:
                 # Tracked nowhere: a new check file, not a shadowed original.
                 continue
@@ -17676,65 +17779,131 @@ class Agent:
         if workspace is None:
             return None
 
-        def _run_status() -> str | None:
-            try:
-                result = subprocess.run(
-                    [
-                        "git",
-                        "-C",
-                        str(workspace),
-                        "status",
-                        "--porcelain=v1",
-                        "--untracked-files=all",
-                    ],
-                    capture_output=True,
-                    text=True,
-                    encoding="utf-8",
-                    errors="replace",
-                    timeout=2.0,
-                    check=False,
-                )
-            except (OSError, subprocess.TimeoutExpired):
-                return None
-            if result.returncode != 0:
-                return None
-            gitlink_paths = self._workspace_gitlink_paths(workspace)
-            return self._filter_ignored_porcelain_status(result.stdout, gitlink_paths)
+        def _run_status() -> tuple[GitRunState, str | None]:
+            result = run_git(
+                ["status", "--porcelain=v1", "--untracked-files=all"],
+                cwd=workspace,
+                timeout=2.0,
+            )
+            if not result.ok:
+                return result.state, None
+            gitlink_state, gitlink_paths = self._workspace_gitlink_paths_observed(
+                workspace
+            )
+            if gitlink_state is not GitRunState.OK:
+                return gitlink_state, None
+            return (
+                GitRunState.OK,
+                self._filter_ignored_porcelain_status(
+                    result.stdout_text,
+                    gitlink_paths,
+                ),
+            )
 
-        return await asyncio.to_thread(_run_status)
+        state, status = await asyncio.to_thread(_run_status)
+        self._runtime_git_state = state
+        return status
 
-    async def _workspace_submit_review_capture(self) -> tuple[str, str]:
+    async def _workspace_submit_review_capture(self) -> tuple[str, str] | None:
         """Capture ``(per-file summary, unified diff)`` for the submit review.
 
         The per-file summary comes from ``git status`` (so untracked scratch
         files appear even though they are absent from ``git diff``); the diff
-        body is ``git diff HEAD`` for tracked changes. Best-effort: any failure
-        yields an empty diff and the review degrades to the summary alone.
+        body is ``git diff HEAD`` for tracked changes. ``None`` means Git could
+        not authoritatively observe the repository and must never be treated as
+        an empty diff.
         """
         workspace = self._workspace_dir_for_status()
         if workspace is None:
-            return "", ""
+            self._submit_review_git_state = GitRunState.NOT_REPOSITORY
+            return None
 
-        def _run_diff() -> str:
-            try:
-                result = subprocess.run(
-                    ["git", "-C", str(workspace), "diff", "HEAD"],
-                    capture_output=True,
-                    text=True,
-                    encoding="utf-8",
-                    errors="replace",
-                    timeout=4.0,
-                    check=False,
+        def _capture() -> tuple[GitRunState, tuple[str, str] | None]:
+            status_result = run_git(
+                ["status", "--porcelain=v1", "--untracked-files=all"],
+                cwd=workspace,
+                timeout=2.0,
+            )
+            if not status_result.ok:
+                return status_result.state, None
+            diff_result = run_git(["diff", "HEAD"], cwd=workspace, timeout=4.0)
+            if diff_result.ok:
+                diff_text = diff_result.stdout_text
+            else:
+                # ``git diff HEAD`` is invalid in a legitimate unborn
+                # repository. Confirm that this is still a repository with a
+                # symbolic, not-yet-created HEAD before falling back to the
+                # two comparisons that do work there. Other failures remain
+                # unknown and must not be presented as a clean review.
+                repository_result = run_git(
+                    ["rev-parse", "--is-inside-work-tree"],
+                    cwd=workspace,
+                    timeout=2.0,
                 )
-            except (OSError, subprocess.TimeoutExpired):
-                return ""
-            if result.returncode != 0:
-                return ""
-            return result.stdout
+                if not repository_result.ok:
+                    return repository_result.state, None
+                if repository_result.stdout_text.strip().casefold() != "true":
+                    return GitRunState.NOT_REPOSITORY, None
+                head_result = run_git(
+                    ["rev-parse", "--verify", "HEAD"],
+                    cwd=workspace,
+                    timeout=2.0,
+                )
+                if head_result.ok:
+                    return diff_result.state, None
+                if head_result.state is not GitRunState.FAILED:
+                    return head_result.state, None
+                symbolic_head_result = run_git(
+                    ["symbolic-ref", "--quiet", "HEAD"],
+                    cwd=workspace,
+                    timeout=2.0,
+                )
+                if not symbolic_head_result.ok:
+                    return symbolic_head_result.state, None
+                cached_result = run_git(
+                    ["diff", "--cached"],
+                    cwd=workspace,
+                    timeout=4.0,
+                )
+                if not cached_result.ok:
+                    return cached_result.state, None
+                worktree_result = run_git(["diff"], cwd=workspace, timeout=4.0)
+                if not worktree_result.ok:
+                    return worktree_result.state, None
+                diff_text = cached_result.stdout_text + worktree_result.stdout_text
+            ignored_state, ignored_paths = self._workspace_ignored_diff_paths_observed(
+                workspace
+            )
+            if ignored_state is not GitRunState.OK:
+                return ignored_state, None
+            file_index = self._filter_ignored_porcelain_status(
+                status_result.stdout_text,
+                ignored_paths,
+            )
+            return GitRunState.OK, (file_index, diff_text)
 
-        file_index = await self._workspace_git_status_porcelain() or ""
-        diff_text = await asyncio.to_thread(_run_diff)
-        return file_index, diff_text
+        state, capture = await asyncio.to_thread(_capture)
+        self._submit_review_git_state = state
+        return capture
+
+    @staticmethod
+    def _submit_review_git_unavailable_payload(state: GitRunState) -> dict[str, Any]:
+        code = (
+            "GIT_NOT_REPOSITORY"
+            if state is GitRunState.NOT_REPOSITORY
+            else "GIT_UNAVAILABLE"
+        )
+        return {
+            "status": "unavailable",
+            "code": code,
+            "reason": "submit_review_git_unavailable",
+            "git_state": state.value,
+            "retryable": False,
+            "message": (
+                "OpenSquilla could not inspect the workspace diff for submit review; "
+                "the submit request was ended without treating the workspace as clean."
+            ),
+        }
 
     @staticmethod
     def _porcelain_status_code(line: str) -> str:
@@ -17882,51 +18051,46 @@ class Agent:
 
     @staticmethod
     def _workspace_gitlink_paths(workspace_dir: Path) -> set[str]:
-        try:
-            result = subprocess.run(
-                ["git", "-C", str(workspace_dir), "ls-files", "-s"],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=2.0,
-                check=False,
-            )
-        except (OSError, subprocess.SubprocessError):
-            return set()
-        if result.returncode != 0:
-            return set()
+        _state, paths = Agent._workspace_gitlink_paths_observed(workspace_dir)
+        return paths
+
+    @staticmethod
+    def _workspace_gitlink_paths_observed(
+        workspace_dir: Path,
+    ) -> tuple[GitRunState, set[str]]:
+        result = run_git(["ls-files", "-s"], cwd=workspace_dir, timeout=2.0)
+        if not result.ok:
+            return result.state, set()
+        return GitRunState.OK, Agent._gitlink_paths_from_index_output(result.stdout_text)
+
+    @staticmethod
+    def _gitlink_paths_from_index_output(output: str) -> set[str]:
         paths: set[str] = set()
-        for line in (result.stdout or "").splitlines():
+        for line in output.splitlines():
             parts = line.split(None, 3)
             if len(parts) == 4 and parts[0] == "160000":
                 paths.add(_normalize_workspace_relative_path(parts[3]))
         return paths
 
     def _workspace_ignored_diff_paths(self, workspace_dir: Path) -> set[str]:
-        ignored = self._workspace_gitlink_paths(workspace_dir)
-        try:
-            result = subprocess.run(
-                [
-                    "git",
-                    "-C",
-                    str(workspace_dir),
-                    "status",
-                    "--porcelain=v1",
-                    "--untracked-files=all",
-                ],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=2.0,
-                check=False,
-            )
-        except (OSError, subprocess.SubprocessError):
-            return ignored
-        if result.returncode != 0:
-            return ignored
-        for line in (result.stdout or "").splitlines():
+        _state, ignored = self._workspace_ignored_diff_paths_observed(workspace_dir)
+        return ignored
+
+    def _workspace_ignored_diff_paths_observed(
+        self,
+        workspace_dir: Path,
+    ) -> tuple[GitRunState, set[str]]:
+        gitlink_state, ignored = self._workspace_gitlink_paths_observed(workspace_dir)
+        if gitlink_state is not GitRunState.OK:
+            return gitlink_state, set()
+        status_result = run_git(
+            ["status", "--porcelain=v1", "--untracked-files=all"],
+            cwd=workspace_dir,
+            timeout=2.0,
+        )
+        if not status_result.ok:
+            return status_result.state, set()
+        for line in status_result.stdout_text.splitlines():
             path = self._porcelain_status_path(line)
             if (
                 path
@@ -17934,7 +18098,7 @@ class Agent:
                 and self._is_root_scratch_artifact_path(path)
             ):
                 ignored.add(path)
-        return ignored
+        return GitRunState.OK, ignored
 
     async def _failed_tool_finalization_recovery_details(
         self,
@@ -18746,12 +18910,37 @@ class Agent:
         }
         append_runtime_event(self.config.runtime_events_path, event)
 
+    def _record_runtime_git_observation_skip(
+        self,
+        *,
+        consumers: tuple[str, ...],
+    ) -> None:
+        """Record one internal-only skip for each unavailable Git state."""
+
+        state = self._runtime_git_state
+        if state is GitRunState.OK:
+            state = GitRunState.FAILED
+            self._runtime_git_state = state
+        self.config.metadata["runtime_git_observation_state"] = state.value
+        if state in self._runtime_git_skip_states_recorded:
+            return
+        self._runtime_git_skip_states_recorded.add(state)
+        self._record_runtime_event(
+            "runtime_git_observation.skipped",
+            feature="runtime_git_observation",
+            reason="git_state_unavailable",
+            git_state=state.value,
+            consumers=list(consumers),
+            injected_to_model=False,
+        )
+
     def _record_tool_loop_runtime_event(self, *, reason: str, **details: Any) -> None:
         if self.config.tool_loop_observer_mode != "log":
             return
         iteration = details.get("iteration")
         hint_text_sha256 = details.pop("hint_text_sha256", None)
         trigger_confidence = details.pop("trigger_confidence", "observed_runtime_signal")
+        runtime_diff_paths = self._workspace_diff_paths_for_runtime_event()
         event = {
             "feature": "runtime_observer",
             "mechanism": "tool_loop_observer",
@@ -18765,7 +18954,9 @@ class Agent:
             "evidence": details,
             "read_files": self._relative_paths_from_records(self._workspace_read_records()),
             "changed_files": self._relative_paths_from_records(self._workspace_write_records()),
-            "diff_paths": self._workspace_diff_paths_for_runtime_event(),
+            "diff_paths": runtime_diff_paths or [],
+            "git_state": self._runtime_git_state.value,
+            "diff_observed": runtime_diff_paths is not None,
             "verification_commands": self._verification_commands_for_runtime_event(),
             "hint_text_sha256": hint_text_sha256,
             "trigger_confidence": trigger_confidence,
@@ -18791,6 +18982,7 @@ class Agent:
             **decision.details,
             **details,
         }
+        runtime_diff_paths = self._workspace_diff_paths_for_runtime_event()
         event = {
             "feature": "runtime_recovery",
             "mechanism": decision.mechanism,
@@ -18807,7 +18999,9 @@ class Agent:
             "evidence": evidence,
             "read_files": self._relative_paths_from_records(self._workspace_read_records()),
             "changed_files": self._relative_paths_from_records(self._workspace_write_records()),
-            "diff_paths": self._workspace_diff_paths_for_runtime_event(),
+            "diff_paths": runtime_diff_paths or [],
+            "git_state": self._runtime_git_state.value,
+            "diff_observed": runtime_diff_paths is not None,
             "verification_commands": self._verification_commands_for_runtime_event(),
             "hint_text_sha256": hint_text_sha256,
             "trigger_confidence": "runtime_recovery_gate",
@@ -18831,6 +19025,7 @@ class Agent:
         if event_name is None:
             return
         evidence = dict(decision.details)
+        runtime_diff_paths = self._workspace_diff_paths_for_runtime_event()
         event = {
             "feature": "post_write_convergence",
             "mechanism": "stable_verified_workspace_diff",
@@ -18847,7 +19042,9 @@ class Agent:
             "evidence": evidence,
             "read_files": self._relative_paths_from_records(self._workspace_read_records()),
             "changed_files": self._relative_paths_from_records(self._workspace_write_records()),
-            "diff_paths": self._workspace_diff_paths_for_runtime_event(),
+            "diff_paths": runtime_diff_paths or [],
+            "git_state": self._runtime_git_state.value,
+            "diff_observed": runtime_diff_paths is not None,
             "verification_commands": self._verification_commands_for_runtime_event(),
             "hint_text_sha256": (
                 hashlib.sha256(hint_text.encode("utf-8")).hexdigest()
@@ -18873,30 +19070,29 @@ class Agent:
                 paths.append(normalized)
         return paths
 
-    def _workspace_diff_paths_for_runtime_event(self) -> list[str]:
+    def _workspace_diff_paths_for_runtime_event(self) -> list[str] | None:
         workspace_dir = self._workspace_dir_for_status()
         if workspace_dir is None:
-            return []
-        ignored_paths = self._workspace_ignored_diff_paths(workspace_dir)
+            self._runtime_git_state = GitRunState.NOT_REPOSITORY
+            return None
+        self._runtime_git_state = GitRunState.OK
+        ignored_state, ignored_paths = self._workspace_ignored_diff_paths_observed(
+            workspace_dir
+        )
+        if ignored_state is not GitRunState.OK:
+            self._runtime_git_state = ignored_state
+            return None
         paths: set[str] = set()
         for args in (
             ("diff", "--name-only"),
             ("diff", "--cached", "--name-only"),
             ("status", "--porcelain=v1", "--untracked-files=all"),
         ):
-            try:
-                result = subprocess.run(
-                    ["git", "-C", str(workspace_dir), *args],
-                    capture_output=True,
-                    text=True,
-                    encoding="utf-8",
-                    errors="replace",
-                    timeout=2.0,
-                    check=False,
-                )
-            except (OSError, subprocess.SubprocessError):
-                continue
-            for line in (result.stdout or "").splitlines():
+            result = run_git(args, cwd=workspace_dir, timeout=2.0)
+            if not result.ok:
+                self._runtime_git_state = result.state
+                return None
+            for line in result.stdout_text.splitlines():
                 if args[0] == "status":
                     text = self._porcelain_status_path(line) or ""
                 else:
@@ -18910,13 +19106,16 @@ class Agent:
 
     def _workspace_diff_paths_for_final_diff_contract(
         self, *, include_untracked: bool = True
-    ) -> list[str]:
+    ) -> list[str] | None:
         workspace_dir = self._workspace_dir_for_status()
         if workspace_dir is None:
             return []
-        ignored_paths = self._workspace_gitlink_paths(workspace_dir) | (
-            self._workspace_internal_diagnostic_paths(workspace_dir)
+        gitlink_state, ignored_paths = self._workspace_gitlink_paths_observed(
+            workspace_dir
         )
+        if gitlink_state is not GitRunState.OK:
+            return None
+        ignored_paths |= self._workspace_internal_diagnostic_paths(workspace_dir)
         commands: tuple[tuple[str, ...], ...] = (
             ("diff", "--name-only"),
             ("diff", "--cached", "--name-only"),
@@ -18925,19 +19124,13 @@ class Agent:
             commands += (("status", "--porcelain=v1", "--untracked-files=all"),)
         paths: set[str] = set()
         for args in commands:
-            try:
-                result = subprocess.run(
-                    ["git", "-C", str(workspace_dir), *args],
-                    capture_output=True,
-                    text=True,
-                    encoding="utf-8",
-                    errors="replace",
-                    timeout=2.0,
-                    check=False,
-                )
-            except (OSError, subprocess.SubprocessError):
-                continue
-            for line in (result.stdout or "").splitlines():
+            result = run_git(args, cwd=workspace_dir, timeout=2.0)
+            if not result.ok:
+                # An unavailable Git runtime or a non-repository workspace is
+                # not an authoritative clean diff. Callers must skip their
+                # final-diff gates instead of treating it as empty.
+                return None
+            for line in result.stdout_text.splitlines():
                 if args[0] == "status":
                     text = self._porcelain_status_path(line) or ""
                 else:
@@ -18969,9 +19162,10 @@ class Agent:
     def _workspace_diff_fingerprint_for_runtime_event(self) -> str | None:
         workspace_dir = self._workspace_dir_for_status()
         if workspace_dir is None:
+            self._runtime_git_state = GitRunState.NOT_REPOSITORY
             return None
         diff_paths = self._workspace_diff_paths_for_runtime_event()
-        if not diff_paths:
+        if diff_paths is None or not diff_paths:
             return None
         payload_parts: list[str] = []
         for args in (
@@ -18979,29 +19173,27 @@ class Agent:
             ("diff", "--cached", "--no-ext-diff", "--binary", "--", *diff_paths),
             ("status", "--porcelain=v1", "--untracked-files=all"),
         ):
-            try:
-                result = subprocess.run(
-                    ["git", "-C", str(workspace_dir), *args],
-                    capture_output=True,
-                    text=True,
-                    encoding="utf-8",
-                    errors="replace",
-                    timeout=2.0,
-                    check=False,
-                )
-            except (OSError, subprocess.SubprocessError):
-                continue
+            result = run_git(args, cwd=workspace_dir, timeout=2.0)
+            if not result.ok:
+                self._runtime_git_state = result.state
+                return None
             payload_parts.append(f"$ git {' '.join(args)}\n")
-            stdout = result.stdout or ""
+            stdout = result.stdout_text
             if args[0] == "status":
+                ignored_state, ignored_paths = (
+                    self._workspace_ignored_diff_paths_observed(workspace_dir)
+                )
+                if ignored_state is not GitRunState.OK:
+                    self._runtime_git_state = ignored_state
+                    return None
                 stdout = self._filter_gitlink_porcelain_status(
                     stdout,
-                    self._workspace_ignored_diff_paths(workspace_dir),
+                    ignored_paths,
                 )
             payload_parts.append(stdout)
             if result.stderr:
                 payload_parts.append("\n[stderr]\n")
-                payload_parts.append(result.stderr)
+                payload_parts.append(result.stderr_text)
         payload = "\n".join(payload_parts)
         if not payload.strip():
             return None

--- a/src/opensquilla/engine/patch_evidence_ledger.py
+++ b/src/opensquilla/engine/patch_evidence_ledger.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import json
-import subprocess
 import time
 from collections import Counter
 from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Any
 
+from opensquilla.git_runtime import GitRunState, run_git
 from opensquilla.safety.secret_redaction import redact_secret_text
 
 _MAX_TOOL_EVENTS = 2000
@@ -136,7 +136,9 @@ class PatchEvidenceLedger:
         git_snapshot = self._git_snapshot()
         read_files = _unique_file_records(read_records)
         changed_files = _unique_file_records(write_records)
-        diff_paths = git_snapshot.get("diff_paths", [])
+        raw_diff_paths = git_snapshot.get("diff_paths")
+        diff_paths = raw_diff_paths if isinstance(raw_diff_paths, list) else []
+        git_diff_observed = bool(git_snapshot.get("diff_observed"))
         path_signal_counts: Counter[str] = Counter()
         for rel_path in set(read_files) | set(changed_files) | set(diff_paths):
             for signal in _path_signals(rel_path):
@@ -170,6 +172,8 @@ class PatchEvidenceLedger:
             },
             "read_files": read_files,
             "changed_files": changed_files,
+            "git_state": git_snapshot.get("git_state"),
+            "git_diff_observed": git_diff_observed,
             "diff_paths": diff_paths,
             "git_status_porcelain": git_snapshot.get("status_porcelain"),
             "verification_commands": self.verification_commands,
@@ -187,16 +191,39 @@ class PatchEvidenceLedger:
 
     def _git_snapshot(self) -> dict[str, Any]:
         if self.workspace_dir is None:
-            return {"diff_paths": [], "status_porcelain": None}
-        status = _run_git(self.workspace_dir, "status", "--porcelain=v1", "--untracked-files=all")
-        diff = _run_git(self.workspace_dir, "diff", "--name-only")
-        staged = _run_git(self.workspace_dir, "diff", "--cached", "--name-only")
+            return {
+                "git_state": GitRunState.NOT_REPOSITORY.value,
+                "diff_observed": False,
+                "diff_paths": [],
+                "status_porcelain": None,
+            }
+        results = []
+        for args in (
+            ("status", "--porcelain=v1", "--untracked-files=all"),
+            ("diff", "--name-only"),
+            ("diff", "--cached", "--name-only"),
+        ):
+            result = run_git(args, cwd=self.workspace_dir, timeout=2.0)
+            if not result.ok:
+                return {
+                    "git_state": result.state.value,
+                    "diff_observed": False,
+                    "diff_paths": [],
+                    "status_porcelain": None,
+                }
+            results.append(result)
+        status_result, diff_result, staged_result = results
+        status = status_result.stdout_text
+        diff = diff_result.stdout_text
+        staged = staged_result.stdout_text
         paths = (
             _paths_from_name_only(diff)
             | _paths_from_name_only(staged)
             | _paths_from_status(status)
         )
         return {
+            "git_state": GitRunState.OK.value,
+            "diff_observed": True,
             "diff_paths": sorted(paths),
             "status_porcelain": status,
         }
@@ -242,24 +269,6 @@ class PatchEvidenceLedger:
                     }
                 )
         return candidates
-
-
-def _run_git(workspace: Path, *args: str) -> str | None:
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(workspace), *args],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=2.0,
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    return result.stdout
 
 
 def _summarize_arguments(arguments: dict[str, Any]) -> dict[str, Any]:

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -205,6 +205,7 @@ from opensquilla.execution_status import (
     mark_execution_status_truncated,
     normalize_execution_status,
 )
+from opensquilla.git_runtime import git_run_mode_scope
 from opensquilla.memory.session_flush import SessionFlushService
 from opensquilla.observability.decision_log import (
     DecisionEntry,
@@ -285,6 +286,8 @@ from opensquilla.router_tiers import (
 from opensquilla.run_mode import RunMode, display_name, execution_target, normalize_run_mode
 from opensquilla.runtime_packs import runtime_pack_state_scope
 from opensquilla.safety import injection_guard, permission_matrix, sandbox, tool_tiers
+from opensquilla.sandbox.integration import sandbox_policy_scope
+from opensquilla.sandbox.policy_models import SandboxPolicy as StoredSandboxPolicy
 from opensquilla.session.compaction_lifecycle import (
     COMPACTION_CHUNK_SUMMARIZED_EVENT,
     COMPACTION_PERSISTED_EVENT,
@@ -329,6 +332,7 @@ from opensquilla.session.terminal_reply import (
 from opensquilla.skills.toolchains.manager import managed_toolchain_state_scope
 from opensquilla.token_estimation import estimate_tokens
 from opensquilla.tools.description_overrides import resolve_tool_description_overrides
+from opensquilla.tools.run_mode import effective_run_mode_for_context
 from opensquilla.tools.types import (
     CallerKind,
     InteractionMode,
@@ -4884,6 +4888,17 @@ class TurnRunner:
                 parent_task_id=getattr(effective_tool_context, "parent_task_id", None),
             )
 
+        def policy_scope():
+            policy = getattr(effective_tool_context, "sandbox_policy", None)
+            if isinstance(policy, StoredSandboxPolicy):
+                return sandbox_policy_scope(policy)
+            return contextlib.nullcontext()
+
+        def git_mode_scope():
+            return git_run_mode_scope(
+                effective_run_mode_for_context(effective_tool_context)
+            )
+
         logical_turn_id = (
             root_turn_id.strip()
             if isinstance(root_turn_id, str) and root_turn_id.strip()
@@ -4922,6 +4937,8 @@ class TurnRunner:
                 with (
                     managed_toolchain_state_scope(configured_state_dir),
                     runtime_pack_state_scope(configured_state_dir),
+                    policy_scope(),
+                    git_mode_scope(),
                     process_scope(),
                 ):
                     async for event in self._run_turn(
@@ -4976,6 +4993,8 @@ class TurnRunner:
                     with (
                         managed_toolchain_state_scope(configured_state_dir),
                         runtime_pack_state_scope(configured_state_dir),
+                        policy_scope(),
+                        git_mode_scope(),
                         process_scope(),
                     ):
                         async for event in self._run_turn(
@@ -7793,6 +7812,7 @@ class TurnRunner:
             gateway_config=getattr(self, "_config", None) is not None,
             channel_backing=detected.channel_backing,
             image_generation=detected.image_generation,
+            git_available=detected.git_available,
         )
         return resolve_runtime_tool_surface(ctx, capabilities=capabilities)
 

--- a/src/opensquilla/engine/runtime_state_capsule.py
+++ b/src/opensquilla/engine/runtime_state_capsule.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import json
-import subprocess
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
 from opensquilla.engine.final_diff_contract import classify_final_diff_path
+from opensquilla.git_runtime import GitRunState, run_git
 from opensquilla.tools.types import ToolContext
 
 
@@ -19,7 +19,11 @@ def build_runtime_state_capsule(
 ) -> dict[str, Any]:
     """Build a compact, factual capsule of current workspace state."""
 
-    diff_paths = _git_dirty_paths(Path(workspace).expanduser().resolve()) if workspace else []
+    if workspace:
+        git_state, diff_paths = _git_dirty_paths(Path(workspace).expanduser().resolve())
+    else:
+        git_state, diff_paths = GitRunState.NOT_REPOSITORY, []
+    diff_observed = git_state is GitRunState.OK
     source_paths = _paths_by_kind(diff_paths, "source")
     scratch_paths = _paths_by_kind(diff_paths, "scratch")
     test_like_paths = _paths_by_kind(diff_paths, "test-like")
@@ -32,6 +36,11 @@ def build_runtime_state_capsule(
         "schema": "runtime_state_capsule_v1",
         "workspace": {
             "epoch": workspace_epoch,
+            "git_state": git_state.value,
+            "diff_observed": diff_observed,
+            # Keep the v1 bool/list shapes for older capsule consumers. The
+            # additive observed/state fields distinguish these fallback values
+            # from an authoritative clean workspace.
             "diff": bool(diff_paths),
             "diff_paths": diff_paths,
             "source_diff": bool(source_paths),
@@ -48,7 +57,11 @@ def build_runtime_state_capsule(
         "last_mutation": last_mutation,
         "finalization": {
             "source_diff_present": bool(source_paths),
-            "blocking_facts": _blocking_facts(source_paths, scratch_paths, changed_receipts),
+            "blocking_facts": (
+                _blocking_facts(source_paths, scratch_paths, changed_receipts)
+                if diff_observed
+                else []
+            ),
         },
     }
 
@@ -133,20 +146,18 @@ def _paths_by_kind(paths: Sequence[str], kind: str) -> list[str]:
     return [path for path in paths if classify_final_diff_path(path) == kind]
 
 
-def _git_dirty_paths(root: Path) -> list[str]:
-    try:
-        completed = subprocess.run(
-            ["git", "status", "--porcelain=v1", "-z", "--untracked-files=all"],
-            cwd=root,
-            check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-        )
-    except OSError:
-        return []
-    if completed.returncode != 0:
-        return []
-    return _parse_git_status_z(completed.stdout.decode("utf-8", errors="replace"))
+def _git_dirty_paths(root: Path) -> tuple[GitRunState, list[str]]:
+    completed = run_git(
+        ("status", "--porcelain=v1", "-z", "--untracked-files=all"),
+        cwd=root,
+        timeout=2.0,
+    )
+    if not completed.ok:
+        return completed.state, []
+    return (
+        GitRunState.OK,
+        _parse_git_status_z(completed.stdout.decode("utf-8", errors="replace")),
+    )
 
 
 def _parse_git_status_z(output: str) -> list[str]:

--- a/src/opensquilla/git_runtime.py
+++ b/src/opensquilla/git_runtime.py
@@ -1,0 +1,520 @@
+"""Safe Git capability discovery and subprocess execution.
+
+The macOS ``/usr/bin/git`` executable is an Apple developer-tool shim.  On a
+machine without Xcode or the Command Line Tools, executing that shim can open an
+installer prompt.  Capability discovery in this module is deliberately passive:
+it never executes a Git candidate and, on macOS, resolves the selected developer
+tool to its real absolute path before returning it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import os
+import platform
+import subprocess
+import threading
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from opensquilla.run_mode import RunMode, normalize_run_mode
+from opensquilla.subprocess_encoding import decode_subprocess_output
+
+_CAPABILITY_CACHE_TTL_SECONDS = 5.0
+_XCODE_SELECT_TIMEOUT_SECONDS = 1.0
+_APPLE_GIT_SHIM = Path("/usr/bin/git")
+_XCODE_SELECT = Path("/usr/bin/xcode-select")
+
+
+class GitCapabilityState(StrEnum):
+    """Whether a safe-to-launch Git executable is available."""
+
+    AVAILABLE = "available"
+    UNAVAILABLE = "unavailable"
+
+
+class GitRunState(StrEnum):
+    """Outcome of one Git invocation."""
+
+    OK = "ok"
+    UNAVAILABLE = "unavailable"
+    NOT_REPOSITORY = "not_repository"
+    TIMED_OUT = "timed_out"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class GitCapability:
+    """Resolved Git executable, or a reason that one cannot be used safely."""
+
+    state: GitCapabilityState
+    executable: Path | None = None
+    source: str | None = None
+    reason: str | None = None
+
+    @property
+    def available(self) -> bool:
+        return self.state is GitCapabilityState.AVAILABLE and self.executable is not None
+
+
+@dataclass(frozen=True)
+class GitRunResult:
+    """Structured result that keeps missing Git distinct from an empty result."""
+
+    state: GitRunState
+    returncode: int | None
+    stdout: bytes
+    stderr: bytes
+    capability: GitCapability
+
+    @property
+    def ok(self) -> bool:
+        return self.state is GitRunState.OK
+
+    @property
+    def stdout_text(self) -> str:
+        return decode_subprocess_output(self.stdout)
+
+    @property
+    def stderr_text(self) -> str:
+        return decode_subprocess_output(self.stderr)
+
+
+type _CapabilityCacheKey = tuple[str, str, str, str, str, str]
+
+_capability_cache: dict[_CapabilityCacheKey, tuple[float, GitCapability]] = {}
+_capability_cache_lock = threading.Lock()
+_ACTIVE_GIT_RUN_MODE: contextvars.ContextVar[RunMode | None] = contextvars.ContextVar(
+    "opensquilla_git_run_mode",
+    default=None,
+)
+
+
+def clear_git_capability_cache() -> None:
+    """Discard all process-local Git capability entries."""
+
+    with _capability_cache_lock:
+        _capability_cache.clear()
+
+
+@contextlib.contextmanager
+def git_run_mode_scope(run_mode: RunMode | str | None):
+    """Bind the Safe/Full resolver preference for one logical turn."""
+
+    token = _ACTIVE_GIT_RUN_MODE.set(normalize_run_mode(run_mode))
+    try:
+        yield
+    finally:
+        _ACTIVE_GIT_RUN_MODE.reset(token)
+
+
+def _environment_value(environment: Mapping[str, str], name: str) -> str:
+    wanted = name.casefold()
+    for key, value in environment.items():
+        if key.casefold() == wanted:
+            return str(value)
+    return ""
+
+
+def _platform_name() -> str:
+    return platform.system().strip().casefold()
+
+
+def _managed_git_path(platform_name: str) -> Path | None:
+    if platform_name != "windows":
+        return None
+    try:
+        from opensquilla.runtime_packs import resolve_component_binary
+    except ImportError:
+        return None
+    try:
+        from opensquilla.sandbox.integration import active_sandbox_policy
+
+        runtime_policy = active_sandbox_policy().runtimes
+    except (ImportError, RuntimeError, TypeError, ValueError):
+        # During early composition there may be no policy facade yet. Preserve
+        # the long-standing default-enabled Runtime Pack behavior in that case.
+        runtime_policy = None
+    if runtime_policy is not None and (
+        not runtime_policy.enabled or not runtime_policy.git_bash
+    ):
+        return None
+    try:
+        return resolve_component_binary("gitBash", "git", allow_host=False)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
+
+
+def _is_executable_file(path: Path, *, windows: bool) -> bool:
+    try:
+        return path.is_file() and (windows or os.access(path, os.X_OK))
+    except OSError:
+        return False
+
+
+def _absolute_path(path: Path) -> Path:
+    return path.expanduser().absolute()
+
+
+def _windows_executable_names(pathext: str) -> tuple[str, ...]:
+    extensions = [part.strip() for part in pathext.split(";") if part.strip()]
+    if not extensions:
+        extensions = [".COM", ".EXE", ".BAT", ".CMD"]
+    names = ["git"]
+    for extension in extensions:
+        suffix = extension if extension.startswith(".") else f".{extension}"
+        names.append(f"git{suffix}")
+    return tuple(dict.fromkeys(names))
+
+
+def _host_git_candidates(
+    environment: Mapping[str, str],
+    *,
+    platform_name: str,
+) -> tuple[Path, ...]:
+    path_value = _environment_value(environment, "PATH")
+    if not path_value:
+        return ()
+    windows = platform_name == "windows"
+    separator = ";" if windows else os.pathsep
+    names = (
+        _windows_executable_names(_environment_value(environment, "PATHEXT"))
+        if windows
+        else ("git",)
+    )
+    candidates: list[Path] = []
+    seen: set[str] = set()
+    for raw_directory in path_value.split(separator):
+        raw_directory = raw_directory.strip().strip('"')
+        if not raw_directory:
+            continue
+        directory = Path(raw_directory).expanduser()
+        # Relative and empty PATH entries are controlled by the process cwd and
+        # are unsuitable for application-owned background Git operations.
+        if not directory.is_absolute():
+            continue
+        for name in names:
+            candidate = _absolute_path(directory / name)
+            key = os.path.normcase(str(candidate)) if windows else str(candidate)
+            if key in seen:
+                continue
+            seen.add(key)
+            if _is_executable_file(candidate, windows=windows):
+                candidates.append(candidate)
+    return tuple(candidates)
+
+
+def _is_apple_git_shim(path: Path) -> bool:
+    candidate = _absolute_path(path)
+    shim = _absolute_path(_APPLE_GIT_SHIM)
+    if candidate == shim:
+        return True
+    try:
+        return candidate.samefile(shim)
+    except OSError:
+        return False
+
+
+def _unavailable(reason: str) -> GitCapability:
+    return GitCapability(
+        state=GitCapabilityState.UNAVAILABLE,
+        executable=None,
+        source=None,
+        reason=reason,
+    )
+
+
+def _available(path: Path, source: str) -> GitCapability:
+    return GitCapability(
+        state=GitCapabilityState.AVAILABLE,
+        executable=_absolute_path(path),
+        source=source,
+        reason=None,
+    )
+
+
+def _resolve_apple_developer_git(environment: Mapping[str, str]) -> GitCapability:
+    if not _is_executable_file(_XCODE_SELECT, windows=False):
+        return _unavailable("xcode_select_unavailable")
+    try:
+        completed = subprocess.run(
+            [str(_XCODE_SELECT), "--print-path"],
+            check=False,
+            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            timeout=_XCODE_SELECT_TIMEOUT_SECONDS,
+            env=dict(environment),
+        )
+    except subprocess.TimeoutExpired:
+        return _unavailable("xcode_select_timed_out")
+    except OSError:
+        return _unavailable("xcode_select_unavailable")
+    if completed.returncode != 0:
+        return _unavailable("apple_developer_tools_unavailable")
+    raw_path = decode_subprocess_output(completed.stdout).strip()
+    if not raw_path or "\x00" in raw_path:
+        return _unavailable("apple_developer_directory_invalid")
+    developer_directory = Path(raw_path).expanduser()
+    if not developer_directory.is_absolute():
+        return _unavailable("apple_developer_directory_invalid")
+    candidate = developer_directory / "usr" / "bin" / "git"
+    if not _is_executable_file(candidate, windows=False) or _is_apple_git_shim(candidate):
+        return _unavailable("apple_developer_git_unavailable")
+    return _available(candidate, "apple_developer")
+
+
+def _resolve_uncached(
+    environment: Mapping[str, str],
+    *,
+    mode: RunMode,
+    platform_name: str,
+    managed_path: Path | None,
+) -> GitCapability:
+    managed = (
+        _available(managed_path, "managed")
+        if managed_path is not None
+        and _is_executable_file(managed_path, windows=platform_name == "windows")
+        else None
+    )
+    host_candidates = _host_git_candidates(environment, platform_name=platform_name)
+
+    if platform_name == "windows":
+        host = _available(host_candidates[0], "host") if host_candidates else None
+        ordered = (host, managed) if mode is RunMode.FULL else (managed, host)
+        return next((candidate for candidate in ordered if candidate is not None), None) or (
+            _unavailable("git_not_found")
+        )
+
+    if platform_name != "darwin":
+        if host_candidates:
+            return _available(host_candidates[0], "host")
+        return _unavailable("git_not_found")
+
+    apple_capability: GitCapability | None = None
+    for candidate in host_candidates:
+        if _is_apple_git_shim(candidate):
+            if apple_capability is None:
+                apple_capability = _resolve_apple_developer_git(environment)
+            if apple_capability.available:
+                return apple_capability
+            continue
+        return _available(candidate, "host")
+    if apple_capability is not None:
+        return apple_capability
+    return _unavailable("git_not_found")
+
+
+def resolve_git_capability(
+    environment: Mapping[str, str] | None = None,
+    run_mode: RunMode | str | None = None,
+    force_refresh: bool = False,
+) -> GitCapability:
+    """Resolve a safe absolute Git executable without executing Git itself."""
+
+    effective_environment = dict(os.environ if environment is None else environment)
+    mode = normalize_run_mode(
+        run_mode if run_mode is not None else _ACTIVE_GIT_RUN_MODE.get()
+    )
+    platform_name = _platform_name()
+    managed_path = _managed_git_path(platform_name)
+    key: _CapabilityCacheKey = (
+        platform_name,
+        mode.value,
+        _environment_value(effective_environment, "PATH"),
+        _environment_value(effective_environment, "PATHEXT"),
+        _environment_value(effective_environment, "DEVELOPER_DIR"),
+        str(managed_path or ""),
+    )
+    now = time.monotonic()
+    if not force_refresh:
+        with _capability_cache_lock:
+            cached = _capability_cache.get(key)
+            if cached is not None and now - cached[0] < _CAPABILITY_CACHE_TTL_SECONDS:
+                return cached[1]
+    capability = _resolve_uncached(
+        effective_environment,
+        mode=mode,
+        platform_name=platform_name,
+        managed_path=managed_path,
+    )
+    with _capability_cache_lock:
+        _capability_cache[key] = (now, capability)
+    return capability
+
+
+def _environment_with_resolved_git(
+    environment: Mapping[str, str],
+    executable: Path,
+) -> dict[str, str]:
+    result = dict(environment)
+    path_key = next((key for key in result if key.casefold() == "path"), "PATH")
+    existing_path = result.get(path_key, "")
+    executable_directory = str(executable.parent)
+    executable_directory_key = os.path.normcase(executable_directory)
+    existing_parts = [part for part in existing_path.split(os.pathsep) if part]
+    remaining_parts = [
+        part
+        for part in existing_parts
+        if os.path.normcase(part) != executable_directory_key
+    ]
+    result[path_key] = os.pathsep.join(
+        (executable_directory, *remaining_parts)
+    )
+    return result
+
+
+def _noninteractive_environment(
+    environment: Mapping[str, str],
+    executable: Path,
+) -> dict[str, str]:
+    result = _environment_with_resolved_git(environment, executable)
+    result["GIT_TERMINAL_PROMPT"] = "0"
+    result["GCM_INTERACTIVE"] = "Never"
+    result["GIT_ASKPASS"] = ""
+    result["SSH_ASKPASS"] = ""
+    result["SSH_ASKPASS_REQUIRE"] = "never"
+    result["GIT_PAGER"] = ""
+    result["PAGER"] = ""
+    result["LC_ALL"] = "C"
+    result["LANG"] = "C"
+    return result
+
+
+def _exception_bytes(value: object | None) -> bytes:
+    if value is None:
+        return b""
+    if isinstance(value, bytes):
+        return value
+    return str(value).encode("utf-8", errors="replace")
+
+
+_NOT_REPOSITORY_MARKERS = (
+    "not a git repository",
+    "this operation must be run in a work tree",
+)
+
+
+def _failed_run_state(stdout: bytes, stderr: bytes) -> GitRunState:
+    message = decode_subprocess_output(stderr + b"\n" + stdout).casefold()
+    if any(marker in message for marker in _NOT_REPOSITORY_MARKERS):
+        return GitRunState.NOT_REPOSITORY
+    return GitRunState.FAILED
+
+
+def run_git(
+    args: Sequence[str],
+    cwd: str | Path | None = None,
+    timeout: float = 2.0,
+    environment: Mapping[str, str] | None = None,
+    run_mode: RunMode | str | None = None,
+    input_bytes: bytes | None = None,
+    allow_user_interaction: bool = False,
+) -> GitRunResult:
+    """Run Git by absolute path and return a structured, non-raising result.
+
+    Application-owned probes are non-interactive by default. Explicit user
+    workflows may opt in to inherited credential helpers and stdin while still
+    using the safely resolved absolute executable.
+    """
+
+    effective_environment = dict(os.environ if environment is None else environment)
+    capability = resolve_git_capability(effective_environment, run_mode)
+    if not capability.available or capability.executable is None:
+        return GitRunResult(
+            state=GitRunState.UNAVAILABLE,
+            returncode=None,
+            stdout=b"",
+            stderr=(capability.reason or "git_unavailable").encode(),
+            capability=capability,
+        )
+    command = [str(capability.executable), *(str(argument) for argument in args)]
+    child_environment = (
+        _environment_with_resolved_git(effective_environment, capability.executable)
+        if allow_user_interaction
+        else _noninteractive_environment(effective_environment, capability.executable)
+    )
+    kwargs: dict[str, Any] = {
+        "cwd": str(Path(cwd).expanduser()) if cwd is not None else None,
+        "env": child_environment,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "check": False,
+        "timeout": timeout,
+    }
+    if input_bytes is None and not allow_user_interaction:
+        kwargs["stdin"] = subprocess.DEVNULL
+    elif input_bytes is not None:
+        kwargs["input"] = input_bytes
+    try:
+        completed = subprocess.run(command, **kwargs)
+    except subprocess.TimeoutExpired as exc:
+        return GitRunResult(
+            state=GitRunState.TIMED_OUT,
+            returncode=None,
+            stdout=_exception_bytes(exc.stdout),
+            stderr=_exception_bytes(exc.stderr),
+            capability=capability,
+        )
+    except (OSError, ValueError) as exc:
+        return GitRunResult(
+            state=GitRunState.FAILED,
+            returncode=None,
+            stdout=b"",
+            stderr=str(exc).encode("utf-8", errors="replace"),
+            capability=capability,
+        )
+    stdout = _exception_bytes(completed.stdout)
+    stderr = _exception_bytes(completed.stderr)
+    state = (
+        GitRunState.OK
+        if completed.returncode == 0
+        else _failed_run_state(stdout, stderr)
+    )
+    return GitRunResult(
+        state=state,
+        returncode=completed.returncode,
+        stdout=stdout,
+        stderr=stderr,
+        capability=capability,
+    )
+
+
+def probe_git_repository(
+    cwd: str | Path,
+    *,
+    timeout: float = 2.0,
+    environment: Mapping[str, str] | None = None,
+    run_mode: RunMode | str | None = None,
+) -> GitRunState:
+    """Return whether *cwd* is an accessible Git work tree."""
+
+    result = run_git(
+        ("rev-parse", "--is-inside-work-tree"),
+        cwd=cwd,
+        timeout=timeout,
+        environment=environment,
+        run_mode=run_mode,
+    )
+    if result.state is not GitRunState.OK:
+        return result.state
+    if result.stdout_text.strip().casefold() == "true":
+        return GitRunState.OK
+    return GitRunState.NOT_REPOSITORY
+
+
+__all__ = [
+    "GitCapability",
+    "GitCapabilityState",
+    "GitRunResult",
+    "GitRunState",
+    "clear_git_capability_cache",
+    "git_run_mode_scope",
+    "probe_git_repository",
+    "resolve_git_capability",
+    "run_git",
+]

--- a/src/opensquilla/identity/templates/system_prompt.j2
+++ b/src/opensquilla/identity/templates/system_prompt.j2
@@ -44,7 +44,9 @@ SOUL.md defines durable voice and persona guidance for this workspace. Treat it 
 - Do not use shell `sed`, redirection, or temporary scripts as the primary way to modify repository source.
 - Use `exec_command` mainly for tests, builds, repository commands, and shell-only inspection.
 - Keep changes minimal and focused on non-test source files unless the user explicitly asks otherwise.
+{% if "git_diff" in tools -%}
 - Inspect the final source diff with `git_diff` before finishing.
+{% endif -%}
 
 {% endif -%}
 
@@ -57,7 +59,12 @@ SOUL.md defines durable voice and persona guidance for this workspace. Treat it 
 - Use `apply_patch` for multi-hunk or multi-file edits when a patch is clearer than exact replacement.
 {% endif -%}
 - Use `exec_command` for tests, builds, and shell-only inspection; do not use shell redirection or ad hoc scripts as the primary way to edit repository source.
-- Use `git_status` and `git_diff` to inspect the final repository state before finishing.
+{% if "git_status" in tools -%}
+- Use `git_status` to inspect the final repository state before finishing.
+{% endif -%}
+{% if "git_diff" in tools -%}
+- Use `git_diff` to inspect the final source diff before finishing.
+{% endif -%}
 - Keep changes minimal and focused on source files relevant to the user task unless the user explicitly asks otherwise.
 
 {% endif -%}

--- a/src/opensquilla/skills/creator/runtime_e2e.py
+++ b/src/opensquilla/skills/creator/runtime_e2e.py
@@ -5,16 +5,26 @@ from __future__ import annotations
 import inspect
 import json
 import re
-import subprocess
 import tempfile
 from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from pathlib import Path
 from typing import Any, cast
 
+from opensquilla.git_runtime import (
+    GitRunResult,
+    GitRunState,
+    probe_git_repository,
+    run_git,
+)
+
 RuntimeResult = dict[str, Any] | Awaitable[dict[str, Any]]
 RuntimeRunner = Callable[..., RuntimeResult]
 RuntimeJudge = Callable[..., RuntimeResult]
+
+
+class _RuntimeWorkspaceGitError(RuntimeError):
+    """A structured Git setup failure that the runtime runner can report."""
 
 
 def _normalise_prompts(eval_prompts: object, skill_md: str) -> list[str]:
@@ -92,14 +102,27 @@ def _normalise_winner(value: object) -> str:
 
 
 def _is_git_repo(path: Path) -> bool:
-    proc = subprocess.run(
-        ["git", "rev-parse", "--is-inside-work-tree"],
-        cwd=path,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    return proc.returncode == 0 and proc.stdout.strip() == "true"
+    return probe_git_repository(path) is GitRunState.OK
+
+
+def _require_runtime_git(
+    args: tuple[str, ...],
+    *,
+    cwd: Path,
+    operation: str,
+) -> None:
+    result = run_git(args, cwd=cwd, timeout=10.0)
+    if result.ok:
+        return
+    raise _RuntimeWorkspaceGitError(_runtime_git_error(operation, result))
+
+
+def _runtime_git_error(operation: str, result: GitRunResult) -> str:
+    if result.state is GitRunState.UNAVAILABLE:
+        reason = result.capability.reason or "git_not_found"
+        return f"runtime E2E workspace requires Git, but it is unavailable ({reason})"
+    detail = result.stderr_text.strip() or result.stdout_text.strip() or result.state.value
+    return f"runtime E2E workspace Git {operation} failed ({detail[:500]})"
 
 
 def _prepare_runtime_workspace(root: Path, workspace_dir: str | None) -> Path:
@@ -110,32 +133,32 @@ def _prepare_runtime_workspace(root: Path, workspace_dir: str | None) -> Path:
 
     runtime_workspace = root / "runtime-workspace"
     runtime_workspace.mkdir(parents=True, exist_ok=True)
-    subprocess.run(
-        ["git", "init"],
+    _require_runtime_git(
+        ("init",),
         cwd=runtime_workspace,
-        capture_output=True,
-        text=True,
-        check=True,
+        operation="init",
     )
-    subprocess.run(
-        ["git", "config", "user.email", "runtime-e2e@example.test"],
+    _require_runtime_git(
+        ("config", "user.email", "runtime-e2e@example.test"),
         cwd=runtime_workspace,
-        check=True,
+        operation="config user.email",
     )
-    subprocess.run(
-        ["git", "config", "user.name", "Runtime E2E"],
+    _require_runtime_git(
+        ("config", "user.name", "Runtime E2E"),
         cwd=runtime_workspace,
-        check=True,
+        operation="config user.name",
     )
     sample = runtime_workspace / "README.md"
     sample.write_text("# Runtime E2E fixture\n\nbaseline\n", encoding="utf-8")
-    subprocess.run(["git", "add", "README.md"], cwd=runtime_workspace, check=True)
-    subprocess.run(
-        ["git", "commit", "-m", "baseline"],
+    _require_runtime_git(
+        ("add", "README.md"),
         cwd=runtime_workspace,
-        capture_output=True,
-        text=True,
-        check=True,
+        operation="add fixture",
+    )
+    _require_runtime_git(
+        ("commit", "-m", "baseline"),
+        cwd=runtime_workspace,
+        operation="commit fixture",
     )
     sample.write_text(
         "# Runtime E2E fixture\n\nbaseline\n\ncandidate change\n",
@@ -376,7 +399,15 @@ def make_runtime_e2e_context(
             skill_dir = candidate_root / skill_name
             skill_dir.mkdir(parents=True)
             (skill_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
-            runtime_workspace = _prepare_runtime_workspace(tmp_path, workspace_dir)
+            try:
+                runtime_workspace = _prepare_runtime_workspace(tmp_path, workspace_dir)
+            except _RuntimeWorkspaceGitError as exc:
+                return {
+                    "route": "meta",
+                    "text": "",
+                    "ok": False,
+                    "error": str(exc),
+                }
 
             from opensquilla.skills.loader import SkillLoader
 

--- a/src/opensquilla/skills/eligibility.py
+++ b/src/opensquilla/skills/eligibility.py
@@ -53,6 +53,18 @@ def _has_bin(name: str, ctx: EligibilityContext) -> bool:
     )
     result = False
     if safe_name:
+        if name.casefold() == "git":
+            try:
+                from opensquilla.git_runtime import resolve_git_capability
+
+                result = resolve_git_capability().available
+            except Exception:
+                # The system Git path may be an unusable platform shim. Treat
+                # capability-resolution failures as missing rather than
+                # advertising a skill that cannot run.
+                result = False
+            ctx.has_bin_cache[name] = result
+            return result
         # Keep the long-standing system lookup seam (and system PATH priority)
         # before consulting validated OpenSquilla activation receipts.
         result = shutil.which(name) is not None

--- a/src/opensquilla/skills/meta/executors/skill_exec.py
+++ b/src/opensquilla/skills/meta/executors/skill_exec.py
@@ -28,6 +28,7 @@ from typing import Any
 import jinja2
 import structlog
 
+from opensquilla.git_runtime import resolve_git_capability
 from opensquilla.process_tree import (
     capture_process_tree_owner,
     create_owned_subprocess_exec,
@@ -238,6 +239,31 @@ def _declared_ambient_env_keys(
         *(getattr(requires, "env_any", ()) or ()),
     )
     return frozenset(name for name in declared if isinstance(name, str) and name)
+
+
+def _skill_requires_git(skill_spec: Any) -> bool:
+    metadata = getattr(skill_spec, "metadata", None)
+    requires = getattr(metadata, "requires", None)
+    bins = getattr(requires, "bins", ()) or ()
+    return any(isinstance(name, str) and name.casefold() == "git" for name in bins)
+
+
+def _pin_safe_git_on_path(child_env: dict[str, str]) -> None:
+    """Make a resolved real Git win over the macOS developer-tools shim."""
+
+    capability = resolve_git_capability()
+    if not capability.available or capability.executable is None:
+        reason = capability.reason or "git_unavailable"
+        raise RuntimeError(f"GIT_UNAVAILABLE: Git is unavailable ({reason}).")
+    path_key = next((key for key in child_env if key.casefold() == "path"), "PATH")
+    existing = child_env.get(path_key, "")
+    safe_directory = str(capability.executable.parent)
+    remaining = [
+        value
+        for value in existing.split(os.pathsep)
+        if value and os.path.normcase(value) != os.path.normcase(safe_directory)
+    ]
+    child_env[path_key] = os.pathsep.join((safe_directory, *remaining))
 
 
 def _ambient_value(source: Mapping[str, str], name: str) -> str | None:
@@ -731,6 +757,11 @@ async def run_skill_exec_step(
         if key in allowed_trusted_keys and value:
             child_env[key] = value
             sensitive_values.add(value)
+    if _skill_requires_git(skill_spec):
+        # Eligibility and child execution must agree on the same executable.
+        # In particular, a later Homebrew Git accepted by the resolver must be
+        # placed ahead of an unusable /usr/bin/git shim in the child PATH.
+        _pin_safe_git_on_path(child_env)
     apply_utf8_child_env(child_env)
 
     # Optional stdin: render Jinja template and pipe to the subprocess.

--- a/src/opensquilla/tools/builtin/code_exec.py
+++ b/src/opensquilla/tools/builtin/code_exec.py
@@ -57,6 +57,7 @@ from opensquilla.tools.write_tracking import (
     mutation_ledger_text_hash,
     record_observed_workspace_mutations,
     snapshot_current_workspace_mutations,
+    workspace_write_deny_effect_preflight,
 )
 
 # Destructive Python patterns that must be surfaced to the unified sandbox gate.
@@ -1068,13 +1069,24 @@ async def execute_code(
         )
     )
     mutation_before = snapshot_current_workspace_mutations()
+    if not full_host:
+        protection_block = workspace_write_deny_effect_preflight(
+            tool_name="execute_code",
+            before=mutation_before,
+        )
+        if protection_block is not None:
+            return protection_block
 
-    def finish(output: str) -> str:
+    def finish(output: str, *, executed: bool = True) -> str:
+        if not executed:
+            return output
         record_observed_workspace_mutations(
             tool_name="execute_code",
             before=mutation_before,
             metadata={"code_hash": mutation_ledger_text_hash(code)},
         )
+        if full_host:
+            return output
         # Effect enforcement runs after the ledger so the raw escape stays
         # honestly recorded before any revert rewrites the workspace.
         return enforce_workspace_write_deny_effects(
@@ -1094,7 +1106,7 @@ async def execute_code(
             hints=hints,
         )
         if isinstance(decision, DenialResult):
-            return finish(json.dumps(decision.to_dict()))
+            return finish(json.dumps(decision.to_dict()), executed=False)
         if isinstance(decision, ApprovedHostExecution):
             host_execution = True
             sandbox_enabled = False
@@ -1108,7 +1120,10 @@ async def execute_code(
             )
             if retry_gate is not None:
                 if not retry_gate.allowed:
-                    return finish(json.dumps(retry_gate.to_envelope(), ensure_ascii=False))
+                    return finish(
+                        json.dumps(retry_gate.to_envelope(), ensure_ascii=False),
+                        executed=False,
+                    )
                 host_execution = True
                 sandbox_enabled = False
                 elevated_code_execution = True
@@ -1126,9 +1141,9 @@ async def execute_code(
                 if runtime is not None:
                     preflight = await preflight_subprocess_managed_network(backend_request, runtime)
                     if isinstance(preflight, DenialResult):
-                        return finish(json.dumps(preflight.to_dict()))
+                        return finish(json.dumps(preflight.to_dict()), executed=False)
                     if isinstance(preflight, dict):
-                        return finish(json.dumps(preflight))
+                        return finish(json.dumps(preflight), executed=False)
                 try:
                     sandbox_result = await _run_backend_with_managed_network_if_needed(
                         backend_request,
@@ -1153,8 +1168,14 @@ async def execute_code(
                     )
                     if escalation is not None:
                         if isinstance(escalation, DenialResult):
-                            return finish(json.dumps(escalation.to_dict(), ensure_ascii=False))
-                        return finish(json.dumps(escalation.to_envelope(), ensure_ascii=False))
+                            return finish(
+                                json.dumps(escalation.to_dict(), ensure_ascii=False),
+                                executed=False,
+                            )
+                        return finish(
+                            json.dumps(escalation.to_envelope(), ensure_ascii=False),
+                            executed=False,
+                        )
                     return finish(
                         _execution_result_json(
                             returncode=-1,
@@ -1162,7 +1183,8 @@ async def execute_code(
                             stderr=f"Execution error: {exc}",
                             timed_out=False,
                             elapsed_ms=0,
-                        )
+                        ),
+                        executed=False,
                     )
                 except Exception as exc:
                     return finish(
@@ -1172,7 +1194,8 @@ async def execute_code(
                             stderr=f"Execution error: {exc}",
                             timed_out=False,
                             elapsed_ms=0,
-                        )
+                        ),
+                        executed=False,
                     )
                 if is_likely_sandbox_denied(sandbox_result):
                     review_action = _code_elevation_action(
@@ -1206,6 +1229,7 @@ async def execute_code(
                     )
                 )
 
+    process_started = False
     try:
         proc = await create_owned_subprocess_exec(
             python_bin,
@@ -1216,6 +1240,7 @@ async def execute_code(
             cwd=str(workdir_path),
             env=safe_env,
         )
+        process_started = True
         process_tree = capture_process_tree_owner(proc, isolated=True)
         try:
             stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
@@ -1263,7 +1288,8 @@ async def execute_code(
                 stderr=f"Execution error: {exc}",
                 timed_out=False,
                 elapsed_ms=0,
-            )
+            ),
+            executed=process_started,
         )
     finally:
         if cleanup_dir:

--- a/src/opensquilla/tools/builtin/git.py
+++ b/src/opensquilla/tools/builtin/git.py
@@ -7,6 +7,7 @@ import os
 from dataclasses import replace
 from pathlib import Path
 
+from opensquilla.git_runtime import resolve_git_capability
 from opensquilla.process_tree import (
     capture_process_tree_owner,
     create_owned_subprocess_exec,
@@ -24,7 +25,7 @@ from opensquilla.sandbox.permissions import (
 from opensquilla.sandbox.policy import build_policy, select_level
 from opensquilla.tools.path_policy import reject_foreign_host_path
 from opensquilla.tools.registry import tool
-from opensquilla.tools.run_mode import full_host_access_active
+from opensquilla.tools.run_mode import current_run_mode, full_host_access_active
 from opensquilla.tools.types import current_tool_context
 from opensquilla.tools.write_tracking import summarize_patch_hygiene_warning
 
@@ -54,7 +55,21 @@ def _reject_foreign_git_path(path: str) -> None:
     reject_foreign_host_path(path, platform=os.name, workspace=workspace)
 
 
+def _git_tool_environment() -> dict[str, str]:
+    """Keep Git diagnostics parseable without disabling user interaction."""
+
+    environment = dict(os.environ)
+    environment["LC_ALL"] = "C"
+    environment["LANG"] = "C"
+    return environment
+
+
 async def _run_git(*args: str, cwd: str | None = None) -> str:
+    capability = resolve_git_capability(run_mode=current_run_mode())
+    if not capability.available or capability.executable is None:
+        reason = capability.reason or "git_unavailable"
+        raise RuntimeError(f"GIT_UNAVAILABLE: Git is unavailable ({reason}).")
+    git_executable = str(capability.executable)
     runtime = get_runtime()
     reject_windows_guest_process(runtime)
     if (
@@ -102,20 +117,30 @@ async def _run_git(*args: str, cwd: str | None = None) -> str:
                 )
                 request_args = _harden_read_only_git_args(args)
         result = await run_under_backend(
-            build_request_for_git(request_args, workspace, action_kind, policy),
+            build_request_for_git(
+                request_args,
+                workspace,
+                action_kind,
+                policy,
+                executable=git_executable,
+            ),
             runtime=runtime,
         )
         output = result.stdout + result.stderr
         if result.returncode != 0:
-            raise RuntimeError(f"git {' '.join(args)} failed (exit {result.returncode}):\n{output}")
+            _raise_git_command_error(args, result.returncode, output)
         return output
-    proc = await create_owned_subprocess_exec(
-        "git",
-        *args,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.STDOUT,
-        cwd=cwd,
-    )
+    try:
+        proc = await create_owned_subprocess_exec(
+            git_executable,
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            cwd=cwd,
+            env=_git_tool_environment(),
+        )
+    except OSError as exc:
+        raise RuntimeError("GIT_UNAVAILABLE: Git became unavailable before launch.") from exc
     process_tree = capture_process_tree_owner(proc, isolated=True)
     try:
         stdout, _ = await proc.communicate()
@@ -131,8 +156,27 @@ async def _run_git(*args: str, cwd: str | None = None) -> str:
 
     output = decode_subprocess_output(stdout)
     if proc.returncode != 0:
-        raise RuntimeError(f"git {' '.join(args)} failed (exit {proc.returncode}):\n{output}")
+        _raise_git_command_error(args, proc.returncode, output)
     return output
+
+
+def _raise_git_command_error(
+    args: tuple[str, ...],
+    returncode: int | None,
+    output: str,
+) -> None:
+    normalized = output.casefold()
+    code = (
+        "GIT_NOT_REPOSITORY"
+        if (
+            "not a git repository" in normalized
+            or "this operation must be run in a work tree" in normalized
+        )
+        else "GIT_COMMAND_FAILED"
+    )
+    raise RuntimeError(
+        f"{code}: git {' '.join(args)} failed (exit {returncode}):\n{output}"
+    )
 
 
 def _harden_read_only_git_args(args: tuple[str, ...]) -> tuple[str, ...]:
@@ -150,15 +194,22 @@ def _harden_read_only_git_args(args: tuple[str, ...]) -> tuple[str, ...]:
     return (*global_options, *args)
 
 
-def build_request_for_git(args: tuple[str, ...], cwd: Path, action_kind: str, policy):
+def build_request_for_git(
+    args: tuple[str, ...],
+    cwd: Path,
+    action_kind: str,
+    policy,
+    *,
+    executable: str = "git",
+):
     from opensquilla.sandbox.integration import build_request
 
     return build_request(
         action_kind=action_kind,
-        argv=("git", *args),
+        argv=(executable, *args),
         cwd=cwd,
         policy=policy,
-        env={},
+        env={"LC_ALL": "C", "LANG": "C"},
     )
 
 

--- a/src/opensquilla/tools/builtin/shell.py
+++ b/src/opensquilla/tools/builtin/shell.py
@@ -178,6 +178,7 @@ from opensquilla.tools.write_tracking import (
     record_observed_workspace_mutations,
     snapshot_current_workspace_mutations,
     summarize_patch_hygiene_warning,
+    workspace_write_deny_effect_preflight,
 )
 
 log = structlog.get_logger(__name__)
@@ -6292,6 +6293,7 @@ async def _run_windows_host_shell_command_with_stdin(
     env: dict[str, str],
     stdin_bytes: bytes,
     effective_timeout: float,
+    on_process_started: Callable[[], None] | None = None,
 ) -> str:
     try:
         with tempfile.TemporaryFile() as output_file:
@@ -6305,6 +6307,8 @@ async def _run_windows_host_shell_command_with_stdin(
                 env=env,
                 creationflags=creationflags,
             )
+            if on_process_started is not None:
+                on_process_started()
             process_tree = capture_process_tree_owner(proc, isolated=os.name == "nt")
             completed = await _communicate_windows_host_shell_process(
                 proc,
@@ -6349,6 +6353,7 @@ async def _run_host_shell_command(
     env: dict[str, str],
     stdin_bytes: bytes | None,
     effective_timeout: float,
+    on_process_started: Callable[[], None] | None = None,
 ) -> str:
     if _use_windows_blocking_exec_stdin() and stdin_bytes is not None:
         return await _run_windows_host_shell_command_with_stdin(
@@ -6357,6 +6362,7 @@ async def _run_host_shell_command(
             env=env,
             stdin_bytes=stdin_bytes,
             effective_timeout=effective_timeout,
+            on_process_started=on_process_started,
         )
     try:
         with tempfile.TemporaryFile() as output_file:
@@ -6383,6 +6389,8 @@ async def _run_host_shell_command(
                 return _exec_timeout_output(effective_timeout, command, output_file.read())
 
             proc = await _create_host_shell_subprocess(command, **subprocess_kwargs)
+            if on_process_started is not None:
+                on_process_started()
             process_tree = capture_process_tree_owner(proc, isolated=True)
             stdin_writer: asyncio.Task[None] | None = None
             remaining = deadline - loop.time()
@@ -6756,13 +6764,21 @@ async def exec_command(
     effective_timeout = _resolve_exec_timeout(timeout)
     stdin_bytes = stdin.encode("utf-8") if stdin is not None else None
     mutation_before = snapshot_current_workspace_mutations()
+    protection_block = workspace_write_deny_effect_preflight(
+        tool_name="exec_command",
+        before=mutation_before,
+    )
+    if protection_block is not None:
+        return protection_block
     source_mutation_signal = (
         _shell_source_mutation_signal(command, cwd)
         if _shell_source_mutation_telemetry_enabled()
         else None
     )
 
-    def finish(output: str) -> str:
+    def finish(output: str, *, executed: bool = True) -> str:
+        if not executed:
+            return output
         metadata: dict[str, Any] = {"command_hash": mutation_ledger_text_hash(command)}
         if source_mutation_signal is not None:
             metadata.update(source_mutation_signal)
@@ -6786,7 +6802,7 @@ async def exec_command(
 
     runtime_unavailable = _strict_runtime_unavailable_envelope(command, merged_env)
     if runtime_unavailable is not None:
-        return finish(json.dumps(runtime_unavailable, ensure_ascii=False))
+        return finish(json.dumps(runtime_unavailable, ensure_ascii=False), executed=False)
 
     if runtime is not None and runtime.effective.sandbox_enabled and not host_execution:
         if windows_process_sandbox:
@@ -6802,7 +6818,7 @@ async def exec_command(
             ),
         )
         if isinstance(decision, DenialResult):
-            return finish(json.dumps(decision.to_dict()))
+            return finish(json.dumps(decision.to_dict()), executed=False)
         if isinstance(decision, ApprovedHostExecution):
             host_execution = True
             backend_retry_granted = True
@@ -6815,7 +6831,10 @@ async def exec_command(
             )
             if retry_gate is not None:
                 if not retry_gate.allowed:
-                    return finish(json.dumps(retry_gate.to_envelope(), ensure_ascii=False))
+                    return finish(
+                        json.dumps(retry_gate.to_envelope(), ensure_ascii=False),
+                        executed=False,
+                    )
                 host_execution = True
                 backend_retry_granted = True
             else:
@@ -6839,9 +6858,9 @@ async def exec_command(
                 )
                 preflight = await preflight_subprocess_managed_network(backend_request, runtime)
                 if isinstance(preflight, DenialResult):
-                    return finish(json.dumps(preflight.to_dict()))
+                    return finish(json.dumps(preflight.to_dict()), executed=False)
                 if isinstance(preflight, dict):
-                    return finish(json.dumps(preflight))
+                    return finish(json.dumps(preflight), executed=False)
                 try:
                     sandbox_result = await _run_backend_with_managed_network(
                         backend_request,
@@ -6870,8 +6889,14 @@ async def exec_command(
                     )
                     if escalation is not None:
                         if isinstance(escalation, DenialResult):
-                            return finish(json.dumps(escalation.to_dict(), ensure_ascii=False))
-                        return finish(json.dumps(escalation.to_envelope(), ensure_ascii=False))
+                            return finish(
+                                json.dumps(escalation.to_dict(), ensure_ascii=False),
+                                executed=False,
+                            )
+                        return finish(
+                            json.dumps(escalation.to_envelope(), ensure_ascii=False),
+                            executed=False,
+                        )
                     raise
                 except Exception as exc:
                     raise ToolError(f"Sandboxed shell execution failed: {exc}") from exc
@@ -6919,16 +6944,23 @@ async def exec_command(
         )
         merged_env = _host_shell_env(merged_env)
 
+    host_process_started = False
+
+    def mark_host_process_started() -> None:
+        nonlocal host_process_started
+        host_process_started = True
+
     host_output = await _run_host_shell_command(
         command,
         cwd=cwd,
         env=merged_env,
         stdin_bytes=stdin_bytes,
         effective_timeout=effective_timeout,
+        on_process_started=mark_host_process_started,
     )
     exit_code_match = re.match(r"exit_code=(-?\d+)\n", host_output)
     if exit_code_match is None:
-        return finish(host_output)
+        return finish(host_output, executed=host_process_started)
     returncode = int(exit_code_match.group(1))
     output = host_output[exit_code_match.end() :]
     output = _append_patch_hygiene_warning(command, cwd, output)

--- a/src/opensquilla/tools/candidate_patch_checkpoint.py
+++ b/src/opensquilla/tools/candidate_patch_checkpoint.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import hashlib
-import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
+
+from opensquilla.git_runtime import GitRunResult, GitRunState, run_git
 
 
 @dataclass(frozen=True)
@@ -28,6 +29,7 @@ class CandidatePatchCheckpoint:
     created_at: float
     head: str | None
     files: dict[str, CandidatePatchFileSnapshot]
+    git_state: GitRunState = GitRunState.OK
 
     @property
     def changed_paths(self) -> list[str]:
@@ -46,13 +48,15 @@ def create_candidate_patch_checkpoint(
     """
 
     root = Path(workspace).expanduser().resolve()
-    paths = _git_dirty_paths(root)
+    git_state, statuses = _git_dirty_statuses(root)
+    paths = sorted(statuses)
     return CandidatePatchCheckpoint(
         workspace=root,
         label=label,
         created_at=time.time(),
-        head=_git_head(root),
+        head=_git_head(root) if git_state is GitRunState.OK else None,
         files={path: _snapshot_path(root, path) for path in paths},
+        git_state=git_state,
     )
 
 
@@ -60,26 +64,71 @@ def restore_candidate_patch_checkpoint(checkpoint: CandidatePatchCheckpoint) -> 
     """Restore the workspace to the checkpoint's dirty-file state."""
 
     root = checkpoint.workspace.expanduser().resolve()
-    current_paths = set(_git_dirty_paths(root))
+    if checkpoint.git_state is not GitRunState.OK:
+        return _checkpoint_restore_skipped(checkpoint, checkpoint.git_state)
+    current_git_state, current_statuses = _git_dirty_statuses(root)
+    if current_git_state is not GitRunState.OK:
+        return _checkpoint_restore_skipped(checkpoint, current_git_state)
+    current_paths = set(current_statuses)
     checkpoint_paths = set(checkpoint.files)
     touched_paths = sorted(current_paths | checkpoint_paths)
-    restored: list[str] = []
-    removed: list[str] = []
+    restore_plan: list[tuple[str, bytes | None, bool]] = []
 
+    # Resolve every Git-dependent restore input before changing files. If Git
+    # becomes unavailable, the checkpoint remains untouched and the caller gets
+    # an explicit skipped result rather than a misleading partial "restored".
     for relative_path in touched_paths:
         snapshot = checkpoint.files.get(relative_path)
         if snapshot is not None:
-            target = root / relative_path
-            if snapshot.exists and snapshot.content is not None:
-                target.parent.mkdir(parents=True, exist_ok=True)
-                target.write_bytes(snapshot.content)
-                restored.append(relative_path)
-            else:
-                _remove_file_if_present(target)
-                removed.append(relative_path)
+            restore_plan.append(
+                (
+                    relative_path,
+                    snapshot.content if snapshot.exists else None,
+                    False,
+                )
+            )
             continue
+        if current_statuses.get(relative_path, "").startswith("??"):
+            restore_plan.append((relative_path, None, False))
+            continue
+        head_state, present_at_head = _git_path_present_at_head(root, relative_path)
+        if head_state is not GitRunState.OK:
+            return _checkpoint_restore_skipped(checkpoint, head_state)
+        if not present_at_head:
+            # A staged-new path is authoritatively absent from HEAD. Removing
+            # the candidate file preserves the checkpoint's pre-candidate
+            # absence without conflating that verdict with a Git failure.
+            restore_plan.append(
+                (
+                    relative_path,
+                    None,
+                    "A" in current_statuses.get(relative_path, ""),
+                )
+            )
+            continue
+        head_result = _git_show_head_path_result(root, relative_path)
+        if not head_result.ok:
+            return _checkpoint_restore_skipped(checkpoint, head_result.state)
+        restore_plan.append((relative_path, head_result.stdout, False))
 
-        head_content = _git_show_head_path(root, relative_path)
+    staged_new_paths = [
+        relative_path
+        for relative_path, _head_content, unstage_new in restore_plan
+        if unstage_new
+    ]
+    if staged_new_paths:
+        unstage_result = run_git(
+            ("rm", "--cached", "-f", "--", *staged_new_paths),
+            cwd=root,
+            timeout=2.0,
+        )
+        if not unstage_result.ok:
+            return _checkpoint_restore_skipped(checkpoint, unstage_result.state)
+
+    restored: list[str] = []
+    removed: list[str] = []
+
+    for relative_path, head_content, _unstage_new in restore_plan:
         target = root / relative_path
         if head_content is None:
             _remove_file_if_present(target)
@@ -91,10 +140,26 @@ def restore_candidate_patch_checkpoint(checkpoint: CandidatePatchCheckpoint) -> 
 
     return {
         "status": "restored",
+        "git_state": GitRunState.OK.value,
         "label": checkpoint.label,
         "path_count": len(touched_paths),
         "restored_paths": restored,
         "removed_paths": removed,
+    }
+
+
+def _checkpoint_restore_skipped(
+    checkpoint: CandidatePatchCheckpoint,
+    state: GitRunState,
+) -> dict[str, object]:
+    return {
+        "status": "skipped",
+        "reason": "git_observation_unavailable",
+        "git_state": state.value,
+        "label": checkpoint.label,
+        "path_count": None,
+        "restored_paths": [],
+        "removed_paths": [],
     }
 
 
@@ -116,24 +181,31 @@ def _snapshot_path(root: Path, relative_path: str) -> CandidatePatchFileSnapshot
     )
 
 
+def _git_dirty_statuses(root: Path) -> tuple[GitRunState, dict[str, str]]:
+    completed = run_git(
+        ("status", "--porcelain=v1", "-z", "--untracked-files=all"),
+        cwd=root,
+        timeout=2.0,
+    )
+    if not completed.ok:
+        return completed.state, {}
+    return (
+        GitRunState.OK,
+        _parse_git_status_map_z(completed.stdout.decode("utf-8", errors="replace")),
+    )
+
+
 def _git_dirty_paths(root: Path) -> list[str]:
-    try:
-        completed = subprocess.run(
-            ["git", "status", "--porcelain=v1", "-z", "--untracked-files=all"],
-            cwd=root,
-            check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-        )
-    except OSError:
-        return []
-    if completed.returncode != 0:
-        return []
-    return _parse_git_status_z(completed.stdout.decode("utf-8", errors="replace"))
+    _state, statuses = _git_dirty_statuses(root)
+    return sorted(statuses)
 
 
 def _parse_git_status_z(output: str) -> list[str]:
-    paths: list[str] = []
+    return sorted(_parse_git_status_map_z(output))
+
+
+def _parse_git_status_map_z(output: str) -> dict[str, str]:
+    paths: dict[str, str] = {}
     entries = output.split("\0")
     index = 0
     while index < len(entries):
@@ -147,35 +219,44 @@ def _parse_git_status_z(output: str) -> list[str]:
             relative_path = entries[index] or relative_path
             index += 1
         if relative_path:
-            paths.append(relative_path.replace("\\", "/"))
-    return sorted(set(paths))
+            paths[relative_path.replace("\\", "/")] = status
+    return paths
 
 
 def _git_head(root: Path) -> str | None:
-    completed = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        cwd=root,
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        text=True,
-    )
-    if completed.returncode != 0:
+    completed = run_git(("rev-parse", "HEAD"), cwd=root, timeout=2.0)
+    if not completed.ok:
         return None
-    return completed.stdout.strip() or None
+    return completed.stdout_text.strip() or None
 
 
 def _git_show_head_path(root: Path, relative_path: str) -> bytes | None:
-    completed = subprocess.run(
-        ["git", "show", "--end-of-options", f"HEAD:{relative_path}"],
-        cwd=root,
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-    )
-    if completed.returncode != 0:
+    completed = _git_show_head_path_result(root, relative_path)
+    if not completed.ok:
         return None
     return completed.stdout
+
+
+def _git_show_head_path_result(root: Path, relative_path: str) -> GitRunResult:
+    return run_git(
+        ("show", "--end-of-options", f"HEAD:{relative_path}"),
+        cwd=root,
+        timeout=2.0,
+    )
+
+
+def _git_path_present_at_head(
+    root: Path,
+    relative_path: str,
+) -> tuple[GitRunState, bool]:
+    result = run_git(
+        ("ls-tree", "--name-only", "HEAD", "--", relative_path),
+        cwd=root,
+        timeout=2.0,
+    )
+    if not result.ok:
+        return result.state, False
+    return GitRunState.OK, bool(result.stdout.strip())
 
 
 def _remove_file_if_present(path: Path) -> None:

--- a/src/opensquilla/tools/policy_runtime.py
+++ b/src/opensquilla/tools/policy_runtime.py
@@ -20,6 +20,9 @@ _CHANNEL_RUNTIME_TOOL_NAMES: frozenset[str] = frozenset({"message"})
 _ADMIN_RUNTIME_TOOL_NAMES: frozenset[str] = frozenset({"agents_list", "subagents"})
 _GATEWAY_RUNTIME_TOOL_NAMES: frozenset[str] = frozenset({"gateway"})
 _SCHEDULER_RUNTIME_TOOL_NAMES: frozenset[str] = frozenset({"cron"})
+_GIT_RUNTIME_TOOL_NAMES: frozenset[str] = frozenset(
+    {"git_status", "git_diff", "git_log", "git_commit"}
+)
 
 
 @dataclass(frozen=True)
@@ -32,6 +35,9 @@ class ToolSurfaceCapabilities:
     gateway_config: bool = False
     channel_backing: bool = False
     image_generation: bool = True
+    # Default True preserves compatibility for callers that construct a
+    # capability snapshot explicitly rather than using the live detector.
+    git_available: bool = True
 
 
 def private_memory_read_tools_blocked(ctx: ToolContext | None) -> bool:
@@ -71,6 +77,19 @@ def _detect_image_generation_capability() -> bool:
         return False
 
 
+def _detect_git_capability() -> bool:
+    """Return whether background Git can be launched without platform prompts."""
+
+    try:
+        from opensquilla.git_runtime import resolve_git_capability
+
+        return resolve_git_capability().available
+    except Exception:
+        # Git is optional. Capability-resolution failures must fail closed so
+        # the macOS developer-tools shim is never advertised as usable.
+        return False
+
+
 def tool_surface_capabilities_from_runtime(
     *,
     session_manager: object | None = None,
@@ -80,6 +99,7 @@ def tool_surface_capabilities_from_runtime(
     channel_manager: object | None = None,
     originating_envelope: object | None = None,
     image_generation: bool | None = None,
+    git_available: bool | None = None,
 ) -> ToolSurfaceCapabilities:
     """Build tool-surface capabilities from injected runtime dependencies."""
 
@@ -93,6 +113,9 @@ def tool_surface_capabilities_from_runtime(
             _detect_image_generation_capability()
             if image_generation is None
             else image_generation
+        ),
+        git_available=(
+            _detect_git_capability() if git_available is None else git_available
         ),
     )
 
@@ -127,6 +150,8 @@ def resolve_runtime_tool_surface(
         denied_tools |= set(_SCHEDULER_RUNTIME_TOOL_NAMES)
     if not caps.gateway_config:
         denied_tools |= set(_GATEWAY_RUNTIME_TOOL_NAMES)
+    if not caps.git_available:
+        denied_tools |= set(_GIT_RUNTIME_TOOL_NAMES)
 
     if ctx.interaction_mode is InteractionMode.UNATTENDED:
         if not caps.channel_backing:
@@ -179,4 +204,5 @@ def detect_runtime_tool_surface_capabilities(
         gateway_config=gateway_config,
         channel_backing=channel_backing,
         image_generation=_detect_image_generation_capability(),
+        git_available=_detect_git_capability(),
     )

--- a/src/opensquilla/tools/run_mode.py
+++ b/src/opensquilla/tools/run_mode.py
@@ -86,41 +86,74 @@ def full_host_access_for_context(ctx: object | None) -> bool:
     )
 
 
+def _declared_run_mode_for_context(ctx: object | None) -> tuple[RunMode | None, bool]:
+    """Resolve context/session declarations without consulting runtime fallback.
+
+    The boolean reports whether the canonical value may be cached on the tool
+    context, preserving ``current_run_mode``'s existing mutation behavior.
+    """
+
+    if ctx is None:
+        return None, False
+    if bool(getattr(ctx, "guest_safe", False)):
+        return RunMode.SAFE, True
+    raw_mode = getattr(ctx, "run_mode", None)
+    if raw_mode is not None:
+        with contextlib.suppress(ValueError):
+            return normalize_run_mode(raw_mode), True
+    run_context_mode = getattr(getattr(ctx, "sandbox_run_context", None), "run_mode", None)
+    run_context_mode_value = getattr(run_context_mode, "value", run_context_mode)
+    if run_context_mode_value is not None:
+        with contextlib.suppress(ValueError):
+            return normalize_run_mode(run_context_mode_value), True
+    session_key = getattr(ctx, "session_key", None)
+    if session_key:
+        with contextlib.suppress(Exception):
+            from opensquilla.gateway.approval_queue import get_approval_queue
+
+            queued_mode = get_approval_queue().get_run_mode(session_key)
+            if queued_mode in _VALID_RUN_MODES:
+                return normalize_run_mode(queued_mode), True
+    elevated = getattr(ctx, "elevated", None)
+    if elevated == "full":
+        return RunMode.FULL, False
+    if elevated in ("on", "bypass"):
+        return RunMode.SAFE, False
+    return None, False
+
+
+def effective_run_mode_for_context(ctx: object | None) -> RunMode:
+    """Return the effective Safe/Full mode for work outside tool dispatch.
+
+    This combines persisted/context declarations with the configured sandbox
+    fallback, matching the mode used by actual process execution.
+    """
+
+    declared_mode, cache_on_context = _declared_run_mode_for_context(ctx)
+    if declared_mode is not None and cache_on_context and ctx is not None:
+        # Match current_run_mode(): session and persisted declarations must be
+        # visible to full_host_access_for_context before it considers the
+        # runtime's default mode.  Otherwise a legacy session explicitly
+        # authorized for Safe can inherit a process-wide Full default here.
+        setattr(ctx, "run_mode", declared_mode.value)
+    if declared_mode is RunMode.FULL or full_host_access_for_context(ctx):
+        return RunMode.FULL
+    return declared_mode or RunMode.SAFE
+
+
 def current_run_mode() -> str | None:
     """Return the active canonical Safe/Full mode for this tool call."""
 
     ctx = current_tool_context.get()
     if ctx is None:
         return None
-    if bool(getattr(ctx, "guest_safe", False)):
-        ctx.run_mode = RunMode.SAFE.value
-        return RunMode.SAFE.value
-    if ctx.run_mode is not None:
-        with contextlib.suppress(ValueError):
-            mode = cast(str, normalize_run_mode(ctx.run_mode).value)
-            ctx.run_mode = mode
-            return mode
-    run_context_mode = getattr(getattr(ctx, "sandbox_run_context", None), "run_mode", None)
-    run_context_mode_value = getattr(run_context_mode, "value", run_context_mode)
-    if run_context_mode_value is not None:
-        with contextlib.suppress(ValueError):
-            mode = cast(str, normalize_run_mode(run_context_mode_value).value)
-            ctx.run_mode = mode
-            return mode
-    if ctx.session_key:
-        with contextlib.suppress(Exception):
-            from opensquilla.gateway.approval_queue import get_approval_queue
-
-            queued_mode = get_approval_queue().get_run_mode(ctx.session_key)
-            if queued_mode in _VALID_RUN_MODES:
-                mode = cast(str, normalize_run_mode(queued_mode).value)
-                ctx.run_mode = mode
-                return mode
-    if ctx.elevated == "full":
-        return "full"
-    if ctx.elevated in ("on", "bypass"):
-        return "safe"
-    return None
+    mode, cache_on_context = _declared_run_mode_for_context(ctx)
+    if mode is None:
+        return None
+    value = cast(str, mode.value)
+    if cache_on_context:
+        ctx.run_mode = value
+    return value
 
 
 def full_host_access_active() -> bool:
@@ -139,6 +172,7 @@ def trusted_sandbox_active() -> bool:
 
 __all__ = [
     "current_run_mode",
+    "effective_run_mode_for_context",
     "full_host_access_active",
     "full_host_access_for_context",
     "sandbox_disabled_full_host_fallback",

--- a/src/opensquilla/tools/source_diff_candidates.py
+++ b/src/opensquilla/tools/source_diff_candidates.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import hashlib
-import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from opensquilla.git_runtime import run_git
 from opensquilla.tools.types import ToolContext
 
 MAX_CANDIDATES = 8
@@ -196,19 +196,14 @@ def _workspace_path(ctx: ToolContext) -> Path | None:
 
 
 def _git_diff_for_path(workspace: Path, relative_path: str) -> str | None:
-    try:
-        result = subprocess.run(
-            ["git", "diff", "--", relative_path],
-            cwd=workspace,
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-    except Exception:
+    result = run_git(
+        ("diff", "--", relative_path),
+        cwd=workspace,
+        timeout=5.0,
+    )
+    if not result.ok:
         return None
-    if result.returncode != 0:
-        return None
-    return result.stdout
+    return result.stdout_text
 
 
 def _normalize_relative_path(path: str) -> str:

--- a/src/opensquilla/tools/source_diff_preservation.py
+++ b/src/opensquilla/tools/source_diff_preservation.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import json
 import shlex
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+from opensquilla.git_runtime import run_git
 from opensquilla.tools.patch_classification import is_instrumentation_only_patch
 from opensquilla.tools.types import ToolContext, current_tool_context
 from opensquilla.tools.write_tracking import (
@@ -452,19 +452,10 @@ def _freeze_exemption_diff(
     argv = ["git", "diff", "HEAD"]
     if parsed.targets and not parsed.whole_worktree:
         argv.extend(["--", *parsed.targets])
-    try:
-        result = subprocess.run(
-            argv,
-            cwd=workspace,
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-    except (OSError, subprocess.SubprocessError):
+    result = run_git(argv[1:], cwd=workspace, timeout=5.0)
+    if not result.ok:
         return None
-    if result.returncode != 0:
-        return None
-    return result.stdout
+    return result.stdout_text
 
 
 def _emit_freeze_exemption_event(

--- a/src/opensquilla/tools/write_policy.py
+++ b/src/opensquilla/tools/write_policy.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import os
 import re
-import subprocess
 from dataclasses import dataclass
 from fnmatch import fnmatchcase
 from pathlib import Path
 
+from opensquilla.git_runtime import GitRunState, run_git
 from opensquilla.tools.types import SafeToolError, ToolContext, current_tool_context
 
 # Env levers in the workspace-write-deny family. Values are read at dispatch
@@ -252,28 +252,27 @@ def _workspace_path_is_git_tracked(
         return True
     if not relative or relative == ".":
         return True
-    try:
-        if as_directory:
-            completed = subprocess.run(
-                ["git", "ls-files", "--", f"{relative}/"],
-                cwd=str(workspace),
-                capture_output=True,
-                text=True,
-                timeout=2,
-            )
-            if completed.returncode != 0:
-                return True
-            return bool(completed.stdout.strip())
-        completed = subprocess.run(
-            ["git", "ls-files", "--error-unmatch", "--", relative],
-            cwd=str(workspace),
-            capture_output=True,
-            text=True,
-            timeout=2,
+    if as_directory:
+        completed = run_git(
+            ("ls-files", "--", f"{relative}/"),
+            cwd=workspace,
+            timeout=2.0,
         )
-    except (OSError, subprocess.SubprocessError):
+        if not completed.ok:
+            return True
+        return bool(completed.stdout.strip())
+    completed = run_git(
+        ("ls-files", "--error-unmatch", "--", relative),
+        cwd=workspace,
+        timeout=2.0,
+    )
+    if completed.state in {
+        GitRunState.UNAVAILABLE,
+        GitRunState.NOT_REPOSITORY,
+        GitRunState.TIMED_OUT,
+    }:
         return True
-    if completed.returncode == 0:
+    if completed.ok:
         return True
     # --error-unmatch exits 1 for a valid repo with no matching tracked file;
     # any other status (e.g. 128 outside a repo) is a lookup failure.

--- a/src/opensquilla/tools/write_tracking.py
+++ b/src/opensquilla/tools/write_tracking.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import re
@@ -427,7 +428,8 @@ def _workspace_write_protection_unavailable_warning(
     ctx.workspace_mutation_records.append(record)
     callback = getattr(ctx, "on_runtime_event", None)
     if callback is not None:
-        try:
+        # Runtime telemetry is best-effort and must not alter the tool result.
+        with contextlib.suppress(Exception):
             callback(
                 {
                     "feature": "workspace_write_deny",
@@ -438,8 +440,6 @@ def _workspace_write_protection_unavailable_warning(
                     "injected_to_model": True,
                 }
             )
-        except Exception:
-            pass
     message = (
         "[workspace write protection unavailable] OpenSquilla could not verify "
         f"write-protected workspace paths after {tool_name} because Git state is "

--- a/src/opensquilla/tools/write_tracking.py
+++ b/src/opensquilla/tools/write_tracking.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import re
-import subprocess
 from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Any
 
+from opensquilla.git_runtime import GitRunState, probe_git_repository, run_git
 from opensquilla.tools import write_policy
 from opensquilla.tools.types import RetryableToolInputError, current_tool_context
 
@@ -70,6 +71,38 @@ _SCRATCH_ONLY_NUDGE_COUNTS = frozenset({3, 6, 10})
 _WORKSPACE_WRITE_PROGRESS_COUNTS = frozenset({1, 3, 6, 10})
 
 
+class WorkspaceMutationSnapshot(dict[str, str]):
+    """Git-backed workspace status plus whether that status is authoritative.
+
+    This remains a ``dict`` subclass so existing embedded callers and tests that
+    compare snapshots with dictionaries keep working.  ``git_state`` prevents
+    an unavailable Git runtime or a non-repository workspace from being
+    mistaken for an authoritatively clean workspace.
+    """
+
+    def __init__(
+        self,
+        entries: dict[str, str] | None = None,
+        *,
+        git_state: GitRunState = GitRunState.OK,
+        observed: bool = True,
+        skip_reason: str | None = None,
+    ) -> None:
+        super().__init__(entries or {})
+        self.git_state = git_state
+        self.observed = observed
+        self.skip_reason = skip_reason
+
+    @property
+    def authoritative(self) -> bool:
+        return self.observed and self.git_state is GitRunState.OK
+
+
+def _snapshot_git_state(snapshot: dict[str, str]) -> GitRunState:
+    state = getattr(snapshot, "git_state", GitRunState.OK)
+    return state if isinstance(state, GitRunState) else GitRunState.FAILED
+
+
 def _normalize_relative_path(path: str) -> str:
     normalized = path.replace("\\", "/")
     while normalized.startswith("./"):
@@ -107,33 +140,42 @@ def mutation_ledger_text_hash(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()
 
 
-def snapshot_current_workspace_mutations() -> dict[str, str]:
+def snapshot_current_workspace_mutations() -> WorkspaceMutationSnapshot:
     ctx = current_tool_context.get()
     if ctx is None or not ctx.workspace_dir:
-        return {}
+        return WorkspaceMutationSnapshot(
+            git_state=GitRunState.NOT_REPOSITORY,
+            observed=False,
+            skip_reason="missing_workspace",
+        )
+    from opensquilla.tools.run_mode import full_host_access_active
+
+    effect_observation_needed = bool(
+        not full_host_access_active()
+        and write_policy.workspace_write_deny_effect_mode() in {"warn", "revert"}
+        and getattr(ctx, "workspace_write_deny_globs", None)
+    )
+    if ctx.on_runtime_event is None and not effect_observation_needed:
+        return WorkspaceMutationSnapshot(
+            git_state=GitRunState.FAILED,
+            observed=False,
+            skip_reason="no_consumer",
+        )
     return snapshot_workspace_mutations(Path(ctx.workspace_dir).expanduser().resolve())
 
 
-def snapshot_workspace_mutations(workspace: Path) -> dict[str, str]:
-    try:
-        completed = subprocess.run(
-            [
-                "git",
-                "status",
-                "--porcelain=v1",
-                "-z",
-                "--untracked-files=all",
-            ],
-            cwd=workspace,
-            check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-        )
-    except OSError:
-        return {}
-    if completed.returncode != 0:
-        return {}
-    return _parse_git_status_z(completed.stdout.decode("utf-8", errors="replace"))
+def snapshot_workspace_mutations(workspace: Path) -> WorkspaceMutationSnapshot:
+    result = run_git(
+        ("status", "--porcelain=v1", "-z", "--untracked-files=all"),
+        cwd=workspace,
+        timeout=2.0,
+    )
+    if not result.ok:
+        return WorkspaceMutationSnapshot(git_state=result.state)
+    return WorkspaceMutationSnapshot(
+        _parse_git_status_z(result.stdout.decode("utf-8", errors="replace")),
+        git_state=GitRunState.OK,
+    )
 
 
 def record_observed_workspace_mutations(
@@ -182,6 +224,10 @@ def diff_workspace_mutations(
     before: dict[str, str],
     after: dict[str, str],
 ) -> list[dict[str, str]]:
+    if _snapshot_git_state(before) is not GitRunState.OK:
+        return []
+    if _snapshot_git_state(after) is not GitRunState.OK:
+        return []
     paths: list[dict[str, str]] = []
     for relative_path in sorted(set(before) | set(after)):
         before_status = before.get(relative_path)
@@ -196,6 +242,43 @@ def diff_workspace_mutations(
             }
         )
     return paths
+
+
+def workspace_write_deny_effect_preflight(
+    *,
+    tool_name: str,
+    before: WorkspaceMutationSnapshot,
+) -> str | None:
+    """Fail closed before a revert-mode command when Git protection is unavailable."""
+
+    if write_policy.workspace_write_deny_effect_mode() != "revert":
+        return None
+    ctx = current_tool_context.get()
+    if (
+        ctx is None
+        or not ctx.workspace_dir
+        or not getattr(ctx, "workspace_write_deny_globs", None)
+    ):
+        return None
+    state = _snapshot_git_state(before)
+    if state is GitRunState.OK:
+        return None
+    return json.dumps(
+        {
+            "status": "blocked",
+            "code": "WORKSPACE_WRITE_PROTECTION_UNAVAILABLE",
+            "reason": "workspace_write_protection_unavailable",
+            "tool": tool_name,
+            "tool_name": tool_name,
+            "git_state": state.value,
+            "retryable": False,
+            "message": (
+                "OpenSquilla cannot safely run this command because Git-backed "
+                "workspace write protection is unavailable."
+            ),
+        },
+        ensure_ascii=False,
+    )
 
 
 def enforce_workspace_write_deny_effects(
@@ -225,6 +308,15 @@ def enforce_workspace_write_deny_effects(
         return output
     workspace = Path(ctx.workspace_dir).expanduser().resolve()
     after = snapshot_workspace_mutations(workspace)
+    before_state = _snapshot_git_state(before)
+    after_state = _snapshot_git_state(after)
+    if before_state is not GitRunState.OK or after_state is not GitRunState.OK:
+        return _workspace_write_protection_unavailable_warning(
+            tool_name=tool_name,
+            mode=mode,
+            state=(before_state if before_state is not GitRunState.OK else after_state),
+            output=output,
+        )
     tracked_only = write_policy.workspace_write_deny_tracked_only()
     violations: list[dict[str, str]] = []
     for entry in diff_workspace_mutations(before, after):
@@ -299,6 +391,67 @@ def enforce_workspace_write_deny_effects(
     return f"{message}\n\n{output}"
 
 
+def _workspace_write_protection_unavailable_warning(
+    *,
+    tool_name: str,
+    mode: str,
+    state: GitRunState,
+    output: str,
+) -> str:
+    """Inject at most one protection warning per logical turn."""
+
+    ctx = current_tool_context.get()
+    if ctx is None:
+        return output
+    turn_key = (
+        getattr(ctx, "execution_id", None)
+        or getattr(ctx, "task_id", None)
+        or f"session-epoch:{getattr(ctx, 'session_epoch', None)}"
+    )
+    already_warned = any(
+        record.get("operation") == "effect_enforcement_unavailable"
+        and record.get("turn_key") == turn_key
+        for record in getattr(ctx, "workspace_mutation_records", [])
+        if isinstance(record, dict)
+    )
+    if already_warned:
+        return output
+    record: dict[str, Any] = {
+        "tool": tool_name,
+        "tool_name": tool_name,
+        "operation": "effect_enforcement_unavailable",
+        "mode": mode,
+        "git_state": state.value,
+        "turn_key": turn_key,
+    }
+    ctx.workspace_mutation_records.append(record)
+    callback = getattr(ctx, "on_runtime_event", None)
+    if callback is not None:
+        try:
+            callback(
+                {
+                    "feature": "workspace_write_deny",
+                    "name": "effect_enforcement_unavailable",
+                    **record,
+                    "agent_id": getattr(ctx, "agent_id", None),
+                    "session_key": getattr(ctx, "session_key", None),
+                    "injected_to_model": True,
+                }
+            )
+        except Exception:
+            pass
+    message = (
+        "[workspace write protection unavailable] OpenSquilla could not verify "
+        f"write-protected workspace paths after {tool_name} because Git state is "
+        f"{state.value}."
+    )
+    if mode == "revert":
+        message += " Automatic restoration could not be guaranteed."
+    else:
+        message += " Review the command's workspace changes before finishing."
+    return f"{message}\n\n{output}"
+
+
 def _effect_enforcement_message(
     *,
     tool_name: str,
@@ -340,16 +493,12 @@ def _workspace_path_present_at_head(workspace: Path, relative_path: str) -> bool
     agent created.
     """
 
-    try:
-        completed = subprocess.run(
-            ["git", "ls-tree", "--name-only", "HEAD", "--", relative_path],
-            cwd=workspace,
-            capture_output=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return False
-    return completed.returncode == 0 and bool(completed.stdout.strip())
+    result = run_git(
+        ("ls-tree", "--name-only", "HEAD", "--", relative_path),
+        cwd=workspace,
+        timeout=10.0,
+    )
+    return result.ok and bool(result.stdout.strip())
 
 
 def _revert_workspace_path(workspace: Path, relative_path: str, status: str) -> bool:
@@ -360,37 +509,27 @@ def _revert_workspace_path(workspace: Path, relative_path: str, status: str) -> 
             return True
         except OSError:
             return False
-    try:
-        completed = subprocess.run(
-            ["git", "checkout", "HEAD", "--", relative_path],
-            cwd=workspace,
-            capture_output=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return False
-    if completed.returncode == 0:
+    completed = run_git(
+        ("checkout", "HEAD", "--", relative_path),
+        cwd=workspace,
+        timeout=10.0,
+    )
+    if completed.ok:
         return True
     # Staged-new paths (e.g. added via `git add`) have no HEAD version to
     # restore; unstage and remove instead. Restricted to paths absent from
     # HEAD so a failed checkout of a HEAD-tracked file is never destructive.
-    try:
-        ls_tree = subprocess.run(
-            ["git", "ls-tree", "--name-only", "HEAD", "--", relative_path],
-            cwd=workspace,
-            capture_output=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return False
-    if ls_tree.returncode != 0 or ls_tree.stdout.strip():
-        return False
-    subprocess.run(
-        ["git", "rm", "--cached", "-f", "--", relative_path],
+    ls_tree = run_git(
+        ("ls-tree", "--name-only", "HEAD", "--", relative_path),
         cwd=workspace,
-        capture_output=True,
-        timeout=10,
-        check=False,
+        timeout=10.0,
+    )
+    if not ls_tree.ok or ls_tree.stdout.strip():
+        return False
+    run_git(
+        ("rm", "--cached", "-f", "--", relative_path),
+        cwd=workspace,
+        timeout=10.0,
     )
     try:
         target.unlink(missing_ok=True)
@@ -659,6 +798,26 @@ def workspace_write_progress_note() -> str:
     workspace_writes = len(getattr(ctx, "workspace_file_writes", []) or [])
     if workspace_writes not in _WORKSPACE_WRITE_PROGRESS_COUNTS and workspace_writes % 10 != 0:
         return ""
+    allowed_tools = getattr(ctx, "allowed_tools", None)
+    git_diff_visible = (
+        "git_diff" not in getattr(ctx, "denied_tools", set())
+        and (allowed_tools is None or "git_diff" in allowed_tools)
+    )
+    workspace_dir = getattr(ctx, "workspace_dir", None)
+    git_repository_available = bool(
+        git_diff_visible
+        and workspace_dir
+        and probe_git_repository(
+            workspace_dir,
+            run_mode=getattr(ctx, "run_mode", None),
+        )
+        is GitRunState.OK
+    )
+    if not git_repository_available:
+        return (
+            " Note: workspace changes are now present. Before final, run focused "
+            "verification for the changed behavior."
+        )
     return (
         " Note: workspace changes are now present. Before final, inspect git_diff "
         "and run focused verification for the changed behavior."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 import tempfile
 from collections.abc import Callable, Iterator
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -78,6 +80,54 @@ _LIVE_MARKERS = (
     "live_channel",
     "live_search",
 )
+
+
+@pytest.fixture
+def unavailable_git_runtime(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    """Force Git unavailable and fail if a flow still tries to launch it."""
+    from opensquilla import git_runtime
+    from opensquilla.git_runtime import GitCapability, GitCapabilityState
+
+    capability = GitCapability(
+        state=GitCapabilityState.UNAVAILABLE,
+        executable=None,
+        source=None,
+        reason="git_not_found",
+    )
+    resolution_calls: list[dict[str, object]] = []
+
+    def resolve_unavailable(
+        environment=None,
+        run_mode=None,
+        force_refresh: bool = False,
+    ) -> GitCapability:
+        resolution_calls.append(
+            {
+                "environment": environment,
+                "run_mode": run_mode,
+                "force_refresh": force_refresh,
+            }
+        )
+        return capability
+
+    original_run = subprocess.run
+
+    def guarded_run(command, *args, **kwargs):
+        raw_program = command[0] if isinstance(command, (list, tuple)) else command
+        program = os.fsdecode(raw_program).strip().strip("\"'")
+        program = program.replace("\\", "/").rsplit("/", 1)[-1]
+        program = program.split(maxsplit=1)[0].casefold()
+        if program in {"git", "git.exe", "xcode-select", "xcode-select.exe"}:
+            raise AssertionError(f"unexpected Git process launch: {command!r}")
+        return original_run(command, *args, **kwargs)
+
+    git_runtime.clear_git_capability_cache()
+    monkeypatch.setattr(git_runtime, "resolve_git_capability", resolve_unavailable)
+    monkeypatch.setattr(subprocess, "run", guarded_run)
+    return SimpleNamespace(
+        capability=capability,
+        resolution_calls=resolution_calls,
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_ci/test_architecture_import_contracts.py
+++ b/tests/test_ci/test_architecture_import_contracts.py
@@ -132,6 +132,11 @@ APPROVED_PACKAGE_IMPORTS: frozenset[tuple[str, str]] = frozenset({
     # The reusable Python Gateway client shares the bounded WebSocket receive
     # contract with the CLI client; contracts remains implementation-free.
     ("gateway_client.py", "contracts"),
+    # The top-level Git resolver consults the optional managed Git Bash
+    # pack and its active runtime policy lazily on Windows; neither dependency
+    # imports the resolver back.
+    ("git_runtime.py", "runtime_packs"),
+    ("git_runtime.py", "sandbox"),
     ("identity", "safety"),
     ("identity", "session"),
     ("mcp", "tools"),

--- a/tests/test_contrib/test_codetask/test_codetask_verification.py
+++ b/tests/test_contrib/test_codetask/test_codetask_verification.py
@@ -16,6 +16,26 @@ from opensquilla.contrib.codetask.types import (
     RegressionResult,
     TaskState,
 )
+from opensquilla.git_runtime import (
+    GitCapability,
+    GitCapabilityState,
+    GitRunResult,
+    GitRunState,
+)
+
+
+def _git_unavailable_result() -> GitRunResult:
+    capability = GitCapability(
+        state=GitCapabilityState.UNAVAILABLE,
+        reason="git_not_found",
+    )
+    return GitRunResult(
+        state=GitRunState.UNAVAILABLE,
+        returncode=None,
+        stdout=b"",
+        stderr=b"git_not_found",
+        capability=capability,
+    )
 
 
 class TestManifestLoading:
@@ -98,6 +118,27 @@ class TestPathSafety:
             ["tests/ok.py", "/etc/passwd", "../../secret", "a/../b", ""]
         )
         assert safe == ["tests/ok.py"]
+
+
+def test_base_worktree_reports_unavailable_git_without_launching_literal_git(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    def unavailable(args, **_kwargs):
+        calls.append(tuple(args))
+        return _git_unavailable_result()
+
+    monkeypatch.setattr(verification, "run_git", unavailable)
+
+    with pytest.raises(verification._WorktreeError, match="Git is unavailable"):
+        with verification._BaseWorktree(tmp_path, "deadbeef"):
+            pass
+
+    assert len(calls) == 1
+    assert calls[0][:3] == ("worktree", "add", "--detach")
+    assert calls[0][-1] == "deadbeef"
 
 
 class TestRegressionFailClosed:

--- a/tests/test_contrib/test_codetask/test_codetask_workspace.py
+++ b/tests/test_contrib/test_codetask/test_codetask_workspace.py
@@ -5,10 +5,30 @@ import subprocess
 import pytest
 
 from opensquilla.contrib.codetask import workspace
+from opensquilla.git_runtime import (
+    GitCapability,
+    GitCapabilityState,
+    GitRunResult,
+    GitRunState,
+)
 
 
 def _git(args, cwd):
     return subprocess.run(["git", *args], cwd=str(cwd), capture_output=True, text=True)
+
+
+def _git_unavailable_result() -> GitRunResult:
+    capability = GitCapability(
+        state=GitCapabilityState.UNAVAILABLE,
+        reason="git_not_found",
+    )
+    return GitRunResult(
+        state=GitRunState.UNAVAILABLE,
+        returncode=None,
+        stdout=b"",
+        stderr=b"git_not_found",
+        capability=capability,
+    )
 
 
 @pytest.fixture
@@ -44,6 +64,36 @@ def test_prepare_clones_and_branches(monkeypatch, tmp_path, source_repo):
     assert prepared.base_commit
     # Source repo is never mutated (we cloned).
     assert (source_repo / "mod.py").exists()
+
+
+@pytest.mark.parametrize("operation", ["scratch", "clone"])
+def test_prepare_fails_fast_when_safe_git_is_unavailable(
+    monkeypatch,
+    tmp_path,
+    operation,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_CODETASK_RUNS_DIR", str(tmp_path / "runs"))
+    calls: list[tuple[tuple[str, ...], object, bool]] = []
+
+    def unavailable(args, *, cwd=None, allow_user_interaction=False, **_kwargs):
+        calls.append((tuple(args), cwd, allow_user_interaction))
+        return _git_unavailable_result()
+
+    monkeypatch.setattr(workspace, "run_git", unavailable)
+
+    with pytest.raises(workspace.WorkspaceError, match="code-task requires Git"):
+        if operation == "scratch":
+            workspace.prepare_scratch_repo("missing-git", slug="demo")
+        else:
+            workspace.prepare_repo(
+                "missing-git",
+                "https://example.invalid/repository.git",
+                slug="demo",
+            )
+
+    assert calls
+    assert calls[0][0][0] == ("init" if operation == "scratch" else "clone")
+    assert calls[0][2] is True
 
 
 def test_build_artifacts_excluded_from_change(monkeypatch, tmp_path, source_repo):

--- a/tests/test_engine/test_agent_finalize_evidence_gate.py
+++ b/tests/test_engine/test_agent_finalize_evidence_gate.py
@@ -220,6 +220,37 @@ async def test_gate_off_by_default_red_final_is_accepted(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_gate_skips_when_git_status_is_unavailable(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "src.py"
+    source.write_text("old\n", encoding="utf-8")
+    provider = _ScriptedProvider(
+        [
+            ("edit", "src.py"),
+            ("exec", "python /tmp/squilla-scratch/fail-run.py"),
+            ("final",),
+        ]
+    )
+    tool_context = ToolContext(workspace_dir=str(tmp_path))
+    agent = Agent(
+        provider=provider,
+        config=_gate_config(tmp_path),
+        tool_handler=_make_tool_handler(tmp_path, tool_context),
+        tool_context=tool_context,
+    )
+
+    async def unavailable_status() -> None:
+        return None
+
+    monkeypatch.setattr(agent, "_workspace_git_status_porcelain", unavailable_status)
+
+    events = [event async for event in agent.run_turn("Fix the bug")]
+
+    assert len(provider.calls) == 3
+    assert _gate_warnings(events) == []
+    assert "finalize_evidence_gate_detections" not in agent.config.metadata
+
+
+@pytest.mark.asyncio
 async def test_gate_challenges_red_final_then_accepts_verified_final(tmp_path) -> None:
     _init_git_workspace(tmp_path)
     runtime_events_path = tmp_path / "runtime_events.jsonl"

--- a/tests/test_engine/test_agent_llm_budget.py
+++ b/tests/test_engine/test_agent_llm_budget.py
@@ -2888,6 +2888,18 @@ def test_configured_hidden_scratch_diff_is_not_source_progress(tmp_path) -> None
     assert observation.scratch_paths == [".artifacts/repro.py"]
 
 
+def test_final_diff_contract_skips_non_repository_workspace(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    agent = Agent(
+        provider=_ContextOverflowProvider(success_after=1),
+        tool_context=ToolContext(workspace_dir=str(workspace)),
+    )
+
+    assert agent._workspace_diff_paths_for_final_diff_contract() is None
+    assert agent._final_diff_contract_observation() is None
+
+
 @pytest.mark.asyncio
 async def test_workspace_edit_gate_allows_real_configured_scratch_edit_file(
     tmp_path,
@@ -3107,6 +3119,7 @@ def test_workspace_edit_gate_rejects_configured_scratch_inside_workspace(
     workspace = tmp_path / "workspace"
     scratch = workspace / ".scratch"
     scratch.mkdir(parents=True)
+    subprocess.run(["git", "init"], cwd=workspace, check=True, capture_output=True)
     tool_context = ToolContext(
         workspace_dir=str(workspace),
         scratch_dir=str(scratch),

--- a/tests/test_engine/test_agent_submit_review.py
+++ b/tests/test_engine/test_agent_submit_review.py
@@ -26,6 +26,12 @@ from opensquilla.engine import (
     ToolResultEvent,
     WarningEvent,
 )
+from opensquilla.git_runtime import (
+    GitCapability,
+    GitCapabilityState,
+    GitRunResult,
+    GitRunState,
+)
 from opensquilla.provider import ChatConfig, Message
 from opensquilla.provider import DoneEvent as ProviderDone
 from opensquilla.provider import TextDeltaEvent as ProviderText
@@ -365,6 +371,134 @@ async def test_confirming_submit_terminates_the_turn(tmp_path) -> None:
     # Only the confirming submit carries the terminate flag.
     assert explicit[0]["details"]["terminates_turn"] is False
     assert explicit[-1]["details"]["terminates_turn"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("git_state", "expected_code"),
+    [
+        (GitRunState.UNAVAILABLE, "GIT_UNAVAILABLE"),
+        (GitRunState.NOT_REPOSITORY, "GIT_NOT_REPOSITORY"),
+    ],
+)
+async def test_explicit_submit_git_unknown_terminates_without_empty_diff_retry(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    git_state: GitRunState,
+    expected_code: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    capability = GitCapability(
+        state=(
+            GitCapabilityState.UNAVAILABLE
+            if git_state is GitRunState.UNAVAILABLE
+            else GitCapabilityState.AVAILABLE
+        ),
+        executable=(
+            None if git_state is GitRunState.UNAVAILABLE else workspace / "git"
+        ),
+        source="test",
+        reason="git_not_found" if git_state is GitRunState.UNAVAILABLE else None,
+    )
+    result = GitRunResult(
+        state=git_state,
+        returncode=None if git_state is GitRunState.UNAVAILABLE else 128,
+        stdout=b"",
+        stderr=b"git unavailable",
+        capability=capability,
+    )
+    monkeypatch.setattr(
+        "opensquilla.engine.agent.run_git",
+        lambda *_args, **_kwargs: result,
+    )
+    provider = _ScriptedProvider([("submit",), ("final",)])
+    tool_context = ToolContext(workspace_dir=str(workspace))
+    agent = Agent(
+        provider=provider,
+        config=_config(tmp_path),
+        tool_handler=_make_tool_handler(workspace, tool_context),
+        tool_context=tool_context,
+    )
+
+    events = [event async for event in agent.run_turn("Submit the work")]
+
+    submit_results = _submit_results(events)
+    assert len(provider.calls) == 1
+    assert len(submit_results) == 1
+    assert submit_results[0].is_error is True
+    payload = json.loads(submit_results[0].result)
+    assert payload["code"] == expected_code
+    assert payload["git_state"] == git_state.value
+    assert payload["retryable"] is False
+    assert "no workspace changes yet" not in submit_results[0].result
+
+
+@pytest.mark.asyncio
+async def test_implicit_submit_review_skips_git_unknown_without_retry(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    capability = GitCapability(
+        state=GitCapabilityState.UNAVAILABLE,
+        reason="git_not_found",
+    )
+    unavailable = GitRunResult(
+        state=GitRunState.UNAVAILABLE,
+        returncode=None,
+        stdout=b"",
+        stderr=b"git_not_found",
+        capability=capability,
+    )
+    monkeypatch.setattr(
+        "opensquilla.engine.agent.run_git",
+        lambda *_args, **_kwargs: unavailable,
+    )
+    provider = _ScriptedProvider([("final",), ("final",)])
+    tool_context = ToolContext(workspace_dir=str(workspace))
+    agent = Agent(
+        provider=provider,
+        config=_config(tmp_path),
+        tool_handler=_make_tool_handler(workspace, tool_context),
+        tool_context=tool_context,
+    )
+
+    events = [event async for event in agent.run_turn("Submit the work")]
+
+    assert len(provider.calls) == 1
+    assert _review_warnings(events) == []
+    assert "submit_review_implicit_recoveries" not in agent.config.metadata
+
+
+@pytest.mark.asyncio
+async def test_submit_review_captures_staged_diff_in_unborn_repository(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    subprocess.run(["git", "init"], cwd=workspace, check=True, capture_output=True)
+    source = workspace / "new.py"
+    source.write_text("print('new')\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", "new.py"],
+        cwd=workspace,
+        check=True,
+        capture_output=True,
+    )
+    agent = Agent(
+        provider=None,  # type: ignore[arg-type]
+        config=_config(tmp_path),
+        tool_context=ToolContext(workspace_dir=str(workspace)),
+    )
+
+    capture = await agent._workspace_submit_review_capture()
+
+    assert capture is not None
+    file_index, diff_text = capture
+    assert agent._submit_review_git_state is GitRunState.OK
+    assert "A  new.py" in file_index
+    assert "diff --git a/new.py b/new.py" in diff_text
+    assert "+print('new')" in diff_text
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/test_agent_verify_mirror_and_variant_challenge.py
+++ b/tests/test_engine/test_agent_verify_mirror_and_variant_challenge.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import os
 import subprocess
 from collections.abc import AsyncIterator
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -28,6 +29,7 @@ from opensquilla.engine.turn_runner.agent_bootstrap_stage import (
     _finalize_variant_challenge_from_env,
     _scratch_verify_mirror_from_env,
 )
+from opensquilla.git_runtime import GitRunState
 from opensquilla.provider import ChatConfig, Message
 from opensquilla.provider import DoneEvent as ProviderDone
 from opensquilla.provider import TextDeltaEvent as ProviderText
@@ -355,6 +357,19 @@ def test_hash_guard_withholds_credit_for_diverged_mirror_copy(tmp_path) -> None:
     assert agent._scratch_verify_mirror_evidence_credit(command) is False
 
 
+def test_hash_guard_withholds_credit_for_missing_original_outside_repository(
+    tmp_path,
+) -> None:
+    agent = _guard_agent(tmp_path)
+    mirror = tmp_path / "scratch" / "verify-mirror" / "tests" / "test_extra.py"
+    mirror.parent.mkdir(parents=True)
+    mirror.write_text("assert extra_case()\n", encoding="utf-8")
+
+    command = f"pytest {mirror.as_posix()}"
+
+    assert agent._scratch_verify_mirror_evidence_credit(command) is False
+
+
 def test_hash_guard_allows_new_check_files_shadowing_nothing(tmp_path) -> None:
     # The workspace is a git repo with no tests/test_extra.py anywhere: the
     # mirror file is the model's own new check, not a weakened copy.
@@ -386,6 +401,33 @@ def test_hash_guard_allows_new_check_files_shadowing_nothing(tmp_path) -> None:
     command = f"pytest {mirror.as_posix()}"
 
     assert agent._scratch_verify_mirror_evidence_credit(command) is True
+
+
+def test_hash_guard_withholds_credit_when_head_blob_probe_becomes_unavailable(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _guard_agent(tmp_path)
+    mirror = tmp_path / "scratch" / "verify-mirror" / "tests" / "test_extra.py"
+    mirror.parent.mkdir(parents=True)
+    mirror.write_text("assert extra_case()\n", encoding="utf-8")
+
+    def fake_run(args, **_kwargs):
+        if args[0] == "rev-parse":
+            return SimpleNamespace(ok=True, state=GitRunState.OK, stdout=b"true\n")
+        assert args[0] == "show"
+        return SimpleNamespace(
+            ok=False,
+            state=GitRunState.UNAVAILABLE,
+            stdout=b"",
+            stderr_text="git_not_found",
+        )
+
+    monkeypatch.setattr("opensquilla.engine.agent.run_git", fake_run)
+
+    command = f"pytest {mirror.as_posix()}"
+
+    assert agent._scratch_verify_mirror_evidence_credit(command) is False
 
 
 def test_hash_guard_withholds_credit_for_deleted_original_with_diverged_head(

--- a/tests/test_engine/test_document_mutation_agent_loop.py
+++ b/tests/test_engine/test_document_mutation_agent_loop.py
@@ -454,7 +454,9 @@ async def test_mutation_finalizer_cannot_stream_internal_protocol_echo() -> None
 
 
 @pytest.mark.asyncio
-async def test_additive_document_patch_uses_same_guarded_writer_lifecycle() -> None:
+async def test_additive_document_patch_uses_same_guarded_writer_lifecycle(
+    unavailable_git_runtime: SimpleNamespace,
+) -> None:
     provider = _ScriptedMutationProvider(
         [
             _document_patch_call_events(
@@ -501,6 +503,7 @@ async def test_additive_document_patch_uses_same_guarded_writer_lifecycle() -> N
     assert provider.calls[1]["tools"] is None
     assert done.document_mutation_outcome["status"] == "applied"
     assert done.text.endswith("The document changes were applied.")
+    assert unavailable_git_runtime.resolution_calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/test_endgame_directive_and_cap_levers.py
+++ b/tests/test_engine/test_endgame_directive_and_cap_levers.py
@@ -18,6 +18,7 @@ import json
 import subprocess
 from collections.abc import AsyncIterator
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -27,6 +28,7 @@ from opensquilla.engine.agent import (
     _ENDGAME_FIX_DIRECTIVE_PREFIX,
     _REASONING_ONLY_ACT_NOW_DIRECTIVE,
 )
+from opensquilla.git_runtime import GitRunState
 from opensquilla.provider import (
     ChatConfig,
     Message,
@@ -626,6 +628,42 @@ async def test_endgame_fix_directive_suppressed_by_substantive_diff(
     events = [event async for event in agent.run_turn("fix the bug")]
 
     assert any(event.kind == "done" for event in events)
+    assert not _fix_directive_texts(provider.calls[1]["messages"])
+    assert _runtime_events(events_path, "endgame_fix_directive") == []
+
+
+@pytest.mark.asyncio
+async def test_endgame_fix_directive_skips_when_git_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, _target = _init_repo(tmp_path)
+    events_path = tmp_path / "events.jsonl"
+    monkeypatch.setattr(
+        "opensquilla.engine.agent.run_git",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            ok=False,
+            state=GitRunState.UNAVAILABLE,
+        ),
+    )
+    provider = _SequenceProvider([_echo_tool_call("use-1"), _final_text()])
+    agent = _echo_agent(
+        provider,
+        AgentConfig(
+            timeout=30.0,
+            endgame_fix_directive_margin_seconds=60,
+            max_iterations=5,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+            runtime_events_path=str(events_path),
+        ),
+        tool_context=_workspace_ctx(repo),
+    )
+
+    events = [event async for event in agent.run_turn("fix the bug")]
+
+    assert any(event.kind == "done" for event in events)
+    assert len(provider.calls) == 2
     assert not _fix_directive_texts(provider.calls[1]["messages"])
     assert _runtime_events(events_path, "endgame_fix_directive") == []
 

--- a/tests/test_engine/test_mid_budget_no_diff_nudge_lever.py
+++ b/tests/test_engine/test_mid_budget_no_diff_nudge_lever.py
@@ -17,11 +17,13 @@ import re
 import subprocess
 from collections.abc import AsyncIterator
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
 from opensquilla.engine import Agent, AgentConfig, ToolResult
+from opensquilla.git_runtime import GitRunState
 from opensquilla.provider import (
     ChatConfig,
     Message,
@@ -358,6 +360,28 @@ def test_evidence_check_uses_config_workspace_for_contextless_agent(
         _lever_config(workspace_dir=str(repo)),
     )
 
+    assert agent._workspace_has_source_change_evidence() is True
+
+
+def test_evidence_check_treats_git_unavailable_as_unknown_progress(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _init_repo(tmp_path / "workspace")
+    agent = _echo_agent(
+        _SequenceProvider([_final_text()]),
+        _lever_config(),
+        tool_context=_workspace_ctx(repo),
+    )
+    monkeypatch.setattr(
+        "opensquilla.engine.agent.run_git",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            ok=False,
+            state=GitRunState.UNAVAILABLE,
+        ),
+    )
+
+    assert agent._workspace_tracked_diff_paths_for_nudge() is None
     assert agent._workspace_has_source_change_evidence() is True
 
 

--- a/tests/test_engine/test_patch_evidence_ledger.py
+++ b/tests/test_engine/test_patch_evidence_ledger.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 from opensquilla.engine.patch_evidence_ledger import PatchEvidenceLedger
+from opensquilla.git_runtime import GitRunState
 from opensquilla.tools.types import ToolContext, current_tool_context
 from opensquilla.tools.write_tracking import record_workspace_file_read
 
@@ -103,6 +107,47 @@ def test_patch_evidence_ledger_redacts_secret_like_text(tmp_path: Path) -> None:
     text = ledger_path.read_text(encoding="utf-8")
     assert secret not in text
     assert "env.OPENROUTER_API_KEY=[REDACTED]" in text
+
+
+def test_patch_evidence_ledger_records_unknown_git_without_claiming_clean(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ledger_path = tmp_path / "ledger.json"
+    calls: list[tuple[str, ...]] = []
+
+    def unavailable(args, **_kwargs):
+        calls.append(tuple(args))
+        return SimpleNamespace(ok=False, state=GitRunState.NOT_REPOSITORY)
+
+    monkeypatch.setattr(
+        "opensquilla.engine.patch_evidence_ledger.run_git",
+        unavailable,
+    )
+    ledger = PatchEvidenceLedger(
+        path=str(ledger_path),
+        workspace_dir=str(tmp_path),
+        session_key="session-1",
+        agent_id="main",
+    )
+
+    ledger.write_final(
+        read_records=[],
+        write_records=[{"relative_path": "src/app.py", "operation": "edit"}],
+        scratch_records=[],
+        final_status="ok",
+        iterations=1,
+        provider_call_count=1,
+    )
+
+    payload = json.loads(ledger_path.read_text(encoding="utf-8"))
+    assert calls == [("status", "--porcelain=v1", "--untracked-files=all")]
+    assert payload["git_state"] == "not_repository"
+    assert payload["git_diff_observed"] is False
+    # Keep the v1 list/int shape for older ledger consumers; the additive
+    # observed flag is the authoritative distinction from a clean workspace.
+    assert payload["diff_paths"] == []
+    assert payload["summary"]["diff_path_count"] == 0
 
 
 def test_record_workspace_file_read_tracks_workspace_relative_path(tmp_path: Path) -> None:

--- a/tests/test_engine/test_runtime_diagnostics.py
+++ b/tests/test_engine/test_runtime_diagnostics.py
@@ -12,6 +12,12 @@ from opensquilla.engine.runtime_diagnostics import (
     normalize_command_family,
 )
 from opensquilla.engine.runtime_recovery import source_loop_recovery_decision
+from opensquilla.git_runtime import (
+    GitCapability,
+    GitCapabilityState,
+    GitRunResult,
+    GitRunState,
+)
 from opensquilla.provider import DoneEvent as ProviderDoneEvent
 from opensquilla.provider import TextDeltaEvent as ProviderTextDeltaEvent
 from opensquilla.provider import ToolDefinition, ToolInputSchema
@@ -113,6 +119,37 @@ def test_runtime_diagnostics_classifies_paths_and_commands() -> None:
         "npm run:build"
     )
     assert normalize_command_family("git diff HEAD") == "git:diff"
+
+
+def test_runtime_diff_paths_preserve_non_repository_as_unknown(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    capability = GitCapability(
+        state=GitCapabilityState.AVAILABLE,
+        executable=workspace / "git",
+        source="test",
+    )
+    result = GitRunResult(
+        state=GitRunState.NOT_REPOSITORY,
+        returncode=128,
+        stdout=b"",
+        stderr=b"not a git repository",
+        capability=capability,
+    )
+    monkeypatch.setattr(
+        "opensquilla.engine.agent.run_git",
+        lambda *_args, **_kwargs: result,
+    )
+    agent = Agent(
+        provider=None,  # type: ignore[arg-type]
+        tool_context=ToolContext(workspace_dir=str(workspace)),
+    )
+
+    assert agent._workspace_diff_paths_for_runtime_event() is None
+    assert agent._runtime_git_state is GitRunState.NOT_REPOSITORY
 
 
 def test_source_loop_recovery_log_mode_observes_only() -> None:
@@ -394,6 +431,72 @@ def _tool_def(name: str) -> ToolDefinition:
 
 
 @pytest.mark.asyncio
+async def test_agent_skips_git_diff_diagnostics_when_no_observer_needs_them(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    unavailable_git_runtime,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    tool_context = ToolContext(workspace_dir=str(workspace))
+
+    def unexpected_diff_probe(_self) -> Any:
+        raise AssertionError("Git diff diagnostics should stay lazy")
+
+    monkeypatch.setattr(
+        Agent,
+        "_workspace_diff_paths_for_runtime_event",
+        unexpected_diff_probe,
+    )
+    monkeypatch.setattr(
+        Agent,
+        "_workspace_diff_fingerprint_for_runtime_event",
+        unexpected_diff_probe,
+    )
+
+    async def handler(call: ToolCall) -> ToolResult:
+        return ToolResult(
+            tool_use_id=call.tool_use_id,
+            tool_name=call.tool_name,
+            content="ok",
+        )
+
+    agent = Agent(
+        provider=_ThreeToolProvider(tool_turns=1),
+        config=AgentConfig(max_iterations=2, flush_enabled=False),
+        tool_definitions=[_tool_def("exec_command")],
+        tool_handler=handler,
+        tool_context=tool_context,
+    )
+
+    events = [event async for event in agent.run_turn("run one command")]
+
+    assert events
+    assert unavailable_git_runtime.resolution_calls
+
+
+@pytest.mark.asyncio
+async def test_plain_chat_finishes_when_git_is_unavailable(
+    tmp_path,
+    unavailable_git_runtime,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    provider = _ThreeToolProvider(tool_turns=0)
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(max_iterations=1, flush_enabled=False),
+        tool_context=ToolContext(workspace_dir=str(workspace)),
+    )
+
+    events = [event async for event in agent.run_turn("hello")]
+
+    assert events
+    assert provider.calls == 1
+    assert unavailable_git_runtime.resolution_calls
+
+
+@pytest.mark.asyncio
 async def test_agent_runtime_diagnostics_write_jsonl_without_model_hint(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
@@ -518,6 +621,79 @@ async def test_agent_source_loop_recovery_warns_model_once(
     assert recovery["mode"] == "warn_model"
     assert recovery["injected_to_model"] is True
     assert recovery["evidence"]["diff_paths"] == ["src/lib.rs"]
+
+
+@pytest.mark.asyncio
+async def test_git_unavailable_skips_runtime_recovery_without_extra_model_retry(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_events_path = tmp_path / "runtime_events.jsonl"
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    unavailable_capability = GitCapability(
+        state=GitCapabilityState.UNAVAILABLE,
+        reason="git_not_found",
+    )
+    unavailable_result = GitRunResult(
+        state=GitRunState.UNAVAILABLE,
+        returncode=None,
+        stdout=b"",
+        stderr=b"git_not_found",
+        capability=unavailable_capability,
+    )
+    monkeypatch.setattr(
+        "opensquilla.engine.agent.run_git",
+        lambda *_args, **_kwargs: unavailable_result,
+    )
+    tool_context = ToolContext(workspace_dir=str(workspace), agent_id="agent-1")
+
+    async def handler(call: ToolCall) -> ToolResult:
+        tool_context.workspace_file_writes.append(_write("src/lib.rs"))
+        return ToolResult(
+            tool_use_id=call.tool_use_id,
+            tool_name=call.tool_name,
+            content="error[E0592]: duplicate definitions with name `fallback_service`",
+            is_error=True,
+        )
+
+    provider = _ThreeToolProvider()
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            max_iterations=5,
+            runtime_events_path=str(runtime_events_path),
+            runtime_recovery_mode="warn_model",
+            progress_watchdog_mode="log",
+            tool_result_projection_max_inline_chars=10_000,
+            tool_failure_loop_block_threshold=0,
+            post_write_convergence_enabled=True,
+        ),
+        tool_definitions=[_tool_def("exec_command")],
+        tool_handler=handler,
+        tool_context=tool_context,
+        session_key="session-1",
+    )
+
+    events = [event async for event in agent.run_turn("fix the bug")]
+
+    assert events
+    assert provider.calls == 4
+    assert "[Runtime recovery]" not in _message_text(provider.messages_by_call[-1])
+    logged = [
+        json.loads(line)
+        for line in runtime_events_path.read_text(encoding="utf-8").splitlines()
+    ]
+    skipped = [
+        event
+        for event in logged
+        if event.get("name") == "runtime_git_observation.skipped"
+    ]
+    assert len(skipped) == 1
+    assert skipped[0]["git_state"] == "unavailable"
+    assert not any(
+        event.get("mechanism") == "source_loop_recovery" for event in logged
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/test_runtime_state_capsule.py
+++ b/tests/test_engine/test_runtime_state_capsule.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 from opensquilla.engine.agent import Agent
 from opensquilla.engine.runtime_state_capsule import (
@@ -13,6 +16,7 @@ from opensquilla.engine.turn_runner.agent_bootstrap_stage import (
     _runtime_state_capsule_mode_from_env,
 )
 from opensquilla.engine.types import AgentConfig
+from opensquilla.git_runtime import GitRunState
 from opensquilla.provider.types import Message
 from opensquilla.tools.mutation_receipts import (
     fingerprint_file,
@@ -96,6 +100,38 @@ def test_runtime_state_capsule_message_is_stable_json(tmp_path: Path) -> None:
     payload = json.loads(message.removeprefix(prefix))
     assert payload["schema"] == "runtime_state_capsule_v1"
     assert payload["workspace"]["source_diff"] is False
+
+
+def test_runtime_state_capsule_marks_git_unknown_without_false_blocking_fact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = ToolContext(workspace_dir=str(tmp_path), workspace_epoch=1)
+    ctx.workspace_mutation_receipts.append(
+        {
+            "relative_path": "src/app.py",
+            "classification": "source",
+            "changed": True,
+            "workspace_epoch": 1,
+        }
+    )
+    monkeypatch.setattr(
+        "opensquilla.engine.runtime_state_capsule.run_git",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            ok=False,
+            state=GitRunState.UNAVAILABLE,
+            stdout=b"",
+        ),
+    )
+
+    capsule = build_runtime_state_capsule(workspace=tmp_path, tool_context=ctx)
+
+    assert capsule["workspace"]["git_state"] == "unavailable"
+    assert capsule["workspace"]["diff_observed"] is False
+    assert capsule["workspace"]["diff"] is False
+    assert capsule["workspace"]["diff_paths"] == []
+    assert capsule["finalization"]["source_diff_present"] is False
+    assert capsule["finalization"]["blocking_facts"] == []
 
 
 def test_agent_runtime_state_capsule_injection_is_opt_in(tmp_path: Path) -> None:

--- a/tests/test_engine/test_runtime_tool_run_budget.py
+++ b/tests/test_engine/test_runtime_tool_run_budget.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 import types
+from pathlib import Path
 
 import pytest
 
+from opensquilla import git_runtime
 from opensquilla.engine.runtime import TurnRunner
+from opensquilla.run_mode import RunMode
+from opensquilla.sandbox.integration import active_sandbox_policy
+from opensquilla.sandbox.policy_models import RuntimePolicySettings, SandboxPolicy
 from opensquilla.tools.types import ToolContext
 
 
@@ -41,3 +47,94 @@ async def test_runtime_assigns_fresh_tool_run_budget_key_per_turn() -> None:
     assert captured[1].tool_run_budget_key
     assert captured[0].tool_run_budget_key != captured[1].tool_run_budget_key
     assert source_context.tool_run_budget_key is None
+
+
+@pytest.mark.asyncio
+async def test_runtime_binds_tool_context_sandbox_policy_for_entire_turn() -> None:
+    runner = TurnRunner(provider_selector=None, session_manager=None)
+    source_context = ToolContext(
+        session_key="agent:main:webchat:runtime-policy",
+        sandbox_policy=SandboxPolicy(
+            runtimes=RuntimePolicySettings(enabled=False, git_bash=False),
+        ),
+    )
+    observed: list[tuple[bool, bool]] = []
+
+    async def fake_run_turn(self, *args, **kwargs):
+        del self, args, kwargs
+        policy = active_sandbox_policy()
+        observed.append((policy.runtimes.enabled, policy.runtimes.git_bash))
+        if False:
+            yield None
+
+    runner._run_turn = types.MethodType(fake_run_turn, runner)
+
+    async for _ in runner.run(
+        "hello",
+        session_key="agent:main:webchat:runtime-policy",
+        tool_context=source_context,
+    ):
+        pass
+
+    assert observed == [(False, False)]
+    # The turn-local policy must not leak into subsequent work on this task.
+    assert active_sandbox_policy().runtimes.enabled is True
+
+
+@pytest.mark.asyncio
+async def test_runtime_binds_effective_git_mode_per_concurrent_turn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    git_runtime.clear_git_capability_cache()
+    monkeypatch.setattr(git_runtime, "_platform_name", lambda: "windows")
+    managed_git = tmp_path / "managed" / "git.exe"
+    host_git = tmp_path / "host" / "git.exe"
+    managed_git.parent.mkdir()
+    host_git.parent.mkdir()
+    managed_git.write_bytes(b"")
+    host_git.write_bytes(b"")
+    monkeypatch.setattr(git_runtime, "_managed_git_path", lambda _platform: managed_git)
+    environment = {"PATH": str(host_git.parent), "PATHEXT": ".exe"}
+    runner = TurnRunner(provider_selector=None, session_manager=None)
+    observed: dict[str, tuple[Path | None, str | None]] = {}
+
+    async def fake_run_turn(self, *args, **kwargs):
+        del self, kwargs
+        ctx = args[5]
+        await asyncio.sleep(0)
+        capability = git_runtime.resolve_git_capability(
+            environment,
+            force_refresh=True,
+        )
+        observed[str(ctx.session_key)] = (capability.executable, capability.source)
+        if False:
+            yield None
+
+    runner._run_turn = types.MethodType(fake_run_turn, runner)
+    full_context = ToolContext(
+        session_key="agent:main:full",
+        run_mode=None,
+        sandbox_run_context=types.SimpleNamespace(run_mode=RunMode.FULL),
+    )
+    safe_context = ToolContext(
+        session_key="agent:main:safe",
+        run_mode=RunMode.SAFE.value,
+    )
+
+    async def consume(session_key: str, context: ToolContext) -> None:
+        async for _ in runner.run("hello", session_key=session_key, tool_context=context):
+            pass
+
+    await asyncio.gather(
+        consume("agent:main:full", full_context),
+        consume("agent:main:safe", safe_context),
+    )
+
+    assert observed == {
+        "agent:main:full": (host_git.absolute(), "host"),
+        "agent:main:safe": (managed_git.absolute(), "managed"),
+    }
+    # The last turn scope must not leak into subsequent work on this task.
+    outside = git_runtime.resolve_git_capability(environment, force_refresh=True)
+    assert (outside.executable, outside.source) == (managed_git.absolute(), "managed")

--- a/tests/test_gateway/test_rpc_artifact_editing.py
+++ b/tests/test_gateway/test_rpc_artifact_editing.py
@@ -1061,6 +1061,7 @@ async def test_source_patch_rejects_invalid_html_before_durable_mutation(
 @pytest.mark.asyncio
 async def test_legacy_ref_is_lazily_adopted_and_source_patch_is_cas_safe(
     artifact_editing_env,
+    unavailable_git_runtime: SimpleNamespace,
 ) -> None:
     env = artifact_editing_env
     ref, document = await _adopt_html(env)
@@ -1265,6 +1266,7 @@ async def test_legacy_ref_is_lazily_adopted_and_source_patch_is_cas_safe(
     assert attempt.status is MutationAttemptStatus.APPLIED
     assert attempt.change_set_id == patched.payload["changeSet"]["id"]
     assert attempt.revision_id == patched.payload["revision"]["id"]
+    assert unavailable_git_runtime.resolution_calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway/test_rpc_tools_visibility.py
+++ b/tests/test_gateway/test_rpc_tools_visibility.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -211,6 +212,36 @@ async def test_default_tools_rpc_hides_owner_only_tools_from_non_owner(method: s
     assert "spawn_subagent" not in owner_names
     assert "send_message" not in owner_names
     assert "generate_image" not in owner_names
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["tools.catalog", "tools.effective"])
+async def test_default_tools_rpc_hides_git_tools_when_runtime_is_unavailable(
+    method: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import opensquilla.tools.builtin  # noqa: F401
+    from opensquilla.tools.registry import get_default_registry
+
+    monkeypatch.setattr(
+        "opensquilla.git_runtime.resolve_git_capability",
+        lambda: SimpleNamespace(available=False),
+    )
+
+    result = await get_dispatcher().dispatch(
+        "r1",
+        method,
+        {"callerKind": "agent"},
+        _ctx(tool_registry=get_default_registry(), is_owner=True),
+    )
+
+    assert result.error is None, result.error
+    assert {
+        "git_status",
+        "git_diff",
+        "git_log",
+        "git_commit",
+    }.isdisjoint(_tool_names(result.payload))
 
 
 @pytest.mark.asyncio

--- a/tests/test_git_runtime.py
+++ b/tests/test_git_runtime.py
@@ -1,0 +1,676 @@
+from __future__ import annotations
+
+import ast
+import os
+import stat
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from opensquilla import git_runtime
+from opensquilla.git_runtime import (
+    GitCapability,
+    GitCapabilityState,
+    GitRunResult,
+    GitRunState,
+)
+
+_DIRECT_PROCESS_LAUNCHERS = frozenset(
+    {
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "create_owned_subprocess_exec",
+        "create_subprocess_exec",
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_capability_cache() -> None:
+    git_runtime.clear_git_capability_cache()
+
+
+def _executable(path: Path, content: str = "#!/bin/sh\nexit 0\n") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def _platform(monkeypatch: pytest.MonkeyPatch, name: str) -> None:
+    monkeypatch.setattr(git_runtime, "_platform_name", lambda: name)
+
+
+@pytest.fixture
+def real_git_environment(tmp_path: Path) -> dict[str, str]:
+    capability = git_runtime.resolve_git_capability(force_refresh=True)
+    if not capability.available:
+        pytest.skip(f"Git capability is unavailable: {capability.reason}")
+    global_config = tmp_path / "empty-gitconfig"
+    global_config.write_text("", encoding="utf-8")
+    environment = dict(os.environ)
+    environment["GIT_CONFIG_NOSYSTEM"] = "1"
+    environment["GIT_CONFIG_GLOBAL"] = str(global_config)
+    return environment
+
+
+def _run_real_git(
+    args: tuple[str, ...],
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+) -> GitRunResult:
+    result = git_runtime.run_git(
+        args,
+        cwd=cwd,
+        timeout=10.0,
+        environment=environment,
+    )
+    assert result.state is GitRunState.OK, result.stderr_text
+    return result
+
+
+def _init_real_repository(repository: Path, environment: dict[str, str]) -> None:
+    repository.mkdir()
+    _run_real_git(
+        ("-c", "init.templateDir=", "init", "-q"),
+        cwd=repository,
+        environment=environment,
+    )
+
+
+def _commit_real_repository(repository: Path, environment: dict[str, str]) -> None:
+    hooks = repository / ".empty-hooks"
+    hooks.mkdir(exist_ok=True)
+    _run_real_git(("add", "--all"), cwd=repository, environment=environment)
+    _run_real_git(
+        (
+            "-c",
+            "user.name=OpenSquilla Test",
+            "-c",
+            "user.email=opensquilla@example.test",
+            "-c",
+            "commit.gpgSign=false",
+            "-c",
+            f"core.hooksPath={hooks}",
+            "commit",
+            "-q",
+            "-m",
+            "base",
+        ),
+        cwd=repository,
+        environment=environment,
+    )
+
+
+def _literal_git_argument(node: ast.expr) -> bool:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return Path(node.value).name.casefold() in {"git", "git.exe"}
+    if isinstance(node, (ast.List, ast.Tuple)) and node.elts:
+        return _literal_git_argument(node.elts[0])
+    return False
+
+
+def test_core_runtime_does_not_launch_literal_git_outside_git_runtime() -> None:
+    """Keep background Git calls behind the Apple-shim-safe runtime boundary."""
+
+    package_root = Path(__file__).parents[1] / "src" / "opensquilla"
+    violations: list[str] = []
+    for relative_root in ("engine", "tools", "cli"):
+        for source_path in sorted((package_root / relative_root).rglob("*.py")):
+            tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call) or not node.args:
+                    continue
+                function_name = (
+                    node.func.attr
+                    if isinstance(node.func, ast.Attribute)
+                    else node.func.id
+                    if isinstance(node.func, ast.Name)
+                    else ""
+                )
+                if function_name not in _DIRECT_PROCESS_LAUNCHERS:
+                    continue
+                if _literal_git_argument(node.args[0]):
+                    relative = source_path.relative_to(package_root)
+                    violations.append(f"{relative}:{node.lineno}")
+    assert violations == []
+
+
+def test_result_properties_decode_bytes() -> None:
+    capability = GitCapability(
+        GitCapabilityState.AVAILABLE,
+        Path("/example/git"),
+        "host",
+        None,
+    )
+    result = GitRunResult(
+        GitRunState.OK,
+        0,
+        "完成".encode(),
+        b"warning",
+        capability,
+    )
+
+    assert capability.available is True
+    assert result.ok is True
+    assert result.stdout_text == "完成"
+    assert result.stderr_text == "warning"
+
+
+def test_linux_resolves_host_git_by_absolute_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _platform(monkeypatch, "linux")
+    executable = _executable(tmp_path / "bin" / "git")
+
+    capability = git_runtime.resolve_git_capability({"PATH": str(executable.parent)})
+
+    assert capability.state is GitCapabilityState.AVAILABLE
+    assert capability.executable == executable.absolute()
+    assert capability.source == "host"
+
+
+def test_linux_missing_git_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    _platform(monkeypatch, "linux")
+
+    capability = git_runtime.resolve_git_capability({"PATH": ""})
+
+    assert capability.state is GitCapabilityState.UNAVAILABLE
+    assert capability.available is False
+    assert capability.reason == "git_not_found"
+
+
+def test_darwin_apple_shim_resolves_selected_developer_git(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _platform(monkeypatch, "darwin")
+    shim = _executable(tmp_path / "apple" / "git")
+    xcode_select = _executable(tmp_path / "usr" / "bin" / "xcode-select")
+    developer_root = tmp_path / "Developer"
+    developer_git = _executable(developer_root / "usr" / "bin" / "git")
+    monkeypatch.setattr(git_runtime, "_APPLE_GIT_SHIM", shim)
+    monkeypatch.setattr(git_runtime, "_XCODE_SELECT", xcode_select)
+    calls: list[tuple[list[str], float]] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        calls.append((command, float(kwargs["timeout"])))
+        return subprocess.CompletedProcess(command, 0, f"{developer_root}\n".encode(), b"")
+
+    monkeypatch.setattr(git_runtime.subprocess, "run", fake_run)
+
+    capability = git_runtime.resolve_git_capability({"PATH": str(shim.parent)})
+
+    assert capability.executable == developer_git.absolute()
+    assert capability.source == "apple_developer"
+    assert calls == [([str(xcode_select), "--print-path"], 1.0)]
+
+
+def test_darwin_invalid_apple_shim_continues_to_later_host_git(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _platform(monkeypatch, "darwin")
+    shim = _executable(tmp_path / "apple" / "git")
+    xcode_select = _executable(tmp_path / "usr" / "bin" / "xcode-select")
+    homebrew_git = _executable(tmp_path / "homebrew" / "git")
+    monkeypatch.setattr(git_runtime, "_APPLE_GIT_SHIM", shim)
+    monkeypatch.setattr(git_runtime, "_XCODE_SELECT", xcode_select)
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 2, b"", b"not installed")
+
+    monkeypatch.setattr(git_runtime.subprocess, "run", fake_run)
+
+    capability = git_runtime.resolve_git_capability(
+        {"PATH": f"{shim.parent}:{homebrew_git.parent}"}
+    )
+
+    assert capability.executable == homebrew_git.absolute()
+    assert capability.source == "host"
+    assert calls == [[str(xcode_select), "--print-path"]]
+
+
+def test_darwin_symlink_to_apple_shim_is_not_treated_as_host_git(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _platform(monkeypatch, "darwin")
+    shim = _executable(tmp_path / "apple" / "git")
+    linked_git = tmp_path / "linked" / "git"
+    linked_git.parent.mkdir(parents=True)
+    linked_git.symlink_to(shim)
+    xcode_select = _executable(tmp_path / "usr" / "bin" / "xcode-select")
+    monkeypatch.setattr(git_runtime, "_APPLE_GIT_SHIM", shim)
+    monkeypatch.setattr(git_runtime, "_XCODE_SELECT", xcode_select)
+    monkeypatch.setattr(
+        git_runtime.subprocess,
+        "run",
+        lambda command, **kwargs: subprocess.CompletedProcess(command, 2, b"", b"missing"),
+    )
+
+    capability = git_runtime.resolve_git_capability({"PATH": str(linked_git.parent)})
+
+    assert capability.state is GitCapabilityState.UNAVAILABLE
+    assert capability.reason == "apple_developer_tools_unavailable"
+
+
+def test_darwin_xcode_select_timeout_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _platform(monkeypatch, "darwin")
+    shim = _executable(tmp_path / "apple" / "git")
+    xcode_select = _executable(tmp_path / "usr" / "bin" / "xcode-select")
+    monkeypatch.setattr(git_runtime, "_APPLE_GIT_SHIM", shim)
+    monkeypatch.setattr(git_runtime, "_XCODE_SELECT", xcode_select)
+
+    def time_out(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        raise subprocess.TimeoutExpired(command, 1.0)
+
+    monkeypatch.setattr(git_runtime.subprocess, "run", time_out)
+
+    capability = git_runtime.resolve_git_capability({"PATH": str(shim.parent)})
+
+    assert capability.state is GitCapabilityState.UNAVAILABLE
+    assert capability.reason == "xcode_select_timed_out"
+
+
+def test_windows_safe_prefers_managed_and_full_prefers_host(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _platform(monkeypatch, "windows")
+    managed_git = _executable(tmp_path / "managed" / "git.exe")
+    host_git = _executable(tmp_path / "host" / "git.exe")
+    monkeypatch.setattr(git_runtime, "_managed_git_path", lambda _platform: managed_git)
+    environment = {"PATH": f"{host_git.parent};{tmp_path / 'other'}", "PATHEXT": ".exe;.cmd"}
+
+    safe = git_runtime.resolve_git_capability(environment, run_mode="safe")
+    full = git_runtime.resolve_git_capability(environment, run_mode="full")
+
+    assert safe.executable == managed_git.absolute()
+    assert safe.source == "managed"
+    assert full.executable == host_git.absolute()
+    assert full.source == "host"
+
+
+def test_windows_turn_scope_sets_default_resolver_priority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _platform(monkeypatch, "windows")
+    managed_git = _executable(tmp_path / "managed" / "git.exe")
+    host_git = _executable(tmp_path / "host" / "git.exe")
+    monkeypatch.setattr(git_runtime, "_managed_git_path", lambda _platform: managed_git)
+    environment = {"PATH": str(host_git.parent), "PATHEXT": ".exe"}
+
+    with git_runtime.git_run_mode_scope("full"):
+        capability = git_runtime.resolve_git_capability(environment)
+
+    assert capability.executable == host_git.absolute()
+    assert capability.source == "host"
+
+
+@pytest.mark.parametrize(
+    ("runtime_enabled", "git_bash_enabled"),
+    [(False, True), (True, False)],
+)
+def test_windows_managed_git_respects_disabled_runtime_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_enabled: bool,
+    git_bash_enabled: bool,
+) -> None:
+    _platform(monkeypatch, "windows")
+    managed_git = _executable(tmp_path / "managed" / "git.exe")
+    monkeypatch.setattr(
+        "opensquilla.runtime_packs.resolve_component_binary",
+        lambda *_args, **_kwargs: managed_git,
+    )
+    monkeypatch.setattr(
+        "opensquilla.sandbox.integration.active_sandbox_policy",
+        lambda: SimpleNamespace(
+            runtimes=SimpleNamespace(
+                enabled=runtime_enabled,
+                git_bash=git_bash_enabled,
+            )
+        ),
+    )
+
+    capability = git_runtime.resolve_git_capability(
+        {"PATH": "", "PATHEXT": ".EXE"},
+        run_mode="safe",
+        force_refresh=True,
+    )
+
+    assert capability.state is GitCapabilityState.UNAVAILABLE
+    assert capability.reason == "git_not_found"
+
+
+def test_force_refresh_bypasses_cached_capability(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _platform(monkeypatch, "linux")
+    executable = _executable(tmp_path / "bin" / "git")
+    environment = {"PATH": str(executable.parent)}
+
+    first = git_runtime.resolve_git_capability(environment)
+    executable.unlink()
+    cached = git_runtime.resolve_git_capability(environment)
+    refreshed = git_runtime.resolve_git_capability(environment, force_refresh=True)
+
+    assert first.available is True
+    assert cached == first
+    assert refreshed.state is GitCapabilityState.UNAVAILABLE
+
+
+def test_run_git_uses_absolute_path_and_noninteractive_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _platform(monkeypatch, "linux")
+    executable = _executable(tmp_path / "bin" / "git")
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0, b"clean\n", b"")
+
+    monkeypatch.setattr(git_runtime.subprocess, "run", fake_run)
+
+    result = git_runtime.run_git(
+        ("status", "--short"),
+        cwd=tmp_path,
+        environment={"PATH": str(executable.parent)},
+    )
+
+    command, kwargs = calls[0]
+    child_environment = kwargs["env"]
+    assert isinstance(child_environment, dict)
+    assert command == [str(executable.absolute()), "status", "--short"]
+    assert kwargs["stdin"] is subprocess.DEVNULL
+    assert child_environment["GIT_TERMINAL_PROMPT"] == "0"
+    assert child_environment["GCM_INTERACTIVE"] == "Never"
+    assert child_environment["LC_ALL"] == "C"
+    assert result.state is GitRunState.OK
+    assert result.stdout == b"clean\n"
+
+
+def test_run_git_user_interaction_preserves_credentials_and_stdin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _platform(monkeypatch, "linux")
+    executable = _executable(tmp_path / "bin" / "git")
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0, b"cloned\n", b"")
+
+    monkeypatch.setattr(git_runtime.subprocess, "run", fake_run)
+    environment = {
+        "PATH": str(executable.parent),
+        "GIT_TERMINAL_PROMPT": "1",
+        "GCM_INTERACTIVE": "Always",
+        "GIT_ASKPASS": "/example/askpass",
+        "SSH_ASKPASS": "/example/ssh-askpass",
+        "LC_ALL": "zh_CN.UTF-8",
+        "LANG": "zh_CN.UTF-8",
+    }
+
+    result = git_runtime.run_git(
+        ("clone", "https://example.test/private.git"),
+        environment=environment,
+        allow_user_interaction=True,
+    )
+
+    command, kwargs = calls[0]
+    child_environment = kwargs["env"]
+    assert isinstance(child_environment, dict)
+    assert command[0] == str(executable.absolute())
+    assert "stdin" not in kwargs
+    for key, value in environment.items():
+        assert child_environment[key] == value
+    assert result.state is GitRunState.OK
+
+
+@pytest.mark.parametrize("allow_user_interaction", [False, True])
+def test_run_git_never_launches_unavailable_apple_shim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    allow_user_interaction: bool,
+) -> None:
+    _platform(monkeypatch, "darwin")
+    shim = _executable(tmp_path / "apple" / "git")
+    xcode_select = _executable(tmp_path / "usr" / "bin" / "xcode-select")
+    monkeypatch.setattr(git_runtime, "_APPLE_GIT_SHIM", shim)
+    monkeypatch.setattr(git_runtime, "_XCODE_SELECT", xcode_select)
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        calls.append(command)
+        assert command[0] == str(xcode_select)
+        return subprocess.CompletedProcess(command, 2, b"", b"not installed")
+
+    monkeypatch.setattr(git_runtime.subprocess, "run", fake_run)
+
+    result = git_runtime.run_git(
+        ("status",),
+        environment={"PATH": str(shim.parent)},
+        allow_user_interaction=allow_user_interaction,
+    )
+
+    assert result.state is GitRunState.UNAVAILABLE
+    assert calls == [[str(xcode_select), "--print-path"]]
+
+
+def test_run_git_unavailable_does_not_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    _platform(monkeypatch, "linux")
+    monkeypatch.setattr(
+        git_runtime.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("Git must not be spawned when unavailable"),
+    )
+
+    result = git_runtime.run_git(("status",), environment={"PATH": ""})
+
+    assert result.state is GitRunState.UNAVAILABLE
+    assert result.returncode is None
+    assert result.capability.available is False
+
+
+def test_run_git_classifies_not_repository(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _platform(monkeypatch, "linux")
+    executable = _executable(tmp_path / "bin" / "git")
+    monkeypatch.setattr(
+        git_runtime.subprocess,
+        "run",
+        lambda command, **kwargs: subprocess.CompletedProcess(
+            command,
+            128,
+            b"",
+            b"fatal: not a git repository (or any of the parent directories): .git\n",
+        ),
+    )
+
+    result = git_runtime.run_git(("status",), environment={"PATH": str(executable.parent)})
+
+    assert result.state is GitRunState.NOT_REPOSITORY
+    assert result.returncode == 128
+
+
+def test_run_git_returns_timeout_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _platform(monkeypatch, "linux")
+    executable = _executable(tmp_path / "bin" / "git")
+
+    def time_out(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        raise subprocess.TimeoutExpired(command, 0.1, output=b"partial", stderr=b"slow")
+
+    monkeypatch.setattr(git_runtime.subprocess, "run", time_out)
+
+    result = git_runtime.run_git(
+        ("status",),
+        timeout=0.1,
+        environment={"PATH": str(executable.parent)},
+    )
+
+    assert result.state is GitRunState.TIMED_OUT
+    assert result.returncode is None
+    assert result.stdout == b"partial"
+    assert result.stderr == b"slow"
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        (b"true\n", GitRunState.OK),
+        (b"false\n", GitRunState.NOT_REPOSITORY),
+    ],
+)
+def test_probe_git_repository_interprets_worktree_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    output: bytes,
+    expected: GitRunState,
+) -> None:
+    capability = GitCapability(
+        GitCapabilityState.AVAILABLE,
+        tmp_path / "git",
+        "host",
+        None,
+    )
+    monkeypatch.setattr(
+        git_runtime,
+        "run_git",
+        lambda *args, **kwargs: GitRunResult(
+            GitRunState.OK,
+            0,
+            output,
+            b"",
+            capability,
+        ),
+    )
+
+    assert git_runtime.probe_git_repository(tmp_path) is expected
+
+
+def test_real_git_plain_directory_is_not_repository(
+    tmp_path: Path,
+    real_git_environment: dict[str, str],
+) -> None:
+    plain_directory = tmp_path / "plain"
+    plain_directory.mkdir()
+
+    state = git_runtime.probe_git_repository(
+        plain_directory,
+        timeout=10.0,
+        environment=real_git_environment,
+    )
+
+    assert state is GitRunState.NOT_REPOSITORY
+
+
+def test_real_git_unborn_repository_is_available(
+    tmp_path: Path,
+    real_git_environment: dict[str, str],
+) -> None:
+    repository = tmp_path / "unborn"
+    _init_real_repository(repository, real_git_environment)
+
+    state = git_runtime.probe_git_repository(
+        repository,
+        timeout=10.0,
+        environment=real_git_environment,
+    )
+
+    assert state is GitRunState.OK
+
+
+def test_real_git_repository_subdirectory_is_available(
+    tmp_path: Path,
+    real_git_environment: dict[str, str],
+) -> None:
+    repository = tmp_path / "repository"
+    _init_real_repository(repository, real_git_environment)
+    nested = repository / "src" / "nested"
+    nested.mkdir(parents=True)
+
+    state = git_runtime.probe_git_repository(
+        nested,
+        timeout=10.0,
+        environment=real_git_environment,
+    )
+
+    assert state is GitRunState.OK
+
+
+def test_real_git_linked_worktree_is_available(
+    tmp_path: Path,
+    real_git_environment: dict[str, str],
+) -> None:
+    repository = tmp_path / "repository"
+    _init_real_repository(repository, real_git_environment)
+    (repository / "tracked.txt").write_text("base\n", encoding="utf-8")
+    _commit_real_repository(repository, real_git_environment)
+    worktree = tmp_path / "linked-worktree"
+    _run_real_git(
+        ("worktree", "add", "-q", "-b", "linked-worktree", str(worktree)),
+        cwd=repository,
+        environment=real_git_environment,
+    )
+
+    state = git_runtime.probe_git_repository(
+        worktree,
+        timeout=10.0,
+        environment=real_git_environment,
+    )
+
+    assert state is GitRunState.OK
+
+
+def test_real_git_clean_and_dirty_status_are_both_successful(
+    tmp_path: Path,
+    real_git_environment: dict[str, str],
+) -> None:
+    repository = tmp_path / "repository"
+    _init_real_repository(repository, real_git_environment)
+    tracked = repository / "tracked.txt"
+    tracked.write_text("base\n", encoding="utf-8")
+    _commit_real_repository(repository, real_git_environment)
+
+    clean = git_runtime.run_git(
+        ("-c", "core.fsmonitor=false", "status", "--porcelain=v1"),
+        cwd=repository,
+        timeout=10.0,
+        environment=real_git_environment,
+    )
+    tracked.write_text("changed\n", encoding="utf-8")
+    dirty = git_runtime.run_git(
+        ("-c", "core.fsmonitor=false", "status", "--porcelain=v1"),
+        cwd=repository,
+        timeout=10.0,
+        environment=real_git_environment,
+    )
+
+    assert clean.state is GitRunState.OK
+    assert clean.stdout == b""
+    assert dirty.state is GitRunState.OK
+    assert dirty.stdout != b""
+    assert b"tracked.txt" in dirty.stdout

--- a/tests/test_git_runtime.py
+++ b/tests/test_git_runtime.py
@@ -231,7 +231,7 @@ def test_darwin_invalid_apple_shim_continues_to_later_host_git(
     monkeypatch.setattr(git_runtime.subprocess, "run", fake_run)
 
     capability = git_runtime.resolve_git_capability(
-        {"PATH": f"{shim.parent}:{homebrew_git.parent}"}
+        {"PATH": os.pathsep.join((str(shim.parent), str(homebrew_git.parent)))}
     )
 
     assert capability.executable == homebrew_git.absolute()

--- a/tests/test_identity/test_user_profile_prompt.py
+++ b/tests/test_identity/test_user_profile_prompt.py
@@ -229,6 +229,17 @@ def test_headless_repo_coding_scaffold_patch_prompt_matches_visible_tools() -> N
     assert "source_symbols" not in prompt
 
 
+def test_headless_repo_coding_scaffold_omits_hidden_git_tool_guidance() -> None:
+    prompt = assemble_system_prompt(
+        AgentProfile(agent_id="main", prompt_mode="headless_repo_coding_scaffold"),
+        tools=["exec_command", "read_file", "edit_file", "write_file"],
+    )
+
+    assert "## Repository Coding Scaffold" in prompt
+    assert "Use `git_status` to inspect the final repository state" not in prompt
+    assert "Use `git_diff` to inspect the final source diff" not in prompt
+
+
 def test_patch_evidence_protocol_renders_when_enabled_in_scaffold_mode() -> None:
     prompt = assemble_system_prompt(
         AgentProfile(
@@ -478,6 +489,16 @@ def test_headless_source_edit_prompt_is_source_edit_focused() -> None:
     assert "## Tool Call Style" not in prompt
     assert "## OpenSquilla CLI Quick Reference" not in prompt
     assert "## Runtime" not in prompt
+
+
+def test_headless_source_edit_prompt_omits_hidden_git_diff_guidance() -> None:
+    prompt = assemble_system_prompt(
+        AgentProfile(agent_id="main", prompt_mode="headless_source_edit"),
+        tools=["read_source", "edit_source", "exec_command"],
+    )
+
+    assert "## Source Edit Contract" in prompt
+    assert "Inspect the final source diff with `git_diff`" not in prompt
 
 
 def test_legacy_prompt_style_restores_compact_directives() -> None:

--- a/tests/test_sandbox/test_trusted_sandbox_execution.py
+++ b/tests/test_sandbox/test_trusted_sandbox_execution.py
@@ -1,11 +1,87 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from opensquilla.tools.types import CallerKind, ToolContext, current_tool_context
+
+
+@pytest.mark.parametrize("run_mode", ["safe", "full"])
+@pytest.mark.asyncio
+async def test_shell_echo_succeeds_when_git_is_unavailable(
+    run_mode: str,
+    tmp_path: Path,
+    unavailable_git_runtime: SimpleNamespace,
+) -> None:
+    from opensquilla.sandbox.config import SandboxSettings
+    from opensquilla.sandbox.integration import configure_runtime, reset_runtime
+    from opensquilla.tools.builtin import shell
+
+    configure_runtime(
+        SandboxSettings(run_mode="safe", backend="noop", allow_legacy_mode=True),
+        workspace=tmp_path,
+    )
+    runtime_events: list[dict[str, object]] = []
+    token = current_tool_context.set(
+        ToolContext(
+            is_owner=True,
+            caller_kind=CallerKind.CLI,
+            session_key=f"no-git-shell-{run_mode}",
+            run_mode=run_mode,
+            workspace_dir=str(tmp_path),
+            on_runtime_event=runtime_events.append,
+        )
+    )
+    try:
+        result = await shell.exec_command("echo opensquilla_no_git", workdir=str(tmp_path))
+    finally:
+        current_tool_context.reset(token)
+        reset_runtime()
+
+    assert "opensquilla_no_git" in result
+    assert "exit_code=0" in result
+    assert unavailable_git_runtime.resolution_calls
+
+
+@pytest.mark.parametrize("run_mode", ["safe", "full"])
+@pytest.mark.asyncio
+async def test_execute_code_succeeds_when_git_is_unavailable(
+    run_mode: str,
+    tmp_path: Path,
+    unavailable_git_runtime: SimpleNamespace,
+) -> None:
+    from opensquilla.sandbox.config import SandboxSettings
+    from opensquilla.sandbox.integration import configure_runtime, reset_runtime
+    from opensquilla.tools.builtin import code_exec
+
+    configure_runtime(
+        SandboxSettings(run_mode="safe", backend="noop", allow_legacy_mode=True),
+        workspace=tmp_path,
+    )
+    runtime_events: list[dict[str, object]] = []
+    token = current_tool_context.set(
+        ToolContext(
+            is_owner=True,
+            caller_kind=CallerKind.CLI,
+            session_key=f"no-git-code-{run_mode}",
+            run_mode=run_mode,
+            workspace_dir=str(tmp_path),
+            on_runtime_event=runtime_events.append,
+        )
+    )
+    try:
+        result = await code_exec.execute_code("print('opensquilla_no_git')")
+    finally:
+        current_tool_context.reset(token)
+        reset_runtime()
+
+    payload = json.loads(result)
+    assert payload["exit_code"] == 0
+    assert payload["stdout"] == "opensquilla_no_git\n"
+    assert unavailable_git_runtime.resolution_calls
 
 
 @pytest.mark.asyncio

--- a/tests/test_sandbox/test_trusted_sandbox_execution.py
+++ b/tests/test_sandbox/test_trusted_sandbox_execution.py
@@ -80,7 +80,7 @@ async def test_execute_code_succeeds_when_git_is_unavailable(
 
     payload = json.loads(result)
     assert payload["exit_code"] == 0
-    assert payload["stdout"] == "opensquilla_no_git\n"
+    assert payload["stdout"].splitlines() == ["opensquilla_no_git"]
     assert unavailable_git_runtime.resolution_calls
 
 

--- a/tests/test_skills/test_runtime_e2e_gate.py
+++ b/tests/test_skills/test_runtime_e2e_gate.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
+
 import pytest
 
+import opensquilla.git_runtime as git_runtime
 from opensquilla.engine.types import AgentConfig, DoneEvent
+from opensquilla.git_runtime import (
+    GitCapability,
+    GitCapabilityState,
+    GitRunResult,
+    GitRunState,
+)
+from opensquilla.skills.creator import runtime_e2e as runtime_e2e_module
 from opensquilla.skills.creator.runtime_e2e import (
     make_runtime_e2e_context,
     run_runtime_e2e_gate,
@@ -26,6 +37,102 @@ composition:
         task: "{{ inputs.user_message | xml_escape | truncate(512) }}"
 ---
 """
+
+
+def _git_result(state: GitRunState) -> GitRunResult:
+    available = state is not GitRunState.UNAVAILABLE
+    capability = GitCapability(
+        state=(
+            GitCapabilityState.AVAILABLE
+            if available
+            else GitCapabilityState.UNAVAILABLE
+        ),
+        executable=Path("/test/bin/git") if available else None,
+        source="test" if available else None,
+        reason=None if available else "git_not_found",
+    )
+    return GitRunResult(
+        state=state,
+        returncode=0 if state is GitRunState.OK else None,
+        stdout=b"",
+        stderr=b"" if available else b"git_not_found",
+        capability=capability,
+    )
+
+
+def test_runtime_e2e_workspace_uses_safe_git_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run_git(
+        args: tuple[str, ...],
+        *,
+        cwd: Path,
+        timeout: float,
+    ) -> GitRunResult:
+        assert cwd == tmp_path / "runtime-workspace"
+        assert timeout == 10.0
+        calls.append(args)
+        return _git_result(GitRunState.OK)
+
+    monkeypatch.setattr(runtime_e2e_module, "run_git", fake_run_git)
+
+    workspace = runtime_e2e_module._prepare_runtime_workspace(tmp_path, None)
+
+    assert workspace == tmp_path / "runtime-workspace"
+    assert calls == [
+        ("init",),
+        ("config", "user.email", "runtime-e2e@example.test"),
+        ("config", "user.name", "Runtime E2E"),
+        ("add", "README.md"),
+        ("commit", "-m", "baseline"),
+    ]
+    assert all(call[0] != "git" for call in calls)
+
+
+@pytest.mark.asyncio
+async def test_runtime_e2e_context_returns_meta_error_when_git_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    capability = GitCapability(
+        state=GitCapabilityState.UNAVAILABLE,
+        reason="git_not_found",
+    )
+
+    def unavailable_capability(*args: object, **kwargs: object) -> GitCapability:
+        return capability
+
+    def forbidden_subprocess(*args: object, **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        raise AssertionError("unavailable Git must not launch a subprocess")
+
+    monkeypatch.setattr(git_runtime, "resolve_git_capability", unavailable_capability)
+    monkeypatch.setattr(git_runtime.subprocess, "run", forbidden_subprocess)
+    ctx = make_runtime_e2e_context(
+        provider=object(),
+        base_config=AgentConfig(model_id="frontier/highest"),
+        skill_loader=object(),
+        tool_definitions=[],
+        tool_handler=None,
+        agent_factory=None,
+        llm_chat=None,
+        tool_invoker=None,
+    )
+
+    result = await ctx["runner"](
+        route="meta",
+        prompt="please use synth test trigger",
+        skill_md=SKILL_MD,
+        baseline_model="frontier/highest",
+    )
+
+    assert result == {
+        "route": "meta",
+        "text": "",
+        "ok": False,
+        "error": "runtime E2E workspace requires Git, but it is unavailable (git_not_found)",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_skills/test_runtime_e2e_gate.py
+++ b/tests/test_skills/test_runtime_e2e_gate.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 
-import opensquilla.git_runtime as git_runtime
 from opensquilla.engine.types import AgentConfig, DoneEvent
 from opensquilla.git_runtime import (
     GitCapability,
@@ -107,8 +106,14 @@ async def test_runtime_e2e_context_returns_meta_error_when_git_unavailable(
     def forbidden_subprocess(*args: object, **kwargs: object) -> subprocess.CompletedProcess[bytes]:
         raise AssertionError("unavailable Git must not launch a subprocess")
 
-    monkeypatch.setattr(git_runtime, "resolve_git_capability", unavailable_capability)
-    monkeypatch.setattr(git_runtime.subprocess, "run", forbidden_subprocess)
+    monkeypatch.setattr(
+        "opensquilla.git_runtime.resolve_git_capability",
+        unavailable_capability,
+    )
+    monkeypatch.setattr(
+        "opensquilla.git_runtime.subprocess.run",
+        forbidden_subprocess,
+    )
     ctx = make_runtime_e2e_context(
         provider=object(),
         base_config=AgentConfig(model_id="frontier/highest"),

--- a/tests/test_skills/test_toolchain_runtime_integration.py
+++ b/tests/test_skills/test_toolchain_runtime_integration.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import pytest
 
+from opensquilla.git_runtime import GitCapability, GitCapabilityState
 from opensquilla.skills import eligibility, runtime_env
 from opensquilla.skills.hub import deps
 from opensquilla.skills.meta.executors import skill_exec
@@ -341,6 +342,85 @@ async def test_skill_exec_receives_managed_runtime_environment(
         })
     assert spawned["argv"] == (sys.executable,)
     assert spawned["kwargs"]["env"] == expected_env
+
+
+@pytest.mark.asyncio
+async def test_skill_exec_pins_resolved_git_ahead_of_apple_shim(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    spec = SimpleNamespace(
+        base_dir=str(tmp_path),
+        entrypoint={"command": "python", "parse": "text"},
+        metadata=SimpleNamespace(requires=SimpleNamespace(bins=["git"])),
+    )
+    loader = SimpleNamespace(get_by_name=lambda _name: spec)
+    safe_git = Path("/opt/homebrew/bin/git")
+    monkeypatch.setattr(
+        skill_exec,
+        "resolve_git_capability",
+        lambda: GitCapability(
+            state=GitCapabilityState.AVAILABLE,
+            executable=safe_git,
+            source="host",
+        ),
+    )
+    monkeypatch.setattr(
+        skill_exec,
+        "managed_skill_env",
+        lambda _base: {"PATH": f"/usr/bin{os.pathsep}{safe_git.parent}"},
+    )
+    spawned = _mock_skill_exec_launcher(monkeypatch)
+
+    output = await skill_exec.run_skill_exec_step(
+        MetaStep(id="run", skill="fake", kind="skill_exec"),
+        "fake",
+        {},
+        {},
+        skill_loader=loader,
+        workspace_dir=str(tmp_path),
+    )
+
+    assert output == "ok"
+    assert spawned["kwargs"]["env"]["PATH"] == (
+        f"{safe_git.parent}{os.pathsep}/usr/bin"
+    )
+
+
+@pytest.mark.asyncio
+async def test_git_skill_exec_fails_before_spawn_when_git_becomes_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    spec = SimpleNamespace(
+        base_dir=str(tmp_path),
+        entrypoint={"command": "python", "parse": "text"},
+        metadata=SimpleNamespace(requires=SimpleNamespace(bins=["git"])),
+    )
+    loader = SimpleNamespace(get_by_name=lambda _name: spec)
+    monkeypatch.setattr(
+        skill_exec,
+        "resolve_git_capability",
+        lambda: GitCapability(
+            state=GitCapabilityState.UNAVAILABLE,
+            reason="git_not_found",
+        ),
+    )
+    monkeypatch.setattr(
+        skill_exec,
+        "create_owned_subprocess_exec",
+        lambda *_args, **_kwargs: pytest.fail("unavailable Git must not spawn a skill"),
+    )
+
+    with pytest.raises(RuntimeError, match=r"^GIT_UNAVAILABLE:"):
+        await skill_exec.run_skill_exec_step(
+            MetaStep(id="run", skill="fake", kind="skill_exec"),
+            "fake",
+            {},
+            {},
+            skill_loader=loader,
+            workspace_dir=str(tmp_path),
+        )
 
 
 @pytest.mark.parametrize("font_override", ["/operator/fonts", ""])

--- a/tests/test_skills_eligibility.py
+++ b/tests/test_skills_eligibility.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from opensquilla.skills.eligibility import EligibilityContext, diagnose_eligibility
 from opensquilla.skills.types import (
     SkillInstallSpec,
@@ -23,6 +25,18 @@ def _env_any_skill() -> SkillSpec:
         metadata=SkillPlatformMeta(
             requires=SkillRequires(env_any=["OPENROUTER_API_KEY", "ARK_API_KEY"])
         ),
+    )
+
+
+def _git_skill() -> SkillSpec:
+    return SkillSpec(
+        name="git-skill",
+        description="Synthetic skill that requires Git.",
+        layer=SkillLayer.BUNDLED,
+        always=False,
+        triggers=[],
+        content="# body",
+        metadata=SkillPlatformMeta(requires=SkillRequires(bins=["git"])),
     )
 
 
@@ -77,3 +91,21 @@ def test_install_metadata_counts_as_declared_dependencies() -> None:
 
     assert report.eligible is True
     assert report.declared is True
+
+
+def test_git_requirement_uses_unified_capability_instead_of_path_lookup(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "opensquilla.git_runtime.resolve_git_capability",
+        lambda: SimpleNamespace(available=False),
+    )
+    monkeypatch.setattr(
+        "opensquilla.skills.eligibility.shutil.which",
+        lambda _name: "/usr/bin/git",
+    )
+
+    report = diagnose_eligibility(_git_skill(), EligibilityContext(os_name="darwin"))
+
+    assert report.eligible is False
+    assert report.missing_bins == ["git"]

--- a/tests/test_tools/test_bootstrap_write_notifications.py
+++ b/tests/test_tools/test_bootstrap_write_notifications.py
@@ -4,6 +4,7 @@ from collections.abc import Awaitable, Callable
 
 import pytest
 
+from opensquilla.git_runtime import GitRunState
 from opensquilla.tools.builtin import filesystem
 from opensquilla.tools.builtin import patch as patch_tool
 from opensquilla.tools.registry import get_default_registry
@@ -51,7 +52,14 @@ async def test_filesystem_write_notifies_bootstrap_or_memory_sources(tmp_path) -
 
 
 @pytest.mark.asyncio
-async def test_filesystem_write_tools_record_workspace_writes(tmp_path) -> None:
+async def test_filesystem_write_tools_record_workspace_writes(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "opensquilla.tools.write_tracking.probe_git_repository",
+        lambda *_args, **_kwargs: GitRunState.OK,
+    )
     target = tmp_path / "src" / "app.py"
     target.parent.mkdir()
     target.write_text("old\n", encoding="utf-8")
@@ -676,7 +684,14 @@ def test_coding_tool_descriptions_explain_file_edit_workflow() -> None:
 
 
 @pytest.mark.asyncio
-async def test_apply_patch_reports_workspace_write_progress(tmp_path) -> None:
+async def test_apply_patch_reports_workspace_write_progress(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "opensquilla.tools.write_tracking.probe_git_repository",
+        lambda *_args, **_kwargs: GitRunState.OK,
+    )
     target = tmp_path / "src" / "app.py"
     target.parent.mkdir()
     target.write_text("old\n", encoding="utf-8")

--- a/tests/test_tools/test_candidate_patch_checkpoint.py
+++ b/tests/test_tools/test_candidate_patch_checkpoint.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
+import pytest
+
+from opensquilla.git_runtime import GitRunState
 from opensquilla.tools.candidate_patch_checkpoint import (
     _git_show_head_path,
     create_candidate_patch_checkpoint,
@@ -16,14 +20,18 @@ def test_git_show_head_path_disambiguates_revision_like_paths(
 ) -> None:
     recorded: list[str] = []
 
-    def fake_run(command: list[str], **kwargs):
-        recorded.extend(command)
-        return subprocess.CompletedProcess(command, 0, stdout=b"content")
+    def fake_run(args, **kwargs):
+        del kwargs
+        recorded.extend(args)
+        return SimpleNamespace(ok=True, stdout=b"content")
 
-    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        "opensquilla.tools.candidate_patch_checkpoint.run_git",
+        fake_run,
+    )
 
     assert _git_show_head_path(tmp_path, "--help") == b"content"
-    assert recorded == ["git", "show", "--end-of-options", "HEAD:--help"]
+    assert recorded == ["show", "--end-of-options", "HEAD:--help"]
 
 
 def _init_git_workspace(path: Path) -> None:
@@ -81,3 +89,53 @@ def test_candidate_patch_checkpoint_preserves_preexisting_dirty_state(
     restore_candidate_patch_checkpoint(checkpoint)
 
     assert source.read_text(encoding="utf-8") == "print('accepted')\n"
+
+
+def test_candidate_checkpoint_unknown_git_skips_restore_without_claiming_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "opensquilla.tools.candidate_patch_checkpoint.run_git",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            ok=False,
+            state=GitRunState.UNAVAILABLE,
+            stdout=b"",
+        ),
+    )
+    checkpoint = create_candidate_patch_checkpoint(tmp_path, label="unknown")
+    candidate = tmp_path / "candidate.py"
+    candidate.write_text("keep me\n", encoding="utf-8")
+
+    result = restore_candidate_patch_checkpoint(checkpoint)
+
+    assert checkpoint.git_state is GitRunState.UNAVAILABLE
+    assert result["status"] == "skipped"
+    assert result["git_state"] == "unavailable"
+    assert candidate.read_text(encoding="utf-8") == "keep me\n"
+
+
+def test_candidate_checkpoint_removes_staged_new_candidate(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _init_git_workspace(workspace)
+    _commit_file(workspace, "src/app.py", "print('base')\n")
+    checkpoint = create_candidate_patch_checkpoint(workspace, label="clean")
+    candidate = workspace / "candidate.py"
+    candidate.write_text("candidate\n", encoding="utf-8")
+    subprocess.run(["git", "add", "candidate.py"], cwd=workspace, check=True)
+
+    result = restore_candidate_patch_checkpoint(checkpoint)
+
+    assert result["status"] == "restored"
+    assert not candidate.exists()
+    status = subprocess.run(
+        ["git", "status", "--porcelain=v1"],
+        cwd=workspace,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert status.stdout == ""

--- a/tests/test_tools/test_git_run_mode.py
+++ b/tests/test_tools/test_git_run_mode.py
@@ -140,7 +140,12 @@ async def test_git_status_run_mode_full_uses_host_subprocess(
 
     assert result == "## main\n"
     assert len(calls) == 1
-    assert calls[0]["args"] == ("/resolved/git", "status", "--short", "--branch")
+    assert calls[0]["args"] == (
+        str(Path("/resolved/git")),
+        "status",
+        "--short",
+        "--branch",
+    )
     kwargs = calls[0]["kwargs"]
     assert kwargs["stdout"] is git.asyncio.subprocess.PIPE
     assert kwargs["stderr"] is git.asyncio.subprocess.STDOUT
@@ -199,7 +204,7 @@ async def test_git_uses_runtime_read_only_profile_and_read_only_mounts(
     assert all(mount.mode == "ro" for mount in request.policy.mounts)
     assert request.env == {"LC_ALL": "C", "LANG": "C"}
     assert request.argv[:4] == (
-        "/resolved/git",
+        str(Path("/resolved/git")),
         "--no-optional-locks",
         "-c",
         "core.fsmonitor=false",

--- a/tests/test_tools/test_git_run_mode.py
+++ b/tests/test_tools/test_git_run_mode.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 
+from opensquilla.git_runtime import GitCapability, GitCapabilityState
 from opensquilla.sandbox.config import SandboxSettings
 from opensquilla.sandbox.integration import configure_runtime, reset_runtime
 from opensquilla.sandbox.permissions import FileSystemPermissionProfile
@@ -20,6 +21,26 @@ class _FakeProcess:
 
     async def communicate(self) -> tuple[bytes, None]:
         return b"## main\n", None
+
+
+class _NotRepositoryProcess(_FakeProcess):
+    returncode = 128
+
+    async def communicate(self) -> tuple[bytes, None]:
+        return b"fatal: not a git repository (or any parent directory): .git\n", None
+
+
+@pytest.fixture(autouse=True)
+def _resolved_git(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        git,
+        "resolve_git_capability",
+        lambda **_kwargs: GitCapability(
+            state=GitCapabilityState.AVAILABLE,
+            executable=Path("/resolved/git"),
+            source="test",
+        ),
+    )
 
 
 def test_read_only_git_diff_disables_repository_controlled_helpers() -> None:
@@ -37,11 +58,65 @@ def test_read_only_git_diff_disables_repository_controlled_helpers() -> None:
 
 
 @pytest.mark.asyncio
+async def test_git_unavailable_is_reported_without_launching_a_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        git,
+        "resolve_git_capability",
+        lambda **_kwargs: GitCapability(
+            state=GitCapabilityState.UNAVAILABLE,
+            reason="git_not_found",
+        ),
+    )
+    monkeypatch.setattr(
+        git,
+        "create_owned_subprocess_exec",
+        lambda *_args, **_kwargs: pytest.fail("unavailable Git must not be launched"),
+    )
+
+    with pytest.raises(RuntimeError, match=r"^GIT_UNAVAILABLE:"):
+        await git._run_git("status")
+
+
+@pytest.mark.asyncio
+async def test_git_non_repository_failure_has_stable_error_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reset_runtime()
+
+    async def fake_create_subprocess_exec(
+        *args: str, **kwargs: Any
+    ) -> _NotRepositoryProcess:
+        del args, kwargs
+        return _NotRepositoryProcess()
+
+    monkeypatch.setattr(git, "create_owned_subprocess_exec", fake_create_subprocess_exec)
+    token = current_tool_context.set(
+        ToolContext(
+            is_owner=True,
+            workspace_dir=str(tmp_path),
+            run_mode="full",
+            session_key="agent:main:test",
+        )
+    )
+    try:
+        with pytest.raises(RuntimeError, match=r"^GIT_NOT_REPOSITORY:"):
+            await git.git_status()
+    finally:
+        current_tool_context.reset(token)
+        reset_runtime()
+
+
+@pytest.mark.asyncio
 async def test_git_status_run_mode_full_uses_host_subprocess(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     reset_runtime()
+    monkeypatch.setenv("GIT_TERMINAL_PROMPT", "1")
+    monkeypatch.setenv("GCM_INTERACTIVE", "Always")
     calls: list[dict[str, Any]] = []
 
     async def fake_create_subprocess_exec(*args: str, **kwargs: Any) -> _FakeProcess:
@@ -64,16 +139,17 @@ async def test_git_status_run_mode_full_uses_host_subprocess(
         reset_runtime()
 
     assert result == "## main\n"
-    assert calls == [
-        {
-            "args": ("git", "status", "--short", "--branch"),
-            "kwargs": {
-                "stdout": git.asyncio.subprocess.PIPE,
-                "stderr": git.asyncio.subprocess.STDOUT,
-                "cwd": str(tmp_path),
-            },
-        }
-    ]
+    assert len(calls) == 1
+    assert calls[0]["args"] == ("/resolved/git", "status", "--short", "--branch")
+    kwargs = calls[0]["kwargs"]
+    assert kwargs["stdout"] is git.asyncio.subprocess.PIPE
+    assert kwargs["stderr"] is git.asyncio.subprocess.STDOUT
+    assert kwargs["cwd"] == str(tmp_path)
+    environment = kwargs["env"]
+    assert environment["LC_ALL"] == "C"
+    assert environment["LANG"] == "C"
+    assert environment["GIT_TERMINAL_PROMPT"] == "1"
+    assert environment["GCM_INTERACTIVE"] == "Always"
 
 
 @pytest.mark.asyncio
@@ -121,8 +197,9 @@ async def test_git_uses_runtime_read_only_profile_and_read_only_mounts(
     assert request.policy.workspace_rw is False
     assert request.policy.tmp_writable is False
     assert all(mount.mode == "ro" for mount in request.policy.mounts)
+    assert request.env == {"LC_ALL": "C", "LANG": "C"}
     assert request.argv[:4] == (
-        "git",
+        "/resolved/git",
         "--no-optional-locks",
         "-c",
         "core.fsmonitor=false",

--- a/tests/test_tools/test_gitless_write_tracking.py
+++ b/tests/test_tools/test_gitless_write_tracking.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from opensquilla.git_runtime import GitRunState
+from opensquilla.tools import write_policy
+from opensquilla.tools.types import ToolContext, current_tool_context
+from opensquilla.tools.write_tracking import (
+    WorkspaceMutationSnapshot,
+    enforce_workspace_write_deny_effects,
+    snapshot_current_workspace_mutations,
+    workspace_write_deny_effect_preflight,
+    workspace_write_progress_note,
+)
+
+
+def _context(workspace: Path, **kwargs: object) -> ToolContext:
+    return ToolContext(workspace_dir=str(workspace), **kwargs)
+
+
+def test_snapshot_is_lazy_without_a_ledger_or_effect_consumer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = _context(tmp_path)
+    token = current_tool_context.set(ctx)
+    monkeypatch.setattr(
+        "opensquilla.tools.write_tracking.run_git",
+        lambda *_args, **_kwargs: pytest.fail("unused mutation snapshots must not launch Git"),
+    )
+    try:
+        snapshot = snapshot_current_workspace_mutations()
+    finally:
+        current_tool_context.reset(token)
+
+    assert snapshot == {}
+    assert snapshot.observed is False
+    assert snapshot.authoritative is False
+    assert snapshot.skip_reason == "no_consumer"
+
+
+def test_revert_preflight_blocks_when_git_snapshot_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_WORKSPACE_WRITE_DENY_EFFECT", "revert")
+    ctx = _context(tmp_path)
+    ctx.workspace_write_deny_globs = ["tests/**"]
+    token = current_tool_context.set(ctx)
+    monkeypatch.setattr(
+        "opensquilla.tools.write_tracking.run_git",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            ok=False,
+            state=GitRunState.UNAVAILABLE,
+            stdout=b"",
+        ),
+    )
+    try:
+        before = snapshot_current_workspace_mutations()
+        raw = workspace_write_deny_effect_preflight(
+            tool_name="exec_command",
+            before=before,
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert raw is not None
+    payload = json.loads(raw)
+    assert payload["status"] == "blocked"
+    assert payload["code"] == "WORKSPACE_WRITE_PROTECTION_UNAVAILABLE"
+    assert payload["git_state"] == "unavailable"
+
+
+def test_warn_mode_reports_unavailable_protection_only_once_per_turn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_WORKSPACE_WRITE_DENY_EFFECT", "warn")
+    events: list[dict[str, object]] = []
+    ctx = _context(tmp_path, execution_id="turn-1", on_runtime_event=events.append)
+    ctx.workspace_write_deny_globs = ["tests/**"]
+    token = current_tool_context.set(ctx)
+    unavailable = WorkspaceMutationSnapshot(git_state=GitRunState.UNAVAILABLE)
+    monkeypatch.setattr(
+        "opensquilla.tools.write_tracking.snapshot_workspace_mutations",
+        lambda _workspace: unavailable,
+    )
+    try:
+        first = enforce_workspace_write_deny_effects(
+            tool_name="exec_command",
+            before=unavailable,
+            output="first",
+        )
+        second = enforce_workspace_write_deny_effects(
+            tool_name="execute_code",
+            before=unavailable,
+            output="second",
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert first.startswith("[workspace write protection unavailable]")
+    assert second == "second"
+    records = [
+        record
+        for record in ctx.workspace_mutation_records
+        if record.get("operation") == "effect_enforcement_unavailable"
+    ]
+    assert len(records) == 1
+    assert [event["name"] for event in events] == ["effect_enforcement_unavailable"]
+
+
+def test_tracked_only_git_unavailable_remains_fail_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "tests" / "test_new.py"
+    target.parent.mkdir()
+    target.write_text("x\n", encoding="utf-8")
+    ctx = _context(tmp_path)
+    ctx.workspace_write_deny_globs = ["tests/**"]
+    monkeypatch.setenv("OPENSQUILLA_WORKSPACE_WRITE_DENY_TRACKED_ONLY", "on")
+    monkeypatch.setattr(
+        write_policy,
+        "run_git",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            ok=False,
+            state=GitRunState.UNAVAILABLE,
+            returncode=None,
+            stdout=b"",
+        ),
+    )
+
+    match = write_policy.match_workspace_write_deny(
+        target,
+        original_path="tests/test_new.py",
+        workspace=tmp_path,
+        ctx=ctx,
+    )
+
+    assert match is not None
+
+
+def test_workspace_progress_note_omits_hidden_or_unavailable_git(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = _context(tmp_path)
+    ctx.workspace_file_writes.append({"relative_path": "src/app.py"})
+    ctx.denied_tools.add("git_diff")
+    token = current_tool_context.set(ctx)
+    monkeypatch.setattr(
+        "opensquilla.tools.write_tracking.probe_git_repository",
+        lambda *_args, **_kwargs: pytest.fail("hidden git_diff must not probe Git"),
+    )
+    try:
+        note = workspace_write_progress_note()
+    finally:
+        current_tool_context.reset(token)
+
+    assert "inspect git_diff" not in note
+    assert "focused verification" in note
+
+
+def test_workspace_progress_note_omits_git_outside_a_repository(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = _context(tmp_path)
+    ctx.workspace_file_writes.append({"relative_path": "src/app.py"})
+    token = current_tool_context.set(ctx)
+    monkeypatch.setattr(
+        "opensquilla.tools.write_tracking.probe_git_repository",
+        lambda *_args, **_kwargs: GitRunState.NOT_REPOSITORY,
+    )
+    try:
+        note = workspace_write_progress_note()
+    finally:
+        current_tool_context.reset(token)
+
+    assert "inspect git_diff" not in note
+    assert "focused verification" in note

--- a/tests/test_tools/test_policy_runtime_boundary.py
+++ b/tests/test_tools/test_policy_runtime_boundary.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+from types import SimpleNamespace
 
 import opensquilla.tools.policy as policy_facade
 from opensquilla.tools import policy_helpers
 from opensquilla.tools.policy_runtime import (
     ToolSurfaceCapabilities,
+    detect_runtime_tool_surface_capabilities,
     resolve_runtime_tool_surface,
     tool_surface_capabilities_from_runtime,
 )
@@ -146,6 +148,33 @@ def test_policy_runtime_preserves_runtime_capability_denylists() -> None:
         "sessions_send",
     } <= result.denied_tools
     assert result.allowed_tools == set()
+
+
+def test_policy_runtime_hides_git_tools_when_git_is_unavailable() -> None:
+    git_tools = {"git_status", "git_diff", "git_log", "git_commit"}
+    ctx = ToolContext(
+        is_owner=True,
+        allowed_tools={"read_file", *git_tools},
+    )
+
+    result = resolve_runtime_tool_surface(
+        ctx,
+        capabilities=ToolSurfaceCapabilities(git_available=False),
+    )
+
+    assert git_tools <= result.denied_tools
+    assert result.allowed_tools == {"read_file"}
+
+
+def test_policy_runtime_detects_git_with_unified_capability_probe(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "opensquilla.git_runtime.resolve_git_capability",
+        lambda: SimpleNamespace(available=False),
+    )
+
+    caps = detect_runtime_tool_surface_capabilities()
+
+    assert caps.git_available is False
 
 
 def test_policy_runtime_builds_capabilities_from_injected_dependencies() -> None:

--- a/tests/test_tools/test_run_mode_full_host_fallback.py
+++ b/tests/test_tools/test_run_mode_full_host_fallback.py
@@ -9,13 +9,16 @@ workspace policy layers stay active; explicit Full run mode is unaffected.
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+from opensquilla.run_mode import RunMode
 from opensquilla.sandbox.config import SandboxSettings
 from opensquilla.sandbox.integration import configure_runtime, reset_runtime
 from opensquilla.tools.run_mode import (
     current_run_mode,
+    effective_run_mode_for_context,
     full_host_access_active,
     full_host_access_for_context,
     trusted_sandbox_active,
@@ -67,6 +70,7 @@ def test_disabled_sandbox_grants_full_host_by_default(
     assert current_run_mode() == "safe"
     assert full_host_access_active() is True
     assert full_host_access_for_context(bypass_context) is True
+    assert effective_run_mode_for_context(bypass_context) is RunMode.FULL
 
 
 def test_disabled_sandbox_never_upgrades_guest_to_full_host(
@@ -82,6 +86,62 @@ def test_disabled_sandbox_never_upgrades_guest_to_full_host(
     )
 
     assert full_host_access_for_context(guest) is False
+    assert effective_run_mode_for_context(guest) is RunMode.SAFE
+
+
+def test_effective_mode_reads_persisted_sandbox_run_context(tmp_path: Path) -> None:
+    reset_runtime()
+    ctx = ToolContext(
+        workspace_dir=str(tmp_path),
+        run_mode=None,
+        sandbox_run_context=SimpleNamespace(run_mode=RunMode.FULL),
+    )
+
+    assert effective_run_mode_for_context(ctx) is RunMode.FULL
+
+
+def test_effective_mode_reads_session_authorization(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    reset_runtime()
+    queue = SimpleNamespace(get_run_mode=lambda _session_key: "full")
+    monkeypatch.setattr(
+        "opensquilla.gateway.approval_queue.get_approval_queue",
+        lambda: queue,
+    )
+    ctx = ToolContext(
+        workspace_dir=str(tmp_path),
+        session_key="agent:main:legacy-approved",
+    )
+
+    assert effective_run_mode_for_context(ctx) is RunMode.FULL
+
+
+def test_effective_mode_keeps_legacy_safe_session_over_full_runtime_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    queue = SimpleNamespace(get_run_mode=lambda _session_key: "safe")
+    runtime = SimpleNamespace(
+        effective=SimpleNamespace(sandbox_enabled=True),
+        default_run_mode="full",
+    )
+    monkeypatch.setattr(
+        "opensquilla.gateway.approval_queue.get_approval_queue",
+        lambda: queue,
+    )
+    monkeypatch.setattr(
+        "opensquilla.sandbox.integration.get_runtime",
+        lambda: runtime,
+    )
+    ctx = ToolContext(
+        workspace_dir=str(tmp_path),
+        session_key="agent:main:legacy-safe",
+    )
+
+    assert effective_run_mode_for_context(ctx) is RunMode.SAFE
+    assert ctx.run_mode == RunMode.SAFE.value
 
 
 def test_guest_context_rejects_even_a_forged_full_run_mode(

--- a/tests/test_tools/test_workspace_write_deny_effects.py
+++ b/tests/test_tools/test_workspace_write_deny_effects.py
@@ -11,19 +11,28 @@ class), through a symlink, or through `ln` itself.
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from pathlib import Path
 
 import pytest
 
+from opensquilla.git_runtime import GitRunState
 from opensquilla.sandbox.config import SandboxSettings
 from opensquilla.sandbox.integration import configure_runtime, reset_runtime
+from opensquilla.sandbox.types import (
+    DenialReason,
+    DenialResult,
+    SecurityLevel,
+    SuggestedNextStep,
+)
 from opensquilla.tools import write_policy
-from opensquilla.tools.builtin import shell
+from opensquilla.tools.builtin import code_exec, shell
 from opensquilla.tools.builtin.code_exec import execute_code
 from opensquilla.tools.builtin.shell import exec_command
 from opensquilla.tools.types import CallerKind, ToolContext, current_tool_context
+from opensquilla.tools.write_tracking import WorkspaceMutationSnapshot
 
 _EFFECT_ENV = "OPENSQUILLA_WORKSPACE_WRITE_DENY_EFFECT"
 _TRACKED_ONLY_ENV = "OPENSQUILLA_WORKSPACE_WRITE_DENY_TRACKED_ONLY"
@@ -136,6 +145,14 @@ def _effect_events(events: list[dict]) -> list[dict]:
     return [event for event in events if event.get("name") == "effect_enforcement"]
 
 
+def _effect_unavailable_events(events: list[dict]) -> list[dict]:
+    return [
+        event
+        for event in events
+        if event.get("name") == "effect_enforcement_unavailable"
+    ]
+
+
 @pytest.mark.asyncio
 async def test_helper_script_escape_is_reverted_and_denied(effect_context, monkeypatch):
     """Reproduces the observed escape class: argv names no protected path."""
@@ -196,6 +213,194 @@ async def test_effect_mode_off_by_default(effect_context):
     assert "[workspace write deny]" not in result
     assert (workspace / "replacer_test.go").read_text(encoding="utf-8") == "hacked\n"
     assert _effect_events(events) == []
+
+
+@pytest.mark.parametrize(
+    ("run_mode", "effect_mode", "expected_runs", "warning_expected"),
+    [
+        ("safe", "off", 1, False),
+        ("safe", "warn", 1, True),
+        ("safe", "revert", 0, False),
+        ("full", "off", 1, False),
+        ("full", "warn", 1, False),
+        ("full", "revert", 1, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_git_unavailable_effect_mode_matrix_in_safe_and_full(
+    effect_context,
+    monkeypatch: pytest.MonkeyPatch,
+    run_mode: str,
+    effect_mode: str,
+    expected_runs: int,
+    warning_expected: bool,
+) -> None:
+    workspace, _scratch, ctx, events = effect_context
+    ctx.run_mode = run_mode
+    monkeypatch.setenv(_EFFECT_ENV, effect_mode)
+    unavailable = WorkspaceMutationSnapshot(git_state=GitRunState.UNAVAILABLE)
+    monkeypatch.setattr(
+        shell,
+        "snapshot_current_workspace_mutations",
+        lambda: unavailable,
+    )
+    executions: list[str] = []
+
+    async def fake_full_host(*_args: object, **_kwargs: object) -> str:
+        executions.append("full")
+        return "ran\n"
+
+    async def fake_host(*_args: object, **kwargs: object) -> str:
+        executions.append("safe")
+        on_process_started = kwargs.get("on_process_started")
+        if callable(on_process_started):
+            on_process_started()
+        return "exit_code=0\nran\n"
+
+    monkeypatch.setattr(shell, "_run_full_host_shell_command", fake_full_host)
+    monkeypatch.setattr(shell, "_run_host_shell_command", fake_host)
+
+    result = await exec_command("printf ran", workdir=str(workspace))
+
+    assert len(executions) == expected_runs
+    assert ("[workspace write protection unavailable]" in result) is warning_expected
+    if expected_runs == 0:
+        payload = json.loads(result)
+        assert payload["code"] == "WORKSPACE_WRITE_PROTECTION_UNAVAILABLE"
+    assert len(_effect_unavailable_events(events)) == int(warning_expected)
+
+
+@pytest.mark.asyncio
+async def test_shell_preexecution_denial_does_not_claim_postexecution_warning(
+    effect_context,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, _scratch, ctx, events = effect_context
+    ctx.run_mode = "safe"
+    monkeypatch.setenv(_EFFECT_ENV, "warn")
+    unavailable = WorkspaceMutationSnapshot(git_state=GitRunState.UNAVAILABLE)
+    monkeypatch.setattr(
+        shell,
+        "snapshot_current_workspace_mutations",
+        lambda: unavailable,
+    )
+    monkeypatch.setattr(
+        shell,
+        "_strict_runtime_unavailable_envelope",
+        lambda *_args, **_kwargs: {
+            "status": "error",
+            "reason": "runtime_unavailable",
+        },
+    )
+
+    async def unexpected_execution(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("pre-execution denial must not launch the command")
+
+    monkeypatch.setattr(shell, "_run_host_shell_command", unexpected_execution)
+    monkeypatch.setattr(shell, "_run_full_host_shell_command", unexpected_execution)
+
+    result = await exec_command("printf never", workdir=str(workspace))
+
+    assert json.loads(result)["reason"] == "runtime_unavailable"
+    assert "[workspace write protection unavailable]" not in result
+    assert _effect_unavailable_events(events) == []
+
+
+@pytest.mark.asyncio
+async def test_execute_code_preexecution_denial_does_not_claim_postexecution_warning(
+    effect_context,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, _scratch, ctx, events = effect_context
+    ctx.run_mode = "safe"
+    monkeypatch.setenv(_EFFECT_ENV, "warn")
+    reset_runtime()
+    unavailable = WorkspaceMutationSnapshot(git_state=GitRunState.UNAVAILABLE)
+    monkeypatch.setattr(
+        code_exec,
+        "snapshot_current_workspace_mutations",
+        lambda: unavailable,
+    )
+
+    denial = DenialResult(
+        reason=DenialReason.POLICY_DENIED,
+        suggested_next_step=SuggestedNextStep.REPLAN,
+        level=SecurityLevel.STANDARD,
+        action_fingerprint="pre-execution-denial",
+        message="denied before execution",
+        retryable=False,
+    )
+
+    async def deny_action(**_kwargs: object) -> tuple[object, object, object]:
+        return denial, object(), object()
+
+    async def unexpected_execution(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("pre-execution denial must not launch Python")
+
+    monkeypatch.setattr(code_exec, "gate_action", deny_action)
+    monkeypatch.setattr(code_exec, "create_owned_subprocess_exec", unexpected_execution)
+
+    result = await execute_code("print('never')")
+
+    assert json.loads(result)["reason"] == DenialReason.POLICY_DENIED.value
+    assert "[workspace write protection unavailable]" not in result
+    assert _effect_unavailable_events(events) == []
+
+
+@pytest.mark.asyncio
+async def test_execute_code_spawn_failure_does_not_claim_postexecution_warning(
+    effect_context,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _workspace, _scratch, ctx, events = effect_context
+    ctx.run_mode = "safe"
+    monkeypatch.setenv(_EFFECT_ENV, "warn")
+    unavailable = WorkspaceMutationSnapshot(git_state=GitRunState.UNAVAILABLE)
+    monkeypatch.setattr(
+        code_exec,
+        "snapshot_current_workspace_mutations",
+        lambda: unavailable,
+    )
+
+    async def fail_before_spawn(*_args: object, **_kwargs: object) -> object:
+        raise OSError("interpreter could not be started")
+
+    monkeypatch.setattr(code_exec, "create_owned_subprocess_exec", fail_before_spawn)
+
+    result = await execute_code("print('never started')")
+
+    payload = json.loads(result)
+    assert payload["exit_code"] == -1
+    assert "interpreter could not be started" in payload["stderr"]
+    assert "[workspace write protection unavailable]" not in result
+    assert _effect_unavailable_events(events) == []
+
+
+@pytest.mark.asyncio
+async def test_shell_spawn_failure_does_not_claim_postexecution_warning(
+    effect_context,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, _scratch, ctx, events = effect_context
+    ctx.run_mode = "safe"
+    monkeypatch.setenv(_EFFECT_ENV, "warn")
+    unavailable = WorkspaceMutationSnapshot(git_state=GitRunState.UNAVAILABLE)
+    monkeypatch.setattr(
+        shell,
+        "snapshot_current_workspace_mutations",
+        lambda: unavailable,
+    )
+
+    async def fail_before_spawn(*_args: object, **_kwargs: object) -> object:
+        raise OSError("shell could not be started")
+
+    monkeypatch.setattr(shell, "_create_host_shell_subprocess", fail_before_spawn)
+
+    result = await exec_command("printf never", workdir=str(workspace))
+
+    assert result == "[error] shell could not be started"
+    assert "[workspace write protection unavailable]" not in result
+    assert _effect_unavailable_events(events) == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/tui/test_opentui_enumerate_files.py
+++ b/tests/unit/cli/tui/test_opentui_enumerate_files.py
@@ -82,20 +82,36 @@ def test_enumerate_workspace_files_uses_git_ls_files_when_available(
     calls: dict[str, list[str]] = {}
 
     def fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        del kwargs
         calls["cmd"] = cmd
         return SimpleNamespace(
-            returncode=0,
+            ok=True,
             stdout=b"src/compact.py\0src/.env\0docs/reset.md\0",
-            stderr=b"",
         )
 
-    monkeypatch.setattr(completion.shutil, "which", lambda name: "/usr/bin/git")
-    monkeypatch.setattr(completion.subprocess, "run", fake_run)
+    monkeypatch.setattr(completion, "run_git", fake_run)
 
     assert enumerate_workspace_files(tmp_path, query="cmp") == ["src/compact.py"]
     # NUL-separated output keeps non-ASCII paths verbatim (no core.quotePath
     # C-quoting), so -z is load-bearing.
     assert "-z" in calls["cmd"]
+
+
+def test_git_files_probe_repository_from_a_subdirectory_without_dot_git(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    subdirectory = tmp_path / "src"
+    subdirectory.mkdir()
+    calls: list[Path] = []
+
+    def fake_run(_args: object, **kwargs: object) -> SimpleNamespace:
+        calls.append(Path(str(kwargs["cwd"])))
+        return SimpleNamespace(ok=True, stdout=b"module.py\0")
+
+    monkeypatch.setattr(completion, "run_git", fake_run)
+
+    assert completion._git_files(subdirectory) == ["module.py"]
+    assert calls == [subdirectory]
 
 
 def test_git_files_returns_non_ascii_paths_verbatim(
@@ -105,11 +121,10 @@ def test_git_files_returns_non_ascii_paths_verbatim(
     _touch(tmp_path / "café.md")
     _touch(tmp_path / "日本語.txt")
     stdout = "café.md".encode() + b"\0" + "日本語.txt".encode() + b"\0"
-    monkeypatch.setattr(completion.shutil, "which", lambda name: "/usr/bin/git")
     monkeypatch.setattr(
-        completion.subprocess,
-        "run",
-        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout=stdout, stderr=b""),
+        completion,
+        "run_git",
+        lambda *args, **kwargs: SimpleNamespace(ok=True, stdout=stdout),
     )
 
     assert enumerate_workspace_files(tmp_path) == ["café.md", "日本語.txt"]
@@ -121,7 +136,6 @@ def test_git_files_tolerates_undecodable_path_bytes(
     # A non-UTF-8 filename byte (e.g. latin-1 0xE9) must never crash completion;
     # it decodes through the filesystem rules (surrogateescape) instead.
     (tmp_path / ".git").mkdir()
-    monkeypatch.setattr(completion.shutil, "which", lambda name: "/usr/bin/git")
     # Windows uses surrogatepass for filesystem decoding, which still raises
     # for this malformed UTF-8 byte. Simulate that handler on every platform so
     # the fallback remains covered outside the Windows CI job too.
@@ -131,10 +145,10 @@ def test_git_files_tolerates_undecodable_path_bytes(
         lambda entry: entry.decode("utf-8", errors="surrogatepass"),
     )
     monkeypatch.setattr(
-        completion.subprocess,
-        "run",
+        completion,
+        "run_git",
         lambda *args, **kwargs: SimpleNamespace(
-            returncode=0, stdout=b"caf\xe9.md\0plain.txt\0", stderr=b""
+            ok=True, stdout=b"caf\xe9.md\0plain.txt\0"
         ),
     )
 


### PR DESCRIPTION
## Scope

Scope boundary:

- Resolve a safe absolute Git executable for OpenSquilla-owned background checks without launching the macOS `/usr/bin/git` installer shim.
- Preserve tri-state Git outcomes across Agent diagnostics, mutation tracking, write protection, CodeTask, skills, CLI completion, and dedicated Git tools.
- Keep CodeTask credential helpers and interactive authentication available for user Git workflows.
- Preserve legacy Safe/Full selection and fail closed for revert-mode write protection when Git observation is unavailable.

Non-goals:

- No filesystem scan, hash, or watcher fallback.
- No interception of explicit Git commands launched through `exec_command`, scripts, npm, or Python subprocesses.
- No database, configuration, RPC, Artifact, HTML editor, or installer migration.

## Branch

Base branch: main

Target exception: hotfix

## Issue

Linked issue: None

If None, reason: No public issue was supplied for this macOS clean-install regression.

## Release Note

Release note: Prevent OpenSquilla background Git checks from opening the macOS developer-tools installer when Git is unavailable, while preserving normal Git and CodeTask workflows.

## Tests

Ruff: `uv run ruff check src tests` — passed

Pytest:

- 265 focused Git/runtime/CodeTask/skill tests passed, 6 skipped.
- 154 Safe/Full, shell process, and write-protection tests passed, 6 skipped.
- Full default suite: 23,940 passed, 250 skipped, 6 environment-dependent failures. The failures are unchanged local prerequisites: LFS router assets, router preload using those assets, two `.codex/worktrees` protected-path tests, missing WeasyPrint system libraries, and macOS BSD `sed -i` syntax.

Build: Standard local wheel build is blocked because this checkout has no verified generated WebUI `static/dist`; the full suite isolated-wheel fixture completed. `src/opensquilla/git_runtime.py` is committed under the configured `src/opensquilla` wheel package.

Regression tests: added

Notes:

- `uv run mypy src/opensquilla --show-error-codes` — passed for 975 source files.
- `git diff --check origin/main...HEAD` — passed.
- The default test path remains offline, deterministic, credential-free, and safe for forks.

## Upgrade Compatibility

No database, persisted configuration, session, RPC, or package-layout migration is required. Existing sessions continue to use their effective Safe/Full mode. Dedicated Git handlers remain registered so old tool calls receive structured unavailable/not-repository results instead of disappearing at dispatch.

## Maintainer Live Check

Maintainer live check: yes

Surface: gateway | release

Please verify a packaged macOS build on a machine without CLT, plus CLT/Homebrew Git and Windows Runtime Pack Git regression coverage.

## Safety

- Background probes are non-interactive and never execute the invalid Apple Git shim.
- Explicit user Git workflows retain authentication and signing behavior.
- Safe revert-mode write protection blocks before execution when Git-backed verification is unavailable; tracked-only uncertainty remains fail closed.
- No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, session artifacts, or private fixtures are included.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No documentation files changed.
- [x] No new secret-bearing or private examples were added.