### PR TITLE
Fix Windows installer progress presentation

### DIFF
--- a/.github/scripts/verify-sandbox-package.mjs
+++ b/.github/scripts/verify-sandbox-package.mjs
@@ -3,11 +3,14 @@ import { dirname, join, resolve } from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
+import { verifyInstallerProgressPolicy } from '../../desktop/electron/scripts/installer-progress-policy.mjs'
+
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const runtimeRoot = join(repoRoot, 'desktop', 'electron', 'runtime')
+const desktopPackageRoot = join(repoRoot, 'desktop', 'electron')
 const manifestPath = join(runtimeRoot, 'runtime-manifest.json')
 const catalogPath = join(runtimeRoot, 'runtime-pack-catalog.json')
-const packageJsonPath = join(repoRoot, 'desktop', 'electron', 'package.json')
+const packageJsonPath = join(desktopPackageRoot, 'package.json')
 const failures = []
 
 function fail(message) {
@@ -153,11 +156,8 @@ if (packageJson) {
     }
   }
 
-  if (packageJson.build?.nsis?.include !== undefined) {
-    fail('Electron NSIS must use managed upgrade cleanup without a custom recursive delete')
-  }
-  if (isFile(join(repoRoot, 'desktop', 'electron', 'build', 'installer.nsh'))) {
-    fail('Electron NSIS custom installer cleanup must not be present')
+  for (const installerProgressFailure of await verifyInstallerProgressPolicy(desktopPackageRoot, packageJson)) {
+    fail(installerProgressFailure)
   }
 }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -632,6 +632,7 @@ jobs:
       - name: Run desktop unit tests
         working-directory: desktop/electron
         run: |
+          node scripts/test-installer-progress-contract.mjs
           node scripts/test-secret-storage-policy.mjs
           node scripts/test-update-resolver.mjs
           node scripts/test-update-check-scheduler.mjs

--- a/desktop/electron/package.json
+++ b/desktop/electron/package.json
@@ -20,6 +20,7 @@
     "verify:icons": "node scripts/verify-icon-config.mjs",
     "verify:package": "npm run verify:icons && node scripts/verify-package.mjs",
     "verify:gateway-smoke": "node scripts/smoke-gateway.mjs",
+    "test:installer-progress": "node scripts/test-installer-progress-contract.mjs",
     "test:bundled-runtimes": "node scripts/test-bundled-runtimes.mjs",
     "test:packaged-session-recovery": "node scripts/test-packaged-session-recovery.mjs",
     "test:packaged-first-send-renderer": "node scripts/test-packaged-first-send-renderer.mjs",
@@ -162,6 +163,7 @@
       "perMachine": false,
       "allowToChangeInstallationDirectory": true,
       "deleteAppDataOnUninstall": false,
+      "include": "scripts/nsis/installer-progress.nsh",
       "installerIcon": "assets/icon.ico",
       "uninstallerIcon": "assets/icon.ico"
     }

