### PR TITLE
Improve macOS Keychain startup recovery

### DIFF
--- a/desktop/electron/src/boot.html
+++ b/desktop/electron/src/boot.html
@@ -556,6 +556,7 @@
         <p id="errorMessage" data-i18n="errorDefault">The gateway did not finish starting.</p>
         <div class="actions">
           <button id="revealLog" type="button" data-i18n="revealLog">Reveal log</button>
+          <button id="openKeychain" type="button" data-i18n="openKeychain" hidden>Open Keychain Access</button>
           <button id="resetSetup" type="button" data-i18n="resetSetup">Reset setup</button>
           <button id="quit" type="button" data-i18n="quit">Quit</button>
           <button id="retry" class="primary" type="button" data-i18n="retry">Retry</button>
@@ -617,7 +618,8 @@
         errorTitle: 'Startup needs attention',
         errorDefault: 'The gateway did not finish starting.',
         profileInUse: 'The previous Gateway has not exited. Wait for it to finish, or quit every OpenSquilla app or terminal using this profile, then try again. If it will not exit, restart the computer. Do not delete profile lock files.',
-        revealLog: 'Reveal log', resetSetup: 'Reset setup', quit: 'Quit', retry: 'Retry',
+        revealLog: 'Reveal log', openKeychain: 'Open Keychain Access', resetSetup: 'Reset setup', quit: 'Quit', retry: 'Retry',
+        keychainUnavailable: 'OpenSquilla cannot read the macOS Keychain. Unlock the login keychain, then click Retry. If the credential cannot be recovered, choose Reset setup and enter the API key again.',
         startupPaused: 'Startup paused',
         resetConfirm: 'Reset desktop setup? This clears the saved provider credential and reopens onboarding. Your workspace path, identity, memory, and chat history are kept.',
         resetPhase: 'Resetting desktop setup',
@@ -641,7 +643,8 @@
         errorTitle: '启动需要处理',
         errorDefault: '网关未能完成启动。',
         profileInUse: '上一个网关尚未退出。请等待其结束，或退出所有正在使用此配置的 OpenSquilla 应用和终端后重试；若仍无法退出，请重启电脑。不要删除配置锁文件。',
-        revealLog: '显示日志', resetSetup: '重新配置', quit: '退出', retry: '重试',
+        revealLog: '显示日志', openKeychain: '打开钥匙串访问', resetSetup: '重新配置', quit: '退出', retry: '重试',
+        keychainUnavailable: 'OpenSquilla 无法读取 macOS 钥匙串。请解锁 login 钥匙串，然后点击“重试”。如果凭据无法恢复，可选择“重新配置”并重新输入 API Key。',
         startupPaused: '启动已暂停',
         resetConfirm: '要重置桌面设置吗？这会清除已保存的提供商凭据并重新进入引导。工作区路径、身份、记忆和聊天记录都会保留。',
         resetPhase: '正在重置桌面设置',
@@ -665,7 +668,8 @@
         errorTitle: '起動の確認が必要です',
         errorDefault: 'ゲートウェイの起動が完了しませんでした。',
         profileInUse: '前のゲートウェイがまだ終了していません。終了を待つか、このプロファイルを使用しているすべての OpenSquilla アプリとターミナルを終了してから再試行してください。終了しない場合はコンピューターを再起動してください。プロファイルのロックファイルは削除しないでください。',
-        revealLog: 'ログを表示', resetSetup: '設定をリセット', quit: '終了', retry: '再試行',
+        revealLog: 'ログを表示', openKeychain: 'キーチェーンアクセスを開く', resetSetup: '設定をリセット', quit: '終了', retry: '再試行',
+        keychainUnavailable: 'OpenSquilla は macOS キーチェーンを読み取れません。login キーチェーンのロックを解除してから再試行してください。復元できない場合は設定をリセットして API キーを再入力してください。',
         startupPaused: '起動を一時停止しました',
         resetConfirm: 'デスクトップ設定をリセットしますか？保存済みのプロバイダー認証情報を消去してオンボーディングを再開します。ワークスペースのパス、ID、メモリ、チャット履歴は保持されます。',
         resetPhase: 'デスクトップ設定をリセットしています',
