### PR TITLE
Stabilize chat scrolling across session changes

### DIFF
--- a/opensquilla-webui/e2e/floating-composer.spec.ts
+++ b/opensquilla-webui/e2e/floating-composer.spec.ts
@@ -299,6 +299,9 @@ test('floating composer reacts only to user scroll and resets across sessions', 
     .click()
   await expect.poll(() => new URL(page.url()).searchParams.get('session')).toBe(SESSION_B)
   await expect(page.getByText('Session B message 48.', { exact: false })).toBeVisible()
+  // Session B deliberately does not restore A's reading position: every
+  // session hand-off starts at the live edge unless the user gestures first.
+  await expect.poll(() => scrollGap(page)).toBeLessThan(2)
   await expect(chat).not.toHaveClass(/chat--composer-collapsed/)
 })
 

--- a/opensquilla-webui/src/components/chat/ChatMessageList.virtualization.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatMessageList.virtualization.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp, nextTick, type App } from 'vue'
+import { createApp, h, nextTick, reactive, ref, type App } from 'vue'
 
 import i18n from '@/i18n'
 import type { ChatRenderedMessage } from '@/types/chat'
@@ -40,6 +40,8 @@ async function mountList(options: {
   forceMountMessageKeys?: ReadonlySet<string>
   followLiveEdge?: boolean
   messages?: ChatRenderedMessage[]
+  sessionKey?: string
+  scrollEpoch?: number
 } = {}) {
   const container = document.createElement('div')
   const host = document.createElement('div')
@@ -51,12 +53,14 @@ async function mountList(options: {
   })
   container.getBoundingClientRect = () => ({ top: 0 } as DOMRect)
 
-  const app = createApp(ChatMessageList, {
+  const componentProps = reactive({
     messages: options.messages ?? Array.from({ length: 200 }, (_, index) => message(index)),
     scrollContainer: container,
     shareMode: options.shareMode ?? false,
     forceMountMessageKeys: options.forceMountMessageKeys,
     followLiveEdge: options.followLiveEdge,
+    sessionKey: options.sessionKey,
+    scrollEpoch: options.scrollEpoch ?? 0,
     selectedMessageIds: new Set<string>(),
     stripTimePrefix: (value: string) => value,
     renderMarkdown: (value: string) => value,
@@ -72,13 +76,18 @@ async function mountList(options: {
     copyMessage: async () => true,
     downloadAttachment: async () => true,
   })
+  const listRef = ref<ChatMessageListVirtualizer | null>(null)
+  const app = createApp({
+    setup: () => () => h(ChatMessageList, { ...componentProps, ref: listRef }),
+  })
   app.use(i18n)
-  const api = app.mount(host) as unknown as ChatMessageListVirtualizer
+  app.mount(host)
+  const api = listRef.value as ChatMessageListVirtualizer
   apps.push(app)
   await nextTick()
   await new Promise(resolve => window.requestAnimationFrame(() => resolve(undefined)))
   await nextTick()
-  return { api, container, host }
+  return { api, container, host, props: componentProps }
 }
 
 beforeEach(() => {
@@ -195,6 +204,55 @@ describe('ChatMessageList long-history virtualization', () => {
     await nextTick()
 
     expect(container.scrollTop).toBe(120)
+  })
+
+  it('drops a queued anchor correction when the scroll epoch changes', async () => {
+    const { container, host, props } = await mountList({ scrollEpoch: 1 })
+    const row = host.querySelector<HTMLElement>('[data-testid="chat-message-row"]')
+    expect(row).toBeTruthy()
+    row!.getBoundingClientRect = () => ({ height: 214, bottom: 120 } as DOMRect)
+
+    const entry = { target: row } as unknown as ResizeObserverEntry
+    for (const callback of resizeObserverCallbacks) callback([entry], {} as ResizeObserver)
+    props.scrollEpoch = 2
+    await nextTick()
+    await nextTick()
+
+    expect(container.scrollTop).toBe(0)
+
+    row!.getBoundingClientRect = () => ({ height: 214, bottom: 120 } as DOMRect)
+    for (const callback of resizeObserverCallbacks) callback([entry], {} as ResizeObserver)
+    await nextTick()
+    await nextTick()
+
+    expect(container.scrollTop).toBe(120)
+  })
+
+  it('drops a queued live-edge pin on a session change and accepts the next one', async () => {
+    const { container, host, props } = await mountList({
+      followLiveEdge: true,
+      sessionKey: 'session-a',
+      scrollEpoch: 1,
+    })
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 12_000 })
+    const row = host.querySelector<HTMLElement>('[data-testid="chat-message-row"]')
+    expect(row).toBeTruthy()
+    row!.getBoundingClientRect = () => ({ height: 40 } as DOMRect)
+
+    const entry = { target: row } as unknown as ResizeObserverEntry
+    for (const callback of resizeObserverCallbacks) callback([entry], {} as ResizeObserver)
+    props.sessionKey = 'session-b'
+    await nextTick()
+    await nextTick()
+
+    expect(container.scrollTop).toBe(0)
+
+    row!.getBoundingClientRect = () => ({ height: 80 } as DOMRect)
+    for (const callback of resizeObserverCallbacks) callback([entry], {} as ResizeObserver)
+    await nextTick()
+    await nextTick()
+
+    expect(container.scrollTop).toBe(12_000)
   })
 
   it('renders the complete canonical history for share mode and the rollback flag', async () => {

--- a/opensquilla-webui/src/components/chat/ChatMessageList.vue
+++ b/opensquilla-webui/src/components/chat/ChatMessageList.vue
@@ -205,6 +205,8 @@ const props = defineProps<{
   goalElapsed?: string
   /** Required for long-history virtualization; omitted by legacy embedders. */
   scrollContainer?: HTMLElement | null
+  /** Session/render epoch used to invalidate deferred scroll corrections. */
+  scrollEpoch?: number
   /** Preview/export paths can force a complete, canonical DOM. */
   virtualizationDisabled?: boolean
   /** Current search match or another externally owned focus target. */
@@ -282,6 +284,18 @@ let viewportFrame = 0
 let pendingAnchorAdjustment = 0
 let anchorAdjustmentScheduled = false
 let liveEdgePinScheduled = false
+let deferredScrollGeneration = 0
+
+function currentScrollEpoch(): number {
+  return props.scrollEpoch ?? 0
+}
+
+function resetDeferredScrollWork() {
+  deferredScrollGeneration += 1
+  pendingAnchorAdjustment = 0
+  anchorAdjustmentScheduled = false
+  liveEdgePinScheduled = false
+}
 
 function readVirtualizationPreference(): boolean {
   if (typeof window === 'undefined') return true
@@ -413,14 +427,19 @@ function scheduleViewportMeasure() {
 function queueAnchorAdjustment(delta: number) {
   const container = props.scrollContainer
   if (!container || Math.abs(delta) < 0.5) return
+  const epoch = currentScrollEpoch()
+  const sessionKey = props.sessionKey
+  const generation = deferredScrollGeneration
   pendingAnchorAdjustment += delta
   if (anchorAdjustmentScheduled) return
   anchorAdjustmentScheduled = true
   void nextTick(() => {
+    if (deferredScrollGeneration !== generation) return
     anchorAdjustmentScheduled = false
     const adjustment = pendingAnchorAdjustment
     pendingAnchorAdjustment = 0
     if (!props.scrollContainer || props.scrollContainer !== container) return
+    if (props.sessionKey !== sessionKey || currentScrollEpoch() !== epoch) return
     applyProgrammaticScroll(container, () => {
       container.scrollTop += adjustment
     })
@@ -431,10 +450,15 @@ function queueAnchorAdjustment(delta: number) {
 function queueLiveEdgePin() {
   const container = props.scrollContainer
   if (!container || liveEdgePinScheduled) return
+  const epoch = currentScrollEpoch()
+  const sessionKey = props.sessionKey
+  const generation = deferredScrollGeneration
   liveEdgePinScheduled = true
   void nextTick(() => {
+    if (deferredScrollGeneration !== generation) return
     liveEdgePinScheduled = false
     if (!props.followLiveEdge || props.scrollContainer !== container) return
+    if (props.sessionKey !== sessionKey || currentScrollEpoch() !== epoch) return
     applyProgrammaticScroll(container, () => {
       container.scrollTop = container.scrollHeight
     })
@@ -638,13 +662,18 @@ watch(virtualizationEnabled, () => {
     scheduleViewportMeasure()
   })
 })
-watch(() => props.sessionKey, () => {
-  measuredSizes.clear()
-  ensuredMessageKeys.value = new Set()
-  focusedMessageKey.value = null
-  measurementVersion.value += 1
-  void nextTick(scheduleViewportMeasure)
-})
+watch(
+  [() => props.sessionKey, () => props.scrollEpoch],
+  () => {
+    resetDeferredScrollWork()
+    measuredSizes.clear()
+    ensuredMessageKeys.value = new Set()
+    focusedMessageKey.value = null
+    measurementVersion.value += 1
+    void nextTick(scheduleViewportMeasure)
+  },
+  { flush: 'sync' },
+)
 watch(() => windowRows.value.map(row => row.key), nextKeys => {
   const retained = new Set(nextKeys)
   for (const key of measuredSizes.keys()) {

--- a/opensquilla-webui/src/components/chat/ClarifyCard.vue
+++ b/opensquilla-webui/src/components/chat/ClarifyCard.vue
@@ -57,7 +57,12 @@
       </p>
     </header>
 
-    <div class="clarify-card__body">
+    <div
+      class="clarify-card__body"
+      role="region"
+      tabindex="0"
+      :aria-label="t('chat.clarify.inputNeeded')"
+    >
       <div v-for="field in displayedFields" :key="field.name" class="clarify-field">
         <div :id="fieldLabelId(field.name)" class="clarify-field__label">
           <span class="clarify-field__name">{{ field.header || field.name }}</span>

--- a/opensquilla-webui/src/components/chat/ConversationMinimap.vue
+++ b/opensquilla-webui/src/components/chat/ConversationMinimap.vue
@@ -385,6 +385,11 @@ function cancelFrame(frame: number) {
 
 function elementNeedsAnchorRemeasure(element: Element): boolean {
   if (!lastAnchorElement || element === lastAnchorElement) return true
+  // The minimap observes direct thread children. When the list root contains
+  // the current last prompt, its own late height change must invalidate the
+  // cached anchor even though document position reports the anchor as a
+  // descendant rather than a following sibling.
+  if (element.contains(lastAnchorElement)) return true
   return Boolean(element.compareDocumentPosition(lastAnchorElement) & Node.DOCUMENT_POSITION_FOLLOWING)
 }
 

--- a/opensquilla-webui/src/components/chat/parts/ReasoningPart.vue
+++ b/opensquilla-webui/src/components/chat/parts/ReasoningPart.vue
@@ -7,6 +7,9 @@
     <div
       ref="bodyElement"
       class="thinking-block__body"
+      role="region"
+      tabindex="0"
+      :aria-label="summary"
       @scroll.passive="onBodyScroll"
     >{{ part.text }}</div>
   </section>
@@ -30,6 +33,9 @@
     <div
       ref="bodyElement"
       class="thinking-fold__body"
+      role="region"
+      tabindex="0"
+      :aria-label="summary"
       @scroll.passive="onBodyScroll"
     >{{ part.text }}</div>
   </details>

--- a/opensquilla-webui/src/composables/chat/useChatHistory.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatHistory.test.ts
@@ -12,6 +12,7 @@ function makeHistory(autoScroll = true, overrides: {
   messages?: ChatMessage[]
   preserveLiveTail?: boolean
   sessionKey?: Ref<string>
+  scrollEpoch?: Ref<number>
   threadRef?: Ref<HTMLElement | null>
   concurrentHistoryReads?: boolean
 } = {}) {
@@ -48,6 +49,7 @@ function makeHistory(autoScroll = true, overrides: {
     lastHeaderDay: ref(''),
     preserveLiveTail: ref(overrides.preserveLiveTail ?? false),
     autoScroll: ref(autoScroll),
+    scrollEpoch: overrides.scrollEpoch,
     stripTimePrefix: text => text,
     scrollToBottom,
   })
@@ -2020,6 +2022,51 @@ describe('useChatHistory scroll anchoring', () => {
     await nextTick()
 
     expect(scrollToBottom).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops a delayed prepend when the reused chat viewport enters a new epoch', async () => {
+    let resolveEarlier!: (value: ChatHistoryResponse) => void
+    const earlier = new Promise<ChatHistoryResponse>(resolve => { resolveEarlier = resolve })
+    const epoch = ref(1)
+    const thread = document.createElement('div')
+    Object.defineProperties(thread, {
+      clientHeight: { configurable: true, value: 300 },
+      scrollHeight: { configurable: true, value: 900 },
+      scrollTop: { configurable: true, value: 120, writable: true },
+    })
+    const threadRef = ref<HTMLElement | null>(thread)
+    const { api, rpc } = makeHistory(false, {
+      scrollEpoch: epoch,
+      threadRef,
+      response: {
+        messages: [historyMessage('m2')],
+        has_more: true,
+        oldest_cursor: 'cursor-2',
+        newest_cursor: 'cursor-2',
+      },
+    })
+    rpc.call
+      .mockResolvedValueOnce({
+        messages: [historyMessage('m2')],
+        has_more: true,
+        oldest_cursor: 'cursor-2',
+        newest_cursor: 'cursor-2',
+      })
+      .mockImplementationOnce(() => earlier)
+
+    await api.loadHistory()
+    const pending = api.loadEarlierHistory()
+    await vi.waitFor(() => expect(rpc.call).toHaveBeenCalledTimes(2))
+    epoch.value = 2
+    resolveEarlier({
+      messages: [historyMessage('m1')],
+      has_more: false,
+      oldest_cursor: 'cursor-1',
+      newest_cursor: 'cursor-2',
+    })
+    await pending
+
+    expect(thread.scrollTop).toBe(120)
   })
 
   it('keeps protocol-shaped assistant documentation canonical', async () => {

--- a/opensquilla-webui/src/composables/chat/useChatHistory.ts
+++ b/opensquilla-webui/src/composables/chat/useChatHistory.ts
@@ -649,6 +649,8 @@ export interface UseChatHistoryOptions {
   lastHeaderDay: Ref<string>
   preserveLiveTail?: Ref<boolean>
   autoScroll?: Ref<boolean>
+  /** Invalidates deferred anchor work when the reused chat viewport changes session. */
+  scrollEpoch?: Ref<number>
   stripTimePrefix: (text: string) => string
   scrollToBottom: () => void
 }
@@ -943,6 +945,7 @@ export function useChatHistory(options: UseChatHistoryOptions) {
   ): Promise<SessionPhaseResult | void> {
     if (!options.sessionKey.value) return
     const key = options.sessionKey.value
+    const requestScrollEpoch = options.scrollEpoch?.value ?? 0
     const crossedSession = resetForSession(key)
     cancelAnchorStabilization()
     const historyStateBeforeLoad = historyState.value
@@ -970,7 +973,11 @@ export function useChatHistory(options: UseChatHistoryOptions) {
         recoveryError: params.prepend ? historyState.value.recoveryError : false,
       }
     }
-    const isCurrentRequest = () => key === options.sessionKey.value && requestSeq === historyRequestSeq
+    const isCurrentRequest = () => (
+      key === options.sessionKey.value
+      && requestSeq === historyRequestSeq
+      && requestScrollEpoch === (options.scrollEpoch?.value ?? 0)
+    )
     const restoreSilentBackgroundState = () => {
       failedHistoryRequest = failedHistoryRequestBeforeLoad
       historyState.value = historyStateBeforeLoad
@@ -1276,12 +1283,15 @@ export function useChatHistory(options: UseChatHistoryOptions) {
 
       if (params.prepend) {
         await nextTick()
+        if (!isCurrentRequest()) return { ok: false, cancelled: true }
         if (prependAnchor) {
           restoreMessageAnchor(prependAnchor)
           stopAnchorStabilization = stabilizeMessageAnchor(prependAnchor, {
             isCurrent: () => options.sessionKey.value === key
               && historySessionKey.value === key
-              && historyRequestSeq === requestSeq,
+              && historyRequestSeq === requestSeq
+              && requestScrollEpoch === (options.scrollEpoch?.value ?? 0)
+              && options.threadRef?.value === prependContainer,
           })
         } else if (prependContainer) {
           applyProgrammaticScroll(prependContainer, () => {

--- a/opensquilla-webui/src/composables/chat/useChatStream.ts
+++ b/opensquilla-webui/src/composables/chat/useChatStream.ts
@@ -908,6 +908,11 @@ export function useChatStream(options: UseChatStreamOptions) {
   }
 
   function resetLiveTurnState() {
+    // Session switches can happen while a render frame or fallback timer is
+    // waiting to flush the previous live turn. Cancel it before clearing the
+    // stream state so the old session cannot request a scroll in the next
+    // session's reused transcript element.
+    clearRenderTimer()
     hideThinkingIndicator()
     clearStreamActivity()
     clearStreamIdleTimer()

--- a/opensquilla-webui/src/styles/chat-view.css
+++ b/opensquilla-webui/src/styles/chat-view.css
@@ -235,6 +235,13 @@
   overflow-anchor: auto;
 }
 
+/* Vue-owned fallback for WebViews without :has(): ChatView mirrors the
+   virtualizer state on the thread element so historical reflow keeps the
+   browser's native anchor in the same cases. */
+.chat-thread--reading-history.chat-thread--nonvirtualized {
+  overflow-anchor: auto;
+}
+
 /* Floating composer (existing conversation, toggle on): reserve the dock's
    measured height in the body itself. This shortens the scroll viewport so no
    visible transcript text can enter the glass panel, including while the
@@ -426,11 +433,13 @@
 .chat-jump-latest {
   position: absolute;
   bottom: calc(100% + 8px);
-  right: 12px;
+  inset-inline-end: 12px;
   z-index: 30;
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  min-block-size: 44px;
+  min-inline-size: 44px;
   padding: 6px 12px;
   border-radius: var(--radius-full);
   border: 1px solid var(--border);

--- a/opensquilla-webui/src/utils/chat/artifactFocus.ts
+++ b/opensquilla-webui/src/utils/chat/artifactFocus.ts
@@ -52,7 +52,12 @@ export function focusArtifactInTranscript(
 ): boolean {
   const card = findArtifactCard(root, artifact)
   if (!card) return false
-  card.scrollIntoView?.({ behavior, block: 'center' })
+  const reduceMotion = typeof window !== 'undefined'
+    && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+  card.scrollIntoView?.({
+    behavior: reduceMotion && behavior === 'smooth' ? 'auto' : behavior,
+    block: 'center',
+  })
   const focusable = card.matches(PRIMARY_FOCUS_SELECTOR)
     ? card
     : card.querySelector<HTMLElement>(PRIMARY_FOCUS_SELECTOR)

--- a/opensquilla-webui/src/utils/chat/chatScrollOwnership.test.ts
+++ b/opensquilla-webui/src/utils/chat/chatScrollOwnership.test.ts
@@ -1,0 +1,228 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  CHAT_WHEEL_DELTA_MODE_LINE,
+  CHAT_WHEEL_DELTA_MODE_PAGE,
+  findNearestScrollableAncestor,
+  getChatWheelDirection,
+  normalizeChatWheelDelta,
+  resolveChatWheelOwnership,
+} from './chatScrollOwnership'
+
+function setScrollMetrics(
+  element: HTMLElement,
+  values: { clientHeight: number, scrollHeight: number, scrollTop: number },
+) {
+  Object.defineProperties(element, {
+    clientHeight: { configurable: true, value: values.clientHeight },
+    scrollHeight: { configurable: true, value: values.scrollHeight },
+    scrollTop: { configurable: true, value: values.scrollTop, writable: true },
+  })
+}
+
+function wheelAt(
+  target: HTMLElement,
+  options: WheelEventInit = {},
+): WheelEvent {
+  const event = new WheelEvent('wheel', { bubbles: true, cancelable: true, ...options })
+  target.dispatchEvent(event)
+  return event
+}
+
+describe('chat scroll ownership', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('normalizes pixel, line, and page wheel units', () => {
+    expect(normalizeChatWheelDelta({ deltaX: 2, deltaY: -3 }, 400))
+      .toEqual({ deltaX: 2, deltaY: -3 })
+    expect(normalizeChatWheelDelta({
+      deltaX: 2,
+      deltaY: -3,
+      deltaMode: CHAT_WHEEL_DELTA_MODE_LINE,
+    }, 400)).toEqual({ deltaX: 32, deltaY: -48 })
+    expect(normalizeChatWheelDelta({
+      deltaX: 0,
+      deltaY: 1,
+      deltaMode: CHAT_WHEEL_DELTA_MODE_PAGE,
+    }, 400)).toEqual({ deltaX: 0, deltaY: 400 })
+  })
+
+  it('filters zoom, horizontal, modified, consumed, and zero-delta gestures', () => {
+    expect(getChatWheelDirection({ deltaX: 0, deltaY: -8 })).toBe('up')
+    expect(getChatWheelDirection({ deltaX: 0, deltaY: 8 })).toBe('down')
+    expect(getChatWheelDirection({ deltaX: 8, deltaY: 2 })).toBeNull()
+    expect(getChatWheelDirection({ deltaX: 0, deltaY: -8, shiftKey: true })).toBeNull()
+    expect(getChatWheelDirection({ deltaX: 0, deltaY: -8, ctrlKey: true })).toBeNull()
+    expect(getChatWheelDirection({ deltaX: 0, deltaY: -8, metaKey: true })).toBeNull()
+    expect(getChatWheelDirection({ deltaX: 0, deltaY: -8, defaultPrevented: true })).toBeNull()
+    expect(getChatWheelDirection({ deltaX: 0, deltaY: 0 })).toBeNull()
+  })
+
+  it('selects the nearest nested scroller while it can consume the direction', () => {
+    const thread = document.createElement('div')
+    const nested = document.createElement('div')
+    const target = document.createElement('span')
+    thread.style.overflowY = 'auto'
+    nested.style.overflowY = 'auto'
+    nested.append(target)
+    thread.append(nested)
+    document.body.append(thread)
+    setScrollMetrics(thread, { clientHeight: 300, scrollHeight: 900, scrollTop: 400 })
+    setScrollMetrics(nested, { clientHeight: 100, scrollHeight: 400, scrollTop: 120 })
+
+    let ownership: ReturnType<typeof resolveChatWheelOwnership> = null
+    target.addEventListener('wheel', event => {
+      ownership = resolveChatWheelOwnership(event as WheelEvent, thread)
+    }, { once: true })
+    wheelAt(target, { deltaY: -20 })
+
+    expect(ownership).toMatchObject({
+      owner: nested,
+      direction: 'up',
+      canScroll: true,
+      atBoundary: false,
+    })
+    expect(findNearestScrollableAncestor(target, thread)).toBe(nested)
+  })
+
+  it('hands an edge gesture to the outer thread when nested scrolling is exhausted', () => {
+    const thread = document.createElement('div')
+    const nested = document.createElement('div')
+    const target = document.createElement('span')
+    thread.style.overflowY = 'auto'
+    nested.style.overflowY = 'auto'
+    nested.append(target)
+    thread.append(nested)
+    document.body.append(thread)
+    setScrollMetrics(thread, { clientHeight: 300, scrollHeight: 900, scrollTop: 400 })
+    setScrollMetrics(nested, { clientHeight: 100, scrollHeight: 400, scrollTop: 0 })
+
+    let ownership: ReturnType<typeof resolveChatWheelOwnership> = null
+    target.addEventListener('wheel', event => {
+      ownership = resolveChatWheelOwnership(event as WheelEvent, thread)
+    }, { once: true })
+    wheelAt(target, { deltaY: -20 })
+
+    expect(ownership).toMatchObject({
+      owner: thread,
+      canScroll: true,
+      atBoundary: false,
+    })
+  })
+
+  it('stops at a nested overscroll boundary when CSS containment is respected', () => {
+    const thread = document.createElement('div')
+    const nested = document.createElement('div')
+    const target = document.createElement('span')
+    thread.style.overflowY = 'auto'
+    nested.style.overflowY = 'auto'
+    nested.style.overscrollBehaviorY = 'contain'
+    nested.append(target)
+    thread.append(nested)
+    document.body.append(thread)
+    setScrollMetrics(thread, { clientHeight: 300, scrollHeight: 900, scrollTop: 400 })
+    setScrollMetrics(nested, { clientHeight: 100, scrollHeight: 400, scrollTop: 0 })
+
+    let ownership: ReturnType<typeof resolveChatWheelOwnership> = null
+    target.addEventListener('wheel', event => {
+      ownership = resolveChatWheelOwnership(event as WheelEvent, thread)
+    }, { once: true })
+    wheelAt(target, { deltaY: -20 })
+
+    expect(ownership).toMatchObject({
+      owner: nested,
+      canScroll: false,
+      atBoundary: true,
+      blockedByOverscroll: true,
+    })
+  })
+
+  it('recognizes shorthand overscroll containment in legacy style surfaces', () => {
+    const thread = document.createElement('div')
+    const nested = document.createElement('div')
+    const target = document.createElement('span')
+    thread.style.overflowY = 'auto'
+    nested.style.overflow = 'hidden auto'
+    nested.style.overscrollBehavior = 'auto contain'
+    nested.append(target)
+    thread.append(nested)
+    document.body.append(thread)
+    setScrollMetrics(thread, { clientHeight: 300, scrollHeight: 900, scrollTop: 400 })
+    setScrollMetrics(nested, { clientHeight: 100, scrollHeight: 400, scrollTop: 0 })
+
+    const ownership = resolveChatWheelOwnership({
+      deltaX: 0,
+      deltaY: -20,
+      target,
+      composedPath: () => [target, nested, thread, document.body],
+    }, thread)
+
+    expect(ownership).toMatchObject({
+      owner: nested,
+      blockedByOverscroll: true,
+    })
+  })
+
+  it('does not claim a target outside an explicit chat boundary', () => {
+    const outside = document.createElement('div')
+    const target = document.createElement('span')
+    outside.style.overflowY = 'auto'
+    outside.append(target)
+    document.body.append(outside)
+    setScrollMetrics(outside, { clientHeight: 100, scrollHeight: 300, scrollTop: 100 })
+    const boundary = document.createElement('div')
+
+    let ownership: ReturnType<typeof resolveChatWheelOwnership> = null
+    target.addEventListener('wheel', event => {
+      ownership = resolveChatWheelOwnership(event as WheelEvent, boundary)
+    }, { once: true })
+    wheelAt(target, { deltaY: 20 })
+
+    expect(ownership).toMatchObject({ owner: null })
+    expect(findNearestScrollableAncestor(target, boundary)).toBeNull()
+  })
+
+  it('retains the nearest edge owner when no outer container can continue', () => {
+    const nested = document.createElement('div')
+    const target = document.createElement('span')
+    nested.style.overflowY = 'auto'
+    nested.append(target)
+    document.body.append(nested)
+    setScrollMetrics(nested, { clientHeight: 100, scrollHeight: 300, scrollTop: 0 })
+
+    let ownership: ReturnType<typeof resolveChatWheelOwnership> = null
+    target.addEventListener('wheel', event => {
+      ownership = resolveChatWheelOwnership(event as WheelEvent)
+    }, { once: true })
+    wheelAt(target, { deltaY: -20 })
+
+    expect(ownership).toMatchObject({
+      owner: nested,
+      canScroll: false,
+      atBoundary: true,
+      blockedByOverscroll: false,
+    })
+  })
+
+  it('includes a scroller that is itself the event target without composedPath', () => {
+    const nested = document.createElement('div')
+    nested.style.overflowY = 'auto'
+    document.body.append(nested)
+    setScrollMetrics(nested, { clientHeight: 100, scrollHeight: 300, scrollTop: 80 })
+
+    const event = {
+      deltaX: 0,
+      deltaY: -20,
+      target: nested,
+    }
+    expect(findNearestScrollableAncestor(nested)).toBe(nested)
+    expect(resolveChatWheelOwnership(event)).toMatchObject({
+      owner: nested,
+      canScroll: true,
+      direction: 'up',
+    })
+  })
+})

--- a/opensquilla-webui/src/utils/chat/chatScrollOwnership.ts
+++ b/opensquilla-webui/src/utils/chat/chatScrollOwnership.ts
@@ -1,0 +1,348 @@
+/**
+ * Small, DOM-only helpers for deciding which chat scroll container owns a
+ * wheel gesture.  The conversation view has a number of intentionally nested
+ * scrollers (reasoning, tool output, questionnaires, and popovers); making
+ * this decision in one place keeps those surfaces from each inventing subtly
+ * different delta and edge rules.
+ */
+
+export const CHAT_WHEEL_DELTA_MODE_PIXEL = 0
+export const CHAT_WHEEL_DELTA_MODE_LINE = 1
+export const CHAT_WHEEL_DELTA_MODE_PAGE = 2
+export const CHAT_WHEEL_LINE_HEIGHT_PX = 16
+export const CHAT_WHEEL_EPSILON_PX = 0.5
+
+export type ChatWheelDirection = 'up' | 'down'
+
+/** The part of WheelEvent used by the helper (also convenient in unit tests). */
+export interface ChatWheelEventLike {
+  deltaX: number
+  deltaY: number
+  deltaMode?: number
+  ctrlKey?: boolean
+  metaKey?: boolean
+  shiftKey?: boolean
+  defaultPrevented?: boolean
+  target?: EventTarget | null
+  composedPath?: () => EventTarget[]
+}
+
+export interface NormalizedChatWheelDelta {
+  deltaX: number
+  deltaY: number
+}
+
+export interface ChatWheelOwnership {
+  direction: ChatWheelDirection
+  deltaX: number
+  deltaY: number
+  /** The nearest container that can consume this direction, if any. */
+  owner: HTMLElement | null
+  /** True when the owner has room in the wheel direction. */
+  canScroll: boolean
+  /** True when the nearest owner is at its directional edge. */
+  atBoundary: boolean
+  /** True when CSS overscroll behavior intentionally stops handoff. */
+  blockedByOverscroll: boolean
+}
+
+export interface ResolveChatWheelOwnershipOptions {
+  /** Height used to expand DOM_DELTA_PAGE values. */
+  pageHeight?: number
+  /** Tolerance for fractional scroll positions and tiny trackpad noise. */
+  epsilonPx?: number
+  /**
+   * Respect `overscroll-behavior-y: contain|none` on nested scrollers.  A
+   * caller that performs an explicit sibling handoff may disable this so the
+   * gesture can continue in the conversation at the nested edge.
+   */
+  respectOverscrollBehavior?: boolean
+}
+
+export interface ScrollableAncestorOptions {
+  epsilonPx?: number
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+/**
+ * Convert pixel, line, and page wheel units to a common pixel scale.  Browser
+ * engines disagree on line height and often emit fractional pixel deltas, so
+ * the chat boundary uses a stable 16px line estimate and the caller's actual
+ * viewport height for page mode.
+ */
+export function normalizeChatWheelDelta(
+  event: Pick<ChatWheelEventLike, 'deltaX' | 'deltaY' | 'deltaMode'>,
+  pageHeight = 0,
+): NormalizedChatWheelDelta | null {
+  const rawX = finiteNumber(event.deltaX)
+  const rawY = finiteNumber(event.deltaY)
+  if (rawX === null || rawY === null) return null
+
+  const mode = event.deltaMode ?? CHAT_WHEEL_DELTA_MODE_PIXEL
+  const safePageHeight = finiteNumber(pageHeight)
+  const multiplier = mode === CHAT_WHEEL_DELTA_MODE_LINE
+    ? CHAT_WHEEL_LINE_HEIGHT_PX
+    : mode === CHAT_WHEEL_DELTA_MODE_PAGE
+      ? (safePageHeight !== null && safePageHeight > 0 ? safePageHeight : 1)
+      : 1
+
+  return {
+    deltaX: rawX * multiplier,
+    deltaY: rawY * multiplier,
+  }
+}
+
+function isPredominantlyHorizontal(
+  delta: NormalizedChatWheelDelta,
+  shiftKey: boolean,
+  epsilonPx: number,
+): boolean {
+  // Shift+wheel is the conventional horizontal-scroll modifier.  Some
+  // browsers report only deltaY for it, so the modifier itself is enough to
+  // keep the transcript from stealing the gesture.
+  if (shiftKey) return true
+  const horizontal = Math.abs(delta.deltaX) > epsilonPx
+  return horizontal && Math.abs(delta.deltaX) >= Math.abs(delta.deltaY)
+}
+
+/**
+ * Return the vertical direction of a chat wheel gesture, or null when the
+ * gesture is not transcript navigation (zoom, horizontal, zero, or already
+ * consumed by another control).
+ */
+export function getChatWheelDirection(
+  event: ChatWheelEventLike,
+  pageHeight = 0,
+  epsilonPx = CHAT_WHEEL_EPSILON_PX,
+): ChatWheelDirection | null {
+  if (event.defaultPrevented || event.ctrlKey || event.metaKey) return null
+  const delta = normalizeChatWheelDelta(event, pageHeight)
+  return delta ? directionForNormalizedDelta(event, delta, epsilonPx) : null
+}
+
+function directionForNormalizedDelta(
+  event: Pick<ChatWheelEventLike, 'shiftKey'>,
+  delta: NormalizedChatWheelDelta,
+  epsilonPx: number,
+): ChatWheelDirection | null {
+  if (Math.abs(delta.deltaY) <= epsilonPx) return null
+  if (isPredominantlyHorizontal(delta, Boolean(event.shiftKey), epsilonPx)) return null
+  return delta.deltaY < 0 ? 'up' : 'down'
+}
+
+/**
+ * Whether a wheel event is eligible for vertical chat ownership.  This is a
+ * named predicate for callers that only need filtering and not an owner.
+ */
+export function isChatVerticalWheel(
+  event: ChatWheelEventLike,
+  pageHeight = 0,
+  epsilonPx = CHAT_WHEEL_EPSILON_PX,
+): boolean {
+  return getChatWheelDirection(event, pageHeight, epsilonPx) !== null
+}
+
+function isHTMLElement(value: EventTarget | null | undefined): value is HTMLElement {
+  return typeof HTMLElement !== 'undefined' && value instanceof HTMLElement
+}
+
+function parentElement(value: EventTarget | null | undefined): HTMLElement | null {
+  if (isHTMLElement(value)) return value
+  if (typeof Node !== 'undefined' && value instanceof Node) {
+    return value.parentElement
+  }
+  return null
+}
+
+function ancestorPath(target: EventTarget | null): EventTarget[] {
+  const path: EventTarget[] = []
+  // Include the event target itself when it is an HTMLElement.  Wheel events
+  // dispatched directly on a nested scroller (and older WebViews that do not
+  // expose composedPath()) otherwise skip the actual owner and start at its
+  // parent.  Text-node targets still begin at their containing element.
+  let current = isHTMLElement(target) ? target : parentElement(target)
+  while (current) {
+    path.push(current)
+    current = current.parentElement
+  }
+  return path
+}
+
+function computedStyleFor(element: HTMLElement): CSSStyleDeclaration | null {
+  if (typeof getComputedStyle === 'function') {
+    try {
+      return getComputedStyle(element)
+    } catch {
+      // Detached or partially mocked elements can reject style computation;
+      // the inline declaration remains a safe best-effort fallback.
+    }
+  }
+  return null
+}
+
+function secondShorthandToken(value: string): string {
+  const tokens = value.trim().split(/\s+/).filter(Boolean)
+  return tokens.length > 1 ? tokens[1] ?? '' : tokens[0] ?? ''
+}
+
+function overflowYFor(element: HTMLElement): string {
+  const inline = element.style.overflowY || element.style.overflow
+  if (inline) return secondShorthandToken(inline)
+  const style = computedStyleFor(element)
+  return secondShorthandToken(style?.overflowY || style?.overflow || '')
+}
+
+function overscrollBehaviorYFor(element: HTMLElement): string {
+  const inline = element.style.overscrollBehaviorY || element.style.overscrollBehavior
+  if (inline) return secondShorthandToken(inline)
+  const style = computedStyleFor(element)
+  return secondShorthandToken(
+    style?.overscrollBehaviorY || style?.overscrollBehavior || '',
+  )
+}
+
+function hasVerticalOverflow(element: HTMLElement, epsilonPx: number): boolean {
+  const overflowY = overflowYFor(element)
+  if (!['auto', 'scroll', 'overlay'].includes(overflowY)) return false
+  return element.scrollHeight > element.clientHeight + epsilonPx
+}
+
+function canScrollInDirection(
+  element: HTMLElement,
+  direction: ChatWheelDirection,
+  epsilonPx: number,
+): boolean {
+  const maxScrollTop = Math.max(0, element.scrollHeight - element.clientHeight)
+  // Safari can expose a negative rubber-band scrollTop at the top. Clamp it
+  // for ownership decisions so bounce does not transfer the gesture upward.
+  const scrollTop = Math.max(0, element.scrollTop)
+  return direction === 'up'
+    ? scrollTop > epsilonPx
+    : scrollTop < maxScrollTop - epsilonPx
+}
+
+function isOverscrollBlocking(element: HTMLElement): boolean {
+  const value = overscrollBehaviorYFor(element).trim().toLowerCase()
+  return value === 'contain' || value === 'none'
+}
+
+/**
+ * Find the nearest ancestor with a real vertical scroll range.  `boundary`,
+ * when supplied, is inclusive and prevents accidentally selecting the page
+ * when a chat sub-surface is being handed off.
+ */
+export function findNearestScrollableAncestor(
+  target: EventTarget | null,
+  boundary: HTMLElement | null = null,
+  options: ScrollableAncestorOptions = {},
+): HTMLElement | null {
+  const epsilonPx = options.epsilonPx ?? CHAT_WHEEL_EPSILON_PX
+  const path = ancestorPath(target)
+  if (boundary && !path.includes(boundary)) return null
+  for (const value of path) {
+    const current = value as HTMLElement
+    if (hasVerticalOverflow(current, epsilonPx)) return current
+    if (current === boundary) break
+  }
+  return null
+}
+
+function pathForEvent(event: ChatWheelEventLike): EventTarget[] {
+  if (typeof event.composedPath === 'function') {
+    const path = event.composedPath()
+    if (path.length > 0) return path
+  }
+  return ancestorPath(event.target ?? null)
+}
+
+/**
+ * Resolve the nearest scroll owner for a vertical wheel event.  A null result
+ * means the event was filtered (horizontal/zoom/etc.) or no scrollable
+ * ancestor exists.  A non-null owner at its edge lets callers decide whether
+ * to hand off to an outer sibling; `blockedByOverscroll` marks the CSS
+ * containment case where the handoff should stop.
+ */
+export function resolveChatWheelOwnership(
+  event: ChatWheelEventLike,
+  boundary: HTMLElement | null = null,
+  options: ResolveChatWheelOwnershipOptions = {},
+): ChatWheelOwnership | null {
+  const pageHeight = options.pageHeight ?? 0
+  const epsilonPx = options.epsilonPx ?? CHAT_WHEEL_EPSILON_PX
+  const delta = normalizeChatWheelDelta(event, pageHeight)
+  const direction = event.defaultPrevented || event.ctrlKey || event.metaKey || !delta
+    ? null
+    : directionForNormalizedDelta(event, delta, epsilonPx)
+  if (!delta || !direction) return null
+
+  const respectOverscrollBehavior = options.respectOverscrollBehavior ?? true
+  const path = pathForEvent(event)
+  const boundaryIndex = boundary
+    ? path.findIndex(target => target === boundary)
+    : path.length
+  // A supplied boundary must actually contain the event target.  Without
+  // this check a sibling/page path could accidentally claim ownership.
+  if (boundary && boundaryIndex < 0) {
+    return {
+      direction,
+      deltaX: delta.deltaX,
+      deltaY: delta.deltaY,
+      owner: null,
+      canScroll: false,
+      atBoundary: false,
+      blockedByOverscroll: false,
+    }
+  }
+
+  let nearestEdgeOwner: HTMLElement | null = null
+  for (const [index, target] of path.entries()) {
+    if (!isHTMLElement(target)) continue
+    if (boundary && index > boundaryIndex) break
+
+    if (hasVerticalOverflow(target, epsilonPx)) {
+      const canScroll = canScrollInDirection(target, direction, epsilonPx)
+      if (canScroll) {
+        return {
+          direction,
+          deltaX: delta.deltaX,
+          deltaY: delta.deltaY,
+          owner: target,
+          canScroll: true,
+          atBoundary: false,
+          blockedByOverscroll: false,
+        }
+      }
+
+      const blockedByOverscroll = respectOverscrollBehavior && isOverscrollBlocking(target)
+      if (blockedByOverscroll || target === boundary) {
+        return {
+          direction,
+          deltaX: delta.deltaX,
+          deltaY: delta.deltaY,
+          owner: target,
+          canScroll: false,
+          atBoundary: true,
+          blockedByOverscroll,
+        }
+      }
+      nearestEdgeOwner ??= target
+    }
+
+    // The boundary is inclusive but nothing outside the chat surface may own
+    // its wheel.  Stop after inspecting it.
+    if (target === boundary) break
+  }
+
+  return {
+    direction,
+    deltaX: delta.deltaX,
+    deltaY: delta.deltaY,
+    owner: nearestEdgeOwner,
+    canScroll: false,
+    atBoundary: nearestEdgeOwner !== null,
+    blockedByOverscroll: false,
+  }
+}

--- a/opensquilla-webui/src/utils/chat/planQuestionnaireWheel.test.ts
+++ b/opensquilla-webui/src/utils/chat/planQuestionnaireWheel.test.ts
@@ -1,7 +1,10 @@
 // @vitest-environment happy-dom
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { handoffPlanQuestionnaireWheel } from './planQuestionnaireWheel'
+import {
+  handoffPlanQuestionnaireTouch,
+  handoffPlanQuestionnaireWheel,
+} from './planQuestionnaireWheel'
 
 function setScrollMetrics(
   element: HTMLElement,
@@ -18,8 +21,22 @@ function wheelFrom(
   target: HTMLElement,
   thread: HTMLElement,
   deltaY: number,
+  options: Partial<WheelEventInit> = {},
 ): { event: WheelEvent, forwarded: boolean } {
-  const event = new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY })
+  const event = new WheelEvent('wheel', {
+    bubbles: true,
+    cancelable: true,
+    deltaY,
+    ...options,
+  })
+  // happy-dom currently ignores modifier fields in WheelEventInit even
+  // though browser engines populate them. Mirror the native readonly fields
+  // so the filtering path is exercised deterministically.
+  for (const key of ['ctrlKey', 'metaKey', 'shiftKey'] as const) {
+    if (options[key] !== undefined) {
+      Object.defineProperty(event, key, { configurable: true, value: options[key] })
+    }
+  }
   let forwarded = false
   target.addEventListener('wheel', current => {
     forwarded = handoffPlanQuestionnaireWheel(current as WheelEvent, thread)
@@ -28,21 +45,56 @@ function wheelFrom(
   return { event, forwarded }
 }
 
+function touchFrom(
+  target: HTMLElement,
+  thread: HTMLElement,
+  startY: number,
+  endY: number,
+): { event: TouchEvent, forwarded: boolean } {
+  const event = new Event('touchmove', { bubbles: true, cancelable: true }) as TouchEvent
+  Object.defineProperty(event, 'touches', {
+    configurable: true,
+    value: [{ identifier: 1, clientX: 10, clientY: endY }],
+  })
+  let forwarded = false
+  target.addEventListener('touchmove', current => {
+    forwarded = handoffPlanQuestionnaireTouch(current as TouchEvent, thread, {
+      identifier: 1,
+      x: 10,
+      y: startY,
+    })
+  }, { once: true })
+  target.dispatchEvent(event)
+  return { event, forwarded }
+}
+
 describe('handoffPlanQuestionnaireWheel', () => {
   let thread: HTMLElement
+  let card: HTMLElement
   let body: HTMLElement
   let choice: HTMLElement
+  let intro: HTMLElement
 
   beforeEach(() => {
     document.body.innerHTML = ''
     thread = document.createElement('div')
+    card = document.createElement('article')
     body = document.createElement('div')
     choice = document.createElement('label')
+    intro = document.createElement('p')
+    thread.style.overflowY = 'auto'
+    card.className = 'clarify-card'
     body.className = 'clarify-card__body'
+    body.style.overflowY = 'auto'
+    intro.className = 'clarify-card__intro--long'
+    intro.style.overflowY = 'auto'
+    intro.style.overscrollBehaviorY = 'contain'
     body.appendChild(choice)
-    document.body.append(thread, body)
+    card.append(intro, body)
+    document.body.append(thread, card)
     setScrollMetrics(thread, { clientHeight: 300, scrollHeight: 900, scrollTop: 400 })
     setScrollMetrics(body, { clientHeight: 100, scrollHeight: 300, scrollTop: 80 })
+    setScrollMetrics(intro, { clientHeight: 100, scrollHeight: 400, scrollTop: 120 })
   })
 
   it('leaves the wheel with the questionnaire while its body can scroll', () => {
@@ -74,11 +126,90 @@ describe('handoffPlanQuestionnaireWheel', () => {
 
   it('forwards wheel gestures over the questionnaire header and footer', () => {
     const header = document.createElement('header')
-    document.body.appendChild(header)
+    card.prepend(header)
 
     const { forwarded } = wheelFrom(header, thread, -20)
 
     expect(forwarded).toBe(true)
     expect(thread.scrollTop).toBe(380)
+  })
+
+  it('keeps a long clarification intro as the wheel owner while it can scroll', () => {
+    const before = thread.scrollTop
+
+    const { event, forwarded } = wheelFrom(intro, thread, -40)
+
+    expect(forwarded).toBe(false)
+    expect(event.defaultPrevented).toBe(false)
+    expect(thread.scrollTop).toBe(before)
+  })
+
+  it('hands a long clarification intro to the thread at its edge', () => {
+    intro.scrollTop = 0
+
+    const { event, forwarded } = wheelFrom(intro, thread, -40)
+
+    expect(forwarded).toBe(true)
+    expect(event.defaultPrevented).toBe(true)
+    expect(thread.scrollTop).toBe(360)
+  })
+
+  it('hands a single-finger questionnaire edge drag to the thread', () => {
+    body.scrollTop = 0
+    const { event, forwarded } = touchFrom(choice, thread, 200, 160)
+
+    expect(forwarded).toBe(true)
+    expect(event.defaultPrevented).toBe(true)
+    expect(thread.scrollTop).toBe(360)
+  })
+
+  it('uses incremental touch deltas instead of replaying the whole drag', () => {
+    body.scrollTop = 0
+    const start = { identifier: 1, x: 10, y: 200 }
+    const move = (clientY: number) => {
+      const event = new Event('touchmove', { bubbles: true, cancelable: true }) as TouchEvent
+      Object.defineProperty(event, 'touches', {
+        configurable: true,
+        value: [{ identifier: 1, clientX: 10, clientY }],
+      })
+      let forwarded = false
+      choice.addEventListener('touchmove', current => {
+        forwarded = handoffPlanQuestionnaireTouch(current as TouchEvent, thread, start)
+      }, { once: true })
+      choice.dispatchEvent(event)
+      return forwarded
+    }
+
+    expect(move(190)).toBe(true)
+    expect(move(180)).toBe(true)
+    expect(start.y).toBe(180)
+    expect(thread.scrollTop).toBe(380)
+  })
+
+  it('uses line and page delta modes when forwarding to the thread', () => {
+    body.scrollTop = 0
+    const line = wheelFrom(choice, thread, -2, { deltaMode: WheelEvent.DOM_DELTA_LINE })
+    expect(line.forwarded).toBe(true)
+    expect(thread.scrollTop).toBe(368)
+
+    body.scrollTop = 200
+    const page = wheelFrom(choice, thread, 1, { deltaMode: WheelEvent.DOM_DELTA_PAGE })
+    expect(page.forwarded).toBe(true)
+    // A page-sized handoff is clamped to the thread's real scroll range.
+    expect(thread.scrollTop).toBe(600)
+  })
+
+  it.each([
+    ['horizontal', { deltaX: 40 }],
+    ['shift', { shiftKey: true }],
+    ['ctrl zoom', { ctrlKey: true }],
+    ['meta zoom', { metaKey: true }],
+  ])('does not forward %s gestures', (_label, options) => {
+    body.scrollTop = 0
+    const { event, forwarded } = wheelFrom(choice, thread, -40, options)
+
+    expect(forwarded).toBe(false)
+    expect(event.defaultPrevented).toBe(false)
+    expect(thread.scrollTop).toBe(400)
   })
 })

--- a/opensquilla-webui/src/utils/chat/planQuestionnaireWheel.ts
+++ b/opensquilla-webui/src/utils/chat/planQuestionnaireWheel.ts
@@ -1,24 +1,12 @@
-const WHEEL_LINE_HEIGHT_PX = 16
+import {
+  resolveChatWheelOwnership,
+} from './chatScrollOwnership'
 
-function questionnaireBodyForTarget(target: EventTarget | null): HTMLElement | null {
+const QUESTIONNAIRE_SCROLL_EPSILON_PX = 0.5
+
+function questionnaireBoundaryForTarget(target: EventTarget | null): HTMLElement | null {
   if (!(target instanceof Element)) return null
-  return target.closest<HTMLElement>('.clarify-card__body')
-}
-
-function questionnaireBodyCanScroll(body: HTMLElement, deltaY: number): boolean {
-  const maxScrollTop = Math.max(0, body.scrollHeight - body.clientHeight)
-  if (deltaY < 0) return body.scrollTop > 0
-  return body.scrollTop < maxScrollTop
-}
-
-function wheelDeltaPixels(event: WheelEvent, pageHeight: number): number {
-  if (event.deltaMode === WheelEvent.DOM_DELTA_LINE) {
-    return event.deltaY * WHEEL_LINE_HEIGHT_PX
-  }
-  if (event.deltaMode === WheelEvent.DOM_DELTA_PAGE) {
-    return event.deltaY * pageHeight
-  }
-  return event.deltaY
+  return target.closest<HTMLElement>('.clarify-card')
 }
 
 /**
@@ -29,14 +17,88 @@ export function handoffPlanQuestionnaireWheel(
   event: WheelEvent,
   thread: HTMLElement | null,
 ): boolean {
-  if (!thread || event.ctrlKey || event.defaultPrevented || event.deltaY === 0) return false
+  if (!thread) return false
 
-  const questionnaireBody = questionnaireBodyForTarget(event.target)
-  if (questionnaireBody && questionnaireBodyCanScroll(questionnaireBody, event.deltaY)) {
-    return false
-  }
+  const boundary = questionnaireBoundaryForTarget(event.target)
+  if (!boundary) return false
+
+  const ownership = resolveChatWheelOwnership(
+    event,
+    boundary,
+    {
+      pageHeight: thread.clientHeight,
+      // This handler is the explicit sibling handoff for the dock.  The
+      // nested questionnaire's own CSS containment should not strand the
+      // reader at an edge when the conversation can continue scrolling.
+      respectOverscrollBehavior: false,
+    },
+  )
+  // The dock is a sibling of `.chat-thread`, so the generic ancestor walk can
+  // decide whether the card's own body/intro owns the gesture, but it cannot
+  // discover the thread as an ancestor.  Keep the inner scroller untouched
+  // while it has room; only then perform the explicit sibling handoff below.
+  if (ownership?.owner && ownership.canScroll) return false
+
+  const direction = ownership?.direction
+  const deltaY = ownership?.deltaY
+  if (!direction || deltaY === undefined) return false
+  const maxScrollTop = Math.max(0, thread.scrollHeight - thread.clientHeight)
+  const threadCanScroll = direction === 'up'
+    ? thread.scrollTop > QUESTIONNAIRE_SCROLL_EPSILON_PX
+    : thread.scrollTop < maxScrollTop - QUESTIONNAIRE_SCROLL_EPSILON_PX
+  if (!threadCanScroll) return false
 
   event.preventDefault()
-  thread.scrollTop += wheelDeltaPixels(event, thread.clientHeight)
+  thread.scrollTop = Math.min(maxScrollTop, Math.max(0, thread.scrollTop + deltaY))
+  return true
+}
+
+/**
+ * Touch equivalent of the dock's wheel handoff. Touchmove cannot rely on the
+ * browser's scroll-chain propagation because the questionnaire is a sibling
+ * overlay, so an edge gesture is explicitly transferred to the thread.
+ */
+export function handoffPlanQuestionnaireTouch(
+  event: TouchEvent,
+  thread: HTMLElement | null,
+  /** Mutable per-gesture cursor; updated to the latest touch point. */
+  start: { identifier: number, x: number, y: number },
+): boolean {
+  if (!thread || event.touches.length !== 1) return false
+  const touch = Array.from(event.touches).find(item => item.identifier === start.identifier)
+  if (!touch) return false
+  const deltaX = touch.clientX - start.x
+  const deltaY = start.y - touch.clientY
+  // `start` is the mutable per-gesture cursor owned by the dock handler. A
+  // touchmove delta is incremental, unlike a wheel event's delta; advance the
+  // cursor even when the nested questionnaire consumes the move so a later
+  // edge handoff cannot replay the whole gesture distance.
+  start.x = touch.clientX
+  start.y = touch.clientY
+  if (Math.abs(deltaY) <= 2 || Math.abs(deltaX) >= Math.abs(deltaY)) return false
+
+  const boundary = questionnaireBoundaryForTarget(event.target)
+  if (!boundary) return false
+  const ownership = resolveChatWheelOwnership({
+    deltaX: 0,
+    deltaY: deltaY > 0 ? -1 : 1,
+    defaultPrevented: event.defaultPrevented,
+    target: event.target,
+    composedPath: () => event.composedPath(),
+  }, boundary, {
+    pageHeight: thread.clientHeight,
+    respectOverscrollBehavior: false,
+  })
+  if (ownership?.owner && ownership.canScroll) return false
+
+  const maxScrollTop = Math.max(0, thread.scrollHeight - thread.clientHeight)
+  const threadCanScroll = deltaY > 0
+    ? thread.scrollTop > QUESTIONNAIRE_SCROLL_EPSILON_PX
+    : thread.scrollTop < maxScrollTop - QUESTIONNAIRE_SCROLL_EPSILON_PX
+  if (!threadCanScroll) return false
+
+  event.preventDefault()
+  const transfer = deltaY > 0 ? -Math.abs(deltaY) : Math.abs(deltaY)
+  thread.scrollTop = Math.min(maxScrollTop, Math.max(0, thread.scrollTop + transfer))
   return true
 }

--- a/opensquilla-webui/src/utils/chat/scrollMutation.test.ts
+++ b/opensquilla-webui/src/utils/chat/scrollMutation.test.ts
@@ -2,7 +2,11 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { applyProgrammaticScroll, consumeProgrammaticScroll } from './scrollMutation'
+import {
+  applyProgrammaticScroll,
+  clearProgrammaticScroll,
+  consumeProgrammaticScroll,
+} from './scrollMutation'
 
 function container(top = 0): HTMLElement {
   const element = document.createElement('div')
@@ -61,6 +65,17 @@ describe('chat scroll mutation ownership', () => {
       expectedScrollTop: 240,
       matched: true,
     })
+  })
+
+  it('clears a pending application correction explicitly', () => {
+    const thread = container(24)
+
+    applyProgrammaticScroll(thread, () => {
+      thread.scrollTop = 180
+    })
+    clearProgrammaticScroll(thread)
+
+    expect(consumeProgrammaticScroll(thread)).toBeNull()
   })
 
   it('retains the pending target when reader movement coalesces with the correction', () => {

--- a/opensquilla-webui/src/utils/chat/scrollMutation.ts
+++ b/opensquilla-webui/src/utils/chat/scrollMutation.ts
@@ -23,6 +23,16 @@ export function applyProgrammaticScroll(
 }
 
 /**
+ * Forget a pending application-owned position without consuming a scroll
+ * event. Chat session hand-offs reuse the same outer element, so a correction
+ * queued for the previous session must not be allowed to classify the first
+ * native event in the next one as programmatic.
+ */
+export function clearProgrammaticScroll(container: HTMLElement): void {
+  expectedProgrammaticScrollTop.delete(container)
+}
+
+/**
  * Returns the consumed application target and whether this event reached it.
  * A mismatch immediately releases the marker so a real reader gesture is never
  * swallowed by a stale correction.

--- a/opensquilla-webui/src/views/ChatView.scroll-follow.test.ts
+++ b/opensquilla-webui/src/views/ChatView.scroll-follow.test.ts
@@ -24,6 +24,45 @@ function threadWheelHandlerSource(): string {
 }
 
 describe('ChatView scroll ownership wiring', () => {
+  it('invalidates deferred work and pins a switched session only once', () => {
+    expect(chatViewSource).toContain('const scrollEpoch = ref(0)')
+    expect(chatViewSource).toContain('watch(sessionKey, beginSessionScrollEpoch, { flush: \'sync\' })')
+    expect(chatViewSource).toContain('clearProgrammaticScroll(threadRef.value)')
+    expect(chatViewSource).toContain('scroll-epoch="scrollEpoch"')
+    expect(chatViewSource).toContain('scheduleInitialSessionPin(scrollEpoch.value)')
+    expect(chatViewSource).toContain('sessionScrollInputEpoch === epoch')
+  })
+
+  it('cancels pending layout pins for explicit reader input', () => {
+    expect(chatViewSource).toContain('@touchcancel.passive="onThreadTouchEnd"')
+    expect(chatViewSource).toContain('@pointercancel="onThreadPointerEnd"')
+    expect(threadWheelHandlerSource()).toContain('cancelTailLayoutPin()')
+    expect(threadScrollHandlerSource()).toContain('if (!scrollMutation?.matched) cancelTailLayoutPin()')
+  })
+
+  it('pauses follow after a source-less native scroll during session landing', () => {
+    const source = threadScrollHandlerSource()
+
+    expect(source).toContain('const gap = metrics.height - metrics.top - metrics.clientHeight')
+    expect(source).toContain('readerMovingAway = true')
+    expect(source).toContain('autoScroll.value = false')
+  })
+
+  it('marks questionnaire edge handoff as reader input before writing scrollTop', () => {
+    const start = chatViewSource.indexOf('function handlePlanQuestionnaireWheel(')
+    const end = chatViewSource.indexOf('\nfunction onPlanQuestionnaireTouchStart(', start)
+    const source = chatViewSource.slice(start, end)
+
+    expect(source).toContain('markThreadScrollIntent(direction)')
+    expect(source.indexOf('markThreadScrollIntent(direction)')).toBeLessThan(
+      source.indexOf('handoffPlanQuestionnaireWheel(event, thread)'),
+    )
+    // The touch helper may call preventDefault when transferring a sibling
+    // gesture, so this listener must remain non-passive.
+    expect(chatViewSource).toContain('@touchmove="onPlanQuestionnaireTouchMove"')
+    expect(chatViewSource).not.toContain('@touchmove.passive="onPlanQuestionnaireTouchMove"')
+  })
+
   it('removes stale reader intent from application-owned composer samples', () => {
     const source = threadScrollHandlerSource()
 
@@ -40,7 +79,7 @@ describe('ChatView scroll ownership wiring', () => {
     const wheelSource = threadWheelHandlerSource()
 
     expect(scrollSource).toContain(
-      'historyNavigationScrollLock.locked && intent !== null',
+      'if (!programmatic && historyNavigationScrollLock.locked)',
     )
     expect(scrollSource).toContain('interruptHistoryNavigationForReader()')
     expect(endSource).toContain(
@@ -54,6 +93,21 @@ describe('ChatView scroll ownership wiring', () => {
     )
     expect(chatViewSource).toContain(
       'conversationMinimapRef.value?.cancelNavigation()',
+    )
+  })
+
+  it('cancels navigation for source-less native scrollbar movement', () => {
+    const source = threadScrollHandlerSource()
+
+    expect(chatViewSource).toContain('sourceLessScrollPointerId')
+    expect(source).toContain('sourceLessScrollPointerId !== null && moved')
+    expect(chatViewSource).toContain("window.addEventListener('pointerup', onThreadPointerEnd)")
+    expect(chatViewSource).toContain("window.removeEventListener('pointerup', onThreadPointerEnd)")
+  })
+
+  it('does not steal modified keyboard shortcuts or IME composition', () => {
+    expect(chatViewSource).toContain(
+      'if (event.isComposing || event.ctrlKey || event.metaKey || event.altKey) return',
     )
   })
 })

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -106,16 +106,25 @@
         <div
           ref="threadRef"
           class="chat-thread"
-          :class="{ 'chat-thread--reading-history': !autoScroll }"
+          :data-session-key="sessionKey"
+          :class="{
+            'chat-thread--reading-history': !autoScroll,
+            'chat-thread--nonvirtualized': messageListRef && !messageListRef.isVirtualized(),
+          }"
           role="region"
           tabindex="0"
           :aria-label="t('chat.conversation')"
           :aria-busy="isStreaming || forkInFlight"
           @scroll="onThreadScroll"
           @wheel.passive="onThreadWheel"
+          @touchstart.passive="onThreadTouchStart"
           @touchmove.passive="onThreadTouchMove"
-          @pointerdown="markThreadScrollIntent('either')"
+          @touchend.passive="onThreadTouchEnd"
+          @touchcancel.passive="onThreadTouchEnd"
+          @pointerdown="onThreadPointerDown"
           @pointermove="onThreadPointerMove"
+          @pointerup="onThreadPointerEnd"
+          @pointercancel="onThreadPointerEnd"
           @keydown="onThreadScrollKeydown"
         >
         <template v-if="isNewChatLanding">
@@ -202,6 +211,7 @@
           :plan-actions-disabled="planActionsDisabled"
           :is-streaming="isStreaming"
           :follow-live-edge="autoScroll"
+          :scroll-epoch="scrollEpoch"
           :goal="currentGoalRun"
           :goal-elapsed="goalLastElapsed"
           @fork-conversation="forkConversation"
@@ -615,6 +625,10 @@
       v-if="dockedPlanQuestionnaire"
       class="plan-questionnaire-dock"
       @wheel="handlePlanQuestionnaireWheel"
+      @touchstart.passive="onPlanQuestionnaireTouchStart"
+      @touchmove="onPlanQuestionnaireTouchMove"
+      @touchend.passive="onPlanQuestionnaireTouchEnd"
+      @touchcancel.passive="onPlanQuestionnaireTouchEnd"
     >
       <ClarifyCard
         :request="dockedPlanQuestionnaire"
@@ -1012,7 +1026,7 @@ import {
   artifactUsesWorkbenchPreview,
   artifactWorkbenchPreviewKind,
 } from '@/utils/workbench/artifactPreview'
-import { focusArtifactInTranscript } from '@/utils/chat/artifactFocus'
+import { findArtifactCard, focusArtifactInTranscript } from '@/utils/chat/artifactFocus'
 import { fetchDisplayAttachmentBlob } from '@/utils/chat/attachmentAccess'
 import { classifyArtifactProductError } from '@/utils/artifactProductErrors'
 import {
@@ -1023,6 +1037,7 @@ import { listPendingMetaDiscards } from '@/utils/chat/metaDiscardOutbox'
 import { createHistoryNavigationScrollLock } from '@/utils/chat/historyNavigationScrollLock'
 import {
   applyProgrammaticScroll,
+  clearProgrammaticScroll,
   consumeProgrammaticScroll,
 } from '@/utils/chat/scrollMutation'
 import {
@@ -1064,7 +1079,14 @@ import {
 import { createPendingInputWal } from '@/utils/chat/pendingInputWal'
 import { agentIdFromSessionKey } from '@/utils/chat/sessionKeys'
 import { shouldDisableLandingSuggestions } from '@/utils/chat/landingSuggestions'
-import { handoffPlanQuestionnaireWheel } from '@/utils/chat/planQuestionnaireWheel'
+import {
+  handoffPlanQuestionnaireTouch,
+  handoffPlanQuestionnaireWheel,
+} from '@/utils/chat/planQuestionnaireWheel'
+import {
+  getChatWheelDirection,
+  resolveChatWheelOwnership,
+} from '@/utils/chat/chatScrollOwnership'
 import { clearAssistantActivityExpansionState } from '@/utils/chat/activityDisclosureState'
 import {
   resolveChatHistoryRecoveryState,
@@ -1363,18 +1385,69 @@ const inputText = ref('')
 const composerRevision = ref(0)
 const aborted = ref(false)
 const autoScroll = ref(true)
+// Every session gets a monotonically increasing scroll epoch. Any queued
+// layout/render callback from an older epoch must become a no-op; the DOM node
+// for the thread is intentionally reused so focus and native scrolling remain
+// stable during route changes.
+const scrollEpoch = ref(0)
+let sessionScrollSwitching = false
+let sessionScrollInputEpoch: number | null = null
+let initialSessionPinFrame: number | null = null
+let sessionScrollBaseline: {
+  top: number
+  height: number
+  clientHeight: number
+} | null = null
 const historyNavigationScrollLock = createHistoryNavigationScrollLock(autoScroll)
 const LIVE_EDGE_EPSILON_PX = 2
 const SCROLL_DIRECTION_EPSILON_PX = 0.5
 let lastObservedThreadScrollTop: number | null = null
 let readerMovingAway = false
+let scrollDiagnosticFrame = 0
+
+let activeTouchIdentifier: number | null = null
+let touchStartX = 0
+let touchStartY = 0
+let questionnaireTouch: { identifier: number, x: number, y: number } | null = null
+let activePointerId: number | null = null
+let pointerStartX = 0
+let pointerStartY = 0
+// Native scrollbar drags and middle-button auto-scroll may emit scroll events
+// without a wheel/touch/keyboard event on the thread. Keep a short-lived
+// pointer marker so those source-less moves can interrupt explicit navigation
+// without mistaking smooth-scroll frames for reader input.
+let sourceLessScrollPointerId: number | null = null
+let activeHistoryNavigationEpoch: number | null = null
+let activeHistoryNavigationSessionKey = ''
+let activeThreadNavigationCancel: (() => void) | null = null
+let activeThreadNavigationTimer: number | null = null
 
 function resetReaderScrollTracking() {
   lastObservedThreadScrollTop = null
   readerMovingAway = false
 }
 
-watch(sessionKey, resetReaderScrollTracking, { flush: 'sync' })
+function recordChatScrollDiagnostic(
+  source: string,
+  writer: string,
+  container: HTMLElement,
+  beforeScrollTop: number | null,
+) {
+  if (!import.meta.env.DEV || typeof console === 'undefined') return
+  const afterScrollTop = container.scrollTop
+  if (beforeScrollTop === afterScrollTop && source !== 'programmatic') return
+  console.debug('[chat-scroll]', {
+    epoch: scrollEpoch.value,
+    sessionKey: sessionKey.value,
+    source,
+    writer,
+    beforeScrollTop,
+    afterScrollTop,
+    bottomGap: container.scrollHeight - afterScrollTop - container.clientHeight,
+    frame: ++scrollDiagnosticFrame,
+  })
+}
+
 watch(autoScroll, following => {
   if (following) readerMovingAway = false
 }, { flush: 'sync' })
@@ -2155,6 +2228,7 @@ const chatHistory = useChatHistory({
   lastHeaderDay,
   preserveLiveTail: preserveHistoryLiveTail,
   autoScroll,
+  scrollEpoch,
   stripTimePrefix,
   scrollToBottom,
 })
@@ -2169,6 +2243,99 @@ const {
   cancelActiveHistory,
   cleanup: cleanupHistory,
 } = chatHistory
+
+function cancelInitialSessionPin() {
+  if (initialSessionPinFrame !== null) {
+    cancelAnimationFrame(initialSessionPinFrame)
+    initialSessionPinFrame = null
+  }
+}
+
+function beginSessionScrollEpoch() {
+  cancelActiveThreadNavigation()
+  scrollEpoch.value += 1
+  sessionScrollSwitching = true
+  sessionScrollInputEpoch = null
+  sessionScrollBaseline = threadRef.value
+    ? {
+        top: threadRef.value.scrollTop,
+        height: threadRef.value.scrollHeight,
+        clientHeight: threadRef.value.clientHeight,
+      }
+    : null
+  cancelInitialSessionPin()
+  cancelTailLayoutPin()
+  activeTouchIdentifier = null
+  questionnaireTouch = null
+  activePointerId = null
+  sourceLessScrollPointerId = null
+  activeHistoryNavigationEpoch = null
+  activeHistoryNavigationSessionKey = ''
+  conversationMinimapRef.value?.cancelNavigation()
+  historyNavigationScrollLock.finish()
+  cancelAnchorStabilization()
+  resetReaderScrollTracking()
+  clearPendingComposerScrollIntent()
+  if (threadRef.value) clearProgrammaticScroll(threadRef.value)
+  if (composerDockPinFrame !== null) {
+    cancelAnimationFrame(composerDockPinFrame)
+    composerDockPinFrame = null
+  }
+  // The selected product policy is that every newly opened session starts at
+  // its live edge. A pre-pin reader gesture is recorded below and takes
+  // precedence over this one initial pin.
+  autoScroll.value = true
+}
+
+function scheduleInitialSessionPin(epoch: number) {
+  cancelInitialSessionPin()
+  void nextTick(() => {
+    if (
+      epoch !== scrollEpoch.value
+      || !sessionScrollSwitching
+      || sessionScrollInputEpoch === epoch
+    ) {
+      if (epoch === scrollEpoch.value) sessionScrollSwitching = false
+      return
+    }
+    initialSessionPinFrame = requestAnimationFrame(() => {
+      initialSessionPinFrame = null
+      if (
+        epoch !== scrollEpoch.value
+        || sessionScrollInputEpoch === epoch
+        || (!isNewChatLanding.value && sessionKey.value !== historySessionKey.value)
+      ) {
+        if (epoch === scrollEpoch.value) sessionScrollSwitching = false
+        return
+      }
+      const thread = threadRef.value
+      if (thread && bottomSentinelRef.value) {
+        const gap = thread.scrollHeight - thread.scrollTop - thread.clientHeight
+        if (gap > LIVE_EDGE_EPSILON_PX) {
+          applyProgrammaticScroll(thread, () => {
+            thread.scrollTop = thread.scrollHeight
+          })
+        }
+      }
+      sessionScrollSwitching = false
+    })
+  })
+}
+
+watch(sessionKey, beginSessionScrollEpoch, { flush: 'sync' })
+watch(
+  () => [sessionKey.value, historySessionKey.value, historyState.value.initialLoadStatus] as const,
+  ([activeKey, loadedKey, status]) => {
+    if (
+      !sessionScrollSwitching
+      || !activeKey
+      || activeKey !== loadedKey
+      || (status !== 'ready' && status !== 'error')
+    ) return
+    scheduleInitialSessionPin(scrollEpoch.value)
+  },
+  { flush: 'post' },
+)
 planMutationAccepted = () => scheduleHistorySync()
 
 const steerDelivery = useChatSteerDelivery({
@@ -3407,7 +3574,78 @@ const dockedPlanQuestionnaire = computed(() => (
 ))
 
 function handlePlanQuestionnaireWheel(event: WheelEvent) {
-  handoffPlanQuestionnaireWheel(event, threadRef.value)
+  const thread = threadRef.value
+  if (!thread) return
+  // The questionnaire may own the gesture until it reaches an edge. Treat a
+  // gesture that is handed off to the transcript as reader input before the
+  // helper writes scrollTop; some engines emit that scroll event synchronously.
+  const direction = getChatWheelDirection(
+    {
+      deltaX: event.deltaX,
+      deltaY: event.deltaY,
+      deltaMode: event.deltaMode,
+      ctrlKey: event.ctrlKey,
+      metaKey: event.metaKey,
+      shiftKey: event.shiftKey,
+      target: event.target,
+      composedPath: () => event.composedPath(),
+      defaultPrevented: false,
+    },
+    thread.clientHeight,
+  )
+  if (!direction) return
+  cancelTailLayoutPin()
+  noteSessionScrollInput()
+  interruptHistoryNavigationForReader()
+  markThreadScrollIntent(direction)
+  const forwarded = handoffPlanQuestionnaireWheel(event, thread)
+  if (!forwarded) {
+    clearPendingComposerScrollIntent()
+    return
+  }
+  if (direction === 'up') pauseFollowingForUpwardIntent()
+}
+
+function onPlanQuestionnaireTouchStart(event: TouchEvent) {
+  if (event.touches.length !== 1) {
+    questionnaireTouch = null
+    return
+  }
+  const touch = event.touches[0]
+  if (!touch) return
+  questionnaireTouch = {
+    identifier: touch.identifier,
+    x: touch.clientX,
+    y: touch.clientY,
+  }
+}
+
+function onPlanQuestionnaireTouchMove(event: TouchEvent) {
+  const start = questionnaireTouch
+  const thread = threadRef.value
+  if (!start || !thread || event.touches.length !== 1) return
+  const touch = Array.from(event.touches).find(item => item.identifier === start.identifier)
+  if (!touch) return
+  const deltaX = touch.clientX - start.x
+  const deltaY = start.y - touch.clientY
+  if (Math.abs(deltaY) <= 2 || Math.abs(deltaX) >= Math.abs(deltaY)) return
+  const direction = deltaY > 0 ? 'up' : 'down'
+  cancelTailLayoutPin()
+  noteSessionScrollInput()
+  interruptHistoryNavigationForReader()
+  // Mark before the helper writes scrollTop: the resulting scroll event is
+  // synchronous in some engines and must be classified as a user handoff.
+  markThreadScrollIntent(direction)
+  const forwarded = handoffPlanQuestionnaireTouch(event, thread, start)
+  if (!forwarded) {
+    clearPendingComposerScrollIntent()
+    return
+  }
+  if (direction === 'up') pauseFollowingForUpwardIntent()
+}
+
+function onPlanQuestionnaireTouchEnd() {
+  questionnaireTouch = null
 }
 
 const rpcEventHandlers = useChatRpcEventHandlers({
@@ -3606,18 +3844,23 @@ const visiblePendingInterruptKeys = computed(() => {
 async function focusPendingApprovalCard() {
   const request = appStore.approvalFocusRequest
   if (!request || request.sessionKey !== sessionKey.value) return
+  const requestScrollEpoch = scrollEpoch.value
 
   await nextTick()
   if (
     appStore.approvalFocusRequest?.requestId !== request.requestId
     || request.sessionKey !== sessionKey.value
+    || requestScrollEpoch !== scrollEpoch.value
   ) return
 
   const card = [...(threadRef.value?.querySelectorAll<HTMLElement>('[data-approval-id]') ?? [])]
     .find(element => element.dataset.approvalId === request.approvalId)
   if (!card) return
 
-  card.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  const reduceMotion = typeof window !== 'undefined'
+    && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+  beginActiveThreadNavigation(!reduceMotion)
+  card.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'center' })
   card.focus({ preventScroll: true })
   appStore.clearApprovalFocusRequest(request.requestId)
 }
@@ -3647,6 +3890,7 @@ function preserveTerminalAnswerAnchor() {
   if (!elementAnchor && !textAnchor) return
 
   const ownerSessionKey = sessionKey.value
+  const ownerScrollEpoch = scrollEpoch.value
   const guard = createScrollHandoffGuard(container)
   const previousRows = Array.from(
     container.querySelectorAll<HTMLElement>('.chat-message-list__row'),
@@ -3657,6 +3901,7 @@ function preserveTerminalAnswerAnchor() {
   const restore = () => {
     if (
       sessionKey.value !== ownerSessionKey
+      || scrollEpoch.value !== ownerScrollEpoch
       || isStreaming.value
       || autoScroll.value
       || threadRef.value !== container
@@ -3800,6 +4045,7 @@ function scrollToStepCard(toolUseId: string) {
   if (card && typeof (card as HTMLElement).scrollIntoView === 'function') {
     const reduceMotion = typeof window !== 'undefined'
       && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+    beginActiveThreadNavigation(!reduceMotion)
     ;(card as HTMLElement).scrollIntoView({ block: 'center', behavior: reduceMotion ? 'auto' : 'smooth' })
   }
 }
@@ -3821,6 +4067,108 @@ let chatViewDisposed = false
 let composerDockResizeObserver: ResizeObserver | null = null
 let composerDockPinFrame: number | null = null
 let lastComposerDockHeight = -1
+let tailResizeObserver: ResizeObserver | null = null
+let tailMutationObserver: MutationObserver | null = null
+let tailLayoutPinFrame: number | null = null
+
+function cancelTailLayoutPin() {
+  if (tailLayoutPinFrame !== null) {
+    cancelAnimationFrame(tailLayoutPinFrame)
+    tailLayoutPinFrame = null
+  }
+}
+
+function queueTailLayoutPin() {
+  const thread = threadRef.value
+  if (!thread || tailLayoutPinFrame !== null) return
+  const epoch = scrollEpoch.value
+  const key = sessionKey.value
+  tailLayoutPinFrame = requestAnimationFrame(() => {
+    tailLayoutPinFrame = null
+    if (
+      epoch !== scrollEpoch.value
+      || key !== sessionKey.value
+      || threadRef.value !== thread
+      || !autoScroll.value
+    ) return
+    const gap = thread.scrollHeight - thread.scrollTop - thread.clientHeight
+    // Keep the established 2px live-edge contract and avoid another scroll
+    // event when a late image/font/layout change did not move the edge.
+    if (gap <= LIVE_EDGE_EPSILON_PX) return
+    applyProgrammaticScroll(thread, () => {
+      thread.scrollTop = thread.scrollHeight
+    })
+  })
+}
+
+function bindTailLayoutObservers() {
+  tailResizeObserver?.disconnect()
+  tailResizeObserver = null
+  tailMutationObserver?.disconnect()
+  tailMutationObserver = null
+  cancelTailLayoutPin()
+
+  const thread = threadRef.value
+  if (!thread) return
+  const epoch = scrollEpoch.value
+  const key = sessionKey.value
+
+  if (typeof ResizeObserver !== 'undefined') {
+    try {
+      const observer = new ResizeObserver(entries => {
+        if (
+          epoch !== scrollEpoch.value
+          || key !== sessionKey.value
+          || threadRef.value !== thread
+        ) return
+        // Observe only the thread's direct children. Their own components
+        // already coalesce internal changes; watching the entire subtree would
+        // turn every streamed token into an independent layout task.
+        if (entries.length > 0) {
+          queueTailLayoutPin()
+        }
+      })
+      for (const child of Array.from(thread.children)) {
+        if (!(child instanceof HTMLElement)) continue
+        try {
+          // `border-box` is intentionally omitted for older WebViews that do
+          // not implement ResizeObserver's box options; the default content
+          // box still provides the height-change signal we need.
+          observer.observe(child)
+        } catch {
+          // A single display:contents/legacy host must not disable observation
+          // for the remaining direct children.
+        }
+      }
+      tailResizeObserver = observer
+    } catch {
+      // Older WebViews may expose ResizeObserver but reject an observation;
+      // the existing ChatMessageList/Composer observers remain the fallback.
+      tailResizeObserver = null
+    }
+  }
+
+  if (typeof MutationObserver !== 'undefined') {
+    try {
+      const observer = new MutationObserver(records => {
+        if (
+          epoch !== scrollEpoch.value
+          || key !== sessionKey.value
+          || threadRef.value !== thread
+        ) return
+        if (records.some(record => record.type === 'childList' && record.target === thread)) {
+          // Rebind to newly mounted direct children, then let their ResizeObserver
+          // report any late image/font/fold growth in the next frame.
+          bindTailLayoutObservers()
+        }
+      })
+      observer.observe(thread, { childList: true })
+      tailMutationObserver = observer
+    } catch {
+      tailMutationObserver = null
+    }
+  }
+}
 
 /* ── Computed ──────────────────────────────────────────────────────── */
 
@@ -3837,6 +4185,11 @@ const isNewChatLanding = computed(() => {
 })
 
 watch(isNewChatLanding, resetComposerRetraction, { flush: 'sync' })
+watch(isNewChatLanding, landing => {
+  if (landing && sessionScrollSwitching) {
+    scheduleInitialSessionPin(scrollEpoch.value)
+  }
+}, { flush: 'post' })
 
 const historyRecoveryState = computed(() => {
   return resolveChatHistoryRecoveryState({
@@ -4609,6 +4962,9 @@ async function openDeliverables() {
 function focusInlineDeliverable(artifact: ArtifactPayload): boolean {
   const reduceMotion = typeof window !== 'undefined'
     && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+  const card = findArtifactCard(threadRef.value, artifact)
+  if (!card) return false
+  beginActiveThreadNavigation(!reduceMotion)
   return focusArtifactInTranscript(
     threadRef.value,
     artifact,
@@ -5204,28 +5560,81 @@ function shareTitle(): string {
 /* ── Streaming ─────────────────────────────────────────────────────── */
 
 function scrollToBottom() {
+  const epoch = scrollEpoch.value
+  const key = sessionKey.value
   nextTick(() => {
     // A stream/event may request a follow while the reader is at the live edge,
     // then the reader can scroll up before Vue applies this next-tick callback.
     // Re-check here so that queued automatic scrolls never override that choice.
-    if (threadRef.value && bottomSentinelRef.value && autoScroll.value) {
-      // The floating composer is represented by bottom padding after the
-      // sentinel. scrollIntoView() aligns the sentinel but leaves that padding
-      // below the viewport, so the live answer remains hidden under the dock
-      // and the geometric bottom gap equals the composer height. Scroll the
-      // container itself to its true maximum instead.
-      applyProgrammaticScroll(threadRef.value, () => {
-        threadRef.value!.scrollTop = threadRef.value!.scrollHeight
-      })
-    }
+    if (
+      epoch !== scrollEpoch.value
+      || key !== sessionKey.value
+      || !threadRef.value
+      || !bottomSentinelRef.value
+      || !autoScroll.value
+    ) return
+    // The floating composer is represented by bottom padding after the
+    // sentinel. scrollIntoView() aligns the sentinel but leaves that padding
+    // below the viewport, so the live answer remains hidden under the dock
+    // and the geometric bottom gap equals the composer height. Scroll the
+    // container itself to its true maximum instead.
+    const thread = threadRef.value
+    const gap = thread.scrollHeight - thread.scrollTop - thread.clientHeight
+    if (gap <= LIVE_EDGE_EPSILON_PX) return
+    applyProgrammaticScroll(thread, () => {
+      thread.scrollTop = thread.scrollHeight
+    })
   })
 }
 
 function onThreadScroll() {
   const el = threadRef.value
   if (!el) return
+  const observedBefore = lastObservedThreadScrollTop
   const currentScrollTop = el.scrollTop
   const scrollMutation = consumeProgrammaticScroll(el)
+  if (!scrollMutation?.matched) cancelTailLayoutPin()
+  if (sessionScrollSwitching) {
+    const baseline = sessionScrollBaseline
+    const metrics = {
+      top: currentScrollTop,
+      height: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    }
+    lastObservedThreadScrollTop = currentScrollTop
+    // A native scrollbar drag/middle-button auto-scroll has no reliable input
+    // event on the thread. Treat it as user input only when the scroll range is
+    // otherwise unchanged; layout/hydration changes normally alter height and
+    // therefore remain eligible for the one initial live-edge pin.
+    if (
+      !scrollMutation?.matched
+      && baseline
+      && baseline.height === metrics.height
+      && baseline.clientHeight === metrics.clientHeight
+      && Math.abs(metrics.top - baseline.top) > SCROLL_DIRECTION_EPSILON_PX
+    ) {
+      noteSessionScrollInput()
+      const gap = metrics.height - metrics.top - metrics.clientHeight
+      if (gap > LIVE_EDGE_EPSILON_PX) {
+        // A native scrollbar drag or middle-button auto-scroll has no input
+        // event of its own. Once it moves the switched-in session away from
+        // the live edge, keep following paused just like a wheel/touch gesture.
+        readerMovingAway = true
+        autoScroll.value = false
+      } else {
+        readerMovingAway = false
+        autoScroll.value = true
+      }
+    }
+    sessionScrollBaseline = metrics
+    recordChatScrollDiagnostic(
+      scrollMutation?.matched ? 'programmatic' : 'session-switch',
+      scrollMutation?.matched ? 'applyProgrammaticScroll' : 'browser-or-user',
+      el,
+      observedBefore,
+    )
+    return
+  }
   const previousScrollTop = scrollMutation?.expectedScrollTop
     ?? lastObservedThreadScrollTop
   lastObservedThreadScrollTop = currentScrollTop
@@ -5235,8 +5644,12 @@ function onThreadScroll() {
   // write sites, so every other position change belongs to the reader.
   const programmatic = scrollMutation?.matched ?? false
   const intent = programmatic ? null : currentThreadScrollIntent()
-  if (!programmatic && historyNavigationScrollLock.locked && intent !== null) {
-    interruptHistoryNavigationForReader()
+  if (!programmatic && historyNavigationScrollLock.locked) {
+    const moved = previousScrollTop !== null
+      && Math.abs(currentScrollTop - previousScrollTop) > SCROLL_DIRECTION_EPSILON_PX
+    if (intent !== null || (sourceLessScrollPointerId !== null && moved)) {
+      interruptHistoryNavigationForReader()
+    }
   } else if (!programmatic && !historyNavigationScrollLock.locked) {
     const movedUp = previousScrollTop !== null
       && currentScrollTop < previousScrollTop - SCROLL_DIRECTION_EPSILON_PX
@@ -5271,6 +5684,12 @@ function onThreadScroll() {
     }
   }
   if (isNewChatLanding.value || !composerFxEnabled.value) {
+    recordChatScrollDiagnostic(
+      programmatic ? 'programmatic' : intent ? `user-${intent}` : 'browser-or-user',
+      programmatic ? 'applyProgrammaticScroll' : 'onThreadScroll',
+      el,
+      observedBefore,
+    )
     resetComposerRetraction()
     return
   }
@@ -5283,62 +5702,159 @@ function onThreadScroll() {
     navigationLocked: historyNavigationScrollLock.locked,
   })
   if (composerCollapsed.value !== wasCollapsed) clearPendingComposerScrollIntent()
+  recordChatScrollDiagnostic(
+    programmatic ? 'programmatic' : intent ? `user-${intent}` : 'browser-or-user',
+    programmatic ? 'applyProgrammaticScroll' : 'onThreadScroll',
+    el,
+    observedBefore,
+  )
 }
 
 function onThreadWheel(event: WheelEvent) {
-  // Browser zoom gestures surface as ctrl+wheel (including trackpad pinch in
-  // Chromium) but do not represent reader movement inside the transcript.
-  if (event.deltaY === 0 || event.ctrlKey) return
   const el = threadRef.value
   if (!el) return
+  // A nested scroller may already have called preventDefault(). It still is a
+  // real reader gesture and must interrupt an in-flight minimap navigation;
+  // ownership below continues to respect the consumed event.
+  const direction = getChatWheelDirection(
+    {
+      deltaX: event.deltaX,
+      deltaY: event.deltaY,
+      deltaMode: event.deltaMode,
+      ctrlKey: event.ctrlKey,
+      metaKey: event.metaKey,
+      shiftKey: event.shiftKey,
+      target: event.target,
+      composedPath: () => event.composedPath(),
+      defaultPrevented: false,
+    },
+    el.clientHeight,
+  )
+  if (!direction) return
+  cancelTailLayoutPin()
+  noteSessionScrollInput()
   // Any wheel gesture inside the transcript takes ownership away from an
   // in-flight minimap animation, including gestures consumed by a nested
   // reasoning/tool scroller. Outside navigation, only a wheel that reaches the
   // thread itself may pause live-edge following.
-  if (historyNavigationScrollLock.locked && !event.defaultPrevented) {
+  if (historyNavigationScrollLock.locked) {
     interruptHistoryNavigationForReader()
   }
   if (!threadConsumesWheel(event, el)) return
-  markThreadScrollIntent(event.deltaY < 0 ? 'up' : 'down')
-  if (event.deltaY < 0) pauseFollowingForUpwardIntent()
+  markThreadScrollIntent(direction)
+  if (direction === 'up') pauseFollowingForUpwardIntent()
 }
 
 function threadConsumesWheel(event: WheelEvent, thread: HTMLElement): boolean {
-  if (event.defaultPrevented) return false
-  const canScroll = (element: HTMLElement) => event.deltaY < 0
-    ? element.scrollTop > SCROLL_DIRECTION_EPSILON_PX
-    : element.scrollTop + element.clientHeight
-      < element.scrollHeight - SCROLL_DIRECTION_EPSILON_PX
-
-  for (const target of event.composedPath()) {
-    if (target === thread) return canScroll(thread)
-    if (!(target instanceof HTMLElement)) continue
-    const style = getComputedStyle(target)
-    const scrollable = ['auto', 'scroll', 'overlay'].includes(style.overflowY)
-      && target.scrollHeight > target.clientHeight + SCROLL_DIRECTION_EPSILON_PX
-    if (!scrollable) continue
-    if (canScroll(target)) return false
-    if (style.overscrollBehaviorY === 'contain' || style.overscrollBehaviorY === 'none') {
-      return false
-    }
-  }
-  return false
+  const ownership = resolveChatWheelOwnership(event, thread, {
+    pageHeight: thread.clientHeight,
+    epsilonPx: SCROLL_DIRECTION_EPSILON_PX,
+  })
+  return ownership?.owner === thread && ownership.canScroll
 }
 
-function onThreadTouchMove() {
-  markThreadScrollIntent('either')
+function noteSessionScrollInput() {
+  if (sessionScrollSwitching) {
+    sessionScrollInputEpoch = scrollEpoch.value
+    cancelInitialSessionPin()
+    sessionScrollSwitching = false
+  }
+}
+
+function onThreadTouchStart(event: TouchEvent) {
+  if (event.touches.length !== 1) {
+    activeTouchIdentifier = null
+    return
+  }
+  const touch = event.touches[0]
+  if (!touch) return
+  activeTouchIdentifier = touch.identifier
+  touchStartX = touch.clientX
+  touchStartY = touch.clientY
+}
+
+function onThreadTouchMove(event: TouchEvent) {
+  const thread = threadRef.value
+  if (!thread || activeTouchIdentifier === null || event.touches.length !== 1) return
+  const touch = Array.from(event.touches).find(item => item.identifier === activeTouchIdentifier)
+  if (!touch) return
+  const deltaX = touch.clientX - touchStartX
+  const deltaY = touchStartY - touch.clientY
+  if (Math.abs(deltaY) <= 2 || Math.abs(deltaX) >= Math.abs(deltaY)) return
+  const direction = deltaY > 0 ? 'up' : 'down'
+  // A single-finger vertical gesture is user input even when a nested
+  // scroller owns the movement. Cancel pending navigation/initial pin first;
+  // only the ownership result below is allowed to pause the outer follow.
+  cancelTailLayoutPin()
+  noteSessionScrollInput()
   interruptHistoryNavigationForReader()
+  const ownership = resolveChatWheelOwnership({
+    deltaX: 0,
+    deltaY: direction === 'up' ? -1 : 1,
+    defaultPrevented: event.defaultPrevented,
+    target: event.target,
+    composedPath: () => event.composedPath(),
+  }, thread, { epsilonPx: SCROLL_DIRECTION_EPSILON_PX })
+  if (ownership?.owner !== thread || !ownership.canScroll) return
+  markThreadScrollIntent(direction)
+  if (direction === 'up') pauseFollowingForUpwardIntent()
+}
+
+function onThreadTouchEnd() {
+  activeTouchIdentifier = null
+}
+
+function onThreadPointerDown(event: PointerEvent) {
+  if (event.pointerType === 'touch' || event.isPrimary === false) return
+  if (
+    event.button === 1
+    || (event.button === 0 && event.target === event.currentTarget)
+  ) {
+    sourceLessScrollPointerId = event.pointerId
+  }
+  if (event.button !== 0) return
+  activePointerId = event.pointerId
+  pointerStartX = event.clientX
+  pointerStartY = event.clientY
 }
 
 function onThreadPointerMove(event: PointerEvent) {
-  if (event.buttons !== 0 || event.pointerType === 'touch') {
-    markThreadScrollIntent('either')
-    interruptHistoryNavigationForReader()
-  }
+  if (
+    activePointerId === null
+    || event.pointerId !== activePointerId
+    || event.buttons === 0
+    || event.isPrimary === false
+  ) return
+  const deltaX = event.clientX - pointerStartX
+  const deltaY = pointerStartY - event.clientY
+  if (Math.abs(deltaY) <= 3 || Math.abs(deltaX) >= Math.abs(deltaY)) return
+  cancelTailLayoutPin()
+  noteSessionScrollInput()
+  const direction = deltaY > 0 ? 'up' : 'down'
+  interruptHistoryNavigationForReader()
+  const thread = threadRef.value
+  if (!thread) return
+  const ownership = resolveChatWheelOwnership({
+    deltaX: 0,
+    deltaY: direction === 'up' ? -1 : 1,
+    defaultPrevented: event.defaultPrevented,
+    target: event.target,
+    composedPath: () => event.composedPath(),
+  }, thread, { epsilonPx: SCROLL_DIRECTION_EPSILON_PX })
+  if (ownership?.owner !== thread || !ownership.canScroll) return
+  markThreadScrollIntent(direction)
+  if (direction === 'up') pauseFollowingForUpwardIntent()
+}
+
+function onThreadPointerEnd(event: PointerEvent) {
+  if (activePointerId === event.pointerId) activePointerId = null
+  if (sourceLessScrollPointerId === event.pointerId) sourceLessScrollPointerId = null
 }
 
 function onThreadScrollKeydown(event: KeyboardEvent) {
-  if (event.target !== event.currentTarget) return
+  // Leave browser/assistive-technology shortcuts and IME composition alone;
+  // only an unmodified navigation key should affect chat follow state.
+  if (event.isComposing || event.ctrlKey || event.metaKey || event.altKey) return
   const up = event.key === 'ArrowUp'
     || event.key === 'PageUp'
     || event.key === 'Home'
@@ -5347,7 +5863,28 @@ function onThreadScrollKeydown(event: KeyboardEvent) {
     || event.key === 'PageDown'
     || event.key === 'End'
     || (event.key === ' ' && !event.shiftKey)
-  if (up || down) markThreadScrollIntent(up ? 'up' : 'down')
+  if (event.target !== event.currentTarget) {
+    // Independent reasoning/tool/questionnaire regions own their keyboard
+    // scroll. They still cancel a pending navigation or session pin, but must
+    // not pause the outer transcript when their own range can move.
+    const target = event.target instanceof HTMLElement ? event.target : null
+    const region = target?.closest('[role="region"][tabindex="0"]')
+    if (
+      !target
+      || region !== target
+      || (!up && !down)
+    ) return
+    cancelTailLayoutPin()
+    noteSessionScrollInput()
+    if (historyNavigationScrollLock.locked) interruptHistoryNavigationForReader()
+    return
+  }
+  if (up || down) {
+    cancelTailLayoutPin()
+    noteSessionScrollInput()
+    if (historyNavigationScrollLock.locked) interruptHistoryNavigationForReader()
+    markThreadScrollIntent(up ? 'up' : 'down')
+  }
   if (up) pauseFollowingForUpwardIntent()
 }
 
@@ -5359,12 +5896,69 @@ function pauseFollowingForUpwardIntent() {
   autoScroll.value = false
 }
 
+/**
+ * Mark a deliberate in-thread destination jump as application-owned. The
+ * lock prevents intermediate smooth-scroll frames from looking like reader
+ * input; wheel/touch/keyboard handlers can cancel it through the returned
+ * callback, and the session epoch makes a late `scrollend` harmless.
+ */
+function beginActiveThreadNavigation(smooth: boolean): () => void {
+  const thread = threadRef.value
+  const epoch = scrollEpoch.value
+  const key = sessionKey.value
+  if (activeHistoryNavigationEpoch !== null) {
+    conversationMinimapRef.value?.cancelNavigation()
+  }
+  cancelActiveThreadNavigation()
+  if (!thread) return () => {}
+
+  historyNavigationScrollLock.start()
+  let finished = false
+  const finish = () => {
+    if (finished) return
+    finished = true
+    thread.removeEventListener('scrollend', finish)
+    if (activeThreadNavigationTimer !== null) {
+      window.clearTimeout(activeThreadNavigationTimer)
+      activeThreadNavigationTimer = null
+    }
+    if (activeThreadNavigationCancel === finish) activeThreadNavigationCancel = null
+    if (epoch !== scrollEpoch.value || key !== sessionKey.value) return
+    historyNavigationScrollLock.finish()
+    syncComposerRetractionFromThread(false)
+  }
+  activeThreadNavigationCancel = finish
+  thread.addEventListener('scrollend', finish, { once: true })
+  activeThreadNavigationTimer = window.setTimeout(finish, smooth ? 1800 : 180)
+  return finish
+}
+
+function cancelActiveThreadNavigation() {
+  const thread = threadRef.value
+  if (thread && activeThreadNavigationCancel) {
+    try {
+      // Abort a native smooth scroll before releasing the lock; otherwise its
+      // late frames can continue into the next destination/session.
+      thread.scrollTo({ top: thread.scrollTop, behavior: 'auto' })
+    } catch {
+      // Older WebViews may not implement ScrollToOptions.
+    }
+  }
+  activeThreadNavigationCancel?.()
+  activeThreadNavigationCancel = null
+  if (activeThreadNavigationTimer !== null) {
+    window.clearTimeout(activeThreadNavigationTimer)
+    activeThreadNavigationTimer = null
+  }
+}
+
 function interruptHistoryNavigationForReader() {
   if (!historyNavigationScrollLock.locked) return
   const firstInterruption = historyNavigationScrollLock.interrupt()
   readerMovingAway = true
   autoScroll.value = false
   if (firstInterruption) conversationMinimapRef.value?.cancelNavigation()
+  if (firstInterruption) cancelActiveThreadNavigation()
 }
 
 function syncComposerRetractionFromThread(updateFollow = true) {
@@ -5383,12 +5977,22 @@ function syncComposerRetractionFromThread(updateFollow = true) {
 }
 
 function onHistoryNavigate() {
+  activeHistoryNavigationEpoch = scrollEpoch.value
+  activeHistoryNavigationSessionKey = sessionKey.value
   cancelAnchorStabilization()
   syncComposerRetractionFromThread()
   historyNavigationScrollLock.start()
 }
 
 function onHistoryNavigateEnd() {
+  const navigationEpoch = activeHistoryNavigationEpoch
+  const navigationSessionKey = activeHistoryNavigationSessionKey
+  activeHistoryNavigationEpoch = null
+  activeHistoryNavigationSessionKey = ''
+  if (
+    navigationEpoch !== scrollEpoch.value
+    || navigationSessionKey !== sessionKey.value
+  ) return
   const navigationInterrupted = historyNavigationScrollLock.finish()
   // Smooth-scroll frames and the final arrival are navigation, not transcript
   // browsing gestures. If the reader interrupted the motion, establish only a
@@ -5416,6 +6020,8 @@ watch(showJumpToLatest, showing => {
 
 function jumpToLatest() {
   cancelAnchorStabilization()
+  conversationMinimapRef.value?.cancelNavigation()
+  cancelActiveThreadNavigation()
   historyNavigationScrollLock.finish()
   expandComposer()
   autoScroll.value = true
@@ -5749,38 +6355,55 @@ function enterDraft() {
 
 let chatViewActive = false
 
+function bindBottomIntersectionObserver() {
+  bottomIntersectionObserver?.disconnect()
+  bottomIntersectionObserver = null
+  if (
+    typeof IntersectionObserver === 'undefined'
+    || !threadRef.value
+    || !bottomSentinelRef.value
+  ) return
+  const epoch = scrollEpoch.value
+  const key = sessionKey.value
+  const thread = threadRef.value
+  const sentinel = bottomSentinelRef.value
+  bottomIntersectionObserver = new IntersectionObserver((entries) => {
+    if (
+      epoch !== scrollEpoch.value
+      || key !== sessionKey.value
+      || threadRef.value !== thread
+      || bottomSentinelRef.value !== sentinel
+    ) return
+    const bottomGap = thread.scrollHeight - thread.scrollTop - thread.clientHeight
+    if (
+      entries.some(entry => entry.isIntersecting)
+      && bottomGap <= LIVE_EDGE_EPSILON_PX
+      && !readerMovingAway
+      && !historyNavigationScrollLock.locked
+    ) {
+      autoScroll.value = true
+    }
+  }, {
+    root: thread,
+    threshold: 1,
+  })
+  bottomIntersectionObserver.observe(sentinel)
+}
+
 onMounted(async () => {
   chatViewActive = true
   chatViewDisposed = false
-  if (
-    typeof IntersectionObserver !== 'undefined'
-    && threadRef.value
-    && bottomSentinelRef.value
-  ) {
-    bottomIntersectionObserver = new IntersectionObserver((entries) => {
-      const thread = threadRef.value
-      const bottomGap = thread
-        ? thread.scrollHeight - thread.scrollTop - thread.clientHeight
-        : Number.POSITIVE_INFINITY
-      if (
-        entries.some(entry => entry.isIntersecting)
-        && bottomGap <= LIVE_EDGE_EPSILON_PX
-        && !readerMovingAway
-        && !historyNavigationScrollLock.locked
-      ) {
-        autoScroll.value = true
-      }
-    }, {
-      root: threadRef.value,
-      threshold: 1,
-    })
-    bottomIntersectionObserver.observe(bottomSentinelRef.value)
-  }
+  // A native scrollbar drag can finish outside the thread element. Keep the
+  // source-less pointer marker from leaking into a later navigation gesture.
+  window.addEventListener('pointerup', onThreadPointerEnd)
+  window.addEventListener('pointercancel', onThreadPointerEnd)
+  bindBottomIntersectionObserver()
   const initialRouteFullPath = route.fullPath
   // Initialize session key. Without an explicit ?session= the view opens as a
   // draft instead of restoring a previous session.
   const initialSession = resolveInitialSession()
   sessionKey.value = initialSession.sessionKey
+  bindTailLayoutObservers()
   let initialDraftProjectGeneration: number | null = null
   let initialAutoSendSnapshot: {
     text: string
@@ -5871,10 +6494,21 @@ onMounted(async () => {
       lastComposerDockHeight = height
       chatRootRef.value?.style.setProperty('--composer-dock-h', `${height + growth}px`)
       if (autoScroll.value && composerDockPinFrame === null) {
+        const epoch = scrollEpoch.value
+        const key = sessionKey.value
+        const scheduledThread = threadRef.value
         composerDockPinFrame = requestAnimationFrame(() => {
           composerDockPinFrame = null
           const thread = threadRef.value
-          if (thread && autoScroll.value) {
+          if (
+            thread
+            && thread === scheduledThread
+            && epoch === scrollEpoch.value
+            && key === sessionKey.value
+            && autoScroll.value
+          ) {
+            const gap = thread.scrollHeight - thread.scrollTop - thread.clientHeight
+            if (gap <= LIVE_EDGE_EPSILON_PX) return
             applyProgrammaticScroll(thread, () => {
               thread.scrollTop = thread.scrollHeight
             })
@@ -5939,7 +6573,25 @@ onMounted(async () => {
   }
 })
 
+watch(
+  () => [sessionKey.value, bottomSentinelRef.value] as const,
+  () => {
+    void nextTick(bindBottomIntersectionObserver)
+  },
+  { flush: 'post' },
+)
+
+watch(
+  () => [sessionKey.value, threadRef.value] as const,
+  () => {
+    void nextTick(bindTailLayoutObservers)
+  },
+  { flush: 'post' },
+)
+
 onUnmounted(() => {
+  window.removeEventListener('pointerup', onThreadPointerEnd)
+  window.removeEventListener('pointercancel', onThreadPointerEnd)
   chatRouteHeaderRegistration.release()
   chatViewActive = false
   appStore.setChatLivePhase('idle')
@@ -5975,6 +6627,13 @@ onUnmounted(() => {
     cancelAnimationFrame(composerDockPinFrame)
     composerDockPinFrame = null
   }
+  cancelInitialSessionPin()
+  cancelTailLayoutPin()
+  tailResizeObserver?.disconnect()
+  tailResizeObserver = null
+  tailMutationObserver?.disconnect()
+  tailMutationObserver = null
+  if (threadRef.value) clearProgrammaticScroll(threadRef.value)
   clearPendingComposerScrollIntent()
   chatRootRef.value?.style.removeProperty('--composer-dock-h')
   // Drop any live share-preview object URL so the blob can be reclaimed.


### PR DESCRIPTION
## Scope
- Isolate asynchronous scroll work when switching chat sessions.
- Unify nested wheel/touch/keyboard ownership and questionnaire edge handoff.
- Coalesce late layout corrections, invalidate virtual-list/history queues, and preserve explicit navigation cancellation.
- Add reduced-motion and focused scroll-region behavior plus development scroll diagnostics.

## Target
- `main`
- Linked issue: None

## Release note
- Not required; this is a chat-page interaction stability fix with no protocol, persistence, or configuration changes.

## Verification
- `npm run typecheck` passed.
- `npm run test:unit` passed: 375 files / 4589 tests.
- Targeted scroll suite passed: 30 tests.
- `npm run build:artifact` passed; theme/runtime guards and dist verification passed.
- `git diff --check` passed.
- Playwright Chromium E2E was attempted but the current macOS sandbox blocks Chromium startup with a `mach_port_rendezvous` permission error; run the browser and device matrix in CI/normal desktop environments.

## Safety and compatibility
- Changes are scoped to chat WebUI components and chat styles/tests.
- Existing 2px live-edge check, 60px recovery threshold, and overflow-anchor behavior are retained.
- No gateway protocol, persisted data, or user configuration migration changes.

## Third-party origin
- None; implementation is repository-local.