### PR TITLE
fix: stop counting packaged routing defaults as profile references

### DIFF
--- a/src/opensquilla/onboarding/mutations.py
+++ b/src/opensquilla/onboarding/mutations.py
@@ -2586,13 +2586,23 @@ def _llm_profile_storage_keys(
 
 
 def _profile_reference_labels(config: GatewayConfig, provider_id: str) -> list[str]:
-    """Return stable, non-secret config paths that reference a provider profile."""
+    """Return stable, non-secret config paths that reference a provider profile.
+
+    Only operator-owned configuration counts. ``squilla_router.tiers`` and the
+    legacy ``llm_ensemble.selection_mode`` carry packaged openrouter-preset
+    defaults that are never persisted and regenerate on every load, so they
+    cannot dangle after the profile is removed — treating them as references
+    made a freshly added openrouter profile impossible to delete (#1297).
+    """
     provider = str(provider_id or "").strip().lower()
     references: list[str] = []
+    default_tiers = _default_tiers()
     tiers = getattr(getattr(config, "squilla_router", None), "tiers", {}) or {}
     if isinstance(tiers, Mapping):
         for tier_name, tier in tiers.items():
             if not isinstance(tier, Mapping):
+                continue
+            if tier == default_tiers.get(tier_name):
                 continue
             tier_provider = str(tier.get("provider") or "").strip().lower()
             if tier_provider == provider:
@@ -2607,7 +2617,7 @@ def _profile_reference_labels(config: GatewayConfig, provider_id: str) -> list[s
 
         selection_mode = str(getattr(ensemble, "selection_mode", "") or "")
         static_provider = STATIC_B5_SELECTION_MODE_PROVIDERS.get(selection_mode, "")
-        if static_provider == provider:
+        if static_provider == provider and ensemble_selection_configured(config):
             references.append("llm_ensemble.selection_mode")
     return references
 

--- a/tests/test_onboarding/test_llm_profiles.py
+++ b/tests/test_onboarding/test_llm_profiles.py
@@ -289,6 +289,55 @@ def test_profile_remove_rejects_disabled_static_ensemble_reference() -> None:
         remove_llm_profile(cfg, provider_id="openrouter")
 
 
+def test_profile_remove_allows_untouched_packaged_defaults() -> None:
+    """A profile blocked only by packaged preset defaults is removable (#1297).
+
+    With a non-openrouter primary, an untouched router still materializes the
+    packaged openrouter tier preset, and the legacy static selection_mode
+    default — neither is persisted, so neither can dangle after removal.
+    """
+    cfg = GatewayConfig(
+        llm={"provider": "tokenrhythm", "api_key": "k"},
+        llm_profiles={"openrouter": {"api_key_env": "OPENROUTER_PROFILE_KEY"}},
+        squilla_router={"preset_binding": "follow_primary", "enabled": False},
+    )
+    assert cfg.squilla_router.tiers["c0"].get("provider") == "openrouter"
+    assert cfg.llm_ensemble.selection_mode == "static_openrouter_b5"
+
+    result = remove_llm_profile(cfg, provider_id="openrouter")
+
+    assert "openrouter" not in result.config.llm_profiles
+    assert result.public_payload == {"provider": "openrouter", "removed": True}
+
+
+def test_profile_remove_counts_customized_preset_tier() -> None:
+    """A tier the operator edited away from the packaged preset stays a reference."""
+    cfg = GatewayConfig(
+        llm={"provider": "tokenrhythm", "api_key": "k"},
+        llm_profiles={"openrouter": {"api_key_env": "OPENROUTER_PROFILE_KEY"}},
+        squilla_router={"preset_binding": "follow_primary", "enabled": False},
+    )
+    cfg.squilla_router.tiers["c0"] = {
+        "provider": "openrouter",
+        "model": "operator-chosen-model",
+    }
+
+    with pytest.raises(ValueError, match=r"squilla_router\.tiers\.c0"):
+        remove_llm_profile(cfg, provider_id="openrouter")
+
+
+def test_profile_remove_ignores_unconfigured_default_selection_mode() -> None:
+    """The dormant stored mode never governs routing until it is configured."""
+    cfg = GatewayConfig(
+        llm_profiles={"openrouter": {"api_key_env": "OPENROUTER_PROFILE_KEY"}},
+        llm_ensemble={"enabled": True},
+    )
+
+    result = remove_llm_profile(cfg, provider_id="openrouter")
+
+    assert "openrouter" not in result.config.llm_profiles
+
+
 def test_profile_remove_unused_entry() -> None:
     cfg = GatewayConfig(llm_profiles={"openai": {"api_key_env": "OPENAI_PROFILE_KEY"}})
 


### PR DESCRIPTION
## Scope

Fixes #1297. A provider profile could never be deleted when its only "references" were factory defaults: every config load materializes the packaged openrouter router-tier preset (`squilla_router.tiers.c0–c3`, `image_model`) and the dormant legacy `llm_ensemble.selection_mode` static default, and `remove_llm_profile` treated those values as operator references — so the remove RPC always answered `still referenced by: squilla_router.tiers.c0…c3, squilla_router.tiers.image_model, llm_ensemble.selection_mode` for an openrouter profile, regardless of whether routing or the ensemble was ever enabled or configured.

Those defaults are never persisted and regenerate on every load, so removing a profile cannot dangle them. `_profile_reference_labels` now counts only operator-owned configuration:

- a router tier counts when its content differs from the packaged preset entry for that tier
- `selection_mode` counts when `ensemble_selection_configured` reports it as operator-owned (explicitly persisted, force-persisted, or env-overlaid)

Explicit references — including a disabled ensemble's explicitly set static mode, and explicitly customized tiers — are still rejected exactly as before, preserving the regression boundary pinned by the existing tests.

- Target branch: `main`
- Linked issue: Fixes #1297
- Release note: Not added (small settings-correctness fix)

## Verification

- `uv run pytest tests/test_onboarding/test_llm_profiles.py -q` — 46 passed, including 4 new regression tests:
  - untouched packaged defaults no longer block removal (mirrors the issue: non-openrouter primary, verification-failed openrouter profile)
  - an operator-customized preset tier still blocks removal
  - an unconfigured default selection_mode does not block removal
  - the pre-existing explicit-reference rejections still hold
- `uv run pytest tests/test_onboarding/ -q` — 980 passed; the 2 failures are pre-existing Windows symlink/developer-mode environment failures that reproduce identically on pristine `upstream/main`
- `uv run ruff check` / `uv run mypy` on the changed files — passed
- `npm --prefix opensquilla-webui run build` and `uv build --wheel` — passed
- End-to-end in the Web UI against a live gateway: added an OpenRouter profile with an invalid key (state "上次验证失败", exactly the issue's precondition), clicked delete, confirmed — before the fix the entry stayed with a `still referenced by` error; after the fix the entry is removed, the success toast shows, and `config.toml` no longer contains the profile while the primary provider and routing settings remain untouched

## Safety and compatibility

No schema, protocol, or persistence changes. Removal stays fail-closed for every explicitly configured reference; only values that cannot exist in a persisted config stop counting. The second caller (`remove_active_llm_profile`) shares the helper and gets the same correction for active-provider replacement.

Note for reviewers: the Web UI already surfaces the RPC error as a danger toast today; the remaining rough edge from the issue — the toast being easy to miss — is cosmetic and left untouched here.