@@ -689,7 +693,8 @@
         errorTitle: 'Le démarrage nécessite votre attention',
         errorDefault: 'La passerelle n\'a pas terminé son démarrage.',
         profileInUse: 'La passerelle précédente n’est pas terminée. Attendez sa fermeture, ou quittez toutes les applications et tous les terminaux OpenSquilla utilisant ce profil, puis réessayez. Si elle ne se ferme pas, redémarrez l’ordinateur. Ne supprimez pas les fichiers de verrouillage du profil.',
-        revealLog: 'Afficher le journal', resetSetup: 'Réinitialiser', quit: 'Quitter', retry: 'Réessayer',
+        revealLog: 'Afficher le journal', openKeychain: 'Ouvrir Trousseaux d’accès', resetSetup: 'Réinitialiser', quit: 'Quitter', retry: 'Réessayer',
+        keychainUnavailable: 'OpenSquilla ne peut pas lire le trousseau macOS. Déverrouillez le trousseau login, puis réessayez. Si l’identifiant ne peut pas être récupéré, réinitialisez la configuration et saisissez à nouveau la clé API.',
         startupPaused: 'Démarrage en pause',
         resetConfirm: 'Réinitialiser la configuration du bureau ? Cela efface les identifiants du fournisseur et relance l’onboarding. Le chemin de l’espace de travail, l’identité, la mémoire et l’historique des discussions sont conservés.',
         resetPhase: 'Réinitialisation de la configuration du bureau',
@@ -713,7 +718,8 @@
         errorTitle: 'Der Start erfordert Ihre Aufmerksamkeit',
         errorDefault: 'Das Gateway hat den Start nicht abgeschlossen.',
         profileInUse: 'Das vorherige Gateway wurde noch nicht beendet. Warten Sie, bis es beendet ist, oder schließen Sie alle OpenSquilla-Apps und -Terminals, die dieses Profil verwenden, und versuchen Sie es erneut. Falls es nicht beendet wird, starten Sie den Computer neu. Löschen Sie keine Profilsperrdateien.',
-        revealLog: 'Protokoll anzeigen', resetSetup: 'Zurücksetzen', quit: 'Beenden', retry: 'Wiederholen',
+        revealLog: 'Protokoll anzeigen', openKeychain: 'Schlüsselbundverwaltung öffnen', resetSetup: 'Zurücksetzen', quit: 'Beenden', retry: 'Wiederholen',
+        keychainUnavailable: 'OpenSquilla kann den macOS-Schlüsselbund nicht lesen. Entsperren Sie den Schlüsselbund „login“ und versuchen Sie es erneut. Wenn die Zugangsdaten nicht wiederhergestellt werden können, setzen Sie die Einrichtung zurück und geben Sie den API-Schlüssel erneut ein.',
         startupPaused: 'Start angehalten',
         resetConfirm: 'Desktop-Einrichtung zurücksetzen? Die gespeicherten Anbieter-Zugangsdaten werden gelöscht und das Onboarding wird neu geöffnet. Arbeitsbereichspfad, Identität, Speicher und Chatverlauf bleiben erhalten.',
         resetPhase: 'Desktop-Einrichtung wird zurückgesetzt',
@@ -737,7 +743,8 @@
         errorTitle: 'El inicio necesita atención',
         errorDefault: 'La pasarela no terminó de iniciarse.',
         profileInUse: 'La pasarela anterior aún no ha terminado. Espera a que se cierre o sal de todas las aplicaciones y terminales de OpenSquilla que usen este perfil y vuelve a intentarlo. Si no se cierra, reinicia el equipo. No elimines los archivos de bloqueo del perfil.',
-        revealLog: 'Mostrar registro', resetSetup: 'Restablecer', quit: 'Salir', retry: 'Reintentar',
+        revealLog: 'Mostrar registro', openKeychain: 'Abrir Acceso a Llaveros', resetSetup: 'Restablecer', quit: 'Salir', retry: 'Reintentar',
+        keychainUnavailable: 'OpenSquilla no puede leer el llavero de macOS. Desbloquea el llavero login y vuelve a intentarlo. Si no se puede recuperar la credencial, restablece la configuración y vuelve a introducir la clave API.',
         startupPaused: 'Inicio en pausa',
         resetConfirm: '¿Restablecer la configuración de escritorio? Esto borra la credencial del proveedor y vuelve a abrir la configuración inicial. Se conservan la ruta del espacio de trabajo, la identidad, la memoria y el historial de chat.',
         resetPhase: 'Restableciendo configuración de escritorio',
