### PR TITLE
Stabilize timing-sensitive CI tests

### DIFF
--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -5917,6 +5917,7 @@ class TestSessionsAbort:
         ]
         assert runtime.wait_calls == ["task-live"]
 
+    @pytest.mark.ci_serial
     @pytest.mark.asyncio
     async def test_abort_runtime_drain_waits_concurrently_under_one_deadline(
         self,
@@ -5962,6 +5963,7 @@ class TestSessionsAbort:
         assert runtime.active_waits == 0
         assert elapsed < 0.15
 
+    @pytest.mark.ci_serial
     @pytest.mark.asyncio
     async def test_abort_runtime_drain_does_not_join_stubborn_cancelled_waiter(
         self,
@@ -5999,6 +6001,7 @@ class TestSessionsAbort:
         release.set()
         await asyncio.wait_for(finished.wait(), timeout=0.2)
 
+    @pytest.mark.ci_serial
     @pytest.mark.asyncio
     async def test_abort_slow_session_lookup_does_not_delay_compaction_cancel(
         self,
@@ -6053,6 +6056,7 @@ class TestSessionsAbort:
         assert owner.cancelled() is True
         assert elapsed < 0.15
 
+    @pytest.mark.ci_serial
     @pytest.mark.asyncio
     async def test_abort_slow_runtime_cancel_cannot_extend_shared_stop_budget(
         self,

--- a/tests/test_live_artifact_prompt_annotations_e2e.py
+++ b/tests/test_live_artifact_prompt_annotations_e2e.py
@@ -529,6 +529,7 @@ def test_certification_rejects_case_that_exceeds_its_pre_reserved_calls() -> Non
         asyncio.run(e2e._run_certification(OverrunningDriver(), hard_cap=64))
 
 
+@pytest.mark.ci_serial
 @pytest.mark.asyncio
 async def test_owned_gateway_preflights_use_real_rpc_bridge_and_zero_provider_calls(
     tmp_path: Path,
@@ -553,6 +554,7 @@ async def test_owned_gateway_preflights_use_real_rpc_bridge_and_zero_provider_ca
         await driver.close()
 
 
+@pytest.mark.ci_serial
 @pytest.mark.asyncio
 async def test_owned_gateway_html_workbench_lifecycle_is_offline_and_immutable(
     tmp_path: Path,
@@ -934,6 +936,7 @@ async def test_owned_gateway_html_workbench_lifecycle_is_offline_and_immutable(
         provider.close()
 
 
+@pytest.mark.ci_serial
 @pytest.mark.asyncio
 async def test_owned_gateway_mutations_use_real_rpc_and_local_provider(
     tmp_path: Path,

--- a/tests/test_recovery/test_recovery_cmd.py
+++ b/tests/test_recovery/test_recovery_cmd.py
@@ -16,6 +16,9 @@ from opensquilla.cli.recovery_cmd import recovery_app
 from opensquilla.recovery.cleanup import cleanup_inspect
 from opensquilla.recovery.locking import ProfileOperationLock
 
+# Keep the contract bounded while allowing for cold CLI imports on saturated CI runners.
+_RECOVERY_SUBPROCESS_TIMEOUT_SECONDS = 30
+
 
 def _workspace(path: Path, marker: str) -> Path:
     path.mkdir(parents=True)
@@ -409,7 +412,7 @@ def test_delete_all_helper_waits_for_parent_pipe_eof_before_reinspection(
         process.stdin.write(_cleanup_approval(inspected))
         process.stdin.flush()
         process.stdin.close()
-        assert process.wait(timeout=10) == 0
+        assert process.wait(timeout=_RECOVERY_SUBPROCESS_TIMEOUT_SECONDS) == 0
         assert process.stdout is not None
         payload = json.loads(process.stdout.read())
         assert payload["outcome"] == "complete"
@@ -481,7 +484,7 @@ def test_delete_all_helper_allows_confirmed_chromium_entry_to_disappear_at_exit(
         process.stdin.write(_cleanup_approval(inspected))
         process.stdin.flush()
         process.stdin.close()
-        assert process.wait(timeout=10) == 0
+        assert process.wait(timeout=_RECOVERY_SUBPROCESS_TIMEOUT_SECONDS) == 0
         assert process.stdout is not None
         payload = json.loads(process.stdout.read())
         assert payload["outcome"] == "complete"
@@ -553,7 +556,7 @@ def test_delete_all_helper_refuses_a_new_unconfirmed_scope_after_parent_exit(
         process.stdin.write(_cleanup_approval(inspected))
         process.stdin.flush()
         process.stdin.close()
-        assert process.wait(timeout=10) == 2
+        assert process.wait(timeout=_RECOVERY_SUBPROCESS_TIMEOUT_SECONDS) == 2
         assert process.stdout is not None
         payload = json.loads(process.stdout.read())
         assert payload["outcome"] == "blocked"


### PR DESCRIPTION
## Scope

- Give the three offline recovery helper subprocess contracts a shared 30-second upper bound.
- Run four strict event-loop wall-clock contracts in the existing `ci_serial` phase.
- Run the three owned-Gateway artifact annotation contracts in `ci_serial` so Windows startup health checks do not contend with thousands of xdist tests.
- Preserve every exit-code, scope, deletion, fail-closed, and 45-second Gateway health assertion.
- Avoid false failures caused by cold CLI imports, model startup, or xdist scheduling pauses on saturated runners.

## Branch target

`main`

## Linked issue

None.

## Release note

Not required: test-only CI stability change.

## Verification

- Focused recovery subprocess tests: 3 passed.
- Repeated focused recovery subprocess tests: 15/15 passed across five runs.
- Focused shared-deadline tests: 4 passed.
- Repeated `ci_serial` shared-deadline tests: 20/20 passed across five runs.
- Owned-Gateway marker collection: exactly 3 intended tests selected.
- Owned-Gateway tests: first two passed together; the router-preload case passed independently in 31.93 seconds after a cold-cache timeout.
- Ruff passed for both changed test modules.
- Diff checks passed.

## Safety and compatibility

- Product/runtime behavior and strict timing assertions are unchanged.
- Recovery subprocess tests remain bounded and continue to fail on hangs.
- Owned-Gateway tests still exercise real local RPC, provider, and router paths; only CI scheduling changes.
- Platform-neutral test-only changes; no persisted state or public contract changes.

## Third-party origin

None.
