### PR TITLE
feat(tokenrhythm): support DeepSeek V4 Pro 0813 and refresh the default ladder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Fresh and managed TokenRhythm configurations now use DeepSeek V4 Flash 0731
+  for C0, DeepSeek V4 Pro 0813 as the direct and C1 default, Kimi K2.7 Code for
+  C2, and GLM 5.2 B5 fusion for C3. Existing custom inline tiers are not
+  migrated, and the mixed-family preset continues to leave thinking levels
+  unset.
 ### Fixed
 
 - Stop now acknowledges immediately for provider and ordinary tool work while

--- a/desktop/electron/package.json
+++ b/desktop/electron/package.json
@@ -54,6 +54,7 @@
     "test:mock-update-flow": "npm run build && node scripts/test-mock-update-flow.mjs",
     "test:onboarding-coordinator": "npm run build && node scripts/test-onboarding-flow-coordinator.mjs",
     "test:onboarding-telemetry": "npm run build && node scripts/test-onboarding-save-telemetry.mjs",
+    "test:router-tier-normalization": "npm run build && node scripts/test-router-tier-normalization.mjs",
     "test:onboarding-flow": "npm run build && node scripts/test-onboarding-flow.mjs",
     "start": "electron .",
     "pack": "npm run build && electron-builder --dir && npm run verify:package",