--- a/desktop/electron/scripts/installer-progress-policy.mjs
+++ b/desktop/electron/scripts/installer-progress-policy.mjs
@@ -1,0 +1,156 @@
+import { lstat, readFile } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+
+export const INSTALLER_PROGRESS_INCLUDE = 'scripts/nsis/installer-progress.nsh'
+
+const REQUIRED_INCLUDES = ['LogicLib.nsh', 'nsDialogs.nsh', 'WinMessages.nsh']
+const REQUIRED_FRAGMENTS = [
+  '!ifndef BUILD_UNINSTALLER',
+  '!macro customPageAfterChangeDir',
+  '!define MUI_PAGE_CUSTOMFUNCTION_SHOW OpenSquillaInstallerProgressShow',
+  'Function OpenSquillaInstallerProgressShow',
+  '!macro customInstall',
+  'Function OpenSquillaInstallerProgressFinish',
+  '${NSD_AddStyle} $1 ${PBS_MARQUEE}',
+  'SendMessage $1 ${PBM_SETMARQUEE} 1 40',
+  'Preparing and unpacking OpenSquilla files. This may take several minutes…',
+  '正在准备并解压 OpenSquilla 文件，请稍候…',
+  '正在準備並解壓縮 OpenSquilla 檔案，請稍候…',
+  'Finishing installation…',
+  '正在完成安装…',
+  '正在完成安裝…',
+]
+
+const ALLOWED_SOURCE_LINES = [
+  /^!include\s+"[^"]+"$/,
+  /^!ifndef\s+[A-Z0-9_.]+$/i,
+  /^!endif$/,
+  /^!define(?:\s+\/ifndef)?\s+[A-Z0-9_.]+\s+.+$/i,
+  /^!macro\s+[A-Z0-9_.]+$/i,
+  /^!macroend$/,
+  /^Function\s+[A-Z0-9_.]+$/i,
+  /^FunctionEnd$/i,
+  /^\$\{(?:If|IfNot|EndIf|NSD_AddStyle)\}(?:\s|$)/,
+  /^(?:Push|Pop|FindWindow|GetDlgItem|SendMessage|StrCmp|Goto|Call)\b/,
+  /^[A-Z0-9_.]+:$/i,
+]
+
+const FORBIDDEN_SOURCE_PATTERNS = [
+  {
+    label: 'file-system mutation',
+    pattern: /^\s*(?:File|Delete|RMDir|CopyFiles|Rename|SetOutPath|CreateDirectory)\b/im,
+  },
+  {
+    label: 'registry mutation',
+    pattern: /^\s*(?:WriteReg\w*|DeleteReg\w*)\b/im,
+  },
+  {
+    label: 'process execution',
+    pattern: /^\s*(?:Exec|ExecWait|ExecShell|CallInstDLL)\b/im,
+  },
+  {
+    label: 'installer state mutation',
+    pattern: /^\s*(?:InstallDir|SetShellVarContext|RequestExecutionLevel|WriteUninstaller|Section|SectionEnd)\b/im,
+  },
+  {
+    label: 'installation path access',
+    pattern: /\$(?:INSTDIR|APPDATA|LOCALAPPDATA|PROGRAMFILES\w*|PROFILE|SMPROGRAMS|DESKTOP)\b/i,
+  },
+  {
+    label: 'installer lifecycle override',
+    pattern: /\b(?:customUn\w*|customRemoveFiles|customInit|customInstallMode|customCheckAppRunning|preInit)\b/i,
+  },
+  {
+    label: 'elevation, process control, or network plugin',
+    pattern: /(?:\bUAC_|\bKillProc::|\btaskkill\b|\binetc::|\bNSISdl::)/i,
+  },
+  {
+    label: 'compile-time command execution',
+    pattern: /^\s*!(?:system|execute|packhdr|appendfile|addplugindir)\b/im,
+  },
+]
+
+async function pathIsFile(path) {
+  const info = await lstat(path).catch(() => null)
+  return info?.isFile() === true
+}
+
+async function pathExists(path) {
+  return (await lstat(path).catch(() => null)) !== null
+}
+
+export function validateInstallerProgressSource(source) {
+  const failures = []
+  const trimmed = source.trim()
+
+  if (!trimmed.startsWith('!ifndef BUILD_UNINSTALLER') || !trimmed.endsWith('!endif')) {
+    failures.push('installer progress include must be fully guarded by BUILD_UNINSTALLER')
+  }
+
+  const includes = [...source.matchAll(/^\s*!include\s+"([^"]+)"\s*$/gim)].map((match) => match[1])
+  if (JSON.stringify(includes) !== JSON.stringify(REQUIRED_INCLUDES)) {
+    failures.push(`installer progress include may only load: ${REQUIRED_INCLUDES.join(', ')}`)
+  }
+
+  const macroNames = [...source.matchAll(/^\s*!macro\s+([^\s]+)\s*$/gim)].map((match) => match[1])
+  if (JSON.stringify(macroNames) !== JSON.stringify(['customPageAfterChangeDir', 'customInstall'])) {
+    failures.push('installer progress include may only define customPageAfterChangeDir and customInstall macros')
+  }
+
+  const functionNames = [...source.matchAll(/^\s*Function\s+([^\s]+)\s*$/gim)].map((match) => match[1])
+  if (
+    JSON.stringify(functionNames)
+    !== JSON.stringify(['OpenSquillaInstallerProgressShow', 'OpenSquillaInstallerProgressFinish'])
+  ) {
+    failures.push('installer progress include may only define the two approved UI functions')
+  }
+
+  for (const fragment of REQUIRED_FRAGMENTS) {
+    if (!source.includes(fragment)) {
+      failures.push(`installer progress include is missing required UI contract: ${fragment}`)
+    }
+  }
+
+  for (const { label, pattern } of FORBIDDEN_SOURCE_PATTERNS) {
+    if (pattern.test(source)) {
+      failures.push(`installer progress include contains forbidden ${label}`)
+    }
+  }
+
+  for (const [index, rawLine] of source.split(/\r?\n/).entries()) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#') || line.startsWith(';')) continue
+    if (!ALLOWED_SOURCE_LINES.some((pattern) => pattern.test(line))) {
+      failures.push(`installer progress include line ${index + 1} is outside the display-only allowlist: ${line}`)
+    }
+  }
+
+  return failures
+}
+
+export async function verifyInstallerProgressPolicy(packageRoot, packageJson) {
+  const failures = []
+  const nsis = packageJson.build?.nsis
+
+  if (nsis?.include !== INSTALLER_PROGRESS_INCLUDE) {
+    failures.push(`NSIS include must be exactly ${INSTALLER_PROGRESS_INCLUDE}`)
+  }
+  if (nsis && Object.hasOwn(nsis, 'script')) {
+    failures.push('NSIS must not define a custom full installer script')
+  }
+
+  const defaultInstallerInclude = join(packageRoot, 'build', 'installer.nsh')
+  if (await pathExists(defaultInstallerInclude)) {
+    failures.push('NSIS default build/installer.nsh override must not be present')
+  }
+
+  const includePath = resolve(packageRoot, INSTALLER_PROGRESS_INCLUDE)
+  if (!(await pathIsFile(includePath))) {
+    failures.push(`installer progress include is missing at ${includePath}`)
+    return failures
+  }
+
+  const source = await readFile(includePath, 'utf8')
+  failures.push(...validateInstallerProgressSource(source))
+  return failures
+}

