### PR TITLE
Preserve steered stream boundaries across retries and reconnects

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
@@ -158,7 +158,7 @@ function createHarness(options: {
 
 describe('useChatRpcEventHandlers route-card ownership', () => {
   it('binds text and thinking events to their physical provider calls', () => {
-    const { api, bindRouterDecisionToModelCall, stop } = createHarness()
+    const { api, stream, bindRouterDecisionToModelCall, stop } = createHarness()
     try {
       api.handlers.onTextDelta({
         session_key: 'agent:main:test',
@@ -199,6 +199,10 @@ describe('useChatRpcEventHandlers route-card ownership', () => {
         ['1.0', 1, 'turn-1'],
         ['2.0', 2, 'turn-1'],
       ])
+      expect(stream.appendDelta).toHaveBeenCalledWith('answer', undefined, {
+        modelCallId: '1.0',
+        iteration: 1,
+      })
     } finally {
       stop()
     }
@@ -553,6 +557,8 @@ describe('useChatRpcEventHandlers live snapshot restoration', () => {
               session_key: 'agent:main:test',
               task_id: 'task-live',
               text: 'Second answer',
+              model_call_id: '2.0',
+              iteration: 2,
               stream_seq: 12,
             },
           },
@@ -565,6 +571,8 @@ describe('useChatRpcEventHandlers live snapshot restoration', () => {
               user_message_id: 'steer-message-1',
               intent: 'steer',
               disposition: 'applied',
+              applied_iteration: 2,
+              model_call_id: '2.0',
               stream_seq: 11,
             },
           },
@@ -574,6 +582,8 @@ describe('useChatRpcEventHandlers live snapshot restoration', () => {
               session_key: 'agent:main:test',
               task_id: 'task-live',
               text: 'First answer',
+              model_call_id: '1.0',
+              iteration: 1,
               stream_seq: 10,
             },
           },
@@ -586,16 +596,16 @@ describe('useChatRpcEventHandlers live snapshot restoration', () => {
       )
       expect(stream.acknowledgeSteerBoundary).toHaveBeenCalledWith(
         'steer-message-1',
-        '',
-        0,
+        '2.0',
+        2,
       )
       expect(vi.mocked(stream.checkpointForUserMessage!).mock.invocationCallOrder[0])
         .toBeLessThan(
           vi.mocked(stream.acknowledgeSteerBoundary!).mock.invocationCallOrder[0]!,
         )
-      expect(vi.mocked(stream.appendDelta).mock.calls.map(call => call[0])).toEqual([
-        'First answer',
-        'Second answer',
+      expect(vi.mocked(stream.appendDelta).mock.calls).toEqual([
+        ['First answer', undefined, { modelCallId: '1.0', iteration: 1 }],
+        ['Second answer', undefined, { modelCallId: '2.0', iteration: 2 }],
       ])
     } finally {
       stop()

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
@@ -63,6 +63,7 @@ import {
   useChatSteerDelivery,
   type ChatSteerDeliveryApi,
 } from './useChatSteerDelivery'
+import type { ChatStreamModelCallIdentity } from './useChatStream'
 
 export interface ChatUsageAccumulator {
   input: number
@@ -86,7 +87,11 @@ export interface ChatRpcStreamApi {
     modelCallId?: string,
     iteration?: number,
   ) => void
-  appendDelta: (text: string, presentation?: 'intermediate' | 'answer') => void
+  appendDelta: (
+    text: string,
+    presentation?: 'intermediate' | 'answer',
+    identity?: ChatStreamModelCallIdentity,
+  ) => void
   scheduleRender: () => void
   appendToolCall: (payload: ToolUsePayload) => void
   appendToolDelta: (payload: ToolDeltaPayload) => void
@@ -1536,15 +1541,25 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
     stream.resetStreamIdleTimer()
     const taskId = payloadTaskId(payload) || activeStreamTaskId.value
     if (taskId && options.taskOwnership?.stopRequestedTaskId.value === taskId) return
+    const modelCallId = String(payload.model_call_id || payload.modelCallId || '').trim()
+    const iteration = Number(payload.iteration || 0)
     options.bindRouterDecisionToModelCall?.(
-      String(payload.model_call_id || payload.modelCallId || ''),
-      Number(payload.iteration || 0),
+      modelCallId,
+      iteration,
       String(payload.turn_id || payload.turnId || ''),
     )
     options.markEnsembleHandoff()
+    const identity: ChatStreamModelCallIdentity | undefined = modelCallId || iteration > 0
+      ? { modelCallId, iteration }
+      : undefined
     const presentation = payload.presentation
     if (presentation === 'intermediate' || presentation === 'answer') {
-      stream.appendDelta(payload.text || '', presentation)
+      if (identity) stream.appendDelta(payload.text || '', presentation, identity)
+      else stream.appendDelta(payload.text || '', presentation)
+    } else if (identity) {
+      // Compatibility frames can omit presentation while still carrying the
+      // physical call identity needed for same-turn steer placement.
+      stream.appendDelta(payload.text || '', undefined, identity)
     } else {
       // Compatibility with older gateways that predate semantic text roles.
       stream.appendDelta(payload.text || '')

--- a/opensquilla-webui/src/composables/chat/useChatSteerDelivery.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSteerDelivery.test.ts
@@ -211,6 +211,43 @@ describe('useChatSteerDelivery', () => {
     }
   })
 
+  it('keeps the client boundary identity when later evidence carries only the durable id', () => {
+    const harness = createHarness()
+    try {
+      const item = harness.addPending()
+      harness.api.accept({
+        clientRequestId: REQUEST.client_request_id,
+        clientMessageId: REQUEST.client_message_id,
+        expectedTurnId: REQUEST.expected_turn_id,
+        userMessageId: 'user-steer',
+        disposition: 'steering',
+        revision: 1,
+      }, item)
+
+      harness.api.disposition({
+        userMessageId: 'user-steer',
+        disposition: 'applied',
+        revision: 2,
+        turnId: REQUEST.expected_turn_id,
+        appliedIteration: 2,
+        modelCallId: '2.0',
+      })
+
+      expect(harness.messages.value).toHaveLength(1)
+      expect(harness.checkpointForUserMessage.mock.calls).toEqual([
+        ['turn-current', 'client-steer'],
+        ['turn-current', 'client-steer'],
+      ])
+      expect(harness.acknowledgeSteerBoundary).toHaveBeenCalledWith(
+        'client-steer',
+        '2.0',
+        2,
+      )
+    } finally {
+      harness.stop()
+    }
+  })
+
   it.each([
     ['cancelled', false, 'restore_to_composer'],
     ['rejected', true, 'resend_after_queue_drains'],

--- a/opensquilla-webui/src/composables/chat/useChatSteerDelivery.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSteerDelivery.ts
@@ -292,7 +292,7 @@ export function useChatSteerDelivery(
       || options.pendingQueue.value.find(item => matchesPending(item, evidence))
     const attempt = pending?.steerAttempt || null
     const pendingIdentity = attempt ? attemptIdentity(attempt) : null
-    const identity: SteerDeliveryIdentity = {
+    let identity: SteerDeliveryIdentity = {
       clientRequestId: evidence.clientRequestId || pendingIdentity?.clientRequestId || '',
       clientMessageId: evidence.clientMessageId || pendingIdentity?.clientMessageId || '',
       expectedTurnId: evidence.expectedTurnId || pendingIdentity?.expectedTurnId || '',
@@ -302,6 +302,16 @@ export function useChatSteerDelivery(
       ...identity,
       userMessageId: evidence.userMessageId,
     }))
+    if (message) {
+      identity = {
+        clientRequestId: identity.clientRequestId || message.steerClientRequestId || '',
+        clientMessageId: identity.clientMessageId
+          || message.steerClientMessageId
+          || message.clientId
+          || '',
+        expectedTurnId: identity.expectedTurnId || evidence.turnId || message.turnId || '',
+      }
+    }
     let created = false
     let pendingRemoved = false
     if (!message && pending && (identity.clientRequestId || identity.clientMessageId)) {

--- a/opensquilla-webui/src/composables/chat/useChatStream.render.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatStream.render.test.ts
@@ -912,6 +912,125 @@ describe('useChatStream render coalescing', () => {
     api.cleanup()
   })
 
+  it('keeps identified old-call tokens above the steer after applied evidence arrives', () => {
+    const { api, messages } = makeStream()
+
+    api.appendDelta('第一段', 'answer', { modelCallId: '1.0', iteration: 1 })
+    api.checkpointForUserMessage('turn-steered', 'steer-1')
+    messages.value.push({
+      role: 'user',
+      text: 'Use English',
+      ts: 2,
+      clientId: 'steer-1',
+      turnId: 'turn-steered',
+      inputDisposition: 'applied',
+    })
+    api.acknowledgeSteerBoundary('steer-1', '2.0', 2)
+
+    api.appendDelta('迟到旧段', 'answer', { modelCallId: '1.0', iteration: 1 })
+    api.appendDelta('Second section.', 'answer', { modelCallId: '2.0', iteration: 2 })
+    const prefix = '第一段迟到旧段'
+    const finalText = `${prefix}Second section.`
+    api.reconcileFinalText(finalText, [{
+      model_call_id: '2.0',
+      iteration: 2,
+      start_codepoint: Array.from(prefix).length,
+      end_codepoint: Array.from(finalText).length,
+    }])
+    api.endStreaming()
+
+    expect(messages.value.map(message => [message.role, message.text])).toEqual([
+      ['assistant', prefix],
+      ['user', 'Use English'],
+      ['assistant', 'Second section.'],
+    ])
+    api.cleanup()
+  })
+
+  it('routes late deltas across multiple steers and a same-iteration model retry', () => {
+    const { api, messages } = makeStream()
+
+    api.appendDelta('A', 'answer', { modelCallId: '1.0', iteration: 1 })
+    api.checkpointForUserMessage('turn-steered', 'steer-1')
+    messages.value.push({
+      role: 'user',
+      text: 'first adjustment',
+      ts: 2,
+      clientId: 'steer-1',
+      turnId: 'turn-steered',
+      inputDisposition: 'applied',
+    })
+    api.acknowledgeSteerBoundary('steer-1', '2.0', 2)
+
+    api.appendDelta('B', 'answer', { modelCallId: '2.1', iteration: 2 })
+    api.checkpointForUserMessage('turn-steered', 'steer-2')
+    messages.value.push({
+      role: 'user',
+      text: 'second adjustment',
+      ts: 3,
+      clientId: 'steer-2',
+      turnId: 'turn-steered',
+      inputDisposition: 'applied',
+    })
+    api.acknowledgeSteerBoundary('steer-2', '3.0', 3)
+
+    api.appendDelta('a', 'answer', { modelCallId: '1.0', iteration: 1 })
+    api.appendDelta('b', 'answer', { modelCallId: '2.1', iteration: 2 })
+    api.appendDelta('C', 'answer', { modelCallId: '3.0', iteration: 3 })
+    api.reconcileFinalText('AaBbC', [
+      {
+        model_call_id: '2.0',
+        iteration: 2,
+        start_codepoint: 2,
+        end_codepoint: 4,
+      },
+      {
+        model_call_id: '3.0',
+        iteration: 3,
+        start_codepoint: 4,
+        end_codepoint: 5,
+      },
+    ])
+    api.endStreaming()
+
+    expect(messages.value.map(message => [message.role, message.text])).toEqual([
+      ['assistant', 'Aa'],
+      ['user', 'first adjustment'],
+      ['assistant', 'Bb'],
+      ['user', 'second adjustment'],
+      ['assistant', 'C'],
+    ])
+    api.cleanup()
+  })
+
+  it('treats client and durable message ids as aliases for one steer boundary', () => {
+    const { api, messages } = makeStream()
+
+    api.appendDelta('before', 'answer', { modelCallId: '1.0', iteration: 1 })
+    api.checkpointForUserMessage('turn-steered', 'client-steer')
+    messages.value.push({
+      role: 'user',
+      text: 'adjust',
+      ts: 2,
+      clientId: 'client-steer',
+      messageId: 'durable-steer',
+      turnId: 'turn-steered',
+      inputDisposition: 'applied',
+    })
+
+    api.checkpointForUserMessage('turn-steered', 'durable-steer')
+    api.acknowledgeSteerBoundary('durable-steer', '2.0', 2)
+    api.appendDelta('after', 'answer', { modelCallId: '2.0', iteration: 2 })
+    api.endStreaming()
+
+    expect(messages.value.map(message => [message.role, message.text])).toEqual([
+      ['assistant', 'before'],
+      ['user', 'adjust'],
+      ['assistant', 'after'],
+    ])
+    api.cleanup()
+  })
+
   it('closes an applied steer boundary when an old gateway omits model-call identity', () => {
     const { api, messages } = makeStream()
 

--- a/opensquilla-webui/src/composables/chat/useChatStream.ts
+++ b/opensquilla-webui/src/composables/chat/useChatStream.ts
@@ -124,6 +124,11 @@ export interface StreamTaskClockSnapshot {
   startedAt?: number | string | null
 }
 
+export interface ChatStreamModelCallIdentity {
+  modelCallId: string
+  iteration: number
+}
+
 function normalizedTaskStartedAt(value: unknown): number | null {
   if (typeof value !== 'number' && typeof value !== 'string') return null
   if (typeof value === 'string' && !value.trim()) return null
@@ -154,6 +159,8 @@ export function useChatStream(options: UseChatStreamOptions) {
   let checkpointedAcrossToolBoundary = false
   let activeStreamTurnId = ''
   let activeAssistantMessageId = ''
+  let activeModelCallId = ''
+  let activeModelCallIteration = 0
   let streamCheckpointSeq = 0
   const streamCheckpoints: Array<{
     message: ChatMessage | null
@@ -165,6 +172,8 @@ export function useChatStream(options: UseChatStreamOptions) {
     applied: boolean
     modelCallId: string
     iteration: number
+    predecessorModelCallId: string
+    predecessorIteration: number
   }> = []
   const streamBubble = ref(false)
   const streamShowHeader = ref(false)
@@ -353,6 +362,8 @@ export function useChatStream(options: UseChatStreamOptions) {
     toolTimes.value = new Map()
     reasoningCharsSinceFlush = 0
     reasoningPresentationPending.value = false
+    activeModelCallId = ''
+    activeModelCallIteration = 0
     streamCheckpointSeq = 0
     streamCheckpoints.length = 0
     // Clear the live-turn log alongside the legacy refs so the next turn's fold
@@ -676,7 +687,9 @@ export function useChatStream(options: UseChatStreamOptions) {
   function checkpointForUserMessage(turnId: string, boundaryKey = '') {
     if (!isStreaming.value || !streamBubble.value) return
     const existing = boundaryKey
-      ? streamCheckpoints.find(checkpoint => checkpoint.boundaryKey === boundaryKey)
+      ? streamCheckpoints.find(checkpoint =>
+          boundaryKeysEquivalent(checkpoint.boundaryKey, boundaryKey),
+        )
       : undefined
     if (existing) {
       existing.turnId = turnId || existing.turnId
@@ -698,6 +711,8 @@ export function useChatStream(options: UseChatStreamOptions) {
       applied: false,
       modelCallId: '',
       iteration: 0,
+      predecessorModelCallId: activeModelCallId,
+      predecessorIteration: activeModelCallIteration,
     }
     streamCheckpoints.push(checkpoint)
     // Reconnect/session restoration may retain the optimistic checkpoint row
@@ -727,10 +742,11 @@ export function useChatStream(options: UseChatStreamOptions) {
     modelCallId = '',
     iteration = 0,
   ) {
-    const checkpoint = streamCheckpoints.find(candidate =>
-      !candidate.applied
-      && (!boundaryKey || candidate.boundaryKey === boundaryKey),
-    ) || streamCheckpoints.find(candidate => !candidate.applied)
+    const checkpoint = boundaryKey
+      ? streamCheckpoints.find(candidate =>
+          !candidate.applied && boundaryKeysEquivalent(candidate.boundaryKey, boundaryKey),
+        )
+      : streamCheckpoints.find(candidate => !candidate.applied)
     if (!checkpoint) return
     checkpoint.applied = true
     if (modelCallId) checkpoint.modelCallId = modelCallId
@@ -749,6 +765,14 @@ export function useChatStream(options: UseChatStreamOptions) {
       ),
     )
     return userIndex >= 0 ? userIndex : options.messages.value.length
+  }
+
+  function boundaryKeysEquivalent(left: string, right: string): boolean {
+    if (!left || !right) return false
+    if (left === right) return true
+    const leftIndex = boundaryMessageIndex(left)
+    const rightIndex = boundaryMessageIndex(right)
+    return leftIndex < options.messages.value.length && leftIndex === rightIndex
   }
 
   function checkpointMessageInsertIndex(checkpoint: typeof streamCheckpoints[number]): number {
@@ -804,8 +828,41 @@ export function useChatStream(options: UseChatStreamOptions) {
     checkpoint.message = options.messages.value[insertIndex]!
   }
 
-  function appendDeltaBeforeAppliedSteer(text: string): boolean {
-    const checkpoint = streamCheckpoints.find(candidate => !candidate.applied)
+  function checkpointForModelCall(
+    identity: ChatStreamModelCallIdentity | undefined,
+  ): typeof streamCheckpoints[number] | undefined {
+    const modelCallId = identity?.modelCallId.trim() || ''
+    const iteration = Number.isInteger(identity?.iteration) && (identity?.iteration || 0) > 0
+      ? identity!.iteration
+      : 0
+    if (modelCallId || iteration) {
+      const predecessor = streamCheckpoints.find(candidate => (
+        modelCallId
+        && candidate.predecessorModelCallId
+        && candidate.predecessorModelCallId === modelCallId
+      ) || (
+        !modelCallId
+        && iteration > 0
+        && candidate.predecessorIteration === iteration
+      ))
+      if (predecessor) return predecessor
+      if (iteration > 0) {
+        const laterBoundary = streamCheckpoints.find(candidate =>
+          candidate.applied
+          && candidate.iteration > 0
+          && iteration < candidate.iteration,
+        )
+        if (laterBoundary) return laterBoundary
+      }
+    }
+    return streamCheckpoints.find(candidate => !candidate.applied)
+  }
+
+  function appendDeltaBeforeSteer(
+    text: string,
+    identity: ChatStreamModelCallIdentity | undefined,
+  ): boolean {
+    const checkpoint = checkpointForModelCall(identity)
     if (!checkpoint) return false
 
     let deltaText = typeof text === 'string' ? text : ''
@@ -944,12 +1001,21 @@ export function useChatStream(options: UseChatStreamOptions) {
   function appendDelta(
     text: string,
     presentation: 'intermediate' | 'answer' = 'answer',
+    identity?: ChatStreamModelCallIdentity,
   ) {
     if (options.aborted.value) return
-    if (appendDeltaBeforeAppliedSteer(text)) return
+    if (appendDeltaBeforeSteer(text, identity)) return
     const deltaText = normalizeIncomingTextDelta(text)
     if (!deltaText) return
     if (!isStreaming.value) startStreaming()
+    const modelCallId = identity?.modelCallId.trim() || ''
+    const iteration = Number.isInteger(identity?.iteration) && (identity?.iteration || 0) > 0
+      ? identity!.iteration
+      : 0
+    if (modelCallId || iteration) {
+      activeModelCallId = modelCallId
+      activeModelCallIteration = iteration
+    }
     setStreamActivity('Writing reply', `write:${streamRound.value}`)
     if (useReducer.value !== true) streamRaw.value += deltaText
 

--- a/src/opensquilla/gateway/session_streams.py
+++ b/src/opensquilla/gateway/session_streams.py
@@ -267,6 +267,37 @@ class SessionStreamRegistry:
         # legacy block, but the sentinel stays internal to snapshot compaction.
         return "__legacy_reasoning__"
 
+    @classmethod
+    def _same_text_model_call(
+        cls,
+        left: dict[str, Any],
+        right: dict[str, Any],
+    ) -> bool:
+        left_call = cls._identity_value(left, "model_call_id", "modelCallId")
+        right_call = cls._identity_value(right, "model_call_id", "modelCallId")
+        if left_call and right_call and left_call != right_call:
+            return False
+
+        left_iteration = left.get("iteration")
+        right_iteration = right.get("iteration")
+        left_iteration = (
+            left_iteration
+            if isinstance(left_iteration, int) and not isinstance(left_iteration, bool)
+            and left_iteration > 0
+            else None
+        )
+        right_iteration = (
+            right_iteration
+            if isinstance(right_iteration, int) and not isinstance(right_iteration, bool)
+            and right_iteration > 0
+            else None
+        )
+        return not (
+            left_iteration is not None
+            and right_iteration is not None
+            and left_iteration != right_iteration
+        )
+
     @staticmethod
     def _delta_field(payload: dict[str, Any]) -> str:
         for field in ("json_fragment", "jsonFragment", "fragment"):
@@ -438,6 +469,9 @@ class SessionStreamRegistry:
                     return
         elif event.event_name == "session.event.text_delta" and len(events) > reset_index + 1:
             if events[-1].event_name == event.event_name:
+                if not self._same_text_model_call(events[-1].payload, event.payload):
+                    events.append(event)
+                    return
                 if (
                     self._generation_epoch(events[-1].payload) is not None
                     and self._generation_epoch(event.payload) is not None

--- a/tests/test_gateway/test_session_streams.py
+++ b/tests/test_gateway/test_session_streams.py
@@ -305,6 +305,44 @@ def test_live_turn_snapshot_preserves_text_steer_text_boundary_order() -> None:
     ]
 
 
+def test_live_turn_snapshot_keeps_adjacent_retry_model_calls_distinct() -> None:
+    registry = SessionStreamRegistry(max_events_per_session=5)
+    session_key = "agent:main:steered-retry"
+    task_id = "task-steered-retry"
+
+    registry.record(
+        session_key,
+        "session.event.text_delta",
+        {
+            "task_id": task_id,
+            "text": "first attempt",
+            "model_call_id": "2.0",
+            "iteration": 2,
+        },
+    )
+    registry.record(
+        session_key,
+        "session.event.text_delta",
+        {
+            "task_id": task_id,
+            "text": "retry attempt",
+            "model_call_id": "2.1",
+            "iteration": 2,
+        },
+    )
+
+    snapshot = registry.live_snapshot(session_key)
+
+    assert [event.payload["text"] for event in snapshot.events] == [
+        "first attempt",
+        "retry attempt",
+    ]
+    assert [event.payload["model_call_id"] for event in snapshot.events] == [
+        "2.0",
+        "2.1",
+    ]
+
+
 def test_live_turn_snapshot_compacts_thinking_per_block_and_preserves_boundaries() -> None:
     registry = SessionStreamRegistry(max_events_per_session=5)
     session_key = "agent:main:reasoning-blocks"


### PR DESCRIPTION
## Scope

Follow-up for the reopened same-turn steering boundary regression. Refs #1307.

The reopened root cause differs from the original cutover handling: text delta events already carried `model_call_id` and `iteration`, but the Web event handler discarded that identity before appending stream content. A delayed delta from the pre-steer call arriving after the applied disposition was therefore appended below the guidance message as continuation output.

## Minimal changes

- Carry optional model-call identity from text deltas into the stream coordinator and route delayed predecessor output to the checkpoint above its guidance message, including reconnect, live snapshot before history hydration, terminal reconciliation, multiple steers, and retry ordering.
- Preserve client and durable guidance message IDs as aliases, while avoiding acknowledgment of unrelated pending boundaries.
- Keep adjacent live snapshot text entries distinct when their model-call identity differs so retry output cannot be compacted across physical calls.
- Add focused Web and Gateway regressions for delayed post-apply deltas, retry and multi-steer ordering, identity aliases, and snapshot compaction.

## Target and linkage

- Base: `main`
- Linked work: Refs #1307
- Release note: Yes — preserves guided response ordering and prevents duplicate or cross-call stream segments after reconnects and retries.

## Tests

- `cd opensquilla-webui && npm exec -- vitest run src/composables/chat/useChatStream.render.test.ts src/composables/chat/useChatRpcEventHandlers.test.ts src/composables/chat/useChatSteerDelivery.test.ts` — 146 passed
- `cd opensquilla-webui && npm run test:unit` — 4508 passed
- `cd opensquilla-webui && npm run typecheck` — passed
- `uv run --extra dev pytest tests/test_gateway/test_session_streams.py -q` — 24 passed
- `uv run --extra dev ruff check src/opensquilla/gateway/session_streams.py tests/test_gateway/test_session_streams.py` — passed
- `uv run --extra dev mypy src/opensquilla/gateway/session_streams.py --show-error-codes` — passed

## Safety and compatibility

- No wire schema, database migration, persisted-history format, or public API change; model-call identity remains optional.
- Older clients and Gateways without identity retain the existing arrival-order fallback. If a legacy Gateway supplies neither `model_call_id` nor `iteration`, physically interleaved delayed and resumed deltas cannot be distinguished with certainty; that is an inherent protocol limitation, not a new compatibility dependency.
- Existing history and terminal reconciliation paths remain unchanged and covered by the Web regression suite.
- Stream state remains scoped per chat composable and Gateway snapshot state remains scoped per session, preserving concurrent multi-session isolation.
- The implementation is Web/platform neutral and introduces no OS-specific behavior or new dependency.
- Tests use synthetic offline data only. No transcripts, credentials, identifiers, or other sensitive runtime data are included.

## Third-party origin

Independent OpenSquilla implementation. No third-party source code, fixtures, comments, or wording were copied.