--- a/desktop/electron/scripts/test-onboarding-flow.mjs
+++ b/desktop/electron/scripts/test-onboarding-flow.mjs
@@ -631,7 +631,7 @@ try {
   assert.equal(await page.locator('#modelSummary').isVisible(), true)
   assert.equal(await page.locator('#modelEditor').isVisible(), false)
   assert.equal(await page.locator('#modelSummaryLabel').innerText(), '推荐模型')
-  assert.equal(await page.locator('#modelSummaryValue').innerText(), 'deepseek-v4-pro')
+  assert.equal(await page.locator('#modelSummaryValue').innerText(), 'deepseek-v4-pro-0813')
   assert.deepEqual(
     await page.evaluate(() => [
       getComputedStyle(document.getElementById('providerSelectLabel')).fontSize,
@@ -742,7 +742,7 @@ try {
 
   assert.equal(await page.locator('#provider').inputValue(), 'tokenrhythm')
   assert.equal(await page.locator('#baseUrl').inputValue(), 'https://tokenrhythm.studio/v1')
-  assert.equal(await page.locator('#model').inputValue(), 'deepseek-v4-pro')
+  assert.equal(await page.locator('#model').inputValue(), 'deepseek-v4-pro-0813')
   assert.equal(await page.locator('#modelRoutingMode').inputValue(), 'squilla_router')
   assert.equal(await page.locator('#routerMode').inputValue(), 'recommended')
 
@@ -800,7 +800,7 @@ try {
   assert.equal(await page.locator('#modelRoutingMode').inputValue(), 'squilla_router')
   assert.equal(await page.locator('#routerMode').inputValue(), 'recommended')
   assert.equal(await page.locator('#modelSummary').isVisible(), true)
-  assert.equal(await page.locator('#modelSummaryValue').innerText(), 'deepseek-v4-pro')
+  assert.equal(await page.locator('#modelSummaryValue').innerText(), 'deepseek-v4-pro-0813')
   await page.locator('#apiKey').fill('synthetic-tokenrhythm-key')
   assert.equal(await page.locator('.inline-search-section').isVisible(), true)
   assert.equal(await page.locator('#inlineSearchHeading').innerText(), 'Choose web search')
@@ -873,12 +873,25 @@ try {
   assert.equal(credential.modelRoutingMode, 'squilla_router')
   assert.equal(credential.routerMode, 'recommended')
   assert.equal(credential.routerDefaultTier, 'c1')
-  assert.equal(credential.routerTiers.c0.model, 'deepseek-v4-flash')
-  assert.equal(credential.routerTiers.c1.model, 'deepseek-v4-pro')
+  assert.equal(credential.model, 'deepseek-v4-pro-0813')
+  assert.equal(credential.routerTiers.c0.model, 'deepseek-v4-flash-0731')
+  assert.equal(credential.routerTiers.c1.model, 'deepseek-v4-pro-0813')
   assert.equal(credential.routerTiers.c2.model, 'kimi-k2.7-code')
   assert.equal(credential.routerTiers.c3.model, 'glm-5.2')
+  assert.equal(credential.routerTiers.c0.supportsImage, false)
+  assert.equal(credential.routerTiers.c1.supportsImage, false)
+  assert.equal(credential.routerTiers.c2.supportsImage, false)
+  assert.equal(credential.routerTiers.c3.supportsImage, false)
+  assert.equal(credential.routerTiers.c3.ensembleEnabled, true)
+  assert.equal(credential.routerTiers.image_model.model, 'kimi-k2.6')
+  assert.equal(credential.routerTiers.image_model.supportsImage, true)
   assert.match(config, /\[squilla_router\]\nenabled = true/)
-  assert.match(config, /\[squilla_router\.tiers\.c1\]\nprovider = "tokenrhythm"\nmodel = "deepseek-v4-pro"/)
+  assert.match(config, /\[llm\][\s\S]*?model = "deepseek-v4-pro-0813"/)
+  assert.match(config, /\[squilla_router\.tiers\.c0\]\nprovider = "tokenrhythm"\nmodel = "deepseek-v4-flash-0731"/)
+  assert.match(config, /\[squilla_router\.tiers\.c1\]\nprovider = "tokenrhythm"\nmodel = "deepseek-v4-pro-0813"/)
+  assert.match(config, /\[squilla_router\.tiers\.c2\]\nprovider = "tokenrhythm"\nmodel = "kimi-k2.7-code"/)
+  assert.match(config, /\[squilla_router\.tiers\.c3\][\s\S]*?model = "glm-5.2"[\s\S]*?ensemble_enabled = true/)
+  assert.doesNotMatch(config, /thinking_level\s*=/)
   assert.match(config, /\[llm_ensemble\]\nenabled = false/)
 
   console.log(JSON.stringify({

--- a/desktop/electron/scripts/test-router-tier-normalization.mjs
+++ b/desktop/electron/scripts/test-router-tier-normalization.mjs
@@ -1,0 +1,41 @@
+import { strict as assert } from 'node:assert'
+
+import { normalizeRouterTiers } from '../dist/router-tier-normalization.js'
+
+const currentFallback = {
+  c0: { provider: 'tokenrhythm', model: 'deepseek-v4-flash-0731' },
+  c1: { provider: 'tokenrhythm', model: 'deepseek-v4-pro-0813' },
+  c2: { provider: 'tokenrhythm', model: 'kimi-k2.7-code' },
+  c3: { provider: 'tokenrhythm', model: 'glm-5.2', ensembleEnabled: true },
+}
+
+const legacyCredentialTiers = {
+  c0: { provider: 'tokenrhythm', model: 'deepseek-v4-flash' },
+  c1: { provider: 'tokenrhythm', model: 'deepseek-v4-pro' },
+  c2: { provider: 'tokenrhythm', model: 'kimi-k2.7-code' },
+  c3: { provider: 'tokenrhythm', model: 'glm-5.2' },
+}
+
+const loaded = normalizeRouterTiers(legacyCredentialTiers, currentFallback)
+assert.deepEqual(
+  Object.fromEntries(Object.entries(loaded).map(([name, tier]) => [name, tier.model])),
+  Object.fromEntries(Object.entries(legacyCredentialTiers).map(([name, tier]) => [name, tier.model])),
+)
+assert.equal(Object.hasOwn(loaded.c3, 'ensembleEnabled'), false)
+
+// saveDesktopCredential normalizes the already-loaded same-provider ladder a
+// second time. The missing legacy opt-in must remain missing on that pass.
+const resaved = normalizeRouterTiers(loaded, currentFallback)
+assert.deepEqual(resaved, loaded)
+assert.equal(Object.hasOwn(resaved.c3, 'ensembleEnabled'), false)
+
+const fresh = normalizeRouterTiers(undefined, currentFallback)
+assert.equal(fresh.c3.ensembleEnabled, true)
+
+const explicitSnakeCase = normalizeRouterTiers(
+  { ...legacyCredentialTiers, c3: { ...legacyCredentialTiers.c3, ensemble_enabled: true } },
+  currentFallback,
+)
+assert.equal(explicitSnakeCase.c3.ensembleEnabled, true)
+
+console.log(JSON.stringify({ ok: true, legacyMissingPreserved: true }))

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -138,6 +138,10 @@ import { appendDesktopLogRecord } from './desktop-log-file.js'
 import {
   ArtifactPreviewLeaseBroker,
 } from './artifact-preview-lease-broker.js'
+import {
+  normalizeRouterTiers,
+  type RouterTier,
+} from './router-tier-normalization.js'
 
 protocol.registerSchemesAsPrivileged([{
   scheme: NATIVE_WORKBENCH_ARTIFACT_SCHEME,
@@ -186,15 +190,6 @@ interface SearchProviderCatalogEntry {
   requiresApiKey: boolean
   note: string
   keyPlaceholder: string
-}
-
-interface RouterTier {
-  provider: string
-  model: string
-  description?: string
-  supportsImage?: boolean
-  imageOnly?: boolean
-  thinkingLevel?: string
 }
 
 interface DesktopConnection {
@@ -1178,7 +1173,7 @@ const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
   {
     id: 'tokenrhythm',
     label: 'TokenRhythm',
-    model: 'deepseek-v4-pro',
+    model: 'deepseek-v4-pro-0813',
     baseUrl: 'https://tokenrhythm.studio/v1',
     apiKeyEnv: 'TOKENRHYTHM_API_KEY',
     requiresApiKey: true,
@@ -1551,10 +1546,10 @@ function minimaxRouterProfile(provider: string): Record<string, RouterTier> {
 
 const ROUTER_PROFILES: Record<string, Record<string, RouterTier>> = {
   tokenrhythm: {
-    c0: { provider: 'tokenrhythm', model: 'deepseek-v4-flash', description: 'Fast DeepSeek route for simple work', supportsImage: false },
-    c1: { provider: 'tokenrhythm', model: 'deepseek-v4-pro', description: 'Balanced DeepSeek route for normal agent work', supportsImage: false },
-    c2: { provider: 'tokenrhythm', model: 'kimi-k2.7-code', description: 'Strong Kimi route for harder coding and analysis', supportsImage: false },
-    c3: { provider: 'tokenrhythm', model: 'glm-5.2', description: 'Highest-tier GLM route for deep review and planning', supportsImage: false },
+    c0: { provider: 'tokenrhythm', model: 'deepseek-v4-flash-0731', description: 'Fast DeepSeek V4 Flash 0731 route for simple work', supportsImage: false },
+    c1: { provider: 'tokenrhythm', model: 'deepseek-v4-pro-0813', description: 'Default DeepSeek V4 Pro 0813 route for normal agent work', supportsImage: false },
+    c2: { provider: 'tokenrhythm', model: 'kimi-k2.7-code', description: 'Strong Kimi 2.7 Code route for harder coding and analysis', supportsImage: false },
+    c3: { provider: 'tokenrhythm', model: 'glm-5.2', description: 'Highest tier: shared B5 fusion; GLM 5.2 is retained for single-model C3 mode', supportsImage: false, ensembleEnabled: true },
     image_model: { provider: 'tokenrhythm', model: 'kimi-k2.6', description: 'Vision route for image attachments', supportsImage: true, imageOnly: true },
   },
   openrouter: {
@@ -1728,35 +1723,6 @@ function defaultRouterTiers(provider: string, mode: RouterMode): Record<string, 
   return cloneRouterTiers(ROUTER_PROFILES[provider] || ROUTER_PROFILES.openrouter)
 }
 
-function normalizeRouterTiers(raw: unknown, fallback: Record<string, RouterTier>): Record<string, RouterTier> {
-  if (!raw || typeof raw !== 'object') return cloneRouterTiers(fallback)
-  const source = raw as Record<string, unknown>
-  const out = cloneRouterTiers(fallback)
-  for (const [rawName, value] of Object.entries(source)) {
-    if (!value || typeof value !== 'object') continue
-    const name = canonicalTierKey(rawName)
-    // Tier keys are emitted raw into TOML table headers ([squilla_router.tiers.NAME]),
-    // so a key that is not a TOML bare key (spaces, dots, quotes, brackets, newlines)
-    // would produce an unparseable config the gateway rejects on every boot. Drop
-    // such keys and fall back to the profile defaults instead.
-    if (!/^[A-Za-z0-9_-]+$/.test(name)) continue
-    const tier = value as Record<string, unknown>
-    const provider = String(tier.provider || out[name]?.provider || '').trim()
-    const model = String(tier.model || out[name]?.model || '').trim()
-    if (!provider || !model) continue
-    out[name] = {
-      ...out[name],
-      provider,
-      model,
-      description: String(tier.description || out[name]?.description || ''),
-      supportsImage: Boolean(tier.supportsImage ?? tier.supports_image ?? out[name]?.supportsImage),
-      imageOnly: Boolean(tier.imageOnly ?? tier.image_only ?? out[name]?.imageOnly),
-      thinkingLevel: String(tier.thinkingLevel ?? tier.thinking_level ?? out[name]?.thinkingLevel ?? ''),
-    }
-  }
-  return out
-}
-
 function routerDefaultModel(tiers: Record<string, RouterTier>, defaultTier: TextRouterTier): string {
   return tiers[defaultTier]?.model || tiers.c1?.model || tiers.c0?.model || ''
 }
@@ -1808,6 +1774,7 @@ function routerTierTomlLines(name: string, tier: RouterTier): string[] {
   if (tier.supportsImage !== undefined) lines.push(`supports_image = ${tier.supportsImage ? 'true' : 'false'}`)
   if (tier.imageOnly !== undefined) lines.push(`image_only = ${tier.imageOnly ? 'true' : 'false'}`)
   if (tier.thinkingLevel) lines.push(`thinking_level = ${tomlString(tier.thinkingLevel)}`)
+  if (tier.ensembleEnabled !== undefined) lines.push(`ensemble_enabled = ${tier.ensembleEnabled ? 'true' : 'false'}`)
   return lines
 }
 

--- a/desktop/electron/src/router-tier-normalization.ts
+++ b/desktop/electron/src/router-tier-normalization.ts
@@ -1,0 +1,75 @@
+export interface RouterTier {
+  provider: string
+  model: string
+  description?: string
+  supportsImage?: boolean
+  imageOnly?: boolean
+  thinkingLevel?: string
+  ensembleEnabled?: boolean
+}
+
+const LEGACY_TEXT_TIER_ALIASES: Record<string, string> = {
+  t0: 'c0',
+  t1: 'c1',
+  t2: 'c2',
+  t3: 'c3',
+}
+
+function canonicalTierKey(name: string): string {
+  return LEGACY_TEXT_TIER_ALIASES[name] ?? name
+}
+
+function cloneRouterTiers(tiers: Record<string, RouterTier>): Record<string, RouterTier> {
+  return Object.fromEntries(Object.entries(tiers).map(([name, tier]) => [name, { ...tier }]))
+}
+
+function normalizeBooleanSetting(raw: unknown, fallback: boolean): boolean {
+  if (typeof raw === 'boolean') return raw
+  if (typeof raw === 'number') return raw !== 0
+  if (typeof raw === 'string') {
+    const value = raw.trim().toLowerCase()
+    if (['1', 'true', 'yes', 'on'].includes(value)) return true
+    if (['0', 'false', 'no', 'off', ''].includes(value)) return false
+  }
+  return fallback
+}
+
+export function normalizeRouterTiers(
+  raw: unknown,
+  fallback: Record<string, RouterTier>,
+): Record<string, RouterTier> {
+  if (!raw || typeof raw !== 'object') return cloneRouterTiers(fallback)
+  const source = raw as Record<string, unknown>
+  const out = cloneRouterTiers(fallback)
+  // A persisted tier ladder owns its ensemble opt-in. Clear the fallback
+  // value before overlaying legacy credentials so upgrading a Desktop build
+  // cannot silently turn an existing single-model C3 into B5 fusion.
+  for (const tier of Object.values(out)) delete tier.ensembleEnabled
+  for (const [rawName, value] of Object.entries(source)) {
+    if (!value || typeof value !== 'object') continue
+    const name = canonicalTierKey(rawName)
+    // Tier keys are emitted raw into TOML table headers. Drop unsafe keys and
+    // retain the profile fallback rather than generating invalid TOML.
+    if (!/^[A-Za-z0-9_-]+$/.test(name)) continue
+    const tier = value as Record<string, unknown>
+    const provider = String(tier.provider || out[name]?.provider || '').trim()
+    const model = String(tier.model || out[name]?.model || '').trim()
+    if (!provider || !model) continue
+    const hasEnsembleEnabled = Object.prototype.hasOwnProperty.call(tier, 'ensembleEnabled')
+      || Object.prototype.hasOwnProperty.call(tier, 'ensemble_enabled')
+    const ensembleEnabled = tier.ensembleEnabled ?? tier.ensemble_enabled
+    out[name] = {
+      ...out[name],
+      provider,
+      model,
+      description: String(tier.description || out[name]?.description || ''),
+      supportsImage: Boolean(tier.supportsImage ?? tier.supports_image ?? out[name]?.supportsImage),
+      imageOnly: Boolean(tier.imageOnly ?? tier.image_only ?? out[name]?.imageOnly),
+      thinkingLevel: String(tier.thinkingLevel ?? tier.thinking_level ?? out[name]?.thinkingLevel ?? ''),
+      ...(hasEnsembleEnabled
+        ? { ensembleEnabled: normalizeBooleanSetting(ensembleEnabled, false) }
+        : {}),
+    }
+  }
+  return out
+}

--- a/docs/features/squilla-router.md
+++ b/docs/features/squilla-router.md
@@ -44,9 +44,9 @@ ladder:
 
 | Tier | Route |
 | --- | --- |
-| C0 | `qwen3.7-flash` |
-| C1 | `deepseek-v4-flash-0731` |
-| C2 | `glm-5.2` |
+| C0 | `deepseek-v4-flash-0731` |
+| C1 | `deepseek-v4-pro-0813` |
+| C2 | `kimi-k2.7-code` |
 | C3 | static TokenRhythm B5 multi-model fusion |
 
 C3 reuses the plan configured under `llm_ensemble`: four proposer models
@@ -57,6 +57,12 @@ tier-specific profile. If the shared plan cannot start or complete, C3 uses the
 global provider/model configured under `[llm]` — the same fixed/direct fallback
 model used by global fusion. The provider/model stored on C3 remains available
 only when C3 is switched back to single-model routing.
+
+The packaged mixed-family ladder leaves tier `thinking_level` unset. Direct
+requests without an explicit thinking setting preserve the provider default;
+Router auto-thinking can still choose a per-turn level (normally `low` on C1).
+Fresh and managed (`preset_binding = "follow_primary"`) configurations receive
+this ladder; custom inline tiers remain authoritative and are not migrated.
 
 For a newly configured C3 tier, the tier-local runtime-policy defaults are one
 successful proposer out of the four-member lineup, one retry after each

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -100,7 +100,7 @@
 
 [llm]
 provider = "tokenrhythm"
-model = "deepseek-v4-flash-0731"
+model = "deepseek-v4-pro-0813"
 # api_key = ""          # TokenRhythm API key; env TOKENRHYTHM_API_KEY also works
 base_url = "https://tokenrhythm.studio/v1"
 # proxy = ""            # e.g. http://127.0.0.1:7890
@@ -147,7 +147,7 @@ base_url = "https://tokenrhythm.studio/v1"
 # reasoning_content, and reasoning tokens count against max_tokens — keep
 # max_tokens = 0 (auto) rather than setting small caps:
 # provider = "tokenrhythm"
-# model = "deepseek-v4-flash-0731"
+# model = "deepseek-v4-pro-0813"
 # api_key = ""          # env TOKENRHYTHM_API_KEY also works
 # base_url = "https://tokenrhythm.studio/v1"
 #
@@ -431,24 +431,25 @@ upgrade_to_c3_compaction_enabled = true
 # that executes on the active provider (or the default tier).
 # tier_provider_mismatch = "route"  # route | veto
 
-# TokenRhythm serves every model in reasoning-streaming mode and rejects
-# thinking-toggle request fields, so these tiers set no thinking_level.
+# This mixed-family TokenRhythm ladder intentionally sets no thinking_level.
+# SquillaRouter auto-thinking can still choose a per-turn level (normally low
+# on C1), and explicit turn settings remain available for compatible models.
 [squilla_router.tiers.c0]
 provider = "tokenrhythm"
-model = "qwen3.7-flash"
-description = "Fast Qwen 3.7 Flash route for trivial chat, short rewrites, extraction, low-risk simple Q&A, and lightweight vision"
-supports_image = true
+model = "deepseek-v4-flash-0731"
+description = "Fast DeepSeek V4 Flash 0731 route for trivial chat, short rewrites, extraction, low-risk simple Q&A, and lightweight coding"
+supports_image = false
 
 [squilla_router.tiers.c1]
 provider = "tokenrhythm"
-model = "deepseek-v4-flash-0731"
-description = "Default DeepSeek V4 Flash 0731 route for normal agent work, coding assistance, debugging, and moderate analysis"
+model = "deepseek-v4-pro-0813"
+description = "Default DeepSeek V4 Pro 0813 route for normal agent work, coding assistance, debugging, and moderate analysis"
 supports_image = false
 
 [squilla_router.tiers.c2]
 provider = "tokenrhythm"
-model = "glm-5.2"
-description = "Stronger GLM 5.2 route for multi-step coding, structured reasoning, larger context synthesis, and harder analysis"
+model = "kimi-k2.7-code"
+description = "Stronger Kimi K2.7 Code route for multi-step coding, structured reasoning, larger context synthesis, and harder analysis"
 supports_image = false
 
 [squilla_router.tiers.c3]

--- a/scripts/live_provider_profile_smoke.py
+++ b/scripts/live_provider_profile_smoke.py
@@ -162,7 +162,7 @@ _DEFAULT_MODELS = {
     "tencent_tokenhub_intl": "deepseek-v3.2",
     "tencent_token_plan": "hy3",
     "tencent_token_plan_anthropic": "hy3",
-    "tokenrhythm": "deepseek-v4-flash",
+    "tokenrhythm": "deepseek-v4-pro-0813",
 }
 
 # Test-only floors for providers whose models spend reasoning tokens out of

--- a/src/opensquilla/cli/init_cmd.py
+++ b/src/opensquilla/cli/init_cmd.py
@@ -13,7 +13,7 @@ from opensquilla.paths import default_opensquilla_home
 def _default_model_for_provider(provider: str) -> str:
     normalized = provider.strip().lower()
     if normalized == "tokenrhythm":
-        return "deepseek-v4-pro"
+        return "deepseek-v4-pro-0813"
     if normalized == "openrouter":
         return "deepseek/deepseek-v4-pro"
     if normalized == "deepseek":

--- a/src/opensquilla/engine/pricing.py
+++ b/src/opensquilla/engine/pricing.py
@@ -449,6 +449,14 @@ _PRICING_TABLE: list[tuple[str, PriceEntry]] = [
     ("gemini-3.1-pro-preview", PriceEntry(2.0, 12.0, cache_read_per_m=0.20)),
     ("claude-haiku-4-5", PriceEntry(1.0, 5.0, cache_read_per_m=0.1, cache_write_per_m=1.25)),
     ("deepseek-v4-flash", PriceEntry(0.14, 0.28, cache_read_per_m=0.0028)),
+    (
+        "deepseek-v4-pro-0813",
+        PriceEntry(
+            1.2903225806451613,
+            3.870967741935484,
+            cache_read_per_m=0.043010752688172046,
+        ),
+    ),
     ("deepseek-v4-pro", PriceEntry(0.435, 0.87, cache_read_per_m=0.003625)),
     ("deepseek-chat", PriceEntry(0.14, 0.28, cache_read_per_m=0.0028)),
     ("deepseek-reasoner", PriceEntry(0.26, 0.38)),

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -410,7 +410,7 @@ class LlmProviderConfig(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="OPENSQUILLA_LLM_")
 
     provider: str = "tokenrhythm"
-    model: str = "deepseek-v4-flash-0731"
+    model: str = "deepseek-v4-pro-0813"
     api_key: str = ""
     api_key_env: str = ""
     base_url: str = "https://tokenrhythm.studio/v1"

--- a/src/opensquilla/provider/catalog_overrides.toml
+++ b/src/opensquilla/provider/catalog_overrides.toml
@@ -812,7 +812,7 @@ cache_read_cost_per_mtok = 0.1863799283154122
 
 [tokenrhythm."kimi-k2.7-code"]
 context_window = 256000
-max_output_tokens = 16384
+max_output_tokens = 128000
 supports_reasoning = true
 supports_tools = true
 supports_vision = true

--- a/src/opensquilla/provider/catalog_overrides.toml
+++ b/src/opensquilla/provider/catalog_overrides.toml
@@ -721,6 +721,17 @@ input_cost_per_mtok = 0.43010752688172044
 output_cost_per_mtok = 0.8602150537634409
 cache_read_cost_per_mtok = 0.0035842293906810036
 
+[tokenrhythm."deepseek-v4-pro-0813"]
+context_window = 1000000
+max_output_tokens = 384000
+supports_reasoning = true
+supports_tools = true
+supports_vision = false
+reasoning_format = "none"
+input_cost_per_mtok = 1.2903225806451613
+output_cost_per_mtok = 3.870967741935484
+cache_read_cost_per_mtok = 0.043010752688172046
+
 [tokenrhythm."glm-5"]
 context_window = 1000000
 max_output_tokens = 128000
@@ -801,7 +812,7 @@ cache_read_cost_per_mtok = 0.1863799283154122
 
 [tokenrhythm."kimi-k2.7-code"]
 context_window = 256000
-max_output_tokens = 128000
+max_output_tokens = 16384
 supports_reasoning = true
 supports_tools = true
 supports_vision = true

--- a/src/opensquilla/provider/compat_policy.py
+++ b/src/opensquilla/provider/compat_policy.py
@@ -57,7 +57,13 @@ _TOKENRHYTHM_DSML_MODEL_IDS = (
     "tokenrhythm/deepseek-v4-flash-0731",
     "tokenrhythm/deepseek-v4-pro",
 )
-_TOKENRHYTHM_V4_MODEL_IDS = frozenset(
+_TOKENRHYTHM_0813_MODEL_IDS = frozenset(
+    {
+        "deepseek-v4-pro-0813",
+        "tokenrhythm/deepseek-v4-pro-0813",
+    }
+)
+_TOKENRHYTHM_LEGACY_CUSTOM_REPLAY_MODEL_IDS = frozenset(
     {
         "deepseek-v4-flash",
         "deepseek-v4-flash-0731",
@@ -67,12 +73,17 @@ _TOKENRHYTHM_V4_MODEL_IDS = frozenset(
         "tokenrhythm/deepseek-v4-pro",
     }
 )
-_TOKENRHYTHM_V4_FLASH_MODEL_IDS = frozenset(
+_TOKENRHYTHM_V4_MODEL_IDS = (
+    _TOKENRHYTHM_LEGACY_CUSTOM_REPLAY_MODEL_IDS | _TOKENRHYTHM_0813_MODEL_IDS
+)
+_TOKENRHYTHM_V4_LOW_EFFORT_MODEL_IDS = frozenset(
     {
         "deepseek-v4-flash",
         "deepseek-v4-flash-0731",
+        "deepseek-v4-pro-0813",
         "tokenrhythm/deepseek-v4-flash",
         "tokenrhythm/deepseek-v4-flash-0731",
+        "tokenrhythm/deepseek-v4-pro-0813",
     }
 )
 _OPENROUTER_DSML_MODEL_IDS = (
@@ -81,16 +92,58 @@ _OPENROUTER_DSML_MODEL_IDS = (
 )
 
 
+def _matches_exact_https_endpoint(
+    base_url: str,
+    *,
+    endpoint_hosts: frozenset[str],
+    endpoint_paths: frozenset[str],
+) -> bool:
+    """Whether *base_url* is one of a rule's exact trusted API roots."""
+
+    if not endpoint_hosts:
+        return True
+    normalized_url = str(base_url or "").strip()
+    if "?" in normalized_url or "#" in normalized_url:
+        return False
+    try:
+        parsed = urlsplit(normalized_url)
+        host = (parsed.hostname or "").lower()
+        port = parsed.port
+    except (UnicodeError, ValueError):
+        return False
+    path = parsed.path.rstrip("/")
+    return bool(
+        parsed.scheme.lower() == "https"
+        and host in endpoint_hosts
+        and (port is None or port == 443)
+        and parsed.username is None
+        and parsed.password is None
+        and not parsed.query
+        and not parsed.fragment
+        and path in endpoint_paths
+    )
+
+
 @dataclass(frozen=True)
 class TextToolModelRule:
     """Allow text-tool dialects only for explicitly matched model ids."""
 
     model_patterns: tuple[str, ...]
     dialects: frozenset[TextToolDialect]
+    endpoint_hosts: frozenset[str] = frozenset()
+    endpoint_paths: frozenset[str] = frozenset()
 
-    def matches(self, model: str) -> bool:
+    def matches(self, model: str, base_url: str = "") -> bool:
         normalized = model.strip().lower()
-        return any(fnmatchcase(normalized, pattern.lower()) for pattern in self.model_patterns)
+        if not any(
+            fnmatchcase(normalized, pattern.lower()) for pattern in self.model_patterns
+        ):
+            return False
+        return _matches_exact_https_endpoint(
+            base_url,
+            endpoint_hosts=self.endpoint_hosts,
+            endpoint_paths=self.endpoint_paths,
+        )
 
 
 @dataclass(frozen=True)
@@ -106,10 +159,14 @@ class TextToolCompatProfile:
     dialects: frozenset[TextToolDialect] = frozenset()
     model_rules: tuple[TextToolModelRule, ...] = ()
 
-    def dialects_for_model(self, model: str) -> frozenset[TextToolDialect]:
+    def dialects_for_model(
+        self,
+        model: str,
+        base_url: str = "",
+    ) -> frozenset[TextToolDialect]:
         enabled = set(self.dialects)
         for rule in self.model_rules:
-            if rule.matches(model):
+            if rule.matches(model, base_url):
                 enabled.update(rule.dialects)
         return frozenset(enabled)
 
@@ -143,24 +200,10 @@ class ReasoningModelRule:
 
         if model.strip().lower() not in self.model_ids:
             return False
-        if not self.endpoint_hosts:
-            return True
-        try:
-            parsed = urlsplit(str(base_url or "").strip())
-            host = (parsed.hostname or "").lower()
-            port = parsed.port
-        except (UnicodeError, ValueError):
-            return False
-        path = parsed.path.rstrip("/")
-        return bool(
-            parsed.scheme.lower() == "https"
-            and host in self.endpoint_hosts
-            and (port is None or port == 443)
-            and parsed.username is None
-            and parsed.password is None
-            and not parsed.query
-            and not parsed.fragment
-            and path in self.endpoint_paths
+        return _matches_exact_https_endpoint(
+            base_url,
+            endpoint_hosts=self.endpoint_hosts,
+            endpoint_paths=self.endpoint_paths,
         )
 
 
@@ -346,8 +389,8 @@ class OpenAICompatPolicy:
 
         Older diagnostics inspected one provider-wide boolean.  Keep that
         observation surface without letting the boolean control execution;
-        callers that need an answer for one model must use
-        ``text_tool_profile.dialects_for_model(model)``.
+        callers that need an answer for one deployment must use
+        ``text_tool_profile.dialects_for_model(model, base_url)``.
         """
 
         return self.text_tool_profile.enabled
@@ -584,6 +627,12 @@ _POLICIES_BY_KIND: dict[str, OpenAICompatPolicy] = {
                     model_patterns=_TOKENRHYTHM_DSML_MODEL_IDS,
                     dialects=frozenset({TEXT_TOOL_DIALECT_DEEPSEEK_DSML}),
                 ),
+                TextToolModelRule(
+                    model_patterns=tuple(sorted(_TOKENRHYTHM_0813_MODEL_IDS)),
+                    dialects=frozenset({TEXT_TOOL_DIALECT_DEEPSEEK_DSML}),
+                    endpoint_hosts=frozenset({"tokenrhythm.studio"}),
+                    endpoint_paths=frozenset({"", "/v1"}),
+                ),
             ),
         ),
         reasoning_model_rules=(
@@ -595,16 +644,22 @@ _POLICIES_BY_KIND: dict[str, OpenAICompatPolicy] = {
                 require_reasoning_content=True,
                 max_reasoning_content_utf16_units=50_000,
                 reasoning_format="deepseek",
-                low_effort_model_ids=_TOKENRHYTHM_V4_FLASH_MODEL_IDS,
+                low_effort_model_ids=_TOKENRHYTHM_V4_LOW_EFFORT_MODEL_IDS,
                 thinking_tool_choice_auto_only=True,
                 prefer_pinned_tool_choice_over_thinking=True,
             ),
             # Custom endpoints keep the previous exact-id replay behavior but
             # do not inherit TokenRhythm's official controls or field limit.
             ReasoningModelRule(
-                model_ids=_TOKENRHYTHM_V4_MODEL_IDS,
+                model_ids=_TOKENRHYTHM_LEGACY_CUSTOM_REPLAY_MODEL_IDS,
                 require_reasoning_content=True,
             ),
+        ),
+        # TokenRhythm rejects a required selector for 0813 even when thinking
+        # is explicitly disabled. The request constraint compares basenames,
+        # so this exact entry covers both raw and provider-qualified ids.
+        implicit_thinking_tool_choice_model_ids=frozenset(
+            {"deepseek-v4-pro-0813"}
         ),
         allow_post_terminal_noop_choice=True,
         allow_post_terminal_null_usage_noop_choice=True,

--- a/src/opensquilla/provider/model_identity.py
+++ b/src/opensquilla/provider/model_identity.py
@@ -7,6 +7,7 @@ DEEPSEEK_V4_MODEL_IDS = frozenset(
         "deepseek-v4-flash",
         "deepseek-v4-flash-0731",
         "deepseek-v4-pro",
+        "deepseek-v4-pro-0813",
     }
 )
 

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -2194,6 +2194,7 @@ def _synthesize_text_tool_events(
     *,
     provider_kind: str,
     model: str,
+    base_url: str = "",
 ) -> list[ToolUseStartEvent | ToolUseEndEvent]:
     """Compatibility helper backed by the scoped, atomic classifier."""
 
@@ -2201,7 +2202,7 @@ def _synthesize_text_tool_events(
     segments = classify_text_tool_segments(
         full_text,
         tools,
-        dialects=policy.text_tool_profile.dialects_for_model(model),
+        dialects=policy.text_tool_profile.dialects_for_model(model, base_url),
         provider_kind=provider_kind,
         model=model,
     )
@@ -3951,7 +3952,10 @@ class OpenAIProvider:
         streamed_thought_signature: str | None = None
         reasoning = ReasoningAccumulator()
         tools_by_name = _tool_by_name(tools)
-        text_tool_dialects = self._compat.text_tool_profile.dialects_for_model(self._model)
+        text_tool_dialects = self._compat.text_tool_profile.dialects_for_model(
+            self._model,
+            self._base_url,
+        )
         text_tool_normalizer: TextToolStreamNormalizer | InertCandidateTextNormalizer
         if inert_candidate_output:
             assert candidate_artifact is not None
@@ -5894,7 +5898,10 @@ class OpenAIProvider:
         trace_tool_calls: list[dict[str, Any]] = []
         tools_by_name = _tool_by_name(tools)
         finish_reasons: list[str] = []
-        text_tool_dialects = self._compat.text_tool_profile.dialects_for_model(self._model)
+        text_tool_dialects = self._compat.text_tool_profile.dialects_for_model(
+            self._model,
+            self._base_url,
+        )
         text_tool_normalizer: TextToolStreamNormalizer | InertCandidateTextNormalizer
         if inert_candidate_output:
             assert candidate_artifact is not None

--- a/src/opensquilla/provider/presets/tokenrhythm.toml
+++ b/src/opensquilla/provider/presets/tokenrhythm.toml
@@ -3,32 +3,33 @@
 # tokenrhythm id never becomes a squilla_router.tier_profile value (the
 # accepted set stays pinned to the legacy nine — downgrade contract), so
 # provider saves and boot defaults apply these tiers inline instead.
-# No thinking_level on purpose: packaged routes preserve the provider-declared
-# default. Explicit turn settings may control exact official V4 models without
-# assigning the same reasoning dialect to the other families in this ladder.
+# No tier thinking_level on purpose: direct requests with no explicit thinking
+# setting preserve the provider default, while Router auto-thinking can still
+# select a per-turn level (C1 normally selects low). Exact official V4 models
+# accept those controls without assigning their dialect to the other families.
 [preset]
 id = "tokenrhythm"
 provider = "tokenrhythm"
 label = "TokenRhythm"
-description = "Curated TokenRhythm router ladder (Qwen 3.7 Flash, DeepSeek V4 Flash 0731, GLM 5.2, then shared B5 fusion), applied as inline tiers."
-default_model = "deepseek-v4-flash-0731"
+description = "Curated TokenRhythm router ladder (DeepSeek V4 Flash 0731, DeepSeek V4 Pro 0813, Kimi K2.7 Code, then shared B5 fusion), applied as inline tiers."
+default_model = "deepseek-v4-pro-0813"
 
 [tiers.c0]
 provider = "tokenrhythm"
-model = "qwen3.7-flash"
-description = "Fast Qwen 3.7 Flash route for trivial chat, short rewrites, extraction, low-risk simple Q&A, and lightweight vision"
-supports_image = true
+model = "deepseek-v4-flash-0731"
+description = "Fast DeepSeek V4 Flash 0731 route for trivial chat, short rewrites, extraction, low-risk simple Q&A, and lightweight coding"
+supports_image = false
 
 [tiers.c1]
 provider = "tokenrhythm"
-model = "deepseek-v4-flash-0731"
-description = "Default DeepSeek V4 Flash 0731 route for normal agent work, coding assistance, debugging, and moderate analysis"
+model = "deepseek-v4-pro-0813"
+description = "Default DeepSeek V4 Pro 0813 route for normal agent work, coding assistance, debugging, and moderate analysis"
 supports_image = false
 
 [tiers.c2]
 provider = "tokenrhythm"
-model = "glm-5.2"
-description = "Stronger GLM 5.2 route for multi-step coding, structured reasoning, larger context synthesis, and harder analysis"
+model = "kimi-k2.7-code"
+description = "Stronger Kimi K2.7 Code route for multi-step coding, structured reasoning, larger context synthesis, and harder analysis"
 supports_image = false
 
 [tiers.c3]

--- a/tests/functional/test_llm_smoke.py
+++ b/tests/functional/test_llm_smoke.py
@@ -114,7 +114,7 @@ async def test_tokenrhythm_live_smoke_returns_expected_token() -> None:
 
     provider = OpenAIProvider(
         api_key=api_key,
-        model=os.environ.get("TOKENRHYTHM_MODEL", "deepseek-v4-flash"),
+        model=os.environ.get("TOKENRHYTHM_MODEL", "deepseek-v4-pro-0813"),
         base_url=os.environ.get("TOKENRHYTHM_BASE_URL", "https://tokenrhythm.studio/v1"),
         provider_kind="tokenrhythm",
     )

--- a/tests/test_cli/test_init_cmd.py
+++ b/tests/test_cli/test_init_cmd.py
@@ -1,6 +1,10 @@
 from opensquilla.cli.init_cmd import _default_model_for_provider
 
 
+def test_init_uses_tokenrhythm_0813_model_default() -> None:
+    assert _default_model_for_provider("tokenrhythm") == "deepseek-v4-pro-0813"
+
+
 def test_init_uses_direct_deepseek_model_default() -> None:
     assert _default_model_for_provider("deepseek") == "deepseek-v4-flash"
 

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -1399,6 +1399,7 @@ def test_desktop_tokenrhythm_single_page_onboarding_defaults_to_router() -> None
 
     assert "routerSupported: true" in tokenrhythm_catalog
     assert "ensembleSelectionMode: 'static_tokenrhythm_b5'" in tokenrhythm_catalog
+    assert "model: 'deepseek-v4-pro-0813'" in tokenrhythm_catalog
     assert "const INLINE_ROUTER_PROFILE_IDS = new Set(['tokenrhythm'])" in main_ts
     assert "!INLINE_ROUTER_PROFILE_IDS.has(credential.provider)" in main_ts
     assert "return selected.routerSupported ? 'squilla_router' : 'direct';" in onboarding_html
@@ -1416,14 +1417,32 @@ def test_desktop_tokenrhythm_single_page_onboarding_defaults_to_router() -> None
     assert "DESKTOP_ENSEMBLE_PROFILES[selectionMode]" in main_ts
 
     expected_models = (
-        "deepseek-v4-flash",
-        "deepseek-v4-pro",
+        "deepseek-v4-flash-0731",
+        "deepseek-v4-pro-0813",
         "kimi-k2.7-code",
         "glm-5.2",
         "kimi-k2.6",
     )
     for model in expected_models:
         assert model in tokenrhythm_profile
+    assert "ensembleEnabled: true" in tokenrhythm_profile
+    assert "thinkingLevel" not in tokenrhythm_profile
+    assert "ensemble_enabled = ${tier.ensembleEnabled ? 'true' : 'false'}" in main_ts
+
+
+def test_desktop_legacy_inline_router_does_not_inherit_new_c3_ensemble() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    normalizer = _read("desktop/electron/src/router-tier-normalization.ts")
+    package_json = json.loads(_read("desktop/electron/package.json"))
+
+    assert "normalizeRouterTiers" in main_ts
+    assert "for (const tier of Object.values(out)) delete tier.ensembleEnabled" in normalizer
+    assert "hasOwnProperty.call(tier, 'ensembleEnabled')" in normalizer
+    assert "hasOwnProperty.call(tier, 'ensemble_enabled')" in normalizer
+    assert "normalizeBooleanSetting(ensembleEnabled, false)" in normalizer
+    assert package_json["scripts"]["test:router-tier-normalization"] == (
+        "npm run build && node scripts/test-router-tier-normalization.mjs"
+    )
 
 
 def test_desktop_onboarding_opens_only_trusted_registration_url_outside_renderer() -> None:

--- a/tests/test_engine/test_pricing.py
+++ b/tests/test_engine/test_pricing.py
@@ -119,6 +119,18 @@ def test_versioned_deepseek_id_prefix_matches_static_entry(
     assert price.input_per_m == pytest.approx(0.435)
 
 
+def test_tokenrhythm_v4_pro_0813_static_price_precedes_generic_pro_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_OPENROUTER_LIVE_PRICING", "0")
+
+    price = lookup_price("deepseek-v4-pro-0813")
+
+    assert price.input_per_m == pytest.approx(1.2903225806451613)
+    assert price.output_per_m == pytest.approx(3.870967741935484)
+    assert price.cache_read_per_m == pytest.approx(0.043010752688172046)
+
+
 def test_price_entry_cache_fields_default_none() -> None:
     entry = PriceEntry(3.0, 15.0)
     assert entry.cache_read_per_m is None

--- a/tests/test_engine/test_runtime_ensemble_credential_guard.py
+++ b/tests/test_engine/test_runtime_ensemble_credential_guard.py
@@ -338,9 +338,9 @@ async def test_static_tokenrhythm_b5_wraps_when_active_provider_is_keyed(
 @pytest.mark.parametrize(
     ("routed_tier", "expected_model", "expect_ensemble"),
     [
-        ("c0", "qwen3.7-flash", False),
-        ("c1", "deepseek-v4-flash-0731", False),
-        ("c2", "glm-5.2", False),
+        ("c0", "deepseek-v4-flash-0731", False),
+        ("c1", "deepseek-v4-pro-0813", False),
+        ("c2", "kimi-k2.7-code", False),
         # Shared C3 triggers the global plan without replacing the configured
         # direct/fallback selector head.
         ("c3", "deepseek-v4-flash-0731", True),

--- a/tests/test_engine/test_session_sanitize.py
+++ b/tests/test_engine/test_session_sanitize.py
@@ -3256,7 +3256,13 @@ async def test_agent_preserves_reasoning_content_for_deepseek_text_replay() -> N
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "model_id", ["deepseek-v4-flash", "deepseek-v4-flash-0731"]
+    "model_id",
+    [
+        "deepseek-v4-flash",
+        "deepseek-v4-flash-0731",
+        "deepseek-v4-pro-0813",
+        "tokenrhythm/deepseek-v4-pro-0813",
+    ],
 )
 async def test_agent_preserves_direct_deepseek_v4_reasoning_without_capabilities(
     model_id: str,

--- a/tests/test_engine/test_usage_event_accounting.py
+++ b/tests/test_engine/test_usage_event_accounting.py
@@ -936,9 +936,9 @@ def test_tokenrhythm_inline_router_c0_c3_reconciles_each_physical_request() -> N
     assert preset is not None
     tiers = preset.tier_defaults()
     expected_models = {
-        "c0": "qwen3.7-flash",
-        "c1": "deepseek-v4-flash-0731",
-        "c2": "glm-5.2",
+        "c0": "deepseek-v4-flash-0731",
+        "c1": "deepseek-v4-pro-0813",
+        "c2": "kimi-k2.7-code",
         "c3": "glm-5.2",
     }
 

--- a/tests/test_gateway/test_router_tier_presets.py
+++ b/tests/test_gateway/test_router_tier_presets.py
@@ -251,9 +251,9 @@ def test_full_default_tree_round_trips_via_to_toml_dict(tmp_path: Path) -> None:
     tiers = cfg.squilla_router.tiers
     assert set(tiers) == {"c0", "c1", "c2", "c3", "image_model"}
     expected_models = {
-        "c0": "qwen3.7-flash",
-        "c1": "deepseek-v4-flash-0731",
-        "c2": "glm-5.2",
+        "c0": "deepseek-v4-flash-0731",
+        "c1": "deepseek-v4-pro-0813",
+        "c2": "kimi-k2.7-code",
         "c3": "glm-5.2",
         "image_model": "kimi-k2.6",
     }

--- a/tests/test_gateway/test_rpc_config_effective.py
+++ b/tests/test_gateway/test_rpc_config_effective.py
@@ -61,7 +61,7 @@ async def test_effective_envelope_and_provenance(cfg: GatewayConfig) -> None:
     fields = result["fields"]
     assert fields["llm.provider"] == {"value": "tokenrhythm", "source": "default"}
     assert fields["llm.model"] == {
-        "value": "deepseek-v4-flash-0731",
+        "value": "deepseek-v4-pro-0813",
         "source": "default",
     }
     assert fields["squilla_router.tiers.c1.model"]["source"] == "preset"

--- a/tests/test_gateway_config_default_provider.py
+++ b/tests/test_gateway_config_default_provider.py
@@ -33,7 +33,7 @@ TOKENRHYTHM_BASE_URL = "https://tokenrhythm.studio/v1"
 def test_keyless_default_resolves_tokenrhythm() -> None:
     cfg = GatewayConfig()
     assert cfg.llm.provider == "tokenrhythm"
-    assert cfg.llm.model == "deepseek-v4-flash-0731"
+    assert cfg.llm.model == "deepseek-v4-pro-0813"
     assert cfg.llm.base_url == TOKENRHYTHM_BASE_URL
 
 
@@ -178,9 +178,9 @@ def test_tokenrhythm_default_binds_router_tiers_to_tokenrhythm() -> None:
     cfg = GatewayConfig()
     tiers = cfg.squilla_router.tiers
     expected_models = {
-        "c0": "qwen3.7-flash",
-        "c1": "deepseek-v4-flash-0731",
-        "c2": "glm-5.2",
+        "c0": "deepseek-v4-flash-0731",
+        "c1": "deepseek-v4-pro-0813",
+        "c2": "kimi-k2.7-code",
         "c3": "glm-5.2",
         "image_model": "kimi-k2.6",
     }
@@ -188,6 +188,9 @@ def test_tokenrhythm_default_binds_router_tiers_to_tokenrhythm() -> None:
         assert tiers[name]["provider"] == "tokenrhythm"
         assert tiers[name]["model"] == model
     assert tiers["c3"]["ensemble_enabled"] is True
+    assert tiers["c0"]["supports_image"] is False
+    assert tiers["c2"]["supports_image"] is False
+    assert all("thinking_level" not in tier for tier in tiers.values())
     assert "ensemble_selection_mode" not in tiers["c3"]
     assert cfg.squilla_router.tier_profile is None
 
@@ -198,7 +201,7 @@ def test_tokenrhythm_curated_ladder_is_not_rebound_to_the_direct_model() -> None
     # packaged profiles.
     cfg = GatewayConfig(llm={"provider": "tokenrhythm", "model": "glm-5.2"})
     assert cfg.llm.model == "glm-5.2"
-    assert cfg.squilla_router.tiers["c1"]["model"] == "deepseek-v4-flash-0731"
+    assert cfg.squilla_router.tiers["c1"]["model"] == "deepseek-v4-pro-0813"
 
 
 def test_tokenrhythm_custom_tiers_are_preserved() -> None:

--- a/tests/test_live_provider_profile_smoke.py
+++ b/tests/test_live_provider_profile_smoke.py
@@ -140,7 +140,7 @@ def test_live_smoke_env_maps_cover_openai_zhipu_kimi_and_minimax() -> None:
 
     assert smoke._MODEL_ENV["tokenrhythm"] == "TOKENRHYTHM_MODEL"
     assert smoke._BASE_ENV["tokenrhythm"] == "TOKENRHYTHM_BASE_URL"
-    assert smoke._DEFAULT_MODELS["tokenrhythm"] == "deepseek-v4-flash"
+    assert smoke._DEFAULT_MODELS["tokenrhythm"] == "deepseek-v4-pro-0813"
     # Reasoning tokens bill against max_tokens: the default 64 budget would
     # return empty content with finish_reason "length".
     assert smoke._MIN_MAX_TOKENS["tokenrhythm"] == 4096

--- a/tests/test_model_router_behavior.py
+++ b/tests/test_model_router_behavior.py
@@ -1291,6 +1291,35 @@ async def test_image_input_routes_directly_to_vision_model_without_prompt_inject
 
 
 @pytest.mark.asyncio
+async def test_tokenrhythm_default_image_route_skips_kimi_code_c2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        squilla_router_step,
+        "_get_strategy",
+        lambda _config: pytest.fail("image routing should not invoke text strategy"),
+    )
+    config = GatewayConfig()
+    assert config.squilla_router.tiers["c2"]["model"] == "kimi-k2.7-code"
+    assert config.squilla_router.tiers["c2"]["supports_image"] is False
+    ctx = TurnContext(
+        message="What is in this screenshot?",
+        session_key="test-tokenrhythm-image",
+        config=config,
+        provider=None,
+        model=config.llm.model,
+        tool_defs=[],
+        system_prompt="system",
+        attachments=[{"type": "image", "mime_type": "image/png"}],
+    )
+
+    routed = await apply_squilla_router(ctx)
+
+    assert routed.metadata["routed_tier"] == "image_model"
+    assert routed.model == "kimi-k2.6"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "fusion_config",
     [

--- a/tests/test_model_router_defaults.py
+++ b/tests/test_model_router_defaults.py
@@ -197,9 +197,9 @@ def test_direct_legacy_openrouter_router_defaults_are_migrated(provider_id: str)
 
 
 TOKENRHYTHM_EXPECTED_TIER_MODELS = {
-    "c0": "qwen3.7-flash",
-    "c1": "deepseek-v4-flash-0731",
-    "c2": "glm-5.2",
+    "c0": "deepseek-v4-flash-0731",
+    "c1": "deepseek-v4-pro-0813",
+    "c2": "kimi-k2.7-code",
     "c3": "glm-5.2",
 }
 
@@ -215,7 +215,7 @@ def test_unset_tier_profile_seeds_tokenrhythm_curated_inline_tiers() -> None:
     for tier, model in TOKENRHYTHM_EXPECTED_TIER_MODELS.items():
         assert cfg.squilla_router.tiers[tier]["provider"] == "tokenrhythm"
         assert cfg.squilla_router.tiers[tier]["model"] == model
-    assert cfg.squilla_router.tiers["c0"]["supports_image"] is True
+    assert cfg.squilla_router.tiers["c0"]["supports_image"] is False
     assert cfg.squilla_router.tiers["c3"]["ensemble_enabled"] is True
     assert "ensemble_selection_mode" not in cfg.squilla_router.tiers["c3"]
     assert cfg.squilla_router.tiers["image_model"]["model"] == "kimi-k2.6"
@@ -241,6 +241,7 @@ def test_tokenrhythm_follow_primary_binding_refreshes_managed_inline_tiers() -> 
 
     for tier, model in TOKENRHYTHM_EXPECTED_TIER_MODELS.items():
         assert cfg.squilla_router.tiers[tier]["model"] == model
+        assert "thinking_level" not in cfg.squilla_router.tiers[tier]
     assert cfg.squilla_router.tiers["c3"]["ensemble_enabled"] is True
     assert "ensemble_selection_mode" not in cfg.squilla_router.tiers["c3"]
 
@@ -274,6 +275,7 @@ def test_tokenrhythm_boot_seed_respects_custom_inline_tiers() -> None:
     )
 
     assert cfg.squilla_router.tier_profile is None
+    assert cfg.squilla_router.preset_binding is None
     for tier in ("c0", "c1", "c2", "c3"):
         assert cfg.squilla_router.tiers[tier]["model"] == "glm-5"
 
@@ -439,7 +441,7 @@ def test_example_toml_enables_runtime_router_defaults() -> None:
     squilla_router = data["squilla_router"]
 
     assert data["llm"]["provider"] == "tokenrhythm"
-    assert data["llm"]["model"] == "deepseek-v4-flash-0731"
+    assert data["llm"]["model"] == "deepseek-v4-pro-0813"
     assert data["llm_ensemble"]["enabled"] is False
     assert data["llm_ensemble"]["selection_mode"] == "static_tokenrhythm_b5"
     assert squilla_router["enabled"] is True
@@ -458,15 +460,16 @@ def test_example_toml_enables_runtime_router_defaults() -> None:
     assert squilla_router["require_router_runtime"] is True
 
     tiers = squilla_router["tiers"]
-    # The packaged mixed-family ladder preserves provider defaults; explicit
-    # turn-level V4 controls do not become tier-wide settings.
+    # The packaged mixed-family ladder has no tier-wide thinking settings;
+    # Router auto-thinking or explicit turn controls may still select one.
     for name in ("c0", "c1", "c2", "c3", "image_model"):
         assert tiers[name]["provider"] == "tokenrhythm"
         assert "thinking_level" not in tiers[name]
-    assert tiers["c0"]["model"] == "qwen3.7-flash"
-    assert tiers["c0"]["supports_image"] is True
-    assert tiers["c1"]["model"] == "deepseek-v4-flash-0731"
-    assert tiers["c2"]["model"] == "glm-5.2"
+    assert tiers["c0"]["model"] == "deepseek-v4-flash-0731"
+    assert tiers["c0"]["supports_image"] is False
+    assert tiers["c1"]["model"] == "deepseek-v4-pro-0813"
+    assert tiers["c2"]["model"] == "kimi-k2.7-code"
+    assert tiers["c2"]["supports_image"] is False
     assert tiers["c3"]["model"] == "glm-5.2"
     assert tiers["c3"]["ensemble_enabled"] is True
     assert "ensemble_selection_mode" not in tiers["c3"]

--- a/tests/test_onboarding/test_mutations.py
+++ b/tests/test_onboarding/test_mutations.py
@@ -501,13 +501,13 @@ def test_tokenrhythm_provider_save_seeds_curated_inline_ladder():
         api_key="sk-test",
     )
     assert res.config.llm.provider == "tokenrhythm"
-    assert res.config.llm.model == "deepseek-v4-flash-0731"
+    assert res.config.llm.model == "deepseek-v4-pro-0813"
     assert res.config.squilla_router.enabled is True
     assert res.config.squilla_router.tier_profile is None
     expected = {
-        "c0": "qwen3.7-flash",
-        "c1": "deepseek-v4-flash-0731",
-        "c2": "glm-5.2",
+        "c0": "deepseek-v4-flash-0731",
+        "c1": "deepseek-v4-pro-0813",
+        "c2": "kimi-k2.7-code",
         "c3": "glm-5.2",
         "image_model": "kimi-k2.6",
     }
@@ -518,6 +518,8 @@ def test_tokenrhythm_provider_save_seeds_curated_inline_ladder():
     assert "tier_profile" not in persisted
     assert persisted["tiers"]["c3"]["model"] == "glm-5.2"
     assert persisted["tiers"]["c3"]["ensemble_enabled"] is True
+    assert persisted["tiers"]["c0"]["supports_image"] is False
+    assert persisted["tiers"]["c2"]["supports_image"] is False
     assert "ensemble_selection_mode" not in persisted["tiers"]["c3"]
 
 

--- a/tests/test_provider/test_live_catalog.py
+++ b/tests/test_provider/test_live_catalog.py
@@ -326,6 +326,37 @@ def test_scoped_live_entries_outrank_corrections_without_leaking() -> None:
     assert catalog.resolve_context_window("deepseek-v4-pro") == 1_000_000
 
 
+def test_tokenrhythm_v4_pro_0813_live_fields_merge_with_scoped_offline_row() -> None:
+    catalog = ModelCatalog()
+    catalog.set_live_provider_entries(
+        "tokenrhythm",
+        {
+            "deepseek-v4-pro-0813": {
+                "context_window": 900_000,
+                "status": "online",
+            }
+        },
+    )
+
+    resolved = catalog.resolve_entry("deepseek-v4-pro-0813", provider="tokenrhythm")
+    assert resolved.source == "live"
+    assert resolved.context_window == 900_000
+    assert resolved.max_output_tokens == 384_000
+    assert resolved.supports_reasoning is True
+    assert resolved.supports_tools is True
+    assert resolved.supports_vision is False
+    assert resolved.reasoning_format == "none"
+    assert resolved.input_cost_per_mtok == pytest.approx(1.2903225806451613)
+    assert resolved.output_cost_per_mtok == pytest.approx(3.870967741935484)
+    assert resolved.cache_read_cost_per_mtok == pytest.approx(0.043010752688172046)
+
+    direct = catalog.resolve_entry("deepseek-v4-pro-0813", provider="deepseek")
+    assert direct.source != "live"
+    assert direct.input_cost_per_mtok is None
+    assert direct.output_cost_per_mtok is None
+    assert direct.cache_read_cost_per_mtok is None
+
+
 def test_scoped_live_keeps_corrections_reasoning_dialect() -> None:
     # The mixed-family catalog remains neutral at reasoning_format="none";
     # exact official V4 wire controls do not mutate catalog capabilities.

--- a/tests/test_provider/test_preset_registry.py
+++ b/tests/test_provider/test_preset_registry.py
@@ -148,16 +148,16 @@ def test_tokenrhythm_curated_ladder() -> None:
     assert preset is not None
     assert preset.synthesized is False
     assert preset.persistable is False
-    assert preset.default_model == "deepseek-v4-flash-0731"
+    assert preset.default_model == "deepseek-v4-pro-0813"
     assert not hasattr(preset, "default_ensemble_selection_mode")
     assert (
         recommended_ensemble_selection_mode_for_provider(preset.provider_id)
         == "static_tokenrhythm_b5"
     )
     expected_models = {
-        "c0": "qwen3.7-flash",
-        "c1": "deepseek-v4-flash-0731",
-        "c2": "glm-5.2",
+        "c0": "deepseek-v4-flash-0731",
+        "c1": "deepseek-v4-pro-0813",
+        "c2": "kimi-k2.7-code",
         "c3": "glm-5.2",
         "image_model": "kimi-k2.6",
     }
@@ -173,6 +173,8 @@ def test_tokenrhythm_curated_ladder() -> None:
         preset.default_model,
         *(entry["model"] for entry in tiers.values()),
     })
+    assert tiers["c0"]["supports_image"] is False
+    assert tiers["c2"]["supports_image"] is False
     assert tiers["image_model"]["supports_image"] is True
     assert tiers["image_model"]["image_only"] is True
     assert tiers["c3"]["ensemble_enabled"] is True

--- a/tests/test_provider/test_resolution.py
+++ b/tests/test_provider/test_resolution.py
@@ -50,7 +50,7 @@ def _catalog_with_model() -> ModelCatalog:
 def test_default_llm_identity_fields_report_default() -> None:
     fields = resolve_effective_llm(_config(), ModelCatalog())
     assert fields["llm.provider"] == ResolvedField("tokenrhythm", "default")
-    assert fields["llm.model"] == ResolvedField("deepseek-v4-flash-0731", "default")
+    assert fields["llm.model"] == ResolvedField("deepseek-v4-pro-0813", "default")
     assert fields["llm.base_url"] == ResolvedField("https://tokenrhythm.studio/v1", "default")
 
 

--- a/tests/test_provider_compat_policy.py
+++ b/tests/test_provider_compat_policy.py
@@ -14,6 +14,10 @@ from opensquilla.provider.compat_policy import (
     compat_policy_for_kind,
     known_policy_kinds,
 )
+from opensquilla.provider.model_identity import (
+    DEEPSEEK_V4_MODEL_IDS,
+    is_deepseek_v4_model_id,
+)
 from opensquilla.provider.openai import (
     OpenAIProvider,
     _should_replay_reasoning_content,
@@ -87,6 +91,13 @@ def test_tokenrhythm_v4_reasoning_is_exact_and_endpoint_scoped() -> None:
     assert official.matches(
         "deepseek-v4-flash", "https://tokenrhythm.studio/v1"
     )
+    assert official.matches(
+        "deepseek-v4-pro-0813", "https://tokenrhythm.studio"
+    )
+    assert official.matches(
+        "tokenrhythm/deepseek-v4-pro-0813",
+        "HTTPS://TOKENRHYTHM.STUDIO:443/v1/",
+    )
     assert not official.matches(
         "tokenrhythm/deepseek-v4-flash-0731",
         "https://api.tokenrhythm.studio/v1",
@@ -97,10 +108,27 @@ def test_tokenrhythm_v4_reasoning_is_exact_and_endpoint_scoped() -> None:
     assert not official.matches(
         "deepseek-v4-flash", "https://tokenrhythm.studio.evil.example/v1"
     )
+    assert not official.matches(
+        "deepseek-v4-pro-0813", "https://tokenrhythm.studio/v1/custom"
+    )
+    assert not official.matches(
+        "deepseek-v4-pro-0813-preview", "https://tokenrhythm.studio/v1"
+    )
+    assert not official.matches(
+        "deepseek-v4-pro-0813", "https://tokenrhythm.studio/v1?"
+    )
+    assert not official.matches(
+        "deepseek-v4-pro-0813", "https://tokenrhythm.studio/v1#"
+    )
     assert official.replay_scope == "tool_call_assistant"
     assert official.max_reasoning_content_utf16_units == 50_000
     assert official.reasoning_format == "deepseek"
     assert custom.matches("deepseek-v4-flash", "https://custom.example/v1")
+    assert not custom.matches("deepseek-v4-pro-0813", "https://custom.example/v1")
+    assert not custom.matches(
+        "tokenrhythm/deepseek-v4-pro-0813",
+        "https://tokenrhythm.studio/v1/custom",
+    )
     assert custom.reasoning_format == ""
     assert policy.supports_native_json_schema_output is False
     # cost_cny is CNY — booking it as USD would corrupt cost rollups.
@@ -129,6 +157,14 @@ def test_tokenrhythm_v4_reasoning_is_exact_and_endpoint_scoped() -> None:
     assert not _should_replay_reasoning_content(
         policy=policy, model="glm-5", caps=None
     )
+
+
+def test_deepseek_v4_identity_includes_only_exact_0813_ids() -> None:
+    assert "deepseek-v4-pro-0813" in DEEPSEEK_V4_MODEL_IDS
+    assert is_deepseek_v4_model_id("deepseek-v4-pro-0813")
+    assert is_deepseek_v4_model_id("tokenrhythm/deepseek-v4-pro-0813")
+    assert not is_deepseek_v4_model_id("deepseek-v4-pro-0813-preview")
+    assert not is_deepseek_v4_model_id("tokenrhythm/deepseek-v4-pro-0813-preview")
 
 
 def test_native_json_schema_output_stays_enabled_by_default() -> None:
@@ -174,6 +210,8 @@ def test_dsml_policy_names_only_exact_packaged_model_ids() -> None:
             "tokenrhythm/deepseek-v4-flash",
             "tokenrhythm/deepseek-v4-flash-0731",
             "tokenrhythm/deepseek-v4-pro",
+            "deepseek-v4-pro-0813",
+            "tokenrhythm/deepseek-v4-pro-0813",
         },
         "openrouter": {
             "deepseek/deepseek-v4-flash",
@@ -188,11 +226,18 @@ def test_dsml_policy_names_only_exact_packaged_model_ids() -> None:
             for rule in profile.model_rules
             if TEXT_TOOL_DIALECT_DEEPSEEK_DSML in rule.dialects
         ]
-        assert len(dsml_rules) == 1
-        assert set(dsml_rules[0].model_patterns) == expected_models
+        expected_rule_count = 2 if provider_kind == "tokenrhythm" else 1
+        assert len(dsml_rules) == expected_rule_count
+        actual_models = {
+            model
+            for rule in dsml_rules
+            for model in rule.model_patterns
+        }
+        assert actual_models == expected_models
         assert not any(
             wildcard in pattern
-            for pattern in dsml_rules[0].model_patterns
+            for rule in dsml_rules
+            for pattern in rule.model_patterns
             for wildcard in "*?["
         )
 
@@ -226,6 +271,8 @@ def test_dsml_policy_rejects_near_misses_and_wrong_providers() -> None:
         ("deepseek", "vendor/deepseek-v4-flash"),
         ("tokenrhythm", "deepseek/deepseek-v4-flash"),
         ("tokenrhythm", "tokenrhythm/deepseek-v4-flash-preview"),
+        ("tokenrhythm", "deepseek-v4-pro-0813"),
+        ("tokenrhythm", "tokenrhythm/deepseek-v4-pro-0813-preview"),
         ("openrouter", "deepseek-v4-flash"),
         ("openrouter", "deepseek/deepseek-v4-flash-0731"),
         ("openrouter", "vendor/deepseek-v4-pro"),
@@ -239,6 +286,41 @@ def test_dsml_policy_rejects_near_misses_and_wrong_providers() -> None:
             model
         )
         assert TEXT_TOOL_DIALECT_DEEPSEEK_DSML not in dialects
+
+
+def test_tokenrhythm_0813_dsml_is_exact_and_endpoint_scoped() -> None:
+    profile = compat_policy_for_kind("tokenrhythm").text_tool_profile
+    for model in (
+        "deepseek-v4-pro-0813",
+        "tokenrhythm/deepseek-v4-pro-0813",
+    ):
+        for base_url in (
+            "https://tokenrhythm.studio",
+            "https://tokenrhythm.studio/v1",
+            "HTTPS://TOKENRHYTHM.STUDIO:443/v1/",
+        ):
+            assert TEXT_TOOL_DIALECT_DEEPSEEK_DSML in profile.dialects_for_model(
+                model,
+                base_url,
+            )
+
+    for base_url in (
+        "http://tokenrhythm.studio/v1",
+        "https://api.tokenrhythm.studio/v1",
+        "https://tokenrhythm.studio.evil.example/v1",
+        "https://customer-proxy.example/v1",
+        "https://tokenrhythm.studio/v1/custom",
+        "https://tokenrhythm.studio:8443/v1",
+        "https://user@tokenrhythm.studio/v1",
+        "https://tokenrhythm.studio/v1?tenant=x",
+        "https://tokenrhythm.studio/v1#fragment",
+        "https://tokenrhythm.studio/v1?",
+        "https://tokenrhythm.studio/v1#",
+    ):
+        assert TEXT_TOOL_DIALECT_DEEPSEEK_DSML not in profile.dialects_for_model(
+            "deepseek-v4-pro-0813",
+            base_url,
+        )
 
 
 def test_openrouter_replay_follows_capability_format() -> None:

--- a/tests/test_provider_model_catalog.py
+++ b/tests/test_provider_model_catalog.py
@@ -91,7 +91,7 @@ def test_provider_scoped_corrections_budget_outranks_snapshot_merge() -> None:
     assert catalog.resolve_context_window("glm-5", provider="tokenrhythm") == 1_000_000
     assert catalog.resolve_context_window("kimi-k2.5", provider="tokenrhythm") == 256_000
     assert catalog.resolve_context_window("kimi-k2.7-code", provider="tokenrhythm") == 256_000
-    assert catalog.resolve_max_tokens("kimi-k2.7-code", provider="tokenrhythm") == 16_384
+    assert catalog.resolve_max_tokens("kimi-k2.7-code", provider="tokenrhythm") == 128_000
     assert catalog.resolve_context_window("qwen3.7-max", provider="tokenrhythm") == 1_000_000
     assert catalog.resolve_max_tokens("qwen3.7-max", provider="tokenrhythm") == 131_072
     # The correction is scoped to TokenRhythm. Direct/provider-less snapshot

--- a/tests/test_provider_model_catalog.py
+++ b/tests/test_provider_model_catalog.py
@@ -91,7 +91,7 @@ def test_provider_scoped_corrections_budget_outranks_snapshot_merge() -> None:
     assert catalog.resolve_context_window("glm-5", provider="tokenrhythm") == 1_000_000
     assert catalog.resolve_context_window("kimi-k2.5", provider="tokenrhythm") == 256_000
     assert catalog.resolve_context_window("kimi-k2.7-code", provider="tokenrhythm") == 256_000
-    assert catalog.resolve_max_tokens("kimi-k2.7-code", provider="tokenrhythm") == 128_000
+    assert catalog.resolve_max_tokens("kimi-k2.7-code", provider="tokenrhythm") == 16_384
     assert catalog.resolve_context_window("qwen3.7-max", provider="tokenrhythm") == 1_000_000
     assert catalog.resolve_max_tokens("qwen3.7-max", provider="tokenrhythm") == 131_072
     # The correction is scoped to TokenRhythm. Direct/provider-less snapshot
@@ -126,6 +126,26 @@ def test_tokenrhythm_v4_flash_0731_offline_metadata_is_exact_and_scoped() -> Non
     ) == 384_000
 
     direct = catalog.resolve_entry("deepseek-v4-flash-0731", provider="deepseek")
+    assert direct.input_cost_per_mtok is None
+    assert direct.output_cost_per_mtok is None
+    assert direct.cache_read_cost_per_mtok is None
+
+
+def test_tokenrhythm_v4_pro_0813_offline_metadata_is_exact_and_scoped() -> None:
+    catalog = ModelCatalog()
+
+    entry = catalog.resolve_entry("deepseek-v4-pro-0813", provider="tokenrhythm")
+    assert entry.context_window == 1_000_000
+    assert entry.max_output_tokens == 384_000
+    assert entry.supports_reasoning is True
+    assert entry.supports_tools is True
+    assert entry.supports_vision is False
+    assert entry.reasoning_format == "none"
+    assert entry.input_cost_per_mtok == pytest.approx(1.2903225806451613)
+    assert entry.output_cost_per_mtok == pytest.approx(3.870967741935484)
+    assert entry.cache_read_cost_per_mtok == pytest.approx(0.043010752688172046)
+
+    direct = catalog.resolve_entry("deepseek-v4-pro-0813", provider="deepseek")
     assert direct.input_cost_per_mtok is None
     assert direct.output_cost_per_mtok is None
     assert direct.cache_read_cost_per_mtok is None

--- a/tests/test_provider_text_tool_normalization.py
+++ b/tests/test_provider_text_tool_normalization.py
@@ -331,6 +331,7 @@ def _collect_stream(
     native_tool_call: bool = False,
     native_query: str = "native",
     compat: OpenAICompatPolicy | None = None,
+    base_url: str = "https://api.openai.com",
     raw_body: bytes | None = None,
     config: ChatConfig | None = None,
 ) -> list[Any]:
@@ -363,6 +364,7 @@ def _collect_stream(
     provider = OpenAIProvider(
         api_key="test",
         model=model,
+        base_url=base_url,
         provider_kind=provider_kind,
         compat=compat,
     )
@@ -606,6 +608,90 @@ def test_dsml_executes_only_for_exact_packaged_provider_model_pairs(
     assert ends[0].arguments == {"query": "x"}
     assert ends[0].synthetic_from_text is True
     assert isinstance(events[-1], DoneEvent)
+
+
+@pytest.mark.parametrize(
+    "model",
+    ("deepseek-v4-pro-0813", "tokenrhythm/deepseek-v4-pro-0813"),
+)
+@pytest.mark.parametrize(
+    "base_url",
+    (
+        "https://tokenrhythm.studio",
+        "https://tokenrhythm.studio/v1",
+        "HTTPS://TOKENRHYTHM.STUDIO:443/v1/",
+    ),
+)
+def test_tokenrhythm_0813_dsml_executes_only_at_official_api_roots(
+    monkeypatch: pytest.MonkeyPatch,
+    model: str,
+    base_url: str,
+) -> None:
+    events = _collect_stream(
+        monkeypatch,
+        provider_kind="tokenrhythm",
+        model=model,
+        base_url=base_url,
+        text_chunks=list(_DSML_CALL),
+        tools=[_SEARCH_TOOL],
+    )
+
+    assert _text(events) == ""
+    assert len(_tool_starts(events)) == len(_tool_ends(events)) == 1
+    assert _tool_ends(events)[0].arguments == {"query": "x"}
+    assert isinstance(events[-1], DoneEvent)
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    (
+        "http://tokenrhythm.studio/v1",
+        "https://api.tokenrhythm.studio/v1",
+        "https://tokenrhythm.studio.evil.example/v1",
+        "https://customer-proxy.example/v1",
+        "https://tokenrhythm.studio/v1/custom",
+        "https://tokenrhythm.studio:8443/v1",
+        "https://user@tokenrhythm.studio/v1",
+        "https://tokenrhythm.studio/v1?tenant=x",
+        "https://tokenrhythm.studio/v1#fragment",
+        "https://tokenrhythm.studio/v1?",
+        "https://tokenrhythm.studio/v1#",
+    ),
+)
+def test_tokenrhythm_0813_dsml_is_literal_at_untrusted_endpoints(
+    monkeypatch: pytest.MonkeyPatch,
+    base_url: str,
+) -> None:
+    events = _collect_stream(
+        monkeypatch,
+        provider_kind="tokenrhythm",
+        model="deepseek-v4-pro-0813",
+        base_url=base_url,
+        text_chunks=list(_DSML_CALL),
+        tools=[_SEARCH_TOOL],
+    )
+
+    assert _text(events) == _DSML_CALL
+    assert _tool_starts(events) == []
+    assert _tool_ends(events) == []
+    assert isinstance(events[-1], DoneEvent)
+
+
+def test_tokenrhythm_0813_dsml_near_miss_is_literal_at_official_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events = _collect_stream(
+        monkeypatch,
+        provider_kind="tokenrhythm",
+        model="deepseek-v4-pro-0813-preview",
+        base_url="https://tokenrhythm.studio/v1",
+        text_chunks=list(_DSML_CALL),
+        tools=[_SEARCH_TOOL],
+    )
+
+    assert _text(events) == _DSML_CALL
+    assert _tool_starts(events) == []
+    assert _tool_ends(events) == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_provider_tokenrhythm_v4_wire_policy.py
+++ b/tests/test_provider_tokenrhythm_v4_wire_policy.py
@@ -27,13 +27,21 @@ from opensquilla.provider.types import (
     ToolInputSchema,
 )
 
-TOKENRHYTHM_V4_MODELS = (
+TOKENRHYTHM_BARE_V4_MODELS = (
     "deepseek-v4-flash",
     "deepseek-v4-flash-0731",
     "deepseek-v4-pro",
+    "deepseek-v4-pro-0813",
+)
+TOKENRHYTHM_V4_MODELS = TOKENRHYTHM_BARE_V4_MODELS + (
     "tokenrhythm/deepseek-v4-flash",
     "tokenrhythm/deepseek-v4-flash-0731",
     "tokenrhythm/deepseek-v4-pro",
+    "tokenrhythm/deepseek-v4-pro-0813",
+)
+TOKENRHYTHM_0813_MODELS = (
+    "deepseek-v4-pro-0813",
+    "tokenrhythm/deepseek-v4-pro-0813",
 )
 TOKENRHYTHM_REASONING_LIMIT_UTF16_UNITS = 50_000
 
@@ -229,6 +237,32 @@ def test_tokenrhythm_custom_endpoint_keeps_legacy_unbounded_tool_replay() -> Non
     assert "reasoning_effort" not in payload
 
 
+@pytest.mark.parametrize("model", TOKENRHYTHM_0813_MODELS)
+@pytest.mark.parametrize(
+    "base_url",
+    (
+        "https://customer-proxy.example/v1",
+        "https://tokenrhythm.studio/v1/custom",
+    ),
+)
+def test_tokenrhythm_0813_custom_endpoint_does_not_replay_reasoning(
+    model: str,
+    base_url: str,
+) -> None:
+    messages = _tool_history("0813 reasoning must remain endpoint-scoped")
+    canonical_before = [message.model_dump(mode="json") for message in messages]
+
+    payload = _payload(
+        _provider(model=model, base_url=base_url),
+        messages,
+    )
+
+    assert "reasoning_content" not in payload["messages"][0]
+    assert "thinking" not in payload
+    assert "reasoning_effort" not in payload
+    assert [message.model_dump(mode="json") for message in messages] == canonical_before
+
+
 def test_tokenrhythm_v4_policy_requires_exact_provider_kind() -> None:
     payload = _payload(
         _provider(provider_kind="openai"),
@@ -245,8 +279,10 @@ def test_tokenrhythm_v4_policy_requires_exact_provider_kind() -> None:
     (
         "deepseek-v3.2",
         "deepseek-v4-flash-preview",
+        "deepseek-v4-pro-0813-preview",
         "untrusted/deepseek-v4-flash",
         "tokenrhythm/deepseek-v4-flash-preview",
+        "tokenrhythm/deepseek-v4-pro-0813-preview",
     ),
 )
 def test_tokenrhythm_v4_policy_does_not_change_non_exact_model_ids(model: str) -> None:
@@ -260,11 +296,12 @@ def test_tokenrhythm_v4_policy_does_not_change_non_exact_model_ids(model: str) -
     assert "reasoning_effort" not in payload
 
 
-@pytest.mark.parametrize("model", TOKENRHYTHM_V4_MODELS[:3])
+@pytest.mark.parametrize("model", TOKENRHYTHM_BARE_V4_MODELS)
 @pytest.mark.parametrize("kind", ("ascii", "cjk", "emoji"))
 @pytest.mark.parametrize(
     ("units", "is_preserved"),
     (
+        (TOKENRHYTHM_REASONING_LIMIT_UTF16_UNITS - 1, True),
         (TOKENRHYTHM_REASONING_LIMIT_UTF16_UNITS, True),
         (TOKENRHYTHM_REASONING_LIMIT_UTF16_UNITS + 1, False),
     ),
@@ -324,10 +361,19 @@ def test_tokenrhythm_projection_does_not_emit_transport_withheld_metric() -> Non
         ("deepseek-v4-pro", ThinkingLevel.LOW, "high"),
         ("deepseek-v4-pro", ThinkingLevel.XHIGH, "high"),
         ("deepseek-v4-pro", ThinkingLevel.ADAPTIVE, "high"),
+        ("deepseek-v4-pro-0813", ThinkingLevel.MINIMAL, "low"),
+        ("deepseek-v4-pro-0813", ThinkingLevel.LOW, "low"),
+        ("deepseek-v4-pro-0813", ThinkingLevel.MEDIUM, "high"),
+        ("deepseek-v4-pro-0813", ThinkingLevel.HIGH, "high"),
+        ("deepseek-v4-pro-0813", ThinkingLevel.XHIGH, "high"),
+        ("deepseek-v4-pro-0813", ThinkingLevel.ADAPTIVE, "high"),
         ("deepseek-v4-flash", None, "high"),
         ("tokenrhythm/deepseek-v4-flash", ThinkingLevel.LOW, "low"),
         ("tokenrhythm/deepseek-v4-flash-0731", ThinkingLevel.LOW, "low"),
         ("tokenrhythm/deepseek-v4-pro", ThinkingLevel.LOW, "high"),
+        ("tokenrhythm/deepseek-v4-pro-0813", ThinkingLevel.MINIMAL, "low"),
+        ("tokenrhythm/deepseek-v4-pro-0813", ThinkingLevel.LOW, "low"),
+        ("tokenrhythm/deepseek-v4-pro-0813", ThinkingLevel.HIGH, "high"),
     ),
 )
 def test_tokenrhythm_v4_thinking_uses_conservative_model_effort_mapping(
@@ -345,7 +391,7 @@ def test_tokenrhythm_v4_thinking_uses_conservative_model_effort_mapping(
     assert payload["reasoning_effort"] == expected_effort
 
 
-@pytest.mark.parametrize("model", TOKENRHYTHM_V4_MODELS[:3])
+@pytest.mark.parametrize("model", TOKENRHYTHM_BARE_V4_MODELS)
 def test_tokenrhythm_v4_thinking_off_sends_explicit_disabled(model: str) -> None:
     payload = _payload(
         _provider(model=model),
@@ -400,6 +446,61 @@ def test_tokenrhythm_v4_unspecified_thinking_degrades_required_tool_choice() -> 
     assert "reasoning_effort" not in payload
 
 
+@pytest.mark.parametrize("model", TOKENRHYTHM_0813_MODELS)
+@pytest.mark.parametrize(
+    ("thinking", "thinking_level", "expected_thinking", "expected_effort"),
+    (
+        (True, ThinkingLevel.LOW, {"type": "enabled"}, "low"),
+        (True, ThinkingLevel.HIGH, {"type": "enabled"}, "high"),
+        (False, ThinkingLevel.OFF, {"type": "disabled"}, None),
+        (False, None, None, None),
+    ),
+)
+def test_tokenrhythm_0813_degrades_required_in_every_thinking_state(
+    model: str,
+    thinking: bool,
+    thinking_level: ThinkingLevel | None,
+    expected_thinking: dict[str, str] | None,
+    expected_effort: str | None,
+) -> None:
+    payload = _payload(
+        _provider(model=model),
+        [Message(role="user", content="Use a tool.")],
+        config=_config(
+            thinking=thinking,
+            thinking_level=thinking_level,
+            tool_choice="required",
+        ),
+        tools=[LOOKUP_TOOL],
+    )
+
+    assert payload["tool_choice"] == "auto"
+    if expected_thinking is None:
+        assert "thinking" not in payload
+    else:
+        assert payload["thinking"] == expected_thinking
+    if expected_effort is None:
+        assert "reasoning_effort" not in payload
+    else:
+        assert payload["reasoning_effort"] == expected_effort
+
+
+def test_tokenrhythm_generic_pro_explicit_off_keeps_required_tool_choice() -> None:
+    payload = _payload(
+        _provider(model="deepseek-v4-pro"),
+        [Message(role="user", content="Use a tool.")],
+        config=_config(
+            thinking=False,
+            thinking_level=ThinkingLevel.OFF,
+            tool_choice="required",
+        ),
+        tools=[LOOKUP_TOOL],
+    )
+
+    assert payload["tool_choice"] == "required"
+    assert payload["thinking"] == {"type": "disabled"}
+
+
 def test_tokenrhythm_v4_unspecified_thinking_named_pin_disables_thinking() -> None:
     named_pin = {"type": "function", "function": {"name": "lookup"}}
     payload = _payload(
@@ -408,6 +509,37 @@ def test_tokenrhythm_v4_unspecified_thinking_named_pin_disables_thinking() -> No
         config=_config(
             thinking=False,
             thinking_level=None,
+            tool_choice=named_pin,
+        ),
+        tools=[LOOKUP_TOOL],
+    )
+
+    assert payload["tool_choice"] == named_pin
+    assert payload["thinking"] == {"type": "disabled"}
+    assert "reasoning_effort" not in payload
+
+
+@pytest.mark.parametrize("model", TOKENRHYTHM_0813_MODELS)
+@pytest.mark.parametrize(
+    ("thinking", "thinking_level"),
+    (
+        (True, ThinkingLevel.LOW),
+        (False, ThinkingLevel.OFF),
+        (False, None),
+    ),
+)
+def test_tokenrhythm_0813_named_pin_wins_in_every_thinking_state(
+    model: str,
+    thinking: bool,
+    thinking_level: ThinkingLevel | None,
+) -> None:
+    named_pin = {"type": "function", "function": {"name": "lookup"}}
+    payload = _payload(
+        _provider(model=model),
+        [Message(role="user", content="Call the selected tool.")],
+        config=_config(
+            thinking=thinking,
+            thinking_level=thinking_level,
             tool_choice=named_pin,
         ),
         tools=[LOOKUP_TOOL],
@@ -459,6 +591,58 @@ def test_tokenrhythm_v4_named_tool_pin_wins_over_thinking() -> None:
     assert payload["tool_choice"] == named_pin
     assert payload["thinking"] == {"type": "disabled"}
     assert "reasoning_effort" not in payload
+
+
+def test_tokenrhythm_0813_required_rewrite_does_not_retry_reactively(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(
+            400,
+            headers={"content-type": "application/json"},
+            json={
+                "error": {
+                    "code": "MODEL_TOOL_CHOICE_NOT_SUPPORTED",
+                    "message": "synthetic selector rejection",
+                }
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "opensquilla.provider.openai.httpx.AsyncClient",
+        patched_async_client,
+    )
+
+    async def run() -> list[ErrorEvent]:
+        return [
+            event
+            async for event in _provider(model="deepseek-v4-pro-0813").chat(
+                [Message(role="user", content="Use a tool.")],
+                tools=[LOOKUP_TOOL],
+                config=_config(
+                    thinking=False,
+                    thinking_level=ThinkingLevel.OFF,
+                    tool_choice="required",
+                ),
+            )
+            if isinstance(event, ErrorEvent)
+        ]
+
+    errors = asyncio.run(run())
+
+    assert len(requests) == 1
+    assert requests[0]["tool_choice"] == "auto"
+    assert len(errors) == 1
 
 
 def test_tokenrhythm_field_limit_400_is_not_retried_reactively(


### PR DESCRIPTION
## Summary

- Add exact TokenRhythm support for `deepseek-v4-pro-0813`.
- Refresh the managed TokenRhythm defaults to C0 `deepseek-v4-flash-0731`, C1 `deepseek-v4-pro-0813`, C2 `kimi-k2.7-code`, C3 `glm-5.2` B5, and image `kimi-k2.6`.
- Keep model/endpoint capability rules fail-closed while preserving reasoning replay, DSML tool normalization, and TokenRhythm tool-choice constraints.
- Align Python, Gateway, CLI, examples, and fresh Electron onboarding defaults.

## Compatibility behavior

TokenRhythm rejects `tool_choice=required` for 0813, so the exact official endpoint rule downgrades it to `auto` without a retry. Named tool pins remain pinned and disable thinking, which is the request shape accepted by TokenRhythm. These rules are restricted to the exact 0813 IDs and official TokenRhythm root or `/v1` endpoints.

## Validation

- `git diff --check` passed.
- Added/updated provider compatibility, DSML, wire, catalog, pricing, routing, onboarding, and desktop contract tests.
- Live TokenRhythm checks covered direct 0813, C0, C2, C3, image routing, streaming, native tools, tool continuation, required-to-auto, named pin, reasoning replay, and B5 ensemble execution.
- No API key or credential was added to the repository, fixtures, or logs.

## Scope and rollout

- Existing persisted Desktop/custom/profile-authoritative configurations are not migrated.
- Fresh, sparse, and managed `preset_binding=follow_primary` configurations use the refreshed ladder.
- C1 may have higher latency/cost than 0731; C3 B5 uses multiple model calls; C2 has a 16K-class output cap.
- This PR does not add automatic C2-to-C3 output-budget upgrades.

## Follow-up

Run the repository CI and the protected live-provider gate before merging. Rotate the temporary validation credential after testing.