--- a/desktop/electron/scripts/nsis/installer-progress.nsh
+++ b/desktop/electron/scripts/nsis/installer-progress.nsh
@@ -1,0 +1,85 @@
+!ifndef BUILD_UNINSTALLER
+  !include "LogicLib.nsh"
+  !include "nsDialogs.nsh"
+  !include "WinMessages.nsh"
+
+  !define /ifndef PBS_MARQUEE 0x08
+  !define OPENSQUILLA_LANG_SIMPCHINESE 2052
+  !define OPENSQUILLA_LANG_TRADCHINESE 1028
+
+  Function OpenSquillaInstallerProgressShow
+    ${IfNot} ${Silent}
+      Push $0
+      Push $1
+
+      FindWindow $0 "#32770" "" $HWNDPARENT
+      ${If} $0 != 0
+        GetDlgItem $1 $0 1004
+        ${If} $1 != 0
+          ${NSD_AddStyle} $1 ${PBS_MARQUEE}
+          SendMessage $1 ${PBM_SETMARQUEE} 1 40
+        ${EndIf}
+
+        GetDlgItem $1 $0 1006
+        ${If} $1 != 0
+          StrCmp $LANGUAGE ${OPENSQUILLA_LANG_SIMPCHINESE} opensquilla_progress_initial_zh_cn
+          StrCmp $LANGUAGE ${OPENSQUILLA_LANG_TRADCHINESE} opensquilla_progress_initial_zh_tw
+          SendMessage $1 ${WM_SETTEXT} 0 "STR:Preparing and unpacking OpenSquilla files. This may take several minutes…"
+          Goto opensquilla_progress_initial_done
+
+          opensquilla_progress_initial_zh_cn:
+            SendMessage $1 ${WM_SETTEXT} 0 "STR:正在准备并解压 OpenSquilla 文件，请稍候…"
+            Goto opensquilla_progress_initial_done
+
+          opensquilla_progress_initial_zh_tw:
+            SendMessage $1 ${WM_SETTEXT} 0 "STR:正在準備並解壓縮 OpenSquilla 檔案，請稍候…"
+
+          opensquilla_progress_initial_done:
+        ${EndIf}
+      ${EndIf}
+
+      Pop $1
+      Pop $0
+    ${EndIf}
+  FunctionEnd
+
+  Function OpenSquillaInstallerProgressFinish
+    ${IfNot} ${Silent}
+      Push $0
+      Push $1
+
+      FindWindow $0 "#32770" "" $HWNDPARENT
+      ${If} $0 != 0
+        GetDlgItem $1 $0 1006
+        ${If} $1 != 0
+          StrCmp $LANGUAGE ${OPENSQUILLA_LANG_SIMPCHINESE} opensquilla_progress_finish_zh_cn
+          StrCmp $LANGUAGE ${OPENSQUILLA_LANG_TRADCHINESE} opensquilla_progress_finish_zh_tw
+          SendMessage $1 ${WM_SETTEXT} 0 "STR:Finishing installation…"
+          Goto opensquilla_progress_finish_done
+
+          opensquilla_progress_finish_zh_cn:
+            SendMessage $1 ${WM_SETTEXT} 0 "STR:正在完成安装…"
+            Goto opensquilla_progress_finish_done
+
+          opensquilla_progress_finish_zh_tw:
+            SendMessage $1 ${WM_SETTEXT} 0 "STR:正在完成安裝…"
+
+          opensquilla_progress_finish_done:
+        ${EndIf}
+      ${EndIf}
+
+      Pop $1
+      Pop $0
+    ${EndIf}
+  FunctionEnd
+
+  !macro customPageAfterChangeDir
+    !define MUI_PAGE_CUSTOMFUNCTION_SHOW OpenSquillaInstallerProgressShow
+  !macroend
+
+  !macro customInstall
+    ${IfNot} ${Silent}
+      Call OpenSquillaInstallerProgressFinish
+    ${EndIf}
+  !macroend
+!endif

--- a/desktop/electron/scripts/test-desktop-gateway-orphan-recovery-flow.mjs
+++ b/desktop/electron/scripts/test-desktop-gateway-orphan-recovery-flow.mjs
@@ -34,6 +34,8 @@ const ORPHAN_RECOVERY_STARTUP_BUDGET_MS = (
   VERIFIED_ORPHAN_GATEWAY_RELEASE_TIMEOUT_MS + INITIAL_DESKTOP_STARTUP_BUDGET_MS
 )
 const CRASH_EXIT_BUDGET_MS = 15_000
+const WINDOWS_ELECTRON_CHILD_CLEANUP_COMMAND_TIMEOUT_MS = 20_000
+const WINDOWS_ELECTRON_CHILD_CLEANUP_BUDGET_MS = 30_000
 
 function createPhaseBudget(name, timeoutMs) {
   const startedAt = Date.now()
@@ -234,7 +236,11 @@ async function stopExitedElectronChildrenOnWindows(parentPid) {
     execFile(
       'powershell.exe',
       ['-NoProfile', '-NonInteractive', '-Command', command],
-      { windowsHide: true, timeout: CRASH_EXIT_BUDGET_MS, killSignal: 'SIGKILL' },
+      {
+        windowsHide: true,
+        timeout: WINDOWS_ELECTRON_CHILD_CLEANUP_COMMAND_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
+      },
       (error) => error ? rejectStop(error) : resolveStop(),
     )
   })
