### PR TITLE
Improve Workbench divider hit target

### DIFF
--- a/opensquilla-webui/e2e/workbench.spec.ts
+++ b/opensquilla-webui/e2e/workbench.spec.ts
@@ -423,8 +423,74 @@ test.describe('Application Workbench', () => {
           && Number(request.height) > 0)
       })).toBe(true)
 
-      // No resize, panel drag, modal, or preview-mode switch occurs in this
-      // flow. The dynamic slot insertion itself must cause the visible rect.
+      const resizer = page.getByTestId('workbench-resizer')
+      await expect(resizer).toBeVisible()
+      const workbenchBox = await workbench.boundingBox()
+      const resizerBox = await resizer.boundingBox()
+      expect(workbenchBox).not.toBeNull()
+      expect(resizerBox).not.toBeNull()
+      expect(resizerBox!.x).toBeLessThan(workbenchBox!.x)
+      expect(resizerBox!.width).toBeGreaterThanOrEqual(16)
+
+      const initialValue = Number(await resizer.getAttribute('aria-valuenow'))
+      const initialNativeWidth = await page.evaluate(() => {
+        const probe = (window as unknown as {
+          __opensquillaNativeWorkbenchProbe: {
+            rectRequests: Array<{ visible?: boolean; width?: number }>
+          }
+        }).__opensquillaNativeWorkbenchProbe
+        const visibleWidths = probe.rectRequests
+          .filter(request => request.visible === true)
+          .map(request => Number(request.width))
+          .filter(width => Number.isFinite(width))
+        return visibleWidths.at(-1) ?? 0
+      })
+
+      // Start from the chat-side half of the handle while the pointer is over
+      // the native preview's content area. This is the regression case for the
+      // clipped/covered resizer hit target.
+      const dragY = workbenchBox!.y + workbenchBox!.height / 2
+      await page.mouse.move(resizerBox!.x + 3, dragY)
+      await page.mouse.down()
+      await page.mouse.move(resizerBox!.x - 37, dragY, { steps: 4 })
+      await expect.poll(async () => Number(await resizer.getAttribute('aria-valuenow')))
+        .toBeGreaterThan(initialValue)
+      await page.mouse.up()
+
+      await expect.poll(() => page.evaluate(() => {
+        const probe = (window as unknown as {
+          __opensquillaNativeWorkbenchProbe: {
+            rectRequests: Array<{ visible?: boolean; width?: number }>
+          }
+        }).__opensquillaNativeWorkbenchProbe
+        const visibleWidths = probe.rectRequests
+          .filter(request => request.visible === true)
+          .map(request => Number(request.width))
+          .filter(width => Number.isFinite(width))
+        return visibleWidths.at(-1) ?? 0
+      })).toBeGreaterThan(initialNativeWidth)
+
+      await expect.poll(() => page.evaluate(() => {
+        const raw = localStorage.getItem('opensquilla.workbench.width.v1')
+        if (!raw) return null
+        try {
+          return JSON.parse(raw) as { source?: string; width?: number }
+        } catch {
+          return null
+        }
+      })).toMatchObject({ source: 'user' })
+      expect(await page.evaluate(() => {
+        const raw = localStorage.getItem('opensquilla.workbench.width.v1')
+        if (!raw) return 0
+        try {
+          return Number((JSON.parse(raw) as { width?: number }).width)
+        } catch {
+          return 0
+        }
+      })).toBeGreaterThan(initialValue)
+
+      // The native bridge must remain active after the divider drag and keep
+      // reporting a visible surface.
       expect(await page.evaluate(() => {
         const probe = (window as unknown as {
           __opensquillaNativeWorkbenchProbe: {

--- a/opensquilla-webui/src/components/workbench/WorkbenchHost.vue
+++ b/opensquilla-webui/src/components/workbench/WorkbenchHost.vue
@@ -518,6 +518,14 @@ onBeforeUnmount(() => {
   color: var(--text);
 }
 
+/* Keep the split resizer's chat-side hit area outside the clipped workbench.
+   The native browser surface starts at the workbench edge and can consume
+   pointer events on its side of the handle, so the handle must remain
+   reachable from the adjacent chat pane. */
+.workbench-host--split {
+  overflow: visible;
+}
+
 .workbench-host--overlay {
   position: fixed;
   z-index: 220;

--- a/opensquilla-webui/src/components/workbench/WorkbenchResizer.vue
+++ b/opensquilla-webui/src/components/workbench/WorkbenchResizer.vue
@@ -311,8 +311,8 @@ defineExpose({ cancel: rollback })
   position: absolute;
   z-index: 2;
   inset-block: 0;
-  inset-inline-start: -5px;
-  width: 10px;
+  inset-inline-start: -8px;
+  width: 16px;
   padding: 0;
   border: 0;
   background: transparent;
@@ -323,9 +323,9 @@ defineExpose({ cancel: rollback })
 .workbench-resizer::before {
   position: absolute;
   inset-block: 0;
-  inset-inline-start: 5px;
-  width: 1px;
-  background: var(--border);
+  inset-inline-start: 8px;
+  width: 2px;
+  background: var(--border-strong);
   content: '';
   transition:
     width var(--dur-fast) var(--ease-out),


### PR DESCRIPTION
## Summary
- Expand the Workbench divider hit area into the adjacent chat pane.
- Keep split-only overflow visible so native browser content cannot hide the DOM handle.
- Add a native preview drag regression covering persisted width updates.

## Scope
- Target branch: `main`
- Linked issue: None
- Release note: usability fix; no public API or config changes.
- Safety: CSS and UI regression coverage only; native surface geometry and IPC contracts are unchanged.
- Third-party origin: None.

## Verification
- `npm run test:unit -- src/components/workbench/WorkbenchResizer.test.ts src/components/workbench/WorkbenchHost.test.ts`
- `npm run typecheck`
- `OPENSQUILLA_WEBUI_BASE_URL=http://127.0.0.1:4617 OPENSQUILLA_PLAYWRIGHT_MANAGE_WEBUI=1 npm run test:e2e -- e2e/workbench.spec.ts` (11 passed)
- `git diff --check`