### PR TITLE
Enable finalized Runtime Pack downloads

### DIFF
--- a/.github/scripts/verify-sandbox-package.mjs
+++ b/.github/scripts/verify-sandbox-package.mjs
@@ -45,11 +45,11 @@ const sha256Pattern = /^[0-9a-f]{64}$/i
 function verifyCatalog(catalog, label, { requireFinalized }) {
   if (!catalog) return
   if (catalog.schemaVersion !== 1) fail(`${label} must use schemaVersion 1`)
-  if (catalog.catalogVersion !== '2026-07-30.1') {
-    fail(`${label} must pin catalogVersion 2026-07-30.1`)
+  if (catalog.catalogVersion !== '2026-08-21.2') {
+    fail(`${label} must pin catalogVersion 2026-08-21.2`)
   }
-  if (catalog.releaseTag !== 'v2026.07.30.1') {
-    fail(`${label} must pin releaseTag v2026.07.30.1`)
+  if (catalog.releaseTag !== 'v2026.08.21.2') {
+    fail(`${label} must pin releaseTag v2026.08.21.2`)
   }
   if (catalog.finalized !== true && catalog.finalized !== false) {
     fail(`${label} must declare a boolean finalized flag`)

--- a/desktop/electron/runtime/runtime-manifest.json
+++ b/desktop/electron/runtime/runtime-manifest.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
-  "runtimeSet": "2026-07-30",
+  "runtimeSet": "2026-08-21",
   "assets": {
     "windows-x64": {
       "python": {
-        "id": "cpython-3.13.14-windows-x64",
-        "version": "3.13.14+20260728",
-        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260728/cpython-3.13.14%2B20260728-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
-        "sha256": "a091ab914f2b7d2dbc52e9cf4a225190f72709fc79a64ec44bc61ca4d2908a64",
+        "id": "cpython-3.13.15-windows-x64",
+        "version": "3.13.15+20260814",
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260814/cpython-3.13.15%2B20260814-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
+        "sha256": "07c977bbe4abad07e3bbc314608633e6c74eab482a7bae81f4361cda970b45e6",
         "archiveType": "tar.gz",
         "installDir": "python",
         "stripComponents": 1,
@@ -20,10 +20,10 @@
         }
       },
       "node": {
-        "id": "node-24.18.1-windows-x64",
-        "version": "24.18.1",
-        "url": "https://nodejs.org/dist/v24.18.1/node-v24.18.1-win-x64.zip",
-        "sha256": "ec56b84a7551893ab2324ebdfdc4ab974a63b4781162600b68a1293cc3e53765",
+        "id": "node-24.19.0-windows-x64",
+        "version": "24.19.0",
+        "url": "https://nodejs.org/dist/v24.19.0/node-v24.19.0-win-x64.zip",
+        "sha256": "57f71ab3652e797d84acddc79c81cc9ff1c6ddb2a1974cdb83f00fee9bff4c73",
         "archiveType": "zip",
         "installDir": "node",
         "stripComponents": 1,
@@ -37,10 +37,10 @@
         }
       },
       "gitBash": {
-        "id": "git-for-windows-2.55.0.3-x64",
-        "version": "2.55.0.windows.3",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.3/PortableGit-2.55.0.3-64-bit.7z.exe",
-        "sha256": "ab00566336b5472120f9a52d34f2e79c5406535792acb0548001ffd0bd090e5d",
+        "id": "git-for-windows-2.55.0.5-x64",
+        "version": "2.55.0.windows.5",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.5/PortableGit-2.55.0.5-64-bit.7z.exe",
+        "sha256": "5aa8a20f6e9abb2c755f0e73c91c687701a46b309ad84a0ca6509380fa4ae290",
         "archiveType": "7z-sfx",
         "installDir": "git-bash",
         "stripComponents": 0,
@@ -57,10 +57,10 @@
     },
     "windows-arm64": {
       "python": {
-        "id": "cpython-3.13.14-windows-arm64",
-        "version": "3.13.14+20260728",
-        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260728/cpython-3.13.14%2B20260728-aarch64-pc-windows-msvc-install_only_stripped.tar.gz",
-        "sha256": "e28e7108a4b36c0c321da8c842a7addf59358e26b5ec9abe002e9e940130f41f",
+        "id": "cpython-3.13.15-windows-arm64",
+        "version": "3.13.15+20260814",
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260814/cpython-3.13.15%2B20260814-aarch64-pc-windows-msvc-install_only_stripped.tar.gz",
+        "sha256": "f6bf0fa39ad3668dc1996052ec6eff58c54aa126bf203cf3728a47a830af2b5d",
         "archiveType": "tar.gz",
         "installDir": "python",
         "stripComponents": 1,
@@ -70,10 +70,10 @@
         }
       },
       "node": {
-        "id": "node-24.18.1-windows-arm64",
-        "version": "24.18.1",
-        "url": "https://nodejs.org/dist/v24.18.1/node-v24.18.1-win-arm64.zip",
-        "sha256": "ffbc7d3e1baf6804f7431ff94f19b9a885a650568c93ea4ccb1bb0038f6af825",
+        "id": "node-24.19.0-windows-arm64",
+        "version": "24.19.0",
+        "url": "https://nodejs.org/dist/v24.19.0/node-v24.19.0-win-arm64.zip",
+        "sha256": "8502f4a50b458d4cc38ed8f2001556c2cd239d464920f74017926ccb1e1c157f",
         "archiveType": "zip",
         "installDir": "node",
         "stripComponents": 1,
@@ -85,10 +85,10 @@
         }
       },
       "gitBash": {
-        "id": "git-for-windows-2.55.0.3-arm64",
-        "version": "2.55.0.windows.3",
-        "url": "https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.3/PortableGit-2.55.0.3-arm64.7z.exe",
-        "sha256": "3bf26b94d9399b16a890776e468334f501742861576cbcdea2d9134643c374bd",
+        "id": "git-for-windows-2.55.0.5-arm64",
+        "version": "2.55.0.windows.5",
+        "url": "https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.5/PortableGit-2.55.0.5-arm64.7z.exe",
+        "sha256": "49d1dd3158017fa9805d07268433dbab7021b2ec1c1cc3fbabaf8b8255764dd0",
         "archiveType": "7z-sfx",
         "installDir": "git-bash",
         "stripComponents": 0,
@@ -101,10 +101,10 @@
     },
     "linux-x64": {
       "python": {
-        "id": "cpython-3.13.14-linux-x64",
-        "version": "3.13.14+20260728",
-        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260728/cpython-3.13.14%2B20260728-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-        "sha256": "6734c3e643c75e860c36ee3a7904e8e6bafbf3232d89b17ffd5fbfa72ab2816c",
+        "id": "cpython-3.13.15-linux-x64",
+        "version": "3.13.15+20260814",
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260814/cpython-3.13.15%2B20260814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
+        "sha256": "aaca2af2ab4d7b68a712660d1334c0cfd5ec13c0312ccd30c29122d8d0342320",
         "archiveType": "tar.gz",
         "installDir": "python",
         "stripComponents": 1,
@@ -114,10 +114,10 @@
         }
       },
       "node": {
-        "id": "node-24.18.1-linux-x64",
-        "version": "24.18.1",
-        "url": "https://nodejs.org/dist/v24.18.1/node-v24.18.1-linux-x64.tar.xz",
-        "sha256": "d6c664df3f3f61458e8c277585571328522d705166723a7c7823a9253a4d15a0",
+        "id": "node-24.19.0-linux-x64",
+        "version": "24.19.0",
+        "url": "https://nodejs.org/dist/v24.19.0/node-v24.19.0-linux-x64.tar.xz",
+        "sha256": "14b342e71204f811bde6153be8e04b62aef63c236fef92b55f9c83154b409647",
         "archiveType": "tar.xz",
         "installDir": "node",
         "stripComponents": 1,
@@ -131,10 +131,10 @@
     },
     "linux-arm64": {
       "python": {
-        "id": "cpython-3.13.14-linux-arm64",
-        "version": "3.13.14+20260728",
-        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260728/cpython-3.13.14%2B20260728-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-        "sha256": "1eaf979af6c6986553b91a9e3b03647f63ce52a888e00892d3bddc96f43748e9",
+        "id": "cpython-3.13.15-linux-arm64",
+        "version": "3.13.15+20260814",
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260814/cpython-3.13.15%2B20260814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
+        "sha256": "985efd78c1c6521b379f7c64c2a25e6a1130f07441d1af8be441aa05260886aa",
         "archiveType": "tar.gz",
         "installDir": "python",
         "stripComponents": 1,
@@ -144,10 +144,10 @@
         }
       },
       "node": {
-        "id": "node-24.18.1-linux-arm64",
-        "version": "24.18.1",
-        "url": "https://nodejs.org/dist/v24.18.1/node-v24.18.1-linux-arm64.tar.xz",
-        "sha256": "7201e3a09dc825bac57867c81913e2b8f0ef87d04cb9082af4cda82f6ff3d88c",
+        "id": "node-24.19.0-linux-arm64",
+        "version": "24.19.0",
+        "url": "https://nodejs.org/dist/v24.19.0/node-v24.19.0-linux-arm64.tar.xz",
+        "sha256": "01443c1e1a29e531ccad5a46fefa6df490d2189c49f7955904aecdbb0fe86fdc",
         "archiveType": "tar.xz",
         "installDir": "node",
         "stripComponents": 1,
@@ -161,10 +161,10 @@
     },
     "darwin-x64": {
       "python": {
-        "id": "cpython-3.13.14-darwin-x64",
-        "version": "3.13.14+20260728",
-        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260728/cpython-3.13.14%2B20260728-x86_64-apple-darwin-install_only_stripped.tar.gz",
-        "sha256": "aa73c37aebebe3b7264dce1e49923719ab0ac0fc590353adf393eee3e2041c18",
+        "id": "cpython-3.13.15-darwin-x64",
+        "version": "3.13.15+20260814",
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260814/cpython-3.13.15%2B20260814-x86_64-apple-darwin-install_only_stripped.tar.gz",
+        "sha256": "bf87354efcd9ae517da606fcda4e3a3f0d73a6f05ca7cba3c6d3c5270074bfc8",
         "archiveType": "tar.gz",
         "installDir": "python",
         "stripComponents": 1,
@@ -174,10 +174,10 @@
         }
       },
       "node": {
-        "id": "node-24.18.1-darwin-x64",
-        "version": "24.18.1",
-        "url": "https://nodejs.org/dist/v24.18.1/node-v24.18.1-darwin-x64.tar.xz",
-        "sha256": "f892c7895720f40d3750bde24f3554242d36f23602b5167b5b73ec4d13938aef",
+        "id": "node-24.19.0-darwin-x64",
+        "version": "24.19.0",
+        "url": "https://nodejs.org/dist/v24.19.0/node-v24.19.0-darwin-x64.tar.xz",
+        "sha256": "d35e95230f46f6f0751df497c56622c6735e05d5e1fb1630996a005b9d328fe4",
         "archiveType": "tar.xz",
         "installDir": "node",
         "stripComponents": 1,
@@ -191,10 +191,10 @@
     },
     "darwin-arm64": {
       "python": {
-        "id": "cpython-3.13.14-darwin-arm64",
-        "version": "3.13.14+20260728",
-        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260728/cpython-3.13.14%2B20260728-aarch64-apple-darwin-install_only_stripped.tar.gz",
-        "sha256": "aa2a054f5e04bde63ae199e3bb6bbb634e457423efd294842deeb1299e7e5932",
+        "id": "cpython-3.13.15-darwin-arm64",
+        "version": "3.13.15+20260814",
+        "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20260814/cpython-3.13.15%2B20260814-aarch64-apple-darwin-install_only_stripped.tar.gz",
+        "sha256": "6d472fc49a4d95e58214a992c4c92aa73fe2a935837a01a9a36bab0bec6d72f3",
         "archiveType": "tar.gz",
         "installDir": "python",
         "stripComponents": 1,
@@ -204,10 +204,10 @@
         }
       },
       "node": {
-        "id": "node-24.18.1-darwin-arm64",
-        "version": "24.18.1",
-        "url": "https://nodejs.org/dist/v24.18.1/node-v24.18.1-darwin-arm64.tar.xz",
-        "sha256": "1d60b703fe5d7e7072489be8187f430f1a095a658c31e5e1e281331a5873fac3",
+        "id": "node-24.19.0-darwin-arm64",
+        "version": "24.19.0",
+        "url": "https://nodejs.org/dist/v24.19.0/node-v24.19.0-darwin-arm64.tar.xz",
+        "sha256": "3f1cf157479c1480352083105e13faf9d008ede98e7e157746b6df940d197b94",
         "archiveType": "tar.xz",
         "installDir": "node",
         "stripComponents": 1,

--- a/desktop/electron/runtime/runtime-pack-catalog.json
+++ b/desktop/electron/runtime/runtime-pack-catalog.json
@@ -1,7 +1,146 @@
 {
+  "catalogVersion": "2026-08-21.2",
+  "finalized": true,
+  "releaseTag": "v2026.08.21.2",
   "schemaVersion": 1,
-  "catalogVersion": "2026-07-30.1",
-  "releaseTag": "v2026.07.30.1",
-  "finalized": false,
-  "targets": {}
+  "targets": {
+    "darwin-arm64": {
+      "node": {
+        "archiveType": "tar.xz",
+        "asset": "OpenSquilla-Runtime-node-2026-08-21.2-darwin-arm64.tar.xz",
+        "sha256": "5dd615fe287631ac61d35d5a03e1f13f5248e1125e706ddbbcd3a15ee5d5d348",
+        "sizeBytes": 27536336,
+        "trustedArchiveSha256": [],
+        "unpackedSizeBytes": 197373784,
+        "version": "24.19.0"
+      },
+      "python": {
+        "archiveType": "tar.xz",
+        "asset": "OpenSquilla-Runtime-python-2026-08-21.2-darwin-arm64.tar.xz",
+        "sha256": "fe7c547108d6e5ac9421d6b6a1bf7f564b13e396a5dc474460bd8c2ddd5f1ae2",
+        "sizeBytes": 12946500,
+        "trustedArchiveSha256": [],
+        "unpackedSizeBytes": 100525574,
+        "version": "3.13.15+20260814"
+      }
+    },
+    "darwin-x64": {
+      "node": {
+        "archiveType": "tar.xz",
+        "asset": "OpenSquilla-Runtime-node-2026-08-21.2-darwin-x64.tar.xz",
+        "sha256": "b227e402954ffe6aeb45a91b82b21551f0c6b2f2695c8e0643c969b43ddb1cb4",
+        "sizeBytes": 29181996,
+        "trustedArchiveSha256": [],
+        "unpackedSizeBytes": 199733635,
+        "version": "24.19.0"
+      },
+      "python": {
+        "archiveType": "tar.xz",
+        "asset": "OpenSquilla-Runtime-python-2026-08-21.2-darwin-x64.tar.xz",
+        "sha256": "3a329e6cc15d661dfe3de6c8c45379b03b3de5a12e1d53ef4632f342b4cfcc17",
+        "sizeBytes": 13459412,
+        "trustedArchiveSha256": [],
+        "unpackedSizeBytes": 101588325,
+        "version": "3.13.15+20260814"
+      }
+    },
+    "linux-arm64": {
+      "node": {
+        "archiveType": "tar.xz",
+        "asset": "OpenSquilla-Runtime-node-2026-08-21.2-linux-arm64.tar.xz",
+        "sha256": "86641bc30a005ebd4cee61b72d89df2b1ea1c6440935bbf68189e5c464cbd282",
+        "sizeBytes": 30973124,
+        "trustedArchiveSha256": [],
+        "unpackedSizeBytes": 198144671,
+        "version": "24.19.0"
+      },
+      "python": {
+        "archiveType": "tar.xz",
+        "asset": "OpenSquilla-Runtime-python-2026-08-21.2-linux-arm64.tar.xz",
+        "sha256": "387819c29c0f3e423ce73c40a7f2a508c28c72b34592a94fee5fb4a81bd26a6d",
+        "sizeBytes": 15828568,
+        "trustedArchiveSha256": [],
+        "unpackedSizeBytes": 149532068,
+        "version": "3.13.15+20260814"
+      }
+    },
+    "linux-x64": {
+      "node": {
+        "archiveType": "tar.xz",
+        "asset": "OpenSquilla-Runtime-node-2026-08-21.2-linux-x64.tar.xz",
+        "sha256": "0ca192ae2ca1699334e3744793842c03604d2e405a2dedd9c72f1668eabe5bec",
+        "sizeBytes": 32015440,
+        "trustedArchiveSha256": [],
+        "unpackedSizeBytes": 202056529,
+        "version": "24.19.0"
+      },
+      "python": {
+        "archiveType": "tar.xz",
+        "asset": "OpenSquilla-Runtime-python-2026-08-21.2-linux-x64.tar.xz",
+        "sha256": "c68e70f7336851225025ff17cd7012b37b327cfde9df90ca161b798493d06dbb",
+        "sizeBytes": 20748400,
+        "trustedArchiveSha256": [],
+        "unpackedSizeBytes": 197014778,
+        "version": "3.13.15+20260814"
+      }
+    },
+    "windows-arm64": {
+      "gitBash": {
+        "archiveType": "tar.xz",
+        "asset": "OpenSquilla-Runtime-gitBash-2026-08-21.2-windows-arm64.tar.xz",
+        "sha256": "abebd0fb577eb21c15879afb24ac4a9224f3d7f643f89ccff11bbb7b74f1102c",
+        "sizeBytes": 76170316,
+        "trustedArchiveSha256": [],
+        "unpackedSizeBytes": 391017226,
+        "version": "2.55.0.windows.5"
+      },
+      "node": {
+        "archiveType": "tar.xz",
+        "asset": "OpenSquilla-Runtime-node-2026-08-21.2-windows-arm64.tar.xz",
+        "sha256": "a55cc13d8b93d7eb970db34370c1b22c40a6430fd0728340672c24042f9dcd30",
+        "sizeBytes": 21792796,
+        "trustedArchiveSha256": [],
+        "unpackedSizeBytes": 96305343,
+        "version": "24.19.0"
+      },
+      "python": {
+        "archiveType": "tar.xz",
+        "asset": "OpenSquilla-Runtime-python-2026-08-21.2-windows-arm64.tar.xz",
+        "sha256": "e898750b066b20024c4f6ed894894aa1b5c76f0ae58a25d55a6f68ba2e2fa7fe",
+        "sizeBytes": 14324472,
+        "trustedArchiveSha256": [],
+        "unpackedSizeBytes": 64974681,
+        "version": "3.13.15+20260814"
+      }
+    },
+    "windows-x64": {
+      "gitBash": {
+        "archiveType": "tar.xz",
+        "asset": "OpenSquilla-Runtime-gitBash-2026-08-21.2-windows-x64.tar.xz",
+        "sha256": "0a3517c8f2b00367bb006d5644d41c76aa39482d34d513ebae86b1918c967023",
+        "sizeBytes": 80870668,
+        "trustedArchiveSha256": [],
+        "unpackedSizeBytes": 410353071,
+        "version": "2.55.0.windows.5"
+      },
+      "node": {
+        "archiveType": "tar.xz",
+        "asset": "OpenSquilla-Runtime-node-2026-08-21.2-windows-x64.tar.xz",
+        "sha256": "31cf63f911f22fd3ecdfe8dcb485d40aab739b16c8407e842ddecb91d8ca6575",
+        "sizeBytes": 25075660,
+        "trustedArchiveSha256": [],
+        "unpackedSizeBytes": 107829437,
+        "version": "24.19.0"
+      },
+      "python": {
+        "archiveType": "tar.xz",
+        "asset": "OpenSquilla-Runtime-python-2026-08-21.2-windows-x64.tar.xz",
+        "sha256": "65303a1f7a67cadfeafd1346fd4fb5669ca87a31241ee8d0ddde02568b759623",
+        "sizeBytes": 15733188,
+        "trustedArchiveSha256": [],
+        "unpackedSizeBytes": 64914079,
+        "version": "3.13.15+20260814"
+      }
+    }
+  }
 }

--- a/desktop/electron/scripts/test-bundled-runtimes.mjs
+++ b/desktop/electron/scripts/test-bundled-runtimes.mjs
@@ -101,10 +101,10 @@ try {
         ? ['gitBash', 'node', 'python']
         : ['node', 'python'],
     )
-    assert.equal(assets.node.version, '24.18.1')
-    assert.equal(assets.python.version, '3.13.14+20260728')
+    assert.equal(assets.node.version, '24.19.0')
+    assert.equal(assets.python.version, '3.13.15+20260814')
     if (target.startsWith('windows-')) {
-      assert.equal(assets.gitBash.version, '2.55.0.windows.3')
+      assert.equal(assets.gitBash.version, '2.55.0.windows.5')
     }
     for (const asset of Object.values(assets)) {
       assert.equal(releaseAssetIds.has(asset.id), false, `duplicate runtime asset id: ${asset.id}`)

--- a/opensquilla-webui/src/components/settings/SandboxSettingsPanel.test.ts
+++ b/opensquilla-webui/src/components/settings/SandboxSettingsPanel.test.ts
@@ -35,14 +35,14 @@ const runtimePackStatus: SandboxRuntimePackStatus = {
   schemaVersion: 1,
   managementSupported: true,
   target: 'windows-x64',
-  catalogVersion: '2026-07-30.1',
+  catalogVersion: '2026-08-21.2',
   sourceOrder: ['oss', 'github'],
   components: [
     {
       componentId: 'python',
       availability: 'ready',
-      catalogVersion: '2026-07-30.1',
-      activeVersion: '3.13.14+20260728',
+      catalogVersion: '2026-08-21.2',
+      activeVersion: '3.13.15+20260814',
       installedBytes: 1234,
       removable: true,
       resumeAvailable: false,
@@ -53,7 +53,7 @@ const runtimePackStatus: SandboxRuntimePackStatus = {
     {
       componentId: 'node',
       availability: 'missing',
-      catalogVersion: '2026-07-30.1',
+      catalogVersion: '2026-08-21.2',
       activeVersion: null,
       installedBytes: null,
       removable: false,
@@ -65,7 +65,7 @@ const runtimePackStatus: SandboxRuntimePackStatus = {
     {
       componentId: 'gitBash',
       availability: 'missing',
-      catalogVersion: '2026-07-30.1',
+      catalogVersion: '2026-08-21.2',
       activeVersion: null,
       installedBytes: null,
       removable: false,
@@ -607,7 +607,7 @@ describe('SandboxSettingsPanel', () => {
 
     expect(el.querySelectorAll('.sandbox-runtime-row')).toHaveLength(3)
     expect(el.querySelector('[data-testid="sandbox-runtime-python"]')?.textContent)
-      .toContain('Installed · 3.13.14+20260728')
+      .toContain('Installed · 3.13.15+20260814')
     expect(el.querySelector('[data-testid="sandbox-runtime-node"]')?.textContent)
       .toContain('Not installed')
     expect(el.querySelector('[data-testid="sandbox-runtime-install-node"]')).toBeTruthy()
@@ -702,7 +702,7 @@ describe('SandboxSettingsPanel', () => {
     await settle()
 
     const pythonRow = el.querySelector('[data-testid="sandbox-runtime-python"]')
-    expect(pythonRow?.textContent).toContain('Installed · 3.13.14+20260728 · Not enabled')
+    expect(pythonRow?.textContent).toContain('Installed · 3.13.15+20260814 · Not enabled')
     expect(el.querySelector('[data-testid="sandbox-runtime-enable-python"]')).toBeTruthy()
     el.querySelector<HTMLButtonElement>('[data-testid="sandbox-runtime-enable-python"]')!.click()
     await settle()
@@ -718,6 +718,30 @@ describe('SandboxSettingsPanel', () => {
       }),
     }))
     expect(call.mock.calls.some(([method]) => method === 'sandbox.runtime.install')).toBe(false)
+  })
+
+  it('keeps the successful download source visible after installation', async () => {
+    const installed = structuredClone(runtimePackStatus)
+    installed.components[0].operation = {
+      operationId: 'operation-installed',
+      componentId: 'python',
+      kind: 'install',
+      state: 'completed',
+      source: 'oss',
+      downloadedBytes: 1234,
+      totalBytes: 1234,
+      progressPercent: 100,
+      startedAtMs: 1,
+      updatedAtMs: 2,
+      error: null,
+    }
+    const { el } = await mountPanel({ runtimeStatus: installed })
+    el.querySelector<HTMLButtonElement>('[data-testid="sandbox-open-runtimes"]')!.click()
+    await settle()
+
+    const pythonText = el.querySelector('[data-testid="sandbox-runtime-python"]')?.textContent
+    expect(pythonText).toContain('1.2 KiB')
+    expect(pythonText).toContain('Beijing OSS')
   })
 
   it('uses exact component action payloads from runtime rows', async () => {

--- a/opensquilla-webui/src/components/settings/SandboxSettingsPanel.vue
+++ b/opensquilla-webui/src/components/settings/SandboxSettingsPanel.vue
@@ -301,6 +301,9 @@
                     && runtime.status.installedBytes !== null"
                 >
                   {{ formatBytes(runtime.status.installedBytes) }}
+                  <template v-if="runtime.status.operation?.source">
+                    · {{ runtimeSourceLabel(runtime.status.operation.source) }}
+                  </template>
                 </small>
                 <small v-else-if="runtime.status.operation?.source">
                   {{ runtimeSourceLabel(runtime.status.operation.source) }}

--- a/opensquilla-webui/src/composables/settings/useSandboxSettings.test.ts
+++ b/opensquilla-webui/src/composables/settings/useSandboxSettings.test.ts
@@ -44,14 +44,14 @@ const readyRuntimeStatus: SandboxRuntimePackStatus = {
   schemaVersion: 1,
   managementSupported: true,
   target: 'windows-x64',
-  catalogVersion: '2026-07-30.1',
+  catalogVersion: '2026-08-21.2',
   sourceOrder: ['oss', 'github'],
   components: [
     {
       componentId: 'python',
       availability: 'ready',
-      catalogVersion: '2026-07-30.1',
-      activeVersion: '3.13.14+20260728',
+      catalogVersion: '2026-08-21.2',
+      activeVersion: '3.13.15+20260814',
       installedBytes: 100,
       removable: true,
       resumeAvailable: false,
@@ -518,7 +518,7 @@ describe('useSandboxSettings runtime packs', () => {
       operationId: 'operation-1',
     })
     expect(call).toHaveBeenCalledWith('sandbox.runtime.remove', { componentId: 'python' })
-    expect(settings.runtimeStatus.value?.catalogVersion).toBe('2026-07-30.1')
+    expect(settings.runtimeStatus.value?.catalogVersion).toBe('2026-08-21.2')
     scope.stop()
   })
 

--- a/src/opensquilla/managed_artifacts.py
+++ b/src/opensquilla/managed_artifacts.py
@@ -151,8 +151,12 @@ def _claim_destination(
     destination_root: Path,
     relative: PurePosixPath,
     seen: set[str],
+    *,
+    case_sensitive_paths: bool = False,
 ) -> Path:
-    key = relative.as_posix().casefold()
+    key = relative.as_posix()
+    if not case_sensitive_paths:
+        key = key.casefold()
     if key in seen:
         raise UnsafeArchiveError(f"Duplicate archive path: {relative.as_posix()}")
     seen.add(key)
@@ -196,6 +200,8 @@ def _validate_tar_members(
     destination: Path,
     compressed_size: int,
     max_extracted_bytes: int | None,
+    *,
+    case_sensitive_paths: bool = False,
 ) -> tuple[
     list[tarfile.TarInfo],
     dict[PurePosixPath, PurePosixPath],
@@ -210,7 +216,12 @@ def _validate_tar_members(
             if len(members) >= _MAX_ARCHIVE_MEMBERS:
                 raise UnsafeArchiveError("Archive contains too many entries")
             relative = _safe_archive_name(member.name)
-            _claim_destination(destination, relative, seen)
+            _claim_destination(
+                destination,
+                relative,
+                seen,
+                case_sensitive_paths=case_sensitive_paths,
+            )
             if not (member.isdir() or member.isfile() or member.issym() or member.islnk()):
                 raise UnsafeArchiveError(
                     f"Archive contains a device or special entry: {member.name!r}"
@@ -270,12 +281,15 @@ def _extract_tar_xz(
     destination: Path,
     compressed_size: int,
     max_extracted_bytes: int | None,
+    *,
+    case_sensitive_paths: bool = False,
 ) -> None:
     members, final_targets = _validate_tar_members(
         archive,
         destination,
         compressed_size,
         max_extracted_bytes,
+        case_sensitive_paths=case_sensitive_paths,
     )
     expected = iter(members)
     with tarfile.open(archive, mode="r|xz") as source:
@@ -397,6 +411,8 @@ def _extract_archive(
     archive_type: str,
     compressed_size: int,
     max_extracted_bytes: int | None = None,
+    *,
+    case_sensitive_paths: bool = False,
 ) -> None:
     destination.mkdir(mode=0o700, parents=True, exist_ok=False)
     if archive_type == "tar.xz":
@@ -405,6 +421,7 @@ def _extract_archive(
             destination,
             compressed_size,
             max_extracted_bytes,
+            case_sensitive_paths=case_sensitive_paths,
         )
         return
     if archive_type == "zip":
@@ -425,6 +442,7 @@ def extract_managed_archive(
     archive_type: str,
     compressed_size: int,
     max_extracted_bytes: int | None = None,
+    case_sensitive_paths: bool = False,
 ) -> None:
     """Safely extract a verified Runtime Pack without sandbox or skill imports."""
 
@@ -444,6 +462,7 @@ def extract_managed_archive(
             archive_type,
             compressed_size,
             max_extracted_bytes,
+            case_sensitive_paths=case_sensitive_paths,
         )
     except (EOFError, lzma.LZMAError, tarfile.TarError, zipfile.BadZipFile) as exc:
         raise UnsafeArchiveError("Managed archive is malformed or truncated") from exc

--- a/src/opensquilla/runtime_packs/manager.py
+++ b/src/opensquilla/runtime_packs/manager.py
@@ -1901,6 +1901,7 @@ class RuntimePackService:
                     archive_type=descriptor.archive_type,
                     compressed_size=descriptor.size_bytes,
                     max_extracted_bytes=descriptor.unpacked_size_bytes,
+                    case_sensitive_paths=descriptor.target.startswith("linux-"),
                 )
             except UnsafeArchiveError:
                 partial.unlink(missing_ok=True)

--- a/src/opensquilla/runtime_packs/resolver.py
+++ b/src/opensquilla/runtime_packs/resolver.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ntpath
 import os
 import shutil
 from collections.abc import Iterable, Mapping
@@ -86,6 +87,20 @@ def _dedupe(paths: Iterable[str | Path], *, windows: bool) -> tuple[Path, ...]:
     return tuple(result)
 
 
+def _dedupe_path_text(paths: Iterable[str], *, windows: bool) -> tuple[str, ...]:
+    """Deduplicate PATH entries without rewriting the approved environment text."""
+
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in paths:
+        key = ntpath.normcase(value) if windows else value
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        result.append(value)
+    return tuple(result)
+
+
 class RuntimePackResolver:
     """Resolve only activated and integrity-checked Runtime Packs."""
 
@@ -161,15 +176,20 @@ class RuntimePackResolver:
         result = dict(environment or {})
         path_key = next((key for key in result if key.casefold() == "path"), "PATH")
         host = tuple(
-            Path(part) for part in result.get(path_key, "").split(os.pathsep) if part.strip()
+            part for part in result.get(path_key, "").split(os.pathsep) if part.strip()
         )
-        resolved = self.path_for(
-            mode,
-            host,
-            policy=policy,
-            require_managed=require_managed,
+        managed = tuple(str(path) for path in self.managed_path(policy))
+        if require_managed:
+            combined = managed
+        elif normalize_run_mode(mode) is RunMode.FULL:
+            combined = (*host, *managed)
+        else:
+            combined = (*managed, *host)
+        resolved = _dedupe_path_text(
+            combined,
+            windows=self.target.startswith("windows-"),
         )
-        result[path_key] = os.pathsep.join(str(path) for path in resolved)
+        result[path_key] = os.pathsep.join(resolved)
         return result
 
     def resolve_component_binary(

--- a/tests/test_gateway/test_rpc_sandbox_runtime.py
+++ b/tests/test_gateway/test_rpc_sandbox_runtime.py
@@ -30,13 +30,13 @@ def _status(*, operation: RuntimeOperation | None = None) -> RuntimePackStatus:
         schema_version=1,
         management_supported=True,
         target="darwin-arm64",
-        catalog_version="2026-07-30.1",
+        catalog_version="2026-08-21.2",
         source_order=(RuntimeSource.GITHUB, RuntimeSource.OSS),
         components=(
             RuntimeComponentStatus(
                 component_id="python",
                 availability=RuntimeAvailability.MISSING,
-                catalog_version="2026-07-30.1",
+                catalog_version="2026-08-21.2",
                 active_version=None,
                 installed_bytes=None,
                 removable=False,
@@ -156,6 +156,7 @@ async def test_policy_defaults_do_not_consult_runtime_pack_installation_state(
 ) -> None:
     import opensquilla.runtime_packs as runtime_packs
     import opensquilla.sandbox.runtime_launcher as runtime_launcher
+    import opensquilla.sandbox.runtime_manifest as runtime_manifest
     from opensquilla.gateway import rpc_sandbox
 
     def status_must_not_run(*_args):
@@ -163,15 +164,19 @@ async def test_policy_defaults_do_not_consult_runtime_pack_installation_state(
 
     monkeypatch.setattr(runtime_packs, "status_snapshot", status_must_not_run)
 
-    def broken_resolver():
-        raise ValueError("corrupt manifest")
+    def resolver_must_not_run():
+        raise AssertionError("the finalized catalog must satisfy the legacy projection")
 
-    monkeypatch.setattr(runtime_launcher, "bundled_runtime_resolver", broken_resolver)
+    monkeypatch.setattr(runtime_launcher, "bundled_runtime_resolver", resolver_must_not_run)
+    monkeypatch.setattr(runtime_manifest, "runtime_target", lambda: "darwin-arm64")
 
     payload = await rpc_sandbox._handle_sandbox_policy_defaults({}, _ctx(tmp_path))
 
-    assert payload["runtimeTarget"] is None
-    assert payload["runtimeVersions"] == {}
+    assert payload["runtimeTarget"] == "darwin-arm64"
+    assert payload["runtimeVersions"] == {
+        "python": {"version": "3.13.15+20260814", "available": False},
+        "node": {"version": "24.19.0", "available": False},
+    }
 
 
 def test_runtime_error_payload_does_not_leak_internal_exception() -> None:

--- a/tests/test_runtime_packs/test_runtime_pack_manager.py
+++ b/tests/test_runtime_packs/test_runtime_pack_manager.py
@@ -94,6 +94,20 @@ def test_default_source_order_prefers_the_regional_primary_and_keeps_fallback(
     assert runtime_pack_manager._configured_source_order() == expected
 
 
+def test_windows_runtime_environment_preserves_approved_path_text(tmp_path: Path) -> None:
+    body = _runtime_archive(tmp_path)
+    service = _service(tmp_path, body, _MemoryOpener(body))
+    resolver = RuntimePackResolver(service)
+    resolver.target = "windows-x64"
+
+    environment = resolver.apply_environment(
+        {"PATH": "./approved-path"},
+        mode=RunMode.SAFE,
+    )
+
+    assert environment["PATH"] == "./approved-path"
+
+
 def test_atomic_state_replace_retries_transient_windows_reader_lock(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_runtime_packs/test_runtime_pack_manager.py
+++ b/tests/test_runtime_packs/test_runtime_pack_manager.py
@@ -60,6 +60,40 @@ def _isolate_synthetic_archive_probes(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(runtime_pack_manager, "_run_probe", probe)
 
 
+def test_default_sources_use_version_scoped_runtime_pack_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENSQUILLA_RUNTIME_PACK_OSS_BASE", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_RUNTIME_PACK_GITHUB_BASE", raising=False)
+    bases = runtime_pack_manager._default_source_bases()
+    assert bases[RuntimeSource.OSS] == (
+        "https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/runtime-packs"
+    )
+    assert bases[RuntimeSource.GITHUB] == (
+        "https://github.com/opensquilla/runtime-packs/releases/download"
+    )
+
+
+@pytest.mark.parametrize(
+    ("locale_name", "expected"),
+    [
+        ("zh_CN", (RuntimeSource.OSS, RuntimeSource.GITHUB)),
+        ("en_US", (RuntimeSource.GITHUB, RuntimeSource.OSS)),
+    ],
+)
+def test_default_source_order_prefers_the_regional_primary_and_keeps_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    locale_name: str,
+    expected: tuple[RuntimeSource, RuntimeSource],
+) -> None:
+    monkeypatch.delenv("OPENSQUILLA_RUNTIME_PACK_SOURCE_ORDER", raising=False)
+    for name in ("LC_ALL", "LC_MESSAGES", "LANGUAGE", "LANG"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(runtime_pack_manager.locale, "getlocale", lambda: (locale_name, "UTF-8"))
+
+    assert runtime_pack_manager._configured_source_order() == expected
+
+
 def test_atomic_state_replace_retries_transient_windows_reader_lock(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -168,6 +202,18 @@ class _AssetMemoryOpener:
         assert timeout == 60
         asset = request.full_url.rsplit("/", 1)[-1]
         body = self.bodies[asset]
+        return _Response(body, status=200, start=0, total=len(body))
+
+
+class _PerSourceMemoryOpener:
+    def __init__(self, *, oss: bytes, github: bytes) -> None:
+        self.bodies = {"oss.example.invalid": oss, "github.example.invalid": github}
+        self.urls: list[str] = []
+
+    def __call__(self, request: Any, *, timeout: int) -> _Response:
+        assert timeout == 60
+        self.urls.append(request.full_url)
+        body = next(body for hostname, body in self.bodies.items() if hostname in request.full_url)
         return _Response(body, status=200, start=0, total=len(body))
 
 
@@ -383,6 +429,71 @@ def test_python_probe_runs_declared_executable_with_runtime_only_path(
 
     probe_output = b"Python 3.12.10\n"
     with pytest.raises(runtime_pack_manager.RuntimePackError, match="python probe failed"):
+        _REAL_RUNTIME_PROBE(descriptor, layout, package)
+
+
+def test_node_probe_requires_node_npm_and_npx_with_runtime_only_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = tmp_path / "probe-package"
+    bin_dir = package / "payload" / "bin"
+    bin_dir.mkdir(parents=True)
+    for name in ("node", "npm", "npx"):
+        (bin_dir / name).write_bytes(b"synthetic executable placeholder")
+    descriptor = RuntimePackDescriptor(
+        component_id="node",
+        target="linux-x64",
+        asset="OpenSquilla-Runtime-node-test-linux-x64.tar.xz",
+        archive_type="tar.xz",
+        version="24.19.0",
+        size_bytes=1,
+        unpacked_size_bytes=1,
+        sha256="a" * 64,
+        trusted_archive_sha256=(),
+    )
+    layout = runtime_pack_manager.PackLayout(
+        component_id="node",
+        target="linux-x64",
+        version="24.19.0",
+        bin_dirs=("bin",),
+        executables={"node": "bin/node", "npm": "bin/npm", "npx": "bin/npx"},
+    )
+    observed: list[tuple[str, str]] = []
+    failing_name: str | None = None
+
+    def run_probe(
+        command: list[str],
+        *,
+        check: bool,
+        capture_output: bool,
+        timeout: int,
+        env: dict[str, str],
+    ) -> subprocess.CompletedProcess[bytes]:
+        del check, capture_output, timeout
+        name = Path(command[0]).name
+        path_key = next(key for key in env if key.casefold() == "path")
+        observed.append((name, env[path_key]))
+        output = b"v24.19.0\n" if name == "node" else b"11.5.1\n"
+        return subprocess.CompletedProcess(
+            command,
+            returncode=1 if name == failing_name else 0,
+            stdout=output,
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(runtime_pack_manager.subprocess, "run", run_probe)
+
+    _REAL_RUNTIME_PROBE(descriptor, layout, package)
+
+    assert observed == [
+        ("node", str(bin_dir)),
+        ("npm", str(bin_dir)),
+        ("npx", str(bin_dir)),
+    ]
+
+    failing_name = "npm"
+    with pytest.raises(runtime_pack_manager.RuntimePackError, match="npm probe failed"):
         _REAL_RUNTIME_PROBE(descriptor, layout, package)
 
 
@@ -604,6 +715,39 @@ def test_corrupt_archive_never_activates(tmp_path: Path) -> None:
     assert completed.error is not None
     assert completed.error.code == "VERIFICATION_FAILED"
     assert service.active_runtime("python") is None
+
+
+@pytest.mark.parametrize(
+    ("source_order", "corrupt_source", "expected_hosts"),
+    [
+        ("oss,github", "oss", ["oss.example.invalid", "github.example.invalid"]),
+        ("github,oss", "github", ["github.example.invalid", "oss.example.invalid"]),
+    ],
+)
+def test_corrupt_primary_bytes_fail_closed_and_fall_back_to_alternate_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source_order: str,
+    corrupt_source: str,
+    expected_hosts: list[str],
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_RUNTIME_PACK_SOURCE_ORDER", source_order)
+    body = _runtime_archive(tmp_path)
+    corrupt = body[:-1] + bytes([body[-1] ^ 1])
+    bodies = {"oss": body, "github": body}
+    bodies[corrupt_source] = corrupt
+    opener = _PerSourceMemoryOpener(oss=bodies["oss"], github=bodies["github"])
+    service = _service(tmp_path, body, opener)
+
+    operation = service.start_install("python")
+    completed = service.wait_for_operation(operation.operation_id, timeout=10)
+
+    assert completed is not None
+    assert completed.state is RuntimeOperationState.COMPLETED
+    assert [next(host for host in expected_hosts if host in url) for url in opener.urls] == (
+        expected_hosts
+    )
+    assert service.active_runtime("python") is not None
 
 
 def test_missing_pack_strict_mode_never_inherits_host_path(tmp_path: Path) -> None:

--- a/tests/test_sandbox/test_release_contract.py
+++ b/tests/test_sandbox/test_release_contract.py
@@ -121,12 +121,19 @@ def test_ci_owns_a_package_contract_verifier() -> None:
     assert "unsafeInstallerInclude" in package_verifier
 
 
-def test_unfinalized_catalog_allows_development_but_blocks_release() -> None:
+def test_finalized_catalog_allows_development_and_release() -> None:
     catalog = json.loads(
         _text("desktop/electron/runtime/runtime-pack-catalog.json")
     )
-    assert catalog["finalized"] is False
-    assert catalog["targets"] == {}
+    assert catalog["finalized"] is True
+    assert set(catalog["targets"]) == {
+        "darwin-arm64",
+        "darwin-x64",
+        "linux-arm64",
+        "linux-x64",
+        "windows-arm64",
+        "windows-x64",
+    }
 
     development = subprocess.run(
         ["node", ".github/scripts/verify-sandbox-package.mjs", "--source"],
@@ -144,5 +151,4 @@ def test_unfinalized_catalog_allows_development_but_blocks_release() -> None:
         capture_output=True,
         check=False,
     )
-    assert release.returncode == 1
-    assert "catalog is not finalized" in release.stderr
+    assert release.returncode == 0, release.stderr

--- a/tests/test_skills/test_managed_toolchains.py
+++ b/tests/test_skills/test_managed_toolchains.py
@@ -14,7 +14,7 @@ import threading
 import zipfile
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import pytest
@@ -541,6 +541,32 @@ def test_tar_extraction_rejects_unsafe_paths(tmp_path: Path, name: str) -> None:
     _write_tar_xz(archive, {name: b"no"})
     with pytest.raises(UnsafeArchiveError):
         manager._extract_archive(archive, tmp_path / "out", "tar.xz", archive.stat().st_size)
+
+
+def test_tar_path_claims_allow_case_distinctions_only_when_explicit() -> None:
+    destination = Path("/synthetic/runtime-pack")
+    upper = PurePosixPath("payload/share/terminfo/E/Eterm")
+    lower = PurePosixPath("payload/share/terminfo/e/eterm")
+
+    portable_seen: set[str] = set()
+    managed_artifacts._claim_destination(destination, upper, portable_seen)
+    with pytest.raises(UnsafeArchiveError, match="Duplicate archive path"):
+        managed_artifacts._claim_destination(destination, lower, portable_seen)
+
+    linux_seen: set[str] = set()
+    managed_artifacts._claim_destination(
+        destination,
+        upper,
+        linux_seen,
+        case_sensitive_paths=True,
+    )
+    managed_artifacts._claim_destination(
+        destination,
+        lower,
+        linux_seen,
+        case_sensitive_paths=True,
+    )
+    assert len(linux_seen) == 2
 
 
 def test_tar_extraction_preserves_only_safe_files_and_execute_bits(tmp_path: Path) -> None:


### PR DESCRIPTION
## Scope

- pin the immutable `opensquilla/runtime-packs` `v2026.08.21.2` catalog with 14 native Python, Node.js, and Git Bash packs across six targets
- update the legacy runtime manifest to Python `3.13.15+20260814`, Node.js `24.19.0`, and Git Bash `2.55.0.windows.5`
- preserve case-distinct archive paths for Linux Runtime Packs while retaining portable collision rejection on macOS and Windows
- test regional source ordering, fail-closed SHA-256 fallback, and Node `node`/`npm`/`npx` probes
- keep the successful GitHub/Beijing OSS source visible after installation

Base: `main`

Linked issue: None

## Release note

Runtime Pack downloads are enabled with an immutable finalized catalog. China locales prefer Beijing OSS with GitHub fallback; other locales prefer GitHub with OSS fallback. This PR is currently usable in GitHub-only mode while OSS credentials are pending.

## Verification

- Runtime Pack Release: https://github.com/opensquilla/runtime-packs/releases/tag/v2026.08.21.2
  - immutable, 19 assets, 14 native packs
  - GitHub asset digests and sizes exactly match `SHA256SUMS` and the finalized catalog
- real macOS arm64 GitHub-only clean-state installation
  - Python `3.13.15`
  - Node.js `v24.19.0`
  - npm/npx `11.17.0`
  - persisted `ready` state and GitHub source survived service restart
- `node .github/scripts/verify-sandbox-package.mjs --release-source`
- `uv run pytest tests/test_runtime_packs/test_runtime_pack_manager.py tests/test_gateway/test_rpc_sandbox_runtime.py tests/test_sandbox/test_release_contract.py tests/test_skills/test_managed_toolchains.py -q` — 140 passed
- `uv run ruff check src tests`
- `uv run mypy src/opensquilla --show-error-codes`
- WebUI targeted tests — 51 passed
- WebUI production build and architecture/security/theme/i18n guards
- Electron bundled-runtime tests and TypeScript build
- full local Python suite — 23,860 passed, 251 skipped; five unrelated host-specific failures: protected `.codex` worktree path checks (2), absent WeasyPrint native library (1), macOS BSD `sed -i` behavior (1), and a loaded-host process timing case that passed alone (1)

## Safety and compatibility

- downloads remain restricted to fixed GitHub and OSS base templates; the catalog cannot inject arbitrary URLs
- every download is pinned by byte size and SHA-256, and corrupt primary bytes are rejected before source fallback
- archive collision checks remain fail-closed on portable filesystems; case-sensitive handling is enabled only for Linux targets
- catalog/RPC schema v1 is unchanged and no configuration, database, or public protocol migration is required
- existing builds shipped an unfinalized catalog, so no previously supported installed-pack contract is removed

## Third-party origins

- Python: `astral-sh/python-build-standalone`
- Node.js: `nodejs.org`
- Git Bash: `git-for-windows/git`
- normalized packs, licenses, notices, and SPDX SBOM are published by `opensquilla/runtime-packs`