@@ -359,17 +365,21 @@ try {
   // Windows process termination does not reliably reap Chromium child
   // processes.  Target only Electron children; the detached Python Gateway is
   // intentionally left alive and verified below.
+  const electronChildCleanup = createPhaseBudget(
+    'windows-electron-child-cleanup',
+    WINDOWS_ELECTRON_CHILD_CLEANUP_BUDGET_MS,
+  )
   await withPhaseDeadline(
     stopExitedElectronChildrenOnWindows(firstMainPid),
-    crashExit,
-    'windows-electron-child-cleanup',
+    electronChildCleanup,
+    'terminate-electron-children',
     firstApp,
     userDataDir,
   )
   assert.equal(
     await withPhaseDeadline(
       verifyDesktopGatewayOwnership(firstRecord),
-      crashExit,
+      electronChildCleanup,
       'verify-orphan-survived',
       firstApp,
       userDataDir,

--- a/desktop/electron/scripts/test-installer-progress-contract.mjs
+++ b/desktop/electron/scripts/test-installer-progress-contract.mjs
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import {
+  INSTALLER_PROGRESS_INCLUDE,
+  validateInstallerProgressSource,
+  verifyInstallerProgressPolicy,
+} from './installer-progress-policy.mjs'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const packageRoot = resolve(scriptDir, '..')
+const packageJson = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'))
+const includePath = resolve(packageRoot, INSTALLER_PROGRESS_INCLUDE)
+const includeSource = await readFile(includePath, 'utf8')
+const appBuilderLib = join(packageRoot, 'node_modules', 'app-builder-lib')
+const assistedInstallerSource = await readFile(join(appBuilderLib, 'templates', 'nsis', 'assistedInstaller.nsh'), 'utf8')
+const installSectionSource = await readFile(join(appBuilderLib, 'templates', 'nsis', 'installSection.nsh'), 'utf8')
+
+assert.deepEqual(await verifyInstallerProgressPolicy(packageRoot, packageJson), [])
+assert.ok(
+  validateInstallerProgressSource(`${includeSource}\nDelete "$TEMP\\unexpected"`).some((failure) =>
+    failure.includes('forbidden file-system mutation'),
+  ),
+  'display-only policy must reject file-system mutation',
+)
+assert.ok(
+  validateInstallerProgressSource(includeSource.replace('!ifndef BUILD_UNINSTALLER\n', '')).some((failure) =>
+    failure.includes('fully guarded by BUILD_UNINSTALLER'),
+  ),
+  'display-only policy must reject an unguarded installer include',
+)
+
+const policyFixtureRoot = await mkdtemp(join(tmpdir(), 'opensquilla-installer-policy-'))
+try {
+  const policyIncludePath = resolve(policyFixtureRoot, INSTALLER_PROGRESS_INCLUDE)
+  const defaultInstallerInclude = join(policyFixtureRoot, 'build', 'installer.nsh')
+  const linkedInstallerInclude = join(policyFixtureRoot, 'linked-installer')
+  await mkdir(dirname(policyIncludePath), { recursive: true })
+  await mkdir(dirname(defaultInstallerInclude), { recursive: true })
+  await writeFile(policyIncludePath, includeSource, 'utf8')
+  await mkdir(linkedInstallerInclude)
+  await symlink(linkedInstallerInclude, defaultInstallerInclude, process.platform === 'win32' ? 'junction' : 'dir')
+  assert.ok(
+    (await verifyInstallerProgressPolicy(policyFixtureRoot, packageJson)).some((failure) =>
+      failure.includes('default build/installer.nsh override must not be present'),
+    ),
+    'display-only policy must reject a symlinked default installer include',
+  )
+} finally {
+  await rm(policyFixtureRoot, { recursive: true, force: true })
+}
+
+const pageHookIndex = assistedInstallerSource.indexOf('!insertmacro customPageAfterChangeDir')
+const installFilesPageIndex = assistedInstallerSource.indexOf('!insertmacro MUI_PAGE_INSTFILES')
+assert.ok(pageHookIndex >= 0, 'electron-builder must expose customPageAfterChangeDir')
+assert.ok(
+  pageHookIndex < installFilesPageIndex,
+  'customPageAfterChangeDir must run before electron-builder declares the install-files page',
+)
+
+const installApplicationFilesIndex = installSectionSource.indexOf('!insertmacro installApplicationFiles')
+const customInstallIndex = installSectionSource.indexOf('!insertmacro customInstall')
+assert.ok(installApplicationFilesIndex >= 0, 'electron-builder installApplicationFiles hook is missing')
+assert.ok(
+  installApplicationFilesIndex < customInstallIndex,
+  'customInstall must remain after electron-builder installs application files',
+)
+
+function nsisPath(path) {
+  return process.platform === 'win32' ? path : path.replaceAll('\\', '/')
+}
+
+async function loadNsisTooling() {
+  const appBuilderLibOutput = join(appBuilderLib, 'out')
+  const nsisUtilImport = await import(
+    pathToFileURL(join(appBuilderLibOutput, 'targets', 'nsis', 'nsisUtil.js')).href
+  )
+  const windowsToolsetImport = await import(pathToFileURL(join(appBuilderLibOutput, 'toolsets', 'windows.js')).href)
+  const nsisUtil = nsisUtilImport.default ?? nsisUtilImport
+  const windowsToolset = windowsToolsetImport.default ?? windowsToolsetImport
+  const makensis = await windowsToolset.getMakeNsisPath(
+    packageJson.build?.toolsets?.nsis,
+    packageJson.build?.nsis?.customNsisBinary,
+  )
+  return {
+    executable: makensis.path,
+    env: makensis.env ?? {},
+    templatesDir: nsisUtil.nsisTemplatesDir,
+  }
+}
+
+async function verifyInstallFilesControls(tooling) {
+  const nsisDir = tooling.env.NSISDIR
+  assert.ok(nsisDir, 'locked legacy NSIS tooling must expose NSISDIR')
+  const installFilesPage = await readFile(
+    join(nsisDir, 'Contrib', 'Modern UI 2', 'Pages', 'InstallFiles.nsh'),
+    'utf8',
+  )
+  const progressControlIndex = installFilesPage.indexOf('GetDlgItem $mui.InstFilesPage.ProgressBar $mui.InstFilesPage 1004')
+  const textControlIndex = installFilesPage.indexOf('GetDlgItem $mui.InstFilesPage.Text $mui.InstFilesPage 1006')
+  const showHookIndex = installFilesPage.indexOf('!insertmacro MUI_PAGE_FUNCTION_CUSTOM SHOW')
+  assert.ok(progressControlIndex >= 0, 'NSIS install-files progress control id changed')
+  assert.ok(textControlIndex >= 0, 'NSIS install-files text control id changed')
+  assert.ok(
+    progressControlIndex < showHookIndex && textControlIndex < showHookIndex,
+    'NSIS must resolve install-files controls before invoking the custom show callback',
+  )
+}
+
+function compileFixture(tooling, fixturePath) {
+  const result = spawnSync(tooling.executable, ['-V2', fixturePath], {
+    cwd: tooling.templatesDir,
+    encoding: 'utf8',
+    env: { ...process.env, ...tooling.env },
+    windowsHide: true,
+  })
+  if (result.error) throw result.error
+  assert.equal(
+    result.status,
+    0,
+    `makensis failed for ${fixturePath}\n${result.stdout ?? ''}\n${result.stderr ?? ''}`,
+  )
+}
+
+const temporaryRoot = await mkdtemp(join(tmpdir(), 'opensquilla-installer-progress-'))
+try {
+  const installerOutput = nsisPath(join(temporaryRoot, 'installer-fixture.exe'))
+  const uninstallerOutput = nsisPath(join(temporaryRoot, 'uninstaller-fixture.exe'))
+  const normalizedInclude = nsisPath(includePath)
+  const installerFixture = join(temporaryRoot, 'installer-fixture.nsi')
+  const uninstallerFixture = join(temporaryRoot, 'uninstaller-fixture.nsi')
+
+  await writeFile(
+    installerFixture,
+    `Unicode true
+!include "${normalizedInclude}"
+!include "MUI2.nsh"
+Name "OpenSquilla installer progress contract"
+OutFile "${installerOutput}"
+RequestExecutionLevel user
+!insertmacro MUI_PAGE_WELCOME
+!insertmacro customPageAfterChangeDir
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+!insertmacro MUI_LANGUAGE "English"
+Section
+  !insertmacro customInstall
+SectionEnd
+`,
+    'utf8',
+  )
+  await writeFile(
+    uninstallerFixture,
+    `Unicode true
+!define BUILD_UNINSTALLER
+!include "${normalizedInclude}"
+Name "OpenSquilla uninstaller progress contract"
+OutFile "${uninstallerOutput}"
+RequestExecutionLevel user
+Section
+SectionEnd
+`,
+    'utf8',
+  )
+
+  const tooling = await loadNsisTooling()
+  await verifyInstallFilesControls(tooling)
+  compileFixture(tooling, installerFixture)
+  compileFixture(tooling, uninstallerFixture)
+} finally {
+  await rm(temporaryRoot, { recursive: true, force: true })
+}
+
+console.log('Installer progress display contract passed')

--- a/desktop/electron/scripts/verify-package.mjs
+++ b/desktop/electron/scripts/verify-package.mjs
@@ -5,6 +5,8 @@ import { dirname, join, resolve } from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
+import { verifyInstallerProgressPolicy } from './installer-progress-policy.mjs'
+
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const packageRoot = resolve(scriptDir, '..')
 const repoRoot = resolve(packageRoot, '..', '..')
@@ -374,12 +376,8 @@ async function verifyInstallerDataPolicy() {
   if (packageJson.build?.nsis?.deleteAppDataOnUninstall !== false) {
     fail('NSIS uninstall must preserve Desktop profile data (deleteAppDataOnUninstall=false)')
   }
-  if (packageJson.build?.nsis?.include !== undefined) {
-    fail('NSIS must use electron-builder managed upgrade cleanup without a custom recursive delete')
-  }
-  const unsafeInstallerInclude = join(packageRoot, 'build', 'installer.nsh')
-  if (await pathExists(unsafeInstallerInclude)) {
-    fail('NSIS custom installer cleanup must not be present')
+  for (const installerProgressFailure of await verifyInstallerProgressPolicy(packageRoot, packageJson)) {
+    fail(installerProgressFailure)
   }
   const protocols = packageJson.build?.protocols
   if (

--- a/scripts/live_long_task_case_driver.py
+++ b/scripts/live_long_task_case_driver.py
@@ -94,6 +94,8 @@ _BROWSER_HELPER: Final = WEBUI_ROOT / "scripts" / "live-long-task-browser.mjs"
 _TERMINAL_EVENTS: Final = frozenset({"session.event.done", "session.event.error"})
 _MAX_CASE_FILE_BYTES: Final = 64 * 1024
 _MAX_BROWSER_RESULT_BYTES: Final = 64 * 1024
+_HISTORY_SETTLE_TIMEOUT_SECONDS: Final = 5.0
+_HISTORY_SETTLE_EVENT_WAIT_SECONDS: Final = 0.05
 _PERFORMANCE_FIXTURE: Final = {
     "historyMessages": 200,
     "reasoningDeltas": 20_000,
@@ -863,6 +865,42 @@ async def _history_evidence(
     )
 
 
+async def _wait_for_assistant_history_evidence(
+    client: GatewayRPCClient,
+    observation: TurnObservation,
+    *,
+    session_key: str,
+    assistant_marker: str,
+    deadline: float,
+) -> tuple[int, int, int, int]:
+    # The terminal stream event can win a narrow race with the assistant
+    # transcript commit. Keep the durable marker assertion, but let history
+    # converge within its own bounded phase. Waiting on the event queue avoids
+    # a blind sleep and keeps the client responsive to late stream frames.
+    settle_deadline = min(
+        deadline,
+        time.monotonic() + _HISTORY_SETTLE_TIMEOUT_SECONDS,
+    )
+    while True:
+        evidence = await _history_evidence(
+            client,
+            session_key=session_key,
+            assistant_marker=assistant_marker,
+        )
+        if evidence[1] > 0:
+            return evidence
+        remaining = settle_deadline - time.monotonic()
+        if remaining <= 0:
+            return evidence
+        try:
+            frame = await client.recv_event(
+                timeout=min(remaining, _HISTORY_SETTLE_EVENT_WAIT_SECONDS)
+            )
+        except TimeoutError:
+            continue
+        observation.consume(frame)
+
+
 async def _cancelled_webui_stop_count(
     client: GatewayRPCClient,
     *,
@@ -935,11 +973,22 @@ async def _send_and_observe(
                 raise TimeoutError("live turn exceeded its case timeout")
             frame = await client.recv_event(timeout=min(remaining, 30.0))
             observation.consume(frame)
-        assistant_bytes, assistant_markers, _, _ = await _history_evidence(
-            client,
-            session_key=session_key,
-            assistant_marker=marker,
-        )
+        if observation.completed and observation.marker_seen_in_stream:
+            assistant_bytes, assistant_markers, _, _ = (
+                await _wait_for_assistant_history_evidence(
+                    client,
+                    observation,
+                    session_key=session_key,
+                    assistant_marker=marker,
+                    deadline=deadline,
+                )
+            )
+        else:
+            assistant_bytes, assistant_markers, _, _ = await _history_evidence(
+                client,
+                session_key=session_key,
+                assistant_marker=marker,
+            )
         return observation, assistant_bytes, assistant_markers
     finally:
         await client.close()

--- a/tests/functional/test_gateway_stop_process_tree_e2e.py
+++ b/tests/functional/test_gateway_stop_process_tree_e2e.py
@@ -102,9 +102,17 @@ class _StopProvider:
                 encoding="utf-8",
             )
             parent_script.write_text(
+                "import pathlib\n"
                 "import subprocess\n"
                 "import sys\n"
-                f"subprocess.Popen([sys.executable, {str(child_script)!r}])\n",
+                "import time\n"
+                f"child_pid = pathlib.Path({str(child_pid)!r})\n"
+                f"subprocess.Popen([sys.executable, {str(child_script)!r}])\n"
+                "deadline = time.monotonic() + 10\n"
+                "while not child_pid.exists() and time.monotonic() < deadline:\n"
+                "    time.sleep(0.05)\n"
+                "if not child_pid.exists():\n"
+                "    raise RuntimeError('child did not publish its pid')\n",
                 encoding="utf-8",
             )
             yield ToolUseStartEvent(
@@ -460,10 +468,7 @@ async def test_stop_kills_leaderless_descendant_and_gateway_accepts_next_task(
         assert not (evidence / "descendant-survived").exists()
 
         await _wait_for_health(port, process, gateway_log)
-        next_frames = [
-            frame
-            async for frame in client.send_message(session_key, "run after Stop")
-        ]
+        next_frames = [frame async for frame in client.send_message(session_key, "run after Stop")]
         assert any("NEXT_TASK_OK" in str(frame) for frame in next_frames)
         await _wait_for_health(port, process, gateway_log)
         assert process.poll() is None

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -2984,6 +2984,15 @@ def test_desktop_orphan_recovery_has_a_real_electron_process_flow() -> None:
         in script
     )
     assert "createPhaseBudget('hard-crash-exit', CRASH_EXIT_BUDGET_MS)" in script
+    assert "const WINDOWS_ELECTRON_CHILD_CLEANUP_COMMAND_TIMEOUT_MS = 20_000" in script
+    assert "const WINDOWS_ELECTRON_CHILD_CLEANUP_BUDGET_MS = 30_000" in script
+    assert (
+        "createPhaseBudget(\n"
+        "    'windows-electron-child-cleanup',\n"
+        "    WINDOWS_ELECTRON_CHILD_CLEANUP_BUDGET_MS,\n"
+        "  )"
+    ) in script
+    assert "timeout: WINDOWS_ELECTRON_CHILD_CLEANUP_COMMAND_TIMEOUT_MS" in script
     assert "phase.remainingMs('first-window')" in script
     assert "phase.remainingMs('control-ui-route')" in script
     assert "DESKTOP_E2E_PHASE_TIMEOUT:" in script

--- a/tests/test_engine/test_interactive_approval_retry.py
+++ b/tests/test_engine/test_interactive_approval_retry.py
@@ -815,6 +815,8 @@ async def test_agent_waits_for_approval_resolution_before_retry_result_reaches_m
     reset_approval_queue()
     approval_prompt_seen = asyncio.Event()
     tool_calls: list[dict[str, Any]] = []
+    execution_timeout = 1.0
+    approval_hold_seconds = execution_timeout + 0.1
 
     async def _handler(call: ToolCall) -> ToolResult:
         tool_calls.append(dict(call.arguments))
@@ -855,7 +857,6 @@ async def test_agent_waits_for_approval_resolution_before_retry_result_reaches_m
                     }
                 ),
             )
-        await asyncio.sleep(0.01)
         return ToolResult(
             tool_use_id=call.tool_use_id,
             tool_name=call.tool_name,
@@ -867,8 +868,8 @@ async def test_agent_waits_for_approval_resolution_before_retry_result_reaches_m
         provider=provider,
         config=AgentConfig(
             max_iterations=2,
-            timeout=0.05,
-            iteration_timeout=0.05,
+            timeout=execution_timeout,
+            iteration_timeout=execution_timeout,
         ),
         tool_definitions=[_exec_definition()],
         tool_handler=_handler,
@@ -885,7 +886,13 @@ async def test_agent_waits_for_approval_resolution_before_retry_result_reaches_m
     try:
         task = asyncio.create_task(_drive())
         await asyncio.wait_for(approval_prompt_seen.wait(), timeout=2.0)
-        await asyncio.sleep(0.08)
+        # Keep the turn pending beyond its execution deadlines without
+        # cancelling it.  The contract under test is that human approval time
+        # is suspended, not that platform scheduling and approval persistence
+        # fit inside a sub-second timing margin.
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(asyncio.shield(task), timeout=approval_hold_seconds)
+        assert task.done() is False
 
         assert len(provider.calls) == 1
         assert len(tool_calls) == 1

--- a/tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py
@@ -2781,18 +2781,16 @@ async def test_plan_run_auto_publish_requires_live_delivery_ready_state(
 
 def _gate_real_publish(
     stage: StreamConsumerStage,
-) -> tuple[threading.Event, threading.Event, threading.Event, list[threading.Thread]]:
+) -> tuple[threading.Event, threading.Event, threading.Event]:
     """Wrap the bound ``run_publish`` with an Event handshake: signal entry,
     block until released, then run the REAL publish (real ArtifactStore
     writes) and signal completion."""
     publish_started = threading.Event()
     release_publish = threading.Event()
     publish_finished = threading.Event()
-    worker_threads: list[threading.Thread] = []
     real_publish = stage._done_handler.run_publish
 
     def gated_publish(inner_inp: Any, accumulated_text: str) -> Any:
-        worker_threads.append(threading.current_thread())
         publish_started.set()
         assert release_publish.wait(timeout=5.0), "publish was never released"
         result = real_publish(inner_inp, accumulated_text)
@@ -2800,7 +2798,7 @@ def _gate_real_publish(
         return result
 
     stage._done_handler.run_publish = gated_publish  # type: ignore[method-assign]
-    return publish_started, release_publish, publish_finished, worker_threads
+    return publish_started, release_publish, publish_finished
 
 
 @pytest.mark.asyncio
@@ -2822,7 +2820,7 @@ async def test_single_cancel_records_completed_publish(tmp_path: Path) -> None:
         ]
     )
     stage, _ = _make_stage(agent_run=agent_run)
-    publish_started, release_publish, publish_finished, _ = _gate_real_publish(stage)
+    publish_started, release_publish, publish_finished = _gate_real_publish(stage)
     state = _make_state()
     inp = _make_input(state=state, tool_context=ctx)
 
@@ -2863,9 +2861,7 @@ async def test_double_cancel_waits_for_worker_before_unwind(tmp_path: Path) -> N
         ]
     )
     stage, _ = _make_stage(agent_run=agent_run)
-    publish_started, release_publish, publish_finished, worker_threads = (
-        _gate_real_publish(stage)
-    )
+    publish_started, release_publish, publish_finished = _gate_real_publish(stage)
     state = _make_state()
     inp = _make_input(state=state, tool_context=ctx)
 
@@ -2897,8 +2893,10 @@ async def test_double_cancel_waits_for_worker_before_unwind(tmp_path: Path) -> N
     # ctx.published_artifacts append happened strictly before the unwind.
     published_snapshot = list(ctx.published_artifacts)
     files_snapshot = sorted(str(p) for p in media_root.rglob("*") if p.is_file())
-    for thread in worker_threads:
-        await asyncio.to_thread(thread.join, 5.0)
+    # ``publish_task`` cannot complete until the worker callable returns. The
+    # callable runs on asyncio's long-lived default executor, so joining that
+    # worker here would either wait for executor shutdown or schedule a
+    # self-join on the same executor thread.
     for _ in range(10):
         await asyncio.sleep(0)
     assert list(ctx.published_artifacts) == published_snapshot

--- a/tests/test_live_long_task_case_driver.py
+++ b/tests/test_live_long_task_case_driver.py
@@ -181,6 +181,80 @@ def test_tool_compaction_reserves_provider_tool_followup_and_summary_legs(
         driver.load_case(path)
 
 
+def test_send_and_observe_waits_for_assistant_history_after_terminal_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_key = "agent:main:webchat:synthetic"
+    marker = "synthetic complete"
+    events = [
+        {
+            "event": "session.event.text_delta",
+            "payload": {"session_key": session_key, "text": marker},
+        },
+        {
+            "event": "session.event.done",
+            "payload": {"session_key": session_key, "reason": "completed"},
+        },
+    ]
+    calls: list[str] = []
+    history_calls = 0
+
+    class Client:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        async def connect(self, _url: str) -> None:
+            calls.append("connect")
+
+        async def call(
+            self,
+            method: str,
+            _params: dict[str, object] | None = None,
+        ) -> dict[str, object]:
+            nonlocal history_calls
+            calls.append(method)
+            if method == "chat.history":
+                history_calls += 1
+                if history_calls == 1:
+                    return {"messages": []}
+                return {"messages": [{"role": "assistant", "text": marker}]}
+            return {}
+
+        async def recv_event(self, *, timeout: float) -> dict[str, object]:
+            assert timeout > 0
+            if events:
+                return events.pop(0)
+            raise TimeoutError
+
+        async def close(self) -> None:
+            calls.append("close")
+
+    monkeypatch.setattr(driver, "GatewayRPCClient", Client)
+
+    observation, assistant_bytes, assistant_markers = asyncio.run(
+        driver._send_and_observe(
+            SimpleNamespace(ws_url="ws://synthetic"),
+            prompt="synthetic prompt",
+            marker=marker,
+            session_key=session_key,
+            timeout_seconds=5,
+        )
+    )
+
+    assert observation.completed is True
+    assert assistant_bytes == len(marker.encode("utf-8"))
+    assert assistant_markers == 1
+    assert history_calls == 2
+    assert calls == [
+        "connect",
+        "sessions.messages.subscribe",
+        "sessions.send",
+        "chat.history",
+        "chat.history",
+        "close",
+    ]
+
+
 def test_gateway_config_contains_env_names_but_not_credential_values(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -59,13 +59,19 @@ def test_desktop_electron_release_config_matches_current_release() -> None:
     assert build["nsis"]["allowToChangeInstallationDirectory"] is True
     assert build["nsis"]["deleteAppDataOnUninstall"] is False
     assert build["nsis"].get("guid") is None  # electron-builder derives it from the stable appId.
-    assert "include" not in build["nsis"]
+    assert build["nsis"]["include"] == "scripts/nsis/installer-progress.nsh"
+    assert "script" not in build["nsis"]
     assert not Path("desktop/electron/build/installer.nsh").exists()
     package_verifier = Path("desktop/electron/scripts/verify-package.mjs").read_text(
         encoding="utf-8"
     )
     assert "deleteAppDataOnUninstall !== false" in package_verifier
-    assert "managed upgrade cleanup without a custom recursive delete" in package_verifier
+    assert "verifyInstallerProgressPolicy" in package_verifier
+    installer_policy = Path(
+        "desktop/electron/scripts/installer-progress-policy.mjs"
+    ).read_text(encoding="utf-8")
+    assert "NSIS must not define a custom full installer script" in installer_policy
+    assert "NSIS default build/installer.nsh override must not be present" in installer_policy
 
 
 def test_release_workflow_builds_desktop_installers() -> None:

--- a/tests/test_sandbox/test_release_contract.py
+++ b/tests/test_sandbox/test_release_contract.py
@@ -112,13 +112,16 @@ def test_ci_owns_a_package_contract_verifier() -> None:
     assert "asset.sizeBytes" in verifier
     assert "asset.unpackedSizeBytes" in verifier
     assert r"\.tar\.xz" in verifier
-    assert "managed upgrade cleanup without a custom recursive delete" in verifier
-    assert "build', 'installer.nsh'" in verifier
+    assert "verifyInstallerProgressPolicy" in verifier
     assert "verify-sandbox-package.mjs" in workflow
 
     package_verifier = _text("desktop/electron/scripts/verify-package.mjs")
-    assert "managed upgrade cleanup without a custom recursive delete" in package_verifier
-    assert "unsafeInstallerInclude" in package_verifier
+    assert "verifyInstallerProgressPolicy" in package_verifier
+
+    installer_policy = _text("desktop/electron/scripts/installer-progress-policy.mjs")
+    assert "NSIS include must be exactly" in installer_policy
+    assert "NSIS must not define a custom full installer script" in installer_policy
+    assert "NSIS default build/installer.nsh override must not be present" in installer_policy
 
 
 def test_finalized_catalog_allows_development_and_release() -> None:


### PR DESCRIPTION
## Summary
- show the Windows NSIS install-files phase as an indeterminate marquee with localized two-stage status text
- keep the customization display-only, silent-install safe, and completely disabled while building the uninstaller
- add fail-closed static policy checks and locked electron-builder/NSIS compile contracts to desktop CI

## Validation
- npm run test:installer-progress
- npm run build
- node ../../.github/scripts/verify-sandbox-package.mjs --source
- native Windows full NSIS fixture build and interactive install with isolated appId/GUID and install directory
- visually confirmed the marquee continued cycling during Nsis7z extraction and installation completed successfully

## Scope
No extraction, cleanup, uninstall, installation-directory, elevation, process, profile-data, silent-install, or application-startup behavior is changed.