### PR TITLE
Reduce CI flake amplification and desktop contention

### DIFF
--- a/.github/ci/suites.v1.json
+++ b/.github/ci/suites.v1.json
@@ -1,5 +1,6 @@
 {
   "schema_version": 1,
+  "windows_test_assignments": ".github/scripts/windows_test_assignments.json",
   "baseline_suites": [
     "readme-locale",
     "workflow-lint"
@@ -29,7 +30,11 @@
     },
     {
       "os": "macos-latest",
-      "shard": "ownership-workbench"
+      "shard": "ownership"
+    },
+    {
+      "os": "macos-latest",
+      "shard": "workbench"
     },
     {
       "os": "windows-latest",

--- a/.github/ci/suites.v1.json
+++ b/.github/ci/suites.v1.json
@@ -1,6 +1,11 @@
 {
   "schema_version": 1,
   "windows_test_assignments": ".github/scripts/windows_test_assignments.json",
+  "macos_recovery_test_inputs": [
+    "tests/test_recovery/**",
+    "tests/test_migration/test_opensquilla_home_migration.py",
+    "tests/test_desktop/test_electron_startup_contract.py"
+  ],
   "baseline_suites": [
     "readme-locale",
     "workflow-lint"
@@ -229,6 +234,8 @@
         "src/opensquilla/persistence/**",
         "src/opensquilla/recovery/**",
         "src/opensquilla/session/**",
+        "tests/test_desktop/test_electron_startup_contract.py",
+        "tests/test_migration/test_opensquilla_home_migration.py",
         "tests/test_recovery/**"
       ]
     },

--- a/.github/scripts/ci_attestation.py
+++ b/.github/scripts/ci_attestation.py
@@ -91,6 +91,14 @@ def _git(*args: str, cwd: Path) -> str:
     return completed.stdout.strip()
 
 
+def _changed_paths(repo: Path, before: str, after: str) -> list[str]:
+    """Return both sides of renames so the planner can route them safely."""
+
+    return _git(
+        "diff", "--no-renames", "--name-only", before, after, cwd=repo
+    ).splitlines()
+
+
 def _require_sha(value: object, label: str) -> str:
     if not isinstance(value, str) or SHA_RE.fullmatch(value) is None:
         raise AttestationError(f"{label} must be a lowercase 40-character SHA")
@@ -745,13 +753,9 @@ def _validate_canonical_source_plan(
         )
         if reconstructed != tested_tree:
             raise AttestationError("attested PR base/head do not reconstruct tested tree")
-        changed_paths = _git(
-            "diff", "--name-only", tested_base, head_sha, cwd=repo
-        ).splitlines()
+        changed_paths = _changed_paths(repo, tested_base, head_sha)
     elif source_event == "merge_group":
-        changed_paths = _git(
-            "diff", "--name-only", tested_base, tested_tree, cwd=repo
-        ).splitlines()
+        changed_paths = _changed_paths(repo, tested_base, tested_tree)
     else:
         raise AttestationError("attestation source event is invalid")
     plan = _plan_paths(repo, changed_paths, ref=tested_tree)
@@ -782,7 +786,7 @@ def _composition_is_safe(
         capture_output=True,
     ).returncode != 0:
         return False, "attested base is not an ancestor of the queue base", ()
-    changed = _git("diff", "--name-only", tested_base_sha, queue_base_sha, cwd=repo).splitlines()
+    changed = _changed_paths(repo, tested_base_sha, queue_base_sha)
     if not changed:
         return False, "advanced-base composition has no verifiable base delta", ()
     plan = _plan_paths(repo, changed)
@@ -1414,7 +1418,7 @@ def _create_command(args: argparse.Namespace) -> int:
             parents = _git("rev-list", "--parents", "-n", "1", "HEAD", cwd=repo).split()
             if len(parents) != 3:
                 raise AttestationError("pull request CI must test a two-parent merge preview")
-            changed_paths = _git("diff", "--name-only", parents[1], head_sha, cwd=repo).splitlines()
+            changed_paths = _changed_paths(repo, parents[1], head_sha)
             plan_basis = "change_set"
         elif isinstance(merge_group, dict):
             base_sha = _require_sha(merge_group.get("base_sha"), "merge-group base SHA")
@@ -1422,9 +1426,7 @@ def _create_command(args: argparse.Namespace) -> int:
                 changed_paths = [".ci/run-all"]
                 plan_basis = "full_fallback"
             else:
-                changed_paths = _git(
-                    "diff", "--name-only", base_sha, "HEAD", cwd=repo
-                ).splitlines()
+                changed_paths = _changed_paths(repo, base_sha, "HEAD")
                 plan_basis = "change_set"
         else:
             raise AttestationError("cannot plan suites outside PR or merge-group CI")

--- a/.github/scripts/plan_ci.py
+++ b/.github/scripts/plan_ci.py
@@ -630,6 +630,33 @@ def _relative_import_name(
     return ".".join(parts)
 
 
+def _static_string_values(value: ast.expr) -> tuple[str, ...] | None:
+    """Return a static string or string sequence without evaluating code."""
+
+    if isinstance(value, ast.Constant) and isinstance(value.value, str):
+        return (value.value,)
+    if isinstance(value, (ast.List, ast.Tuple)):
+        values: list[str] = []
+        for item in value.elts:
+            if not isinstance(item, ast.Constant) or not isinstance(item.value, str):
+                return None
+            values.append(item.value)
+        return tuple(values)
+    return None
+
+
+def _expression_mentions_test_module(value: ast.expr) -> bool:
+    """Return whether a dynamic expression visibly names the test module tree."""
+
+    for node in ast.walk(value):
+        if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+            continue
+        literal = node.value
+        if literal.startswith(("tests.", "test_")) or ".test_" in literal:
+            return True
+    return False
+
+
 def _build_test_reverse_dependencies(
     *,
     repo: Path,
@@ -681,7 +708,69 @@ def _build_test_reverse_dependencies(
         except (SyntaxError, ValueError) as exc:
             raise PlanError(f"cannot parse test module {consumer_path}: {exc}") from exc
 
+        importlib_bindings: set[str] = set()
+        import_module_bindings: set[str] = set()
+        builtins_bindings: set[str] = set()
+        builtin_import_bindings: set[str] = {"__import__"}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "importlib":
+                        importlib_bindings.add(alias.asname or "importlib")
+                    elif alias.name == "builtins":
+                        builtins_bindings.add(alias.asname or "builtins")
+            elif isinstance(node, ast.ImportFrom) and node.module == "importlib":
+                import_module_bindings.update(
+                    alias.asname or alias.name
+                    for alias in node.names
+                    if alias.name == "import_module"
+                )
+            elif isinstance(node, ast.ImportFrom) and node.module == "builtins":
+                builtin_import_bindings.update(
+                    alias.asname or alias.name
+                    for alias in node.names
+                    if alias.name == "__import__"
+                )
+
+        pytest_plugin_modules: list[str] = []
+        for statement in tree.body:
+            value: ast.expr | None = None
+            owns_pytest_plugins = False
+            if isinstance(statement, ast.Assign):
+                owns_pytest_plugins = any(
+                    isinstance(target, ast.Name) and target.id == "pytest_plugins"
+                    for target in statement.targets
+                )
+                value = statement.value
+            elif isinstance(statement, ast.AnnAssign):
+                owns_pytest_plugins = (
+                    isinstance(statement.target, ast.Name)
+                    and statement.target.id == "pytest_plugins"
+                )
+                value = statement.value
+            elif isinstance(statement, ast.AugAssign):
+                owns_pytest_plugins = (
+                    isinstance(statement.target, ast.Name)
+                    and statement.target.id == "pytest_plugins"
+                )
+            if not owns_pytest_plugins:
+                continue
+            if value is None:
+                raise PlanError(
+                    f"cannot resolve pytest_plugins declaration in {consumer_path}"
+                )
+            static_plugins = _static_string_values(value)
+            if static_plugins is None:
+                raise PlanError(
+                    f"cannot resolve pytest_plugins declaration in {consumer_path}"
+                )
+            pytest_plugin_modules.extend(static_plugins)
+
         imported_paths: set[str] = set()
+        for module_name in pytest_plugin_modules:
+            imported = resolve(module_name)
+            if imported is not None and imported != consumer_path:
+                imported_paths.add(imported)
         for node in ast.walk(tree):
             module_names: list[str] = []
             if isinstance(node, ast.Import):
@@ -702,17 +791,29 @@ def _build_test_reverse_dependencies(
                             if alias.name != "*":
                                 module_names.append(f"{base}.{alias.name}")
             elif isinstance(node, ast.Call) and node.args:
-                function_name = ""
+                dynamic_import = False
                 if isinstance(node.func, ast.Name):
-                    function_name = node.func.id
+                    dynamic_import = node.func.id in (
+                        import_module_bindings | builtin_import_bindings
+                    )
                 elif isinstance(node.func, ast.Attribute) and isinstance(
                     node.func.value, ast.Name
                 ):
-                    function_name = f"{node.func.value.id}.{node.func.attr}"
-                if function_name in {"__import__", "importlib.import_module"} and isinstance(
-                    node.args[0], ast.Constant
-                ) and isinstance(node.args[0].value, str):
-                    module_names.append(node.args[0].value)
+                    dynamic_import = (
+                        node.func.attr == "import_module"
+                        and node.func.value.id in importlib_bindings
+                    ) or (
+                        node.func.attr == "__import__"
+                        and node.func.value.id in builtins_bindings
+                    )
+                if dynamic_import:
+                    static_modules = _static_string_values(node.args[0])
+                    if static_modules is not None and len(static_modules) == 1:
+                        module_names.extend(static_modules)
+                    elif _expression_mentions_test_module(node.args[0]):
+                        raise PlanError(
+                            f"cannot resolve dynamic test module import in {consumer_path}"
+                        )
 
             for module_name in module_names:
                 imported = resolve(module_name)

--- a/.github/scripts/plan_ci.py
+++ b/.github/scripts/plan_ci.py
@@ -4,12 +4,15 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import fnmatch
 import hashlib
+import io
 import json
 import os
 import subprocess
 import sys
+import tarfile
 from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path, PurePosixPath
 from typing import Any, Final
@@ -19,6 +22,7 @@ DEFAULT_CONFIG: Final = Path(".github/ci/suites.v1.json")
 _WINDOWS_ASSIGNMENTS_CONFIG_KEY: Final = "windows_test_assignments"
 _WINDOWS_ASSIGNMENTS_PATH_KEY: Final = "_windows_test_assignments_path"
 _LOADED_WINDOWS_ASSIGNMENTS_KEY: Final = "_loaded_windows_test_assignments"
+_MACOS_RECOVERY_TEST_INPUTS_KEY: Final = "macos_recovery_test_inputs"
 
 _DOC_EXACT: Final = {
     "CHANGELOG.md",
@@ -338,6 +342,36 @@ def load_config(path: Path, *, repo: Path | None = None) -> dict[str, Any]:
         # does not need the test assignment payload; exact test planning does.
         value[_WINDOWS_ASSIGNMENTS_PATH_KEY] = repo.resolve() / assignments_path
 
+    macos_recovery_inputs = _require_string_list(
+        value.get(_MACOS_RECOVERY_TEST_INPUTS_KEY),
+        _MACOS_RECOVERY_TEST_INPUTS_KEY,
+    )
+    for pattern in macos_recovery_inputs:
+        candidate = PurePosixPath(pattern)
+        if (
+            "\\" in pattern
+            or candidate.is_absolute()
+            or candidate.as_posix() != pattern
+            or not pattern.startswith("tests/")
+            or ".." in candidate.parts
+        ):
+            raise PlanError(
+                f"invalid {_MACOS_RECOVERY_TEST_INPUTS_KEY} pattern: {pattern!r}"
+            )
+    macos_recovery_suite = suites.get("macos-recovery")
+    if not isinstance(macos_recovery_suite, Mapping):
+        raise PlanError("suite 'macos-recovery' must be configured")
+    missing_digest_inputs = sorted(
+        set(macos_recovery_inputs)
+        - set(macos_recovery_suite["execution_inputs"])
+    )
+    if missing_digest_inputs:
+        raise PlanError(
+            f"{_MACOS_RECOVERY_TEST_INPUTS_KEY} must be covered by the "
+            "macos-recovery execution digest: "
+            + ", ".join(missing_digest_inputs)
+        )
+
     groups = value.get("desktop_groups")
     if not isinstance(groups, dict) or set(groups) != {
         "profiles",
@@ -505,6 +539,213 @@ def _safe_test_execution_target(
     return None
 
 
+def _windows_test_assignments(config: Mapping[str, Any]) -> Mapping[str, str]:
+    """Return the effective governed assignment map, loading it once per plan."""
+
+    raw_assignments = config.get(_LOADED_WINDOWS_ASSIGNMENTS_KEY)
+    if isinstance(raw_assignments, Mapping):
+        return raw_assignments
+    assignments_path = config.get(_WINDOWS_ASSIGNMENTS_PATH_KEY)
+    if not isinstance(assignments_path, Path):
+        raise PlanError("Windows test assignment path was not loaded with the contract")
+    assignments = _load_windows_test_assignments(
+        assignments_path,
+        allowed_shards=set(config["full_python_matrix"]["windows"]),
+    )
+    if isinstance(config, dict):
+        config[_LOADED_WINDOWS_ASSIGNMENTS_KEY] = assignments
+    return assignments
+
+
+def _is_test_module_path(path: str) -> bool:
+    candidate = PurePosixPath(path)
+    return (
+        path.startswith("tests/")
+        and candidate.name.startswith("test_")
+        and candidate.suffix == ".py"
+    )
+
+
+def _test_module_name(path: str) -> str:
+    candidate = PurePosixPath(path)
+    if not _is_test_module_path(path):
+        raise PlanError(f"cannot derive test module name from {path!r}")
+    return ".".join((*candidate.parts[:-1], candidate.stem))
+
+
+def _test_module_sources(
+    repo: Path, *, ref: str | None
+) -> dict[str, str]:
+    """Read every current test module without executing repository code."""
+
+    sources: dict[str, str] = {}
+    if ref is None:
+        for path in _repository_files_for_validation(repo):
+            if not _is_test_module_path(path):
+                continue
+            candidate = repo / path
+            if candidate.is_symlink():
+                raise PlanError(f"test dependency analysis rejects symlink: {path}")
+            try:
+                sources[path] = candidate.read_text(encoding="utf-8-sig")
+            except (OSError, UnicodeError) as exc:
+                raise PlanError(f"cannot read test module {path}: {exc}") from exc
+        return sources
+
+    try:
+        completed = subprocess.run(
+            ["git", "archive", "--format=tar", ref, "--", "tests"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+        with tarfile.open(fileobj=io.BytesIO(completed.stdout), mode="r:") as archive:
+            for member in archive.getmembers():
+                path = PurePosixPath(member.name).as_posix()
+                if not _is_test_module_path(path):
+                    continue
+                if not member.isfile():
+                    raise PlanError(
+                        f"test dependency analysis rejects non-file at {ref}: {path}"
+                    )
+                extracted = archive.extractfile(member)
+                if extracted is None:
+                    raise PlanError(f"cannot read test module at {ref}: {path}")
+                sources[path] = extracted.read().decode("utf-8-sig", errors="strict")
+    except (OSError, subprocess.CalledProcessError, tarfile.TarError, UnicodeError) as exc:
+        raise PlanError(f"cannot inspect test modules at ref {ref!r}: {exc}") from exc
+    return sources
+
+
+def _relative_import_name(
+    importer_module: str, *, level: int, module: str | None
+) -> str:
+    package = importer_module.split(".")[:-1]
+    keep = len(package) - (level - 1)
+    if level <= 0 or keep <= 0:
+        raise PlanError(f"invalid relative import in test module {importer_module}")
+    parts = package[:keep]
+    if module:
+        parts.extend(module.split("."))
+    return ".".join(parts)
+
+
+def _build_test_reverse_dependencies(
+    *,
+    repo: Path,
+    ref: str | None,
+    governed_paths: Iterable[str],
+) -> dict[str, frozenset[str]]:
+    """Return test-module consumers keyed by the helper module they import.
+
+    Governed paths are included in the module index even when a file was
+    deleted in the selected tree. That lets a remaining consumer of a deleted
+    helper participate in the safe execution closure.
+    """
+
+    sources = _test_module_sources(repo, ref=ref)
+    known_paths = set(sources)
+    known_paths.update(governed_paths)
+    module_to_path: dict[str, str] = {}
+    suffix_to_paths: dict[str, set[str]] = {}
+    for path in sorted(known_paths):
+        module_name = _test_module_name(path)
+        previous = module_to_path.setdefault(module_name, path)
+        if previous != path:
+            raise PlanError(f"duplicate test module identity: {module_name}")
+        parts = module_name.split(".")
+        for offset in range(len(parts)):
+            suffix_to_paths.setdefault(".".join(parts[offset:]), set()).add(path)
+
+    def resolve(module_name: str) -> str | None:
+        exact = module_to_path.get(module_name)
+        if exact is not None:
+            return exact
+        matches = suffix_to_paths.get(module_name, set())
+        if len(matches) == 1:
+            return next(iter(matches))
+        looks_like_test = module_name.rsplit(".", 1)[-1].startswith("test_")
+        if len(matches) > 1 and looks_like_test:
+            raise PlanError(f"ambiguous imported test module: {module_name}")
+        if not matches and looks_like_test and (
+            module_name.startswith("tests.") or ".test_" in module_name
+        ):
+            raise PlanError(f"unresolved imported test module: {module_name}")
+        return None
+
+    reverse: dict[str, set[str]] = {}
+    for consumer_path, source in sorted(sources.items()):
+        importer_module = _test_module_name(consumer_path)
+        try:
+            tree = ast.parse(source, filename=consumer_path)
+        except (SyntaxError, ValueError) as exc:
+            raise PlanError(f"cannot parse test module {consumer_path}: {exc}") from exc
+
+        imported_paths: set[str] = set()
+        for node in ast.walk(tree):
+            module_names: list[str] = []
+            if isinstance(node, ast.Import):
+                module_names.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                if node.level:
+                    base = _relative_import_name(
+                        importer_module,
+                        level=node.level,
+                        module=node.module,
+                    )
+                else:
+                    base = node.module or ""
+                if base:
+                    module_names.append(base)
+                    if resolve(base) is None:
+                        for alias in node.names:
+                            if alias.name != "*":
+                                module_names.append(f"{base}.{alias.name}")
+            elif isinstance(node, ast.Call) and node.args:
+                function_name = ""
+                if isinstance(node.func, ast.Name):
+                    function_name = node.func.id
+                elif isinstance(node.func, ast.Attribute) and isinstance(
+                    node.func.value, ast.Name
+                ):
+                    function_name = f"{node.func.value.id}.{node.func.attr}"
+                if function_name in {"__import__", "importlib.import_module"} and isinstance(
+                    node.args[0], ast.Constant
+                ) and isinstance(node.args[0].value, str):
+                    module_names.append(node.args[0].value)
+
+            for module_name in module_names:
+                imported = resolve(module_name)
+                if imported is not None and imported != consumer_path:
+                    imported_paths.add(imported)
+
+        for imported in imported_paths:
+            reverse.setdefault(imported, set()).add(consumer_path)
+    return {path: frozenset(consumers) for path, consumers in reverse.items()}
+
+
+def _test_dependency_closure(
+    path: str, reverse_dependencies: Mapping[str, frozenset[str]]
+) -> set[str]:
+    selected = {path}
+    pending = [path]
+    while pending:
+        imported = pending.pop()
+        for consumer in sorted(reverse_dependencies.get(imported, ())):
+            if consumer in selected:
+                continue
+            selected.add(consumer)
+            pending.append(consumer)
+    return selected
+
+
+def _is_macos_recovery_test(path: str, config: Mapping[str, Any]) -> bool:
+    return any(
+        _matches_input(path, pattern)
+        for pattern in config[_MACOS_RECOVERY_TEST_INPUTS_KEY]
+    )
+
+
 def _add_python_target(
     path: str, targets: set[str], suites: set[str], reasons: set[str]
 ) -> str | None:
@@ -577,39 +818,43 @@ def _add_test_target(
     suites: set[str],
     reasons: set[str],
     windows_shards: set[str],
-    config: Mapping[str, Any],
+    assignments: Mapping[str, str],
+    reverse_dependencies: Mapping[str, frozenset[str]],
     repo: Path,
     ref: str | None,
-) -> bool:
-    """Select an exact governed test and its single Windows responsibility shard."""
+) -> set[str] | None:
+    """Select one governed test plus every recursive test-module consumer."""
 
-    raw_assignments = config.get(_LOADED_WINDOWS_ASSIGNMENTS_KEY)
-    if not isinstance(raw_assignments, Mapping):
-        assignments_path = config.get(_WINDOWS_ASSIGNMENTS_PATH_KEY)
-        if not isinstance(assignments_path, Path):
-            raise PlanError("Windows test assignment path was not loaded with the contract")
-        raw_assignments = _load_windows_test_assignments(
-            assignments_path,
-            allowed_shards=set(config["full_python_matrix"]["windows"]),
-        )
-        if isinstance(config, dict):
-            config[_LOADED_WINDOWS_ASSIGNMENTS_KEY] = raw_assignments
-    shard = raw_assignments.get(path)
-    if not isinstance(shard, str):
-        return False
+    if not isinstance(assignments.get(path), str):
+        return None
     execution_target = _safe_test_execution_target(path, repo=repo, ref=ref)
     if execution_target is None:
         reasons.add("deleted_test_without_safe_target")
-        return False
+        return None
+
+    selected_paths = _test_dependency_closure(path, reverse_dependencies)
+    selected_targets = {path: execution_target}
+    for selected_path in sorted(selected_paths - {path}):
+        shard = assignments.get(selected_path)
+        if not isinstance(shard, str):
+            reasons.add("test_dependency_ungoverned")
+            return None
+        if not _path_exists(repo, selected_path, ref=ref, directory=False):
+            reasons.add("test_dependency_missing")
+            return None
+        selected_targets[selected_path] = selected_path
+
     if "python-full" not in suites:
         suites.add("python-targeted")
-        targets.add(execution_target)
+        targets.update(selected_targets.values())
     suites.add("windows-high-risk")
-    windows_shards.add(shard)
+    windows_shards.update(str(assignments[selected_path]) for selected_path in selected_paths)
     reasons.add("test_only_targeted")
     if execution_target != path:
         reasons.add("deleted_test_targeted")
-    return True
+    if len(selected_paths) > 1:
+        reasons.add("test_dependency_closure")
+    return selected_paths
 
 
 def _tracked_blob_ids(repo: Path, ref: str) -> dict[str, tuple[str, str]]:
@@ -835,6 +1080,8 @@ def plan_changes(
     targeted_windows_shards: set[str] = set()
     windows_full_matrix = False
     desktop_cells: set[tuple[str, str]] = set()
+    test_reverse_dependencies: dict[str, frozenset[str]] | None = None
+    test_dependency_analysis_failed = False
     full_fallback = False
     all_docs = bool(paths) and not invalid_paths
 
@@ -882,41 +1129,75 @@ def plan_changes(
             continue
 
         if path.startswith("tests/"):
-            if not _add_test_target(
+            assignments = _windows_test_assignments(config)
+            if not isinstance(assignments.get(path), str):
+                full_fallback = True
+                reasons.add("unknown_path")
+                continue
+            if test_dependency_analysis_failed:
+                full_fallback = True
+                reasons.add("test_dependency_analysis_uncertain")
+                continue
+            if test_reverse_dependencies is None:
+                try:
+                    test_reverse_dependencies = _build_test_reverse_dependencies(
+                        repo=repo,
+                        ref=ref,
+                        governed_paths=assignments,
+                    )
+                except PlanError:
+                    test_dependency_analysis_failed = True
+                    full_fallback = True
+                    reasons.add("test_dependency_analysis_uncertain")
+                    continue
+
+            selected_test_paths = _add_test_target(
                 path,
                 targets,
                 suites,
                 reasons,
                 targeted_windows_shards,
-                config,
+                assignments,
+                test_reverse_dependencies,
                 repo,
                 ref,
-            ):
+            )
+            if selected_test_paths is None:
                 full_fallback = True
-                reasons.add("unknown_path")
+                reasons.add("test_dependency_unsafe")
                 continue
 
-            if path.startswith("tests/test_packaging/") or path == (
-                "tests/test_release_consistency.py"
-            ):
-                suites.add("release-packaging")
-                reasons.add("packaging_changed")
-            if _managed_toolchain_targets(path) is not None:
-                suites.add("managed-toolchain")
-                reasons.add("toolchain_changed")
+            for selected_test_path in sorted(selected_test_paths):
+                if selected_test_path.startswith("tests/test_packaging/") or (
+                    selected_test_path == "tests/test_release_consistency.py"
+                ):
+                    suites.add("release-packaging")
+                    reasons.add("packaging_changed")
+                if _managed_toolchain_targets(selected_test_path) is not None:
+                    suites.add("managed-toolchain")
+                    reasons.add("toolchain_changed")
+                if _is_macos_recovery_test(selected_test_path, config):
+                    suites.add("macos-recovery")
+                    reasons.add("macos_recovery_test_changed")
 
-            # Test filenames often contain product-domain words such as
-            # ``workbench`` or ``recovery``. Those words do not change the
-            # product and must not wake native E2E. A reviewed path_patterns
-            # entry remains the explicit escape hatch for a test that really
-            # owns a Desktop harness contract.
-            groups = _explicit_desktop_groups(path, config)
-            if groups:
-                suites.add("desktop-recovery-e2e")
-                desktop_cells.update(
-                    _desktop_cells(groups=groups, os_scope=_os_scope(path), config=config)
-                )
-                reasons.update(f"desktop_{group}_test_changed" for group in groups)
+                # Test filenames often contain product-domain words such as
+                # ``workbench`` or ``recovery``. Those words do not change the
+                # product and must not wake native E2E. A reviewed path_patterns
+                # entry remains the explicit escape hatch for a test that really
+                # owns a Desktop harness contract.
+                groups = _explicit_desktop_groups(selected_test_path, config)
+                if groups:
+                    suites.add("desktop-recovery-e2e")
+                    desktop_cells.update(
+                        _desktop_cells(
+                            groups=groups,
+                            os_scope=_os_scope(selected_test_path),
+                            config=config,
+                        )
+                    )
+                    reasons.update(
+                        f"desktop_{group}_test_changed" for group in groups
+                    )
             continue
 
         if path.startswith("opensquilla-webui/") or path.startswith(

--- a/.github/scripts/plan_ci.py
+++ b/.github/scripts/plan_ci.py
@@ -16,6 +16,9 @@ from typing import Any, Final
 
 SCHEMA_VERSION: Final = 1
 DEFAULT_CONFIG: Final = Path(".github/ci/suites.v1.json")
+_WINDOWS_ASSIGNMENTS_CONFIG_KEY: Final = "windows_test_assignments"
+_WINDOWS_ASSIGNMENTS_PATH_KEY: Final = "_windows_test_assignments_path"
+_LOADED_WINDOWS_ASSIGNMENTS_KEY: Final = "_loaded_windows_test_assignments"
 
 _DOC_EXACT: Final = {
     "CHANGELOG.md",
@@ -97,19 +100,6 @@ _MANAGED_TOOLCHAIN_TEST_PREFIXES: Final = (
     "tests/test_skills/test_subtitle_burner",
     "tests/test_skills/test_video_still_animator",
 )
-_PLATFORM_TEST_PREFIXES: Final = (
-    "tests/test_compat/",
-    "tests/test_desktop/",
-    "tests/test_migration/",
-    "tests/test_migrations/",
-    "tests/test_packaging/",
-    "tests/test_persistence/",
-    "tests/test_recovery/",
-    "tests/test_sandbox/",
-    "tests/test_scheduler/",
-    "tests/test_session/",
-    "tests/test_uninstall/",
-)
 _PYTHON_TARGET_RULES: Final[tuple[tuple[tuple[str, ...], tuple[str, ...]], ...]] = (
     (
         ("src/opensquilla/provider/", "src/opensquilla/router_tiers.py"),
@@ -151,32 +141,6 @@ _PYTHON_TARGET_RULES: Final[tuple[tuple[tuple[str, ...], tuple[str, ...]], ...]]
     (("src/opensquilla/observability/",), ("tests/test_observability",)),
     (("src/opensquilla/search/",), ("tests/test_search",)),
     (("src/opensquilla/onboarding/",), ("tests/test_onboarding",)),
-)
-_TEST_TARGET_RULES: Final[tuple[tuple[str, tuple[str, ...]], ...]] = (
-    ("tests/test_provider", ("tests/test_provider", "tests/test_provider*.py")),
-    (
-        "tests/test_gateway",
-        (
-            "tests/functional/test_gateway_*_e2e.py",
-            "tests/test_gateway",
-            "tests/test_gateway*.py",
-        ),
-    ),
-    ("tests/test_engine", ("tests/test_engine", "tests/test_engine*.py")),
-    ("tests/test_channels/", ("tests/test_channels",)),
-    ("tests/test_memory", ("tests/test_memory", "tests/test_memory*.py")),
-    (
-        "tests/test_skills",
-        ("tests/test_meta_skill*.py", "tests/test_skills", "tests/test_skills*.py"),
-    ),
-    ("tests/test_cli/", ("tests/test_cli",)),
-    ("tests/integration/cli/", ("tests/integration/cli", "tests/test_cli")),
-    ("tests/test_onboarding/", ("tests/test_onboarding",)),
-    ("tests/test_identity/", ("tests/test_identity",)),
-    ("tests/test_mcp/", ("tests/test_mcp",)),
-    ("tests/test_health/", ("tests/test_health",)),
-    ("tests/test_observability/", ("tests/test_observability",)),
-    ("tests/test_search/", ("tests/test_search",)),
 )
 _FIXED_PLATFORM_MATRIX: Final[dict[str, tuple[tuple[str, str], ...]]] = {
     "workflow-lint": (("ubuntu-latest", "default"),),
@@ -246,6 +210,60 @@ def _require_string_list(value: object, label: str) -> list[str]:
     return list(value)
 
 
+def _load_windows_test_assignments(
+    path: Path, *, allowed_shards: set[str]
+) -> dict[str, str]:
+    """Load the governed exact test-to-shard map used by Windows CI."""
+
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PlanError(f"cannot read Windows test assignments {path}: {exc}") from exc
+    if not isinstance(value, dict) or value.get("schema_version") != 1:
+        raise PlanError("unsupported Windows test assignment schema")
+    baseline = value.get("baseline_assignments")
+    if not isinstance(baseline, dict) or set(baseline) != allowed_shards:
+        raise PlanError(
+            "Windows test assignments must define every configured shard exactly once"
+        )
+
+    assignments: dict[str, str] = {}
+    for shard, raw_paths in baseline.items():
+        paths = _require_string_list(raw_paths, f"Windows shard {shard!r} assignments")
+        for test_path in paths:
+            candidate = PurePosixPath(test_path)
+            if (
+                candidate.as_posix() != test_path
+                or not test_path.startswith("tests/")
+                or not candidate.name.startswith("test_")
+                or candidate.suffix != ".py"
+            ):
+                raise PlanError(f"invalid Windows test assignment path: {test_path!r}")
+            if test_path in assignments:
+                raise PlanError(f"duplicate Windows test assignment: {test_path}")
+            assignments[test_path] = str(shard)
+
+    overrides = value.get("overrides", [])
+    if not isinstance(overrides, list):
+        raise PlanError("Windows test assignment overrides must be a list")
+    seen_overrides: set[str] = set()
+    for raw_override in overrides:
+        if not isinstance(raw_override, dict):
+            raise PlanError("Windows test assignment override must be an object")
+        test_path = raw_override.get("path")
+        from_shard = raw_override.get("from")
+        to_shard = raw_override.get("to")
+        if not isinstance(test_path, str) or test_path in seen_overrides:
+            raise PlanError("Windows test assignment override path is invalid or duplicated")
+        if assignments.get(test_path) != from_shard:
+            raise PlanError(f"Windows test assignment override source drifted: {test_path}")
+        if to_shard not in allowed_shards or to_shard == from_shard:
+            raise PlanError(f"Windows test assignment override target is invalid: {test_path}")
+        assignments[test_path] = str(to_shard)
+        seen_overrides.add(test_path)
+    return assignments
+
+
 def load_config(path: Path, *, repo: Path | None = None) -> dict[str, Any]:
     """Load and validate the v1 suite contract."""
 
@@ -303,6 +321,22 @@ def load_config(path: Path, *, repo: Path | None = None) -> dict[str, Any]:
         )
         if not shards:
             raise PlanError(f"full_python_matrix {platform_name} must not be empty")
+
+    assignments_path = value.get(_WINDOWS_ASSIGNMENTS_CONFIG_KEY)
+    if (
+        not isinstance(assignments_path, str)
+        or not assignments_path
+        or PurePosixPath(assignments_path).is_absolute()
+        or PurePosixPath(assignments_path).as_posix() != assignments_path
+        or ".." in PurePosixPath(assignments_path).parts
+    ):
+        raise PlanError(
+            f"{_WINDOWS_ASSIGNMENTS_CONFIG_KEY} must be a normalized repository-relative path"
+        )
+    if repo is not None:
+        # Parsing is intentionally lazy. Digest-only and source-only planning
+        # does not need the test assignment payload; exact test planning does.
+        value[_WINDOWS_ASSIGNMENTS_PATH_KEY] = repo.resolve() / assignments_path
 
     groups = value.get("desktop_groups")
     if not isinstance(groups, dict) or set(groups) != {
@@ -393,12 +427,18 @@ def _add_os_reason_codes(scopes: set[str], reasons: set[str]) -> None:
     reasons.update(labels[scope] for scope in scopes)
 
 
-def _desktop_groups(path: str, config: Mapping[str, Any]) -> set[str]:
-    explicit = {
+def _explicit_desktop_groups(path: str, config: Mapping[str, Any]) -> set[str]:
+    """Return only reviewed path-pattern mappings, without keyword inference."""
+
+    return {
         str(group)
         for group, raw_group in config["desktop_groups"].items()
         if any(fnmatch.fnmatchcase(path, pattern) for pattern in raw_group["path_patterns"])
     }
+
+
+def _desktop_groups(path: str, config: Mapping[str, Any]) -> set[str]:
+    explicit = _explicit_desktop_groups(path, config)
     if explicit:
         return explicit
     lowered = path.casefold()
@@ -424,13 +464,45 @@ def _desktop_cells(
     if "ubuntu-latest" in platforms:
         cells.update(("ubuntu-latest", group) for group in selected_groups)
     if "macos-latest" in platforms:
-        if "profiles" in selected_groups:
-            cells.add(("macos-latest", "profiles"))
-        if selected_groups.intersection({"ownership", "workbench"}):
-            cells.add(("macos-latest", "ownership-workbench"))
+        cells.update(("macos-latest", group) for group in selected_groups)
     if "windows-latest" in platforms:
         cells.update(("windows-latest", group) for group in selected_groups)
     return cells
+
+
+def _path_exists(repo: Path, path: str, *, ref: str | None, directory: bool) -> bool:
+    """Return whether *path* is present in the selected worktree or Git tree."""
+
+    if ref is None:
+        candidate = repo / path
+        return candidate.is_dir() if directory else candidate.is_file()
+    completed = subprocess.run(
+        ["git", "cat-file", "-t", f"{ref}:{path}"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    expected_type = "tree" if directory else "blob"
+    return completed.returncode == 0 and completed.stdout.strip() == expected_type
+
+
+def _safe_test_execution_target(
+    path: str, *, repo: Path, ref: str | None
+) -> str | None:
+    """Use an exact test when present, otherwise its nearest existing test directory."""
+
+    if _path_exists(repo, path, ref=ref, directory=False):
+        return path
+    candidate = PurePosixPath(path).parent
+    while candidate.as_posix() == "tests" or candidate.as_posix().startswith("tests/"):
+        relative = candidate.as_posix()
+        if _path_exists(repo, relative, ref=ref, directory=True):
+            return relative
+        if relative == "tests":
+            break
+        candidate = candidate.parent
+    return None
 
 
 def _add_python_target(
@@ -500,22 +572,44 @@ def _add_python_target(
 
 
 def _add_test_target(
-    path: str, targets: set[str], suites: set[str], reasons: set[str]
+    path: str,
+    targets: set[str],
+    suites: set[str],
+    reasons: set[str],
+    windows_shards: set[str],
+    config: Mapping[str, Any],
+    repo: Path,
+    ref: str | None,
 ) -> bool:
-    if path.startswith(_PLATFORM_TEST_PREFIXES):
-        if "python-full" not in suites:
-            suites.add("python-targeted")
-            targets.add(str(PurePosixPath(path).parent))
-        reasons.add("python_platform_sensitive")
-        return True
-    for prefix, rule_targets in _TEST_TARGET_RULES:
-        if path.startswith(prefix):
-            if "python-full" not in suites:
-                suites.add("python-targeted")
-                targets.update(rule_targets)
-            reasons.add("python_targeted")
-            return True
-    return False
+    """Select an exact governed test and its single Windows responsibility shard."""
+
+    raw_assignments = config.get(_LOADED_WINDOWS_ASSIGNMENTS_KEY)
+    if not isinstance(raw_assignments, Mapping):
+        assignments_path = config.get(_WINDOWS_ASSIGNMENTS_PATH_KEY)
+        if not isinstance(assignments_path, Path):
+            raise PlanError("Windows test assignment path was not loaded with the contract")
+        raw_assignments = _load_windows_test_assignments(
+            assignments_path,
+            allowed_shards=set(config["full_python_matrix"]["windows"]),
+        )
+        if isinstance(config, dict):
+            config[_LOADED_WINDOWS_ASSIGNMENTS_KEY] = raw_assignments
+    shard = raw_assignments.get(path)
+    if not isinstance(shard, str):
+        return False
+    execution_target = _safe_test_execution_target(path, repo=repo, ref=ref)
+    if execution_target is None:
+        reasons.add("deleted_test_without_safe_target")
+        return False
+    if "python-full" not in suites:
+        suites.add("python-targeted")
+        targets.add(execution_target)
+    suites.add("windows-high-risk")
+    windows_shards.add(shard)
+    reasons.add("test_only_targeted")
+    if execution_target != path:
+        reasons.add("deleted_test_targeted")
+    return True
 
 
 def _tracked_blob_ids(repo: Path, ref: str) -> dict[str, tuple[str, str]]:
@@ -669,6 +763,8 @@ def suite_execution_digests(
 def _execution_matrices(
     required_suites: Sequence[str],
     desktop_cells: set[tuple[str, str]],
+    targeted_windows_shards: set[str],
+    windows_full_matrix: bool,
     config: Mapping[str, Any],
 ) -> tuple[dict[str, list[str]], list[dict[str, str]]]:
     """Return canonical Python and all-platform execution matrices."""
@@ -681,7 +777,11 @@ def _execution_matrices(
             else []
         ),
         "windows": (
-            list(config["full_python_matrix"]["windows"])
+            (
+                list(config["full_python_matrix"]["windows"])
+                if windows_full_matrix
+                else sorted(targeted_windows_shards)
+            )
             if "windows-high-risk" in suites
             else []
         ),
@@ -732,6 +832,8 @@ def plan_changes(
     suites = set(config["baseline_suites"])
     reasons: set[str] = set()
     targets: set[str] = set()
+    targeted_windows_shards: set[str] = set()
+    windows_full_matrix = False
     desktop_cells: set[tuple[str, str]] = set()
     full_fallback = False
     all_docs = bool(paths) and not invalid_paths
@@ -766,6 +868,7 @@ def plan_changes(
         if path == ".github/scripts/windows_test_assignments.json":
             suites.update({"python-targeted", "windows-high-risk"})
             targets.add("tests/test_ci/test_windows_test_shards.py")
+            windows_full_matrix = True
             reasons.add("windows_shard_layout_changed")
             continue
         if (
@@ -776,6 +879,44 @@ def plan_changes(
         ):
             full_fallback = True
             reasons.add("ci_policy_changed")
+            continue
+
+        if path.startswith("tests/"):
+            if not _add_test_target(
+                path,
+                targets,
+                suites,
+                reasons,
+                targeted_windows_shards,
+                config,
+                repo,
+                ref,
+            ):
+                full_fallback = True
+                reasons.add("unknown_path")
+                continue
+
+            if path.startswith("tests/test_packaging/") or path == (
+                "tests/test_release_consistency.py"
+            ):
+                suites.add("release-packaging")
+                reasons.add("packaging_changed")
+            if _managed_toolchain_targets(path) is not None:
+                suites.add("managed-toolchain")
+                reasons.add("toolchain_changed")
+
+            # Test filenames often contain product-domain words such as
+            # ``workbench`` or ``recovery``. Those words do not change the
+            # product and must not wake native E2E. A reviewed path_patterns
+            # entry remains the explicit escape hatch for a test that really
+            # owns a Desktop harness contract.
+            groups = _explicit_desktop_groups(path, config)
+            if groups:
+                suites.add("desktop-recovery-e2e")
+                desktop_cells.update(
+                    _desktop_cells(groups=groups, os_scope=_os_scope(path), config=config)
+                )
+                reasons.update(f"desktop_{group}_test_changed" for group in groups)
             continue
 
         if path.startswith("opensquilla-webui/") or path.startswith(
@@ -802,6 +943,7 @@ def plan_changes(
                 suites.add("macos-recovery")
             if not os_scope or "windows-latest" in os_scope:
                 suites.add("windows-high-risk")
+                windows_full_matrix = True
             groups = _desktop_groups(path, config)
             if groups:
                 reasons.update(f"desktop_{group}_changed" for group in groups)
@@ -815,15 +957,17 @@ def plan_changes(
             continue
 
         if path in _PACKAGING_EXACT or path.startswith(
-            ("src/opensquilla/uninstall/", "tests/test_packaging/")
+            ("src/opensquilla/uninstall/",)
         ):
             suites.update({"release-packaging", "windows-high-risk"})
+            windows_full_matrix = True
             reasons.add("packaging_changed")
             continue
 
         managed_toolchain_targets = _managed_toolchain_targets(path)
         if managed_toolchain_targets is not None:
             suites.update({"managed-toolchain", "python-targeted", "windows-high-risk"})
+            windows_full_matrix = True
             targets.update(managed_toolchain_targets)
             reasons.add("toolchain_changed")
             continue
@@ -852,6 +996,7 @@ def plan_changes(
                         suites.add("macos-recovery")
                     if not os_scope or "windows-latest" in os_scope:
                         suites.add("windows-high-risk")
+                        windows_full_matrix = True
                     reasons.update(f"desktop_{group}_changed" for group in groups)
                 elif path.startswith("src/opensquilla/gateway/"):
                     suites.add("webui-chat-recovery")
@@ -860,6 +1005,7 @@ def plan_changes(
                         suites.add("macos-recovery")
                     if not os_scope or "windows-latest" in os_scope:
                         suites.add("windows-high-risk")
+                        windows_full_matrix = True
                     if not groups:
                         desktop_cells.update(
                             _desktop_cells(groups=groups, os_scope=os_scope, config=config)
@@ -871,24 +1017,9 @@ def plan_changes(
                 elif os_scope:
                     if "windows-latest" in os_scope:
                         suites.add("windows-high-risk")
+                        windows_full_matrix = True
                     if "macos-latest" in os_scope:
                         suites.add("macos-recovery")
-                continue
-            full_fallback = True
-            reasons.add("unknown_path")
-            continue
-
-        if path.startswith("tests/"):
-            if _add_test_target(path, targets, suites, reasons):
-                groups = _desktop_groups(path, config)
-                if path.startswith(_PLATFORM_TEST_PREFIXES) or groups:
-                    suites.update({"macos-recovery", "windows-high-risk"})
-                    desktop_cells.update(
-                        _desktop_cells(groups=groups, os_scope=os_scope, config=config)
-                    )
-                    if desktop_cells:
-                        suites.update({"desktop-recovery-e2e", "webui-chat-recovery"})
-                    reasons.update(f"desktop_{group}_changed" for group in groups)
                 continue
             full_fallback = True
             reasons.add("unknown_path")
@@ -904,6 +1035,7 @@ def plan_changes(
                     "windows-high-risk",
                 }
             )
+            windows_full_matrix = True
             targets.update({"tests/test_migration", "tests/test_migrations"})
             desktop_cells.update(
                 _desktop_cells(groups={"profiles"}, os_scope=os_scope, config=config)
@@ -930,6 +1062,7 @@ def plan_changes(
             for cell in config["full_desktop_matrix"]
         }
         targets = {"tests"}
+        windows_full_matrix = True
     elif "python-full" in suites:
         suites.discard("python-targeted")
         suites.discard("windows-compat")
@@ -945,6 +1078,8 @@ def plan_changes(
     python_matrix, platform_matrix = _execution_matrices(
         required_suites,
         desktop_cells,
+        targeted_windows_shards,
+        windows_full_matrix,
         config,
     )
     digests = suite_execution_digests(

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
               if [[ "${CI_OPTIMIZATION_MODE}" == "legacy" ]]; then
                 printf '.ci/run-all\n' > "${changed_files}"
               else
-                git diff --name-only \
+                git diff --no-renames --name-only \
                   "${{ github.event.pull_request.base.sha }}" \
                   "${{ github.event.pull_request.head.sha }}" > "${changed_files}"
               fi
@@ -226,7 +226,7 @@ jobs:
               before="${{ github.event.before }}"
               after="${{ github.event.after }}"
               if [[ -n "${before}" && "${before}" != "0000000000000000000000000000000000000000" ]]; then
-                git diff --name-only "${before}" "${after}" > "${changed_files}"
+                git diff --no-renames --name-only "${before}" "${after}" > "${changed_files}"
               else
                 printf '.ci/run-all\n' > "${changed_files}"
               fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1363,14 +1363,27 @@ jobs:
                       r"; pending synthetic targets: .+$",
                       re.MULTILINE,
                   ),
+                  "companion_patterns": (),
               },
               {
                   "id": "windows-isolated-acl-worker-timeout-v1",
                   "os": "Windows",
                   "cases": {"offline-document-workbench-e2e"},
                   "pattern": re.compile(
-                      r"^(?:E\s+)?AssertionError: isolated Windows ACL hardening timed out: .+$",
+                      r"^(?:(?:E\s+)|(?:FAILED\s+\S+\s+-\s+))?"
+                      r"AssertionError: isolated Windows ACL hardening timed out: .+$",
                       re.MULTILINE,
+                  ),
+                  # pytest can print the same allowed exception once in its
+                  # traceback and again in the short failure summary.  Remove
+                  # only the structural traceback header; any unrelated
+                  # terminal exception inside that traceback remains visible
+                  # to the residual-failure scan below.
+                  "companion_patterns": (
+                      re.compile(
+                          r"^\s*Traceback \(most recent call last\):\s*$",
+                          re.MULTILINE,
+                      ),
                   ),
               },
               {
@@ -1378,27 +1391,107 @@ jobs:
                   "os": "macOS",
                   "cases": {"offline-document-workbench-e2e"},
                   "pattern": re.compile(
-                      r"^Error: (?:electronApplication\.evaluate: Error: )?"
+                      r"^(?:(?:Error: )?electronApplication\.evaluate: Error: |Error: )"
                       r"ELECTRON_FOREGROUND_PREREQUISITE_MISSING: .+$",
                       re.MULTILINE,
+                  ),
+                  # The outer offline-workbench runner reports the native
+                  # subprocess exit after streaming the structured inner
+                  # exception.  It is part of that same exception stack, not
+                  # a second failure, and is bound to the exact child script.
+                  "companion_patterns": (
+                      re.compile(
+                          r"^Error: .*test-native-workbench-v2-electron\.mjs "
+                          r"failed with exit code 1$",
+                          re.MULTILINE,
+                      ),
                   ),
               },
           )
           hard_failure_markers = (
-              "TRUSTED_OVERLAY_FOCUS_CONTRACT_FAILED:",
-              "TRUSTED_OVERLAY_INPUT_CONTRACT_FAILED:",
-              "DESKTOP_E2E_PHASE_TIMEOUT:",
-              "DESKTOP_E2E_PHASE_FAILED:",
-              "DESKTOP_E2E_PROCESS_EXITED:",
+              (
+                  "trusted-overlay-focus-contract-failed-v1",
+                  "TRUSTED_OVERLAY_FOCUS_CONTRACT_FAILED:",
+              ),
+              (
+                  "trusted-overlay-input-contract-failed-v1",
+                  "TRUSTED_OVERLAY_INPUT_CONTRACT_FAILED:",
+              ),
+              ("desktop-e2e-phase-timeout-v1", "DESKTOP_E2E_PHASE_TIMEOUT:"),
+              ("desktop-e2e-phase-failed-v1", "DESKTOP_E2E_PHASE_FAILED:"),
+              ("desktop-e2e-process-exited-v1", "DESKTOP_E2E_PROCESS_EXITED:"),
           )
-          matches = [
-              rule["id"]
+          generic_failure_markers = (
+              (
+                  "generic-assertion-error-v1",
+                  re.compile(
+                      r"^\s*(?:E\s+)?AssertionError(?:\s*[:(]|\s*$)",
+                      re.MULTILINE,
+                  ),
+              ),
+              (
+                  "generic-error-or-exception-v1",
+                  re.compile(
+                      r"^\s*(?:E\s+)?(?!AssertionError\s*:)(?:Error|Exception|"
+                      r"[A-Za-z_][A-Za-z0-9_.]*(?:Error|Exception))\s*:",
+                      re.MULTILINE,
+                  ),
+              ),
+              (
+                  "python-traceback-v1",
+                  re.compile(
+                      r"^\s*Traceback \(most recent call last\):\s*$",
+                      re.MULTILINE,
+                  ),
+              ),
+              (
+                  "fatal-crash-process-exit-v1",
+                  re.compile(
+                      r"^(?:\s*(?:FATAL(?: ERROR)?|PANIC)\s*:|"
+                      r".*\b(?:Segmentation fault|core dumped)\b.*|"
+                      r".*\b(?:process|command)\b.*\b(?:crashed|exited unexpectedly|"
+                      r"failed with exit code|exited with (?:code|signal))\b.*)$",
+                      re.IGNORECASE | re.MULTILINE,
+                  ),
+              ),
+          )
+          matched_rules = [
+              rule
               for rule in rules
               if rule["os"] == runner_os
               and case_name in rule["cases"]
               and rule["pattern"].search(text) is not None
           ]
-          blocked_markers = sorted(marker for marker in hard_failure_markers if marker in text)
+          matches = [rule["id"] for rule in matched_rules]
+
+          # Remove every occurrence of the one permitted terminal exception,
+          # including duplicate summaries and narrowly bound outer wrappers.
+          # Any other terminal failure left in the combined case log blocks
+          # the retry, even when a permitted signature also occurred.
+          residual = text
+          for rule in matched_rules:
+              residual = rule["pattern"].sub("", residual)
+              for companion_pattern in rule["companion_patterns"]:
+                  residual = companion_pattern.sub("", residual)
+
+          blocked_markers = {
+              marker_id
+              for marker_id, marker_text in hard_failure_markers
+              if marker_text in text
+          }
+          generic_residual = residual
+          for _, marker_text in hard_failure_markers:
+              generic_residual = re.sub(
+                  rf"^.*{re.escape(marker_text)}.*$",
+                  "",
+                  generic_residual,
+                  flags=re.MULTILINE,
+              )
+          blocked_markers.update(
+              marker_id
+              for marker_id, marker_pattern in generic_failure_markers
+              if marker_pattern.search(generic_residual) is not None
+          )
           retryable = len(matches) == 1 and not blocked_markers
           record = {
               "schema_version": 1,
@@ -1407,7 +1500,7 @@ jobs:
               "attempt": 1,
               "classification": matches[0] if retryable else "non_retryable",
               "retryable": retryable,
-              "blocked_markers": blocked_markers,
+              "blocked_markers": sorted(blocked_markers),
               "log_sha256": hashlib.sha256(payload).hexdigest(),
           }
           with Path(output_name).open("a", encoding="utf-8") as handle:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1015,11 +1015,12 @@ jobs:
 
           worker_args=()
           if [[ "${{ matrix.shard }}" == "recovery-migration" ||
-                "${{ matrix.shard }}" == "gateway-sqlite" ]]; then
-            # These shards start Windows ``spawn`` children and gateway
-            # subprocesses from several tests.  Keep the other shards at four
-            # workers, but leave headroom for those process-start handshakes
-            # instead of changing their bounded readiness/timing assertions.
+                "${{ matrix.shard }}" == "gateway-sqlite" ||
+                "${{ matrix.shard }}" == "desktop-installer-contracts" ]]; then
+            # These shards start Windows ``spawn`` children, Node/Electron
+            # processes, or gateways from several tests.  Leave runner
+            # headroom for those process-start handshakes instead of changing
+            # their bounded readiness/timing assertions.
             worker_args+=(--workers=2)
           fi
 
@@ -1144,11 +1145,9 @@ jobs:
           retention-days: 14
 
   desktop-recovery-e2e:
-    # Windows hosted runners can retain Chromium network resources briefly
-    # after a heavy Electron test process exits.  Run the independent recovery
-    # groups on fresh Windows runners so an earlier test cannot starve a later
-    # one of local socket buffers. Linux and macOS retain the full serial
-    # contract, which is useful for their native recovery coverage.
+    # Every matrix cell gets a fresh hosted runner.  Keep ownership and the
+    # heavier workbench cell separate on both Windows and macOS so process,
+    # native-focus, and local-socket state cannot leak across those domains.
     name: Desktop recovery E2E (${{ matrix.os }}, ${{ matrix.shard }})
     needs: [classify-changes, frontend-artifact]
     if: ${{ always() && needs.classify-changes.result == 'success' && needs.frontend-artifact.result == 'success' && contains(fromJSON(needs.classify-changes.outputs.required_suites), 'desktop-recovery-e2e') }}
@@ -1165,6 +1164,9 @@ jobs:
       OPENSQUILLA_TURN_CALL_LOG: "0"
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
       CI_E2E_SHARD: ${{ matrix.shard }}
+      # Keep merge-critical workbench coverage deterministic and bounded.
+      # Scheduled/manual runs retain the wider geometry/rearm stress cycles.
+      OPENSQUILLA_WORKBENCH_E2E_MODE: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'smoke' || 'stress' }}
 
     steps:
       - name: Prepare Desktop recovery report
@@ -1179,6 +1181,7 @@ jobs:
             printf 'runner_arch=%s\n' "${RUNNER_ARCH}"
             printf 'commit_sha=%s\n' "${GITHUB_SHA}"
             printf 'run_attempt=%s\n' "${GITHUB_RUN_ATTEMPT}"
+            printf 'workbench_e2e_mode=%s\n' "${OPENSQUILLA_WORKBENCH_E2E_MODE}"
           } > "${report_dir}/environment.txt"
           printf 'e2e_status=not_started\n' > "${report_dir}/first-failure.txt"
 
@@ -1326,12 +1329,93 @@ jobs:
             fi
           }
 
-          is_retryable_windows_failure() {
-            local log_path="$1"
-            [[ "${RUNNER_OS}" == "Windows" ]] || return 1
-            grep -Fq 'Gateway did not become healthy' "${log_path}" \
-              || grep -Fq 'Timed out waiting for post-exit delete-all helper completion' "${log_path}" \
-              || grep -Fq 'Windows ACL hardening timed out' "${log_path}"
+          classify_retryable_infrastructure_failure() {
+            local name="$1"
+            local log_path="$2"
+            local classifications="${CI_REPORT_DIR}/retry-classifications.jsonl"
+            local evidence_dir="${CI_REPORT_DIR}/retry-evidence"
+            mkdir -p "${evidence_dir}"
+            python3 - "${name}" "${RUNNER_OS}" "${log_path}" "${classifications}" "${evidence_dir}" <<'PY'
+          import hashlib
+          import json
+          import re
+          import shutil
+          import sys
+          from pathlib import Path
+
+          case_name, runner_os, log_name, output_name, evidence_name = sys.argv[1:]
+          log_path = Path(log_name)
+          payload = log_path.read_bytes()
+          text = payload.decode("utf-8", errors="replace")
+
+          # Retry only a single case for narrowly identified hosted-runner
+          # handoff/input failures.  Generic timeouts, connection failures,
+          # crashes, assertion errors, and product output mismatches are not
+          # retryable.  Case + OS binding prevents a coincidental message in
+          # another functional assertion from matching.
+          rules = (
+              {
+                  "id": "windows-delete-helper-handoff-timeout-v1",
+                  "os": "Windows",
+                  "cases": {"desktop-cleanup-flow"},
+                  "pattern": re.compile(
+                      r"^Error: Timed out waiting for post-exit delete-all helper completion\."
+                      r"; pending synthetic targets: .+$",
+                      re.MULTILINE,
+                  ),
+              },
+              {
+                  "id": "windows-isolated-acl-worker-timeout-v1",
+                  "os": "Windows",
+                  "cases": {"offline-document-workbench-e2e"},
+                  "pattern": re.compile(
+                      r"^(?:E\s+)?AssertionError: isolated Windows ACL hardening timed out: .+$",
+                      re.MULTILINE,
+                  ),
+              },
+              {
+                  "id": "macos-electron-foreground-prerequisite-v1",
+                  "os": "macOS",
+                  "cases": {"offline-document-workbench-e2e"},
+                  "pattern": re.compile(
+                      r"^Error: (?:electronApplication\.evaluate: Error: )?"
+                      r"ELECTRON_FOREGROUND_PREREQUISITE_MISSING: .+$",
+                      re.MULTILINE,
+                  ),
+              },
+          )
+          hard_failure_markers = (
+              "TRUSTED_OVERLAY_FOCUS_CONTRACT_FAILED:",
+              "TRUSTED_OVERLAY_INPUT_CONTRACT_FAILED:",
+              "DESKTOP_E2E_PHASE_TIMEOUT:",
+              "DESKTOP_E2E_PHASE_FAILED:",
+              "DESKTOP_E2E_PROCESS_EXITED:",
+          )
+          matches = [
+              rule["id"]
+              for rule in rules
+              if rule["os"] == runner_os
+              and case_name in rule["cases"]
+              and rule["pattern"].search(text) is not None
+          ]
+          blocked_markers = sorted(marker for marker in hard_failure_markers if marker in text)
+          retryable = len(matches) == 1 and not blocked_markers
+          record = {
+              "schema_version": 1,
+              "case": case_name,
+              "os": runner_os,
+              "attempt": 1,
+              "classification": matches[0] if retryable else "non_retryable",
+              "retryable": retryable,
+              "blocked_markers": blocked_markers,
+              "log_sha256": hashlib.sha256(payload).hexdigest(),
+          }
+          with Path(output_name).open("a", encoding="utf-8") as handle:
+              handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+          if retryable:
+              shutil.copy2(log_path, Path(evidence_name) / log_path.name)
+          raise SystemExit(0 if retryable else 1)
+          PY
           }
 
           case "${{ matrix.shard }}" in
@@ -1409,9 +1493,10 @@ jobs:
 
             first_log="${CI_REPORT_DIR}/${name}-attempt-1.log"
             printf 'failed_case=%s\n' "${name}" > "${CI_REPORT_DIR}/first-failure.txt"
-            if is_retryable_windows_failure "${first_log}"
+            if classify_retryable_infrastructure_failure "${name}" "${first_log}"
             then
-              printf 'retry_case=%s\n' "${name}" >> "${CI_REPORT_DIR}/first-failure.txt"
+              printf 'retry_case=%s\nretry_reason=classified_hosted_runner_infrastructure\n' \
+                "${name}" >> "${CI_REPORT_DIR}/first-failure.txt"
               if run_case "${name}" "${script}" 2; then
                 continue
               fi
@@ -1429,6 +1514,8 @@ jobs:
             ${{ runner.temp }}/desktop-recovery-e2e/environment.txt
             ${{ runner.temp }}/desktop-recovery-e2e/first-failure.txt
             ${{ runner.temp }}/desktop-recovery-e2e/desktop-e2e-cases.jsonl
+            ${{ runner.temp }}/desktop-recovery-e2e/retry-classifications.jsonl
+            ${{ runner.temp }}/desktop-recovery-e2e/retry-evidence
           if-no-files-found: error
           retention-days: 14
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1346,7 +1346,11 @@ jobs:
           case_name, runner_os, log_name, output_name, evidence_name = sys.argv[1:]
           log_path = Path(log_name)
           payload = log_path.read_bytes()
-          text = payload.decode("utf-8", errors="replace")
+          text = (
+              payload.decode("utf-8", errors="replace")
+              .replace("\r\n", "\n")
+              .replace("\r", "\n")
+          )
 
           # Retry only a single case for narrowly identified hosted-runner
           # handoff/input failures.  Generic timeouts, connection failures,

--- a/desktop/electron/scripts/test-desktop-gateway-orphan-recovery-flow.mjs
+++ b/desktop/electron/scripts/test-desktop-gateway-orphan-recovery-flow.mjs
@@ -14,24 +14,159 @@ import {
   verifyDesktopGatewayOwnership,
   waitForDesktopGatewayOwnershipRelease,
 } from '../dist/desktop-gateway-ownership.js'
+import { DESKTOP_GATEWAY_STARTUP_TIMEOUT_MS } from '../dist/gateway-lifecycle.js'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const packageRoot = resolve(scriptDir, '..')
 const repoRoot = resolve(packageRoot, '../..')
 
-async function waitFor(check, label, timeoutMs = 60_000) {
+// Keep these phase budgets aligned with the product lifecycle in main.ts:
+// orphan recovery can legitimately spend up to 80s releasing the verified
+// predecessor, Gateway health owns a 120s cold-start budget, and Control UI
+// readiness has a final 45s route budget. A phase shares one deadline instead
+// of accidentally receiving a fresh timeout for every individual assertion.
+const VERIFIED_ORPHAN_GATEWAY_RELEASE_TIMEOUT_MS = 80_000
+const CONTROL_UI_ROUTE_TIMEOUT_MS = 45_000
+const INITIAL_DESKTOP_STARTUP_BUDGET_MS = (
+  DESKTOP_GATEWAY_STARTUP_TIMEOUT_MS + CONTROL_UI_ROUTE_TIMEOUT_MS
+)
+const ORPHAN_RECOVERY_STARTUP_BUDGET_MS = (
+  VERIFIED_ORPHAN_GATEWAY_RELEASE_TIMEOUT_MS + INITIAL_DESKTOP_STARTUP_BUDGET_MS
+)
+const CRASH_EXIT_BUDGET_MS = 15_000
+
+function createPhaseBudget(name, timeoutMs) {
   const startedAt = Date.now()
-  let lastError
-  while (Date.now() - startedAt < timeoutMs) {
-    try {
-      const value = await check()
-      if (value) return value
-    } catch (error) {
-      lastError = error
+  return {
+    name,
+    timeoutMs,
+    elapsedMs: () => Date.now() - startedAt,
+    remainingMs(step) {
+      const elapsedMs = Date.now() - startedAt
+      const remainingMs = timeoutMs - elapsedMs
+      if (remainingMs <= 0) {
+        throw new Error(
+          `DESKTOP_E2E_PHASE_TIMEOUT: phase=${name} step=${step} `
+          + `elapsedMs=${elapsedMs} budgetMs=${timeoutMs}`,
+        )
+      }
+      return remainingMs
+    },
+  }
+}
+
+function appProcessState(app) {
+  if (!app) return null
+  const child = app.process()
+  return {
+    pid: child.pid ?? null,
+    exitCode: child.exitCode,
+    signalCode: child.signalCode,
+    killed: child.killed,
+  }
+}
+
+async function ownershipDiagnostics(userDataDir) {
+  const root = join(userDataDir, 'gateway-ownership')
+  const entries = await readdir(root, { withFileTypes: true }).catch(() => [])
+  return entries.filter(entry => entry.isDirectory()).map((entry) => {
+    const ownershipDir = join(root, entry.name)
+    const loaded = loadDesktopGatewayOwnershipRecord(ownershipDir)
+    return {
+      directory: entry.name,
+      status: loaded.status,
+      pid: loaded.status === 'valid' ? loaded.record.pid : null,
+      port: loaded.status === 'valid' ? loaded.record.port : null,
+      version: loaded.status === 'valid' ? loaded.record.version : null,
     }
+  })
+}
+
+async function phaseDiagnostics(app, userDataDir, phase) {
+  let windows = []
+  try {
+    windows = app ? await Promise.all(app.windows().map(async (page) => {
+      const url = page.url()
+      try {
+        return {
+          url,
+          title: await page.title(),
+          bodyText: await page.locator('body').innerText({ timeout: 1_000 }).then(
+            text => text.slice(0, 2_000),
+          ).catch(() => null),
+        }
+      } catch (error) {
+        return { url, diagnosticError: error?.message || String(error) }
+      }
+    })) : []
+  } catch (error) {
+    windows = [{ diagnosticError: error?.message || String(error) }]
+  }
+  return {
+    phase: phase.name,
+    elapsedMs: phase.elapsedMs(),
+    budgetMs: phase.timeoutMs,
+    process: appProcessState(app),
+    windows,
+    ownership: await ownershipDiagnostics(userDataDir),
+  }
+}
+
+async function phaseError(message, app, userDataDir, phase, cause = null) {
+  const diagnostics = await phaseDiagnostics(app, userDataDir, phase).catch(error => ({
+    diagnosticError: error?.message || String(error),
+  }))
+  const causeSuffix = cause ? ` Cause: ${cause?.message || cause}` : ''
+  return new Error(
+    `DESKTOP_E2E_PHASE_FAILED: phase=${phase.name} ${message}.${causeSuffix} `
+    + `Diagnostics: ${JSON.stringify(diagnostics)}`,
+  )
+}
+
+function assertAppRunning(app, phase, step) {
+  const state = appProcessState(app)
+  if (state && (state.exitCode !== null || state.signalCode !== null)) {
+    throw new Error(
+      `DESKTOP_E2E_PROCESS_EXITED: phase=${phase.name} step=${step} `
+      + `process=${JSON.stringify(state)}`,
+    )
+  }
+}
+
+async function withPhaseDeadline(promise, phase, step, app, userDataDir) {
+  const timeoutMs = phase.remainingMs(step)
+  let timer = null
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, rejectTimeout) => {
+        timer = setTimeout(() => rejectTimeout(new Error(
+          `DESKTOP_E2E_PHASE_TIMEOUT: phase=${phase.name} step=${step} `
+          + `elapsedMs=${phase.elapsedMs()} budgetMs=${phase.timeoutMs}`,
+        )), timeoutMs)
+      }),
+    ])
+  } catch (error) {
+    throw await phaseError(`step=${step}`, app, userDataDir, phase, error)
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+async function waitFor(check, label, timeoutMs, diagnose = null) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    const value = await check()
+    if (value) return value
     await delay(200)
   }
-  const suffix = lastError ? ` Last error: ${lastError.message || lastError}` : ''
+  let diagnostic = null
+  if (diagnose) {
+    diagnostic = await diagnose().catch(error => ({
+      diagnosticError: error?.message || String(error),
+    }))
+  }
+  const suffix = diagnostic === null ? '' : ` Diagnostics: ${JSON.stringify(diagnostic)}`
   throw new Error(`Timed out waiting for ${label}.${suffix}`)
 }
 
@@ -47,9 +182,10 @@ async function freeLoopbackPort() {
   return address.port
 }
 
-async function ownershipDirectory(userDataDir) {
+async function ownershipDirectory(userDataDir, app, phase) {
   const root = join(userDataDir, 'gateway-ownership')
   return await waitFor(async () => {
+    assertAppRunning(app, phase, 'ownership-record')
     const entries = await readdir(root, { withFileTypes: true }).catch(() => [])
     for (const entry of entries) {
       if (!entry.isDirectory()) continue
@@ -57,7 +193,9 @@ async function ownershipDirectory(userDataDir) {
       if (loadDesktopGatewayOwnershipRecord(candidate).status === 'valid') return candidate
     }
     return null
-  }, 'Desktop Gateway ownership record')
+  }, 'Desktop Gateway ownership record', phase.remainingMs('ownership-record'), () => (
+    phaseDiagnostics(app, userDataDir, phase)
+  ))
 }
 
 function processAlive(pid) {
@@ -69,9 +207,19 @@ function processAlive(pid) {
   }
 }
 
-async function waitForControlUi(app) {
-  const page = await app.firstWindow({ timeout: 60_000 })
-  await waitFor(() => page.url().includes('/control/'), 'Desktop Control UI', 60_000)
+async function waitForControlUi(app, userDataDir, phase) {
+  let page
+  try {
+    page = await app.firstWindow({ timeout: phase.remainingMs('first-window') })
+  } catch (error) {
+    throw await phaseError('step=first-window', app, userDataDir, phase, error)
+  }
+  await waitFor(() => {
+    assertAppRunning(app, phase, 'control-ui-route')
+    return page.url().includes('/control/')
+  }, 'Desktop Control UI', phase.remainingMs('control-ui-route'), () => (
+    phaseDiagnostics(app, userDataDir, phase)
+  ))
   return page
 }
 
@@ -86,7 +234,7 @@ async function stopExitedElectronChildrenOnWindows(parentPid) {
     execFile(
       'powershell.exe',
       ['-NoProfile', '-NonInteractive', '-Command', command],
-      { windowsHide: true },
+      { windowsHide: true, timeout: CRASH_EXIT_BUDGET_MS, killSignal: 'SIGKILL' },
       (error) => error ? rejectStop(error) : resolveStop(),
     )
   })
@@ -118,6 +266,7 @@ let secondApp
 let firstOwnershipDir = null
 let firstRecord = null
 const ownedInstances = []
+let flowSucceeded = false
 
 const launchEnvironment = {
   ...process.env,
@@ -131,15 +280,20 @@ const launchEnvironment = {
   LC_ALL: 'en_US.UTF-8',
 }
 
-async function launchDesktop() {
-  return await electron.launch({
-    args: [
-      '--use-mock-keychain',
-      `--user-data-dir=${userDataDir}`,
-      packageRoot,
-    ],
-    env: launchEnvironment,
-  })
+async function launchDesktop(phase, step) {
+  try {
+    return await electron.launch({
+      args: [
+        '--use-mock-keychain',
+        `--user-data-dir=${userDataDir}`,
+        packageRoot,
+      ],
+      env: launchEnvironment,
+      timeout: phase.remainingMs(step),
+    })
+  } catch (error) {
+    throw await phaseError(`step=${step}`, null, userDataDir, phase, error)
+  }
 }
 
 try {
@@ -165,14 +319,27 @@ try {
     updatedAt: now,
   }, null, 2), { mode: 0o600 })
 
-  firstApp = await launchDesktop()
-  await waitForControlUi(firstApp)
-  firstOwnershipDir = await ownershipDirectory(userDataDir)
+  const initialStartup = createPhaseBudget(
+    'initial-desktop-startup',
+    INITIAL_DESKTOP_STARTUP_BUDGET_MS,
+  )
+  firstApp = await launchDesktop(initialStartup, 'electron-launch')
+  await waitForControlUi(firstApp, userDataDir, initialStartup)
+  firstOwnershipDir = await ownershipDirectory(userDataDir, firstApp, initialStartup)
   const firstLoaded = loadDesktopGatewayOwnershipRecord(firstOwnershipDir)
   assert.equal(firstLoaded.status, 'valid')
   firstRecord = firstLoaded.record
   ownedInstances.push({ ownershipDir: firstOwnershipDir, record: firstRecord })
-  assert.equal(await verifyDesktopGatewayOwnership(firstRecord), true)
+  assert.equal(
+    await withPhaseDeadline(
+      verifyDesktopGatewayOwnership(firstRecord),
+      initialStartup,
+      'verify-initial-gateway-ownership',
+      firstApp,
+      userDataDir,
+    ),
+    true,
+  )
 
   // Simulate a hard Electron crash. The detached dev Gateway must survive with
   // its profile lock and ownership record, reproducing the real orphan case.
@@ -180,30 +347,77 @@ try {
   const firstMainPid = firstMain.pid
   assert.ok(firstMainPid)
   const firstMainExit = new Promise((resolveExit) => firstMain.once('exit', resolveExit))
+  const crashExit = createPhaseBudget('hard-crash-exit', CRASH_EXIT_BUDGET_MS)
   firstMain.kill('SIGKILL')
-  await firstMainExit
-  firstApp = null
+  await withPhaseDeadline(
+    firstMainExit,
+    crashExit,
+    'electron-main-exit',
+    firstApp,
+    userDataDir,
+  )
   // Windows process termination does not reliably reap Chromium child
   // processes.  Target only Electron children; the detached Python Gateway is
   // intentionally left alive and verified below.
-  await stopExitedElectronChildrenOnWindows(firstMainPid)
-  assert.equal(await verifyDesktopGatewayOwnership(firstRecord), true)
+  await withPhaseDeadline(
+    stopExitedElectronChildrenOnWindows(firstMainPid),
+    crashExit,
+    'windows-electron-child-cleanup',
+    firstApp,
+    userDataDir,
+  )
+  assert.equal(
+    await withPhaseDeadline(
+      verifyDesktopGatewayOwnership(firstRecord),
+      crashExit,
+      'verify-orphan-survived',
+      firstApp,
+      userDataDir,
+    ),
+    true,
+  )
+  firstApp = null
 
-  secondApp = await launchDesktop()
-  await waitForControlUi(secondApp)
-  const secondOwnershipDir = await ownershipDirectory(userDataDir)
+  const orphanRecoveryStartup = createPhaseBudget(
+    'verified-orphan-recovery-and-restart',
+    ORPHAN_RECOVERY_STARTUP_BUDGET_MS,
+  )
+  secondApp = await launchDesktop(orphanRecoveryStartup, 'electron-relaunch')
+  await waitForControlUi(secondApp, userDataDir, orphanRecoveryStartup)
+  const secondOwnershipDir = await ownershipDirectory(
+    userDataDir,
+    secondApp,
+    orphanRecoveryStartup,
+  )
   assert.equal(secondOwnershipDir, firstOwnershipDir)
   const secondRecord = await waitFor(() => {
+    assertAppRunning(secondApp, orphanRecoveryStartup, 'replacement-ownership-record')
     const loaded = loadDesktopGatewayOwnershipRecord(secondOwnershipDir)
     return loaded.status === 'valid' && loaded.record.pid !== firstRecord.pid
       ? loaded.record
       : null
-  }, 'replacement Desktop Gateway ownership record')
+  }, 'replacement Desktop Gateway ownership record', orphanRecoveryStartup.remainingMs(
+    'replacement-ownership-record',
+  ), () => phaseDiagnostics(secondApp, userDataDir, orphanRecoveryStartup))
   ownedInstances.push({ ownershipDir: secondOwnershipDir, record: secondRecord })
 
   assert.notEqual(secondRecord.pid, firstRecord.pid)
-  assert.equal(await verifyDesktopGatewayOwnership(secondRecord), true)
-  await waitFor(() => !processAlive(firstRecord.pid), 'orphan Gateway process exit')
+  assert.equal(
+    await withPhaseDeadline(
+      verifyDesktopGatewayOwnership(secondRecord),
+      orphanRecoveryStartup,
+      'verify-replacement-gateway-ownership',
+      secondApp,
+      userDataDir,
+    ),
+    true,
+  )
+  await waitFor(() => {
+    assertAppRunning(secondApp, orphanRecoveryStartup, 'orphan-process-exit')
+    return !processAlive(firstRecord.pid)
+  }, 'orphan Gateway process exit', orphanRecoveryStartup.remainingMs(
+    'orphan-process-exit',
+  ), () => phaseDiagnostics(secondApp, userDataDir, orphanRecoveryStartup))
 
   await secondApp.close()
   secondApp = null
@@ -216,6 +430,7 @@ try {
   )
 
   console.log(JSON.stringify({ ok: true, orphanPid: firstRecord.pid, replacementPid: secondRecord.pid }))
+  flowSucceeded = true
 } finally {
   if (secondApp) await secondApp.close().catch(() => null)
   if (firstApp) await firstApp.close().catch(() => null)
@@ -231,7 +446,7 @@ try {
   // Never remove a synthetic profile from underneath a process that did not
   // accept the bounded cleanup request; retain it for CI diagnostics instead.
   const stillLive = ownedInstances.filter(({ record }) => processAlive(record.pid))
-  if (stillLive.length === 0) {
+  if (flowSucceeded && stillLive.length === 0) {
     // Chromium can retain DIPS briefly after Electron exits on Windows.
     await removeSyntheticProfile(isolationRoot)
   } else {

--- a/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
+++ b/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
@@ -15,6 +15,13 @@ const scriptPath = fileURLToPath(import.meta.url)
 const scriptDir = dirname(scriptPath)
 const fixtureRoot = join(scriptDir, 'fixtures', 'native-workbench-smoke')
 const require = createRequire(import.meta.url)
+const workbenchE2eMode = process.env.OPENSQUILLA_WORKBENCH_E2E_MODE || 'stress'
+if (!['smoke', 'stress'].includes(workbenchE2eMode)) {
+  throw new Error(
+    `OPENSQUILLA_WORKBENCH_E2E_MODE must be smoke or stress, got ${workbenchE2eMode}.`,
+  )
+}
+const stressMode = workbenchE2eMode === 'stress'
 const [fixtureFont, gsapSource, lottieSource] = await Promise.all([
   readFile(join(
     scriptDir,
@@ -601,14 +608,203 @@ try {
         },
       })
 
-      async function waitFor(check, label, timeoutMs = 10_000) {
+      async function waitFor(check, label, timeoutMs = 10_000, diagnose = null) {
         const deadline = Date.now() + timeoutMs
         while (Date.now() < deadline) {
           const value = await check()
           if (value) return value
           await new Promise(resolveWait => setTimeout(resolveWait, 25))
         }
-        throw new Error(`Timed out waiting for ${label}.`)
+        let diagnostic = null
+        if (diagnose) {
+          try {
+            diagnostic = await diagnose()
+          } catch (error) {
+            diagnostic = { diagnosticError: error?.message || String(error) }
+          }
+        }
+        const suffix = diagnostic === null ? '' : ` Diagnostics: ${JSON.stringify(diagnostic)}`
+        throw new Error(`Timed out waiting for ${label}.${suffix}`)
+      }
+
+      async function trustedAnnotationInputState(overlay) {
+        const contents = overlay?.view?.webContents
+        const nativeState = {
+          ownerFocused: owner.isFocused(),
+          ownerVisible: owner.isVisible(),
+          ownerMinimized: owner.isMinimized(),
+          nativeFocused: Boolean(contents && !contents.isDestroyed() && contents.isFocused()),
+          webContentsDestroyed: Boolean(!contents || contents.isDestroyed()),
+          overlayVisible: Boolean(overlay?.view?.getVisible()),
+        }
+        if (!contents || contents.isDestroyed()) return nativeState
+        const rendererState = await contents.executeJavaScript(`(() => {
+          const textarea = document.getElementById('annotation-body')
+          return {
+            activeElement: document.activeElement?.id || document.activeElement?.tagName || null,
+            documentFocused: document.hasFocus(),
+            editorFocused: document.activeElement === textarea,
+            selectionStart: textarea?.selectionStart ?? null,
+            selectionEnd: textarea?.selectionEnd ?? null,
+            value: textarea?.value ?? null,
+            inputProbe: window.__opensquillaNativeInputProbe ?? null,
+          }
+        })()`)
+        return { ...nativeState, ...rendererState }
+      }
+
+      function trustedAnnotationFocusReady(state) {
+        return Boolean(
+          state.ownerFocused
+          && state.nativeFocused
+          && state.documentFocused
+          && state.editorFocused,
+        )
+      }
+
+      async function restoreTrustedAnnotationInputFocus(overlay, label) {
+        const recover = async () => {
+          const contents = overlay?.view?.webContents
+          if (!contents || contents.isDestroyed()) {
+            throw new Error(`TRUSTED_OVERLAY_FOCUS_CONTRACT_FAILED: ${label}: renderer is gone.`)
+          }
+          if (process.platform === 'darwin') app.focus({ steal: true })
+          if (owner.isMinimized()) owner.restore()
+          owner.show()
+          owner.focus()
+          contents.focus()
+          await contents.executeJavaScript(`(() => {
+            const textarea = document.getElementById('annotation-body')
+            if (!textarea) throw new Error('annotation textarea is missing')
+            textarea.focus({ preventScroll: true })
+          })()`, true)
+        }
+
+        try {
+          await recover()
+          const state = await waitFor(async () => {
+            const candidate = await trustedAnnotationInputState(overlay)
+            if (trustedAnnotationFocusReady(candidate)) return candidate
+            await recover()
+            return null
+          }, label, 10_000, () => trustedAnnotationInputState(overlay))
+          annotationNativeOwnerFocusAvailable = true
+          return state
+        } catch (error) {
+          const state = await trustedAnnotationInputState(overlay).catch(diagnosticError => ({
+            diagnosticError: diagnosticError?.message || String(diagnosticError),
+          }))
+          const classification = state.ownerFocused
+            ? 'TRUSTED_OVERLAY_FOCUS_CONTRACT_FAILED'
+            : 'ELECTRON_FOREGROUND_PREREQUISITE_MISSING'
+          throw new Error(
+            `${classification}: ${label}. ${error?.message || error} `
+            + `Final state: ${JSON.stringify(state)}`,
+          )
+        }
+      }
+
+      async function requireRetainedTrustedAnnotationFocus(overlay, label) {
+        try {
+          return await waitFor(async () => {
+            const state = await trustedAnnotationInputState(overlay)
+            return trustedAnnotationFocusReady(state) ? state : null
+          }, label, 10_000, () => trustedAnnotationInputState(overlay))
+        } catch (error) {
+          const state = await trustedAnnotationInputState(overlay).catch(diagnosticError => ({
+            diagnosticError: diagnosticError?.message || String(diagnosticError),
+          }))
+          const classification = state.ownerFocused
+            ? 'TRUSTED_OVERLAY_FOCUS_CONTRACT_FAILED'
+            : 'ELECTRON_FOREGROUND_PREREQUISITE_MISSING'
+          throw new Error(`${classification}: ${error?.message || error}`)
+        }
+      }
+
+      async function armTrustedAnnotationInputProbe(overlay, label) {
+        const token = `${label}:${Date.now()}:${Math.random()}`
+        const contents = overlay.view.webContents
+        return await contents.executeJavaScript(`(() => {
+          const textarea = document.getElementById('annotation-body')
+          if (!textarea) throw new Error('annotation textarea is missing')
+          if (!window.__opensquillaNativeInputProbeInstalled) {
+            const observe = (event) => {
+              if (event.target?.id !== 'annotation-body') return
+              const probe = window.__opensquillaNativeInputProbe
+              if (!probe) return
+              const entry = {
+                data: typeof event.data === 'string' ? event.data : null,
+                inputType: event.inputType || null,
+                isComposing: Boolean(event.isComposing),
+                value: event.target.value,
+              }
+              probe[event.type].push(entry)
+            }
+            document.addEventListener('beforeinput', observe, true)
+            document.addEventListener('input', observe, true)
+            window.__opensquillaNativeInputProbeInstalled = true
+          }
+          window.__opensquillaNativeInputProbe = {
+            token: ${JSON.stringify(token)},
+            initialValue: textarea.value,
+            beforeinput: [],
+            input: [],
+          }
+          return window.__opensquillaNativeInputProbe
+        })()`)
+      }
+
+      async function waitForTrustedAnnotationInput(overlay, probe, expectedValue, label) {
+        let observedState
+        try {
+          observedState = await waitFor(async () => {
+            const state = await trustedAnnotationInputState(overlay)
+            const observed = state.inputProbe
+            return (
+              observed?.token === probe.token
+              && observed.input.length > 0
+              && state.value === expectedValue
+            ) ? state : null
+          }, label, 10_000, () => trustedAnnotationInputState(overlay))
+        } catch (error) {
+          const state = await trustedAnnotationInputState(overlay).catch(diagnosticError => ({
+            diagnosticError: diagnosticError?.message || String(diagnosticError),
+          }))
+          const classification = !state.ownerFocused
+            ? 'ELECTRON_FOREGROUND_PREREQUISITE_MISSING'
+            : 'TRUSTED_OVERLAY_INPUT_CONTRACT_FAILED'
+          throw new Error(`${classification}: ${error?.message || error}`)
+        }
+        // The renderer event proves the real input path ran. Re-establish the
+        // native foreground precondition before the caller proceeds so an
+        // unrelated host focus steal cannot poison a later assertion.
+        const focusedState = await restoreTrustedAnnotationInputFocus(
+          overlay,
+          `${label} post-input focus`,
+        )
+        return {
+          ...focusedState,
+          inputProbe: observedState.inputProbe,
+        }
+      }
+
+      async function sendTrustedAnnotationCharacter(overlay, character, expectedValue, label) {
+        await restoreTrustedAnnotationInputFocus(overlay, `${label} focus`)
+        const probe = await armTrustedAnnotationInputProbe(overlay, label)
+        overlay.view.webContents.sendInputEvent({
+          type: 'char',
+          keyCode: character,
+        })
+        return await waitForTrustedAnnotationInput(overlay, probe, expectedValue, label)
+      }
+
+      async function insertTrustedAnnotationText(overlay, text, expectedValue, label) {
+        await restoreTrustedAnnotationInputFocus(overlay, `${label} focus`)
+        const probe = await armTrustedAnnotationInputProbe(overlay, label)
+        // insertText uses Chromium's text-input/IME commit path rather than
+        // changing the DOM value directly.
+        overlay.view.webContents.insertText(text)
+        return await waitForTrustedAnnotationInput(overlay, probe, expectedValue, label)
       }
 
       async function closeAnnotationOverlayAndDrain(request, label) {
@@ -636,7 +832,7 @@ try {
       owner.show()
       owner.focus()
       await new Promise(resolveWait => setTimeout(resolveWait, 100))
-      const annotationNativeOwnerFocusAvailable = owner.isFocused()
+      let annotationNativeOwnerFocusAvailable = owner.isFocused()
 
       function view(surfaceId) {
         const resultView = manager.surfaces.get(surfaceId)?.view
@@ -1056,12 +1252,9 @@ try {
       // sendInputEvent does not activate a WebContentsView the way a native
       // OS pointer event does. Restore the trusted view after the deliberately
       // blocked DevTools request before exercising click and geometry focus.
-      if (process.platform === 'darwin') app.focus({ steal: true })
-      owner.focus()
-      annotationOverlay.view.webContents.focus()
-      await annotationOverlay.view.webContents.executeJavaScript(
-        "document.getElementById('annotation-body').focus()",
-        true,
+      await restoreTrustedAnnotationInputFocus(
+        annotationOverlay,
+        'trusted annotation textarea focus after blocked DevTools request',
       )
       annotationOverlay.view.webContents.sendInputEvent({
         type: 'mouseDown',
@@ -1087,25 +1280,31 @@ try {
       const annotationOverlayOnTop = owner.contentView.children.at(-1) === annotationOverlay.view
       const annotationOverlayFocusCycles = []
       let previousOverlayBounds = annotationOverlayBounds
-      for (const [index, scrollDelta] of [96, -24, 24, -32, 32].entries()) {
+      const annotationGeometryDeltas = fixture.stressMode
+        ? [96, -24, 24, -32, 32]
+        : [96]
+      for (const [index, scrollDelta] of annotationGeometryDeltas.entries()) {
+        await restoreTrustedAnnotationInputFocus(
+          annotationOverlay,
+          `trusted annotation focus before geometry refresh ${index + 1}`,
+        )
         await v3Contents.executeJavaScript(`window.scrollBy(0, ${scrollDelta})`)
         const movedBounds = await waitFor(() => {
           const bounds = annotationOverlay.view.getBounds()
           return bounds.y !== previousOverlayBounds.y ? bounds : null
         }, `trusted annotation overlay geometry refresh ${index + 1}`)
-        const focusState = await waitFor(
-          async () => {
-            const editorFocused = await annotationOverlay.view.webContents.executeJavaScript(
-              "document.activeElement?.id === 'annotation-body'",
-            )
-            const ownerFocused = owner.isFocused()
-            const nativeFocused = annotationOverlay.view.webContents.isFocused()
-            return editorFocused && (!ownerFocused || nativeFocused)
-              ? { editorFocused, ownerFocused, nativeFocused }
-              : null
-          },
-          `trusted annotation native focus after geometry refresh ${index + 1}`,
-        )
+        // The first cycle proves geometry refresh itself retains focus. Later
+        // stress cycles actively recover foreground ownership, which keeps the
+        // repetition useful without coupling it to unrelated host focus steals.
+        const focusState = index === 0
+          ? await requireRetainedTrustedAnnotationFocus(
+            annotationOverlay,
+            'trusted annotation native focus after geometry refresh 1',
+          )
+          : await restoreTrustedAnnotationInputFocus(
+            annotationOverlay,
+            `trusted annotation native focus after geometry refresh ${index + 1}`,
+          )
         annotationOverlayFocusCycles.push({
           bounds: movedBounds,
           ...focusState,
@@ -1115,25 +1314,44 @@ try {
       const annotationOverlayMovedBounds = annotationOverlayFocusCycles[0].bounds
       const annotationOverlayFocusedAfterGeometry =
         annotationOverlayFocusCycles.every(cycle =>
-          cycle.editorFocused && (!cycle.ownerFocused || cycle.nativeFocused))
+          cycle.editorFocused && cycle.ownerFocused && cycle.nativeFocused)
+      await restoreTrustedAnnotationInputFocus(
+        annotationOverlay,
+        'trusted annotation selection before native keyboard input',
+      )
       await annotationOverlay.view.webContents.executeJavaScript(
         "document.getElementById('annotation-body').select()",
       )
-      for (const character of 'ASCII annotation ') {
-        annotationOverlay.view.webContents.sendInputEvent({
-          type: 'char',
-          keyCode: character,
+      const annotationInputHandshakes = []
+      let expectedAnnotationValue = ''
+      for (const [index, character] of [...'ASCII annotation '].entries()) {
+        expectedAnnotationValue += character
+        const state = await sendTrustedAnnotationCharacter(
+          annotationOverlay,
+          character,
+          expectedAnnotationValue,
+          `trusted overlay native character ${index + 1}`,
+        )
+        annotationInputHandshakes.push({
+          kind: 'char',
+          beforeinputCount: state.inputProbe.beforeinput.length,
+          inputCount: state.inputProbe.input.length,
+          value: state.value,
         })
       }
-      // insertText uses Chromium's text-input/IME commit path rather than
-      // changing the DOM value directly.
-      annotationOverlay.view.webContents.insertText('中文输入')
-      await waitFor(
-        async () => await annotationOverlay.view.webContents.executeJavaScript(
-          "document.getElementById('annotation-body').value === 'ASCII annotation 中文输入'",
-        ),
+      expectedAnnotationValue += '中文输入'
+      const annotationImeState = await insertTrustedAnnotationText(
+        annotationOverlay,
+        '中文输入',
+        expectedAnnotationValue,
         'trusted overlay real keyboard and IME input',
       )
+      annotationInputHandshakes.push({
+        kind: 'ime',
+        beforeinputCount: annotationImeState.inputProbe.beforeinput.length,
+        inputCount: annotationImeState.inputProbe.input.length,
+        value: annotationImeState.value,
+      })
       const annotationOverlayTypedValue =
         await annotationOverlay.view.webContents.executeJavaScript(
           "document.getElementById('annotation-body').value",
@@ -1273,10 +1491,8 @@ try {
           emptyBodyMessage: 'Describe the next requested change.',
         },
       })
-      await waitFor(
-        async () => await annotationOverlay.view.webContents.executeJavaScript(
-          "document.activeElement?.id === 'annotation-body'",
-        ),
+      await restoreTrustedAnnotationInputFocus(
+        annotationOverlay,
         'rearmed annotation textarea focus',
       )
       const annotationRearmCopy =
@@ -1314,16 +1530,19 @@ try {
           form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
           return textarea.validationMessage
         })()`)
-      annotationOverlay.view.webContents.insertText('Rearmed input')
-      const annotationRearmTypedValue = await waitFor(
-        async () => {
-          const value = await annotationOverlay.view.webContents.executeJavaScript(
-            "document.getElementById('annotation-body').value",
-          )
-          return value === 'Rearmed input' ? value : null
-        },
+      const annotationRearmInputState = await insertTrustedAnnotationText(
+        annotationOverlay,
+        'Rearmed input',
+        'Rearmed input',
         'rearmed annotation overlay input',
       )
+      const annotationRearmTypedValue = annotationRearmInputState.value
+      annotationInputHandshakes.push({
+        kind: 'rearm-ime',
+        beforeinputCount: annotationRearmInputState.inputProbe.beforeinput.length,
+        inputCount: annotationRearmInputState.inputProbe.input.length,
+        value: annotationRearmInputState.value,
+      })
       const annotationRearmSubmitEventsBeforeNewline = events.filter(event =>
         event.type === 'annotation-submit'
         && event.detail?.annotationId === 'annotation_rearmed_fixture').length
@@ -1373,7 +1592,8 @@ try {
         annotationId: 'annotation_rearmed_fixture',
       }, 'rearmed annotation acknowledgement')
       const annotationRearmFocusCycles = []
-      for (let cycle = 0; cycle < 3; cycle += 1) {
+      const annotationRearmCycleCount = fixture.stressMode ? 3 : 1
+      for (let cycle = 0; cycle < annotationRearmCycleCount; cycle += 1) {
         const cycleEventsBefore = events.length
         const cyclePicker = await manager.setArtifactAnnotationMode({
           version: 3,
@@ -1410,36 +1630,24 @@ try {
           annotationId: cycleAnnotationId,
           initialBody: '',
         })
-        await waitFor(
-          async () => await annotationOverlay.view.webContents.executeJavaScript(
-            "document.activeElement?.id === 'annotation-body'",
-          ),
+        await restoreTrustedAnnotationInputFocus(
+          annotationOverlay,
           `annotation rearm editor focus cycle ${cycle + 1}`,
         )
         const cycleBody = `Rearmed IME ${cycle + 1} 中文输入`
-        annotationOverlay.view.webContents.insertText(cycleBody)
-        const typedValue = await waitFor(
-          async () => {
-            const value = await annotationOverlay.view.webContents.executeJavaScript(
-              "document.getElementById('annotation-body').value",
-            )
-            return value === cycleBody ? value : null
-          },
+        const cycleInputState = await insertTrustedAnnotationText(
+          annotationOverlay,
+          cycleBody,
+          cycleBody,
           `annotation rearm IME input cycle ${cycle + 1}`,
         )
-        const cycleFocusState = await waitFor(
-          async () => {
-            const editorFocused = await annotationOverlay.view.webContents.executeJavaScript(
-              "document.activeElement?.id === 'annotation-body'",
-            )
-            const ownerFocused = owner.isFocused()
-            const nativeFocused = annotationOverlay.view.webContents.isFocused()
-            return editorFocused && (!ownerFocused || nativeFocused)
-              ? { editorFocused, ownerFocused, nativeFocused }
-              : null
-          },
-          `annotation rearm native focus cycle ${cycle + 1}`,
-        )
+        annotationInputHandshakes.push({
+          kind: 'stress-ime',
+          beforeinputCount: cycleInputState.inputProbe.beforeinput.length,
+          inputCount: cycleInputState.inputProbe.input.length,
+          value: cycleInputState.value,
+        })
+        const cycleFocusState = cycleInputState
         const cycleClose = await closeAnnotationOverlayAndDrain({
           version: 3,
           surfaceId: 'artifact:v3-bridge',
@@ -1449,7 +1657,7 @@ try {
           picker: cyclePicker.ok,
           overlay: cycleOverlayResult.ok,
           ...cycleFocusState,
-          typedValue,
+          typedValue: cycleInputState.value,
           closed: cycleClose.ok,
         })
       }
@@ -2246,6 +2454,7 @@ try {
       owner.destroy()
 
       return {
+        stressMode: fixture.stressMode,
         fullProbes,
         fullReload,
         fullStorageSurvivedReload,
@@ -2289,6 +2498,7 @@ try {
         annotationNativeOwnerFocusAvailable,
         annotationOverlayFocusCycles,
         annotationOverlayFocusedAfterGeometry,
+        annotationInputHandshakes,
         annotationOverlayTypedValue,
         annotationPreviewKeys,
         annotationEmptySubmitRetained,
@@ -2394,6 +2604,7 @@ try {
       privilegedGatewayAlias,
       stunPort: stunAddress.port,
       turnTcpPort: turnTcpAddress.port,
+      stressMode,
     },
   )
 
@@ -2638,13 +2849,18 @@ try {
   assert.equal(result.annotationOverlayOnTop, true)
   assert.equal(
     result.annotationOverlayFocusCycles.length,
-    5,
+    result.stressMode ? 5 : 1,
     'trusted annotation focus must survive repeated geometry refreshes',
   )
   assert.equal(
     result.annotationOverlayFocusedAfterGeometry,
     true,
     'the trusted annotation editor must retain native keyboard focus across geometry refreshes',
+  )
+  assert.equal(
+    result.annotationInputHandshakes.every(handshake => handshake.inputCount > 0),
+    true,
+    'every native character and IME commit must be acknowledged by a renderer input event',
   )
   assert.equal(result.annotationOverlayTypedValue, 'ASCII annotation 中文输入')
   assert.equal(
@@ -2704,15 +2920,16 @@ try {
   assert.equal(result.annotationRearmShiftEnterDidNotSubmit, true)
   assert.equal(result.annotationRearmSubmitAfterInterruptedComposition, true)
   assert.equal(result.annotationRearmOverlayClose.ok, true)
-  assert.equal(result.annotationRearmFocusCycles.length, 3)
+  assert.equal(result.annotationRearmFocusCycles.length, result.stressMode ? 3 : 1)
   assert.equal(
     result.annotationRearmFocusCycles.every(cycle =>
       cycle.picker
       && cycle.overlay
       && cycle.editorFocused
+      && cycle.ownerFocused
+      && cycle.nativeFocused
       && cycle.closed
-      && cycle.typedValue.includes('中文输入')
-      && (!cycle.ownerFocused || cycle.nativeFocused)),
+      && cycle.typedValue.includes('中文输入')),
     true,
     'trusted annotation editor must survive repeated close/rearm/IME cycles',
   )

--- a/tests/test_ci/test_ci_attestation.py
+++ b/tests/test_ci/test_ci_attestation.py
@@ -27,6 +27,7 @@ verify_queue = MODULE["verify_queue"]
 list_attestation_artifacts = MODULE["_list_attestation_artifacts"]
 plan_paths = MODULE["_plan_paths"]
 composition_is_safe = MODULE["_composition_is_safe"]
+changed_paths = MODULE["_changed_paths"]
 reconstructed_queue_tree = MODULE["_reconstructed_queue_tree"]
 verify_nightly_health = MODULE["verify_nightly_health"]
 wait_for_base_successful_ci = MODULE["_wait_for_base_successful_ci"]
@@ -154,6 +155,25 @@ def _write(repo: Path, relative: str, value: str) -> None:
     path = repo / relative
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(value, encoding="utf-8")
+
+
+def test_changed_paths_preserves_both_sides_of_a_rename(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "CI Test")
+    _git(repo, "config", "user.email", "ci@example.invalid")
+    old_path = "tests/test_gateway/test_rpc_sessions.py"
+    new_path = "tests/test_gateway/test_rpc_sessions_fork.py"
+    _write(repo, old_path, "def test_old(): pass\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "add governed test")
+    before = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "mv", old_path, new_path)
+    _git(repo, "commit", "-m", "rename governed test")
+    after = _git(repo, "rev-parse", "HEAD")
+
+    assert set(changed_paths(repo, before, after)) == {old_path, new_path}
 
 
 def _seed_suite_execution_input_fixtures(repo: Path) -> None:

--- a/tests/test_ci/test_plan_ci.py
+++ b/tests/test_ci/test_plan_ci.py
@@ -41,6 +41,12 @@ def _plan(
     return plan_changes(paths, repo=tmp_path, config=suite_config)
 
 
+def _write_test_module(root: Path, path: str, source: str = "") -> None:
+    candidate = root / path
+    candidate.parent.mkdir(parents=True, exist_ok=True)
+    candidate.write_text(source, encoding="utf-8")
+
+
 def _matrix(plan: dict[str, Any]) -> set[tuple[str, str]]:
     return {(cell["os"], cell["shard"]) for cell in plan["desktop_matrix"]}
 
@@ -108,18 +114,19 @@ def test_ordinary_python_change_selects_targets_without_full_fallback(
 
 
 def test_pr_1347_test_only_change_uses_exact_targets_and_windows_shards(
-    tmp_path: Path, suite_config: dict[str, Any]
+    suite_config: dict[str, Any],
 ) -> None:
     paths = [
         "tests/test_gateway/test_rpc_sessions.py",
         "tests/test_live_artifact_prompt_annotations_e2e.py",
         "tests/test_recovery/test_recovery_cmd.py",
     ]
+    importing_consumer = "tests/test_gateway/test_p1a_exact_abort_contract.py"
 
-    plan = _plan(tmp_path, suite_config, *paths)
+    plan = plan_changes(paths, repo=Path.cwd(), config=suite_config)
 
     assert plan["full_fallback"] is False
-    assert plan["python_targets"] == sorted(paths)
+    assert plan["python_targets"] == sorted([*paths, importing_consumer])
     assert plan["python_matrix"] == {
         "ubuntu": [],
         "windows": [
@@ -130,12 +137,17 @@ def test_pr_1347_test_only_change_uses_exact_targets_and_windows_shards(
     }
     assert plan["desktop_matrix"] == []
     assert set(plan["required_suites"]) == {
+        "macos-recovery",
         "python-targeted",
         "readme-locale",
         "windows-high-risk",
         "workflow-lint",
     }
-    assert plan["reason_codes"] == ["test_only_targeted"]
+    assert plan["reason_codes"] == [
+        "macos_recovery_test_changed",
+        "test_dependency_closure",
+        "test_only_targeted",
+    ]
 
 
 def test_deleted_governed_test_uses_existing_parent_and_keeps_windows_shard(
@@ -167,6 +179,114 @@ def test_governed_test_rename_targets_old_parent_and_new_exact_file(
     assert plan["python_targets"] == ["tests/test_gateway", new_path]
     assert plan["python_matrix"]["windows"] == ["gateway-sqlite"]
     assert "deleted_test_targeted" in plan["reason_codes"]
+
+
+def test_cross_shard_test_helper_adds_importing_consumer_and_shard(
+    tmp_path: Path, suite_config: dict[str, Any]
+) -> None:
+    helper = "tests/test_skills/test_hub_management_service.py"
+    consumer = "tests/test_skills_hash_consumers.py"
+    _write_test_module(tmp_path, helper)
+    _write_test_module(
+        tmp_path,
+        consumer,
+        "from tests.test_skills.test_hub_management_service import FakeSource\n",
+    )
+
+    plan = plan_changes([helper], repo=tmp_path, config=suite_config)
+
+    assert plan["full_fallback"] is False
+    assert plan["python_targets"] == [helper, consumer]
+    assert plan["python_matrix"]["windows"] == ["core", "recovery-migration"]
+    assert "test_dependency_closure" in plan["reason_codes"]
+
+
+def test_test_helper_dependency_closure_is_recursive_and_cycle_safe(
+    tmp_path: Path, suite_config: dict[str, Any]
+) -> None:
+    core = "tests/test_skills/test_hub_management_service.py"
+    recovery = "tests/test_skills_hash_consumers.py"
+    desktop = "tests/test_engine/test_runtime_meta_invoke_surfacing.py"
+    _write_test_module(
+        tmp_path,
+        core,
+        "from tests.test_engine.test_runtime_meta_invoke_surfacing import DesktopHelper\n",
+    )
+    _write_test_module(
+        tmp_path,
+        recovery,
+        "from tests.test_skills.test_hub_management_service import CoreHelper\n",
+    )
+    _write_test_module(
+        tmp_path,
+        desktop,
+        "from tests.test_skills_hash_consumers import RecoveryHelper\n",
+    )
+
+    plan = plan_changes([core], repo=tmp_path, config=suite_config)
+
+    assert plan["full_fallback"] is False
+    assert plan["python_targets"] == sorted([core, recovery, desktop])
+    assert plan["python_matrix"]["windows"] == [
+        "core",
+        "desktop-installer-contracts",
+        "recovery-migration",
+    ]
+    assert "test_dependency_closure" in plan["reason_codes"]
+
+
+def test_ungoverned_test_module_consumer_fails_closed(
+    tmp_path: Path, suite_config: dict[str, Any]
+) -> None:
+    helper = "tests/test_skills/test_hub_management_service.py"
+    consumer = "tests/unknown/test_helper_consumer.py"
+    _write_test_module(tmp_path, helper)
+    _write_test_module(
+        tmp_path,
+        consumer,
+        "from tests.test_skills.test_hub_management_service import FakeSource\n",
+    )
+
+    plan = plan_changes([helper], repo=tmp_path, config=suite_config)
+
+    assert plan["full_fallback"] is True
+    assert plan["python_targets"] == ["tests"]
+    assert "test_dependency_ungoverned" in plan["reason_codes"]
+    assert "test_dependency_unsafe" in plan["reason_codes"]
+
+
+def test_uncertain_test_module_parse_fails_closed(
+    tmp_path: Path, suite_config: dict[str, Any]
+) -> None:
+    helper = "tests/test_skills/test_hub_management_service.py"
+    _write_test_module(tmp_path, helper, "def broken(:\n")
+
+    plan = plan_changes([helper], repo=tmp_path, config=suite_config)
+
+    assert plan["full_fallback"] is True
+    assert plan["python_targets"] == ["tests"]
+    assert "test_dependency_analysis_uncertain" in plan["reason_codes"]
+
+
+def test_deleted_test_helper_keeps_cross_directory_consumer(
+    tmp_path: Path, suite_config: dict[str, Any]
+) -> None:
+    helper = "tests/test_skills/test_hub_management_service.py"
+    consumer = "tests/test_skills_hash_consumers.py"
+    (tmp_path / "tests/test_skills").mkdir(parents=True)
+    _write_test_module(
+        tmp_path,
+        consumer,
+        "from tests.test_skills.test_hub_management_service import FakeSource\n",
+    )
+
+    plan = plan_changes([helper], repo=tmp_path, config=suite_config)
+
+    assert plan["full_fallback"] is False
+    assert plan["python_targets"] == ["tests/test_skills", consumer]
+    assert plan["python_matrix"]["windows"] == ["core", "recovery-migration"]
+    assert "deleted_test_targeted" in plan["reason_codes"]
+    assert "test_dependency_closure" in plan["reason_codes"]
 
 
 def test_deleted_governed_test_at_ref_uses_parent_tree(
@@ -311,8 +431,6 @@ def test_python_native_risk_domains_select_only_corresponding_desktop_group(
         "tests/test_gateway/test_desktop_ownership.py",
         "tests/test_gateway/test_rpc_sandbox_runtime.py",
         "tests/test_gateway/test_rpc_workbench_resources.py",
-        "tests/test_desktop/test_electron_startup_contract.py",
-        "tests/test_recovery/test_recovery_cmd.py",
     ],
 )
 def test_test_only_domain_words_do_not_wake_native_desktop_e2e(
@@ -329,6 +447,53 @@ def test_test_only_domain_words_do_not_wake_native_desktop_e2e(
     assert "desktop-recovery-e2e" not in plan["required_suites"]
     assert "macos-recovery" not in plan["required_suites"]
     assert "test_only_targeted" in plan["reason_codes"]
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "tests/test_recovery/test_atomic_and_locking.py",
+        "tests/test_recovery/test_engine.py",
+    ],
+)
+def test_darwin_recovery_test_keeps_macos_python_without_native_e2e(
+    tmp_path: Path,
+    suite_config: dict[str, Any],
+    path: str,
+) -> None:
+    plan = _plan(tmp_path, suite_config, path)
+
+    assert plan["full_fallback"] is False
+    assert plan["python_targets"] == [path]
+    assert "macos-recovery" in plan["required_suites"]
+    assert _platform_cells(plan, "macos-recovery") == {
+        ("macos-latest", "recovery")
+    }
+    assert "desktop-recovery-e2e" not in plan["required_suites"]
+    assert plan["desktop_matrix"] == []
+    assert "macos_recovery_test_changed" in plan["reason_codes"]
+
+
+def test_macos_recovery_test_routing_is_covered_by_suite_digest(
+    suite_config: dict[str, Any],
+) -> None:
+    assert set(suite_config["macos_recovery_test_inputs"]) <= set(
+        suite_config["suites"]["macos-recovery"]["execution_inputs"]
+    )
+
+
+def test_macos_recovery_test_routing_without_digest_coverage_is_rejected(
+    tmp_path: Path,
+) -> None:
+    config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    config["suites"]["macos-recovery"]["execution_inputs"].remove(
+        "tests/test_recovery/**"
+    )
+    config_path = tmp_path / "suites.v1.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(PlanError, match="must be covered by the macos-recovery"):
+        load_config(config_path)
 
 
 def test_explicit_test_path_pattern_can_select_native_desktop_e2e(

--- a/tests/test_ci/test_plan_ci.py
+++ b/tests/test_ci/test_plan_ci.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import runpy
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -27,6 +28,16 @@ def suite_config() -> dict[str, Any]:
 def _plan(
     tmp_path: Path, suite_config: dict[str, Any], *paths: str
 ) -> dict[str, Any]:
+    for relative in paths:
+        candidate = Path(relative)
+        if (
+            relative.startswith("tests/")
+            and candidate.name.startswith("test_")
+            and candidate.suffix == ".py"
+        ):
+            test_path = tmp_path / candidate
+            test_path.parent.mkdir(parents=True, exist_ok=True)
+            test_path.touch()
     return plan_changes(paths, repo=tmp_path, config=suite_config)
 
 
@@ -94,6 +105,121 @@ def test_ordinary_python_change_selects_targets_without_full_fallback(
         "tests/test_provider*.py",
     ]
     assert plan["reason_codes"] == ["python_targeted"]
+
+
+def test_pr_1347_test_only_change_uses_exact_targets_and_windows_shards(
+    tmp_path: Path, suite_config: dict[str, Any]
+) -> None:
+    paths = [
+        "tests/test_gateway/test_rpc_sessions.py",
+        "tests/test_live_artifact_prompt_annotations_e2e.py",
+        "tests/test_recovery/test_recovery_cmd.py",
+    ]
+
+    plan = _plan(tmp_path, suite_config, *paths)
+
+    assert plan["full_fallback"] is False
+    assert plan["python_targets"] == sorted(paths)
+    assert plan["python_matrix"] == {
+        "ubuntu": [],
+        "windows": [
+            "desktop-installer-contracts",
+            "gateway-sqlite",
+            "recovery-migration",
+        ],
+    }
+    assert plan["desktop_matrix"] == []
+    assert set(plan["required_suites"]) == {
+        "python-targeted",
+        "readme-locale",
+        "windows-high-risk",
+        "workflow-lint",
+    }
+    assert plan["reason_codes"] == ["test_only_targeted"]
+
+
+def test_deleted_governed_test_uses_existing_parent_and_keeps_windows_shard(
+    tmp_path: Path, suite_config: dict[str, Any]
+) -> None:
+    path = "tests/test_gateway/test_rpc_sessions.py"
+    (tmp_path / "tests/test_gateway").mkdir(parents=True)
+
+    plan = plan_changes([path], repo=tmp_path, config=suite_config)
+
+    assert plan["full_fallback"] is False
+    assert plan["python_targets"] == ["tests/test_gateway"]
+    assert plan["python_matrix"]["windows"] == ["gateway-sqlite"]
+    assert "deleted_test_targeted" in plan["reason_codes"]
+
+
+def test_governed_test_rename_targets_old_parent_and_new_exact_file(
+    tmp_path: Path, suite_config: dict[str, Any]
+) -> None:
+    old_path = "tests/test_gateway/test_rpc_sessions.py"
+    new_path = "tests/test_gateway/test_rpc_sessions_fork.py"
+    new_test = tmp_path / new_path
+    new_test.parent.mkdir(parents=True)
+    new_test.touch()
+
+    plan = plan_changes([old_path, new_path], repo=tmp_path, config=suite_config)
+
+    assert plan["full_fallback"] is False
+    assert plan["python_targets"] == ["tests/test_gateway", new_path]
+    assert plan["python_matrix"]["windows"] == ["gateway-sqlite"]
+    assert "deleted_test_targeted" in plan["reason_codes"]
+
+
+def test_deleted_governed_test_at_ref_uses_parent_tree(
+    tmp_path: Path, suite_config: dict[str, Any]
+) -> None:
+    repo = tmp_path / "repo"
+    test_dir = repo / "tests/test_gateway"
+    test_dir.mkdir(parents=True)
+    deleted_path = test_dir / "test_rpc_sessions.py"
+    deleted_path.touch()
+    (test_dir / "test_retained.py").touch()
+    for command in (
+        ("init", "-b", "main"),
+        ("config", "user.name", "CI Test"),
+        ("config", "user.email", "ci@example.invalid"),
+        ("add", "."),
+        ("commit", "-m", "add tests"),
+    ):
+        subprocess.run(["git", *command], cwd=repo, check=True, capture_output=True)
+    deleted_path.unlink()
+    subprocess.run(
+        ["git", "add", "-u"], cwd=repo, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "delete test"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+    plan = plan_changes(
+        ["tests/test_gateway/test_rpc_sessions.py"],
+        repo=repo,
+        config=suite_config,
+        ref="HEAD",
+    )
+
+    assert plan["full_fallback"] is False
+    assert plan["python_targets"] == ["tests/test_gateway"]
+    assert plan["python_matrix"]["windows"] == ["gateway-sqlite"]
+    assert "deleted_test_targeted" in plan["reason_codes"]
+
+
+def test_deleted_unregistered_test_still_fails_closed(
+    tmp_path: Path, suite_config: dict[str, Any]
+) -> None:
+    path = "tests/unknown/test_removed_contract.py"
+    (tmp_path / "tests/unknown").mkdir(parents=True)
+
+    plan = plan_changes([path], repo=tmp_path, config=suite_config)
+
+    assert plan["full_fallback"] is True
+    assert "unknown_path" in plan["reason_codes"]
 
 
 def test_shared_python_core_requests_complete_offline_python_only(
@@ -180,32 +306,47 @@ def test_python_native_risk_domains_select_only_corresponding_desktop_group(
 
 
 @pytest.mark.parametrize(
-    ("path", "group"),
+    "path",
     [
-        ("tests/test_gateway/test_desktop_ownership.py", "ownership"),
-        ("tests/test_gateway/test_rpc_sandbox_runtime.py", "ownership"),
-        ("tests/test_gateway/test_rpc_workbench_resources.py", "workbench"),
+        "tests/test_gateway/test_desktop_ownership.py",
+        "tests/test_gateway/test_rpc_sandbox_runtime.py",
+        "tests/test_gateway/test_rpc_workbench_resources.py",
+        "tests/test_desktop/test_electron_startup_contract.py",
+        "tests/test_recovery/test_recovery_cmd.py",
     ],
 )
-def test_known_test_targets_retain_their_desktop_risk_domain(
+def test_test_only_domain_words_do_not_wake_native_desktop_e2e(
     tmp_path: Path,
     suite_config: dict[str, Any],
     path: str,
-    group: str,
 ) -> None:
     plan = _plan(tmp_path, suite_config, path)
 
     assert plan["full_fallback"] is False
-    assert {cell[1] for cell in _matrix(plan) if cell[0] == "ubuntu-latest"} == {
-        group
+    assert plan["python_targets"] == [path]
+    assert len(plan["python_matrix"]["windows"]) == 1
+    assert plan["desktop_matrix"] == []
+    assert "desktop-recovery-e2e" not in plan["required_suites"]
+    assert "macos-recovery" not in plan["required_suites"]
+    assert "test_only_targeted" in plan["reason_codes"]
+
+
+def test_explicit_test_path_pattern_can_select_native_desktop_e2e(
+    tmp_path: Path, suite_config: dict[str, Any]
+) -> None:
+    path = "tests/test_gateway/test_rpc_workbench_resources.py"
+    suite_config["desktop_groups"]["workbench"]["path_patterns"].append(path)
+
+    plan = _plan(tmp_path, suite_config, path)
+
+    assert plan["full_fallback"] is False
+    assert _matrix(plan) == {
+        ("macos-latest", "workbench"),
+        ("ubuntu-latest", "workbench"),
+        ("windows-latest", "workbench"),
     }
-    assert {
-        "desktop-recovery-e2e",
-        "macos-recovery",
-        "python-targeted",
-        "windows-high-risk",
-    } <= set(plan["required_suites"])
-    assert f"desktop_{group}_changed" in plan["reason_codes"]
+    assert "desktop-recovery-e2e" in plan["required_suites"]
+    assert "desktop_workbench_test_changed" in plan["reason_codes"]
 
 
 @pytest.mark.parametrize(
@@ -238,13 +379,25 @@ def test_desktop_domain_selects_only_its_windows_shard(
     plan = _plan(tmp_path, suite_config, path)
 
     assert plan["full_fallback"] is False
-    macos_shard = "profiles" if windows_shard == "profiles" else "ownership-workbench"
     assert _matrix(plan) == {
-        ("macos-latest", macos_shard),
+        ("macos-latest", windows_shard),
         ("ubuntu-latest", windows_shard),
         ("windows-latest", windows_shard),
     }
     assert reason in plan["reason_codes"]
+
+
+def test_full_desktop_matrix_keeps_macos_ownership_and_workbench_isolated(
+    suite_config: dict[str, Any],
+) -> None:
+    macos_cells = {
+        cell["shard"]
+        for cell in suite_config["full_desktop_matrix"]
+        if cell["os"] == "macos-latest"
+    }
+
+    assert macos_cells == {"profiles", "ownership", "workbench"}
+    assert "ownership-workbench" not in macos_cells
 
 
 def test_windows_specific_platform_change_stays_on_windows(
@@ -432,7 +585,6 @@ def test_desktop_case_manifest_routes_each_known_case_to_its_executing_group(
     [
         "src/opensquilla/recovery/restore.py",
         "migrations/0001.sql",
-        "tests/test_desktop/test_electron_startup_contract.py",
     ],
 )
 def test_frontend_artifact_consumer_plan_always_includes_its_producer(

--- a/tests/test_ci/test_plan_ci.py
+++ b/tests/test_ci/test_plan_ci.py
@@ -201,6 +201,83 @@ def test_cross_shard_test_helper_adds_importing_consumer_and_shard(
     assert "test_dependency_closure" in plan["reason_codes"]
 
 
+@pytest.mark.parametrize(
+    "consumer_source",
+    [
+        (
+            "from importlib import import_module as load_module\n"
+            "helper = load_module('tests.test_skills.test_hub_management_service')\n"
+        ),
+        (
+            "import importlib as loader\n"
+            "helper = loader.import_module("
+            "'tests.test_skills.test_hub_management_service')\n"
+        ),
+    ],
+)
+def test_dynamic_import_alias_adds_cross_shard_consumer(
+    tmp_path: Path,
+    suite_config: dict[str, Any],
+    consumer_source: str,
+) -> None:
+    helper = "tests/test_skills/test_hub_management_service.py"
+    consumer = "tests/test_skills_hash_consumers.py"
+    _write_test_module(tmp_path, helper)
+    _write_test_module(tmp_path, consumer, consumer_source)
+
+    plan = plan_changes([helper], repo=tmp_path, config=suite_config)
+
+    assert plan["full_fallback"] is False
+    assert plan["python_targets"] == [helper, consumer]
+    assert plan["python_matrix"]["windows"] == ["core", "recovery-migration"]
+    assert "test_dependency_closure" in plan["reason_codes"]
+
+
+def test_pytest_plugins_adds_cross_shard_consumer(
+    tmp_path: Path, suite_config: dict[str, Any]
+) -> None:
+    helper = "tests/test_skills/test_hub_management_service.py"
+    consumer = "tests/test_skills_hash_consumers.py"
+    _write_test_module(tmp_path, helper)
+    _write_test_module(
+        tmp_path,
+        consumer,
+        "pytest_plugins = ['tests.test_skills.test_hub_management_service']\n",
+    )
+
+    plan = plan_changes([helper], repo=tmp_path, config=suite_config)
+
+    assert plan["full_fallback"] is False
+    assert plan["python_targets"] == [helper, consumer]
+    assert plan["python_matrix"]["windows"] == ["core", "recovery-migration"]
+
+
+@pytest.mark.parametrize(
+    "consumer_source",
+    [
+        (
+            "from importlib import import_module\n"
+            "helper = import_module(f'tests.test_skills.{module_name}')\n"
+        ),
+        "pytest_plugins = plugin_modules\n",
+    ],
+)
+def test_uncertain_dynamic_test_loader_fails_closed(
+    tmp_path: Path,
+    suite_config: dict[str, Any],
+    consumer_source: str,
+) -> None:
+    helper = "tests/test_skills/test_hub_management_service.py"
+    consumer = "tests/test_skills_hash_consumers.py"
+    _write_test_module(tmp_path, helper)
+    _write_test_module(tmp_path, consumer, consumer_source)
+
+    plan = plan_changes([helper], repo=tmp_path, config=suite_config)
+
+    assert plan["full_fallback"] is True
+    assert "test_dependency_analysis_uncertain" in plan["reason_codes"]
+
+
 def test_test_helper_dependency_closure_is_recursive_and_cycle_safe(
     tmp_path: Path, suite_config: dict[str, Any]
 ) -> None:

--- a/tests/test_ci/test_windows_test_shards.py
+++ b/tests/test_ci/test_windows_test_shards.py
@@ -335,6 +335,17 @@ def test_task_runtime_leak_smoke_is_marked_ci_serial() -> None:
     )
 
 
+def test_runner_saturated_subprocess_contracts_are_marked_ci_serial() -> None:
+    assert "pytest.mark.ci_serial" in _function_decorators(
+        Path("tests/test_gateway/test_goal_rpc.py"),
+        "test_continuation_transport_loss_after_accept_runs_but_shutdown_compensates",
+    )
+    assert "pytest.mark.ci_serial" in _function_decorators(
+        Path("tests/test_scripts/test_verify_webui_artifact.py"),
+        "test_node_and_python_source_fingerprints_share_order_and_line_endings",
+    )
+
+
 @pytest.mark.parametrize(
     "function_name",
     [

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -1698,6 +1698,7 @@ def test_desktop_recovery_e2e_runs_compiled_flows_on_all_release_platforms() -> 
     assert "node scripts/test-ci-case-telemetry.mjs" in desktop_unit["run"]
 
 
+@pytest.mark.parametrize("line_ending", ("\n", "\r\n"), ids=("lf", "crlf"))
 @pytest.mark.parametrize(
     ("case_name", "runner_os", "message", "expected_signature"),
     (
@@ -1739,6 +1740,7 @@ def test_desktop_retry_classifier_accepts_only_structured_infrastructure_signatu
     runner_os: str,
     message: str,
     expected_signature: str,
+    line_ending: str,
 ) -> None:
     run = next(
         step["run"]
@@ -1750,7 +1752,8 @@ def test_desktop_retry_classifier_accepts_only_structured_infrastructure_signatu
     output = tmp_path / "classifications.jsonl"
     evidence = tmp_path / "evidence"
     evidence.mkdir()
-    log.write_text(message, encoding="utf-8")
+    payload = message.replace("\n", line_ending).encode()
+    log.write_bytes(payload)
 
     accepted = subprocess.run(
         [sys.executable, "-", case_name, runner_os, str(log), str(output), str(evidence)],
@@ -1764,7 +1767,7 @@ def test_desktop_retry_classifier_accepts_only_structured_infrastructure_signatu
     assert record["classification"] == expected_signature
     assert record["retryable"] is True
     assert re.fullmatch(r"[0-9a-f]{64}", record["log_sha256"])
-    assert (evidence / log.name).read_text(encoding="utf-8") == message
+    assert (evidence / log.name).read_bytes() == payload
 
     # The same wording from a different functional case is not retryable.
     rejected = subprocess.run(

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -1705,15 +1705,24 @@ def test_desktop_recovery_e2e_runs_compiled_flows_on_all_release_platforms() -> 
         (
             "offline-document-workbench-e2e",
             "Windows",
+            "Traceback (most recent call last):\n"
+            "    at synthetic_allowed_stack\n"
             "E           AssertionError: isolated Windows ACL hardening timed out: "
-            "stdout='synthetic'\n",
+            "stdout='synthetic'\n"
+            "FAILED tests/synthetic.py - AssertionError: isolated Windows ACL hardening "
+            "timed out: stdout='synthetic'\n",
             "windows-isolated-acl-worker-timeout-v1",
         ),
         (
             "offline-document-workbench-e2e",
             "macOS",
-            "Error: electronApplication.evaluate: Error: "
-            "ELECTRON_FOREGROUND_PREREQUISITE_MISSING: owner is not foreground\n",
+            "electronApplication.evaluate: Error: "
+            "ELECTRON_FOREGROUND_PREREQUISITE_MISSING: owner is not foreground\n"
+            "    at synthetic_allowed_stack (native-workbench.mjs:1:1)\n"
+            "Error: /synthetic/test-native-workbench-v2-electron.mjs failed with exit "
+            "code 1\n"
+            "    at synthetic_outer_stack (offline-workbench.mjs:1:1)\n"
+            "Error: ELECTRON_FOREGROUND_PREREQUISITE_MISSING: owner is not foreground\n",
             "macos-electron-foreground-prerequisite-v1",
         ),
     ),
@@ -1826,7 +1835,70 @@ def test_desktop_retry_classifier_rejects_generic_product_failures(tmp_path: Pat
     assert hard_failure.returncode == 1
     records = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
     assert records[-1]["classification"] == "non_retryable"
-    assert records[-1]["blocked_markers"] == ["TRUSTED_OVERLAY_INPUT_CONTRACT_FAILED:"]
+    assert records[-1]["blocked_markers"] == [
+        "trusted-overlay-input-contract-failed-v1"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("additional_failure", "expected_marker"),
+    (
+        (
+            "AssertionError: submitted document content differs from the saved revision\n",
+            "generic-assertion-error-v1",
+        ),
+        (
+            "FATAL: renderer process crashed while committing the document\n",
+            "fatal-crash-process-exit-v1",
+        ),
+    ),
+)
+def test_desktop_retry_classifier_rejects_allowed_signature_with_another_terminal_failure(
+    tmp_path: Path,
+    additional_failure: str,
+    expected_marker: str,
+) -> None:
+    run = next(
+        step["run"]
+        for step in _workflow("ci.yml")["jobs"]["desktop-recovery-e2e"]["steps"]
+        if step.get("name") == "Run compiled Desktop recovery flows"
+    )
+    classifier = run.split("<<'PY'\n", 1)[1].split("\nPY\n", 1)[0]
+    log = tmp_path / "attempt-1.log"
+    output = tmp_path / "classifications.jsonl"
+    evidence = tmp_path / "evidence"
+    evidence.mkdir()
+    log.write_text(
+        "electronApplication.evaluate: Error: "
+        "ELECTRON_FOREGROUND_PREREQUISITE_MISSING: owner is not foreground\n"
+        "    at synthetic_allowed_stack (native-workbench.mjs:1:1)\n"
+        "Error: /synthetic/test-native-workbench-v2-electron.mjs failed with exit code 1\n"
+        + additional_failure,
+        encoding="utf-8",
+    )
+
+    rejected = subprocess.run(
+        [
+            sys.executable,
+            "-",
+            "offline-document-workbench-e2e",
+            "macOS",
+            str(log),
+            str(output),
+            str(evidence),
+        ],
+        input=classifier,
+        text=True,
+        check=False,
+    )
+
+    assert rejected.returncode == 1
+    record = json.loads(output.read_text(encoding="utf-8"))
+    assert record["classification"] == "non_retryable"
+    assert record["retryable"] is False
+    assert record["blocked_markers"] == [expected_marker]
+    assert all("submitted document content" not in marker for marker in record["blocked_markers"])
+    assert list(evidence.iterdir()) == []
 
 
 def test_v1_editor_failure_evidence_is_captured_before_desktop_shutdown() -> None:

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -1626,6 +1626,14 @@ def test_desktop_recovery_e2e_runs_compiled_flows_on_all_release_platforms() -> 
     assert job["env"]["PLAYWRIGHT_BROWSERS_PATH"] == (
         "${{ github.workspace }}/.cache/ms-playwright"
     )
+    assert job["env"]["OPENSQUILLA_WORKBENCH_E2E_MODE"] == (
+        "${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') "
+        "&& 'smoke' || 'stress' }}"
+    )
+    prepare = next(
+        step for step in steps if step.get("name") == "Prepare Desktop recovery report"
+    )
+    assert "workbench_e2e_mode" in prepare["run"]
     assert "${{ runner.arch }}" in playwright_cache["with"]["key"]
     assert "steps.playwright-browser.outputs.revision" in playwright_cache["with"]["key"]
     assert "restore-keys" not in playwright_cache["with"]
@@ -1644,15 +1652,23 @@ def test_desktop_recovery_e2e_runs_compiled_flows_on_all_release_platforms() -> 
     assert '--shard "${{ matrix.shard }}"' in run["run"]
     assert '--attempt "${attempt}"' in run["run"]
     assert 'desktop-e2e-cases.jsonl' in run["run"]
-    assert "is_retryable_windows_failure()" in run["run"]
-    assert '[[ "${RUNNER_OS}" == "Windows" ]] || return 1' in run["run"]
-    assert "grep -Fq 'Gateway did not become healthy'" in run["run"]
-    assert (
-        "grep -Fq 'Timed out waiting for post-exit delete-all helper completion'"
-        in run["run"]
+    assert "classify_retryable_infrastructure_failure()" in run["run"]
+    assert 'if classify_retryable_infrastructure_failure "${name}" "${first_log}"' in (
+        run["run"]
     )
-    assert "grep -Fq 'Windows ACL hardening timed out'" in run["run"]
-    assert 'if is_retryable_windows_failure "${first_log}"' in run["run"]
+    assert '"windows-delete-helper-handoff-timeout-v1"' in run["run"]
+    assert '"windows-isolated-acl-worker-timeout-v1"' in run["run"]
+    assert '"macos-electron-foreground-prerequisite-v1"' in run["run"]
+    assert '"cases": {"desktop-cleanup-flow"}' in run["run"]
+    assert '"cases": {"offline-document-workbench-e2e"}' in run["run"]
+    assert '"classification": matches[0] if retryable else "non_retryable"' in (
+        run["run"]
+    )
+    assert '"log_sha256": hashlib.sha256(payload).hexdigest()' in run["run"]
+    assert '"TRUSTED_OVERLAY_INPUT_CONTRACT_FAILED:"' in run["run"]
+    assert '"DESKTOP_E2E_PHASE_TIMEOUT:"' in run["run"]
+    assert "Gateway did not become healthy" not in run["run"]
+    assert "grep -Fq" not in run["run"]
     assert 'run_case "${name}" "${script}" 2' in run["run"]
     assert "exit 1" in run["run"]
     assert summary_upload["if"] == "${{ success() }}"
@@ -1661,6 +1677,8 @@ def test_desktop_recovery_e2e_runs_compiled_flows_on_all_release_platforms() -> 
         "-attempt-${{ github.run_attempt }}"
     )
     assert "desktop-e2e-cases.jsonl" in summary_upload["with"]["path"]
+    assert "retry-classifications.jsonl" in summary_upload["with"]["path"]
+    assert "retry-evidence" in summary_upload["with"]["path"]
     assert "*.log" not in summary_upload["with"]["path"]
     assert failure_upload["if"] == "${{ failure() }}"
     assert failure_upload["with"]["path"] == (
@@ -1672,6 +1690,143 @@ def test_desktop_recovery_e2e_runs_compiled_flows_on_all_release_platforms() -> 
         if step.get("name") == "Run desktop unit tests"
     )
     assert "node scripts/test-ci-case-telemetry.mjs" in desktop_unit["run"]
+
+
+@pytest.mark.parametrize(
+    ("case_name", "runner_os", "message", "expected_signature"),
+    (
+        (
+            "desktop-cleanup-flow",
+            "Windows",
+            "Error: Timed out waiting for post-exit delete-all helper completion.; "
+            "pending synthetic targets: synthetic-home\n",
+            "windows-delete-helper-handoff-timeout-v1",
+        ),
+        (
+            "offline-document-workbench-e2e",
+            "Windows",
+            "E           AssertionError: isolated Windows ACL hardening timed out: "
+            "stdout='synthetic'\n",
+            "windows-isolated-acl-worker-timeout-v1",
+        ),
+        (
+            "offline-document-workbench-e2e",
+            "macOS",
+            "Error: electronApplication.evaluate: Error: "
+            "ELECTRON_FOREGROUND_PREREQUISITE_MISSING: owner is not foreground\n",
+            "macos-electron-foreground-prerequisite-v1",
+        ),
+    ),
+)
+def test_desktop_retry_classifier_accepts_only_structured_infrastructure_signatures(
+    tmp_path: Path,
+    case_name: str,
+    runner_os: str,
+    message: str,
+    expected_signature: str,
+) -> None:
+    run = next(
+        step["run"]
+        for step in _workflow("ci.yml")["jobs"]["desktop-recovery-e2e"]["steps"]
+        if step.get("name") == "Run compiled Desktop recovery flows"
+    )
+    classifier = run.split("<<'PY'\n", 1)[1].split("\nPY\n", 1)[0]
+    log = tmp_path / "attempt-1.log"
+    output = tmp_path / "classifications.jsonl"
+    evidence = tmp_path / "evidence"
+    evidence.mkdir()
+    log.write_text(message, encoding="utf-8")
+
+    accepted = subprocess.run(
+        [sys.executable, "-", case_name, runner_os, str(log), str(output), str(evidence)],
+        input=classifier,
+        text=True,
+        check=False,
+    )
+
+    assert accepted.returncode == 0
+    record = json.loads(output.read_text(encoding="utf-8"))
+    assert record["classification"] == expected_signature
+    assert record["retryable"] is True
+    assert re.fullmatch(r"[0-9a-f]{64}", record["log_sha256"])
+    assert (evidence / log.name).read_text(encoding="utf-8") == message
+
+    # The same wording from a different functional case is not retryable.
+    rejected = subprocess.run(
+        [sys.executable, "-", "theme-flow", runner_os, str(log), str(output), str(evidence)],
+        input=classifier,
+        text=True,
+        check=False,
+    )
+    assert rejected.returncode == 1
+    records = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+    assert records[-1]["classification"] == "non_retryable"
+    assert records[-1]["retryable"] is False
+
+
+def test_desktop_retry_classifier_rejects_generic_product_failures(tmp_path: Path) -> None:
+    run = next(
+        step["run"]
+        for step in _workflow("ci.yml")["jobs"]["desktop-recovery-e2e"]["steps"]
+        if step.get("name") == "Run compiled Desktop recovery flows"
+    )
+    classifier = run.split("<<'PY'\n", 1)[1].split("\nPY\n", 1)[0]
+    log = tmp_path / "attempt-1.log"
+    output = tmp_path / "classifications.jsonl"
+    evidence = tmp_path / "evidence"
+    evidence.mkdir()
+    log.write_text(
+        "AssertionError: expected saved document content to equal the submitted content\n"
+        "Error: Gateway did not become healthy\n",
+        encoding="utf-8",
+    )
+
+    rejected = subprocess.run(
+        [
+            sys.executable,
+            "-",
+            "offline-document-workbench-e2e",
+            "Windows",
+            str(log),
+            str(output),
+            str(evidence),
+        ],
+        input=classifier,
+        text=True,
+        check=False,
+    )
+
+    assert rejected.returncode == 1
+    record = json.loads(output.read_text(encoding="utf-8"))
+    assert record["classification"] == "non_retryable"
+    assert record["retryable"] is False
+    assert list(evidence.iterdir()) == []
+
+    # A functional contract marker always wins even if a runner signature is
+    # also present in the combined diagnostic log.
+    log.write_text(
+        "Error: ELECTRON_FOREGROUND_PREREQUISITE_MISSING: synthetic\n"
+        "Error: TRUSTED_OVERLAY_INPUT_CONTRACT_FAILED: wrong submitted value\n",
+        encoding="utf-8",
+    )
+    hard_failure = subprocess.run(
+        [
+            sys.executable,
+            "-",
+            "offline-document-workbench-e2e",
+            "macOS",
+            str(log),
+            str(output),
+            str(evidence),
+        ],
+        input=classifier,
+        text=True,
+        check=False,
+    )
+    assert hard_failure.returncode == 1
+    records = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+    assert records[-1]["classification"] == "non_retryable"
+    assert records[-1]["blocked_markers"] == ["TRUSTED_OVERLAY_INPUT_CONTRACT_FAILED:"]
 
 
 def test_v1_editor_failure_evidence_is_captured_before_desktop_shutdown() -> None:
@@ -1806,6 +1961,7 @@ def test_windows_high_risk_job_runs_parallel_reported_shards() -> None:
     assert "--maxfail=1" not in test_step["run"]
     assert '"${{ matrix.shard }}" == "recovery-migration"' in test_step["run"]
     assert '"${{ matrix.shard }}" == "gateway-sqlite"' in test_step["run"]
+    assert '"${{ matrix.shard }}" == "desktop-installer-contracts"' in test_step["run"]
     assert "worker_args+=(--workers=2)" in test_step["run"]
     assert '"${worker_args[@]}"' in test_step["run"]
     assert "set -euo pipefail" in test_step["run"]

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -220,7 +220,10 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     )
     assert 'printf \'.ci/run-all\\n\' > "${changed_files}"' in merge_group_case
     assert "git diff --name-only" not in merge_group_case
-    assert 'git diff --name-only "${before}" "${after}" > "${changed_files}"' in text
+    assert (
+        'git diff --no-renames --name-only "${before}" "${after}" > "${changed_files}"'
+        in text
+    )
     assert 'printf \'.ci/run-all\\n\' > "${changed_files}"' in text
     assert "runtime_changed" in text
     assert "test_changed" in text
@@ -415,7 +418,10 @@ def test_default_ci_keeps_main_pushes_targeted_and_manual_runs_full() -> None:
 
     assert 'before="${{ github.event.before }}"' in text
     assert 'after="${{ github.event.after }}"' in text
-    assert 'git diff --name-only "${before}" "${after}" > "${changed_files}"' in text
+    assert (
+        'git diff --no-renames --name-only "${before}" "${after}" > "${changed_files}"'
+        in text
+    )
     assert 'workflow_dispatch' in text
     assert 'printf \'.ci/run-all\\n\' > "${changed_files}"' in text
 
@@ -2137,6 +2143,29 @@ def test_macos_recovery_runs_native_contracts_and_cannot_wash_failures_green() -
     assert "--reruns" not in serialized
     assert "pytest-rerunfailures" not in serialized
     assert "|| true" not in test_step["run"]
+
+
+def test_macos_recovery_planner_inputs_match_workflow_pytest_targets() -> None:
+    config = json.loads(Path(".github/ci/suites.v1.json").read_text(encoding="utf-8"))
+    expected_targets = {
+        path[:-3] if path.endswith("/**") else path
+        for path in config["macos_recovery_test_inputs"]
+    }
+    job = _workflow("ci.yml")["jobs"]["macos-recovery"]
+    test_step = next(
+        step
+        for step in job["steps"]
+        if step.get("name") == "Test native profile recovery contracts"
+    )
+    array = re.search(r"pytest_args=\(\n(?P<body>.*?)\n\s*\)", test_step["run"], re.DOTALL)
+
+    assert array is not None
+    workflow_targets = {
+        line.strip()
+        for line in array.group("body").splitlines()
+        if line.strip().startswith("tests/")
+    }
+    assert workflow_targets == expected_targets
 
 
 def test_ubuntu_quality_keeps_targeted_pr_tests_and_full_ci_uses_balanced_matrix() -> None:

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -2430,6 +2430,24 @@ def test_offline_document_workbench_gate_composes_owned_gateway_and_real_electro
     assert "real Electron process" in gate
     assert "OPENSQUILLA_REQUIRE_ELECTRON_FOREGROUND === '1'" in native
     assert "requires an unlocked foreground GUI session" in native
+    assert "OPENSQUILLA_WORKBENCH_E2E_MODE || 'stress'" in native
+    assert "const annotationGeometryDeltas = fixture.stressMode" in native
+    assert "? [96, -24, 24, -32, 32]" in native
+    assert "const annotationRearmCycleCount = fixture.stressMode ? 3 : 1" in native
+    assert "restoreTrustedAnnotationInputFocus" in native
+    assert "state.ownerFocused" in native
+    assert "&& state.nativeFocused" in native
+    assert "&& state.documentFocused" in native
+    assert "&& state.editorFocused" in native
+    assert "(!ownerFocused || nativeFocused)" not in native
+    assert "(!cycle.ownerFocused || cycle.nativeFocused)" not in native
+    assert native.count("type: 'char'") == 1
+    assert native.count(".insertText(") == 1
+    assert "window.__opensquillaNativeInputProbe" in native
+    assert "observed.input.length > 0" in native
+    assert "ELECTRON_FOREGROUND_PREREQUISITE_MISSING" in native
+    assert "TRUSTED_OVERLAY_FOCUS_CONTRACT_FAILED" in native
+    assert "TRUSTED_OVERLAY_INPUT_CONTRACT_FAILED" in native
     assert ci.count(
         "offline-document-workbench-e2e:scripts/test-offline-document-workbench-e2e.mjs"
     ) == 3
@@ -2883,15 +2901,33 @@ def test_desktop_orphan_recovery_has_a_real_electron_process_flow() -> None:
     script = _read(
         "desktop/electron/scripts/test-desktop-gateway-orphan-recovery-flow.mjs"
     )
+    main = _read("desktop/electron/src/main.ts")
+    lifecycle = _read("desktop/electron/src/gateway-lifecycle.ts")
 
     assert package_json["scripts"]["test:gateway-orphan-recovery-flow"] == (
         "npm run build && node scripts/test-desktop-gateway-orphan-recovery-flow.mjs"
     )
     assert "firstMain.kill('SIGKILL')" in script
     assert "verifyDesktopGatewayOwnership(firstRecord)" in script
-    assert "await launchDesktop()" in script
+    assert "await launchDesktop(" in script
     assert "loaded.record.pid !== firstRecord.pid" in script
     assert "waitForDesktopGatewayOwnershipRelease" in script
+    assert "export const DESKTOP_GATEWAY_STARTUP_TIMEOUT_MS = 120_000" in lifecycle
+    assert "const VERIFIED_ORPHAN_GATEWAY_RELEASE_TIMEOUT_MS = 80_000" in main
+    assert "const VERIFIED_ORPHAN_GATEWAY_RELEASE_TIMEOUT_MS = 80_000" in script
+    assert "DESKTOP_GATEWAY_STARTUP_TIMEOUT_MS + CONTROL_UI_ROUTE_TIMEOUT_MS" in script
+    assert (
+        "VERIFIED_ORPHAN_GATEWAY_RELEASE_TIMEOUT_MS + INITIAL_DESKTOP_STARTUP_BUDGET_MS"
+        in script
+    )
+    assert "createPhaseBudget('hard-crash-exit', CRASH_EXIT_BUDGET_MS)" in script
+    assert "phase.remainingMs('first-window')" in script
+    assert "phase.remainingMs('control-ui-route')" in script
+    assert "DESKTOP_E2E_PHASE_TIMEOUT:" in script
+    assert "DESKTOP_E2E_PHASE_FAILED:" in script
+    assert "DESKTOP_E2E_PROCESS_EXITED:" in script
+    assert "if (flowSucceeded && stillLive.length === 0)" in script
+    assert "async function waitFor(check, label, timeoutMs = 60_000)" not in script
 
 
 def test_desktop_dual_source_update_resolver_wires_static_channels() -> None:

--- a/tests/test_gateway/test_goal_rpc.py
+++ b/tests/test_gateway/test_goal_rpc.py
@@ -3232,6 +3232,7 @@ async def test_prepare_shutdown_fences_resume_waiting_for_goal_transition_lock(
         assert len(runs) == 1
 
 
+@pytest.mark.ci_serial
 @pytest.mark.parametrize("lost_boundary", ["subscription", "shutdown"])
 @pytest.mark.asyncio
 async def test_continuation_transport_loss_after_accept_runs_but_shutdown_compensates(

--- a/tests/test_scripts/test_verify_webui_artifact.py
+++ b/tests/test_scripts/test_verify_webui_artifact.py
@@ -271,6 +271,7 @@ def test_verify_wheel_requires_byte_identical_artifact(tmp_path: Path) -> None:
         verify_wheel(dist, wheel, webui_root=webui)
 
 
+@pytest.mark.ci_serial
 @pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
 def test_node_and_python_source_fingerprints_share_order_and_line_endings(
     tmp_path: Path,


### PR DESCRIPTION
## Scope

- Make test-only changes use exact pytest targets, recursive reverse-import consumers, and only their governed Windows shards.
- Preserve macOS-owned Python recovery coverage without waking unrelated native Electron E2E.
- Keep unknown, unregistered, deleted-without-safe-parent, ambiguous/dynamic test loading, dependency, and CI-policy changes fail-closed.
- Preserve both sides of Git renames so governed test moves remain safely targetable.
- Split macOS ownership and workbench E2E onto fresh runners and reduce process-heavy Windows shards to two xdist workers.
- Harden real Electron focus/keyboard/IME handshakes and add bounded smoke versus stress coverage.
- Replace broad retry strings with one-case, exact OS/case/signature infrastructure retry classification and evidence.
- Align orphan recovery E2E deadlines with the product lifecycle and preserve actionable phase diagnostics.

For the three files in #1347, the canonical plan changes from 29 full execution cells to seven: four exact Python targets (including the importing consumer), only `desktop-installer-contracts`, `gateway-sqlite`, and `recovery-migration` on Windows, and the owned macOS recovery suite. The unrelated native Desktop matrix remains empty.

## Branch target

`main`

## Linked issue

None.

## Verification

- `217 passed` across planner, attestation, and workflow contracts after the final rebase (`71 + 34 + 112`).
- The broader affected contract run reached `399 passed, 1 skipped`; three nested xdist harness tests could not start only because the reused local venv lacks the `pytest-xdist` plugin (`-n/--dist` unrecognized). The repository dev lock and hosted CI install that plugin, and the directly changed serial-marker contract passed.
- The two-parameter goal transport test and Node/Python fingerprint test passed independently in controller mode (`3 passed`).
- Real Electron native workbench passed in default stress, explicit stress, and explicit smoke modes.
- Electron TypeScript build passed.
- `actionlint .github/workflows/ci.yml`
- Ruff on all changed Python files.
- Node syntax checks for both changed Electron E2E scripts.
- Python compile, suite JSON validation, and `git diff --check`.
- Canonical #1347 planner output verified: `full_fallback=false`, four exact targets, three Windows shards, one macOS recovery cell, empty native Desktop matrix (seven versus 29 total execution cells, about 76% fewer).
- The first hosted #1348 run passed the split macOS ownership/workbench jobs, Ubuntu Desktop E2E, Windows ownership/workbench, and the two-worker desktop-installer shard; its only failure was the old recovery subprocess timeout fixed by merged #1347.
- The post-rebase hosted run passed both split macOS E2E jobs, Ubuntu Desktop E2E, Windows ownership/workbench, and the serial phase of the two-worker Windows installer shard. Its only failures were three workflow-contract cases exposing Windows CRLF input in the retry classifier; the follow-up normalizes only the decoded matching text, preserves raw SHA/evidence bytes, and covers all allowed signatures under both LF and CRLF.

The real orphan flow could not complete in this temporary local worktree because Electron remained on `boot.html` without creating a Gateway ownership record. The new phase diagnostics observed that pre-existing startup condition; build, syntax, and static lifecycle contracts passed. Native CI remains the authoritative cross-platform execution check.

## Safety and compatibility

- No required correctness or release suite is deleted.
- Static imports, supported dynamic imports, `pytest_plugins`, deleted helpers, recursive consumers, and cycles are covered; unresolved or ambiguous dependency analysis falls back to the full matrix.
- Planner macOS selectors, suite execution digests, and actual workflow pytest targets have an exact cross-file contract.
- Default local and scheduled workbench mode remains full `stress`; pull requests and merge groups retain real keyboard/IME, geometry, and rearm correctness in bounded `smoke` mode.
- Product assertions, Gateway failures, and `TRUSTED_OVERLAY_*` / `DESKTOP_E2E_*` failures are never retried.
- Nightly health and trusted CI attestation policy remain unchanged and fail-closed.
- No ruleset or merge-queue setting is changed.
- No persisted state, client protocol, runtime behavior, or public interface changes.

## Release note

Not required; CI and test-harness only.

## Third-party origin

None. No third-party code or data added.
