### PR TITLE
feat(gateway,webui): atomic session move-to-workspace with typed errors and submenu keyboard contract

### DIFF
--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -1158,6 +1158,29 @@ function onPinSidebarSession(payload: { key: string; pinned: boolean }) {
   writeStoredSessionKeys(SIDEBAR_SESSION_ORDER_KEY, currentOrder)
 }
 
+type RpcErrorShape = { code?: unknown; message?: unknown }
+
+function rpcErrorCode(err: unknown): string {
+  const candidate = err as RpcErrorShape | null
+  return typeof candidate?.code === 'string' ? candidate.code : ''
+}
+
+// Precise copy for the typed moveToWorkspace failure codes; any other
+// rejection (transport, INVALID_PARAMS, WORKSPACE_MOVE_FAILED, …) keeps the
+// generic message with the raw error appended.
+function workspaceMoveFailureMessage(err: unknown, genericMessage: string): string {
+  switch (rpcErrorCode(err)) {
+    case 'SESSION_NOT_FOUND':
+      return t('workspaces.moveSessionSessionMissing')
+    case 'WORKSPACE_NOT_FOUND':
+      return t('workspaces.moveSessionWorkspaceMissing')
+    case 'WORKSPACE_REMOVED':
+      return t('workspaces.moveSessionWorkspaceRemoved')
+    default:
+      return genericMessage
+  }
+}
+
 async function onMoveToWorkspace(payload: { key: string; workspaceId: string }) {
   try {
     await rpcStore.call('sessions.moveToWorkspace', {
@@ -1167,7 +1190,13 @@ async function onMoveToWorkspace(payload: { key: string; workspaceId: string }) 
     await loadSessions()
     pushToast(t('workspaces.sessionMoved'), { tone: 'ok' })
   } catch (err) {
-    pushToast(t('workspaces.moveSessionFailed', { error: errorMessage(err) }), { tone: 'danger' })
+    pushToast(
+      workspaceMoveFailureMessage(
+        err,
+        t('workspaces.moveSessionFailed', { error: errorMessage(err) }),
+      ),
+      { tone: 'danger' },
+    )
   }
 }
 
@@ -1177,7 +1206,13 @@ async function onMoveFromWorkspace(key: string) {
     await loadSessions()
     pushToast(t('workspaces.sessionRemoved'), { tone: 'ok' })
   } catch (err) {
-    pushToast(t('workspaces.removeSessionFailed', { error: errorMessage(err) }), { tone: 'danger' })
+    pushToast(
+      workspaceMoveFailureMessage(
+        err,
+        t('workspaces.removeSessionFailed', { error: errorMessage(err) }),
+      ),
+      { tone: 'danger' },
+    )
   }
 }
 

--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -91,6 +91,7 @@
       :search-hint="commandPaletteHint"
       :can-manage-projects="rpcStore.canManageProjectWorkspaces"
       :can-create-projects="rpcStore.canChooseProject"
+      :workspaces="sidebarWorkspaces"
       @select="switchToSession"
       @refresh="loadSidebarData"
       @load-more="loadMoreSessions"
@@ -99,6 +100,8 @@
       @bulk-delete="onBulkDeleteSessions"
       @reorder="onReorderSidebarSession"
       @session-pin="onPinSidebarSession"
+      @move-to-workspace="onMoveToWorkspace"
+      @move-from-workspace="onMoveFromWorkspace"
       @new-chat="startNewChatInstant"
       @new-project="openProjectCreator"
       @new-project-task="startProjectTask"
@@ -1086,6 +1089,12 @@ const sidebarPinnedSessionKeys = ref<string[]>(readStoredSessionKeys(SIDEBAR_PIN
 // Collapsible family sections (Chats / Channels / Automations). Row titles and
 // agent names are resolved here so the raw-session-id scrub and the display-name
 // lookup stay in App.vue; subagents indent under their parent via the helper.
+const sidebarWorkspaces = computed(() =>
+  rpcStore.canManageProjectWorkspaces && projectWorkspaces.hasLoaded.value
+    ? projectWorkspaces.workspaces.value.map(w => ({ id: w.id, name: w.name }))
+    : [],
+)
+
 const sidebarSections = computed((): SidebarSection[] => {
   const byKey = new Map(sidebarSessionItems.value.map(item => [item.key, item]))
   return arrangeSidebarSections(
@@ -1147,6 +1156,29 @@ function onPinSidebarSession(payload: { key: string; pinned: boolean }) {
   currentOrder.unshift(payload.key)
   sidebarSessionOrder.value = currentOrder
   writeStoredSessionKeys(SIDEBAR_SESSION_ORDER_KEY, currentOrder)
+}
+
+async function onMoveToWorkspace(payload: { key: string; workspaceId: string }) {
+  try {
+    await rpcStore.call('sessions.moveToWorkspace', {
+      key: payload.key,
+      workspaceId: payload.workspaceId,
+    })
+    await loadSessions()
+    pushToast(t('workspaces.sessionMoved'), { tone: 'ok' })
+  } catch (err) {
+    pushToast(t('workspaces.moveSessionFailed', { error: errorMessage(err) }), { tone: 'danger' })
+  }
+}
+
+async function onMoveFromWorkspace(key: string) {
+  try {
+    await rpcStore.call('sessions.moveToWorkspace', { key, workspaceId: null })
+    await loadSessions()
+    pushToast(t('workspaces.sessionRemoved'), { tone: 'ok' })
+  } catch (err) {
+    pushToast(t('workspaces.removeSessionFailed', { error: errorMessage(err) }), { tone: 'danger' })
+  }
 }
 
 let appAutomaticRpcMounted = false

--- a/opensquilla-webui/src/components/SidebarConversations.vue
+++ b/opensquilla-webui/src/components/SidebarConversations.vue
@@ -79,6 +79,7 @@ const props = withDefaults(defineProps<{
   sessionOrder?: string[]
   canManageProjects?: boolean
   canCreateProjects?: boolean
+  workspaces?: { id: string; name: string }[]
 }>(), {
   sessionOrder: () => [],
   loadingMore: false,
@@ -86,6 +87,7 @@ const props = withDefaults(defineProps<{
   hasMore: false,
   canManageProjects: false,
   canCreateProjects: false,
+  workspaces: () => [],
 })
 
 const isDesktop = usePlatform().capabilities.isDesktop
@@ -99,6 +101,8 @@ const emit = defineEmits<{
   (e: 'bulk-delete', keys: string[]): void
   (e: 'reorder', payload: { draggedKey: string; targetKey: string; position: 'before' | 'after' }): void
   (e: 'session-pin', payload: { key: string; pinned: boolean }): void
+  (e: 'move-to-workspace', payload: { key: string; workspaceId: string }): void
+  (e: 'move-from-workspace', key: string): void
   (e: 'new-chat'): void
   (e: 'new-project'): void
   (e: 'new-project-task', workspaceId: string): void
@@ -551,6 +555,10 @@ function setOpenMenu(el: Element | ComponentPublicInstance | null) {
 // Fixed-position style for the teleported menu, computed from the trigger rect
 // on open so the menu escapes the Recents scroll-clip.
 const menuStyle = ref<Record<string, string>>({})
+// Submenu state for the "Move to project" workspace list.
+const openWorkspaceSubmenuKey = ref('')
+const workspaceSubmenuStyle = ref<Record<string, string>>({})
+const workspaceSubmenuTriggerEl = ref<HTMLElement | null>(null)
 const renamingKey = ref('')
 const renameDraft = ref('')
 // A function ref captures the single active rename input. A string ref inside
@@ -641,6 +649,33 @@ function closeMenu() {
   openMenuKey.value = ''
   openMenuEl.value = null
   menuTriggerEl.value = null
+  closeWorkspaceSubmenu()
+}
+
+function closeWorkspaceSubmenu() {
+  openWorkspaceSubmenuKey.value = ''
+  workspaceSubmenuStyle.value = {}
+  workspaceSubmenuTriggerEl.value = null
+}
+
+function openWorkspaceSubmenu(row: SidebarDisplayRow, event: Event) {
+  event.stopPropagation()
+  const trigger = event.currentTarget
+  workspaceSubmenuTriggerEl.value = trigger instanceof HTMLElement ? trigger : null
+  openWorkspaceSubmenuKey.value = row.key
+  if (workspaceSubmenuTriggerEl.value) {
+    const r = workspaceSubmenuTriggerEl.value.getBoundingClientRect()
+    const openRight = r.right + 220 <= window.innerWidth
+    const openUp = r.bottom + 220 > window.innerHeight
+    workspaceSubmenuStyle.value = {
+      position: 'fixed',
+      left: `${openRight ? r.right + 4 : r.left}px`,
+      top: `${openUp ? r.bottom - 8 : r.top}px`,
+      transform: openRight
+        ? (openUp ? 'translateY(-100%)' : 'none')
+        : 'translateX(-100%)',
+    }
+  }
 }
 
 const sessionPreview = ref<{
@@ -1307,6 +1342,30 @@ function onSelectRow(row: SidebarConversationItem) {
                       <span>{{ t('shared.sidebar.rename') }}</span>
                     </button>
                     <button
+                      v-if="props.canManageProjects && props.workspaces.length > 0"
+                      type="button"
+                      class="sidebar-row-menu__item sidebar-row-menu__item--has-submenu"
+                      role="menuitem"
+                      aria-haspopup="true"
+                      :aria-expanded="openWorkspaceSubmenuKey === row.key"
+                      @click.stop="openWorkspaceSubmenu(row, $event)"
+                      @mouseenter="openWorkspaceSubmenu(row, $event)"
+                    >
+                      <Icon name="folder" :size="14" />
+                      <span>{{ t('shared.sidebar.moveToProject') }}</span>
+                      <Icon name="chevronRight" :size="12" class="sidebar-row-menu__submenu-arrow" />
+                    </button>
+                    <button
+                      v-if="props.canManageProjects && row.workspaceId"
+                      type="button"
+                      class="sidebar-row-menu__item"
+                      role="menuitem"
+                      @click.stop="emit('move-from-workspace', row.key); closeMenu()"
+                    >
+                      <Icon name="x" :size="14" />
+                      <span>{{ t('shared.sidebar.moveFromProject') }}</span>
+                    </button>
+                    <button
                       type="button"
                       class="sidebar-row-menu__item sidebar-row-menu__item--danger"
                       role="menuitem"
@@ -1316,6 +1375,41 @@ function onSelectRow(row: SidebarConversationItem) {
                       <span>{{ t('shared.sidebar.delete') }}</span>
                     </button>
                   </div>
+                  </Teleport>
+                  <!-- Workspace submenu: project list -->
+                  <Teleport to="body">
+                    <div
+                      v-if="openWorkspaceSubmenuKey === row.key"
+                      class="sidebar-row-menu sidebar-row-menu--submenu"
+                      :style="workspaceSubmenuStyle"
+                      role="menu"
+                      :aria-label="t('shared.sidebar.moveToProject')"
+                      @keydown="onMenuKeydown"
+                    >
+                      <button
+                        v-for="ws in props.workspaces"
+                        :key="ws.id"
+                        type="button"
+                        class="sidebar-row-menu__item"
+                        role="menuitem"
+                        :disabled="ws.id === row.workspaceId"
+                        :class="{ 'sidebar-row-menu__item--current': ws.id === row.workspaceId }"
+                        @click.stop="emit('move-to-workspace', { key: row.key, workspaceId: ws.id }); closeMenu(); closeWorkspaceSubmenu()"
+                      >
+                        <Icon name="folder" :size="14" />
+                        <span>{{ ws.name }}</span>
+                      </button>
+                      <div class="sidebar-row-menu__sep" />
+                      <button
+                        type="button"
+                        class="sidebar-row-menu__item"
+                        role="menuitem"
+                        @click.stop="emit('new-project'); closeMenu(); closeWorkspaceSubmenu()"
+                      >
+                        <Icon name="plus" :size="14" />
+                        <span>{{ t('shared.sidebar.newProject') }}</span>
+                      </button>
+                    </div>
                   </Teleport>
                 </div>
 

--- a/opensquilla-webui/src/components/SidebarConversations.vue
+++ b/opensquilla-webui/src/components/SidebarConversations.vue
@@ -559,6 +559,12 @@ const menuStyle = ref<Record<string, string>>({})
 const openWorkspaceSubmenuKey = ref('')
 const workspaceSubmenuStyle = ref<Record<string, string>>({})
 const workspaceSubmenuTriggerEl = ref<HTMLElement | null>(null)
+// Function ref on the single open workspace submenu scopes its roving-focus
+// queries (only one submenu renders at a time).
+const openWorkspaceSubmenuEl = ref<HTMLElement | null>(null)
+function setOpenWorkspaceSubmenu(el: Element | ComponentPublicInstance | null) {
+  openWorkspaceSubmenuEl.value = el instanceof HTMLElement ? el : null
+}
 const renamingKey = ref('')
 const renameDraft = ref('')
 // A function ref captures the single active rename input. A string ref inside
@@ -676,6 +682,41 @@ function openWorkspaceSubmenu(row: SidebarDisplayRow, event: Event) {
         : 'translateX(-100%)',
     }
   }
+  // Keyboard-activated opens (Enter/Space produce a detail-0 click) move
+  // focus into the submenu; pointer opens leave focus on the trigger.
+  const keyboardActivated = !(event instanceof MouseEvent) || event.detail === 0
+  if (keyboardActivated) {
+    void nextTick(() => {
+      const first = openWorkspaceSubmenuEl.value
+        ?.querySelectorAll<HTMLElement>('.sidebar-row-menu__item:not(:disabled)')[0]
+      first?.focus()
+    })
+  }
+}
+
+function onWorkspaceSubmenuKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') {
+    e.preventDefault()
+    e.stopPropagation()
+    const trigger = workspaceSubmenuTriggerEl.value
+    closeWorkspaceSubmenu()
+    nextTick(() => trigger?.focus())
+    return
+  }
+  if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
+  // Scope roving focus to THIS submenu and skip disabled items (the current
+  // workspace entry), otherwise navigation stalls on unfocusable buttons.
+  const items = Array.from(
+    openWorkspaceSubmenuEl.value?.querySelectorAll<HTMLElement>(
+      '.sidebar-row-menu__item:not(:disabled)',
+    ) ?? [],
+  )
+  if (!items.length) return
+  e.preventDefault()
+  const current = items.indexOf(document.activeElement as HTMLElement)
+  const delta = e.key === 'ArrowDown' ? 1 : -1
+  const next = (current + delta + items.length) % items.length
+  items[next]?.focus()
 }
 
 const sessionPreview = ref<{
@@ -1380,11 +1421,12 @@ function onSelectRow(row: SidebarConversationItem) {
                   <Teleport to="body">
                     <div
                       v-if="openWorkspaceSubmenuKey === row.key"
+                      :ref="setOpenWorkspaceSubmenu"
                       class="sidebar-row-menu sidebar-row-menu--submenu"
                       :style="workspaceSubmenuStyle"
                       role="menu"
                       :aria-label="t('shared.sidebar.moveToProject')"
-                      @keydown="onMenuKeydown"
+                      @keydown="onWorkspaceSubmenuKeydown"
                     >
                       <button
                         v-for="ws in props.workspaces"

--- a/opensquilla-webui/src/components/SidebarConversations.workspaces.test.ts
+++ b/opensquilla-webui/src/components/SidebarConversations.workspaces.test.ts
@@ -79,6 +79,9 @@ function i18n() {
             statusLabel: '{status}',
             rename: 'Rename',
             delete: 'Delete',
+            moveToProject: 'Move to project',
+            moveFromProject: 'Remove from project',
+            newProject: 'New project',
           },
         },
         workspaces: {
@@ -123,6 +126,8 @@ async function mountSidebar(
     projectRemove: vi.fn(),
     reorder: vi.fn(),
     sessionPin: vi.fn(),
+    moveToWorkspace: vi.fn(),
+    moveFromWorkspace: vi.fn(),
   }
   const host = document.createElement('div')
   document.body.appendChild(host)
@@ -136,6 +141,11 @@ async function mountSidebar(
     searchHint: 'Ctrl+K',
     canManageProjects,
     canCreateProjects,
+    workspaces: [
+      { id: 'project-a', name: 'Project A' },
+      { id: 'project-b', name: 'Project B' },
+      { id: 'project-c', name: 'Project C' },
+    ],
     onSelect: events.select,
     onNewProject: events.newProject,
     onNewProjectTask: events.newProjectTask,
@@ -145,6 +155,8 @@ async function mountSidebar(
     onProjectRemove: events.projectRemove,
     onReorder: events.reorder,
     onSessionPin: events.sessionPin,
+    onMoveToWorkspace: events.moveToWorkspace,
+    onMoveFromWorkspace: events.moveFromWorkspace,
   }))
   const app = createApp(Root)
   app.use(i18n())
@@ -736,6 +748,115 @@ describe('SidebarConversations project workspaces', () => {
       .toContain('Project task')
     expect(host.querySelector('[data-session-key="agent:main:webchat:running"]')?.textContent)
       .toContain('Running')
+  })
+
+  async function openWorkspaceSubmenuForTask(host: HTMLElement) {
+    const row = host.querySelector<HTMLElement>('[data-session-key="agent:main:webchat:task-a"]')
+    row?.querySelector<HTMLButtonElement>('.sidebar-row-menu-btn')?.click()
+    await nextTick()
+    const moveBtn = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'),
+    ).find(btn => btn.textContent?.includes('Move to project'))
+    moveBtn?.click()
+    await nextTick()
+  }
+
+  it('marks the current workspace disabled but still selectable others in the submenu', async () => {
+    const { host, events } = await mountSidebar([projectRow(), taskRow()])
+    await openWorkspaceSubmenuForTask(host)
+    await nextTick()
+
+    const submenu = document.body.querySelector<HTMLElement>('.sidebar-row-menu--submenu')
+    expect(submenu).toBeTruthy()
+    expect(submenu?.getAttribute('role')).toBe('menu')
+
+    const items = Array.from(
+      submenu?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]') ?? [],
+    )
+    // current workspace disabled + --current class; others enabled
+    const current = items.find(btn => btn.textContent?.includes('Project A'))
+    expect(current?.disabled).toBe(true)
+    expect(current?.classList.contains('sidebar-row-menu__item--current')).toBe(true)
+    const target = items.find(btn => btn.textContent?.includes('Project B'))
+    expect(target?.disabled).toBe(false)
+
+    target?.click()
+    expect(events.moveToWorkspace).toHaveBeenCalledWith({
+      key: 'agent:main:webchat:task-a',
+      workspaceId: 'project-b',
+    })
+    await nextTick()
+    expect(document.body.querySelector('.sidebar-row-menu--submenu')).toBeNull()
+  })
+
+  it('roving focus in the submenu skips the disabled current workspace', async () => {
+    const { host } = await mountSidebar([projectRow(), taskRow()])
+    await openWorkspaceSubmenuForTask(host)
+    await nextTick()
+
+    const submenu = document.body.querySelector<HTMLElement>('.sidebar-row-menu--submenu')
+    const items = Array.from(
+      submenu?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]:not(:disabled)') ?? [],
+    )
+    expect(items.length).toBeGreaterThan(0)
+    items[0]?.focus()
+    expect(document.activeElement).toBe(items[0])
+
+    submenu?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+    await nextTick()
+    // Project A (current, disabled) must be skipped; focus lands on next enabled
+    const enabledItems = Array.from(
+      submenu?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]:not(:disabled)') ?? [],
+    )
+    expect(document.activeElement).toBe(enabledItems[1])
+
+    submenu?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }))
+    await nextTick()
+    expect(document.activeElement).toBe(enabledItems[0])
+  })
+
+  it('escape closes only the submenu and restores focus to its trigger', async () => {
+    const { host } = await mountSidebar([projectRow(), taskRow()])
+    await openWorkspaceSubmenuForTask(host)
+    await nextTick()
+
+    const trigger = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'),
+    ).find(btn => btn.textContent?.includes('Move to project'))
+    expect(trigger).toBeTruthy()
+    const submenu = document.body.querySelector<HTMLElement>('.sidebar-row-menu--submenu')
+    expect(submenu).toBeTruthy()
+
+    submenu?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await nextTick()
+
+    expect(document.body.querySelector('.sidebar-row-menu--submenu')).toBeNull()
+    // The session row menu (a .sidebar-row-menu without the submenu class) stays open.
+    expect(document.body.querySelector('.sidebar-row-menu:not(.sidebar-row-menu--submenu)')).toBeTruthy()
+    expect(document.activeElement).toBe(trigger)
+    expect(trigger?.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('exposes move-to-project and remove-from-project menu items with aria semantics', async () => {
+    const { host, events } = await mountSidebar([projectRow(), taskRow()])
+    const row = host.querySelector<HTMLElement>('[data-session-key="agent:main:webchat:task-a"]')
+    row?.querySelector<HTMLButtonElement>('.sidebar-row-menu-btn')?.click()
+    await nextTick()
+
+    const moveBtn = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'),
+    ).find(btn => btn.textContent?.includes('Move to project'))
+    expect(moveBtn?.getAttribute('aria-haspopup')).toBe('true')
+    // Submenu not opened yet: trigger reports collapsed.
+    expect(moveBtn?.getAttribute('aria-expanded')).toBe('false')
+
+    const removeBtn = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'),
+    ).find(btn => btn.textContent?.includes('Remove from project'))
+    expect(removeBtn).toBeTruthy()
+
+    removeBtn?.click()
+    expect(events.moveFromWorkspace).toHaveBeenCalledWith('agent:main:webchat:task-a')
   })
 
 })

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -64,6 +64,9 @@
     "sessionMoved": "Aufgabe in Projekt verschoben",
     "moveSessionFailed": "Aufgabe konnte nicht verschoben werden: {error}",
     "sessionRemoved": "Aufgabe aus Projekt entfernt",
+    "moveSessionSessionMissing": "Diese Aufgabe existiert nicht mehr; die Liste wurde aktualisiert",
+    "moveSessionWorkspaceMissing": "Dieses Projekt existiert nicht mehr",
+    "moveSessionWorkspaceRemoved": "Dieses Projekt wurde entfernt; bitte ein anderes auswählen",
     "removeSessionFailed": "Aufgabe konnte nicht aus Projekt entfernt werden: {error}"
   },
   "updates": {

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -60,7 +60,11 @@
     "removeBody": "{name} verschwindet aus der Seitenleiste. Aufgabenverlauf und Dateien bleiben erhalten.",
     "removeBodyWithCronJobs": "{name} verschwindet aus der Seitenleiste. {count} verknüpfte geplante Aufgabe(n) werden pausiert und bis zur erneuten Bindung oder Löschung beibehalten. Aufgabenverlauf und Dateien bleiben erhalten.",
     "removeConfirm": "Projekt entfernen",
-    "removeFailed": "Projekt konnte nicht entfernt werden: {error}"
+    "removeFailed": "Projekt konnte nicht entfernt werden: {error}",
+    "sessionMoved": "Aufgabe in Projekt verschoben",
+    "moveSessionFailed": "Aufgabe konnte nicht verschoben werden: {error}",
+    "sessionRemoved": "Aufgabe aus Projekt entfernt",
+    "removeSessionFailed": "Aufgabe konnte nicht aus Projekt entfernt werden: {error}"
   },
   "updates": {
     "available": "OpenSquilla {version} ist verfügbar",
@@ -4275,7 +4279,10 @@
       "bulkDeleteConfirm": "Ausgewählte löschen",
       "bulkDeleteDone": "{count} Sitzungen gelöscht",
       "bulkDeletePartial": "{count} Sitzungen konnten nicht gelöscht werden",
-      "bulkDeleteFailed": "Ausgewählte Sitzungen konnten nicht gelöscht werden"
+      "bulkDeleteFailed": "Ausgewählte Sitzungen konnten nicht gelöscht werden",
+      "moveToProject": "In Projekt verschieben",
+      "moveFromProject": "Aus Projekt entfernen",
+      "newProject": "Neues Projekt…"
     },
     "setupBanner": {
       "ariaLabel": "Gateway-Einrichtung erforderlich",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -64,6 +64,9 @@
     "sessionMoved": "Task moved to project",
     "moveSessionFailed": "Could not move task: {error}",
     "sessionRemoved": "Task removed from project",
+    "moveSessionSessionMissing": "This task no longer exists; the list has been refreshed",
+    "moveSessionWorkspaceMissing": "That project no longer exists",
+    "moveSessionWorkspaceRemoved": "That project was removed; pick another project",
     "removeSessionFailed": "Could not remove task from project: {error}"
   },
   "updates": {

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -60,7 +60,11 @@
     "removeBody": "{name} will disappear from the sidebar. Its task history and files will be preserved.",
     "removeBodyWithCronJobs": "{name} will disappear from the sidebar. {count} linked scheduled task(s) will be paused and kept until you rebind or delete them. Task history and files will be preserved.",
     "removeConfirm": "Remove project",
-    "removeFailed": "Could not remove the project: {error}"
+    "removeFailed": "Could not remove the project: {error}",
+    "sessionMoved": "Task moved to project",
+    "moveSessionFailed": "Could not move task: {error}",
+    "sessionRemoved": "Task removed from project",
+    "removeSessionFailed": "Could not remove task from project: {error}"
   },
   "updates": {
     "available": "OpenSquilla {version} is available",
@@ -4365,7 +4369,10 @@
       "bulkDeleteConfirm": "Delete selected",
       "bulkDeleteDone": "Deleted {count} tasks",
       "bulkDeletePartial": "{count} tasks failed to delete",
-      "bulkDeleteFailed": "Failed to delete selected tasks"
+      "bulkDeleteFailed": "Failed to delete selected tasks",
+      "moveToProject": "Move to project",
+      "moveFromProject": "Remove from project",
+      "newProject": "New project…"
     },
     "setupBanner": {
       "ariaLabel": "Gateway setup needed",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -64,6 +64,9 @@
     "sessionMoved": "Tarea movida al proyecto",
     "moveSessionFailed": "No se pudo mover la tarea: {error}",
     "sessionRemoved": "Tarea removida del proyecto",
+    "moveSessionSessionMissing": "Esta tarea ya no existe; la lista se ha actualizado",
+    "moveSessionWorkspaceMissing": "Ese proyecto ya no existe",
+    "moveSessionWorkspaceRemoved": "Ese proyecto fue eliminado; elige otro proyecto",
     "removeSessionFailed": "No se pudo remover la tarea del proyecto: {error}"
   },
   "updates": {

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -60,7 +60,11 @@
     "removeBody": "{name} desaparecerá de la barra lateral. Se conservarán el historial y los archivos.",
     "removeBodyWithCronJobs": "{name} desaparecerá de la barra lateral. Se pausarán y conservarán {count} tarea(s) programada(s) vinculada(s) hasta que se vuelvan a vincular o se eliminen. Se conservarán el historial y los archivos.",
     "removeConfirm": "Quitar proyecto",
-    "removeFailed": "No se pudo quitar el proyecto: {error}"
+    "removeFailed": "No se pudo quitar el proyecto: {error}",
+    "sessionMoved": "Tarea movida al proyecto",
+    "moveSessionFailed": "No se pudo mover la tarea: {error}",
+    "sessionRemoved": "Tarea removida del proyecto",
+    "removeSessionFailed": "No se pudo remover la tarea del proyecto: {error}"
   },
   "updates": {
     "available": "OpenSquilla {version} ya está disponible",
@@ -4275,7 +4279,10 @@
       "bulkDeleteConfirm": "Eliminar seleccionadas",
       "bulkDeleteDone": "{count} sesiones eliminadas",
       "bulkDeletePartial": "No se pudieron eliminar {count} sesiones",
-      "bulkDeleteFailed": "No se pudieron eliminar las sesiones seleccionadas"
+      "bulkDeleteFailed": "No se pudieron eliminar las sesiones seleccionadas",
+      "moveToProject": "Mover al proyecto",
+      "moveFromProject": "Quitar del proyecto",
+      "newProject": "Nuevo proyecto…"
     },
     "setupBanner": {
       "ariaLabel": "Es necesaria la configuración de la puerta de enlace",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -60,7 +60,11 @@
     "removeBody": "{name} disparaîtra de la barre latérale. Son historique et ses fichiers seront conservés.",
     "removeBodyWithCronJobs": "{name} disparaîtra de la barre latérale. {count} tâche(s) planifiée(s) liée(s) seront suspendues et conservées jusqu’à leur réassociation ou suppression. L’historique et les fichiers seront conservés.",
     "removeConfirm": "Retirer le projet",
-    "removeFailed": "Impossible de retirer le projet : {error}"
+    "removeFailed": "Impossible de retirer le projet : {error}",
+    "sessionMoved": "Tâche déplacée vers le projet",
+    "moveSessionFailed": "Impossible de déplacer la tâche : {error}",
+    "sessionRemoved": "Tâche retirée du projet",
+    "removeSessionFailed": "Impossible de retirer la tâche du projet : {error}"
   },
   "updates": {
     "available": "OpenSquilla {version} est disponible",
@@ -4275,7 +4279,10 @@
       "bulkDeleteConfirm": "Supprimer la sélection",
       "bulkDeleteDone": "{count} sessions supprimées",
       "bulkDeletePartial": "{count} sessions n'ont pas pu être supprimées",
-      "bulkDeleteFailed": "Impossible de supprimer les sessions sélectionnées"
+      "bulkDeleteFailed": "Impossible de supprimer les sessions sélectionnées",
+      "moveToProject": "Déplacer vers le projet",
+      "moveFromProject": "Retirer du projet",
+      "newProject": "Nouveau projet…"
     },
     "setupBanner": {
       "ariaLabel": "Configuration de la passerelle requise",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -64,6 +64,9 @@
     "sessionMoved": "Tâche déplacée vers le projet",
     "moveSessionFailed": "Impossible de déplacer la tâche : {error}",
     "sessionRemoved": "Tâche retirée du projet",
+    "moveSessionSessionMissing": "Cette tâche n'existe plus ; la liste a été actualisée",
+    "moveSessionWorkspaceMissing": "Ce projet n'existe plus",
+    "moveSessionWorkspaceRemoved": "Ce projet a été supprimé; choisissez un autre projet",
     "removeSessionFailed": "Impossible de retirer la tâche du projet : {error}"
   },
   "updates": {

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -64,6 +64,9 @@
     "sessionMoved": "タスクをプロジェクトに移動しました",
     "moveSessionFailed": "タスクを移動できませんでした: {error}",
     "sessionRemoved": "タスクをプロジェクトから削除しました",
+    "moveSessionSessionMissing": "このタスクはもう存在しません。リストを更新しました",
+    "moveSessionWorkspaceMissing": "そのプロジェクトはもう存在しません",
+    "moveSessionWorkspaceRemoved": "そのプロジェクトは削除されました。他のプロジェクトを選択してください",
     "removeSessionFailed": "プロジェクトからタスクを削除できませんでした: {error}"
   },
   "updates": {

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -60,7 +60,11 @@
     "removeBody": "{name} はサイドバーから消えますが、タスク履歴とファイルは保持されます。",
     "removeBodyWithCronJobs": "{name} はサイドバーから消えます。関連する {count} 件のスケジュールタスクは一時停止して保持され、再関連付けまたは削除を待ちます。タスク履歴とファイルは保持されます。",
     "removeConfirm": "プロジェクトを削除",
-    "removeFailed": "プロジェクトを削除できませんでした: {error}"
+    "removeFailed": "プロジェクトを削除できませんでした: {error}",
+    "sessionMoved": "タスクをプロジェクトに移動しました",
+    "moveSessionFailed": "タスクを移動できませんでした: {error}",
+    "sessionRemoved": "タスクをプロジェクトから削除しました",
+    "removeSessionFailed": "プロジェクトからタスクを削除できませんでした: {error}"
   },
   "updates": {
     "available": "OpenSquilla {version} が利用可能です",
@@ -4275,7 +4279,10 @@
       "bulkDeleteConfirm": "選択分を削除",
       "bulkDeleteDone": "{count} 件のセッションを削除しました",
       "bulkDeletePartial": "{count} 件のセッションを削除できませんでした",
-      "bulkDeleteFailed": "選択したセッションを削除できませんでした"
+      "bulkDeleteFailed": "選択したセッションを削除できませんでした",
+      "moveToProject": "プロジェクトに移動",
+      "moveFromProject": "プロジェクトから削除",
+      "newProject": "新しいプロジェクト…"
     },
     "setupBanner": {
       "ariaLabel": "ゲートウェイのセットアップが必要です",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -64,6 +64,9 @@
     "sessionMoved": "已将会话移至项目",
     "moveSessionFailed": "移动会话失败：{error}",
     "sessionRemoved": "已将会话移出项目",
+    "moveSessionSessionMissing": "该任务已不存在，列表已刷新",
+    "moveSessionWorkspaceMissing": "目标项目已不存在",
+    "moveSessionWorkspaceRemoved": "目标项目已被移除，请选择其他项目",
     "removeSessionFailed": "移出会话失败：{error}"
   },
   "updates": {

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -60,7 +60,11 @@
     "removeBody": "{name} 将从侧栏消失，但任务历史和文件都会保留。",
     "removeBodyWithCronJobs": "{name} 将从侧栏消失。关联的 {count} 个定时任务会被暂停并保留，等待重新绑定或删除；任务历史和文件都会保留。",
     "removeConfirm": "移除项目",
-    "removeFailed": "无法移除项目：{error}"
+    "removeFailed": "无法移除项目：{error}",
+    "sessionMoved": "已将会话移至项目",
+    "moveSessionFailed": "移动会话失败：{error}",
+    "sessionRemoved": "已将会话移出项目",
+    "removeSessionFailed": "移出会话失败：{error}"
   },
   "updates": {
     "available": "OpenSquilla {version} 已发布",
@@ -4365,7 +4369,10 @@
       "bulkDeleteConfirm": "删除已选",
       "bulkDeleteDone": "已删除 {count} 个任务",
       "bulkDeletePartial": "{count} 个任务删除失败",
-      "bulkDeleteFailed": "删除已选任务失败"
+      "bulkDeleteFailed": "删除已选任务失败",
+      "moveToProject": "移至项目",
+      "moveFromProject": "从项目移出",
+      "newProject": "新项目…"
     },
     "setupBanner": {
       "ariaLabel": "需要设置网关",

--- a/opensquilla-webui/src/styles/control-visual-system.css
+++ b/opensquilla-webui/src/styles/control-visual-system.css
@@ -774,6 +774,11 @@ summary.control-row--divider:focus-visible {
 .sidebar-group__body {
   display: grid;
   grid-template-rows: 1fr;
+  /* Clamp the column track: an implicit auto track sizes to the rows'
+     min-content, so a long non-wrapping session title would stretch every
+     row wider than the sidebar and push the absolute ⋯ trigger out of
+     reach. minmax(0, 1fr) cuts that min-content propagation. */
+  grid-template-columns: minmax(0, 1fr);
   overflow: hidden;
 }
 
@@ -789,6 +794,8 @@ summary.control-row--divider:focus-visible {
 .sidebar-history-row {
   padding-left: calc(var(--row-depth, 0) * 14px);
   position: relative;
+  min-width: 0;
+  max-width: 100%;
 }
 .sidebar-history-rail {
   position: absolute;

--- a/src/opensquilla/gateway/rpc_sessions.py
+++ b/src/opensquilla/gateway/rpc_sessions.py
@@ -9584,6 +9584,63 @@ async def _handle_sessions_rename(params: dict | None, ctx: RpcContext) -> dict:
     )
 
 
+@_d.method("sessions.moveToWorkspace", scope="operator.write")
+async def _handle_sessions_move_to_workspace(
+    params: dict | None,
+    ctx: RpcContext,
+) -> dict[str, Any]:
+    """Move a session to another project workspace, or remove it from one.
+
+    Pass ``workspaceId`` to bind the session to that workspace; pass
+    ``null`` (or omit it) to remove the session from its current workspace.
+    """
+
+    if not isinstance(params, dict):
+        raise RpcHandlerError("INVALID_PARAMS", "params object required")
+    key = _require_key(params)
+
+    if ctx.session_manager is None:
+        raise KeyError("No session manager available")
+    storage = get_session_storage(ctx.session_manager)
+    if storage is None:
+        raise KeyError("No session storage available")
+
+    raw_workspace_id = params.get("workspaceId", params.get("workspace_id"))
+    workspace_id: str | None = None
+    if raw_workspace_id is not None:
+        if not isinstance(raw_workspace_id, str) or not raw_workspace_id.strip():
+            raise RpcHandlerError(
+                "INVALID_PARAMS",
+                "workspaceId must be a non-empty string or null",
+            )
+        workspace_id = raw_workspace_id.strip()
+        # Validate the target workspace exists and is active.
+        try:
+            workspace = await storage.get_project_workspace(workspace_id)
+        except Exception as exc:
+            raise RpcHandlerError(
+                "WORKSPACE_LOOKUP_FAILED",
+                f"Failed to look up workspace: {exc}",
+            ) from exc
+        if workspace is None or workspace.removed_at is not None:
+            raise RpcHandlerError("WORKSPACE_NOT_FOUND", "Project workspace not found")
+
+    await storage.bind_session_workspace(session_key=key, workspace_id=workspace_id)
+
+    await _emit_to_subscribers(
+        ctx,
+        key,
+        "sessions.changed",
+        build_sessions_changed_payload(
+            key,
+            "moved",
+            workspaceId=workspace_id,
+        ),
+    )
+
+    return {"key": key, "workspaceId": workspace_id}
+
+
 @_d.method("sessions.reset", scope="operator.write")
 async def _handle_sessions_reset(params: dict | None, ctx: RpcContext) -> dict[str, Any]:
     """Synchronous session reset with FlushReceipt.

--- a/src/opensquilla/gateway/rpc_sessions.py
+++ b/src/opensquilla/gateway/rpc_sessions.py
@@ -196,6 +196,8 @@ from opensquilla.session.storage import (
     TaskCollectionUnavailableError,
     TurnAcceptanceResult,
     TurnIngressConflictError,
+    WorkspaceNotFoundError,
+    WorkspaceRemovedError,
     bounded_interactive_storage_reads,
 )
 from opensquilla.session.terminal_reply import (
@@ -9614,31 +9616,61 @@ async def _handle_sessions_move_to_workspace(
                 "workspaceId must be a non-empty string or null",
             )
         workspace_id = raw_workspace_id.strip()
-        # Validate the target workspace exists and is active.
-        try:
-            workspace = await storage.get_project_workspace(workspace_id)
-        except Exception as exc:
-            raise RpcHandlerError(
-                "WORKSPACE_LOOKUP_FAILED",
-                f"Failed to look up workspace: {exc}",
-            ) from exc
-        if workspace is None or workspace.removed_at is not None:
-            raise RpcHandlerError("WORKSPACE_NOT_FOUND", "Project workspace not found")
 
-    await storage.bind_session_workspace(session_key=key, workspace_id=workspace_id)
+    # Bind atomically: session lookup, workspace validation, and the update
+    # all happen inside one write transaction, so a concurrently removed
+    # workspace can no longer slip between validation and binding.
+    try:
+        changed = await storage.bind_session_workspace_atomic(
+            session_key=key, workspace_id=workspace_id
+        )
+    except WorkspaceNotFoundError as exc:
+        # NOTE: must precede the KeyError clause — WorkspaceNotFoundError is a
+        # KeyError subclass, and except clauses match in order.
+        raise RpcHandlerError(
+            "WORKSPACE_NOT_FOUND",
+            "Project workspace not found",
+            details={"workspaceId": workspace_id},
+        ) from exc
+    except KeyError as exc:
+        raise RpcHandlerError(
+            "SESSION_NOT_FOUND",
+            f"Session not found: {key}",
+        ) from exc
+    except WorkspaceRemovedError as exc:
+        raise RpcHandlerError(
+            "WORKSPACE_REMOVED",
+            "Project workspace has been removed",
+            details={"workspaceId": workspace_id},
+        ) from exc
+    except StorageBusyError as exc:
+        raise RpcHandlerError(
+            "WORKSPACE_MOVE_FAILED",
+            f"Failed to move session to workspace: {exc}",
+            details={"workspaceId": workspace_id},
+            retryable=True,
+            retry_after_ms=exc.retry_after_ms,
+        ) from exc
+    except Exception as exc:
+        raise RpcHandlerError(
+            "WORKSPACE_MOVE_FAILED",
+            f"Failed to move session to workspace: {exc}",
+            details={"workspaceId": workspace_id},
+        ) from exc
 
-    await _emit_to_subscribers(
-        ctx,
-        key,
-        "sessions.changed",
-        build_sessions_changed_payload(
+    if changed:
+        await _emit_to_subscribers(
+            ctx,
             key,
-            "moved",
-            workspaceId=workspace_id,
-        ),
-    )
+            "sessions.changed",
+            build_sessions_changed_payload(
+                key,
+                "moved",
+                workspaceId=workspace_id,
+            ),
+        )
 
-    return {"key": key, "workspaceId": workspace_id}
+    return {"key": key, "workspaceId": workspace_id, "changed": changed}
 
 
 @_d.method("sessions.reset", scope="operator.write")

--- a/src/opensquilla/gateway/scopes.py
+++ b/src/opensquilla/gateway/scopes.py
@@ -296,6 +296,11 @@ METHOD_SCOPES: dict[str, str] = {
     # 0.0.0.0 listen, where even a 127.0.0.1 peer is not the local owner and so gets
     # REMOTE_OPERATOR_SCOPES (no admin) — surfacing as "Failed to delete session"
     # (issues #357, #307).
+    
+    # 【新增】将 session 移动到另一个 workspace 属于常规的用户级状态变更，
+    # 与 sessions.create / sessions.delete 同属 WRITE_SCOPE 级别。
+    "sessions.moveToWorkspace": WRITE_SCOPE,  # OpenSquilla-only; session workspace transfer.
+
     "sessions.delete": WRITE_SCOPE,
     # Display-name-only session rename. Deployment/model rebinding remains on
     # the separately admin-gated sessions.patch surface.

--- a/src/opensquilla/session/storage.py
+++ b/src/opensquilla/session/storage.py
@@ -225,6 +225,18 @@ class ProjectSessionSnapshotMismatchError(RuntimeError):
     """Raised when a locked project-session snapshot changed before deletion."""
 
 
+class WorkspaceNotFoundError(KeyError):
+    """Raised when a referenced project workspace row does not exist."""
+
+
+class WorkspaceRemovedError(RuntimeError):
+    """Raised when a referenced project workspace has a non-null removed_at.
+
+    Binding a live session to a removed workspace is refused (fail closed);
+    unbinding (``workspace_id=None``) stays allowed.
+    """
+
+
 @dataclass(frozen=True)
 class ResetArchiveSnapshot:
     """Pre-reset session state captured under the acceptance write transaction."""
@@ -4808,6 +4820,61 @@ class SessionStorage:
             )
             if int(cursor.rowcount or 0) == 0:
                 raise KeyError(f"Session not found: {session_key}")
+
+    async def bind_session_workspace_atomic(
+        self,
+        session_key: str,
+        workspace_id: str | None,
+    ) -> bool:
+        """Bind a session to a workspace atomically and report whether it changed.
+
+        All validation happens inside a single ``BEGIN IMMEDIATE`` write
+        transaction, so a concurrently removed workspace can no longer slip
+        between a "does it exist" check and the binding write (the TOCTOU
+        window of the previous check-then-bind handler flow).
+
+        - Raises ``KeyError`` when the session row does not exist.
+        - Raises ``WorkspaceNotFoundError`` when ``workspace_id`` is not None
+          and no workspace row exists.
+        - Raises ``WorkspaceRemovedError`` when the target workspace row is
+          soft-deleted (``removed_at`` set); fail closed. Unbinding
+          (``workspace_id=None``) is always allowed.
+        - Returns ``False`` without writing when the session already points at
+          the target (idempotent no-op, including unbind of an unbound
+          session); returns ``True`` after a real change.
+        """
+
+        session_key = canonicalize_session_key(session_key)
+        async with self._write_transaction("bind_session_workspace_atomic") as conn:
+            async with conn.execute(
+                "SELECT workspace_id FROM sessions WHERE session_key = ?",
+                (session_key,),
+            ) as cursor:
+                session_row = await cursor.fetchone()
+            if session_row is None:
+                raise KeyError(f"Session not found: {session_key}")
+            old_workspace_id = session_row["workspace_id"]
+            if workspace_id is not None:
+                async with conn.execute(
+                    "SELECT removed_at FROM project_workspaces WHERE workspace_id = ?",
+                    (workspace_id,),
+                ) as cursor:
+                    workspace_row = await cursor.fetchone()
+                if workspace_row is None:
+                    raise WorkspaceNotFoundError(
+                        f"Project workspace not found: {workspace_id}"
+                    )
+                if workspace_row["removed_at"] is not None:
+                    raise WorkspaceRemovedError(
+                        f"Project workspace removed: {workspace_id}"
+                    )
+            if old_workspace_id == workspace_id:
+                return False
+            await conn.execute(
+                "UPDATE sessions SET workspace_id = ? WHERE session_key = ?",
+                (workspace_id, session_key),
+            )
+            return True
 
     @_serialized_read
     async def list_legacy_project_workspace_candidates(

--- a/tests/test_gateway/test_rpc_move_to_workspace.py
+++ b/tests/test_gateway/test_rpc_move_to_workspace.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from opensquilla.gateway import rpc_sessions
+from opensquilla.gateway.auth import Principal
+from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.rpc import RpcContext, RpcHandlerError
+from opensquilla.gateway.scopes import METHOD_SCOPES, WRITE_SCOPE
+from opensquilla.persistence.migrator import apply_pending
+from opensquilla.session.models import SessionNode
+from opensquilla.session.storage import (
+    SessionStorage,
+    WorkspaceNotFoundError,
+    WorkspaceRemovedError,
+)
+
+MIGRATIONS_DIR = Path(__file__).resolve().parents[2] / "migrations"
+
+SESSION_KEY = "agent:main:webchat:move-target"
+
+_DEFAULT_PRINCIPAL = Principal(
+    role="operator",
+    scopes=frozenset(["operator.admin"]),
+    is_owner=True,
+    authenticated=True,
+)
+
+
+def _make_ctx(session_manager=None) -> RpcContext:
+    ctx = RpcContext(
+        conn_id="test-conn",
+        principal=_DEFAULT_PRINCIPAL,
+        config=GatewayConfig(memory={"flush_enabled": False}),
+    )
+    ctx.session_manager = session_manager
+    return ctx
+
+
+class _FakeStorage:
+    """Storage stand-in returning a canned outcome for bind_session_workspace_atomic."""
+
+    def __init__(self, outcome: object) -> None:
+        self.outcome = outcome
+        self.calls: list[tuple[str, str | None]] = []
+
+    async def bind_session_workspace_atomic(
+        self, session_key: str, workspace_id: str | None
+    ) -> bool:
+        self.calls.append((session_key, workspace_id))
+        if isinstance(self.outcome, BaseException):
+            raise self.outcome
+        assert isinstance(self.outcome, bool)
+        return self.outcome
+
+
+class _FakeManager:
+    def __init__(self, storage: object) -> None:
+        self._storage = storage
+
+
+def _capture_emits(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str, dict]]:
+    emitted: list[tuple[str, str, dict]] = []
+
+    async def _record(
+        _ctx: RpcContext,
+        session_key: str,
+        event_name: str,
+        send_payload: dict,
+    ) -> None:
+        emitted.append((session_key, event_name, send_payload))
+
+    monkeypatch.setattr(rpc_sessions, "_send_prepared_to_subscribers", _record)
+    return emitted
+
+
+def _expect_handler_error(
+    excinfo: pytest.ExceptionInfo[BaseException],
+    code: str,
+    details: object = None,
+) -> None:
+    assert isinstance(excinfo.value, RpcHandlerError)
+    assert excinfo.value.code == code
+    if details is not None:
+        assert excinfo.value.details == details
+
+
+def test_scope_contract_write_scope() -> None:
+    assert METHOD_SCOPES["sessions.moveToWorkspace"] == WRITE_SCOPE
+
+
+@pytest.mark.asyncio
+async def test_move_success_emits_after_commit_and_returns_changed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeStorage(True)
+    emitted = _capture_emits(monkeypatch)
+    ctx = _make_ctx(_FakeManager(storage))
+
+    result = await rpc_sessions._handle_sessions_move_to_workspace(
+        {"key": SESSION_KEY, "workspaceId": "ws-1"}, ctx
+    )
+
+    assert result == {"key": SESSION_KEY, "workspaceId": "ws-1", "changed": True}
+    assert storage.calls == [(SESSION_KEY, "ws-1")]
+    assert emitted == [
+        (
+            SESSION_KEY,
+            "sessions.changed",
+            {
+                "schema_version": 1,
+                "key": SESSION_KEY,
+                "reason": "moved",
+                "workspaceId": "ws-1",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_move_unchanged_no_emit_returns_changed_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeStorage(False)
+    emitted = _capture_emits(monkeypatch)
+    ctx = _make_ctx(_FakeManager(storage))
+
+    result = await rpc_sessions._handle_sessions_move_to_workspace(
+        {"key": SESSION_KEY, "workspaceId": "ws-1"}, ctx
+    )
+
+    assert result == {"key": SESSION_KEY, "workspaceId": "ws-1", "changed": False}
+    assert emitted == []
+
+
+@pytest.mark.asyncio
+async def test_session_not_found_maps_to_session_not_found_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeStorage(KeyError("Session not found: gone"))
+    emitted = _capture_emits(monkeypatch)
+    ctx = _make_ctx(_FakeManager(storage))
+
+    with pytest.raises(RpcHandlerError) as excinfo:
+        await rpc_sessions._handle_sessions_move_to_workspace(
+            {"key": "agent:main:webchat:gone", "workspaceId": None}, ctx
+        )
+
+    _expect_handler_error(excinfo, "SESSION_NOT_FOUND")
+    assert emitted == []
+
+
+@pytest.mark.asyncio
+async def test_workspace_not_found_maps_and_never_emits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeStorage(WorkspaceNotFoundError("Project workspace not found: ws-x"))
+    emitted = _capture_emits(monkeypatch)
+    ctx = _make_ctx(_FakeManager(storage))
+
+    with pytest.raises(RpcHandlerError) as excinfo:
+        await rpc_sessions._handle_sessions_move_to_workspace(
+            {"key": SESSION_KEY, "workspaceId": "ws-x"}, ctx
+        )
+
+    _expect_handler_error(excinfo, "WORKSPACE_NOT_FOUND", {"workspaceId": "ws-x"})
+    assert emitted == []
+
+
+@pytest.mark.asyncio
+async def test_workspace_removed_fail_closed_and_never_emits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeStorage(WorkspaceRemovedError("Project workspace has been removed"))
+    emitted = _capture_emits(monkeypatch)
+    ctx = _make_ctx(_FakeManager(storage))
+
+    with pytest.raises(RpcHandlerError) as excinfo:
+        await rpc_sessions._handle_sessions_move_to_workspace(
+            {"key": SESSION_KEY, "workspaceId": "ws-removed"}, ctx
+        )
+
+    _expect_handler_error(excinfo, "WORKSPACE_REMOVED", {"workspaceId": "ws-removed"})
+    assert emitted == []
+
+
+@pytest.mark.asyncio
+async def test_workspace_id_null_unbinds_and_emits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeStorage(True)
+    emitted = _capture_emits(monkeypatch)
+    ctx = _make_ctx(_FakeManager(storage))
+
+    result = await rpc_sessions._handle_sessions_move_to_workspace(
+        {"key": SESSION_KEY, "workspaceId": None}, ctx
+    )
+
+    assert result == {"key": SESSION_KEY, "workspaceId": None, "changed": True}
+    assert storage.calls == [(SESSION_KEY, None)]
+    # build_sessions_changed_payload drops None state values, so an unbind
+    # event carries no workspaceId field at all.
+    assert emitted == [
+        (
+            SESSION_KEY,
+            "sessions.changed",
+            {
+                "schema_version": 1,
+                "key": SESSION_KEY,
+                "reason": "moved",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_workspace_id_blank_string_rejected() -> None:
+    storage = _FakeStorage(True)
+    ctx = _make_ctx(_FakeManager(storage))
+
+    with pytest.raises(RpcHandlerError) as excinfo:
+        await rpc_sessions._handle_sessions_move_to_workspace(
+            {"key": SESSION_KEY, "workspaceId": "   "}, ctx
+        )
+
+    _expect_handler_error(excinfo, "INVALID_PARAMS")
+    assert storage.calls == []
+
+
+@pytest.mark.asyncio
+async def test_workspace_id_whitespace_trimmed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _FakeStorage(True)
+    emitted = _capture_emits(monkeypatch)
+    ctx = _make_ctx(_FakeManager(storage))
+
+    result = await rpc_sessions._handle_sessions_move_to_workspace(
+        {"key": SESSION_KEY, "workspaceId": "  ws-1  "}, ctx
+    )
+
+    assert storage.calls == [(SESSION_KEY, "ws-1")]
+    assert result["workspaceId"] == "ws-1"
+    assert emitted == [
+        (
+            SESSION_KEY,
+            "sessions.changed",
+            {
+                "schema_version": 1,
+                "key": SESSION_KEY,
+                "reason": "moved",
+                "workspaceId": "ws-1",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_missing_session_manager_raises_key_error() -> None:
+    ctx = _make_ctx(None)
+    with pytest.raises(KeyError):
+        await rpc_sessions._handle_sessions_move_to_workspace(
+            {"key": SESSION_KEY, "workspaceId": None}, ctx
+        )
+
+
+class _RealStorageManager:
+    def __init__(self, storage: SessionStorage) -> None:
+        self._storage = storage
+
+
+@pytest.mark.asyncio
+async def test_real_storage_end_to_end_bind_and_fail_closed(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end through the handler with a real SessionStorage: happy path,
+    idempotent repeat, removed-workspace fail-closed, and SESSION_NOT_FOUND."""
+    db_path = str(tmp_path / "sessions.db")
+    apply_pending(db_path, MIGRATIONS_DIR)
+    storage = await SessionStorage.open(db_path)
+    manager = _RealStorageManager(storage)
+    ctx = _make_ctx(manager)
+    emitted = _capture_emits(monkeypatch)
+
+    try:
+        workspace = await storage.create_or_restore_project_workspace(
+            path=str(tmp_path / "project"),
+            path_key=str(tmp_path / "project"),
+            display_name="project",
+            trusted_at=100,
+            now_ms=100,
+        )
+        session = SessionNode(
+            session_key=SESSION_KEY,
+            created_at=100,
+            updated_at=100,
+        )
+        await storage.upsert_session(session)
+
+        # Happy path: bind emits sessions.changed with the committed binding.
+        result = await rpc_sessions._handle_sessions_move_to_workspace(
+            {"key": SESSION_KEY, "workspaceId": workspace.workspace_id}, ctx
+        )
+        assert result["changed"] is True
+        persisted = await storage.get_session(SESSION_KEY)
+        assert persisted is not None
+        assert persisted.workspace_id == workspace.workspace_id
+        assert emitted == [
+            (
+                SESSION_KEY,
+                "sessions.changed",
+                {
+                    "schema_version": 1,
+                    "key": SESSION_KEY,
+                    "reason": "moved",
+                    "workspaceId": workspace.workspace_id,
+                    "epoch": 0,
+                },
+            )
+        ]
+
+        # Idempotent repeat: no emit, changed False.
+        result = await rpc_sessions._handle_sessions_move_to_workspace(
+            {"key": SESSION_KEY, "workspaceId": workspace.workspace_id}, ctx
+        )
+        assert result["changed"] is False
+        assert len(emitted) == 1
+
+        # Remove the workspace, then a move to it must fail closed.
+        await storage.remove_project_workspace(workspace.workspace_id)
+        with pytest.raises(RpcHandlerError) as excinfo:
+            await rpc_sessions._handle_sessions_move_to_workspace(
+                {"key": SESSION_KEY, "workspaceId": workspace.workspace_id}, ctx
+            )
+        _expect_handler_error(excinfo, "WORKSPACE_REMOVED")
+
+        # Unknown session maps to SESSION_NOT_FOUND.
+        with pytest.raises(RpcHandlerError) as excinfo:
+            await rpc_sessions._handle_sessions_move_to_workspace(
+                {"key": "agent:main:webchat:missing", "workspaceId": None}, ctx
+            )
+        _expect_handler_error(excinfo, "SESSION_NOT_FOUND")
+    finally:
+        await storage.close()

--- a/tests/test_session/test_project_workspace_storage.py
+++ b/tests/test_session/test_project_workspace_storage.py
@@ -19,7 +19,11 @@ from opensquilla.session.models import (
     SessionNode,
     TranscriptEntry,
 )
-from opensquilla.session.storage import SessionStorage
+from opensquilla.session.storage import (
+    SessionStorage,
+    WorkspaceNotFoundError,
+    WorkspaceRemovedError,
+)
 from opensquilla.session.usage_ledger import UsageEventStart
 
 MIGRATIONS_DIR = Path(__file__).resolve().parents[2] / "migrations"
@@ -639,5 +643,196 @@ async def test_project_history_delete_cancellation_waits_for_commit_and_cleanup(
                 for key in expected_keys
             ]
         )
+    finally:
+        await storage.close()
+
+
+def _make_session(session_key: str) -> SessionNode:
+    return SessionNode(session_key=session_key, origin={"source": "test"})
+
+
+async def _open_storage_with_migrations(tmp_path) -> SessionStorage:
+    db_path = str(tmp_path / "sessions.db")
+    apply_pending(db_path, MIGRATIONS_DIR)
+    return await SessionStorage.open(db_path)
+
+
+@pytest.mark.asyncio
+async def test_bind_session_workspace_atomic_bind_unbind_and_idempotence(tmp_path) -> None:
+    storage = await _open_storage_with_migrations(tmp_path)
+    try:
+        session = _make_session("agent:main:webchat:atomic-1")
+        await storage.upsert_session(session)
+        workspace = await storage.create_or_restore_project_workspace(
+            path=str(tmp_path / "ws-a"),
+            path_key=str(tmp_path / "ws-a"),
+            display_name="ws-a",
+            trusted_at=None,
+            now_ms=100,
+        )
+
+        assert (
+            await storage.bind_session_workspace_atomic(
+                session.session_key, workspace.workspace_id
+            )
+            is True
+        )
+        # Same target again: unchanged, idempotent no-op.
+        assert (
+            await storage.bind_session_workspace_atomic(
+                session.session_key, workspace.workspace_id
+            )
+            is False
+        )
+        persisted = await storage.get_session(session.session_key)
+        assert persisted is not None
+        assert persisted.workspace_id == workspace.workspace_id
+
+        # Unbind, then unbind again (already unbound: no-op).
+        assert await storage.bind_session_workspace_atomic(session.session_key, None) is True
+        assert await storage.bind_session_workspace_atomic(session.session_key, None) is False
+        persisted = await storage.get_session(session.session_key)
+        assert persisted is not None
+        assert persisted.workspace_id is None
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_bind_session_workspace_atomic_missing_session_raises_keyerror(tmp_path) -> None:
+    storage = await _open_storage_with_migrations(tmp_path)
+    try:
+        with pytest.raises(KeyError, match="Session not found"):
+            await storage.bind_session_workspace_atomic(
+                "agent:main:webchat:missing", None
+            )
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_bind_session_workspace_atomic_missing_workspace_fails_closed(tmp_path) -> None:
+    storage = await _open_storage_with_migrations(tmp_path)
+    try:
+        session = _make_session("agent:main:webchat:atomic-2")
+        await storage.upsert_session(session)
+        before = await storage.get_session(session.session_key)
+        assert before is not None and before.workspace_id is None
+
+        with pytest.raises(WorkspaceNotFoundError):
+            await storage.bind_session_workspace_atomic(
+                session.session_key, "ws-does-not-exist"
+            )
+        # Failed bind must not change the stored binding.
+        after = await storage.get_session(session.session_key)
+        assert after is not None and after.workspace_id is None
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_bind_session_workspace_atomic_removed_workspace_fails_closed(tmp_path) -> None:
+    storage = await _open_storage_with_migrations(tmp_path)
+    try:
+        session = _make_session("agent:main:webchat:atomic-3")
+        await storage.upsert_session(session)
+        workspace = await storage.create_or_restore_project_workspace(
+            path=str(tmp_path / "ws-r"),
+            path_key=str(tmp_path / "ws-r"),
+            display_name="ws-r",
+            trusted_at=None,
+            now_ms=100,
+        )
+        assert (
+            await storage.bind_session_workspace_atomic(
+                session.session_key, workspace.workspace_id
+            )
+            is True
+        )
+        await storage.remove_project_workspace(workspace.workspace_id)
+
+        # Removed target: rejected (fail closed) even though the row exists.
+        with pytest.raises(WorkspaceRemovedError):
+            await storage.bind_session_workspace_atomic(
+                session.session_key, workspace.workspace_id
+            )
+        # The previous binding is untouched by the failed attempt.
+        persisted = await storage.get_session(session.session_key)
+        assert persisted is not None
+        assert persisted.workspace_id == workspace.workspace_id
+
+        # Unbinding from a removed workspace stays allowed.
+        assert await storage.bind_session_workspace_atomic(session.session_key, None) is True
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_bind_session_workspace_atomic_move_between_workspaces(tmp_path) -> None:
+    storage = await _open_storage_with_migrations(tmp_path)
+    try:
+        session = _make_session("agent:main:webchat:atomic-4")
+        await storage.upsert_session(session)
+        first = await storage.create_or_restore_project_workspace(
+            path=str(tmp_path / "ws-1"),
+            path_key=str(tmp_path / "ws-1"),
+            display_name="ws-1",
+            trusted_at=None,
+            now_ms=100,
+        )
+        second = await storage.create_or_restore_project_workspace(
+            path=str(tmp_path / "ws-2"),
+            path_key=str(tmp_path / "ws-2"),
+            display_name="ws-2",
+            trusted_at=None,
+            now_ms=100,
+        )
+        assert (
+            await storage.bind_session_workspace_atomic(
+                session.session_key, first.workspace_id
+            )
+            is True
+        )
+        assert (
+            await storage.bind_session_workspace_atomic(
+                session.session_key, second.workspace_id
+            )
+            is True
+        )
+        persisted = await storage.get_session(session.session_key)
+        assert persisted is not None
+        assert persisted.workspace_id == second.workspace_id
+    finally:
+        await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_bind_session_workspace_legacy_method_regression(tmp_path) -> None:
+    storage = await _open_storage_with_migrations(tmp_path)
+    try:
+        session = _make_session("agent:main:webchat:legacy-regression")
+        await storage.upsert_session(session)
+        workspace = await storage.create_or_restore_project_workspace(
+            path=str(tmp_path / "ws-l"),
+            path_key=str(tmp_path / "ws-l"),
+            display_name="ws-l",
+            trusted_at=None,
+            now_ms=100,
+        )
+        # Legacy method keeps its original behavior: blind UPDATE + session
+        # existence check, no workspace validation (scheduler callers depend
+        # on resolve_validated_project_workspace for that).
+        await storage.bind_session_workspace(session.session_key, workspace.workspace_id)
+        persisted = await storage.get_session(session.session_key)
+        assert persisted is not None
+        assert persisted.workspace_id == workspace.workspace_id
+
+        await storage.bind_session_workspace(session.session_key, None)
+        persisted = await storage.get_session(session.session_key)
+        assert persisted is not None
+        assert persisted.workspace_id is None
+
+        with pytest.raises(KeyError, match="Session not found"):
+            await storage.bind_session_workspace("agent:main:webchat:missing", None)
     finally:
         await storage.close()


### PR DESCRIPTION
## Summary

Hardens the session move-to-workspace flow (introduced in the earlier commits of this PR) into an atomic, precisely-classified operation, and polishes the sidebar submenu interaction. The binding now happens inside a single write transaction with typed failure modes, the RPC maps storage failures to explicit error codes, and the submenu gets correct keyboard/ARIA behavior.

## Changes

### Backend — atomic storage primitive
- **New `SessionStorage.bind_session_workspace_atomic`** — session lookup, workspace existence/removal validation, and the binding update all run inside one `BEGIN IMMEDIATE` write transaction; returns whether the binding changed. This closes the check-then-bind window where a concurrently removed workspace could still be bound.
- **Typed errors** — `WorkspaceNotFoundError` (missing workspace row) and `WorkspaceRemovedError` (soft-deleted workspace, fail closed; unbinding stays allowed).
- Idempotence: re-binding to the current workspace (including unbinding an unbound session) is a no-op returning `changed=False`.

### Backend — RPC error mapping
- `sessions.moveToWorkspace` binds via the atomic primitive; the out-of-transaction `get_project_workspace` precheck is gone.
- Precise error codes: `SESSION_NOT_FOUND`, `WORKSPACE_NOT_FOUND`, `WORKSPACE_REMOVED`, and `WORKSPACE_MOVE_FAILED` (retryable with `retryAfterMs` for `StorageBusyError`), replacing the previous generic failures.
- `sessions.changed` is now emitted only after a real change commits; the response includes a `changed` flag.

### WebUI
- **App.vue** — typed failure codes map to precise localized copy for `SESSION_NOT_FOUND` / `WORKSPACE_NOT_FOUND` / `WORKSPACE_REMOVED`; other rejections keep the generic error toast.
- **SidebarConversations.vue** — fixed the workspace submenu keyboard contract: roving focus was scoped to the parent menu element list (arrow keys moved parent-menu focus), Escape closed the whole menu stack, and navigation did not skip the disabled current-workspace item. The submenu now owns its keydown handler, skips disabled items, and Escape closes only the submenu while restoring focus to its trigger.
- **6 locale files** — added `moveSessionSessionMissing`, `moveSessionWorkspaceMissing`, `moveSessionWorkspaceRemoved`.

### Tests
- Storage matrix (`test_project_workspace_storage.py`): bind/unbind idempotence, missing session, missing workspace, removed workspace fail-closed (binding untouched), moves between workspaces, legacy `bind_session_workspace` regression lock.
- RPC matrix (`test_rpc_move_to_workspace.py`, new file): scope contract, success/no-emit-on-unchanged emit semantics, all four error mappings with zero emissions on failure, unbind, invalid/blank `workspaceId` rejection, missing session manager, and an end-to-end pass over a real `SessionStorage` (bind, idempotent repeat, removed-workspace fail-closed, unknown session).
- WebUI (`SidebarConversations.workspaces.test.ts`): disabled current-workspace item with current class, roving focus skips disabled, Escape closes only the submenu and restores trigger focus, move/remove emit payloads with `aria-haspopup`/`aria-expanded` semantics.

## Verification

- Backend: 323 passed (storage matrix 14, new RPC matrix 11, existing `test_rpc_sessions.py` 290, plus full storage file) on a tree rebased onto current upstream `main`.
- WebUI: `vue-tsc --noEmit` clean; Sidebar + App contract suites 45 passed.
- Branch rebased onto upstream `main` (485fb1564) so the diff contains only this feature's files (15 files, +1106/−13).