@@ -774,6 +781,7 @@
     const progressCount = document.getElementById('progressCount');
     const errorPanel = document.getElementById('errorPanel');
     const errorMessage = document.getElementById('errorMessage');
+    const openKeychainButton = document.getElementById('openKeychain');
     const recoveryPanel = document.getElementById('recoveryPanel');
     const recoveryTitle = document.getElementById('recoveryTitle');
     const recoveryIntro = document.getElementById('recoveryIntro');
@@ -859,6 +867,7 @@
       // local default phase string only when no label was provided.
       phase.textContent = payload && payload.label ? String(payload.label) : msg.phaseDefault;
       errorPanel.classList.remove('visible');
+      openKeychainButton.hidden = true;
       recoveryPanel.classList.remove('visible');
       document.body.classList.remove('recovering');
       // Leaving the error state: resume the elapsed timer. The determinate
@@ -871,11 +880,15 @@
 
     function applyError(payload) {
       const rawMessage = payload && payload.message ? String(payload.message) : msg.errorDefault;
-      const message = rawMessage.includes('OPENSQUILLA_PROFILE_IN_USE')
-        ? msg.profileInUse
-        : rawMessage;
+      const keychainUnavailable = payload && payload.code === 'keychain_unavailable';
+      const message = keychainUnavailable
+        ? msg.keychainUnavailable
+        : rawMessage.includes('OPENSQUILLA_PROFILE_IN_USE')
+          ? msg.profileInUse
+          : rawMessage;
       phase.textContent = msg.startupPaused;
       errorMessage.textContent = message;
+      openKeychainButton.hidden = !keychainUnavailable;
       errorPanel.classList.add('visible');
       recoveryPanel.classList.remove('visible');
       document.body.classList.remove('recovering');
@@ -1020,7 +1033,10 @@
       try {
         const result = await resumeStartup();
         if (result && result.ok === false) {
-          applyError({ message: result.error || msg.errorDefault });
+          applyError({
+            message: result.error || msg.errorDefault,
+            code: result.code,
+          });
         }
         return result;
       } catch (error) {
@@ -1056,6 +1072,15 @@
       document.getElementById('retry').addEventListener('click', () => retryStartup());
       document.getElementById('recoveryRetry').addEventListener('click', () => retryStartup());
       document.getElementById('revealLog').addEventListener('click', () => api.revealGatewayLog());
+      openKeychainButton.addEventListener('click', async () => {
+        openKeychainButton.disabled = true;
+        try {
+          const opened = await api.openKeychainAccess();
+          if (!opened) errorMessage.textContent = msg.keychainUnavailable;
+        } finally {
+          openKeychainButton.disabled = false;
+        }
+      });
       document.getElementById('quit').addEventListener('click', () => api.quitApp());
       const resetButton = document.getElementById('resetSetup');
       if (typeof api.resetDesktopSettings === 'function') {

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -385,6 +385,19 @@ interface BootStatus {
 interface BootError {
   message: string
   at: string
+  code?: BootErrorCode
+}
+
+type BootErrorCode = 'keychain_unavailable'
+
+class DesktopStartupError extends Error {
+  constructor(
+    readonly code: BootErrorCode,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'DesktopStartupError'
+  }
 }
 
 interface MacInstallContext {
@@ -1239,6 +1252,21 @@ function assertSupportedMacInstallLocation(): void {
   if (message) throw new Error(message)
 }
 
+const MAC_KEYCHAIN_ACCESS_PATHS = [
+  '/System/Library/CoreServices/Applications/Keychain Access.app',
+  '/Applications/Utilities/Keychain Access.app',
+] as const
+
+async function openMacKeychainAccess(): Promise<boolean> {
+  if (process.platform !== 'darwin') return false
+  for (const applicationPath of MAC_KEYCHAIN_ACCESS_PATHS) {
+    if (!existsSync(applicationPath)) continue
+    const error = await shell.openPath(applicationPath)
+    if (!error) return true
+  }
+  return false
+}
+
 function sendBootStatus(phaseId: BootPhaseId): void {
   bootStatus = { phaseId, label: desktopT('boot.' + phaseId), at: new Date().toISOString() }
   bootError = null
@@ -1250,6 +1278,7 @@ function sendBootError(error: unknown): void {
   bootError = {
     message: error instanceof Error ? error.message : String(error),
     at: new Date().toISOString(),
+    ...(error instanceof DesktopStartupError ? { code: error.code } : {}),
   }
   mainWindow?.webContents.send('desktop:boot:error', bootError)
 }
@@ -2019,13 +2048,17 @@ function desktopSecretStorageBackend(): SecretEncryption {
   return secretStorageBackendCache
 }
 
+function invalidateSecretStorageBackendCache(): void {
+  secretStorageBackendCache = null
+}
+
 function encryptSecret(secret: string): { value: string; encryption: SecretEncryption } {
   const policyBackend = desktopSecretStoragePolicyBackend()
   const availableBackend = desktopSecretStorageBackend()
   if (policyBackend === 'safeStorage') {
     if (availableBackend !== 'safeStorage') {
       throw new Error(
-        'The OS keychain is unavailable. Unlock it and reopen OpenSquilla before saving credentials.'
+        'The OS keychain is unavailable. Unlock it and try saving credentials again.'
       )
     }
     try {
@@ -6526,7 +6559,8 @@ async function runOnboarding(): Promise<DesktopConnection> {
       || Boolean(existing?.encryptedApiKey && existing.encryption === 'safeStorage')
     )
   ) {
-    throw new Error(
+    throw new DesktopStartupError(
+      'keychain_unavailable',
       'OpenSquilla needs the OS keychain to read or safely adopt this credential, '
       + 'but the keychain is currently unavailable. Unlock it and reopen '
       + 'OpenSquilla, or use "Reset setup" to start over.'
@@ -13009,6 +13043,10 @@ async function performOnboardingSave(
         () => readPendingMigrationProviderSetup(),
       )
       credential = await telemetry.stage('settings_persist', async () => {
+        // Keychain availability may have changed while the onboarding window
+        // remained open. Re-check it on every save attempt instead of carrying
+        // a transient locked-keychain result across a user unlock.
+        invalidateSecretStorageBackendCache()
         if (pendingMigration?.phase === 'needs-setup' && pendingMigration.provider) {
           return await saveImportedDesktopCredential(
             pendingMigration,
@@ -13303,6 +13341,11 @@ ipcMain.handle('desktop:boot:state', () => ({
   recovery: recoveryStateSnapshot(),
 }))
 
+ipcMain.handle('desktop:boot:open-keychain', async (event) => {
+  if (!trustedRecoveryIpc(event)) throw new Error('Untrusted Keychain access request.')
+  return await openMacKeychainAccess()
+})
+
 interface BootResumeAuthority {
   child: ChildProcessWithoutNullStreams
   profileKey: string
@@ -13333,7 +13376,8 @@ function bootResumeAuthorityIsCurrent(authority: BootResumeAuthority): boolean {
     && desktopOpenFlowRevision === authority.openFlowRevision
 }
 
-async function resumeBootStartup(): Promise<{ ok: boolean; error?: string }> {
+async function resumeBootStartup(): Promise<{ ok: boolean; error?: string; code?: BootErrorCode }> {
+  invalidateSecretStorageBackendCache()
   const pendingStart = gatewayStartPromise
   const initialAuthority = pendingStart ? null : currentBootResumeAuthority()
   bootError = null
@@ -13366,7 +13410,11 @@ async function resumeBootStartup(): Promise<{ ok: boolean; error?: string }> {
     // direct resume, an exit handler or a newer quit/reset/restart owns any
     // state after this exact child/profile/revision loses authority.
     if (pendingStart || !initialAuthority || !bootResumeAuthorityIsCurrent(initialAuthority)) {
-      return { ok: false, error: message }
+      return {
+        ok: false,
+        error: message,
+        ...(error instanceof DesktopStartupError ? { code: error.code } : {}),
+      }
     }
     if (gatewayState.status !== 'ready') {
       gatewayState.status = 'error'
@@ -13393,6 +13441,7 @@ ipcMain.handle('desktop:boot:resume', async () => {
   }
 })
 ipcMain.handle('desktop:boot:retry', async () => {
+  invalidateSecretStorageBackendCache()
   // The Control UI "Restart runtime" action intentionally forces a new child.
   // The boot page uses desktop:boot:resume instead so a slow owned child can be
   // accepted after it becomes healthy instead of being torn down first.

--- a/desktop/electron/src/preload.cts
+++ b/desktop/electron/src/preload.cts
@@ -91,6 +91,7 @@ contextBridge.exposeInMainWorld('opensquillaDesktop', {
   saveOnboarding: (payload: unknown) => ipcRenderer.invoke('desktop:onboarding:save', payload),
   cancelOnboarding: () => ipcRenderer.invoke('desktop:onboarding:cancel'),
   getBootState: () => ipcRenderer.invoke('desktop:boot:state'),
+  openKeychainAccess: () => ipcRenderer.invoke('desktop:boot:open-keychain'),
   resumeStartup: () => ipcRenderer.invoke('desktop:boot:resume'),
   retryStartup: () => ipcRenderer.invoke('desktop:boot:retry'),
   quitApp: () => ipcRenderer.invoke('desktop:boot:quit'),

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -298,6 +298,7 @@ def test_desktop_retry_waits_for_all_owned_gateways_and_fails_closed() -> None:
     # awaited before respawn rather than reused. The boot page has a separate
     # non-destructive resume path below.
     assert "if (gatewayStartPromise)" in retry
+    assert "invalidateSecretStorageBackendCache()" in retry
     join_call = "const exited = await stopAndJoinAllLifecycleOwnedGateways()"
     assert join_call in retry
     assert "if (!exited)" in retry
@@ -354,6 +355,8 @@ def test_desktop_boot_resume_waits_for_the_existing_owned_gateway() -> None:
     )
 
     assert "resumeStartup: () => ipcRenderer.invoke('desktop:boot:resume')" in preload
+    assert "openKeychainAccess: () => ipcRenderer.invoke('desktop:boot:open-keychain')" in preload
+    assert "invalidateSecretStorageBackendCache()" in resume_flow
     assert "const pendingStart = gatewayStartPromise" in resume_flow
     assert "await resumeOwnedGatewayStartup(" in resume_flow
     assert "if (!gateway)" in resume_flow
@@ -554,7 +557,8 @@ def test_boot_retry_surfaces_failed_restart_and_prevents_repeat_clicks() -> None
     assert "const result = await resumeStartup()" in retry_flow
     assert "result && result.ok === false" in retry_flow
     assert "result.error || msg.errorDefault" in retry_flow
-    assert "applyError({ message: result.error || msg.errorDefault })" in retry_flow
+    assert "message: result.error || msg.errorDefault" in retry_flow
+    assert "code: result.code" in retry_flow
     assert "errorPanel.classList.add('visible')" in apply_error
     assert "retryButton.disabled = false" in retry_flow
     assert "recoveryRetryButton.disabled = false" in retry_flow
@@ -575,6 +579,44 @@ def test_boot_retry_surfaces_failed_restart_and_prevents_repeat_clicks() -> None
     )
     assert "rawMessage.includes('OPENSQUILLA_PROFILE_IN_USE')" in apply_error
     assert boot_html.count("profileInUse:") == 6
+
+
+def test_keychain_startup_recovery_is_actionable_without_plaintext_fallback() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    preload = _read("desktop/electron/src/preload.cts")
+    boot_html = _read("desktop/electron/src/boot.html")
+
+    assert "type BootErrorCode = 'keychain_unavailable'" in main_ts
+    assert "code?: BootErrorCode" in main_ts
+    assert "throw new DesktopStartupError(" in main_ts
+    assert "'keychain_unavailable'" in main_ts
+    assert "...(error instanceof DesktopStartupError ? { code: error.code } : {})" in main_ts
+    assert "function invalidateSecretStorageBackendCache(): void" in main_ts
+    assert "const MAC_KEYCHAIN_ACCESS_PATHS = [" in main_ts
+    assert "/System/Library/CoreServices/Applications/Keychain Access.app" in main_ts
+    assert "/Applications/Utilities/Keychain Access.app" in main_ts
+    assert "if (process.platform !== 'darwin') return false" in main_ts
+
+    open_keychain = _section(
+        main_ts,
+        "ipcMain.handle('desktop:boot:open-keychain'",
+        "interface BootResumeAuthority",
+    )
+    assert "trustedRecoveryIpc(event)" in open_keychain
+    assert "openMacKeychainAccess()" in open_keychain
+    assert "ipcRenderer.invoke('desktop:boot:open-keychain')" in preload
+
+    assert 'id="openKeychain"' in boot_html
+    assert 'data-i18n="openKeychain"' in boot_html
+    assert "payload.code === 'keychain_unavailable'" in boot_html
+    assert "openKeychainButton.hidden = !keychainUnavailable" in boot_html
+    assert "api.openKeychainAccess()" in boot_html
+    assert "keychainUnavailable:" in boot_html
+    assert boot_html.count("openKeychain:") == 6
+    assert boot_html.count("keychainUnavailable:") == 6
+
+    encryption = _section(main_ts, "function encryptSecret", "function decryptSecret")
+    assert "catch {\n      return plainSecret(secret)" not in encryption
 
 
 def test_boot_error_and_recovery_states_freeze_determinate_progress() -> None:
@@ -808,6 +850,8 @@ def test_primary_repair_ui_is_accessible_without_profile_choices() -> None:
 def test_primary_repair_ui_scaffold_has_all_six_locales() -> None:
     boot_html = _read("desktop/electron/src/boot.html")
     locale_keys = (
+        "openKeychain",
+        "keychainUnavailable",
         "recoveryTitle",
         "recoveryTitleLockBusy",
         "recoveryTitleUpdate",

--- a/tests/test_desktop/test_onboarding_main_process_flow_contract.py
+++ b/tests/test_desktop/test_onboarding_main_process_flow_contract.py
@@ -103,6 +103,7 @@ def test_onboarding_save_preserves_recovery_and_writer_ordering() -> None:
     settings_stage = save.index("telemetry.stage('settings_persist'")
     imported = save.index("await saveImportedDesktopCredential(")
     ordinary = save.index("await saveDesktopCredential(payload, true)")
+    refresh_keychain = save.index("invalidateSecretStorageBackendCache()")
     settings_persisted = save.index("telemetry.markSettingsPersistedConfirmed()")
     finalize_stage = save.index("telemetry.stage('local_finalize'")
     locale = save.index("applyDesktopLocaleChoice(payload.locale)")
@@ -117,8 +118,8 @@ def test_onboarding_save_preserves_recovery_and_writer_ordering() -> None:
 
     assert telemetry_start < recovery_stage < recovery < admission < writer_admitted
     assert writer_admitted < marker_stage < marker < settings_stage
-    assert settings_stage < imported < settings_persisted
-    assert settings_stage < ordinary < settings_persisted
+    assert settings_stage < refresh_keychain < imported < settings_persisted
+    assert refresh_keychain < ordinary < settings_persisted
     assert settings_persisted < finalize_stage < locale < clear_marker < finish
     assert finish < handoff_stage < lifecycle_guard < complete < telemetry_finish
     assert "app.isPackaged" in save


### PR DESCRIPTION
## Summary

- classify macOS Keychain startup failures with a stable boot error code;
- invalidate the secret-storage backend cache before startup retry and every onboarding save;
- add a trusted, fixed-path action to open Keychain Access from the boot page;
- keep fail-closed safeStorage policy, credential format, workspace data, and reset semantics unchanged;
- add startup and onboarding contract coverage for the recovery flow.

## Base and scope

- Base: `main`
- Refs: #1359
- This is a follow-up to the already-merged HTML Agent Loop work. It does not repeat that feature's commits.
- The two local UX HTML mockups are intentionally excluded.

## Testing

- `.venv/bin/pytest -q tests/test_desktop` — 143 passed
- `npm run build` in `desktop/electron` — passed
- `npm run test:secret-storage` — passed
- `git diff --check` — passed

## Safety and compatibility

- No plaintext credential fallback, credential format change, database migration, or workspace/chat deletion.
- The Keychain Access action accepts no path, URL, command, or script; it only opens the fixed macOS system application and returns false on other platforms.
- Existing `Reset setup` behavior is preserved.

## Manual validation note

Normal startup of the current `0.5.3` worktree build was verified. The complete signed-package `login` lock → startup error → unlock → Retry flow was not manually completed because this test profile currently has no OpenSquilla Safe Storage item; no API key was recorded or included.

## Release note

User-facing recovery improvement for macOS Keychain-unavailable startup and onboarding states.
