### PR TITLE
Fix desktop document edit turn bindings

### DIFF
--- a/desktop/electron/scripts/test-artifact-preview-lease-broker.mjs
+++ b/desktop/electron/scripts/test-artifact-preview-lease-broker.mjs
@@ -220,6 +220,8 @@ try {
   assert.equal(renewed.ok, true)
   assert.equal(renewed.ok && renewed.payload.lease_id, leaseId)
 
+  const releaseSurfacePin = broker.pinSurface(exactGrant)
+  assert.equal(typeof releaseSurfacePin?.release, 'function')
   const revoked = await broker.revoke({
     version: 1,
     leaseId,
@@ -227,8 +229,80 @@ try {
     authToken: 'synthetic-bearer',
   })
   assert.equal(revoked.ok, true)
+  assert.equal(revoked.status, 202)
+  assert.equal(broker.authorizesSurface(exactGrant), true)
+  await releaseSurfacePin.release()
   assert.equal(broker.authorizesSurface(exactGrant), false)
   assert.equal(broker.resolveSurfaceArtifactId(exactGrant), null)
+
+  let replacementNow = Date.now()
+  let replacementSequence = 0
+  const replacementDeletes = []
+  const replacementBroker = new ArtifactPreviewLeaseBroker({
+    getOwnedGatewayUrl: () => gatewayUrl,
+    now: () => replacementNow,
+    fetchImpl: async (input, init) => {
+      const url = new URL(String(input))
+      if (init?.method === 'DELETE') {
+        replacementDeletes.push(url.pathname)
+        return new Response(null, { status: 204 })
+      }
+      replacementSequence += 1
+      const token = String(replacementSequence).padStart(32, 'e')
+      const origin = `http://p-${token}.localhost:48721`
+      return new Response(JSON.stringify({
+        version: 1,
+        lease_id: `apl-replacement_${replacementSequence}`,
+        effective_mode: 'offline',
+        launch_url: `${origin}/index.html`,
+        entrypoint: 'index.html',
+        expires_at: new Date(
+          replacementNow + (replacementSequence === 1 ? 1_000 : 60 * 60 * 1_000),
+        ).toISOString(),
+        preview_origin: origin,
+        idle_timeout_seconds: 28_800,
+        source: {
+          kind: 'single_file',
+          collection_status: 'not_applicable',
+          file_count: 1,
+          total_bytes: 42,
+          warning_codes: [],
+        },
+      }), {
+        status: 201,
+        headers: { 'content-type': 'application/json' },
+      })
+    },
+  })
+  const replacementCreated = await replacementBroker.create({
+    version: 1,
+    artifactId: 'art-replacement',
+    scopeId: `${scopeId}:replacement`,
+    mode: 'offline',
+  })
+  assert.equal(replacementCreated.ok, true)
+  const replacementOriginalGrant = {
+    launchUrl: replacementCreated.payload.launch_url,
+    expectedOrigin: replacementCreated.payload.preview_origin,
+    scopeId: `${scopeId}:replacement`,
+    mode: 'offline',
+  }
+  const replacementPin = replacementBroker.pinSurface(replacementOriginalGrant)
+  assert.ok(replacementPin)
+  replacementNow += 2_000
+  const recoveredGrant = await replacementPin.ensureCurrent()
+  assert.ok(recoveredGrant)
+  assert.notEqual(recoveredGrant.launchUrl, replacementOriginalGrant.launchUrl)
+  assert.equal(replacementSequence, 2)
+  const retiredRevoke = await replacementBroker.revoke({
+    version: 1,
+    leaseId: replacementCreated.payload.lease_id,
+    scopeId: `${scopeId}:replacement`,
+  })
+  assert.equal(retiredRevoke.ok, true)
+  assert.equal(retiredRevoke.status, 202)
+  await replacementPin.release()
+  assert.deepEqual(replacementDeletes, ['/api/v1/artifact-preview-leases/apl-replacement_2'])
 
   const denied = await broker.create({
     version: 1,

--- a/desktop/electron/scripts/test-desktop-artifact-bridge-loopback.mjs
+++ b/desktop/electron/scripts/test-desktop-artifact-bridge-loopback.mjs
@@ -12,6 +12,7 @@ let slowReload = false
 let releaseSlowReload
 let slowReloadAbortObserved = false
 let lateReloadCount = 0
+let bindingReleaseCount = 0
 const slowReloadGate = new Promise(resolve => { releaseSlowReload = resolve })
 const annotationDigest = 'b'.repeat(64)
 const annotationElementProof = 'c'.repeat(64)
@@ -71,7 +72,13 @@ const target = {
 }
 
 const audit = []
-const bridge = new DesktopArtifactBridge({ getActiveTarget: () => target })
+const bridge = new DesktopArtifactBridge({
+  getActiveTarget: () => target,
+  acquireActiveTargetBinding: async () => ({
+    target,
+    release: () => { bindingReleaseCount += 1 },
+  }),
+})
 const transport = new DesktopArtifactBridgeLoopbackTransport(bridge, {
   audit: entry => audit.push(entry),
 })
@@ -120,6 +127,35 @@ assert.deepEqual(capabilities, {
     reloadSurface: true,
   },
 })
+
+const bindingResponse = await post('/v1/bindings/acquire', { version: 5 })
+assert.equal(bindingResponse.status, 201)
+const bindingBody = await bindingResponse.json()
+assert.match(bindingBody.value.bindingToken, /^[A-Za-z0-9_-]{43}$/)
+assert.equal(bindingBody.value.capabilities.version, 5)
+const boundReloadResponse = await post('/v1/invoke', {
+  version: 5,
+  bindingToken: bindingBody.value.bindingToken,
+  method: 'screenshot',
+  request: { version: 5 },
+})
+assert.equal(boundReloadResponse.status, 200)
+assert.equal((await boundReloadResponse.json()).ok, true)
+for (let index = 0; index < 2; index += 1) {
+  const releaseResponse = await post('/v1/bindings/release', {
+    version: 5,
+    bindingToken: bindingBody.value.bindingToken,
+  })
+  assert.equal(releaseResponse.status, 200)
+}
+assert.equal(bindingReleaseCount, 1, 'binding release must be idempotent')
+const expiredBindingResponse = await post('/v1/invoke', {
+  version: 5,
+  bindingToken: bindingBody.value.bindingToken,
+  method: 'reloadSurface',
+  request: { version: 5 },
+})
+assert.equal((await expiredBindingResponse.json()).code, 'unavailable')
 
 const resolvedAnnotationResponse = await post('/v1/invoke', {
   version: 3,
@@ -318,6 +354,34 @@ assert.equal(oversizedResponse.status, 413)
 assert.ok(audit.length >= 9)
 assert.ok(audit.every(entry => !JSON.stringify(entry).includes(token)))
 assert.ok(audit.every(entry => !('payload' in entry)))
+
+let actionAbortObserved = false
+const actionTimeoutBridge = new DesktopArtifactBridge({
+  getActiveTarget: () => ({
+    capabilities: { browserAct: true },
+    isCurrent: () => true,
+    browserAct: async (_request, signal) => {
+      await new Promise(resolve => signal.addEventListener('abort', resolve, { once: true }))
+      actionAbortObserved = true
+      throw new Error('synthetic lost action reply')
+    },
+  }),
+  operationTimeoutMs: 100,
+})
+const actionTestKeepalive = setTimeout(() => undefined, 1_000)
+const unknownAction = await actionTimeoutBridge.browserAct({
+  version: 5,
+  action: 'press',
+  key: 'Enter',
+  candidateHandle: 'candidate_timeout_12345678',
+}).finally(() => clearTimeout(actionTestKeepalive))
+assert.deepEqual(unknownAction, {
+  ok: false,
+  method: 'browserAct',
+  code: 'action-result-unknown',
+  message: 'The Desktop artifact action result is unknown; inspect again.',
+})
+assert.equal(actionAbortObserved, true)
 
 await transport.close()
 await assert.rejects(() => fetch(`${endpoint}/v1/capabilities`, {

--- a/desktop/electron/scripts/test-native-workbench-surface.mjs
+++ b/desktop/electron/scripts/test-native-workbench-surface.mjs
@@ -969,14 +969,16 @@ assert.deepEqual(controlledBridge.getCapabilities(), {
   captureSelection: true,
   resolveAnnotationSelection: true,
   focusAnnotation: true,
-  browserInspect: true,
-  browserAct: true,
+  browserInspect: false,
+  browserAct: false,
   bindCandidatePreview: false,
   restoreCanonicalPreview: false,
   screenshot: true,
   officeFlush: false,
   reloadSurface: true,
 })
+assert.equal(controlledBridge.getCapabilities(5).browserInspect, true)
+assert.equal(controlledBridge.getCapabilities(5).browserAct, true)
 assert.equal((await controlledBridge.captureSelection({ version: 3 })).ok, true)
 assert.equal((await controlledBridge.resolveAnnotationSelection({
   version: 3,

--- a/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
+++ b/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
@@ -583,6 +583,8 @@ try {
       })
       await owner.loadURL('data:text/html,<title>Trusted Control UI fixture</title>')
       let reentrantReplacementPromise = null
+      const candidateReleaseHandles = []
+      const previewPinReleases = []
       let manager
       manager = new Manager({
         getPrivilegedGatewayUrl: () => fixture.privilegedGatewayUrl,
@@ -603,6 +605,39 @@ try {
                 scopeId: 'synthetic:terminal-replacement',
               },
             })
+          }
+        },
+        resolveCandidatePreview: async candidateHandle => ({
+          candidateHandle,
+          candidateArtifactId: `art-${candidateHandle}`,
+          leaseId: `apl-${candidateHandle}`,
+          launchUrl: `${fixture.previewOrigin}/binding-candidate`,
+          expectedOrigin: fixture.previewOrigin,
+          scopeId: candidateHandle.includes('binding_a')
+            ? 'synthetic:v4-binding-a'
+            : 'synthetic:v4-binding-b',
+          mode: 'offline',
+        }),
+        releaseCandidatePreview: async candidateHandle => {
+          candidateReleaseHandles.push(candidateHandle)
+        },
+        pinArtifactPreview: grant => {
+          let released = false
+          const currentGrant = { ...grant }
+          return {
+            currentGrant: () => ({ ...currentGrant }),
+            ensureCurrent: async () => released ? null : { ...currentGrant },
+            release: async () => {
+              if (released) return
+              released = true
+              const surfaceId = currentGrant.scopeId.endsWith('-a')
+                ? 'artifact:v4-binding-a'
+                : 'artifact:v4-binding-b'
+              previewPinReleases.push({
+                scopeId: currentGrant.scopeId,
+                surfacePresent: manager.surfaces.has(surfaceId),
+              })
+            },
           }
         },
       })
@@ -1958,6 +1993,188 @@ try {
         enabled: true,
       })
 
+      const v4BindingA = await manager.createSurface({
+        version: 4,
+        surfaceId: 'artifact:v4-binding-a',
+        kind: 'artifact-preview',
+        payload: {
+          launchUrl: `${fixture.previewOrigin}/binding-a`,
+          expectedOrigin: fixture.previewOrigin,
+          scopeId: 'synthetic:v4-binding-a',
+          mode: 'full',
+        },
+      }, 'art-v4-binding-a')
+      if (!v4BindingA.ok) throw new Error(v4BindingA.message || 'v4 binding A failed.')
+      const v4BindingAView = view('artifact:v4-binding-a')
+      manager.setSurfaceRect({
+        surfaceId: 'artifact:v4-binding-a',
+        x: 400,
+        y: 80,
+        width: 400,
+        height: 500,
+        visible: true,
+      })
+      await waitFor(() => v4BindingAView.getVisible(), 'visible v4 binding A')
+      const turnBindingA = await manager.acquireArtifactBridgeTargetBinding()
+      if (!turnBindingA) throw new Error('v4 turn binding A was unavailable.')
+      const sameSurfaceSecondBinding = await manager.acquireArtifactBridgeTargetBinding()
+      const bindingAInitial = await turnBindingA.target.browserInspect(
+        { version: 5, scope: 'document', maxNodes: 8 },
+        new AbortController().signal,
+      )
+
+      const v4BindingB = await manager.createSurface({
+        version: 4,
+        surfaceId: 'artifact:v4-binding-b',
+        kind: 'artifact-preview',
+        payload: {
+          launchUrl: `${fixture.previewOrigin}/binding-b`,
+          expectedOrigin: fixture.previewOrigin,
+          scopeId: 'synthetic:v4-binding-b',
+          mode: 'full',
+        },
+      }, 'art-v4-binding-b')
+      if (!v4BindingB.ok) throw new Error(v4BindingB.message || 'v4 binding B failed.')
+      const v4BindingBView = view('artifact:v4-binding-b')
+      manager.setSurfaceRect({
+        surfaceId: 'artifact:v4-binding-b',
+        x: 400,
+        y: 80,
+        width: 400,
+        height: 500,
+        visible: true,
+      })
+      await waitFor(() => v4BindingBView.getVisible(), 'visible v4 binding B')
+      const turnBindingB = await manager.acquireArtifactBridgeTargetBinding()
+      if (!turnBindingB) throw new Error('v4 turn binding B was unavailable.')
+      const bindingSwitchStress = []
+      for (let iteration = 0; iteration < 20; iteration += 1) {
+        const activeSurfaceId = iteration % 2 === 0
+          ? 'artifact:v4-binding-a'
+          : 'artifact:v4-binding-b'
+        const activation = manager.activateSurface(activeSurfaceId)
+        if (!activation.ok) throw new Error(activation.message || 'v4 binding switch failed.')
+        const [bindingAStress, bindingBStress] = await Promise.all([
+          turnBindingA.target.browserInspect(
+            { version: 5, scope: 'document', maxNodes: 8 },
+            new AbortController().signal,
+          ),
+          turnBindingB.target.browserInspect(
+            { version: 5, scope: 'document', maxNodes: 8 },
+            new AbortController().signal,
+          ),
+        ])
+        bindingSwitchStress.push({
+          activeSurfaceId,
+          bindingAScopeId: bindingAStress.scopeId,
+          bindingAGeneration: bindingAStress.bindingGeneration,
+          bindingBScopeId: bindingBStress.scopeId,
+          bindingBGeneration: bindingBStress.bindingGeneration,
+        })
+      }
+      manager.activateSurface('artifact:v4-binding-b')
+      const detachedBindingA = await manager.destroySurface('artifact:v4-binding-a')
+      const bindingAStayedPinned = manager.surfaces.has('artifact:v4-binding-a')
+        && !v4BindingAView.getVisible()
+      const [bindingAAfterSwitch, bindingBAfterSwitch] = await Promise.all([
+        turnBindingA.target.browserInspect(
+          { version: 5, scope: 'document', maxNodes: 8 },
+          new AbortController().signal,
+        ),
+        turnBindingB.target.browserInspect(
+          { version: 5, scope: 'document', maxNodes: 8 },
+          new AbortController().signal,
+        ),
+      ])
+      const candidateHandleA = 'candidate_v4_binding_a_1234'
+      const bindingACandidate = await turnBindingA.target.bindCandidatePreview(
+        { version: 5, candidateHandle: candidateHandleA },
+        new AbortController().signal,
+      )
+      const candidateSnapshotBeforeCrash = await turnBindingA.target.browserInspect(
+        {
+          version: 5,
+          scope: 'document',
+          maxNodes: 8,
+          candidateHandle: candidateHandleA,
+        },
+        new AbortController().signal,
+      )
+      const originalCdpCommand = manager.cdpCommand.bind(manager)
+      let droppedActionReply = false
+      manager.cdpCommand = async (record, method, params) => {
+        const value = await originalCdpCommand(record, method, params)
+        if (method === 'Runtime.callFunctionOn' && !droppedActionReply) {
+          droppedActionReply = true
+          throw new Error('synthetic action reply loss')
+        }
+        return value
+      }
+      let actionResultUnknownCode = ''
+      try {
+        await turnBindingA.target.browserAct(
+          {
+            version: 5,
+            action: 'press',
+            key: 'Enter',
+            candidateHandle: candidateHandleA,
+          },
+          new AbortController().signal,
+        )
+      } catch (error) {
+        actionResultUnknownCode = error?.code || ''
+      } finally {
+        manager.cdpCommand = originalCdpCommand
+      }
+      const candidateSnapshotAfterUnknownAction = await turnBindingA.target.browserInspect(
+        {
+          version: 5,
+          scope: 'document',
+          maxNodes: 8,
+          candidateHandle: candidateHandleA,
+        },
+        new AbortController().signal,
+      )
+      const bindingAContentsBeforeCrash = view('artifact:v4-binding-a').webContents
+      emitRendererGone(bindingAContentsBeforeCrash)
+      const candidateSnapshotAfterRecovery = await turnBindingA.target.browserInspect(
+        {
+          version: 5,
+          scope: 'document',
+          maxNodes: 8,
+          candidateHandle: candidateHandleA,
+        },
+        new AbortController().signal,
+      )
+      const bindingAContentsAfterRecovery = view('artifact:v4-binding-a').webContents
+      const candidateReboundAfterRecovery = manager.surfaces
+        .get('artifact:v4-binding-a')?.candidatePreview?.handle === candidateHandleA
+      emitRendererGone(bindingAContentsAfterRecovery)
+      let secondBindingFailureCode = ''
+      try {
+        await turnBindingA.target.browserInspect(
+          {
+            version: 5,
+            scope: 'document',
+            maxNodes: 8,
+            candidateHandle: candidateHandleA,
+          },
+          new AbortController().signal,
+        )
+      } catch (error) {
+        secondBindingFailureCode = error?.code || ''
+      }
+      await turnBindingA.release()
+      const bindingADestroyedBeforePinRelease = previewPinReleases.some(entry =>
+        entry.scopeId === 'synthetic:v4-binding-a'
+        && entry.surfacePresent === false)
+      const bindingAReleasedEventCount = events.filter(event =>
+        event.surfaceId === 'artifact:v4-binding-a'
+        && event.type === 'agent-edit-released').length
+      await turnBindingB.release()
+      const bindingBSurfaceRetained = manager.surfaces.has('artifact:v4-binding-b')
+      await manager.destroySurface('artifact:v4-binding-b')
+
       const isolated = await manager.createSurface({
         version: 2,
         surfaceId: 'artifact:v2-isolated',
@@ -2558,6 +2775,47 @@ try {
           width: v3Screenshot.width,
           height: v3Screenshot.height,
         },
+        v4BindingA,
+        sameSurfaceSecondBindingWasRejected: sameSurfaceSecondBinding === null,
+        bindingAInitial: {
+          scopeId: bindingAInitial.scopeId,
+          generation: bindingAInitial.bindingGeneration,
+        },
+        detachedBindingA,
+        bindingAStayedPinned,
+        bindingAAfterSwitch: {
+          scopeId: bindingAAfterSwitch.scopeId,
+          generation: bindingAAfterSwitch.bindingGeneration,
+        },
+        bindingBAfterSwitch: {
+          scopeId: bindingBAfterSwitch.scopeId,
+          generation: bindingBAfterSwitch.bindingGeneration,
+        },
+        bindingSwitchStress,
+        bindingACandidate,
+        candidateSnapshotBeforeCrash: {
+          scopeId: candidateSnapshotBeforeCrash.scopeId,
+          candidateHandle: candidateSnapshotBeforeCrash.candidateHandle,
+          generation: candidateSnapshotBeforeCrash.bindingGeneration,
+        },
+        actionResultUnknownCode,
+        candidateSnapshotAfterUnknownAction: {
+          candidateHandle: candidateSnapshotAfterUnknownAction.candidateHandle,
+          generation: candidateSnapshotAfterUnknownAction.bindingGeneration,
+        },
+        candidateSnapshotAfterRecovery: {
+          scopeId: candidateSnapshotAfterRecovery.scopeId,
+          candidateHandle: candidateSnapshotAfterRecovery.candidateHandle,
+          generation: candidateSnapshotAfterRecovery.bindingGeneration,
+        },
+        bindingAContentsReplaced:
+          bindingAContentsAfterRecovery.id !== bindingAContentsBeforeCrash.id,
+        candidateReboundAfterRecovery,
+        secondBindingFailureCode,
+        bindingADestroyedBeforePinRelease,
+        bindingAReleasedEventCount,
+        bindingBSurfaceRetained,
+        candidateReleaseHandles,
         isolationState,
         offlineLocal,
         offlineNetworkWarning,
@@ -2828,7 +3086,11 @@ try {
     webSecurity: true,
     webviewTag: false,
   })
-  assert.deepEqual(result.annotationOverlayVisualStructure, {
+  const {
+    textareaHeight: annotationTextareaHeight,
+    ...annotationOverlayVisualStructure
+  } = result.annotationOverlayVisualStructure
+  assert.deepEqual(annotationOverlayVisualStructure, {
     role: 'dialog',
     ariaModal: 'false',
     labelledBy: 'annotation-title',
@@ -2838,10 +3100,14 @@ try {
     initialBody: 'Initial annotation',
     submitDisabled: false,
     cardRadius: '12px',
-    textareaHeight: '73px',
     submitHeight: '32px',
     tabOrder: ['annotation-body', 'annotation-cancel', 'annotation-submit'],
   })
+  assert.ok(
+    Number.parseFloat(annotationTextareaHeight) >= 73
+      && Number.parseFloat(annotationTextareaHeight) < 74,
+    'annotation textarea height must remain within one fractional Windows DPI pixel',
+  )
   assert.equal(result.annotationOverlayDevToolsBlocked, true)
   assert.ok(result.annotationOverlayBounds.width <= 304)
   assert.ok(result.annotationOverlayBounds.height <= 160)
@@ -3009,6 +3275,89 @@ try {
   assert.ok(result.v3Screenshot.width > 0 && result.v3Screenshot.height > 0)
   assert.equal(result.v3Reload.reloaded, true, 'v3 reload must stay on the active surface')
   assert.ok(result.v3NavigationEventCount > 0, 'v3 surfaces must preserve v2 navigation events')
+  assert.equal(result.v4BindingA.ok, true)
+  assert.equal(
+    result.sameSurfaceSecondBindingWasRejected,
+    true,
+    'one native surface must admit only one editing turn binding',
+  )
+  assert.deepEqual(result.bindingAInitial, {
+    scopeId: 'synthetic:v4-binding-a',
+    generation: 1,
+  })
+  assert.equal(result.detachedBindingA.ok, true)
+  assert.equal(result.detachedBindingA.code, 'AGENT_EDIT_IN_PROGRESS')
+  assert.equal(
+    result.bindingAStayedPinned,
+    true,
+    'UI detach must hide rather than destroy a turn-bound surface',
+  )
+  assert.equal(result.bindingAAfterSwitch.scopeId, 'synthetic:v4-binding-a')
+  assert.equal(result.bindingBAfterSwitch.scopeId, 'synthetic:v4-binding-b')
+  assert.equal(result.bindingSwitchStress.length, 20)
+  for (const [iteration, snapshot] of result.bindingSwitchStress.entries()) {
+    assert.equal(
+      snapshot.activeSurfaceId,
+      iteration % 2 === 0 ? 'artifact:v4-binding-a' : 'artifact:v4-binding-b',
+    )
+    assert.equal(snapshot.bindingAScopeId, 'synthetic:v4-binding-a')
+    assert.equal(snapshot.bindingAGeneration, result.bindingAInitial.generation)
+    assert.equal(snapshot.bindingBScopeId, 'synthetic:v4-binding-b')
+    assert.equal(snapshot.bindingBGeneration, result.bindingBAfterSwitch.generation)
+  }
+  assert.equal(
+    result.bindingAAfterSwitch.generation,
+    result.bindingAInitial.generation,
+    'switching the active UI surface must not mutate the old binding generation',
+  )
+  assert.equal(result.bindingACandidate.bound, true)
+  assert.equal(
+    result.candidateSnapshotBeforeCrash.candidateHandle,
+    'candidate_v4_binding_a_1234',
+  )
+  assert.equal(
+    result.actionResultUnknownCode,
+    'action-result-unknown',
+    'a lost browser action reply must require inspection rather than replay',
+  )
+  assert.equal(
+    result.candidateSnapshotAfterUnknownAction.candidateHandle,
+    'candidate_v4_binding_a_1234',
+    'the binding must accept a fresh inspection after an uncertain action',
+  )
+  assert.equal(result.candidateSnapshotAfterRecovery.scopeId, 'synthetic:v4-binding-a')
+  assert.equal(
+    result.candidateSnapshotAfterRecovery.candidateHandle,
+    'candidate_v4_binding_a_1234',
+  )
+  assert.ok(
+    result.candidateSnapshotAfterRecovery.generation
+      > result.candidateSnapshotBeforeCrash.generation,
+    'surface recovery must invalidate the old binding generation',
+  )
+  assert.equal(result.bindingAContentsReplaced, true)
+  assert.equal(result.candidateReboundAfterRecovery, true)
+  assert.equal(
+    result.secondBindingFailureCode,
+    'binding-terminal-unavailable',
+    'a second surface failure must terminate the binding without another rebuild',
+  )
+  assert.equal(
+    result.bindingADestroyedBeforePinRelease,
+    true,
+    'a UI-detached surface must be destroyed before its canonical preview pin is released',
+  )
+  assert.equal(result.bindingAReleasedEventCount, 1)
+  assert.equal(
+    result.bindingBSurfaceRetained,
+    true,
+    'releasing a still-UI-owned binding must leave its canonical surface available',
+  )
+  assert.deepEqual(
+    result.candidateReleaseHandles,
+    ['candidate_v4_binding_a_1234'],
+    'candidate cleanup must remain exactly once across recovery and terminal release',
+  )
   assert.equal(
     result.isolationState.storageWasCleared,
     true,

--- a/desktop/electron/src/artifact-preview-lease-broker.ts
+++ b/desktop/electron/src/artifact-preview-lease-broker.ts
@@ -64,7 +64,14 @@ export interface ArtifactPreviewSurfaceGrant {
   mode: ArtifactPreviewLeaseMode
 }
 
+export interface ArtifactPreviewSurfacePin {
+  currentGrant(): ArtifactPreviewSurfaceGrant
+  ensureCurrent(): Promise<ArtifactPreviewSurfaceGrant | null>
+  release(): Promise<void>
+}
+
 interface IssuedArtifactPreview {
+  leaseId: string
   artifactId: string
   gatewayOrigin: string
   launchUrl: string
@@ -73,6 +80,13 @@ interface IssuedArtifactPreview {
   authToken?: string
   mode: ArtifactPreviewLeaseMode
   expiresAtMs: number
+  bindingPins: number
+  revokePending: boolean
+  renewTimer: ReturnType<typeof setInterval> | null
+  renewInFlight: boolean
+  replacementAttempted: boolean
+  replacementInFlight: Promise<boolean> | null
+  retiredLeaseIds: Set<string>
 }
 
 interface ArtifactPreviewLeaseBrokerOptions {
@@ -88,6 +102,7 @@ const PREVIEW_HOST_PATTERN = /^p-[a-f0-9]{32}\.localhost$/i
 const MAX_RESPONSE_BYTES = 1024 * 1024
 const MAX_CREDENTIAL_BYTES = 16 * 1024
 const DEFAULT_REQUEST_TIMEOUT_MS = 15_000
+const PINNED_LEASE_RENEW_INTERVAL_MS = 15 * 60 * 1000
 
 function objectRecord(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
@@ -355,6 +370,7 @@ export class ArtifactPreviewLeaseBroker {
 
   clear(): void {
     this.generation += 1
+    for (const lease of this.issued.values()) this.stopPinnedRenewal(lease)
     this.issued.clear()
   }
 
@@ -368,8 +384,16 @@ export class ArtifactPreviewLeaseBroker {
   async revokeAll(): Promise<void> {
     this.generation += 1
     const issued = [...this.issued.entries()]
-    this.issued.clear()
+    for (const [leaseId, lease] of issued) {
+      if (lease.bindingPins > 0) {
+        lease.revokePending = true
+      } else {
+        this.stopPinnedRenewal(lease)
+        this.issued.delete(leaseId)
+      }
+    }
     await Promise.allSettled(issued.map(([leaseId, lease]) => {
+      if (lease.bindingPins > 0) return Promise.resolve()
       if (parseOwnedGatewayOrigin(this.options.getOwnedGatewayUrl()) !== lease.gatewayOrigin) {
         return Promise.resolve()
       }
@@ -449,6 +473,7 @@ export class ArtifactPreviewLeaseBroker {
         return failure(502, 'INVALID_RESPONSE', 'The Gateway returned an expired preview lease.')
       }
       this.issued.set(parsed.payload.lease_id, {
+        leaseId: parsed.payload.lease_id,
         artifactId: request.artifactId,
         gatewayOrigin,
         launchUrl: parsed.payload.launch_url,
@@ -457,6 +482,13 @@ export class ArtifactPreviewLeaseBroker {
         authToken: request.authToken,
         mode: parsed.payload.effective_mode,
         expiresAtMs: parsed.expiresAtMs,
+        bindingPins: 0,
+        revokePending: false,
+        renewTimer: null,
+        renewInFlight: false,
+        replacementAttempted: false,
+        replacementInFlight: null,
+        retiredLeaseIds: new Set(),
       })
       return { ok: true, status: response.status, payload: parsed.payload }
     } catch {
@@ -492,7 +524,8 @@ export class ArtifactPreviewLeaseBroker {
     )
     if (!response.ok) {
       if (response.status === 404 || response.status === 410) {
-        this.issued.delete(request.leaseId)
+        this.stopPinnedRenewal(issued)
+        if (issued.bindingPins === 0) this.issued.delete(request.leaseId)
       }
       return response
     }
@@ -526,11 +559,17 @@ export class ArtifactPreviewLeaseBroker {
       )
     }
     const issued = this.currentIssuedLease(request.leaseId, request.scopeId)
+      ?? this.retiredIssuedLease(request.leaseId, request.scopeId)
     if (!issued) {
       return failure(404, 'BROKER_LEASE_NOT_FOUND', 'The Desktop preview lease is unavailable.')
     }
+    if (issued.bindingPins > 0) {
+      issued.revokePending = true
+      return { ok: true, status: 202, payload: undefined }
+    }
     // Revoke local authority before the network request. A failed Gateway call
     // must never leave a renderer-revoked launch URL eligible for a new surface.
+    this.stopPinnedRenewal(issued)
     this.issued.delete(request.leaseId)
     const response = await this.request(
       new URL(
@@ -546,6 +585,174 @@ export class ArtifactPreviewLeaseBroker {
       return failure(502, 'INVALID_RESPONSE', 'The Gateway returned an invalid preview response.')
     }
     return { ok: true, status: response.status, payload: undefined }
+  }
+
+  pinSurface(grant: ArtifactPreviewSurfaceGrant): ArtifactPreviewSurfacePin | null {
+    const lease = this.issuedLeaseForSurface(grant)
+    if (!lease) return null
+    const [, issued] = lease
+    issued.bindingPins += 1
+    this.startPinnedRenewal(issued)
+    let released = false
+    return {
+      currentGrant: () => this.surfaceGrant(issued),
+      ensureCurrent: async () => {
+        if (released || issued.bindingPins < 1) return null
+        if (issued.replacementInFlight) await issued.replacementInFlight
+        if (
+          this.issued.get(issued.leaseId) !== issued
+          || issued.expiresAtMs <= this.now()
+        ) {
+          if (!await this.replacePinnedLease(issued)) return null
+        }
+        return this.issued.get(issued.leaseId) === issued
+          && issued.expiresAtMs > this.now()
+          ? this.surfaceGrant(issued)
+          : null
+      },
+      release: async () => {
+        if (released) return
+        released = true
+        issued.bindingPins = Math.max(0, issued.bindingPins - 1)
+        if (issued.bindingPins === 0) this.stopPinnedRenewal(issued)
+        if (issued.bindingPins !== 0 || !issued.revokePending) return
+        this.issued.delete(issued.leaseId)
+        if (parseOwnedGatewayOrigin(this.options.getOwnedGatewayUrl()) !== issued.gatewayOrigin) return
+        await this.request(
+          new URL(
+            `/api/v1/artifact-preview-leases/${encodeURIComponent(issued.leaseId)}`,
+            issued.gatewayOrigin,
+          ),
+          'DELETE',
+          issued.scopeId,
+          issued.authToken,
+        )
+      },
+    }
+  }
+
+  private startPinnedRenewal(issued: IssuedArtifactPreview): void {
+    if (issued.renewTimer) return
+    issued.renewTimer = setInterval(() => {
+      if (
+        issued.bindingPins < 1
+        || issued.renewInFlight
+        || this.issued.get(issued.leaseId) !== issued
+      ) return
+      issued.renewInFlight = true
+      void this.renew({
+        version: 1,
+        leaseId: issued.leaseId,
+        scopeId: issued.scopeId,
+        ...(issued.authToken ? { authToken: issued.authToken } : {}),
+      }).then(async result => {
+        if (!result.ok && (result.status === 404 || result.status === 410)) {
+          await this.replacePinnedLease(issued)
+        }
+      }).finally(() => {
+        issued.renewInFlight = false
+      })
+    }, PINNED_LEASE_RENEW_INTERVAL_MS)
+    issued.renewTimer.unref?.()
+  }
+
+  private surfaceGrant(issued: IssuedArtifactPreview): ArtifactPreviewSurfaceGrant {
+    return {
+      launchUrl: issued.launchUrl,
+      expectedOrigin: issued.expectedOrigin,
+      scopeId: issued.scopeId,
+      mode: issued.mode,
+    }
+  }
+
+  private async replacePinnedLease(issued: IssuedArtifactPreview): Promise<boolean> {
+    if (issued.replacementInFlight) return await issued.replacementInFlight
+    if (issued.replacementAttempted || issued.bindingPins < 1) return false
+    issued.replacementAttempted = true
+    const replacement = this.replacePinnedLeaseNow(issued)
+    issued.replacementInFlight = replacement
+    try {
+      return await replacement
+    } finally {
+      issued.replacementInFlight = null
+    }
+  }
+
+  private async replacePinnedLeaseNow(issued: IssuedArtifactPreview): Promise<boolean> {
+    const gatewayOrigin = parseOwnedGatewayOrigin(this.options.getOwnedGatewayUrl())
+    if (!gatewayOrigin || gatewayOrigin !== issued.gatewayOrigin) return false
+    const response = await this.requestJson(
+      new URL(
+        `/api/v1/artifacts/${encodeURIComponent(issued.artifactId)}/preview-leases`,
+        issued.gatewayOrigin,
+      ),
+      'POST',
+      issued.scopeId,
+      issued.authToken,
+      JSON.stringify({ version: 1, mode: issued.mode, client: 'desktop' }),
+    )
+    if (!response.ok || response.status !== 201) return false
+    let parsed: ReturnType<typeof parseLeasePayload>
+    try {
+      parsed = parseLeasePayload(response.payload, issued.mode)
+    } catch {
+      return false
+    }
+    const replacementId = parsed.payload.lease_id
+    const replacementCurrent = (
+      issued.bindingPins > 0
+      && parsed.expiresAtMs > this.now()
+      && parseOwnedGatewayOrigin(this.options.getOwnedGatewayUrl()) === issued.gatewayOrigin
+      && (!this.issued.has(replacementId) || this.issued.get(replacementId) === issued)
+    )
+    if (!replacementCurrent) {
+      await this.request(
+        new URL(
+          `/api/v1/artifact-preview-leases/${encodeURIComponent(replacementId)}`,
+          issued.gatewayOrigin,
+        ),
+        'DELETE',
+        issued.scopeId,
+        issued.authToken,
+      )
+      return false
+    }
+    const retiredLeaseId = issued.leaseId
+    if (this.issued.get(retiredLeaseId) === issued) this.issued.delete(retiredLeaseId)
+    issued.retiredLeaseIds.add(retiredLeaseId)
+    issued.leaseId = replacementId
+    issued.launchUrl = parsed.payload.launch_url
+    issued.expectedOrigin = parsed.payload.preview_origin
+    issued.mode = parsed.payload.effective_mode
+    issued.expiresAtMs = parsed.expiresAtMs
+    this.issued.set(replacementId, issued)
+    this.startPinnedRenewal(issued)
+    return true
+  }
+
+  private stopPinnedRenewal(issued: IssuedArtifactPreview): void {
+    if (!issued.renewTimer) return
+    clearInterval(issued.renewTimer)
+    issued.renewTimer = null
+  }
+
+  private issuedLeaseForSurface(
+    grant: ArtifactPreviewSurfaceGrant,
+  ): [string, IssuedArtifactPreview] | null {
+    const gatewayOrigin = parseOwnedGatewayOrigin(this.options.getOwnedGatewayUrl())
+    if (!gatewayOrigin) return null
+    for (const entry of this.issued) {
+      const issued = entry[1]
+      if (
+        issued.gatewayOrigin === gatewayOrigin
+        && issued.launchUrl === grant.launchUrl
+        && issued.expectedOrigin === grant.expectedOrigin
+        && issued.scopeId === grant.scopeId
+        && issued.mode === grant.mode
+        && issued.expiresAtMs > this.now()
+      ) return entry
+    }
+    return null
   }
 
   authorizesSurface(grant: ArtifactPreviewSurfaceGrant): boolean {
@@ -565,6 +772,7 @@ export class ArtifactPreviewLeaseBroker {
         issued.expiresAtMs <= this.now()
         || issued.gatewayOrigin !== gatewayOrigin
       ) {
+        this.stopPinnedRenewal(issued)
         this.issued.delete(leaseId)
         continue
       }
@@ -591,10 +799,28 @@ export class ArtifactPreviewLeaseBroker {
       || issued.scopeId !== scopeId
       || issued.expiresAtMs <= this.now()
     ) {
+      this.stopPinnedRenewal(issued)
       this.issued.delete(leaseId)
       return null
     }
     return issued
+  }
+
+  private retiredIssuedLease(
+    leaseId: string,
+    scopeId: string,
+  ): IssuedArtifactPreview | null {
+    const gatewayOrigin = parseOwnedGatewayOrigin(this.options.getOwnedGatewayUrl())
+    if (!gatewayOrigin) return null
+    for (const issued of new Set(this.issued.values())) {
+      if (
+        issued.gatewayOrigin === gatewayOrigin
+        && issued.scopeId === scopeId
+        && issued.retiredLeaseIds.has(leaseId)
+        && issued.bindingPins > 0
+      ) return issued
+    }
+    return null
   }
 
   private async requestJson(

--- a/desktop/electron/src/desktop-artifact-bridge-contract.ts
+++ b/desktop/electron/src/desktop-artifact-bridge-contract.ts
@@ -5,14 +5,17 @@
  * remains accepted on the wire so an older Gateway can be upgraded
  * independently of the Electron shell.
  */
-export const DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION = 4 as const
+export const DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION = 5 as const
+export const DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V4 = 4 as const
 export const DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V3 = 3 as const
 export const DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSIONS = [
   DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V3,
+  DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V4,
   DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION,
 ] as const
 export type DesktopArtifactBridgeProtocolVersion =
   typeof DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V3
+  | typeof DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V4
   | typeof DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION
 
 export const DESKTOP_ARTIFACT_BRIDGE_METHODS = [
@@ -57,7 +60,7 @@ export interface DesktopArtifactBridgeCapabilities {
  */
 export const DESKTOP_ARTIFACT_BRIDGE_CONTRACT = {
   version: DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION,
-  surfaceBinding: 'active' as const,
+  surfaceBinding: 'turn' as const,
   methods: DESKTOP_ARTIFACT_BRIDGE_METHODS,
   acceptsSurfaceId: false as const,
   acceptsUrl: false as const,
@@ -271,6 +274,8 @@ export interface DesktopArtifactBrowserSnapshot {
   scopeId?: string
   /** Opaque candidate handle while a candidate preview is bound. */
   candidateHandle?: string | null
+  /** v5 process-local binding generation; never projected to the model. */
+  bindingGeneration?: number
 }
 
 export interface DesktopArtifactBrowserActResult {
@@ -405,8 +410,8 @@ function parseV4OnlyRequest(
   label: string,
 ): Record<string, unknown> {
   const request = parseRequest(value, allowedKeys, label)
-  if (requestVersion(value) !== DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION) {
-    throw new Error(`The Desktop artifact ${label} requires protocol-v4.`)
+  if (requestVersion(value) < DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V4) {
+    throw new Error(`The Desktop artifact ${label} requires protocol-v4 or newer.`)
   }
   return request
 }
@@ -671,7 +676,7 @@ export function parseDesktopArtifactBindCandidatePreviewRequest(
     'candidate preview binding',
   )
   return {
-    version: DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION,
+    version: request.version as DesktopArtifactBridgeProtocolVersion,
     candidateHandle: parseCandidateHandle(request.candidateHandle),
   }
 }
@@ -685,7 +690,7 @@ export function parseDesktopArtifactRestoreCanonicalPreviewRequest(
     'canonical preview restore',
   )
   return {
-    version: DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION,
+    version: request.version as DesktopArtifactBridgeProtocolVersion,
     candidateHandle: parseCandidateHandle(request.candidateHandle),
   }
 }

--- a/desktop/electron/src/desktop-artifact-bridge-loopback.ts
+++ b/desktop/electron/src/desktop-artifact-bridge-loopback.ts
@@ -26,7 +26,7 @@ type AuditOutcome = 'allowed' | 'rejected' | 'failed'
 
 export interface DesktopArtifactBridgeLoopbackAudit {
   event: 'desktop_artifact_bridge_transport'
-  operation: 'capabilities' | DesktopArtifactBridgeMethod | 'unknown'
+  operation: 'capabilities' | 'bindingAcquire' | 'bindingRelease' | DesktopArtifactBridgeMethod | 'unknown'
   outcome: AuditOutcome
   code: string
   durationMs: number
@@ -117,6 +117,42 @@ function writeJson(response: ServerResponse, status: number, payload: unknown): 
     'x-content-type-options': 'nosniff',
   })
   response.end(body)
+}
+
+async function writeJsonSettled(
+  response: ServerResponse,
+  status: number,
+  payload: unknown,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      response.off('finish', onFinish)
+      response.off('close', onClose)
+      response.off('error', onError)
+    }
+    const onFinish = () => {
+      cleanup()
+      resolve()
+    }
+    const onClose = () => {
+      cleanup()
+      if (response.writableFinished) resolve()
+      else reject(new Error('The Desktop binding response closed before delivery.'))
+    }
+    const onError = (error: Error) => {
+      cleanup()
+      reject(error)
+    }
+    response.once('finish', onFinish)
+    response.once('close', onClose)
+    response.once('error', onError)
+    try {
+      writeJson(response, status, payload)
+    } catch (error) {
+      cleanup()
+      reject(error)
+    }
+  })
 }
 
 class TransportRequestError extends Error {
@@ -216,6 +252,7 @@ export class DesktopArtifactBridgeLoopbackTransport {
     this.endpoint = null
     this.tokenText = null
     this.startPromise = null
+    await this.bridge.releaseAllBindings()
     if (!server) return
     await new Promise<void>((resolve) => server.close(() => resolve()))
   }
@@ -305,14 +342,57 @@ export class DesktopArtifactBridgeLoopbackTransport {
         this.assertBeforeDeadline(deadlineAt)
         outcome = 'allowed'
         code = 'ok'
-        writeJson(response, 200, { ok: true, value: this.bridge.getCapabilities() })
+        writeJson(response, 200, {
+          ok: true,
+          value: this.bridge.getCapabilities(
+            body.version as (typeof DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSIONS)[number],
+          ),
+        })
+        return
+      }
+
+      if (request.url === '/v1/bindings/acquire') {
+        operation = 'bindingAcquire'
+        if (!isObjectRecord(body) || !exactKeys(body, ['version']) || body.version !== DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION) {
+          throw new TransportRequestError(400, 'invalid-request', 'The binding request is invalid.')
+        }
+        const binding = await this.bridge.acquireBinding()
+        if (!binding) throw new TransportRequestError(409, 'unavailable', 'No editable Desktop artifact surface is available.')
+        try {
+          this.assertBeforeDeadline(deadlineAt)
+          await writeJsonSettled(response, 201, {
+            ok: true,
+            value: {
+              version: DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION,
+              ...binding,
+            },
+          })
+          outcome = 'allowed'
+          code = 'ok'
+        } catch (error) {
+          await this.bridge.releaseBinding(binding.bindingToken)
+          throw error
+        }
+        return
+      }
+
+      if (request.url === '/v1/bindings/release') {
+        operation = 'bindingRelease'
+        if (!isObjectRecord(body) || !exactKeys(body, ['version', 'bindingToken']) || body.version !== DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION || typeof body.bindingToken !== 'string' || !/^[A-Za-z0-9_-]{43}$/.test(body.bindingToken)) {
+          throw new TransportRequestError(400, 'invalid-request', 'The binding release request is invalid.')
+        }
+        await this.bridge.releaseBinding(body.bindingToken)
+        outcome = 'allowed'
+        code = 'ok'
+        writeJson(response, 200, { ok: true, value: { released: true } })
         return
       }
 
       if (request.url !== '/v1/invoke') {
         throw new TransportRequestError(404, 'not-found', 'The Desktop bridge endpoint was not found.')
       }
-      if (!isObjectRecord(body) || !exactKeys(body, ['version', 'method', 'request'])) {
+      const isV5 = isObjectRecord(body) && body.version === DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION
+      if (!isObjectRecord(body) || !exactKeys(body, isV5 ? ['version', 'method', 'request', 'bindingToken'] : ['version', 'method', 'request'])) {
         throw new TransportRequestError(400, 'invalid-request', 'The bridge invocation is invalid.')
       }
       // The envelope and typed request must negotiate the same protocol.  A
@@ -334,7 +414,9 @@ export class DesktopArtifactBridgeLoopbackTransport {
       this.assertBeforeDeadline(deadlineAt)
       const invocationController = new AbortController()
       const result = await this.beforeDeadline(
-        this.invokeBridge(method, body.request, invocationController.signal),
+        isV5
+          ? this.invokeBoundBridge(method, body.request, body.bindingToken, invocationController.signal)
+          : this.invokeBridge(method, body.request, invocationController.signal),
         deadlineAt,
         invocationController,
       )
@@ -416,6 +498,18 @@ export class DesktopArtifactBridgeLoopbackTransport {
     signal: AbortSignal,
   ): Promise<DesktopArtifactBridgeResult<M>> {
     return this.bridge[method](request, signal) as Promise<DesktopArtifactBridgeResult<M>>
+  }
+
+  private invokeBoundBridge<M extends DesktopArtifactBridgeMethod>(
+    method: M,
+    request: unknown,
+    bindingToken: unknown,
+    signal: AbortSignal,
+  ): Promise<DesktopArtifactBridgeResult<M>> {
+    if (typeof bindingToken !== 'string' || !/^[A-Za-z0-9_-]{43}$/.test(bindingToken)) {
+      return Promise.resolve({ ok: false, method, code: 'invalid-request', message: 'The Desktop artifact binding token is invalid.' })
+    }
+    return this.bridge.invokeBound(method, request, bindingToken, signal)
   }
 
   private now(): number {

--- a/desktop/electron/src/desktop-artifact-bridge.ts
+++ b/desktop/electron/src/desktop-artifact-bridge.ts
@@ -1,6 +1,8 @@
+import { randomBytes } from 'node:crypto'
 import {
   DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION,
   DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V3,
+  DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V4,
   DESKTOP_ARTIFACT_BRIDGE_UNSUPPORTED_CAPABILITIES,
   parseDesktopArtifactBrowserActRequest,
   parseDesktopArtifactBrowserInspectRequest,
@@ -25,6 +27,8 @@ export type DesktopArtifactBridgeErrorCode =
   | 'unsupported'
   | 'timed-out'
   | 'operation-failed'
+  | 'binding-terminal-unavailable'
+  | 'action-result-unknown'
 
 export interface DesktopArtifactBridgeSuccess<M extends DesktopArtifactBridgeMethod> {
   ok: true
@@ -72,7 +76,22 @@ export interface DesktopArtifactBridgeTarget {
 
 export interface DesktopArtifactBridgeOptions {
   getActiveTarget(): DesktopArtifactBridgeTarget | null
+  acquireActiveTargetBinding?():
+    | DesktopArtifactBridgeTargetBinding
+    | null
+    | Promise<DesktopArtifactBridgeTargetBinding | null>
   operationTimeoutMs?: number
+}
+
+export interface DesktopArtifactBridgeTargetBinding {
+  target: DesktopArtifactBridgeTarget
+  release(): void | Promise<void>
+}
+
+interface DesktopArtifactBridgeBindingRecord {
+  target: DesktopArtifactBridgeTarget
+  release: () => void | Promise<void>
+  queue: Promise<void>
 }
 
 const REQUEST_PARSERS = {
@@ -106,6 +125,7 @@ function handlerFor<M extends DesktopArtifactBridgeMethod>(
  */
 export class DesktopArtifactBridge {
   private operationQueue: Promise<void> = Promise.resolve()
+  private readonly bindings = new Map<string, DesktopArtifactBridgeBindingRecord>()
   private readonly operationTimeoutMs: number
 
   constructor(private readonly options: DesktopArtifactBridgeOptions) {
@@ -115,7 +135,9 @@ export class DesktopArtifactBridge {
       : 15_000
   }
 
-  getCapabilities(): DesktopArtifactBridgeCapabilities {
+  getCapabilities(
+    requestedVersion: DesktopArtifactBridgeProtocolVersion = DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V4,
+  ): DesktopArtifactBridgeCapabilities {
     const target = this.activeTarget()
     if (!target || !this.targetIsCurrent(target)) {
       return { ...DESKTOP_ARTIFACT_BRIDGE_UNSUPPORTED_CAPABILITIES }
@@ -125,20 +147,111 @@ export class DesktopArtifactBridge {
       // surface's negotiated version.  This prevents a v3 legacy preview
       // from being mistaken for an autonomous v4 browser surface by the
       // Gateway, without removing its old screenshot/reload operations.
-      version: target.protocolVersion === DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V3
-        ? DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V3
-        : DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION,
+      version: requestedVersion === DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION
+        ? DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION
+        : target.protocolVersion === DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V3
+          ? DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V3
+          : DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V4,
       available: true,
       captureSelection: this.methodAvailable(target, 'captureSelection'),
       resolveAnnotationSelection: this.methodAvailable(target, 'resolveAnnotationSelection'),
       focusAnnotation: this.methodAvailable(target, 'focusAnnotation'),
-      browserInspect: this.methodAvailable(target, 'browserInspect'),
-      browserAct: this.methodAvailable(target, 'browserAct'),
-      bindCandidatePreview: this.methodAvailable(target, 'bindCandidatePreview'),
-      restoreCanonicalPreview: this.methodAvailable(target, 'restoreCanonicalPreview'),
+      browserInspect: requestedVersion === DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION && this.methodAvailable(target, 'browserInspect'),
+      browserAct: requestedVersion === DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION && this.methodAvailable(target, 'browserAct'),
+      bindCandidatePreview: requestedVersion === DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION && this.methodAvailable(target, 'bindCandidatePreview'),
+      restoreCanonicalPreview: requestedVersion === DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION && this.methodAvailable(target, 'restoreCanonicalPreview'),
       screenshot: this.methodAvailable(target, 'screenshot'),
       officeFlush: this.methodAvailable(target, 'officeFlush'),
       reloadSurface: this.methodAvailable(target, 'reloadSurface'),
+    }
+  }
+
+  async acquireBinding(): Promise<{
+    bindingToken: string
+    capabilities: DesktopArtifactBridgeCapabilities
+  } | null> {
+    const acquired = await this.options.acquireActiveTargetBinding?.()
+    if (!acquired) return null
+    try {
+      if (!this.targetIsCurrent(acquired.target)) {
+        await acquired.release()
+        return null
+      }
+      const bindingToken = randomBytes(32).toString('base64url')
+      const capabilities = this.capabilitiesFor(acquired.target)
+      this.bindings.set(bindingToken, {
+        target: acquired.target,
+        release: acquired.release,
+        queue: Promise.resolve(),
+      })
+      return { bindingToken, capabilities }
+    } catch (error) {
+      await acquired.release()
+      throw error
+    }
+  }
+
+  async releaseBinding(bindingToken: string): Promise<void> {
+    const record = this.bindings.get(bindingToken)
+    if (!record) return
+    this.bindings.delete(bindingToken)
+    await record.queue.catch(() => undefined)
+    await record.release()
+  }
+
+  async releaseAllBindings(): Promise<void> {
+    await Promise.allSettled([...this.bindings.keys()].map(token => this.releaseBinding(token)))
+  }
+
+  invokeBound<M extends DesktopArtifactBridgeMethod>(
+    method: M,
+    value: unknown,
+    bindingToken: string,
+    signal?: AbortSignal,
+  ): Promise<DesktopArtifactBridgeResult<M>> {
+    const record = this.bindings.get(bindingToken)
+    if (!record) {
+      return Promise.resolve({
+        ok: false,
+        method,
+        code: 'unavailable',
+        message: 'The Desktop artifact binding is unavailable.',
+      })
+    }
+    let request: DesktopArtifactBridgeRequestByMethod[M]
+    try {
+      request = REQUEST_PARSERS[method](value) as DesktopArtifactBridgeRequestByMethod[M]
+    } catch (error) {
+      return Promise.resolve({
+        ok: false,
+        method,
+        code: 'invalid-request',
+        message: error instanceof Error ? error.message : 'The Desktop artifact request is invalid.',
+      })
+    }
+    const operation = record.queue.then(
+      () => this.perform(method, request, record.target, signal),
+      () => this.perform(method, request, record.target, signal),
+    )
+    record.queue = operation.then(() => undefined, () => undefined)
+    return operation
+  }
+
+  private capabilitiesFor(target: DesktopArtifactBridgeTarget): DesktopArtifactBridgeCapabilities {
+    const available = (method: DesktopArtifactBridgeMethod) => this.methodAvailable(target, method)
+    return {
+      version: DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION,
+      available: true,
+      captureSelection: available('captureSelection'),
+      resolveAnnotationSelection: available('resolveAnnotationSelection'),
+      focusAnnotation: available('focusAnnotation'),
+      browserInspect: available('browserInspect'),
+      browserAct: available('browserAct'),
+      screenshot: available('screenshot'),
+      officeFlush: available('officeFlush'),
+      reloadSurface: available('reloadSurface'),
+      bindCandidatePreview: available('bindCandidatePreview'),
+      restoreCanonicalPreview: available('restoreCanonicalPreview'),
     }
   }
 
@@ -313,13 +426,35 @@ export class DesktopArtifactBridge {
       return { ok: true, method, value }
     } catch (error) {
       const timedOut = controller.signal.aborted
+      // Once browserAct has entered its handler, a timeout or cancellation
+      // cannot prove whether the page observed the input. Never classify that
+      // boundary as safely retryable: the caller must inspect again.
+      const actionResultUnknown = method === 'browserAct' && timedOut
+      const operationCode: DesktopArtifactBridgeErrorCode | null = (
+        !timedOut
+        && error
+        && typeof error === 'object'
+        && 'code' in error
+        && (
+          (error as { code?: unknown }).code === 'binding-terminal-unavailable'
+          || (error as { code?: unknown }).code === 'action-result-unknown'
+        )
+      ) ? (error as { code: DesktopArtifactBridgeErrorCode }).code : null
       return {
         ok: false,
         method,
-        code: timedOut ? 'timed-out' : 'operation-failed',
-        message: timedOut
-          ? 'The Desktop artifact operation timed out.'
-          : 'The Desktop artifact operation failed.',
+        code: actionResultUnknown
+          ? 'action-result-unknown'
+          : timedOut ? 'timed-out' : operationCode || 'operation-failed',
+        message: actionResultUnknown
+          ? 'The Desktop artifact action result is unknown; inspect again.'
+          : timedOut
+            ? 'The Desktop artifact operation timed out.'
+          : operationCode === 'action-result-unknown'
+            ? 'The Desktop artifact action result is unknown; inspect again.'
+            : operationCode === 'binding-terminal-unavailable'
+              ? 'The bound Desktop artifact surface is unavailable.'
+              : 'The Desktop artifact operation failed.',
       }
     } finally {
       if (timeout) clearTimeout(timeout)

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -594,6 +594,7 @@ const nativeWorkbenchSurfaces = new NativeWorkbenchSurfaceManager({
   getWindow: () => currentMainWindow(),
   resolveCandidatePreview: resolveCandidatePreviewFromGateway,
   releaseCandidatePreview: releaseCandidatePreviewFromGateway,
+  pinArtifactPreview: grant => artifactPreviewLeaseBroker.pinSurface(grant),
   emit: event => {
     if (event.type === 'error' || event.type === 'crashed') {
       desktopLog('native_workbench_surface_failed', {
@@ -614,6 +615,7 @@ const nativeWorkbenchSurfaces = new NativeWorkbenchSurfaceManager({
 })
 const desktopArtifactBridge = new DesktopArtifactBridge({
   getActiveTarget: () => nativeWorkbenchSurfaces.getActiveArtifactBridgeTarget(),
+  acquireActiveTargetBinding: () => nativeWorkbenchSurfaces.acquireArtifactBridgeTargetBinding(),
 })
 const desktopArtifactBridgeLoopback = new DesktopArtifactBridgeLoopbackTransport(
   desktopArtifactBridge,

--- a/desktop/electron/src/native-workbench-surface-contract.ts
+++ b/desktop/electron/src/native-workbench-surface-contract.ts
@@ -2,6 +2,7 @@ import {
   DESKTOP_ARTIFACT_BRIDGE_CONTRACT,
   DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION,
   DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V3,
+  DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V4,
 } from './desktop-artifact-bridge-contract.js'
 
 export const NATIVE_WORKBENCH_PROTOCOL_VERSION = 1 as const
@@ -9,7 +10,7 @@ export const NATIVE_WORKBENCH_PROTOCOL_VERSION_V2 = 2 as const
 export const NATIVE_WORKBENCH_PROTOCOL_VERSION_V3 =
   DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V3
 export const NATIVE_WORKBENCH_PROTOCOL_VERSION_V4 =
-  DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION
+  DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V4
 export const NATIVE_WORKBENCH_MAX_SURFACES = 8
 export const NATIVE_WORKBENCH_MAX_HTML_BYTES = 5 * 1024 * 1024
 export const NATIVE_WORKBENCH_ARTIFACT_SCHEME = 'opensquilla-artifact'
@@ -200,6 +201,7 @@ export type NativeWorkbenchSurfaceEventType =
   | 'annotation-submit'
   | 'annotation-cancel'
   | 'annotation-overlay-fallback'
+  | 'agent-edit-released'
 
 export interface NativeWorkbenchSurfaceEvent {
   version:

--- a/desktop/electron/src/native-workbench-surface.ts
+++ b/desktop/electron/src/native-workbench-surface.ts
@@ -56,7 +56,10 @@ import type {
   DesktopArtifactBrowserSnapshot,
   DesktopArtifactFocusAnnotationRequest,
 } from './desktop-artifact-bridge-contract.js'
-import type { DesktopArtifactBridgeTarget } from './desktop-artifact-bridge.js'
+import type {
+  DesktopArtifactBridgeTarget,
+  DesktopArtifactBridgeTargetBinding,
+} from './desktop-artifact-bridge.js'
 import { installDesktopZoomShortcuts } from './desktop-zoom-shortcuts.js'
 
 function artifactHtmlCsp(allowRemoteResources: boolean): string {
@@ -108,6 +111,8 @@ interface NativeWorkbenchSurfaceRecord {
   disposed: boolean
   crashed: boolean
   cleanupPromise: Promise<void> | null
+  artifactBridgePins: number
+  uiReleaseRequested: boolean
   missingResourceReported: boolean
   blockedNetworkReported: boolean
   privilegedOriginReported: boolean
@@ -145,6 +150,30 @@ interface NativeWorkbenchSurfaceRecord {
   cdpQueue: Promise<void>
   cdpReady: boolean
   debuggerExpectedDetach: boolean
+}
+
+interface NativeWorkbenchArtifactBridgeBindingState {
+  record: NativeWorkbenchSurfaceRecord
+  target: DesktopArtifactBridgeTarget
+  previewPin: NativeWorkbenchArtifactPreviewPin
+  generation: number
+  recoveryAttempted: boolean
+  terminal: boolean
+  released: boolean
+  candidateHandle: string | null
+}
+
+interface NativeWorkbenchArtifactPreviewGrant {
+  launchUrl: string
+  expectedOrigin: string
+  scopeId: string
+  mode: NativeWorkbenchPreviewMode
+}
+
+interface NativeWorkbenchArtifactPreviewPin {
+  currentGrant(): NativeWorkbenchArtifactPreviewGrant
+  ensureCurrent(): Promise<NativeWorkbenchArtifactPreviewGrant | null>
+  release(): Promise<void>
 }
 
 interface NativeWorkbenchBrowserAnchor {
@@ -915,6 +944,9 @@ export interface NativeWorkbenchSurfaceManagerOptions {
     candidateHandle: string,
     signal: AbortSignal,
   ) => Promise<void>
+  pinArtifactPreview?: (
+    grant: NativeWorkbenchArtifactPreviewGrant,
+  ) => NativeWorkbenchArtifactPreviewPin | null
 }
 
 export interface NativeWorkbenchCandidatePreviewBinding {
@@ -1079,6 +1111,10 @@ export class NativeWorkbenchSurfaceManager {
   private readonly annotationOverlays = new Map<BrowserWindow, NativeWorkbenchAnnotationOverlayRecord>()
   private readonly hookedWindows = new WeakSet<BrowserWindow>()
   private readonly unresponsiveWindows = new WeakSet<BrowserWindow>()
+  private readonly artifactBridgeBindings = new Map<
+    string,
+    NativeWorkbenchArtifactBridgeBindingState
+  >()
   private activeSurfaceId: string | null = null
 
   constructor(private readonly options: NativeWorkbenchSurfaceManagerOptions) {}
@@ -1100,6 +1136,14 @@ export class NativeWorkbenchSurfaceManager {
     activePreviewArtifactId: string | null,
   ): Promise<NativeWorkbenchSurfaceResult> {
     const previous = this.surfaces.get(request.surfaceId)
+    if (previous?.artifactBridgePins) {
+      return {
+        ok: false,
+        retryable: true,
+        code: 'AGENT_EDIT_IN_PROGRESS',
+        message: 'Agent editing is continuing in the background.',
+      }
+    }
     if (previous) await this.destroyRecord(previous)
     if (this.surfaces.size >= NATIVE_WORKBENCH_MAX_SURFACES) {
       return {
@@ -1185,6 +1229,8 @@ export class NativeWorkbenchSurfaceManager {
       disposed: false,
       crashed: false,
       cleanupPromise: null,
+      artifactBridgePins: 0,
+      uiReleaseRequested: false,
       missingResourceReported: false,
       blockedNetworkReported: false,
       privilegedOriginReported: false,
@@ -1596,6 +1642,12 @@ export class NativeWorkbenchSurfaceManager {
       || !record.view.getVisible()
       || record.view.webContents.isDestroyed()
     ) return null
+    return this.artifactBridgeTargetForRecord(record)
+  }
+
+  private artifactBridgeTargetForRecord(
+    record: NativeWorkbenchSurfaceRecord,
+  ): DesktopArtifactBridgeTarget {
     return {
       protocolVersion: record.version === NATIVE_WORKBENCH_PROTOCOL_VERSION_V3
         ? NATIVE_WORKBENCH_PROTOCOL_VERSION_V3
@@ -2030,6 +2082,334 @@ export class NativeWorkbenchSurfaceManager {
     return { restored: true }
   }
 
+  private artifactBridgeBindingError(code: string, message: string): Error {
+    const error = new Error(message) as Error & { code?: string }
+    error.code = code
+    return error
+  }
+
+  private bindingRecordNeedsRecovery(
+    state: NativeWorkbenchArtifactBridgeBindingState,
+  ): boolean {
+    const record = state.record
+    try {
+      return record.disposed
+        || record.crashed
+        || record.view.webContents.isDestroyed()
+        || !record.cdpReady
+        || !record.view.webContents.debugger.isAttached()
+        || this.surfaces.get(record.id) !== record
+    } catch {
+      return true
+    }
+  }
+
+  private async refreshArtifactBridgeCanonicalGrant(
+    state: NativeWorkbenchArtifactBridgeBindingState,
+  ): Promise<boolean> {
+    const grant = await state.previewPin.ensureCurrent()
+    if (!grant || grant.scopeId !== state.record.scopeId) {
+      state.terminal = true
+      throw this.artifactBridgeBindingError(
+        'binding-terminal-unavailable',
+        'The bound Desktop artifact preview lease is unavailable.',
+      )
+    }
+    const record = state.record
+    const changed = record.canonicalDocumentUrl !== grant.launchUrl
+      || record.canonicalExpectedOrigin !== grant.expectedOrigin
+      || record.canonicalMode !== grant.mode
+    if (!changed) return false
+    record.canonicalDocumentUrl = grant.launchUrl
+    record.canonicalExpectedOrigin = grant.expectedOrigin
+    record.canonicalMode = grant.mode
+    state.generation += 1
+    return true
+  }
+
+  private async recoverArtifactBridgeBinding(
+    state: NativeWorkbenchArtifactBridgeBindingState,
+    signal: AbortSignal,
+  ): Promise<void> {
+    if (state.released || state.terminal || state.recoveryAttempted || signal.aborted) {
+      state.terminal = true
+      throw this.artifactBridgeBindingError(
+        'binding-terminal-unavailable',
+        'The bound Desktop artifact surface is unavailable.',
+      )
+    }
+    state.recoveryAttempted = true
+    const failed = state.record
+    await this.refreshArtifactBridgeCanonicalGrant(state)
+    const candidateHandle = state.candidateHandle ?? failed.candidatePreview?.handle ?? null
+    const canonicalArtifactId = failed.canonicalPreviewArtifactId
+    const uiReleaseRequested = failed.uiReleaseRequested
+    const request: NativeWorkbenchCreateRequest = {
+      version: NATIVE_WORKBENCH_PROTOCOL_VERSION_V4,
+      surfaceId: failed.id,
+      kind: 'artifact-preview',
+      payload: {
+        launchUrl: failed.canonicalDocumentUrl,
+        expectedOrigin: failed.canonicalExpectedOrigin || '',
+        scopeId: failed.scopeId,
+        mode: failed.canonicalMode,
+      },
+    }
+    failed.artifactBridgePins = 0
+    try {
+      await this.destroyRecord(failed, { preserveCandidatePreview: true })
+      const created = await this.createSurfaceNow(request, canonicalArtifactId)
+      if (!created.ok) throw new Error(created.message || 'Surface recovery failed.')
+      const replacement = this.surfaces.get(failed.id)
+      if (!replacement || replacement.disposed || replacement.crashed) {
+        throw new Error('The replacement surface is unavailable.')
+      }
+      replacement.artifactBridgePins = 1
+      replacement.uiReleaseRequested = uiReleaseRequested
+      replacement.visibleRequested = false
+      this.setPhysicalVisibility(replacement, false)
+      state.record = replacement
+      state.target = this.artifactBridgeTargetForRecord(replacement)
+      state.generation += 1
+      if (candidateHandle) {
+        await this.bindCandidatePreview(replacement, candidateHandle, signal)
+        state.candidateHandle = candidateHandle
+      }
+    } catch (error) {
+      state.terminal = true
+      const replacement = this.surfaces.get(failed.id)
+      if (replacement && replacement !== failed) {
+        replacement.artifactBridgePins = 0
+        await this.destroyRecord(replacement).catch(() => undefined)
+      }
+      if (candidateHandle && this.options.releaseCandidatePreview) {
+        await this.options.releaseCandidatePreview(
+          candidateHandle,
+          new AbortController().signal,
+        ).catch(() => undefined)
+      }
+      throw this.artifactBridgeBindingError(
+        'binding-terminal-unavailable',
+        'The bound Desktop artifact surface could not be recovered.',
+      )
+    }
+  }
+
+  private async invokeArtifactBridgeBinding<T>(
+    state: NativeWorkbenchArtifactBridgeBindingState,
+    method: keyof DesktopArtifactBridgeTarget,
+    request: unknown,
+    signal: AbortSignal,
+    recoverable: boolean,
+  ): Promise<T> {
+    if (state.released || state.terminal) {
+      throw this.artifactBridgeBindingError(
+        'binding-terminal-unavailable',
+        'The bound Desktop artifact surface is unavailable.',
+      )
+    }
+    const canonicalGrantChanged = await this.refreshArtifactBridgeCanonicalGrant(state)
+    if (canonicalGrantChanged || this.bindingRecordNeedsRecovery(state)) {
+      await this.recoverArtifactBridgeBinding(state, signal)
+    }
+
+    const run = async (): Promise<T> => {
+      const handler = state.target[method]
+      if (typeof handler !== 'function') {
+        throw new Error(`The Desktop artifact surface does not support ${String(method)}.`)
+      }
+      return await (handler as (
+        value: unknown,
+        operationSignal: AbortSignal,
+      ) => T | Promise<T>)(request, signal)
+    }
+
+    const recordSuccess = (value: T): T => {
+      if (method === 'bindCandidatePreview') {
+        state.candidateHandle = (request as { candidateHandle?: string }).candidateHandle || null
+      } else if (method === 'restoreCanonicalPreview') {
+        state.candidateHandle = null
+      }
+      return value
+    }
+
+    try {
+      return recordSuccess(await run())
+    } catch (error) {
+      const needsRecovery = this.bindingRecordNeedsRecovery(state)
+      if (method === 'browserAct' && needsRecovery) {
+        throw this.artifactBridgeBindingError(
+          'action-result-unknown',
+          'The Desktop artifact action result is unknown; inspect again.',
+        )
+      }
+      if (!recoverable || !needsRecovery) throw error
+      await this.recoverArtifactBridgeBinding(state, signal)
+      try {
+        return recordSuccess(await run())
+      } catch {
+        state.terminal = true
+        throw this.artifactBridgeBindingError(
+          'binding-terminal-unavailable',
+          'The bound Desktop artifact surface is unavailable after recovery.',
+        )
+      }
+    }
+  }
+
+  private artifactBridgeBindingTarget(
+    state: NativeWorkbenchArtifactBridgeBindingState,
+  ): DesktopArtifactBridgeTarget {
+    const initial = state.target
+    return {
+      ...initial,
+      isCurrent: () => !state.released && !state.terminal,
+      capabilities: {
+        ...initial.capabilities,
+        browserAct: initial.capabilities.bindCandidatePreview === true,
+      },
+      resolveAnnotationSelection: initial.resolveAnnotationSelection
+        ? (request, signal) => this.invokeArtifactBridgeBinding(
+            state, 'resolveAnnotationSelection', request, signal, true,
+          )
+        : undefined,
+      focusAnnotation: initial.focusAnnotation
+        ? (request, signal) => this.invokeArtifactBridgeBinding(
+            state, 'focusAnnotation', request, signal, true,
+          )
+        : undefined,
+      browserInspect: initial.browserInspect
+        ? (request, signal) => this.invokeArtifactBridgeBinding(
+            state, 'browserInspect', request, signal, true,
+          )
+        : undefined,
+      browserAct: initial.browserAct
+        ? (request, signal) => this.invokeArtifactBridgeBinding(
+            state, 'browserAct', request, signal, false,
+          )
+        : undefined,
+      bindCandidatePreview: initial.bindCandidatePreview
+        ? (request, signal) => this.invokeArtifactBridgeBinding(
+            state, 'bindCandidatePreview', request, signal, true,
+          )
+        : undefined,
+      restoreCanonicalPreview: initial.restoreCanonicalPreview
+        ? (request, signal) => this.invokeArtifactBridgeBinding(
+            state, 'restoreCanonicalPreview', request, signal, true,
+          )
+        : undefined,
+      screenshot: initial.screenshot
+        ? (request, signal) => this.invokeArtifactBridgeBinding(
+            state, 'screenshot', request, signal, true,
+          )
+        : undefined,
+      reloadSurface: initial.reloadSurface
+        ? (request, signal) => this.invokeArtifactBridgeBinding(
+            state, 'reloadSurface', request, signal, true,
+          )
+        : undefined,
+    }
+  }
+
+  async acquireArtifactBridgeTargetBinding(): Promise<DesktopArtifactBridgeTargetBinding | null> {
+    if (!this.activeSurfaceId) return null
+    const record = this.surfaces.get(this.activeSurfaceId)
+    if (
+      !record
+      || record.artifactBridgePins > 0
+      || this.artifactBridgeBindings.has(record.id)
+    ) return null
+    const target = this.getActiveArtifactBridgeTarget()
+    if (!target || record.version !== NATIVE_WORKBENCH_PROTOCOL_VERSION_V4) return null
+    const previewPin = record.kind === 'artifact-preview'
+      && record.canonicalExpectedOrigin
+      && this.options.pinArtifactPreview
+      ? this.options.pinArtifactPreview({
+          launchUrl: record.canonicalDocumentUrl,
+          expectedOrigin: record.canonicalExpectedOrigin,
+          scopeId: record.scopeId,
+          mode: record.canonicalMode,
+        })
+      : null
+    if (record.kind === 'artifact-preview' && !previewPin) return null
+    if (!previewPin) return null
+    record.artifactBridgePins += 1
+    let state: NativeWorkbenchArtifactBridgeBindingState | null = null
+    try {
+      state = {
+        record,
+        target,
+        previewPin,
+        generation: 1,
+        recoveryAttempted: false,
+        terminal: false,
+        released: false,
+        candidateHandle: record.candidatePreview?.handle ?? null,
+      }
+      this.artifactBridgeBindings.set(record.id, state)
+      const bindingState = state
+      const bindingTarget = this.artifactBridgeBindingTarget(bindingState)
+      let released = false
+      return {
+        target: bindingTarget,
+        release: async () => {
+          if (released) return
+          released = true
+          bindingState.released = true
+          if (this.artifactBridgeBindings.get(record.id) === bindingState) {
+            this.artifactBridgeBindings.delete(record.id)
+          }
+          const current = bindingState.record
+          if (
+            bindingState.candidateHandle
+            && current.candidatePreview?.handle === bindingState.candidateHandle
+            && !current.disposed
+            && !current.crashed
+          ) {
+            try {
+              await this.restoreCanonicalPreview(
+                current,
+                bindingState.candidateHandle,
+                new AbortController().signal,
+              )
+              bindingState.candidateHandle = null
+            } catch {
+              bindingState.terminal = true
+            }
+          }
+          current.artifactBridgePins = Math.max(0, current.artifactBridgePins - 1)
+          if (
+            current.artifactBridgePins === 0
+            && (current.uiReleaseRequested || current.crashed || bindingState.terminal)
+          ) {
+            await this.destroyRecord(current)
+          } else if (
+            bindingState.candidateHandle
+            && this.options.releaseCandidatePreview
+          ) {
+            await this.options.releaseCandidatePreview(
+              bindingState.candidateHandle,
+              new AbortController().signal,
+            ).catch(() => undefined)
+          }
+          await previewPin.release()
+          this.options.emit({
+            version: NATIVE_WORKBENCH_PROTOCOL_VERSION_V4,
+            surfaceId: record.id,
+            type: 'agent-edit-released',
+          })
+        },
+      }
+    } catch (error) {
+      if (state && this.artifactBridgeBindings.get(record.id) === state) {
+        this.artifactBridgeBindings.delete(record.id)
+      }
+      record.artifactBridgePins = Math.max(0, record.artifactBridgePins - 1)
+      await previewPin.release()
+      throw error
+    }
+  }
+
   private trustedCandidatePreviewUrl(launchUrl: string, expectedOrigin: string): boolean {
     try {
       const parsed = new URL(launchUrl)
@@ -2081,14 +2461,19 @@ export class NativeWorkbenchSurfaceManager {
 
   private isActiveArtifactBridgeRecord(record: NativeWorkbenchSurfaceRecord): boolean {
     try {
-      return this.activeSurfaceId === record.id
-        && this.surfaces.get(record.id) === record
+      const live = this.surfaces.get(record.id) === record
         && isArtifactBridgeProtocolVersion(record.version)
         && !record.disposed
         && !record.crashed
-        && record.visibleRequested
-        && record.view.getVisible()
         && !record.view.webContents.isDestroyed()
+      return live && (
+        record.artifactBridgePins > 0
+        || (
+          this.activeSurfaceId === record.id
+          && record.visibleRequested
+          && record.view.getVisible()
+        )
+      )
     } catch {
       return false
     }
@@ -2354,6 +2739,23 @@ export class NativeWorkbenchSurfaceManager {
     record.browserAnchorGeneration += 1
   }
 
+  private artifactBridgeBindingGeneration(
+    record: NativeWorkbenchSurfaceRecord,
+  ): number | undefined {
+    const state = this.artifactBridgeBindings.get(record.id)
+    return state?.record === record && !state.released
+      ? state.generation
+      : undefined
+  }
+
+  private bumpArtifactBridgeBindingGeneration(
+    record: NativeWorkbenchSurfaceRecord,
+  ): void {
+    const state = this.artifactBridgeBindings.get(record.id)
+    if (state?.record !== record || state.released) return
+    state.generation += 1
+  }
+
   private async browserRoot(
     record: NativeWorkbenchSurfaceRecord,
     objectGroup: string,
@@ -2418,6 +2820,7 @@ export class NativeWorkbenchSurfaceManager {
         activePreviewArtifactId: record.activePreviewArtifactId,
         scopeId: record.scopeId,
         candidateHandle: record.candidatePreview?.handle ?? null,
+        bindingGeneration: this.artifactBridgeBindingGeneration(record),
       }
     }
     const objectGroup = `opensquilla-browser-${randomUUID()}`
@@ -2502,6 +2905,7 @@ export class NativeWorkbenchSurfaceManager {
         activePreviewArtifactId: record.activePreviewArtifactId,
         scopeId: record.scopeId,
         candidateHandle: record.candidatePreview?.handle ?? null,
+        bindingGeneration: this.artifactBridgeBindingGeneration(record),
       }
     } finally {
       await this.cdpCommand(record, 'Runtime.releaseObjectGroup', { objectGroup })
@@ -2581,31 +2985,42 @@ export class NativeWorkbenchSurfaceManager {
       } else {
         throw new Error('The browser action is unsupported.')
       }
-      const acted = await this.cdpCommand(record, 'Runtime.callFunctionOn', {
-        objectId: foundObjectId,
-        objectGroup,
-        functionDeclaration,
-        arguments: argumentsList,
-        awaitPromise: true,
-        returnByValue: true,
-        silent: true,
-      }) as { exceptionDetails?: unknown; result?: { value?: unknown } }
-      if (acted.exceptionDetails) throw new Error('The browser action failed.')
-      const raw = acted.result?.value
-      if (!raw || typeof raw !== 'object' || (raw as Record<string, unknown>).ok !== true) {
-        const reason = raw && typeof raw === 'object'
-          ? (raw as Record<string, unknown>).reason
-          : null
-        throw new Error(typeof reason === 'string' ? reason : 'The browser action failed.')
-      }
-      this.assertBrowserRecord(record, signal)
-      this.assertCandidateRequestBinding(record, request.candidateHandle)
-      // Actions can change the DOM without navigation. Never let an anchor
-      // survive an action; the model must inspect again before acting again.
-      this.invalidateBrowserAnchors(record)
-      return {
-        performed: true,
-        changed: (raw as Record<string, unknown>).changed === true,
+      try {
+        const acted = await this.cdpCommand(record, 'Runtime.callFunctionOn', {
+          objectId: foundObjectId,
+          objectGroup,
+          functionDeclaration,
+          arguments: argumentsList,
+          awaitPromise: true,
+          returnByValue: true,
+          silent: true,
+        }) as { exceptionDetails?: unknown; result?: { value?: unknown } }
+        if (acted.exceptionDetails) throw new Error('The browser action failed.')
+        const raw = acted.result?.value
+        if (!raw || typeof raw !== 'object' || (raw as Record<string, unknown>).ok !== true) {
+          const reason = raw && typeof raw === 'object'
+            ? (raw as Record<string, unknown>).reason
+            : null
+          throw new Error(typeof reason === 'string' ? reason : 'The browser action failed.')
+        }
+        this.assertBrowserRecord(record, signal)
+        this.assertCandidateRequestBinding(record, request.candidateHandle)
+        // Actions can change the DOM without navigation. Never let an anchor
+        // survive an action; the model must inspect again before acting again.
+        this.invalidateBrowserAnchors(record)
+        return {
+          performed: true,
+          changed: (raw as Record<string, unknown>).changed === true,
+        }
+      } catch {
+        // Runtime.callFunctionOn may have reached the page even when CDP lost
+        // the reply. Clear every anchor and force a fresh inspection instead
+        // of allowing a blind replay of a potentially completed side effect.
+        this.invalidateBrowserAnchors(record)
+        throw this.artifactBridgeBindingError(
+          'action-result-unknown',
+          'The Desktop artifact action result is unknown; inspect again.',
+        )
       }
     } finally {
       await this.cdpCommand(record, 'Runtime.releaseObjectGroup', { objectGroup })
@@ -3456,11 +3871,25 @@ export class NativeWorkbenchSurfaceManager {
   private async destroySurfaceNow(surfaceId: string): Promise<NativeWorkbenchSurfaceResult> {
     const record = this.surfaces.get(surfaceId)
     if (!record) return { ok: true }
+    if (record.artifactBridgePins > 0) {
+      record.uiReleaseRequested = true
+      record.visibleRequested = false
+      this.setPhysicalVisibility(record, false)
+      void this.cancelAnnotationInteraction(record, 'surface-hidden', true)
+      return {
+        ok: true,
+        code: 'AGENT_EDIT_IN_PROGRESS',
+        message: 'Agent editing is continuing in the background.',
+      }
+    }
     await this.destroyRecord(record)
     return { ok: true }
   }
 
-  private destroyRecord(record: NativeWorkbenchSurfaceRecord): Promise<void> {
+  private destroyRecord(
+    record: NativeWorkbenchSurfaceRecord,
+    options: { preserveCandidatePreview?: boolean } = {},
+  ): Promise<void> {
     if (record.cleanupPromise) return record.cleanupPromise
     const isCurrent = this.surfaces.get(record.id) === record
     if (isCurrent) this.surfaces.delete(record.id)
@@ -3488,7 +3917,10 @@ export class NativeWorkbenchSurfaceManager {
       }
     } catch {}
 
-    const cleanupPromise = this.cleanupDisposedRecord(record)
+    const cleanupPromise = this.cleanupDisposedRecord(
+      record,
+      options.preserveCandidatePreview === true,
+    )
     record.cleanupPromise = cleanupPromise
     this.recordCleanups.add(cleanupPromise)
     void cleanupPromise.then(
@@ -3498,8 +3930,15 @@ export class NativeWorkbenchSurfaceManager {
     return cleanupPromise
   }
 
-  private async cleanupDisposedRecord(record: NativeWorkbenchSurfaceRecord): Promise<void> {
-    if (record.candidatePreview && this.options.releaseCandidatePreview) {
+  private async cleanupDisposedRecord(
+    record: NativeWorkbenchSurfaceRecord,
+    preserveCandidatePreview: boolean,
+  ): Promise<void> {
+    if (
+      !preserveCandidatePreview
+      && record.candidatePreview
+      && this.options.releaseCandidatePreview
+    ) {
       await this.options.releaseCandidatePreview(
         record.candidatePreview.handle,
         new AbortController().signal,
@@ -4403,6 +4842,7 @@ export class NativeWorkbenchSurfaceManager {
           record.privilegedOriginReported = false
         }
         record.annotationDocumentGeneration += 1
+        this.bumpArtifactBridgeBindingGeneration(record)
         this.invalidateBrowserAnchors(record)
         void this.cancelAnnotationInteraction(record, 'surface-navigation', true)
       },
@@ -4482,6 +4922,7 @@ export class NativeWorkbenchSurfaceManager {
     contents.on('did-navigate-in-page', () => {
       if (isArtifactBridgeProtocolVersion(record.version)) {
         record.annotationDocumentGeneration += 1
+        this.bumpArtifactBridgeBindingGeneration(record)
         this.invalidateBrowserAnchors(record)
         void this.cancelAnnotationInteraction(record, 'surface-navigation', true)
       }
@@ -4803,6 +5244,16 @@ export class NativeWorkbenchSurfaceManager {
     if (record.disposed || record.crashed) return false
     record.crashed = true
     record.visibleRequested = false
+    this.setPhysicalVisibility(record, false)
+    this.invalidateBrowserAnchors(record)
+    if (record.artifactBridgePins > 0) {
+      // A turn binding owns one deterministic recovery attempt. Preserve the
+      // exact record and candidate mapping until its next operation decides
+      // whether recovery is safe; UI lifecycle events must not pre-empt it.
+      void this.cancelAnnotationInteraction(record, 'surface-failed', true)
+      this.dispatchEvent(record, type, detail)
+      return true
+    }
     // Begin the complete teardown before calling renderer-owned event code.
     // destroyRecord removes the slot and marks the record disposed
     // synchronously, so callback re-entry cannot revive or replace a surface

--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -211,6 +211,7 @@
           :copy-icon="chatRouteHeaderCopyIcon"
           :copy-live-text="chatRouteHeaderCopyLiveText"
           :deliverable-count="chatRouteHeaderDeliverableCount"
+          :has-new-deliverable="chatRouteHeaderHasNewDeliverable"
           :share-mode="chatRouteHeaderShareMode"
           :shareable-message-count="chatRouteHeaderShareableMessageCount"
           @open-deliverables="chatRouteHeader.invoke('openDeliverables')"
@@ -553,6 +554,7 @@ const {
   copyIcon: chatRouteHeaderCopyIcon,
   copyLiveText: chatRouteHeaderCopyLiveText,
   deliverableCount: chatRouteHeaderDeliverableCount,
+  hasNewDeliverable: chatRouteHeaderHasNewDeliverable,
   shareMode: chatRouteHeaderShareMode,
   shareableMessageCount: chatRouteHeaderShareableMessageCount,
 } = chatRouteHeader.model

--- a/opensquilla-webui/src/components/chat/ActivityToolDetails.vue
+++ b/opensquilla-webui/src/components/chat/ActivityToolDetails.vue
@@ -298,6 +298,40 @@ function formatBytes(value: number): string {
 }
 
 function formatLine(line: ActivityToolDetailLine): string {
+  if (line.kind === 'document-category') {
+    const category = {
+      DOCUMENT_PREVIEW_UNAVAILABLE: t('shared.runTrace.documentPreviewUnavailableCategory'),
+      DOCUMENT_ACTION_RESULT_UNKNOWN: t('shared.runTrace.documentActionUnknownCategory'),
+      DOCUMENT_EDIT_FAILED: t('shared.runTrace.documentEditFailedCategory'),
+    }[line.category]
+    return t('shared.runTrace.documentErrorCategory', {
+      category,
+      code: line.category,
+    })
+  }
+  if (line.kind === 'document-message') {
+    return t({
+      'document.previewUnavailable': 'shared.runTrace.documentPreviewUnavailableMessage',
+      'document.actionResultUnknown': 'shared.runTrace.documentActionUnknownMessage',
+      'document.editFailed': 'shared.runTrace.documentEditFailedMessage',
+    }[line.messageKey])
+  }
+  if (line.kind === 'document-retry') {
+    return t({
+      same_turn: 'shared.runTrace.documentRetrySameTurn',
+      new_turn: 'shared.runTrace.documentRetryNewTurn',
+      never: 'shared.runTrace.documentRetryNever',
+    }[line.policy])
+  }
+  if (line.kind === 'document-next-action') {
+    return t({
+      retry: 'shared.runTrace.documentNextRetry',
+      reinspect: 'shared.runTrace.documentNextReinspect',
+      finalize_without_tools: 'shared.runTrace.documentNextFinalize',
+      start_new_turn: 'shared.runTrace.documentNextNewTurn',
+      stop: 'shared.runTrace.documentNextStop',
+    }[line.action])
+  }
   if (line.kind === 'bytes') {
     return t('shared.runTrace.activityBytesWritten', { size: formatBytes(line.bytes) })
   }

--- a/opensquilla-webui/src/components/chat/ChatHeaderActions.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatHeaderActions.test.ts
@@ -18,6 +18,7 @@ const BASE_PROPS = {
   copyIcon: 'copy' as const,
   copyLiveText: '',
   deliverableCount: 2,
+  hasNewDeliverable: false,
   shareMode: false,
   shareableMessageCount: 3,
 }
@@ -286,6 +287,18 @@ describe('ChatHeaderActions', () => {
     expect(el.textContent).not.toContain('Workbench')
     expect(deliverables?.getAttribute('aria-label')).toBe('Deliverables (2)')
     expect(deliverables?.querySelector('.chat-header__count-badge')?.textContent).toBe('2')
+  })
+
+  it('shows a small New marker without replacing the deliverable count', async () => {
+    const { el } = await mountHeader(800, { hasNewDeliverable: true })
+    const deliverables = el.querySelector<HTMLButtonElement>(
+      '[data-testid="chat-session-action-deliverables"]',
+    )!
+
+    expect(deliverables.querySelector('[data-testid="chat-deliverables-new-badge"]')?.textContent)
+      .toBe('New')
+    expect(deliverables.querySelector('.chat-header__count-badge')?.textContent).toBe('2')
+    expect(deliverables.getAttribute('aria-label')).toBe('Deliverables (2), New')
   })
 
   it.each([

--- a/opensquilla-webui/src/components/chat/ChatHeaderActions.vue
+++ b/opensquilla-webui/src/components/chat/ChatHeaderActions.vue
@@ -39,6 +39,12 @@
         <Icon name="fileText" :size="14" />
         <span class="chat-share-btn__label">{{ t('chat.deliverables') }}</span>
         <span class="chat-header__count-badge" aria-hidden="true">{{ deliverableBadge }}</span>
+        <span
+          v-if="hasNewDeliverable"
+          class="chat-header__new-badge"
+          data-testid="chat-deliverables-new-badge"
+          aria-hidden="true"
+        >New</span>
       </button>
       <button
         v-if="!shareMode"
@@ -78,6 +84,11 @@
           class="chat-header__count-badge chat-header__count-badge--corner"
           aria-hidden="true"
         >{{ deliverableBadge }}</span>
+        <span
+          v-if="primaryAction === 'deliverables' && hasNewDeliverable"
+          class="chat-header__new-dot"
+          aria-hidden="true"
+        ></span>
       </button>
 
       <button
@@ -127,6 +138,7 @@
         >
           <Icon name="fileText" :size="16" />
           <span>{{ t('chat.deliverables') }}</span>
+          <span v-if="hasNewDeliverable" class="chat-header__new-badge" aria-hidden="true">New</span>
           <span class="chat-header__count-badge" aria-hidden="true">{{ deliverableBadge }}</span>
         </button>
         <button
@@ -187,6 +199,7 @@ const props = defineProps<{
   copyIcon: IconName
   copyLiveText: string
   deliverableCount: number
+  hasNewDeliverable: boolean
   shareMode: boolean
   shareableMessageCount: number
 }>()
@@ -216,7 +229,10 @@ let layoutFrame: number | null = null
 let hasMeasuredLayout = false
 
 const copyLabel = computed(() => props.copyState === 'ok' ? t('chat.copied') : t('chat.copySessionKey'))
-const deliverablesLabel = computed(() => t('chat.deliverablesCount', { count: props.deliverableCount }))
+const deliverablesLabel = computed(() => {
+  const label = t('chat.deliverablesCount', { count: props.deliverableCount })
+  return props.hasNewDeliverable ? `${label}, New` : label
+})
 const deliverableBadge = computed(() => props.deliverableCount > 99
   ? '99+'
   : String(props.deliverableCount))
@@ -604,6 +620,32 @@ defineExpose({ focusAction, closeMenu })
   position: absolute;
 }
 
+.chat-header__new-badge {
+  align-items: center;
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg-elevated));
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--border));
+  border-radius: var(--radius-full);
+  color: var(--accent);
+  display: inline-flex;
+  font-size: 0.5625rem;
+  font-weight: 750;
+  height: 16px;
+  letter-spacing: 0.02em;
+  line-height: 14px;
+  padding-inline: 5px;
+}
+
+.chat-header__new-dot {
+  background: var(--accent);
+  border: 2px solid var(--bg-elevated);
+  border-radius: 50%;
+  height: 8px;
+  inset-block-start: 0;
+  inset-inline-start: 0;
+  position: absolute;
+  width: 8px;
+}
+
 .topbar-state--deliverables .chat-header__count-badge,
 .chat-header__count-badge.topbar-state--deliverables {
   background: var(--topbar-state-fill);
@@ -656,6 +698,14 @@ defineExpose({ focusAction, closeMenu })
 
 .chat-header__menu-item > .chat-header__count-badge {
   margin-inline-start: auto;
+}
+
+.chat-header__menu-item > .chat-header__new-badge {
+  margin-inline-start: auto;
+}
+
+.chat-header__menu-item > .chat-header__new-badge + .chat-header__count-badge {
+  margin-inline-start: 0;
 }
 
 .chat-header__menu-divider {

--- a/opensquilla-webui/src/components/run/RunTrace.activity-presentation.test.ts
+++ b/opensquilla-webui/src/components/run/RunTrace.activity-presentation.test.ts
@@ -400,6 +400,115 @@ describe('RunTrace activity presentation', () => {
     expect(el.querySelector('.activity-tool-details')).toBeNull()
   })
 
+  it.each([undefined, 'activity' as const])(
+    'removes successful document disclosure in %s presentation',
+    async (presentation) => {
+      const sensitive = JSON.stringify({
+        source: '<html>private source</html>',
+        expectedSha256: 'a'.repeat(64),
+        cursor: 'private-cursor',
+        grant: 'private-grant',
+        bindingToken: 'private-binding-token',
+      })
+      const el = await mountTimeline([
+        group('document.update', [
+          call('document-success-one', {
+            name: 'document_apply',
+            inputRaw: sensitive,
+            inputPreview: sensitive,
+            result: sensitive,
+            resultPreview: sensitive,
+          }),
+          call('document-success-two', {
+            name: 'document_patch',
+            inputRaw: sensitive,
+            inputPreview: sensitive,
+            result: sensitive,
+            resultPreview: sensitive,
+          }),
+        ]),
+      ], presentation ? { presentation } : {})
+
+      const row = el.querySelector('.tool-row--group')
+      expect(row?.hasAttribute('aria-expanded')).toBe(false)
+      expect(el.querySelector('.step-chevron')).toBeNull()
+      expect(el.querySelector('.tool-row-body')).toBeNull()
+      expect(el.textContent).not.toMatch(/private|sha256|cursor|grant|binding/i)
+    },
+  )
+
+  it.each([undefined, 'activity' as const])(
+    'shows only safe document failure guidance in %s presentation',
+    async (presentation) => {
+      const sensitive = JSON.stringify({
+        category: 'DOCUMENT_PREVIEW_UNAVAILABLE',
+        message_key: 'document.previewUnavailable',
+        user_message: '<html>private source</html>',
+        retry_policy: 'new_turn',
+        next_action: 'finalize_without_tools',
+        expectedSha256: 'a'.repeat(64),
+        cursor: 'private-cursor',
+        grant: 'private-grant',
+        bindingToken: 'private-binding-token',
+      })
+      const onShowResult = vi.fn()
+      const el = await mountTimeline([
+        group('document.update', [call('document-failure', {
+          name: 'document_apply',
+          status: 'error',
+          isError: true,
+          inputRaw: sensitive,
+          inputPreview: sensitive,
+          result: sensitive,
+          resultPreview: sensitive,
+        })]),
+      ], {
+        ...(presentation ? { presentation } : {}),
+        onShowResult,
+      })
+
+      expect(el.querySelector('.step-chevron')).not.toBeNull()
+      expect(el.textContent).toContain('Preview unavailable')
+      expect(el.textContent).toContain('Retry policy: start a new task')
+      expect(el.textContent).not.toMatch(/private|sha256|cursor|grant|binding|<html>/i)
+      expect(el.querySelector('.activity-tool-details__view')).toBeNull()
+      expect(el.querySelector('.tool-row-section')).toBeNull()
+      expect(onShowResult).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each([undefined, 'activity' as const])(
+    'restores a safe document failure disclosure from structured history in %s presentation',
+    async (presentation) => {
+      const persistedFailure = JSON.stringify({
+        ok: false,
+        status: 'error',
+        category: 'DOCUMENT_PREVIEW_UNAVAILABLE',
+        message_key: 'document.previewUnavailable',
+        retry_policy: 'new_turn',
+        next_action: 'finalize_without_tools',
+        source: '<html>private source</html>',
+        bindingToken: 'private-binding-token',
+      })
+      const el = await mountTimeline([
+        group('document.read', [call('restored-document-failure', {
+          name: 'document_browser_inspect',
+          status: 'success',
+          isError: false,
+          result: persistedFailure,
+          resultPreview: persistedFailure,
+        })]),
+      ], presentation ? { presentation, itemOpen: true } : {})
+
+      expect(el.querySelector('.step-chevron')).not.toBeNull()
+      expect(el.textContent).toContain('Preview unavailable')
+      expect(el.textContent).toContain('Retry policy: start a new task')
+      expect(el.textContent).not.toMatch(/private|binding|<html>/i)
+      expect(el.querySelector('.activity-tool-details__view')).toBeNull()
+      expect(el.querySelector('.tool-row-section')).toBeNull()
+    },
+  )
+
   it('shows long activity details in one bounded preview and preserves raw forwarding', async () => {
     const result = 'file contents\n'.repeat(30)
     const onShowResult = vi.fn()

--- a/opensquilla-webui/src/components/run/RunTrace.vue
+++ b/opensquilla-webui/src/components/run/RunTrace.vue
@@ -129,11 +129,11 @@
             type="button"
             class="tool-row tool-row--group"
             :data-op="item.group.operationKey"
-            :aria-expanded="groupOpen(item.group)"
+            :aria-expanded="groupHasDetails(item.group) ? groupOpen(item.group) : undefined"
             @click="toggleGroupDisclosure(item.group)"
           >
             <Icon
-              v-if="presentation === 'activity'"
+              v-if="presentation === 'activity' && groupHasDetails(item.group)"
               class="tool-row__activity-icon"
               :class="activityGroupIconClass(item.group)"
               :name="item.group.iconName"
@@ -148,7 +148,7 @@
             <span v-if="presentation !== 'activity'" class="step-count">{{ t('shared.runTrace.callsCount', { count: item.group.calls.length }) }}</span>
             <span v-if="item.group.secondary && (!item.group.isRunning || groupOpen(item.group))" class="tool-row__arg">{{ item.group.secondary }}</span>
             <Icon
-              v-if="presentation === 'activity'"
+              v-if="presentation === 'activity' && groupHasDetails(item.group)"
               class="step-chevron tool-row__activity-arrow"
               name="chevronRight"
               :size="13"
@@ -157,7 +157,7 @@
             />
             <span class="tool-row__trailing">
               <span v-if="showGroupStatus(item.group)" class="tool-row__status">{{ resolvedGroupStatusText(item.group) }}</span>
-              <Icon v-if="presentation !== 'activity'" class="step-chevron" name="chevronRight" :size="14" />
+              <Icon v-if="presentation !== 'activity' && groupHasDetails(item.group)" class="step-chevron" name="chevronRight" :size="14" />
             </span>
           </button>
           <TransitionGroup
@@ -180,7 +180,7 @@
                 class="tool-row tool-row--member"
                 :class="rowClass(call)"
                 :data-op="operationKey(call)"
-                :aria-expanded="callOpen(call)"
+                :aria-expanded="callHasDetails(call) ? callOpen(call) : undefined"
                 @click="toggleItemDisclosure(call)"
               >
                 <Icon
@@ -212,13 +212,13 @@
                   <span v-if="elapsedFor(call)" class="tool-row__elapsed">{{ elapsedFor(call) }}</span>
                   <Icon v-if="presentation !== 'activity' && iconFor(call).glyph === 'check'" class="tool-row__state-icon tool-row__state-icon--ok" name="check" :size="13" />
                   <Icon v-else-if="presentation !== 'activity' && iconFor(call).glyph === 'x'" class="tool-row__state-icon tool-row__state-icon--err" name="x" :size="13" />
-                  <Icon v-if="presentation !== 'activity'" class="step-chevron" name="chevronRight" :size="14" />
+                  <Icon v-if="presentation !== 'activity' && callHasDetails(call)" class="step-chevron" name="chevronRight" :size="14" />
                 </span>
               </button>
               <Transition name="activity-tool-detail" :css="presentation === 'activity'">
                 <div v-if="callOpen(call)" class="tool-row-body">
                   <ActivityToolDetails
-                    v-if="presentation === 'activity'"
+                    v-if="presentation === 'activity' || isDocumentCall(call)"
                     :call="call"
                     :label="call.displayName"
                     :operation-key="operationKey(call)"
@@ -250,7 +250,7 @@
               class="tool-row"
               :class="rowClass(call)"
               :data-op="operationKey(call)"
-              :aria-expanded="callOpen(call)"
+              :aria-expanded="callHasDetails(call) ? callOpen(call) : undefined"
               @click="toggleItemDisclosure(call)"
             >
               <Icon
@@ -280,13 +280,13 @@
                 <span v-if="elapsedFor(call)" class="tool-row__elapsed">{{ elapsedFor(call) }}</span>
                 <Icon v-if="presentation !== 'activity' && iconFor(call).glyph === 'check'" class="tool-row__state-icon tool-row__state-icon--ok" name="check" :size="13" />
                 <Icon v-else-if="presentation !== 'activity' && iconFor(call).glyph === 'x'" class="tool-row__state-icon tool-row__state-icon--err" name="x" :size="13" />
-                <Icon v-if="presentation !== 'activity'" class="step-chevron" name="chevronRight" :size="14" />
+                <Icon v-if="presentation !== 'activity' && callHasDetails(call)" class="step-chevron" name="chevronRight" :size="14" />
               </span>
             </button>
             <Transition name="activity-tool-detail" :css="presentation === 'activity'">
               <div v-if="callOpen(call)" class="tool-row-body">
                 <ActivityToolDetails
-                  v-if="presentation === 'activity'"
+                  v-if="presentation === 'activity' || isDocumentCall(call)"
                   :call="call"
                   :label="item.group.label"
                   :operation-key="operationKey(call)"
@@ -621,6 +621,7 @@ import { toolState } from '@/utils/chat/toParts'
 import { composeTree, statusVisual, type StatusVisual } from '@/components/run/runTrace'
 import { copyTextWithFallback } from '@/utils/browser'
 import { useToolDetailPreference } from '@/composables/useToolDetailPreference'
+import { hasActivityToolDetail } from '@/utils/chat/activityToolDetails'
 
 const { t } = useI18n()
 const { mode: toolDetailDisplayMode } = useToolDetailPreference()
@@ -1080,6 +1081,11 @@ function operationKey(call: ChatToolCallRenderItem): string {
   return toolOperationKey(call.name)
 }
 
+function isDocumentCall(call: ChatToolCallRenderItem): boolean {
+  const key = operationKey(call)
+  return key === 'document.read' || key === 'document.update'
+}
+
 function callDefaultOpen(call: ChatToolCallRenderItem): boolean {
   if (call.isError || call.status === 'error') return true
   if (props.presentation === 'activity') return false
@@ -1089,6 +1095,7 @@ function callDefaultOpen(call: ChatToolCallRenderItem): boolean {
 }
 
 function callOpen(call: ChatToolCallRenderItem): boolean {
+  if (!callHasDetails(call)) return false
   // A recorded toggle inverts the default, so error auto-expand still honors
   // an explicit user collapse.
   return callDefaultOpen(call) !== isItemOpen(itemStateId(call.renderKey))
@@ -1107,6 +1114,7 @@ function itemStateId(renderKey: string): string {
 }
 
 function groupOpen(group: ChatToolCallGroup): boolean {
+  if (!groupHasDetails(group)) return false
   return groupDefaultOpen(group) !== isGroupOpen(groupStateId(group.groupId))
 }
 
@@ -1128,10 +1136,12 @@ function toggleTargetOverride(target: DefaultOpenTarget) {
 }
 
 function toggleGroupDisclosure(group: ChatToolCallGroup) {
+  if (!groupHasDetails(group)) return
   emit('toggleGroup', groupStateId(group.groupId))
 }
 
 function toggleItemDisclosure(call: ChatToolCallRenderItem) {
+  if (!callHasDetails(call)) return
   emit('toggleItem', itemStateId(call.renderKey))
 }
 
@@ -1188,12 +1198,19 @@ function activityGroupIconClass(group: ChatToolCallGroup) {
 }
 
 function callHasDetails(call: ChatToolCallRenderItem): boolean {
+  if (props.presentation === 'activity' || isDocumentCall(call)) {
+    return hasActivityToolDetail(call, operationKey(call))
+  }
   return Boolean(
     call.inputRaw
     || call.inputPreview
     || call.result
     || call.resultPreview,
   )
+}
+
+function groupHasDetails(group: ChatToolCallGroup): boolean {
+  return group.calls.some(callHasDetails)
 }
 
 function showGroupStatus(group: ChatToolCallGroup): boolean {
@@ -1251,6 +1268,8 @@ function activityTerminalStatusText(call: ChatToolCallRenderItem): string {
 }
 
 function forwardShowResult(content: string, title: string, context?: ToolResultContext) {
+  const key = toolOperationKey(context?.toolName || '')
+  if (key === 'document.read' || key === 'document.update') return
   emit('showResult', content, title, context)
 }
 

--- a/opensquilla-webui/src/components/workbench/ArtifactDocumentPanel.vue
+++ b/opensquilla-webui/src/components/workbench/ArtifactDocumentPanel.vue
@@ -124,6 +124,7 @@
       <ArtifactPreviewPanel
         v-else
         ref="previewRef"
+        :agent-edit-in-progress="agentEditInProgress"
         :artifact="headArtifact"
         :auth-token="authToken"
         :base-origin="baseOrigin"
@@ -294,6 +295,7 @@ type SourceHandle = {
 }
 
 const props = withDefaults(defineProps<{
+  agentEditInProgress?: boolean
   artifact: ArtifactPayload
   documentActions?: ArtifactDocumentActions | null
   documentFeatures?: boolean
@@ -322,6 +324,7 @@ const props = withDefaults(defineProps<{
     screenshotUrl?: string
   } | null
 }>(), {
+  agentEditInProgress: false,
   documentSnapshot: () => ({
     key: '',
     loading: false,

--- a/opensquilla-webui/src/components/workbench/ArtifactPreviewPanel.vue
+++ b/opensquilla-webui/src/components/workbench/ArtifactPreviewPanel.vue
@@ -65,7 +65,17 @@
 
     <div class="artifact-preview__viewport">
       <div
-        v-if="preview.state.value === 'loading'"
+        v-if="agentEditInProgress"
+        class="artifact-preview__status"
+        data-testid="artifact-preview-agent-edit-in-progress"
+        role="status"
+      >
+        <Icon name="info" :size="18" />
+        <strong>{{ t('workbench.artifactPreview.agentEditInProgress') }}</strong>
+      </div>
+
+      <div
+        v-else-if="preview.state.value === 'loading'"
         class="artifact-preview__status"
         role="status"
         :aria-label="t('chat.loadingPreview')"
@@ -202,6 +212,7 @@ import {
 import { ARTIFACT_PREVIEW_ESCAPE_MESSAGE } from '@/utils/workbench/artifactPreview'
 
 const props = withDefaults(defineProps<{
+  agentEditInProgress?: boolean
   artifact: ArtifactPayload
   authToken?: string
   baseOrigin?: string
@@ -218,6 +229,7 @@ const props = withDefaults(defineProps<{
   showHeader?: boolean
   suspended?: boolean
 }>(), {
+  agentEditInProgress: false,
   authToken: '',
   baseOrigin: '',
   nativeHtml: false,

--- a/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.test.ts
+++ b/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.test.ts
@@ -1804,6 +1804,205 @@ describe('artifact Workbench provider', () => {
     await runtime.dispose?.('closed')
   })
 
+  it('shows a non-error agent-edit placeholder and rebuilds from the latest head after release', async () => {
+    const legacy = createLegacyArtifactWorkspace(artifact, 'session-a')
+    const revision1 = {
+      ...legacy.revisions[0],
+      revisionId: 'revision-1',
+      documentId: 'document-1',
+      artifactId: 'artifact-head-1',
+      generation: 1,
+    }
+    const revision2 = {
+      ...revision1,
+      revisionId: 'revision-2',
+      parentRevisionId: 'revision-1',
+      artifactId: 'artifact-head-2',
+      artifactSha256: 'b'.repeat(64),
+      generation: 2,
+    }
+    const workspace = {
+      ...legacy,
+      source: 'document-api' as const,
+      document: {
+        ...legacy.document,
+        documentId: 'document-1',
+        headRevisionId: 'revision-1',
+        capabilities: {
+          ...legacy.document.capabilities,
+          preview: true,
+          edit: true,
+          source: true,
+          agentEdit: true,
+        },
+      },
+      revisions: [revision1],
+      headArtifact: {
+        ...artifact,
+        id: revision1.artifactId,
+        documentId: 'document-1',
+      },
+    }
+    let leaseSequence = 0
+    const createLease = vi.fn(async () => {
+      leaseSequence += 1
+      const token = String(leaseSequence).padStart(32, '0')
+      return {
+        ok: true as const,
+        status: 201,
+        payload: {
+          version: 1 as const,
+          lease_id: `apl-agent-edit-${leaseSequence}`,
+          effective_mode: 'full' as const,
+          launch_url: `http://p-${token}.localhost:48721/index.html`,
+          entrypoint: 'index.html',
+          expires_at: '2099-01-01T00:00:00Z',
+          preview_origin: `http://p-${token}.localhost:48721`,
+          idle_timeout_seconds: 28_800,
+          source: {
+            kind: 'single_file' as const,
+            collection_status: 'not_applicable' as const,
+            file_count: 1,
+            total_bytes: 128,
+            warning_codes: [],
+          },
+        },
+      }
+    })
+    const createSurface = vi.fn()
+      .mockResolvedValueOnce({
+        ok: false as const,
+        code: 'AGENT_EDIT_IN_PROGRESS',
+        message: 'agent edit owns this surface',
+        retryable: true,
+      })
+      .mockResolvedValue({ ok: true as const })
+    const revokeLease = vi.fn(async () => ({
+      ok: true as const,
+      status: 204,
+      payload: undefined,
+    }))
+    const nativeApi: NativeWorkbenchApi = {
+      getCapabilities: vi.fn(async () => ({
+        protocolVersions: [4] as Array<4>,
+        modes: ['full', 'offline'] as Array<'full' | 'offline'>,
+        maxSurfaces: 8,
+      })),
+      getArtifactAnnotationCapabilities: vi.fn(async () => ({
+        version: 4 as const,
+        available: false,
+        picker: false,
+        trustedOverlay: false,
+        overlayCopyVersion: 1 as const,
+      })),
+      createArtifactPreviewLease: createLease,
+      renewArtifactPreviewLease: vi.fn(async () => ({
+        ok: true as const,
+        status: 200,
+        payload: {
+          version: 1 as const,
+          lease_id: `apl-agent-edit-${leaseSequence}`,
+          expires_at: '2099-01-01T00:00:00Z',
+        },
+      })),
+      revokeArtifactPreviewLease: revokeLease,
+      createSurface,
+      setSurfaceRect: vi.fn(async () => ({ ok: true as const })),
+      activateSurface: vi.fn(async () => ({ ok: true as const })),
+      destroySurface: vi.fn(async () => ({ ok: true as const })),
+      onSurfaceEvent: vi.fn(() => () => undefined),
+    }
+    let refreshAttempt = 0
+    let staleSnapshot = false
+    const loadDocument = vi.fn(async () => {
+      refreshAttempt += 1
+      if (refreshAttempt === 1) {
+        // The document store preserves the previous head when its first
+        // release-triggered refresh races state propagation.
+        staleSnapshot = true
+        return
+      }
+      staleSnapshot = false
+      workspace.document.headRevisionId = revision2.revisionId
+      workspace.revisions = [revision1, revision2]
+      workspace.headArtifact = {
+        ...workspace.headArtifact,
+        id: revision2.artifactId,
+      }
+    })
+    const renderState: Record<string, unknown> = {}
+    const reportError = vi.fn()
+    const item = createArtifactPreviewWorkbenchItem({
+      artifact,
+      nativeHtml: true,
+      sessionKey: 'session-a',
+    })
+    const definition = createArtifactWorkbenchDefinitions({
+      artifactDocuments: {
+        load: loadDocument,
+        snapshot: vi.fn(() => ({
+          key: 'fixture',
+          loading: false,
+          loaded: true,
+          stale: staleSnapshot,
+          error: null,
+          workspace,
+        })),
+        headArtifact: vi.fn(() => workspace.headArtifact),
+      },
+      authToken: () => 'synthetic-token',
+      baseOrigin: 'http://127.0.0.1:18791',
+      confirmRemoteResources: vi.fn(async () => true),
+      currentSessionId: () => 'session-a',
+      openArtifact: vi.fn(),
+      platform: {
+        id: 'desktop',
+        capabilities: { canOpenArtifactsNatively: true },
+        files: {},
+      } as unknown as Platform,
+      previewLeasesEnabled: true,
+      pushToast: vi.fn(),
+      t: key => key,
+    }).find(candidate => candidate.kind === 'artifact-preview')!
+    const runtime = await definition.createRuntime!(item, {
+      nativeWorkbenchApi: nativeApi,
+      getRenderState: () => renderState,
+      updateRenderState: patch => Object.assign(renderState, patch),
+      isItemOpen: () => true,
+      setExpanded: vi.fn(),
+      reportError,
+    })
+
+    expect(renderState).toMatchObject({
+      agentEditInProgress: true,
+      previewBlocked: true,
+      previewLeaseError: '',
+    })
+    expect(reportError).not.toHaveBeenCalled()
+    expect(revokeLease).toHaveBeenCalledWith(expect.objectContaining({
+      leaseId: 'apl-agent-edit-1',
+      scopeId: 'session-a',
+    }))
+
+    await runtime.handleNativeSurfaceEvent?.({
+      version: 4,
+      surfaceId: item.id,
+      type: 'agent-edit-released',
+    }, item)
+
+    expect(loadDocument).toHaveBeenCalledTimes(2)
+    expect(loadDocument).toHaveBeenLastCalledWith(
+      artifact,
+      'session-a',
+      { force: true },
+    )
+    expect(createLease).toHaveBeenCalledTimes(2)
+    expect(createSurface).toHaveBeenCalledTimes(2)
+    expect(renderState.agentEditInProgress).toBe(false)
+    expect(reportError).not.toHaveBeenCalled()
+    await runtime.dispose?.('closed')
+  })
+
   it('refreshes annotation capability after reactivating a replacement surface', async () => {
     const legacy = createLegacyArtifactWorkspace(artifact, 'session-a')
     const workspace = {

--- a/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.ts
+++ b/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.ts
@@ -350,6 +350,8 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
   private component: ArtifactPreviewPanelHandle | null = null
   private blockedHeadRevisionId = ''
   private createdSurface = false
+  private agentEditReleaseObserved = false
+  private agentEditResumeInFlight: Promise<void> | null = null
   private generation = 0
   private item: WorkbenchItem
   private lease: ArtifactPreviewLease | null = null
@@ -404,6 +406,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
       annotationAvailable: false,
       annotationMode: false,
       annotationModeStopping: false,
+      agentEditInProgress: false,
     })
   }
 
@@ -1077,6 +1080,11 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
     item: WorkbenchItem,
   ) {
     this.item = item
+    if (event.type === 'agent-edit-released') {
+      this.agentEditReleaseObserved = true
+      await this.resumeAfterAgentEditReleased()
+      return
+    }
     if (!this.createdSurface) return
     if (event.type === 'annotation-selected') {
       await this.handleAnnotationSelected(event.detail?.selection)
@@ -1728,6 +1736,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
 
   async dispose() {
     this.component = null
+    this.agentEditReleaseObserved = false
     await this.releaseNativeSurface(true)
     await this.releaseLease()
     this.rect = null
@@ -2051,7 +2060,11 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
     }
     const generation = ++this.generation
     this.createdSurface = true
-    this.context.updateRenderState({ nativeSurfaceState: 'loading' })
+    this.agentEditReleaseObserved = false
+    this.context.updateRenderState({
+      agentEditInProgress: false,
+      nativeSurfaceState: 'loading',
+    })
     let expectedOrigin = ''
     try {
       expectedOrigin = new URL(lease.launch_url).origin
@@ -2074,6 +2087,19 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
     if (generation !== this.generation) return
     if (!result.ok) {
       this.createdSurface = false
+      if (result.code === 'AGENT_EDIT_IN_PROGRESS') {
+        await this.releaseLease()
+        this.context.updateRenderState({
+          agentEditInProgress: true,
+          nativeSurfaceState: 'loading',
+          previewBlocked: true,
+          previewLeaseError: '',
+          previewReadiness: 'loading',
+          previewState: 'loading',
+        })
+        if (this.agentEditReleaseObserved) await this.resumeAfterAgentEditReleased()
+        return
+      }
       throw surfaceError('Failed to create the native Workbench surface', result.message)
     }
     if (!await this.syncSurfaceRect()) return
@@ -2091,6 +2117,90 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
     await this.refreshAnnotationCapability(generation)
     if (generation !== this.generation || !this.createdSurface) return
     await this.restoreAnnotationModeAfterSurfaceRefresh()
+  }
+
+  private async resumeAfterAgentEditReleased() {
+    if (this.agentEditResumeInFlight) {
+      await this.agentEditResumeInFlight
+      return
+    }
+    if (!this.context.isItemOpen()) return
+    const resume = this.resumeAfterAgentEditReleasedNow()
+    this.agentEditResumeInFlight = resume
+    try {
+      await resume
+    } finally {
+      this.agentEditResumeInFlight = null
+    }
+  }
+
+  private async resumeAfterAgentEditReleasedNow() {
+    const artifact = artifactFromWorkbenchItem(this.item)
+    if (!artifact || !this.context.isItemOpen()) return
+    this.context.updateRenderState({
+      agentEditInProgress: false,
+      nativeSurfaceState: 'loading',
+      previewBlocked: true,
+      previewLeaseError: '',
+      previewReadiness: 'loading',
+      previewState: 'loading',
+    })
+    try {
+      if (!await this.loadFreshCanonicalDocumentHead()) {
+        throw surfaceError('Failed to load the latest document head')
+      }
+      if (!this.context.isItemOpen()) return
+      if (!await this.releaseNativeSurface(true)) {
+        throw surfaceError('Failed to replace the native Workbench surface')
+      }
+      await this.releaseLease()
+      await this.prepareLeasePreview()
+      this.agentEditReleaseObserved = false
+    } catch (error) {
+      await this.handleLeaseFailure(error)
+    }
+  }
+
+  private async loadFreshCanonicalDocumentHead(): Promise<boolean> {
+    const artifact = artifactFromWorkbenchItem(this.item)
+    const documents = this.options.artifactDocuments
+    if (!artifact || !documents) return false
+    const sessionKey = artifactSessionKey(this.item, this.options)
+    // A failed refresh deliberately preserves the previous workspace with
+    // snapshot.stale=true.  Never mint a replacement lease from that cached
+    // head after an agent edit.  One immediate second read covers the narrow
+    // release-vs-document-state propagation race without adding a generic
+    // retry loop or extending any timeout.
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        await documents.load(artifact, sessionKey, { force: true })
+      } catch {
+        continue
+      }
+      if (this.canonicalDocumentSnapshotFresh(
+        documents.snapshot(artifact, sessionKey),
+      )) return true
+    }
+    return false
+  }
+
+  private canonicalDocumentSnapshotFresh(
+    snapshot: ArtifactDocumentWorkspaceSnapshot,
+  ): boolean {
+    const workspace = snapshot.workspace
+    if (
+      snapshot.loading
+      || !snapshot.loaded
+      || snapshot.stale
+      || workspace?.source !== 'document-api'
+    ) return false
+    const head = workspace.revisions.find(
+      revision => revision.revisionId === workspace.document.headRevisionId,
+    )
+    return Boolean(
+      head
+      && String(workspace.headArtifact.id || '') === String(head.artifactId || ''),
+    )
   }
 
   private async replaceLeasePreview() {
@@ -2971,6 +3081,7 @@ export function createArtifactWorkbenchDefinitions(
         authToken: options.authToken(),
         baseOrigin: options.baseOrigin,
         nativeHtml: state.nativeSurface,
+        agentEditInProgress: runtimeStateValue(state, 'agentEditInProgress', false),
         nativeSurfaceState: runtimeStateValue(
           state,
           'nativeSurfaceState',

--- a/opensquilla-webui/src/composables/chat/useChatRouteHeaderBridge.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRouteHeaderBridge.test.ts
@@ -45,6 +45,7 @@ function owner(title: string): {
       copyIcon: ref('copy'),
       copyLiveText: ref(''),
       deliverableCount: ref(0),
+      hasNewDeliverable: ref(false),
       shareMode: ref(false),
       shareableMessageCount: ref(1),
     },

--- a/opensquilla-webui/src/composables/chat/useChatRouteHeaderBridge.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRouteHeaderBridge.ts
@@ -22,6 +22,7 @@ export interface ChatRouteHeaderModel {
   copyIcon: Readonly<Ref<IconName>>
   copyLiveText: Readonly<Ref<string>>
   deliverableCount: Readonly<Ref<number>>
+  hasNewDeliverable: Readonly<Ref<boolean>>
   shareMode: Readonly<Ref<boolean>>
   shareableMessageCount: Readonly<Ref<number>>
 }
@@ -52,6 +53,7 @@ export interface ChatRouteHeaderBridge {
     copyIcon: ComputedRef<IconName>
     copyLiveText: ComputedRef<string>
     deliverableCount: ComputedRef<number>
+    hasNewDeliverable: ComputedRef<boolean>
     shareMode: ComputedRef<boolean>
     shareableMessageCount: ComputedRef<number>
   }
@@ -127,6 +129,7 @@ export function provideChatRouteHeaderBridge(): ChatRouteHeaderBridge {
       copyIcon: computed(() => ownerValue('copyIcon', DEFAULT_COPY_ICON)),
       copyLiveText: computed(() => ownerValue('copyLiveText', '')),
       deliverableCount: computed(() => ownerValue('deliverableCount', 0)),
+      hasNewDeliverable: computed(() => ownerValue('hasNewDeliverable', false)),
       shareMode: computed(() => ownerValue('shareMode', false)),
       shareableMessageCount: computed(() => ownerValue('shareableMessageCount', 0)),
     },

--- a/opensquilla-webui/src/composables/chat/useDeliverableUpdateIndicator.test.ts
+++ b/opensquilla-webui/src/composables/chat/useDeliverableUpdateIndicator.test.ts
@@ -1,0 +1,97 @@
+import { nextTick, ref } from 'vue'
+import { describe, expect, it } from 'vitest'
+import type { ChatRenderedMessage } from '@/types/chat'
+import { useDeliverableUpdateIndicator } from './useDeliverableUpdateIndicator'
+
+function message(
+  id: string,
+  status: 'applied' | 'not_applied',
+  restoredFromHistory = false,
+): ChatRenderedMessage {
+  return {
+    id,
+    role: 'assistant',
+    displayRole: 'assistant',
+    roleLabel: 'Assistant',
+    text: '',
+    timeStr: '',
+    showHeader: true,
+    restoredFromHistory,
+    turnOutcome: {
+      turnId: id,
+      status: 'completed',
+      documentMutationOutcome: { version: 1, status, resultRevisionId: id },
+    },
+  }
+}
+
+describe('useDeliverableUpdateIndicator', () => {
+  it('marks only newly applied live mutations and clears on acknowledgement', async () => {
+    const sessionKey = ref('session-a')
+    const messages = ref<ChatRenderedMessage[]>([message('old', 'applied', true)])
+    const isStreaming = ref(false)
+    const indicator = useDeliverableUpdateIndicator({ sessionKey, messages, isStreaming })
+
+    expect(indicator.hasNewDeliverable.value).toBe(false)
+
+    messages.value = [...messages.value, message('failed', 'not_applied')]
+    await nextTick()
+    expect(indicator.hasNewDeliverable.value).toBe(false)
+
+    messages.value = [...messages.value, message('new', 'applied')]
+    await nextTick()
+    expect(indicator.hasNewDeliverable.value).toBe(true)
+
+    indicator.acknowledge()
+    expect(indicator.hasNewDeliverable.value).toBe(false)
+  })
+
+  it('resets the marker and baselines existing updates when the session changes', async () => {
+    const sessionKey = ref('session-a')
+    const messages = ref<ChatRenderedMessage[]>([])
+    const isStreaming = ref(false)
+    const indicator = useDeliverableUpdateIndicator({ sessionKey, messages, isStreaming })
+
+    messages.value = [message('new-a', 'applied')]
+    await nextTick()
+    expect(indicator.hasNewDeliverable.value).toBe(true)
+
+    sessionKey.value = 'session-b'
+    messages.value = [message('existing-b', 'applied')]
+    await nextTick()
+    expect(indicator.hasNewDeliverable.value).toBe(false)
+  })
+
+  it('recognizes a live turn outcome even when completion is restored through history sync', async () => {
+    const sessionKey = ref('session-a')
+    const messages = ref<ChatRenderedMessage[]>([message('old', 'applied', true)])
+    const isStreaming = ref(false)
+    const indicator = useDeliverableUpdateIndicator({ sessionKey, messages, isStreaming })
+
+    isStreaming.value = true
+    messages.value = [
+      ...messages.value,
+      {
+        id: 'live-user',
+        role: 'user',
+        displayRole: 'user',
+        roleLabel: 'You',
+        text: 'edit',
+        timeStr: '',
+        showHeader: true,
+        turnKey: 'turn:live',
+      },
+    ]
+    await nextTick()
+
+    isStreaming.value = false
+    messages.value = [
+      ...messages.value,
+      { ...message('live-result', 'applied', true), turnKey: 'turn:live' },
+      { ...message('unrelated-history', 'applied', true), turnKey: 'turn:old' },
+    ]
+    await nextTick()
+
+    expect(indicator.hasNewDeliverable.value).toBe(true)
+  })
+})

--- a/opensquilla-webui/src/composables/chat/useDeliverableUpdateIndicator.ts
+++ b/opensquilla-webui/src/composables/chat/useDeliverableUpdateIndicator.ts
@@ -1,0 +1,97 @@
+import { computed, ref, watch, type Ref } from 'vue'
+import type { ChatRenderedMessage } from '@/types/chat'
+
+interface DeliverableUpdateIndicatorOptions {
+  sessionKey: Readonly<Ref<string>>
+  messages: Readonly<Ref<readonly ChatRenderedMessage[]>>
+  isStreaming: Readonly<Ref<boolean>>
+}
+
+interface AppliedMutationMarker {
+  key: string
+  restoredFromHistory: boolean
+  turnKey: string
+}
+
+function appliedMutationMarkers(
+  messages: readonly ChatRenderedMessage[],
+): AppliedMutationMarker[] {
+  return messages.flatMap((message, index) => {
+    const mutation = message.turnOutcome?.documentMutationOutcome
+    if (mutation?.status !== 'applied') return []
+    const identity = mutation.resultRevisionId
+      || mutation.changeSetId
+      || mutation.attemptId
+      || message.turnId
+      || message.messageId
+      || message.id
+      || `message-${message.sourceIndex ?? index}`
+    return [{
+      key: String(identity),
+      restoredFromHistory: message.restoredFromHistory === true,
+      turnKey: String(message.turnKey || ''),
+    }]
+  })
+}
+
+function latestUserTurnKey(messages: readonly ChatRenderedMessage[]): string {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index]
+    if (message?.displayRole !== 'user') continue
+    const turnKey = String(message.turnKey || '')
+    if (turnKey) return turnKey
+  }
+  return ''
+}
+
+/**
+ * Keeps a small, session-local unread marker for newly applied document edits.
+ * Restored history establishes a baseline and never creates a fresh marker.
+ */
+export function useDeliverableUpdateIndicator(
+  options: DeliverableUpdateIndicatorOptions,
+) {
+  const hasNewDeliverable = ref(false)
+  const markers = computed(() => appliedMutationMarkers(options.messages.value))
+  const latestTurnKey = computed(() => latestUserTurnKey(options.messages.value))
+  let observedSessionKey = ''
+  let observedMutationKeys = new Set<string>()
+  let liveTurnKey = ''
+
+  watch(
+    [options.sessionKey, markers, latestTurnKey, options.isStreaming],
+    ([sessionKey, nextMarkers, nextTurnKey, isStreaming]) => {
+    if (sessionKey !== observedSessionKey) {
+      observedSessionKey = sessionKey
+      observedMutationKeys = new Set(nextMarkers.map(marker => marker.key))
+      liveTurnKey = isStreaming ? nextTurnKey : ''
+      hasNewDeliverable.value = false
+      return
+    }
+
+    if (isStreaming && nextTurnKey) liveTurnKey = nextTurnKey
+    const hasFreshMutation = nextMarkers.some(marker => (
+      !observedMutationKeys.has(marker.key)
+      && (
+        !marker.restoredFromHistory
+        || (Boolean(liveTurnKey) && marker.turnKey === liveTurnKey)
+      )
+    ))
+    for (const marker of nextMarkers) observedMutationKeys.add(marker.key)
+    if (hasFreshMutation) {
+      hasNewDeliverable.value = true
+      liveTurnKey = ''
+    }
+  },
+  { immediate: true },
+  )
+
+  function acknowledge() {
+    hasNewDeliverable.value = false
+  }
+
+  return {
+    hasNewDeliverable,
+    acknowledge,
+  }
+}

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -180,6 +180,7 @@
       "readyWithWarnings": "Die Vorschau wird mit Warnungen ausgeführt.",
       "warningsShort": "Warnungen",
       "suspended": "Vorschau pausiert",
+      "agentEditInProgress": "Die Bearbeitung wird im Hintergrund fortgesetzt.",
       "nativePreview": "Interaktive Vorschau",
       "allowRemoteResources": "Online-Bilder, -Stile und -Medien zulassen",
       "blockRemoteResources": "Online-Bilder, -Stile und -Medien blockieren",
@@ -4316,7 +4317,22 @@
       "activityContentSize": "{lines} Zeilen · {characters} Zeichen",
       "activityExitCode": "Exit-Code {code}",
       "activityNotCompleted": "Nicht abgeschlossen",
-      "activityPublished": "Veröffentlicht"
+      "activityPublished": "Veröffentlicht",
+      "documentErrorCategory": "Kategorie: {category} ({code})",
+      "documentPreviewUnavailableCategory": "Vorschau nicht verfügbar",
+      "documentActionUnknownCategory": "Aktionsergebnis unbekannt",
+      "documentEditFailedCategory": "Dokumentbearbeitung fehlgeschlagen",
+      "documentPreviewUnavailableMessage": "Die Bearbeitungsvorschau ist nicht verfügbar. Nicht übernommene Änderungen wurden verworfen.",
+      "documentActionUnknownMessage": "Die Aktion wurde möglicherweise ausgeführt. Prüfen Sie die Vorschau, bevor Sie fortfahren.",
+      "documentEditFailedMessage": "Der Dokumentvorgang wurde nicht abgeschlossen.",
+      "documentRetrySameTurn": "Wiederholung: in dieser Aufgabe fortfahren",
+      "documentRetryNewTurn": "Wiederholung: neue Aufgabe starten",
+      "documentRetryNever": "Wiederholung: nicht erneut versuchen",
+      "documentNextRetry": "Nächster Schritt: erneut versuchen",
+      "documentNextReinspect": "Nächster Schritt: erneut prüfen",
+      "documentNextFinalize": "Nächster Schritt: ohne weitere Werkzeuge beenden",
+      "documentNextNewTurn": "Nächster Schritt: neue Aufgabe starten",
+      "documentNextStop": "Nächster Schritt: stoppen"
     }
   },
   "channelStatus": {

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -180,6 +180,7 @@
       "readyWithWarnings": "The preview is running with warnings.",
       "warningsShort": "Warnings",
       "suspended": "Preview paused",
+      "agentEditInProgress": "Editing is continuing in the background.",
       "nativePreview": "Interactive preview",
       "allowRemoteResources": "Allow online images, styles, and media",
       "blockRemoteResources": "Block online images, styles, and media",
@@ -4404,7 +4405,22 @@
       "activityContentSize": "{lines} lines · {characters} characters",
       "activityExitCode": "Exit code {code}",
       "activityNotCompleted": "Didn't complete",
-      "activityPublished": "Published"
+      "activityPublished": "Published",
+      "documentErrorCategory": "Category: {category} ({code})",
+      "documentPreviewUnavailableCategory": "Preview unavailable",
+      "documentActionUnknownCategory": "Action result unknown",
+      "documentEditFailedCategory": "Document edit failed",
+      "documentPreviewUnavailableMessage": "The editing preview is unavailable. No uncommitted changes were applied.",
+      "documentActionUnknownMessage": "The action may have run. Inspect the current preview before continuing.",
+      "documentEditFailedMessage": "The document operation did not complete.",
+      "documentRetrySameTurn": "Retry policy: continue in this task",
+      "documentRetryNewTurn": "Retry policy: start a new task",
+      "documentRetryNever": "Retry policy: do not retry",
+      "documentNextRetry": "Next action: retry",
+      "documentNextReinspect": "Next action: inspect again",
+      "documentNextFinalize": "Next action: finish without more tools",
+      "documentNextNewTurn": "Next action: start a new task",
+      "documentNextStop": "Next action: stop"
     }
   },
   "channelStatus": {

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -180,6 +180,7 @@
       "readyWithWarnings": "La vista previa se está ejecutando con advertencias.",
       "warningsShort": "Advertencias",
       "suspended": "Vista previa en pausa",
+      "agentEditInProgress": "La edición continúa en segundo plano.",
       "nativePreview": "Vista previa interactiva",
       "allowRemoteResources": "Permitir imágenes, estilos y contenido multimedia en línea",
       "blockRemoteResources": "Bloquear imágenes, estilos y contenido multimedia en línea",
@@ -4316,7 +4317,22 @@
       "activityContentSize": "{lines} líneas · {characters} caracteres",
       "activityExitCode": "Código de salida {code}",
       "activityNotCompleted": "No se completó",
-      "activityPublished": "Publicado"
+      "activityPublished": "Publicado",
+      "documentErrorCategory": "Categoría: {category} ({code})",
+      "documentPreviewUnavailableCategory": "Vista previa no disponible",
+      "documentActionUnknownCategory": "Resultado de la acción desconocido",
+      "documentEditFailedCategory": "Error al editar el documento",
+      "documentPreviewUnavailableMessage": "La vista previa de edición no está disponible. No se aplicaron cambios sin confirmar.",
+      "documentActionUnknownMessage": "Es posible que la acción se haya ejecutado. Inspecciona la vista previa antes de continuar.",
+      "documentEditFailedMessage": "La operación del documento no se completó.",
+      "documentRetrySameTurn": "Política de reintento: continuar en esta tarea",
+      "documentRetryNewTurn": "Política de reintento: iniciar una tarea nueva",
+      "documentRetryNever": "Política de reintento: no reintentar",
+      "documentNextRetry": "Siguiente paso: reintentar",
+      "documentNextReinspect": "Siguiente paso: inspeccionar de nuevo",
+      "documentNextFinalize": "Siguiente paso: finalizar sin más herramientas",
+      "documentNextNewTurn": "Siguiente paso: iniciar una tarea nueva",
+      "documentNextStop": "Siguiente paso: detener"
     }
   },
   "channelStatus": {

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -180,6 +180,7 @@
       "readyWithWarnings": "L’aperçu fonctionne avec des avertissements.",
       "warningsShort": "Avertissements",
       "suspended": "Aperçu en pause",
+      "agentEditInProgress": "La modification se poursuit en arrière-plan.",
       "nativePreview": "Aperçu interactif",
       "allowRemoteResources": "Autoriser les images, styles et médias en ligne",
       "blockRemoteResources": "Bloquer les images, styles et médias en ligne",
@@ -4316,7 +4317,22 @@
       "activityContentSize": "{lines} lignes · {characters} caractères",
       "activityExitCode": "Code de sortie {code}",
       "activityNotCompleted": "Non terminé",
-      "activityPublished": "Publié"
+      "activityPublished": "Publié",
+      "documentErrorCategory": "Catégorie : {category} ({code})",
+      "documentPreviewUnavailableCategory": "Aperçu indisponible",
+      "documentActionUnknownCategory": "Résultat de l’action inconnu",
+      "documentEditFailedCategory": "Échec de la modification du document",
+      "documentPreviewUnavailableMessage": "L’aperçu d’édition est indisponible. Aucune modification non validée n’a été appliquée.",
+      "documentActionUnknownMessage": "L’action a peut-être été exécutée. Inspectez l’aperçu avant de continuer.",
+      "documentEditFailedMessage": "L’opération sur le document n’a pas abouti.",
+      "documentRetrySameTurn": "Nouvelle tentative : poursuivre dans cette tâche",
+      "documentRetryNewTurn": "Nouvelle tentative : démarrer une nouvelle tâche",
+      "documentRetryNever": "Nouvelle tentative : ne pas réessayer",
+      "documentNextRetry": "Étape suivante : réessayer",
+      "documentNextReinspect": "Étape suivante : inspecter à nouveau",
+      "documentNextFinalize": "Étape suivante : terminer sans autre outil",
+      "documentNextNewTurn": "Étape suivante : démarrer une nouvelle tâche",
+      "documentNextStop": "Étape suivante : arrêter"
     }
   },
   "channelStatus": {

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -180,6 +180,7 @@
       "readyWithWarnings": "プレビューは警告付きで実行されています。",
       "warningsShort": "警告あり",
       "suspended": "プレビューを一時停止しました",
+      "agentEditInProgress": "編集はバックグラウンドで続行中です。",
       "nativePreview": "インタラクティブプレビュー",
       "allowRemoteResources": "オンラインの画像、スタイル、メディアを許可",
       "blockRemoteResources": "オンラインの画像、スタイル、メディアをブロック",
@@ -4316,7 +4317,22 @@
       "activityContentSize": "{lines} 行 · {characters} 文字",
       "activityExitCode": "終了コード {code}",
       "activityNotCompleted": "完了できませんでした",
-      "activityPublished": "公開済み"
+      "activityPublished": "公開済み",
+      "documentErrorCategory": "カテゴリ: {category} ({code})",
+      "documentPreviewUnavailableCategory": "プレビューを利用できません",
+      "documentActionUnknownCategory": "操作結果が不明です",
+      "documentEditFailedCategory": "ドキュメントの編集に失敗しました",
+      "documentPreviewUnavailableMessage": "編集プレビューを利用できません。未確定の変更は適用されていません。",
+      "documentActionUnknownMessage": "操作が実行された可能性があります。続行前に現在のプレビューを確認してください。",
+      "documentEditFailedMessage": "ドキュメント操作は完了しませんでした。",
+      "documentRetrySameTurn": "再試行方針: このタスクで続行",
+      "documentRetryNewTurn": "再試行方針: 新しいタスクを開始",
+      "documentRetryNever": "再試行方針: 再試行しない",
+      "documentNextRetry": "次の操作: 再試行",
+      "documentNextReinspect": "次の操作: 再確認",
+      "documentNextFinalize": "次の操作: ツールを使わずに終了",
+      "documentNextNewTurn": "次の操作: 新しいタスクを開始",
+      "documentNextStop": "次の操作: 停止"
     }
   },
   "channelStatus": {

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -180,6 +180,7 @@
       "readyWithWarnings": "预览已运行，但存在警告。",
       "warningsShort": "存在警告",
       "suspended": "预览已暂停",
+      "agentEditInProgress": "编辑正在后台继续。",
       "nativePreview": "互动预览",
       "allowRemoteResources": "允许加载在线图片、样式和媒体",
       "blockRemoteResources": "禁止加载在线图片、样式和媒体",
@@ -4404,7 +4405,22 @@
       "activityContentSize": "{lines} 行 · {characters} 个字符",
       "activityExitCode": "退出码 {code}",
       "activityNotCompleted": "未通过",
-      "activityPublished": "已发布"
+      "activityPublished": "已发布",
+      "documentErrorCategory": "类别：{category}（{code}）",
+      "documentPreviewUnavailableCategory": "编辑预览不可用",
+      "documentActionUnknownCategory": "操作结果未知",
+      "documentEditFailedCategory": "文档编辑失败",
+      "documentPreviewUnavailableMessage": "编辑预览不可用，未提交的修改均未应用。",
+      "documentActionUnknownMessage": "操作可能已执行，请先重新检查当前预览再继续。",
+      "documentEditFailedMessage": "文档操作未完成。",
+      "documentRetrySameTurn": "重试策略：在当前任务中继续",
+      "documentRetryNewTurn": "重试策略：开始新任务",
+      "documentRetryNever": "重试策略：不要重试",
+      "documentNextRetry": "下一步：重试",
+      "documentNextReinspect": "下一步：重新检查",
+      "documentNextFinalize": "下一步：不再调用工具并结束",
+      "documentNextNewTurn": "下一步：开始新任务",
+      "documentNextStop": "下一步：停止"
     }
   },
   "channelStatus": {

--- a/opensquilla-webui/src/platform/desktop.ts
+++ b/opensquilla-webui/src/platform/desktop.ts
@@ -58,6 +58,7 @@ const NATIVE_SURFACE_EVENT_TYPES = new Set<NativeWorkbenchSurfaceEventType>([
   'annotation-submit',
   'annotation-cancel',
   'annotation-overlay-fallback',
+  'agent-edit-released',
 ])
 
 function normalizeArtifactAnnotationSelection(

--- a/opensquilla-webui/src/platform/types.ts
+++ b/opensquilla-webui/src/platform/types.ts
@@ -319,6 +319,7 @@ export type NativeWorkbenchSurfaceEventType =
   | 'annotation-submit'
   | 'annotation-cancel'
   | 'annotation-overlay-fallback'
+  | 'agent-edit-released'
 
 export interface NativeWorkbenchSurfaceEvent {
   version: NativeWorkbenchProtocolVersion

--- a/opensquilla-webui/src/utils/chat/activityToolDetails.test.ts
+++ b/opensquilla-webui/src/utils/chat/activityToolDetails.test.ts
@@ -48,6 +48,90 @@ describe('activity tool detail projection', () => {
     },
   )
 
+  it('shows only allowlisted document failure guidance', () => {
+    const sensitive = JSON.stringify({
+      category: 'DOCUMENT_PREVIEW_UNAVAILABLE',
+      message_key: 'document.previewUnavailable',
+      user_message: '<html>secret source</html>',
+      retry_policy: 'new_turn',
+      next_action: 'finalize_without_tools',
+      expectedSha256: 'a'.repeat(64),
+      cursor: 'private-cursor',
+      bindingToken: 'private-binding-token',
+    })
+    const projection = projectActivityToolDetail(call({
+      name: 'document_apply',
+      status: 'error',
+      isError: true,
+      inputRaw: sensitive,
+      result: sensitive,
+    }), 'document.update')
+
+    expect(projection).toEqual({
+      lines: [
+        { kind: 'document-category', category: 'DOCUMENT_PREVIEW_UNAVAILABLE' },
+        { kind: 'document-message', messageKey: 'document.previewUnavailable' },
+        { kind: 'document-retry', policy: 'new_turn' },
+        { kind: 'document-next-action', action: 'finalize_without_tools' },
+      ],
+      rawContent: '',
+    })
+    expect(JSON.stringify(projection)).not.toMatch(/sha256|cursor|binding|secret source/i)
+  })
+
+  it('maps unknown document failure fields to localized-safe generic values', () => {
+    const projection = projectActivityToolDetail(call({
+      name: 'document_apply',
+      status: 'error',
+      isError: true,
+      result: JSON.stringify({
+        category: 'PRIVATE_SERVER_FAILURE_WITH_TOKEN',
+        message_key: 'private.rawMessage',
+        user_message: 'private source and token',
+      }),
+    }), 'document.update')
+
+    expect(projection).toEqual({
+      lines: [
+        { kind: 'document-category', category: 'DOCUMENT_EDIT_FAILED' },
+        { kind: 'document-message', messageKey: 'document.editFailed' },
+        { kind: 'document-retry', policy: 'never' },
+        { kind: 'document-next-action', action: 'stop' },
+      ],
+      rawContent: '',
+    })
+    expect(JSON.stringify(projection)).not.toMatch(/private|token|source/i)
+  })
+
+  it('recovers a safe failure disclosure from compatibility history flags', () => {
+    const projection = projectActivityToolDetail(call({
+      name: 'document_browser_inspect',
+      status: 'success',
+      isError: false,
+      result: JSON.stringify({
+        ok: false,
+        status: 'error',
+        category: 'DOCUMENT_PREVIEW_UNAVAILABLE',
+        message_key: 'document.previewUnavailable',
+        retry_policy: 'new_turn',
+        next_action: 'finalize_without_tools',
+        source: '<html>private source</html>',
+        bindingToken: 'private-binding-token',
+      }),
+    }), 'document.read')
+
+    expect(projection).toEqual({
+      lines: [
+        { kind: 'document-category', category: 'DOCUMENT_PREVIEW_UNAVAILABLE' },
+        { kind: 'document-message', messageKey: 'document.previewUnavailable' },
+        { kind: 'document-retry', policy: 'new_turn' },
+        { kind: 'document-next-action', action: 'finalize_without_tools' },
+      ],
+      rawContent: '',
+    })
+    expect(JSON.stringify(projection)).not.toMatch(/private|binding|source/i)
+  })
+
   it('shows workspace-relative file details without putting raw paths in lines', () => {
     const projection = projectActivityToolDetail(call({
       inputRaw: JSON.stringify({

--- a/opensquilla-webui/src/utils/chat/activityToolDetails.ts
+++ b/opensquilla-webui/src/utils/chat/activityToolDetails.ts
@@ -6,6 +6,23 @@ export type ActivityToolDetailLine =
   | { kind: 'content-size'; lines: number; characters: number }
   | { kind: 'exit-code'; code: number }
   | { kind: 'published' }
+  | {
+      kind: 'document-category'
+      category: 'DOCUMENT_PREVIEW_UNAVAILABLE'
+        | 'DOCUMENT_ACTION_RESULT_UNKNOWN'
+        | 'DOCUMENT_EDIT_FAILED'
+    }
+  | {
+      kind: 'document-message'
+      messageKey: 'document.previewUnavailable'
+        | 'document.actionResultUnknown'
+        | 'document.editFailed'
+    }
+  | { kind: 'document-retry'; policy: 'same_turn' | 'new_turn' | 'never' }
+  | {
+      kind: 'document-next-action'
+      action: 'retry' | 'reinspect' | 'finalize_without_tools' | 'start_new_turn' | 'stop'
+    }
 
 export interface ActivityToolDetailProjection {
   lines: ActivityToolDetailLine[]
@@ -293,13 +310,9 @@ function pushUnique(
   line: ActivityToolDetailLine | null,
 ) {
   if (!line) return
-  const key = 'text' in line
-    ? `${line.kind}:${line.text}`
-    : JSON.stringify(line)
+  const key = JSON.stringify(line)
   const duplicate = lines.some(item => (
-    'text' in item
-      ? `${item.kind}:${item.text}`
-      : JSON.stringify(item)
+    JSON.stringify(item)
   ) === key)
   if (!duplicate) lines.push(line)
 }
@@ -312,7 +325,69 @@ export function projectActivityToolDetail(
   // one-time grants. Those belong in diagnostics, not in the ordinary chat
   // activity disclosure.
   if (operationKey === 'document.read' || operationKey === 'document.update') {
-    return { lines: [], rawContent: '' }
+    const resultRecord = parseRecord(call.result || call.resultPreview)
+    const nestedError = asRecord(resultRecord?.error)
+    const category = recordString(resultRecord, ['category', 'error_category', 'errorCategory', 'code'])
+      || recordString(nestedError, ['category', 'code'])
+    const recordedStatus = recordString(resultRecord, ['status', 'state']).toLowerCase()
+    const recordedFailure = Boolean(
+      call.isError
+      || call.status === 'error'
+      || resultRecord?.ok === false
+      || nestedError
+      || ['error', 'failed', 'failure'].includes(recordedStatus)
+      || category,
+    )
+    // Compatibility history can lose the transient call error flags while
+    // retaining the structured bridge result.  Derive failure only from
+    // stable structured fields; successful document calls remain completely
+    // non-disclosable and never enter a raw/result/copy path.
+    if (!recordedFailure) return { lines: [], rawContent: '' }
+    const messageKey = recordString(resultRecord, ['message_key', 'messageKey'])
+      || recordString(nestedError, ['message_key', 'messageKey'])
+    const retryPolicy = recordString(resultRecord, ['retry_policy', 'retryPolicy'])
+      || recordString(nestedError, ['retry_policy', 'retryPolicy'])
+    const nextAction = recordString(resultRecord, ['next_action', 'nextAction'])
+      || recordString(nestedError, ['next_action', 'nextAction'])
+    const allowedCategory = new Set([
+      'DOCUMENT_PREVIEW_UNAVAILABLE',
+      'DOCUMENT_ACTION_RESULT_UNKNOWN',
+      'DOCUMENT_EDIT_FAILED',
+    ]).has(category)
+      ? category as 'DOCUMENT_PREVIEW_UNAVAILABLE'
+        | 'DOCUMENT_ACTION_RESULT_UNKNOWN'
+        | 'DOCUMENT_EDIT_FAILED'
+      : 'DOCUMENT_EDIT_FAILED'
+    const allowedMessageKey = new Set([
+      'document.previewUnavailable',
+      'document.actionResultUnknown',
+      'document.editFailed',
+    ]).has(messageKey)
+      ? messageKey as 'document.previewUnavailable'
+        | 'document.actionResultUnknown'
+        | 'document.editFailed'
+      : 'document.editFailed'
+    const allowedRetry = new Set(['same_turn', 'new_turn', 'never']).has(retryPolicy)
+      ? retryPolicy as 'same_turn' | 'new_turn' | 'never'
+      : 'never'
+    const allowedAction = new Set([
+      'retry', 'reinspect', 'finalize_without_tools', 'start_new_turn', 'stop',
+    ]).has(nextAction)
+      ? nextAction as 'retry'
+        | 'reinspect'
+        | 'finalize_without_tools'
+        | 'start_new_turn'
+        | 'stop'
+      : 'stop'
+    const lines: ActivityToolDetailLine[] = [
+      { kind: 'document-category', category: allowedCategory },
+      { kind: 'document-message', messageKey: allowedMessageKey },
+    ]
+    lines.push({ kind: 'document-retry', policy: allowedRetry })
+    lines.push({ kind: 'document-next-action', action: allowedAction })
+    // Document details never enter raw/full-result/copy paths. Only the
+    // stable allowlisted projection above can reach the DOM.
+    return { lines, rawContent: '' }
   }
   const inputRecord = parseRecord(call.inputRaw || call.inputPreview)
   const resultRecord = parseRecord(call.result || call.resultPreview)
@@ -394,4 +469,12 @@ export function projectActivityToolDetail(
     lines: lines.slice(0, 3),
     ...rawDetails(call),
   }
+}
+
+export function hasActivityToolDetail(
+  call: ChatToolCallRenderItem,
+  operationKey: string,
+): boolean {
+  const projection = projectActivityToolDetail(call, operationKey)
+  return projection.lines.length > 0 || Boolean(projection.rawContent)
 }

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -842,6 +842,7 @@ import { useChatApprovals } from '@/composables/chat/useChatApprovals'
 import { useChatAttachments } from '@/composables/chat/useChatAttachments'
 import { useChatCompaction } from '@/composables/chat/useChatCompaction'
 import { useChatComposerShortcuts } from '@/composables/chat/useChatComposerShortcuts'
+import { useDeliverableUpdateIndicator } from '@/composables/chat/useDeliverableUpdateIndicator'
 import { useChatRouteHeaderBridge } from '@/composables/chat/useChatRouteHeaderBridge'
 import {
   goalHasRenderedTerminalAnchor,
@@ -2196,6 +2197,14 @@ const chatRenderedMessages = useChatRenderedMessages({
   timeTranslator: t,
 })
 const { renderedMessages } = chatRenderedMessages
+const {
+  hasNewDeliverable,
+  acknowledge: acknowledgeDeliverableUpdate,
+} = useDeliverableUpdateIndicator({
+  sessionKey,
+  messages: renderedMessages,
+  isStreaming,
+})
 const sessionCreationRouterPresentation = computed(() => (
   projectSessionCreationRouterPresentation(renderedMessages.value, isStreaming.value)
 ))
@@ -4907,6 +4916,7 @@ function focusHeaderAction(
 
 async function openDeliverables() {
   if (sessionArtifacts.value.length === 0) return
+  acknowledgeDeliverableUpdate()
   if (
     workbenchEnabled.value
     && workbenchResourcesEnabled.value
@@ -5410,6 +5420,7 @@ const chatRouteHeaderRegistration = chatRouteHeader.register({
   copyIcon: sessionCopyIcon,
   copyLiveText: sessionCopyLiveText,
   deliverableCount: headerDeliverableCount,
+  hasNewDeliverable,
   shareMode,
   shareableMessageCount,
 }, {

--- a/opensquilla-webui/src/workbench/artifactDocumentProvider.ts
+++ b/opensquilla-webui/src/workbench/artifactDocumentProvider.ts
@@ -936,6 +936,11 @@ export function createRpcArtifactDocumentProvider(
       // Downloads must dereference the mutable document head at request time,
       // even between a successful save and the asynchronous metadata refresh.
       download_url: resolved.latestDownloadUrl,
+      // Keep the stable mutable-document identity on the derived head payload.
+      // The immutable artifact id changes on every commit and must not become
+      // the workspace/cache key during the release-triggered preview rebuild.
+      documentId: resolved.documentId,
+      document_id: resolved.documentId,
     }
     return {
       document: resolved,

--- a/scripts/live_artifact_prompt_annotations_e2e.py
+++ b/scripts/live_artifact_prompt_annotations_e2e.py
@@ -78,6 +78,7 @@ DESKTOP_BRIDGE_URL_ENV = "OPENSQUILLA_DESKTOP_ARTIFACT_BRIDGE_URL"
 DESKTOP_BRIDGE_TOKEN_ENV = "OPENSQUILLA_DESKTOP_ARTIFACT_BRIDGE_TOKEN"
 DESKTOP_BRIDGE_VERSION = 3
 DESKTOP_BRIDGE_V4_VERSION = 4
+DESKTOP_BRIDGE_V5_VERSION = 5
 
 DIRECT_MODEL = "glm-5.2"
 ROUTER_MODELS = {
@@ -909,7 +910,7 @@ class _BridgeSelection:
 
 
 class SyntheticDesktopBridge:
-    """Minimal authenticated v4 bridge used only inside the isolated worker."""
+    """Minimal authenticated v5 bridge used only inside the isolated worker."""
 
     def __init__(self) -> None:
         self._token = base64.urlsafe_b64encode(secrets.token_bytes(32)).decode("ascii").rstrip("=")
@@ -917,8 +918,9 @@ class SyntheticDesktopBridge:
         self._thread: threading.Thread | None = None
         self._lock = threading.Lock()
         self._selections: dict[str, _BridgeSelection] = {}
-        self._candidate_handle: str | None = None
-        self._candidate_bound = False
+        self._bindings: dict[str, dict[str, Any]] = {
+            "legacy": {"candidateHandle": None, "candidateBound": False, "generation": 1}
+        }
         self._gateway_endpoint: str | None = None
         self._active_preview_artifact_id: str | None = None
         self._scope_id: str | None = None
@@ -951,7 +953,7 @@ class SyntheticDesktopBridge:
         owner = self
 
         class Handler(http.server.BaseHTTPRequestHandler):
-            server_version = "OpenSquillaSyntheticBridge/3"
+            server_version = "OpenSquillaSyntheticBridge/5"
 
             def log_message(self, _format: str, *_args: object) -> None:
                 return
@@ -990,8 +992,7 @@ class SyntheticDesktopBridge:
         self._thread = None
         with self._lock:
             self._selections.clear()
-            self._candidate_handle = None
-            self._candidate_bound = False
+            self._bindings.clear()
             self._gateway_endpoint = None
             self._active_preview_artifact_id = None
             self._scope_id = None
@@ -1000,6 +1001,23 @@ class SyntheticDesktopBridge:
             server.server_close()
         if thread is not None:
             thread.join(timeout=2.0)
+
+    @staticmethod
+    def _capabilities() -> dict[str, Any]:
+        return {
+            "version": DESKTOP_BRIDGE_V5_VERSION,
+            "available": True,
+            "captureSelection": False,
+            "resolveAnnotationSelection": True,
+            "focusAnnotation": False,
+            "browserInspect": True,
+            "browserAct": True,
+            "screenshot": True,
+            "officeFlush": False,
+            "reloadSurface": True,
+            "bindCandidatePreview": True,
+            "restoreCanonicalPreview": True,
+        }
 
     def _json_response(
         self,
@@ -1095,35 +1113,79 @@ class SyntheticDesktopBridge:
         if (
             handler.path == "/v1/capabilities"
             and isinstance(body, dict)
-            and body.get("version") in {DESKTOP_BRIDGE_VERSION, DESKTOP_BRIDGE_V4_VERSION}
+            and body.get("version")
+            in {DESKTOP_BRIDGE_VERSION, DESKTOP_BRIDGE_V4_VERSION, DESKTOP_BRIDGE_V5_VERSION}
         ):
+            self._json_response(
+                handler,
+                200,
+                {"ok": True, "value": self._capabilities()},
+            )
+            return
+        if (
+            handler.path == "/v1/bindings/acquire"
+            and isinstance(body, dict)
+            and body.get("version") == DESKTOP_BRIDGE_V5_VERSION
+        ):
+            binding_token = (
+                base64.urlsafe_b64encode(secrets.token_bytes(32))
+                .decode("ascii")
+                .rstrip("=")
+            )
+            with self._lock:
+                self._bindings[binding_token] = {
+                    "candidateHandle": None,
+                    "candidateBound": False,
+                    "generation": 1,
+                }
             self._json_response(
                 handler,
                 200,
                 {
                     "ok": True,
                     "value": {
-                        "version": DESKTOP_BRIDGE_V4_VERSION,
-                        "available": True,
-                        "captureSelection": False,
-                        "resolveAnnotationSelection": True,
-                        "focusAnnotation": False,
-                        "browserInspect": True,
-                        "browserAct": True,
-                        "screenshot": True,
-                        "officeFlush": False,
-                        "reloadSurface": True,
-                        "bindCandidatePreview": True,
-                        "restoreCanonicalPreview": True,
+                        "version": DESKTOP_BRIDGE_V5_VERSION,
+                        "bindingToken": binding_token,
+                        "capabilities": self._capabilities(),
                     },
                 },
             )
             return
         if (
+            handler.path == "/v1/bindings/release"
+            and isinstance(body, dict)
+            and body.get("version") == DESKTOP_BRIDGE_V5_VERSION
+            and isinstance(body.get("bindingToken"), str)
+        ):
+            with self._lock:
+                self._bindings.pop(str(body["bindingToken"]), None)
+            self._json_response(handler, 200, {"ok": True, "value": {"released": True}})
+            return
+        binding_token = body.get("bindingToken") if isinstance(body, dict) else None
+        protocol_version = body.get("version") if isinstance(body, dict) else None
+        binding_key = (
+            str(binding_token)
+            if protocol_version == DESKTOP_BRIDGE_V5_VERSION
+            else "legacy"
+        )
+        with self._lock:
+            binding = self._bindings.get(binding_key)
+        is_bound_v5 = (
+            protocol_version == DESKTOP_BRIDGE_V5_VERSION
+            and isinstance(binding_token, str)
+            and binding is not None
+        )
+        is_legacy = (
+            protocol_version in {DESKTOP_BRIDGE_VERSION, DESKTOP_BRIDGE_V4_VERSION}
+            and binding_token is None
+            and binding is not None
+        )
+        if (
             handler.path != "/v1/invoke"
             or not isinstance(body, dict)
-            or body.get("version") not in {DESKTOP_BRIDGE_VERSION, DESKTOP_BRIDGE_V4_VERSION}
+            or not (is_bound_v5 or is_legacy)
             or not isinstance(body.get("request"), dict)
+            or body["request"].get("version") != protocol_version
         ):
             self._json_response(
                 handler,
@@ -1136,7 +1198,8 @@ class SyntheticDesktopBridge:
         if method == "bindCandidatePreview":
             handle = request.get("candidateHandle")
             if (
-                request.get("version") != DESKTOP_BRIDGE_V4_VERSION
+                request.get("version")
+                not in {DESKTOP_BRIDGE_V4_VERSION, DESKTOP_BRIDGE_V5_VERSION}
                 or not isinstance(handle, str)
                 or not handle.startswith("candidate_")
             ):
@@ -1151,8 +1214,21 @@ class SyntheticDesktopBridge:
                 )
                 return
             with self._lock:
-                self._candidate_handle = handle
-                self._candidate_bound = True
+                current = self._bindings.get(binding_key)
+                if current is None:
+                    self._json_response(
+                        handler,
+                        409,
+                        {
+                            "ok": False,
+                            "code": "binding-unavailable",
+                            "message": "Binding is unavailable.",
+                        },
+                    )
+                    return
+                current["candidateHandle"] = handle
+                current["candidateBound"] = True
+                current["generation"] = int(current["generation"]) + 1
             self._json_response(
                 handler,
                 200,
@@ -1161,8 +1237,11 @@ class SyntheticDesktopBridge:
             return
         if method == "restoreCanonicalPreview":
             with self._lock:
-                self._candidate_handle = None
-                self._candidate_bound = False
+                current = self._bindings.get(binding_key)
+                if current is not None:
+                    current["candidateHandle"] = None
+                    current["candidateBound"] = False
+                    current["generation"] = int(current["generation"]) + 1
             self._json_response(
                 handler,
                 200,
@@ -1170,7 +1249,10 @@ class SyntheticDesktopBridge:
             )
             return
         if method == "browserInspect":
-            if request.get("version") != DESKTOP_BRIDGE_V4_VERSION:
+            if request.get("version") not in {
+                DESKTOP_BRIDGE_V4_VERSION,
+                DESKTOP_BRIDGE_V5_VERSION,
+            }:
                 self._json_response(
                     handler,
                     400,
@@ -1184,8 +1266,10 @@ class SyntheticDesktopBridge:
             scope = request.get("scope")
             max_nodes = request.get("maxNodes")
             with self._lock:
-                bound = self._candidate_bound
-                candidate_handle = self._candidate_handle
+                current = self._bindings.get(binding_key)
+                bound = bool(current and current["candidateBound"])
+                candidate_handle = current["candidateHandle"] if current else None
+                binding_generation = int(current["generation"]) if current else 0
                 canonical_artifact_id = self._active_preview_artifact_id
                 canonical_scope_id = self._scope_id
             if scope not in {"document", "selection", "viewport"} or not isinstance(max_nodes, int):
@@ -1249,6 +1333,11 @@ class SyntheticDesktopBridge:
                         "activePreviewArtifactId": active_artifact_id,
                         "scopeId": active_scope_id,
                         "candidateHandle": candidate_handle if bound else None,
+                        **(
+                            {"bindingGeneration": binding_generation}
+                            if protocol_version == DESKTOP_BRIDGE_V5_VERSION
+                            else {}
+                        ),
                     },
                 },
             )
@@ -1280,6 +1369,10 @@ class SyntheticDesktopBridge:
             )
             return
         if method == "reloadSurface":
+            with self._lock:
+                current = self._bindings.get(binding_key)
+                if current is not None:
+                    current["generation"] = int(current["generation"]) + 1
             self._json_response(
                 handler,
                 200,
@@ -1288,7 +1381,8 @@ class SyntheticDesktopBridge:
             return
         if (
             method != "resolveAnnotationSelection"
-            or request.get("version") not in {DESKTOP_BRIDGE_VERSION, DESKTOP_BRIDGE_V4_VERSION}
+            or request.get("version")
+            not in {DESKTOP_BRIDGE_VERSION, DESKTOP_BRIDGE_V4_VERSION, DESKTOP_BRIDGE_V5_VERSION}
         ):
             self._json_response(
                 handler,
@@ -1301,7 +1395,7 @@ class SyntheticDesktopBridge:
             selection = self._selections.get(str(selection_id))
         expected_request = selection.request() if selection is not None else None
         if expected_request is not None:
-            # v4 keeps the v3 annotation-selection payload for compatibility;
+            # v4/v5 keep the v3 annotation-selection payload for compatibility;
             # only the envelope version changes during capability negotiation.
             expected_request["version"] = request.get("version")
         if selection is None or request != expected_request:

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -6755,7 +6755,18 @@ class Agent:
                 self._tool_context.turn_cleanup_callbacks.clear()
                 for callback in callbacks:
                     try:
-                        callback()
+                        result = callback()
+                        if inspect.isawaitable(result):
+                            cleanup_task = asyncio.ensure_future(result)
+                            cleanup_cancelled = False
+                            while not cleanup_task.done():
+                                try:
+                                    await asyncio.shield(cleanup_task)
+                                except asyncio.CancelledError:
+                                    cleanup_cancelled = True
+                            cleanup_task.result()
+                            if cleanup_cancelled:
+                                logger.debug("agent.turn_authority_cleanup_completed_after_cancel")
                     except Exception:  # noqa: BLE001 - cleanup must not mask turn outcome
                         logger.warning(
                             "agent.turn_authority_cleanup_failed",

--- a/src/opensquilla/gateway/agent_tasks.py
+++ b/src/opensquilla/gateway/agent_tasks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from collections.abc import AsyncIterator, Iterable
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
 
 import structlog
 
@@ -19,6 +19,7 @@ class AgentTaskRegistry:
     def __init__(self) -> None:
         self._tasks: dict[str, asyncio.Task] = {}
         self._unsettled_tasks: dict[str, set[asyncio.Task]] = {}
+        self._cleanup_tasks: dict[str, set[asyncio.Task[None]]] = {}
         self._admission_locks: dict[str, asyncio.Lock] = {}
 
     @contextlib.asynccontextmanager
@@ -67,6 +68,14 @@ class AgentTaskRegistry:
                         unsettled.difference_update(completed)
                         if not unsettled:
                             self._unsettled_tasks.pop(session_key, None)
+            cleanup_tasks = {
+                task
+                for session_key in keys
+                for task in self._cleanup_tasks.get(session_key, ())
+                if not task.done()
+            }
+            if cleanup_tasks:
+                await asyncio.gather(*cleanup_tasks, return_exceptions=True)
 
             async with contextlib.AsyncExitStack() as fences:
                 for session_key in keys:
@@ -77,6 +86,12 @@ class AgentTaskRegistry:
                     not task.done()
                     for session_key in keys
                     for task in self._unsettled_tasks.get(session_key, ())
+                ):
+                    continue
+                if any(
+                    not task.done()
+                    for session_key in keys
+                    for task in self._cleanup_tasks.get(session_key, ())
                 ):
                     continue
                 for session_key in keys:
@@ -92,6 +107,7 @@ class AgentTaskRegistry:
         task: asyncio.Task,
         *,
         cancel_existing: bool = True,
+        terminal_cleanup: Callable[[], Awaitable[None]] | None = None,
     ) -> None:
         """Register a running agent task for a session.
 
@@ -119,6 +135,30 @@ class AgentTaskRegistry:
         self._unsettled_tasks.setdefault(key, set()).add(task)
 
         def _on_done(t: asyncio.Task) -> None:
+            if terminal_cleanup is not None:
+                async def _cleanup() -> None:
+                    try:
+                        await terminal_cleanup()
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:  # noqa: BLE001 - task outcome remains authoritative
+                        log.warning(
+                            "agent_task.terminal_cleanup_failed",
+                            session_key=key,
+                            exc_info=True,
+                        )
+
+                cleanup_task = asyncio.create_task(_cleanup())
+                self._cleanup_tasks.setdefault(key, set()).add(cleanup_task)
+
+                def _cleanup_done(completed: asyncio.Task[None]) -> None:
+                    cleanups = self._cleanup_tasks.get(key)
+                    if cleanups is not None:
+                        cleanups.discard(completed)
+                        if not cleanups:
+                            self._cleanup_tasks.pop(key, None)
+
+                cleanup_task.add_done_callback(_cleanup_done)
             if self._tasks.get(key) is t:
                 self._tasks.pop(key, None)
             unsettled = self._unsettled_tasks.get(key)

--- a/src/opensquilla/gateway/desktop_artifact_bridge.py
+++ b/src/opensquilla/gateway/desktop_artifact_bridge.py
@@ -19,14 +19,15 @@ import re
 import secrets
 import threading
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Coroutine, Mapping
 from dataclasses import dataclass
 from typing import Any, Final, Literal, cast
 from urllib.parse import urlsplit
 
 DESKTOP_ARTIFACT_BRIDGE_URL_ENV: Final = "OPENSQUILLA_DESKTOP_ARTIFACT_BRIDGE_URL"
 DESKTOP_ARTIFACT_BRIDGE_TOKEN_ENV: Final = "OPENSQUILLA_DESKTOP_ARTIFACT_BRIDGE_TOKEN"
-DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION: Final = 4
+DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION: Final = 5
+DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V4: Final = 4
 DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V3: Final = 3
 
 _LOOPBACK_HOST: Final = "127.0.0.1"
@@ -117,6 +118,47 @@ class DesktopArtifactBridgeError(RuntimeError):
         self.status = status
 
 
+class TurnAuthorityCleanup:
+    """Cancellation-safe exactly-once cleanup for one process-local authority."""
+
+    __slots__ = ("_callback", "_lock", "_task", "_ingress_owned")
+
+    def __init__(self, callback: Callable[[], Coroutine[Any, Any, None]]) -> None:
+        self._callback = callback
+        self._lock = asyncio.Lock()
+        self._task: asyncio.Task[None] | None = None
+        self._ingress_owned = True
+
+    def __repr__(self) -> str:
+        return "TurnAuthorityCleanup(authority=<redacted>)"
+
+    @property
+    def ingress_owned(self) -> bool:
+        return self._ingress_owned
+
+    def handoff(self) -> None:
+        """Transfer cleanup responsibility away from the ingress scope."""
+
+        self._ingress_owned = False
+
+    async def aclose(self) -> None:
+        async with self._lock:
+            task = self._task
+            if task is None:
+                task = asyncio.create_task(self._callback())
+                self._task = task
+
+        cancelled = False
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                cancelled = True
+        task.result()
+        if cancelled:
+            raise asyncio.CancelledError
+
+
 @dataclass(frozen=True, slots=True)
 class DesktopArtifactBridgeCapabilities:
     version: int
@@ -174,6 +216,9 @@ class DesktopArtifactBrowserSnapshot:
     active_preview_artifact_id: str | None = None
     scope_id: str | None = None
     candidate_handle: str | None = None
+    # Protocol-v5 process-local surface generation. It is consumed by the
+    # document verifier and is never projected into model-visible tool output.
+    binding_generation: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -210,6 +255,55 @@ def _boolean(value: object, *, label: str) -> bool:
             "invalid-response", f"The Desktop bridge {label} is invalid."
         )
     return value
+
+
+def _parse_capabilities(value: object) -> DesktopArtifactBridgeCapabilities:
+    payload = _record(value, label="capabilities response")
+    remote_version = payload.get("version")
+    if remote_version not in {
+        DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V3,
+        DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V4,
+        DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION,
+    }:
+        raise DesktopArtifactBridgeError(
+            "invalid-response", "The Desktop bridge protocol version is invalid."
+        )
+    return DesktopArtifactBridgeCapabilities(
+        version=int(remote_version),
+        available=_boolean(payload.get("available"), label="available capability"),
+        capture_selection=_boolean(
+            payload.get("captureSelection"), label="selection capability"
+        ),
+        resolve_annotation_selection=_boolean(
+            payload.get("resolveAnnotationSelection"),
+            label="annotation selection resolution capability",
+        ),
+        focus_annotation=_boolean(
+            payload.get("focusAnnotation"), label="annotation focus capability"
+        ),
+        browser_inspect=_boolean(
+            payload.get("browserInspect"), label="browser inspection capability"
+        ),
+        browser_act=_boolean(payload.get("browserAct"), label="browser action capability"),
+        screenshot=_boolean(payload.get("screenshot"), label="screenshot capability"),
+        office_flush=_boolean(payload.get("officeFlush"), label="Office flush capability"),
+        reload_surface=_boolean(payload.get("reloadSurface"), label="reload capability"),
+        bind_candidate_preview=(
+            _boolean(
+                payload.get("bindCandidatePreview"), label="candidate binding capability"
+            )
+            if "bindCandidatePreview" in payload
+            else False
+        ),
+        restore_canonical_preview=(
+            _boolean(
+                payload.get("restoreCanonicalPreview"),
+                label="canonical preview restore capability",
+            )
+            if "restoreCanonicalPreview" in payload
+            else False
+        ),
+    )
 
 
 def _optional_string(value: object, *, label: str, max_chars: int = 16_384) -> str | None:
@@ -300,9 +394,6 @@ class DesktopArtifactBridgeClient:
     def __init__(self, *, endpoint: str, token: str) -> None:
         self._port = _validate_endpoint(endpoint)
         self._token = _validate_token(token)
-        # Start with v3 for a rolling upgrade: both old and new Electron
-        # shells accept it.  A v4 capability response upgrades subsequent
-        # calls to v4 without requiring a restart or a second credential.
         self._protocol_version = DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V3
         self._capabilities_negotiated = False
 
@@ -322,55 +413,73 @@ class DesktopArtifactBridgeClient:
         return isinstance(token, str) and secrets.compare_digest(self._token, token)
 
     async def capabilities(self, *, deadline_ms: int = 2_000) -> DesktopArtifactBridgeCapabilities:
+        try:
+            response = await self._post(
+                "/v1/capabilities", {"version": self._protocol_version}, deadline_ms=deadline_ms
+            )
+        except DesktopArtifactBridgeError:
+            if self._protocol_version != DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION:
+                raise
+            # New Gateway + old Desktop is deliberately source-only. Negotiate
+            # the old fixed methods but never advertise autonomous candidates.
+            self._protocol_version = DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V4
+            response = await self._post(
+                "/v1/capabilities", {"version": self._protocol_version}, deadline_ms=deadline_ms
+            )
+        if response.get("ok") is not True:
+            raise self._response_error(response)
+        capabilities = _parse_capabilities(response.get("value"))
+        self._protocol_version = capabilities.version
+        self._capabilities_negotiated = True
+        return capabilities
+
+    async def acquire_binding(
+        self, *, deadline_ms: int = 2_000
+    ) -> BoundDesktopArtifactBridgeClient | None:
+        self._protocol_version = DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION
+        advertised = await self.capabilities(deadline_ms=deadline_ms)
+        if advertised.version != DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION:
+            return None
         response = await self._post(
-            "/v1/capabilities",
-            {"version": self._protocol_version},
+            "/v1/bindings/acquire",
+            {"version": DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION},
             deadline_ms=deadline_ms,
         )
         if response.get("ok") is not True:
             raise self._response_error(response)
-        value = _record(response.get("value"), label="capabilities response")
-        remote_version = value.get("version")
-        if remote_version not in {
-            DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V3,
-            DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION,
-        }:
+        value = _record(response.get("value"), label="binding response")
+        token = value.get("bindingToken")
+        if not isinstance(token, str) or not _TOKEN_RE.fullmatch(token):
             raise DesktopArtifactBridgeError(
-                "invalid-response", "The Desktop bridge protocol version is invalid."
+                "invalid-response", "The Desktop binding token is invalid."
             )
-        self._protocol_version = int(remote_version)
-        self._capabilities_negotiated = True
-        return DesktopArtifactBridgeCapabilities(
-            version=self._protocol_version,
-            available=_boolean(value.get("available"), label="available capability"),
-            capture_selection=_boolean(value.get("captureSelection"), label="selection capability"),
-            resolve_annotation_selection=_boolean(
-                value.get("resolveAnnotationSelection"),
-                label="annotation selection resolution capability",
-            ),
-            focus_annotation=_boolean(
-                value.get("focusAnnotation"), label="annotation focus capability"
-            ),
-            browser_inspect=_boolean(
-                value.get("browserInspect"), label="browser inspection capability"
-            ),
-            browser_act=_boolean(value.get("browserAct"), label="browser action capability"),
-            screenshot=_boolean(value.get("screenshot"), label="screenshot capability"),
-            office_flush=_boolean(value.get("officeFlush"), label="Office flush capability"),
-            reload_surface=_boolean(value.get("reloadSurface"), label="reload capability"),
-            bind_candidate_preview=(
-                _boolean(value.get("bindCandidatePreview"), label="candidate binding capability")
-                if "bindCandidatePreview" in value
-                else False
-            ),
-            restore_canonical_preview=(
-                _boolean(
-                    value.get("restoreCanonicalPreview"),
-                    label="canonical preview restore capability",
+        try:
+            if value.get("version") != DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION:
+                raise DesktopArtifactBridgeError(
+                    "invalid-response", "The Desktop binding version is invalid."
                 )
-                if "restoreCanonicalPreview" in value
-                else False
-            ),
+            capabilities = _parse_capabilities(value.get("capabilities"))
+            if capabilities.version != DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION:
+                raise DesktopArtifactBridgeError(
+                    "invalid-response", "The Desktop binding capabilities are invalid."
+                )
+        except DesktopArtifactBridgeError:
+            try:
+                await self._post(
+                    "/v1/bindings/release",
+                    {
+                        "version": DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION,
+                        "bindingToken": token,
+                    },
+                    deadline_ms=deadline_ms,
+                )
+            except DesktopArtifactBridgeError:
+                # Cleanup is best-effort and must not replace the validation
+                # error that made this newly issued binding unusable.
+                pass
+            raise
+        return BoundDesktopArtifactBridgeClient(
+            parent=self, binding_token=token, capabilities=capabilities
         )
 
     async def capture_selection(
@@ -639,6 +748,25 @@ class DesktopArtifactBridgeClient:
                 raise DesktopArtifactBridgeError(
                     "invalid-response", "The Desktop bridge candidate identity is invalid."
                 )
+        binding_generation: int | None = None
+        if "bindingGeneration" in value:
+            raw_binding_generation = value.get("bindingGeneration")
+            if (
+                isinstance(raw_binding_generation, bool)
+                or not isinstance(raw_binding_generation, int)
+                or raw_binding_generation < 1
+            ):
+                raise DesktopArtifactBridgeError(
+                    "invalid-response", "The Desktop bridge binding generation is invalid."
+                )
+            binding_generation = raw_binding_generation
+        if (
+            self._invoke_protocol_version() == DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION
+            and binding_generation is None
+        ):
+            raise DesktopArtifactBridgeError(
+                "invalid-response", "The Desktop bridge binding generation is unavailable."
+            )
         nodes: list[DesktopArtifactBrowserNode] = []
         for raw_node in raw_nodes:
             node = _record(raw_node, label="browser node")
@@ -683,6 +811,7 @@ class DesktopArtifactBridgeClient:
             active_preview_artifact_id=active_preview_artifact_id,
             scope_id=scope_id,
             candidate_handle=response_candidate_handle,
+            binding_generation=binding_generation,
         )
 
     async def browser_click(
@@ -913,11 +1042,17 @@ class DesktopArtifactBridgeClient:
             raise ValueError("Desktop artifact candidate handle is invalid")
 
     def _require_protocol_v4(self, operation: str) -> None:
-        if self._protocol_version < DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION:
+        if self._protocol_version < DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V4:
             raise DesktopArtifactBridgeError(
                 "unsupported",
                 f"Desktop protocol-v4 is required for {operation}.",
             )
+
+    def _invoke_protocol_version(self) -> int:
+        # v5 invocation authority is turn-bound. The process-scoped client is
+        # still used by annotation and other non-turn RPCs, so those calls must
+        # remain on the unbound v4 envelope even after a v5 capability probe.
+        return min(self._protocol_version, DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION_V4)
 
     async def _call(
         self,
@@ -928,13 +1063,14 @@ class DesktopArtifactBridgeClient:
     ) -> dict[str, Any]:
         if method not in _BRIDGE_METHODS:
             raise ValueError("Desktop artifact bridge method is invalid")
+        protocol_version = self._invoke_protocol_version()
         response = await self._post(
             "/v1/invoke",
             {
-                "version": self._protocol_version,
+                "version": protocol_version,
                 "method": method,
                 "request": {
-                    "version": self._protocol_version,
+                    "version": protocol_version,
                     **request,
                 },
             },
@@ -950,7 +1086,9 @@ class DesktopArtifactBridgeClient:
 
     async def _post(
         self,
-        path: Literal["/v1/capabilities", "/v1/invoke"],
+        path: Literal[
+            "/v1/capabilities", "/v1/invoke", "/v1/bindings/acquire", "/v1/bindings/release"
+        ],
         payload: dict[str, object],
         *,
         deadline_ms: int,
@@ -1059,6 +1197,87 @@ class DesktopArtifactBridgeClient:
     def _validate_anchor(anchor: str) -> None:
         if not isinstance(anchor, str) or not _ANCHOR_RE.fullmatch(anchor):
             raise ValueError("Desktop artifact browser anchor is invalid")
+
+
+class BoundDesktopArtifactBridgeClient(DesktopArtifactBridgeClient):
+    """Turn-scoped facade whose opaque token never leaves Gateway memory."""
+
+    __slots__ = ("_binding_token", "_bound_capabilities", "_closed")
+
+    def __init__(
+        self,
+        *,
+        parent: DesktopArtifactBridgeClient,
+        binding_token: str,
+        capabilities: DesktopArtifactBridgeCapabilities,
+    ) -> None:
+        super().__init__(
+            endpoint=f"http://127.0.0.1:{parent._port}",
+            token=parent._token,
+        )
+        self._protocol_version = DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION
+        self._capabilities_negotiated = True
+        self._binding_token = binding_token
+        self._bound_capabilities = capabilities
+        self._closed = False
+
+    def __repr__(self) -> str:
+        return "BoundDesktopArtifactBridgeClient(loopback=<redacted>, binding=<redacted>)"
+
+    async def capabilities(self, *, deadline_ms: int = 2_000) -> DesktopArtifactBridgeCapabilities:
+        del deadline_ms
+        if self._closed:
+            raise DesktopArtifactBridgeError(
+                "binding-unavailable", "The Desktop binding is unavailable."
+            )
+        return self._bound_capabilities
+
+    async def aclose(self, *, deadline_ms: int = 2_000) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        token, self._binding_token = self._binding_token, ""
+        try:
+            await self._post(
+                "/v1/bindings/release",
+                {"version": DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION, "bindingToken": token},
+                deadline_ms=deadline_ms,
+            )
+        except DesktopArtifactBridgeError:
+            # Release is idempotent and Desktop also drops all bindings at shutdown.
+            pass
+
+    def _invoke_protocol_version(self) -> int:
+        return DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION
+
+    async def _call(
+        self,
+        method: BridgeMethod,
+        request: dict[str, object],
+        *,
+        deadline_ms: int,
+    ) -> dict[str, Any]:
+        if self._closed:
+            raise DesktopArtifactBridgeError(
+                "binding-unavailable", "The Desktop binding is unavailable."
+            )
+        response = await self._post(
+            "/v1/invoke",
+            {
+                "version": DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION,
+                "bindingToken": self._binding_token,
+                "method": method,
+                "request": {"version": DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION, **request},
+            },
+            deadline_ms=deadline_ms,
+        )
+        if response.get("ok") is not True:
+            raise self._response_error(response)
+        if response.get("method") != method:
+            raise DesktopArtifactBridgeError(
+                "invalid-response", "The Desktop bridge method response is invalid."
+            )
+        return _record(response.get("value"), label="operation response")
 
 
 def desktop_artifact_bridge_client_from_environment(

--- a/src/opensquilla/gateway/routing.py
+++ b/src/opensquilla/gateway/routing.py
@@ -753,6 +753,9 @@ def tool_context_from_envelope(
         ),
         artifact_candidate_loop_controller=artifact_candidate_loop_controller,
         artifact_preview_service=artifact_preview_service,
+        turn_cleanup_callbacks=list(
+            envelope.runtime_services.get("turn_cleanup_callbacks") or ()
+        ),
     )
     if sandbox_run_context_fresh:
         # Runtime-only authority marker copied from the RouteEnvelope field,

--- a/src/opensquilla/gateway/rpc_sessions.py
+++ b/src/opensquilla/gateway/rpc_sessions.py
@@ -14,6 +14,7 @@ import time
 import uuid
 import weakref
 from collections.abc import Awaitable, Callable, Mapping, Sequence
+from contextvars import ContextVar
 from dataclasses import asdict, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn, cast
@@ -3566,8 +3567,49 @@ async def _accepted_turn_response(
     return payload
 
 
+class _IngressTurnAuthorityScope:
+    """Own newly acquired turn authorities until runtime admission succeeds."""
+
+    def __init__(self) -> None:
+        self.authorities: list[Any] = []
+
+    def register(self, authority: Any) -> None:
+        self.authorities.append(authority)
+
+    async def close_untransferred(self) -> None:
+        for authority in tuple(self.authorities):
+            if getattr(authority, "ingress_owned", False) is not True:
+                continue
+            try:
+                await authority.aclose()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 - preserve the ingress outcome
+                log.warning("sessions.send.turn_authority_cleanup_failed", exc_info=True)
+
+
+_INGRESS_TURN_AUTHORITY_SCOPE: ContextVar[_IngressTurnAuthorityScope | None] = ContextVar(
+    "opensquilla_ingress_turn_authority_scope",
+    default=None,
+)
+
+
 @_d.method("sessions.send", scope="operator.write")
 async def _handle_sessions_send_impl(
+    params: dict | None,
+    ctx: RpcContext,
+    **kwargs: Any,
+) -> dict:
+    scope = _IngressTurnAuthorityScope()
+    token = _INGRESS_TURN_AUTHORITY_SCOPE.set(scope)
+    try:
+        return await _handle_sessions_send_impl_inner(params, ctx, **kwargs)
+    finally:
+        _INGRESS_TURN_AUTHORITY_SCOPE.reset(token)
+        await scope.close_untransferred()
+
+
+async def _handle_sessions_send_impl_inner(
     params: dict | None,
     ctx: RpcContext,
     *,
@@ -5018,6 +5060,7 @@ async def _handle_sessions_send_impl(
             and not guest_safe
         ):
             from opensquilla.gateway.desktop_artifact_bridge import (
+                TurnAuthorityCleanup,
                 get_desktop_artifact_bridge_client,
             )
 
@@ -5037,20 +5080,46 @@ async def _handle_sessions_send_impl(
                 # ten-tool loop could stage a draft that can never be committed.
                 # Keep the useful durable source-writer compatibility path
                 # rather than exposing a candidate that can only be discarded.
+                turn_authority_cleanup = None
                 try:
-                    bridge_capabilities = await desktop_artifact_bridge.capabilities()
+                    bound_desktop_artifact_bridge = await desktop_artifact_bridge.acquire_binding()
+                    turn_authority_cleanup = (
+                        TurnAuthorityCleanup(bound_desktop_artifact_bridge.aclose)
+                        if bound_desktop_artifact_bridge is not None
+                        else None
+                    )
+                    authority_scope = _INGRESS_TURN_AUTHORITY_SCOPE.get()
+                    if turn_authority_cleanup is not None and authority_scope is not None:
+                        authority_scope.register(turn_authority_cleanup)
+                    bridge_capabilities = (
+                        await bound_desktop_artifact_bridge.capabilities()
+                        if bound_desktop_artifact_bridge is not None
+                        else None
+                    )
                 except Exception:  # noqa: BLE001 - preserve unavailable bridge semantics
+                    bound_desktop_artifact_bridge = None
                     bridge_capabilities = None
-                if not _desktop_artifact_bridge_supports_candidate_loop(
-                    bridge_capabilities
+                if (
+                    not _desktop_artifact_bridge_supports_candidate_loop(
+                        bridge_capabilities
+                    )
+                    or turn_authority_cleanup is None
                 ):
+                    if turn_authority_cleanup is not None:
+                        await turn_authority_cleanup.aclose()
                     artifact_turn_context = _prompt_annotation_source_only_context(
                         artifact_turn_context
                     )
                 else:
                     route_envelope.runtime_services["desktop_artifact_bridge"] = (
-                        desktop_artifact_bridge
+                        bound_desktop_artifact_bridge
                     )
+                    route_envelope.runtime_services["turn_authority_cleanup"] = (
+                        turn_authority_cleanup
+                    )
+                    route_envelope.runtime_services.setdefault(
+                        "turn_cleanup_callbacks", []
+                    ).append(turn_authority_cleanup.aclose)
             else:
                 # A browser-less web client must not receive the autonomous
                 # writer/finish contract.  It can still use the durable
@@ -5936,6 +6005,10 @@ async def _handle_sessions_send_impl(
                     session_key=key,
                     attempts_remaining=_prompt_annotation_acceptance_retries,
                 )
+                authority_scope = _INGRESS_TURN_AUTHORITY_SCOPE.get()
+                if authority_scope is not None:
+                    await authority_scope.close_untransferred()
+                    authority_scope.authorities.clear()
                 return cast(
                     dict[Any, Any],
                     await _handle_sessions_send_impl(
@@ -6357,7 +6430,23 @@ async def _handle_sessions_send_impl(
             task = asyncio.create_task(_run_direct_turn())
             setattr(task, "_opensquilla_started", False)
             setattr(task, "_opensquilla_terminal_emitted", False)
-            direct_registry.register(key, task)
+            turn_authority = route_envelope.runtime_services.get(
+                "turn_authority_cleanup"
+            )
+            try:
+                direct_registry.register(
+                    key,
+                    task,
+                    terminal_cleanup=(
+                        turn_authority.aclose if turn_authority is not None else None
+                    ),
+                )
+            except BaseException:
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+                raise
+            if turn_authority is not None:
+                turn_authority.handoff()
             return acceptance
 
         try:
@@ -6592,7 +6681,23 @@ async def _handle_sessions_send_impl(
             task = asyncio.create_task(_run_direct_turn())
             setattr(task, "_opensquilla_started", False)
             setattr(task, "_opensquilla_terminal_emitted", False)
-            direct_registry.register(key, task)
+            turn_authority = route_envelope.runtime_services.get(
+                "turn_authority_cleanup"
+            )
+            try:
+                direct_registry.register(
+                    key,
+                    task,
+                    terminal_cleanup=(
+                        turn_authority.aclose if turn_authority is not None else None
+                    ),
+                )
+            except BaseException:
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+                raise
+            if turn_authority is not None:
+                turn_authority.handoff()
 
         await _emit_to_subscribers(
             ctx,

--- a/src/opensquilla/gateway/task_runtime.py
+++ b/src/opensquilla/gateway/task_runtime.py
@@ -387,9 +387,17 @@ def _reusable_route_envelope(envelope: RouteEnvelope) -> RouteEnvelope:
             "sandbox_run_context",
         ):
             metadata.pop(key, None)
+    runtime_services = dict(envelope.runtime_services)
+    for key in (
+        "desktop_artifact_bridge",
+        "turn_authority_cleanup",
+        "turn_cleanup_callbacks",
+    ):
+        runtime_services.pop(key, None)
     return replace(
         envelope,
         metadata=metadata,
+        runtime_services=runtime_services,
         sandbox_run_context_fresh=False,
     )
 
@@ -650,6 +658,7 @@ class _RuntimeTask:
     terminal_assistant_message_id: str | None = None
     terminal_assistant_message_content: str | None = None
     document_mutation_outcome: dict[str, Any] | None = None
+    turn_authority_cleanup: Any | None = field(default=None, repr=False)
     stream_event_sink: TaskStreamEventSink | None = None
     finalizer_completed: bool = False
     accepted_config: Any | None = None
@@ -789,6 +798,25 @@ def _cleanup_guest_profile(task: _RuntimeTask) -> None:
         guest_profile_root,
         managed_root=guest_managed_root,
     )
+
+
+async def _cleanup_turn_authority(task: _RuntimeTask) -> None:
+    """Release one task's process-local turn authority exactly once."""
+
+    authority = task.turn_authority_cleanup
+    if authority is None:
+        return
+    try:
+        await authority.aclose()
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # noqa: BLE001 - terminal cleanup must continue
+        log.warning(
+            "task_runtime.turn_authority_cleanup_failed",
+            task_id=task.task_id,
+            session_key=task.envelope.session_key,
+            exc_info=True,
+        )
 
 
 @dataclass(frozen=True)
@@ -1936,26 +1964,38 @@ class TaskRuntime:
     ) -> TaskHandle:
         """Persist and activate one direct enqueue without cancellation drift."""
 
-        reservation = await self.reserve(
-            envelope,
-            message,
-            attachments=attachments,
-            mode=mode,
-            run_kind=run_kind,
-            no_memory_capture=no_memory_capture,
-            ingress_pipeline_steps=ingress_pipeline_steps,
-            semantic_message=semantic_message,
-            persisted_user_message_id=persisted_user_message_id,
-            persisted_user_message_ids=persisted_user_message_ids,
-            message_count=message_count,
-            fresh_user_session=fresh_user_session,
-            stream_event_sink=stream_event_sink,
-            accepted_run_mode_override=accepted_run_mode_override,
-            task_id=task_id,
-            provider_request_correlation=provider_request_correlation,
-            update_envelope_cache=update_envelope_cache,
-            overflow_policy=overflow_policy,
+        turn_authority_cleanup = envelope.runtime_services.get(
+            "turn_authority_cleanup"
         )
+        try:
+            reservation = await self.reserve(
+                envelope,
+                message,
+                attachments=attachments,
+                mode=mode,
+                run_kind=run_kind,
+                no_memory_capture=no_memory_capture,
+                ingress_pipeline_steps=ingress_pipeline_steps,
+                semantic_message=semantic_message,
+                persisted_user_message_id=persisted_user_message_id,
+                persisted_user_message_ids=persisted_user_message_ids,
+                message_count=message_count,
+                fresh_user_session=fresh_user_session,
+                stream_event_sink=stream_event_sink,
+                accepted_run_mode_override=accepted_run_mode_override,
+                task_id=task_id,
+                provider_request_correlation=provider_request_correlation,
+                turn_authority_cleanup=turn_authority_cleanup,
+                update_envelope_cache=update_envelope_cache,
+                overflow_policy=overflow_policy,
+            )
+        except BaseException:
+            # Queue rejection and shutdown can happen before a reservation
+            # exists. Runtime admission still owns releasing any one-turn
+            # Desktop authority supplied to this enqueue operation.
+            if turn_authority_cleanup is not None:
+                await turn_authority_cleanup.aclose()
+            raise
         try:
             if self._accepted_config_provider is not None:
                 await self.freeze_acceptance(reservation)
@@ -1988,9 +2028,23 @@ class TaskRuntime:
             # activation in a fresh child; otherwise the reservation already owns
             # the live task and only the caller cancellation remains to propagate.
             if not reservation.activated:
-                await self._wait_for_task_settlement(
-                    asyncio.create_task(self.activate(reservation))
-                )
+                try:
+                    await self._wait_for_task_settlement(
+                        asyncio.create_task(self.activate(reservation))
+                    )
+                except BaseException:
+                    if not reservation.activated:
+                        await self._wait_for_task_settlement(
+                            asyncio.create_task(self.abort_reservation(reservation))
+                        )
+            raise
+        except BaseException:
+            # Activation may fail while capturing accepted configuration or
+            # before it registers the runtime task. The durable row does not
+            # retain one-turn Desktop authority, so release the inert
+            # reservation here; a post-boundary failure is owned by _execute.
+            if not reservation.activated:
+                await self.abort_reservation(reservation)
             raise
 
     @staticmethod
@@ -2028,6 +2082,7 @@ class TaskRuntime:
         *,
         task_id: str | None = None,
         provider_request_correlation: ProviderRequestCorrelation | None = None,
+        turn_authority_cleanup: Any | None = None,
         update_envelope_cache: bool = True,
         overflow_policy: PendingOverflowPolicy | str | None = None,
         bypass_pending_limit: bool = False,
@@ -2127,6 +2182,11 @@ class TaskRuntime:
             persisted_user_message_ids=normalized_message_ids,
             message_count=message_count,
             fresh_user_session=fresh_user_session,
+            turn_authority_cleanup=(
+                turn_authority_cleanup
+                if turn_authority_cleanup is not None
+                else envelope.runtime_services.get("turn_authority_cleanup")
+            ),
             stream_event_sink=stream_event_sink,
             accepted_run_mode_override=accepted_run_mode_override,
             provider_request_correlation=provider_request_correlation,
@@ -2247,6 +2307,9 @@ class TaskRuntime:
                 reservation
             )
             self._signal_driver_state_changed()
+        authority = runtime_task.turn_authority_cleanup
+        if authority is not None:
+            authority.handoff()
         try:
             runtime_task.envelope = _materialize_guest_task_envelope(
                 runtime_task.envelope,
@@ -2278,6 +2341,7 @@ class TaskRuntime:
                 )
             reservation.aborted = True
             self._signal_driver_state_changed()
+        await _cleanup_turn_authority(reservation.runtime_task)
         _cleanup_guest_profile(reservation.runtime_task)
 
     async def _emit_queued_activation(
@@ -4351,6 +4415,7 @@ class TaskRuntime:
         finally:
             self._user_input_broker.cancel_task(task.task_id)
             await self._settle_attached_plan_run(task)
+            await _cleanup_turn_authority(task)
             _cleanup_guest_profile(task)
 
     async def _freeze_collaboration_context(self, task: _RuntimeTask) -> None:
@@ -4486,7 +4551,9 @@ class TaskRuntime:
                 self._last_envelope_by_session.get(task.envelope.session_key)
                 is previous_envelope
             ):
-                self._last_envelope_by_session[task.envelope.session_key] = task.envelope
+                self._last_envelope_by_session[task.envelope.session_key] = (
+                    _reusable_route_envelope(task.envelope)
+                )
         if metadata["collaboration_mode"] == "plan":
             task.no_memory_capture = True
         plan_run = await self._start_attached_plan_run(task)
@@ -4504,7 +4571,9 @@ class TaskRuntime:
                     self._last_envelope_by_session.get(task.envelope.session_key)
                     is previous_envelope
                 ):
-                    self._last_envelope_by_session[task.envelope.session_key] = task.envelope
+                    self._last_envelope_by_session[task.envelope.session_key] = (
+                        _reusable_route_envelope(task.envelope)
+                    )
 
     async def _start_attached_plan_run(self, task: _RuntimeTask) -> Any | None:
         run_id = str(task.envelope.metadata.get("plan_run_id") or "").strip()
@@ -5902,6 +5971,7 @@ class TaskRuntime:
             # A driver cancelled before its first event-loop step never enters
             # ``_execute`` and therefore has no execution ``finally`` block.
             if not task.execution_started:
+                await _cleanup_turn_authority(task)
                 _cleanup_guest_profile(task)
         if not claimed:
             return

--- a/src/opensquilla/tools/builtin/document_browser.py
+++ b/src/opensquilla/tools/builtin/document_browser.py
@@ -32,6 +32,35 @@ _V4_BROWSER_CAPABILITIES = frozenset(
 )
 
 
+class DocumentBridgeToolError(SafeToolError):
+    """Sanitized bridge failure with loop-control metadata for dispatch."""
+
+    def __init__(
+        self,
+        user_message: str,
+        *,
+        category: str,
+        retry_policy: str,
+        next_action: str,
+        terminal_binding_loss: bool = False,
+    ) -> None:
+        super().__init__(user_message)
+        self.category = category
+        self.retry_policy = retry_policy
+        self.next_action = next_action
+        self.terminal_binding_loss = terminal_binding_loss
+
+
+def _terminal_preview_error(message: str) -> DocumentBridgeToolError:
+    return DocumentBridgeToolError(
+        message,
+        category="DOCUMENT_PREVIEW_UNAVAILABLE",
+        retry_policy="new_turn",
+        next_action="finalize_without_tools",
+        terminal_binding_loss=True,
+    )
+
+
 def _json(payload: object) -> str:
     return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
 
@@ -39,7 +68,7 @@ def _json(payload: object) -> str:
 def _ctx() -> Any:
     context = current_tool_context.get()
     if context is None:
-        raise SafeToolError(
+        raise _terminal_preview_error(
             "DOCUMENT_BROWSER_UNAVAILABLE: No bound document preview is available."
         )
     surfaced = getattr(context, "surfaced_tools", None)
@@ -53,7 +82,7 @@ def _ctx() -> Any:
             "document_browser_reload",
         )
     ):
-        raise SafeToolError(
+        raise _terminal_preview_error(
             "DOCUMENT_BROWSER_UNAVAILABLE: Browser tools are not authorized for this turn."
         )
     if surfaced is not None and not any(
@@ -65,12 +94,12 @@ def _ctx() -> Any:
             "document_browser_reload",
         )
     ):
-        raise SafeToolError(
+        raise _terminal_preview_error(
             "DOCUMENT_BROWSER_UNAVAILABLE: Browser tools are not authorized for this turn."
         )
     bridge = getattr(context, "desktop_artifact_bridge", None)
     if bridge is None:
-        raise SafeToolError(
+        raise _terminal_preview_error(
             "DOCUMENT_BROWSER_UNAVAILABLE: The bound desktop preview is unavailable."
         )
     return context
@@ -90,7 +119,7 @@ async def _capability(context: Any, name: str) -> None:
     try:
         value = await capabilities()
     except Exception as exc:  # noqa: BLE001 - never expose transport details
-        raise SafeToolError(
+        raise _terminal_preview_error(
             "DOCUMENT_BROWSER_UNAVAILABLE: The bound desktop preview is unavailable."
         ) from exc
     # Browser inspection/action is intentionally a protocol-v4 capability.
@@ -103,7 +132,7 @@ async def _capability(context: Any, name: str) -> None:
         if raw_version is None and isinstance(value, Mapping):
             raw_version = value.get("version")
         if isinstance(raw_version, bool) or not isinstance(raw_version, int) or raw_version < 4:
-            raise SafeToolError(
+            raise _terminal_preview_error(
                 "DOCUMENT_BROWSER_UNAVAILABLE: Protocol-v4 bound preview is required."
             )
     # The in-process bridge client exposes snake_case dataclass fields, while
@@ -125,7 +154,7 @@ async def _capability(context: Any, name: str) -> None:
         else any(getattr(value, alias, False) is True for alias in names)
     )
     if not bool(advertised):
-        raise SafeToolError(
+        raise _terminal_preview_error(
             f"DOCUMENT_BROWSER_UNAVAILABLE: The preview does not support {name}."
         )
 
@@ -136,9 +165,33 @@ def _bridge_error(exc: BaseException, operation: str) -> SafeToolError:
     # source-only repair or finish(discard).
     code = str(getattr(exc, "code", "failed") or "failed")
     safe_code = "".join(ch for ch in code.upper() if ch.isalnum() or ch == "_")[:48]
-    return SafeToolError(
-        f"DOCUMENT_BROWSER_{operation.upper()}_{safe_code or 'FAILED'}: "
-        "The bound preview operation did not complete."
+    normalized_code = code.strip().lower().replace("_", "-")
+    terminal_binding_loss = normalized_code in {
+        "binding-terminal-unavailable",
+        "binding-unavailable",
+        "transport-unavailable",
+        "unavailable",
+    }
+    action_result_unknown = normalized_code == "action-result-unknown"
+    category = (
+        "DOCUMENT_PREVIEW_UNAVAILABLE"
+        if terminal_binding_loss
+        else "DOCUMENT_ACTION_RESULT_UNKNOWN"
+        if action_result_unknown
+        else f"DOCUMENT_BROWSER_{operation.upper()}_{safe_code or 'FAILED'}"
+    )
+    return DocumentBridgeToolError(
+        f"{category}: The bound preview operation did not complete.",
+        category=category,
+        retry_policy="new_turn" if terminal_binding_loss else "same_turn",
+        next_action=(
+            "finalize_without_tools"
+            if terminal_binding_loss
+            else "reinspect"
+            if action_result_unknown
+            else "retry"
+        ),
+        terminal_binding_loss=terminal_binding_loss,
     )
 
 
@@ -181,7 +234,7 @@ async def _assert_candidate_preview_identity(context: Any, *, operation: str) ->
         return None
     expected_candidate_handle = getattr(controller, "preview_handle", None)
     if not isinstance(expected_candidate_handle, str):
-        raise SafeToolError(
+        raise _terminal_preview_error(
             "DOCUMENT_BROWSER_PREVIEW_UNAVAILABLE: The candidate preview handle is unavailable."
         )
     await _capability(context, "browser_inspect")
@@ -297,6 +350,7 @@ async def _invalidate_candidate_verification(context: Any, *, reason: str) -> No
 
     setattr(context, "_artifact_browser_verification_token", None)
     setattr(context, "_artifact_browser_verification_sha256", None)
+    setattr(context, "_artifact_browser_binding_generation", None)
     controller = getattr(context, "artifact_candidate_loop_controller", None)
     invalidate = getattr(controller, "invalidate_verification", None)
     if callable(invalidate):
@@ -381,7 +435,7 @@ async def document_browser_inspect(
         else None
     )
     if candidate_is_staged and not isinstance(candidate_handle, str):
-        raise SafeToolError(
+        raise _terminal_preview_error(
             "DOCUMENT_BROWSER_PREVIEW_UNAVAILABLE: The candidate preview handle is unavailable."
         )
     try:
@@ -401,7 +455,7 @@ async def document_browser_inspect(
     )
     if candidate_is_staged:
         if not bool(getattr(context, "_artifact_candidate_preview_bound", False)):
-            raise SafeToolError(
+            raise _terminal_preview_error(
                 "DOCUMENT_BROWSER_PREVIEW_UNAVAILABLE: The current Electron client "
                 "cannot bind this candidate preview."
             )
@@ -425,6 +479,19 @@ async def document_browser_inspect(
                 "the current candidate; inspect the current candidate again."
             )
         sha256 = candidate_sha256
+    binding_generation = getattr(snapshot, "binding_generation", None)
+    if candidate_is_staged and (
+        isinstance(binding_generation, bool)
+        or not isinstance(binding_generation, int)
+        or binding_generation < 1
+    ):
+        await _invalidate_candidate_verification(
+            context,
+            reason="browser_binding_generation_unavailable",
+        )
+        raise SafeToolError(
+            "DOCUMENT_BROWSER_VERIFICATION_STALE: The preview binding changed; inspect again."
+        )
     nodes = [
         {
             "anchor": node.anchor,
@@ -444,6 +511,7 @@ async def document_browser_inspect(
         "generation": generation,
         "revisionId": revision_id,
         "candidateEpoch": candidate_epoch,
+        "bindingGeneration": binding_generation,
     }
     token = _new_verification_token(sha256=sha256, payload=receipt_payload)
     # ToolContext is intentionally process-local and not serialized.  Keeping
@@ -451,6 +519,7 @@ async def document_browser_inspect(
     # adding a public token store or a database migration.
     setattr(context, "_artifact_browser_verification_token", token)
     setattr(context, "_artifact_browser_verification_sha256", sha256)
+    setattr(context, "_artifact_browser_binding_generation", binding_generation)
     if candidate_controller is not None and candidate_is_staged and sha256 is not None:
         try:
             await candidate_controller.record_verification(
@@ -487,6 +556,11 @@ async def _final_browser_health_check(context: Any, expected_sha256: str) -> str
     model's immediately preceding inspect result.
     """
 
+    expected_binding_generation = getattr(
+        context,
+        "_artifact_browser_binding_generation",
+        None,
+    )
     try:
         raw = await document_browser_inspect(scope="document", maxNodes=1)
         payload = json.loads(raw)
@@ -502,13 +576,23 @@ async def _final_browser_health_check(context: Any, expected_sha256: str) -> str
         )
     candidate_sha = payload.get("candidateSha256")
     token = payload.get("verificationToken")
+    fresh_binding_generation = getattr(
+        context,
+        "_artifact_browser_binding_generation",
+        None,
+    )
     if (
         payload.get("status") != "verification_passed"
         or not isinstance(candidate_sha, str)
         or candidate_sha.lower() != expected_sha256.lower()
         or not isinstance(token, str)
         or not re.fullmatch(_TOKEN_RE, token)
+        or expected_binding_generation != fresh_binding_generation
     ):
+        await _invalidate_candidate_verification(
+            context,
+            reason="finish_binding_generation_stale",
+        )
         raise SafeToolError(
             "DOCUMENT_FINISH_VERIFICATION_STALE: The candidate changed; inspect again."
         )
@@ -988,6 +1072,7 @@ async def document_finish(
         setattr(context, "_artifact_candidate_preview_cleanup_pending", restore_pending)
         setattr(context, "_artifact_browser_verification_token", None)
         setattr(context, "_artifact_browser_verification_sha256", None)
+        setattr(context, "_artifact_browser_binding_generation", None)
         # Native restore deliberately retains its opaque handle when the
         # Gateway release fails, so a later cleanup pass can retry.  Retiring
         # the Gateway mapping here would make that retry impossible (the
@@ -1016,7 +1101,7 @@ async def document_finish(
             "DOCUMENT_FINISH_VERIFICATION_REQUIRED: Commit requires a fresh verification token."
         )
     if not bool(getattr(context, "_artifact_candidate_preview_bound", False)):
-        raise SafeToolError(
+        raise _terminal_preview_error(
             "DOCUMENT_FINISH_PREVIEW_UNAVAILABLE: The candidate preview is not bound "
             "to the active Electron surface."
         )
@@ -1078,6 +1163,7 @@ async def document_finish(
         setattr(context, "_artifact_candidate_preview_cleanup_pending", not restored)
         setattr(context, "_artifact_browser_verification_token", None)
         setattr(context, "_artifact_browser_verification_sha256", None)
+        setattr(context, "_artifact_browser_binding_generation", None)
         if restored:
             _retire_candidate_preview(context, controller)
         else:

--- a/src/opensquilla/tools/dispatch.py
+++ b/src/opensquilla/tools/dispatch.py
@@ -1791,6 +1791,7 @@ async def _candidate_loop_effect_result(
         if context is not None:
             setattr(context, "_artifact_browser_verification_token", None)
             setattr(context, "_artifact_browser_verification_sha256", None)
+            setattr(context, "_artifact_browser_binding_generation", None)
         if callable(invalidate):
             try:
                 await invalidate(reason="candidate_loop_operation")
@@ -1834,32 +1835,42 @@ async def _candidate_loop_effect_result(
         )
     if candidate_preview_unavailable:
         # Without a bindable preview the candidate can never produce the
-        # verification receipt required by document_finish(commit).  Keep the
-        # lifecycle tool available so the model remains responsible for the
-        # explicit discard decision; a plain-text stop is nudged back into the
-        # loop, while the global deadline/cost/call fuses still reject an
-        # abandoned draft during turn cleanup.
+        # verification receipt required by document_finish(commit). End the
+        # tool loop immediately; the turn finalizer rejects the staged draft.
+        result.content = json.dumps(
+            {
+                "status": "error",
+                "category": "DOCUMENT_PREVIEW_UNAVAILABLE",
+                "message_key": "document.previewUnavailable",
+                "retry_policy": "new_turn",
+                "next_action": "finalize_without_tools",
+                "retry_allowed": False,
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        result.is_error = True
         result.effect_outcome = ToolEffectOutcome(
-            effect_state="started",
-            retry_policy="same_turn",
-            loop_action="continue",
+            effect_state="none",
+            retry_policy="new_turn",
+            loop_action="finalize_without_tools",
             outcome_code="document_preview_unavailable",
             safe_details={
                 "documentMutationOutcome": {
                     "version": 1,
                     "status": "not_applied",
                     "phase": "candidate",
-                    "retryPolicy": "same_turn",
+                    "retryPolicy": "new_turn",
                     "code": "document_preview_unavailable",
                 }
             },
         )
         _set_mutation_payload_control(
             result,
-            retry_policy="same_turn",
+            retry_policy="new_turn",
             outcome_code="document_preview_unavailable",
         )
-        result.terminates_turn = False
+        result.terminates_turn = True
         result.terminal_response_text = None
         return result
     # The ordinary tool-run budget is a global circuit breaker, not a model
@@ -1910,38 +1921,58 @@ async def _candidate_loop_effect_result(
     payload_retry_disallowed = (
         isinstance(payload, dict) and payload.get("retry_allowed") is False
     )
+    bridge_category = str(getattr(exception, "category", "") or "")
+    bridge_retry_policy = str(getattr(exception, "retry_policy", "") or "")
+    bridge_next_action = str(getattr(exception, "next_action", "") or "")
+    if bridge_category:
+        result.content = json.dumps(
+            {
+                "status": "error",
+                "category": bridge_category,
+                "message_key": (
+                    "document.previewUnavailable"
+                    if getattr(exception, "terminal_binding_loss", False) is True
+                    else "document.actionResultUnknown"
+                    if bridge_category == "DOCUMENT_ACTION_RESULT_UNKNOWN"
+                    else "document.editFailed"
+                ),
+                "retry_policy": bridge_retry_policy or "same_turn",
+                "next_action": bridge_next_action or "retry",
+                "retry_allowed": bridge_retry_policy != "new_turn",
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        result.is_error = True
     browser_preview_unavailable = (
         tool_call.tool_name.startswith("document_browser_")
-        and (
-            "DOCUMENT_BROWSER_UNAVAILABLE" in result.content
-            or "DOCUMENT_BROWSER_PREVIEW_UNAVAILABLE" in result.content
-        )
+        and getattr(exception, "terminal_binding_loss", False) is True
     )
     if browser_preview_unavailable:
-        # A missing/v3 bridge cannot be repaired by another browser iteration,
-        # but it is still the model's decision to abandon the candidate.  Feed
-        # the failure back with document_finish(discard) still available.
+        # A terminal binding loss cannot be repaired by another browser
+        # iteration. Close the tool loop after the first failure; turn cleanup
+        # safely discards any uncommitted candidate.
         result.effect_outcome = ToolEffectOutcome(
             effect_state="none",
-            retry_policy="same_turn",
-            loop_action="continue",
+            retry_policy="new_turn",
+            loop_action="finalize_without_tools",
             outcome_code="document_preview_unavailable",
             safe_details={
                 "documentMutationOutcome": {
                     "version": 1,
                     "status": "not_applied",
                     "phase": "verification",
-                    "retryPolicy": "same_turn",
+                    "retryPolicy": "new_turn",
                     "code": "document_preview_unavailable",
                 }
             },
         )
         _set_mutation_payload_control(
             result,
-            retry_policy="same_turn",
+            retry_policy="new_turn",
             outcome_code="document_preview_unavailable",
         )
-        result.terminates_turn = False
+        result.terminates_turn = True
         result.terminal_response_text = None
         return result
     durable_ambiguous = _candidate_finish_is_ambiguous(

--- a/src/opensquilla/tools/types.py
+++ b/src/opensquilla/tools/types.py
@@ -225,7 +225,7 @@ class ToolContext:
     # Process-local authority cleanup registered by ingress/runtime adapters.
     # The shared Agent turn boundary invokes these callbacks on every terminal
     # path without importing feature-specific tool implementations.
-    turn_cleanup_callbacks: list[Callable[[], None]] = field(
+    turn_cleanup_callbacks: list[Callable[[], Any]] = field(
         default_factory=list,
         repr=False,
     )

--- a/tests/fixtures/skill_profile_lease_worker.py
+++ b/tests/fixtures/skill_profile_lease_worker.py
@@ -81,14 +81,12 @@ class _OfflineSource(SkillSource):
         return SkillMeta(name=identifier, source_id=self.source_id)
 
 
-def _hold_profile_lease(profile_home: Path, ready: Path, release: Path) -> None:
+def _hold_profile_lease(profile_home: Path, ready: Path) -> None:
     with ProfileOperationLock(profile_home):
         ready.write_text("ready", encoding="utf-8")
-        deadline = time.monotonic() + 15.0
-        while not release.exists():
-            if time.monotonic() >= deadline:
-                os._exit(_HOLDER_TIMEOUT_EXIT_CODE)
-            time.sleep(0.01)
+        # The parent owns the write end. A deliberate close releases the lease,
+        # and an abnormal parent exit produces EOF without a fixture deadline.
+        sys.stdin.buffer.read(1)
 
 
 def _offline_install(
@@ -175,7 +173,7 @@ def _probe_unleased_build_services(
 def main() -> None:
     mode = sys.argv[1]
     if mode == "hold":
-        _hold_profile_lease(Path(sys.argv[2]), Path(sys.argv[3]), Path(sys.argv[4]))
+        _hold_profile_lease(Path(sys.argv[2]), Path(sys.argv[3]))
         return
     if mode == "install":
         _offline_install(

--- a/tests/functional/test_gateway_stop_process_tree_e2e.py
+++ b/tests/functional/test_gateway_stop_process_tree_e2e.py
@@ -101,13 +101,21 @@ class _StopProvider:
                 "time.sleep(30)\n",
                 encoding="utf-8",
             )
+            # Keep the long-lived descendant in the same process tree without
+            # retaining the leader's asyncio pipes. On Windows, Process.wait()
+            # does not finish its transport until inherited pipes disconnect.
             parent_script.write_text(
                 "import pathlib\n"
                 "import subprocess\n"
                 "import sys\n"
                 "import time\n"
                 f"child_pid = pathlib.Path({str(child_pid)!r})\n"
-                f"subprocess.Popen([sys.executable, {str(child_script)!r}])\n"
+                "subprocess.Popen(\n"
+                f"    [sys.executable, {str(child_script)!r}],\n"
+                "    stdin=subprocess.DEVNULL,\n"
+                "    stdout=subprocess.DEVNULL,\n"
+                "    stderr=subprocess.DEVNULL,\n"
+                ")\n"
                 "deadline = time.monotonic() + 10\n"
                 "while not child_pid.exists() and time.monotonic() < deadline:\n"
                 "    time.sleep(0.05)\n"
@@ -176,8 +184,6 @@ class _StopProvider:
                     break
             if wait_result is None or wait_result.get("exited") is not True:
                 raise AssertionError("process wait did not confirm direct leader exit")
-            (self.evidence_dir / "leader-terminal").write_text("confirmed")
-            (self.evidence_dir / "provider-blocked").write_text("ready")
             while True:
                 await asyncio.sleep(1)
         yield TextDeltaEvent(text="NEXT_TASK_OK")
@@ -435,6 +441,9 @@ async def test_stop_kills_leaderless_descendant_and_gateway_accepts_next_task(
     )
     client = GatewayClient()
     first_frames: list[dict[str, Any]] = []
+    leader_wait_result: asyncio.Future[dict[str, Any]] = (
+        asyncio.get_running_loop().create_future()
+    )
     descendant_identity: tuple[str, int] | None = None
     try:
         await _wait_for_health(port, process, gateway_log)
@@ -444,14 +453,26 @@ async def test_stop_kills_leaderless_descendant_and_gateway_accepts_next_task(
         async def consume_first() -> None:
             async for frame in client.send_message(session_key, "start owned process"):
                 first_frames.append(frame)
+                if (
+                    frame.get("event") == "session.event.tool_result"
+                    and frame.get("tool_use_id") == "wait-background-leader-1"
+                    and not leader_wait_result.done()
+                ):
+                    leader_wait_result.set_result(frame)
 
         first_turn = asyncio.create_task(consume_first())
         await _wait_for_file(evidence / "child.pid")
         descendant_identity = _open_process_liveness(
             int((evidence / "child.pid").read_text(encoding="utf-8"))
         )
-        await _wait_for_file(evidence / "leader-terminal")
-        await _wait_for_file(evidence / "provider-blocked")
+        wait_frame = await asyncio.wait_for(
+            asyncio.shield(leader_wait_result),
+            timeout=10.0,
+        )
+        wait_payload = json.loads(str(wait_frame.get("result", "")))
+        assert wait_frame.get("is_error") is False
+        assert wait_payload.get("action") == "wait"
+        assert wait_payload.get("exited") is True
         task_id = client._active_turn_ids[session_key]
         stopped = await client.call(
             "chat.abort",

--- a/tests/test_gateway/test_agent_tasks.py
+++ b/tests/test_gateway/test_agent_tasks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -148,3 +149,43 @@ async def test_quiesce_sessions_drains_replaced_task_cancellation_tail() -> None
             if not task.done():
                 task.cancel()
         await asyncio.gather(first, replacement, quiescing, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_quiesce_sessions_waits_for_direct_task_authority_cleanup_once() -> None:
+    registry = AgentTaskRegistry()
+    session_key = "agent:main:webchat:registry-authority-cleanup"
+    task_started = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+    quiesce_entered = asyncio.Event()
+    async def direct_task() -> None:
+        task_started.set()
+        await asyncio.Event().wait()
+
+    async def terminal_cleanup_impl() -> None:
+        cleanup_started.set()
+        await release_cleanup.wait()
+
+    terminal_cleanup = AsyncMock(side_effect=terminal_cleanup_impl)
+    task = asyncio.create_task(direct_task())
+    registry.register(
+        session_key,
+        task,
+        terminal_cleanup=terminal_cleanup,
+    )
+    await task_started.wait()
+
+    async def quiesce() -> None:
+        async with registry.quiesce_sessions([session_key]):
+            quiesce_entered.set()
+
+    quiescing = asyncio.create_task(quiesce())
+    await cleanup_started.wait()
+    assert terminal_cleanup.await_count == 1
+    assert quiesce_entered.is_set() is False
+
+    release_cleanup.set()
+    await asyncio.gather(quiescing)
+    assert quiesce_entered.is_set()
+    terminal_cleanup.assert_awaited_once_with()

--- a/tests/test_gateway/test_desktop_artifact_bridge.py
+++ b/tests/test_gateway/test_desktop_artifact_bridge.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 from typing import Any
@@ -12,6 +13,7 @@ from opensquilla.gateway.desktop_artifact_bridge import (
     DESKTOP_ARTIFACT_BRIDGE_URL_ENV,
     DesktopArtifactBridgeClient,
     DesktopArtifactBridgeError,
+    TurnAuthorityCleanup,
     desktop_artifact_bridge_client_from_environment,
     desktop_artifact_bridge_token_valid,
 )
@@ -112,6 +114,184 @@ def _install_response_sequence(
 
     monkeypatch.setattr(bridge_module.http.client, "HTTPConnection", connection_factory)
     return calls
+
+
+@pytest.mark.asyncio
+async def test_v5_binding_is_opaque_bound_and_released_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binding_token = base64.urlsafe_b64encode(bytes(reversed(range(32)))).rstrip(b"=").decode()
+    capabilities = {
+        "version": 5,
+        "available": True,
+        "captureSelection": False,
+        "resolveAnnotationSelection": True,
+        "focusAnnotation": True,
+        "browserInspect": True,
+        "browserAct": True,
+        "screenshot": True,
+        "officeFlush": False,
+        "reloadSurface": True,
+        "bindCandidatePreview": True,
+        "restoreCanonicalPreview": True,
+    }
+    advertised_capabilities = {**capabilities, "browserAct": False}
+    calls = _install_response_sequence(monkeypatch, [
+        {"ok": True, "value": advertised_capabilities},
+        {
+            "ok": True,
+            "value": {
+                "version": 5,
+                "bindingToken": binding_token,
+                "capabilities": capabilities,
+            },
+        },
+        {"ok": True, "method": "reloadSurface", "value": {"reloaded": True}},
+        {"ok": True, "value": {"released": True}},
+    ])
+    client = DesktopArtifactBridgeClient(endpoint="http://127.0.0.1:4321", token=_token())
+
+    bound = await client.acquire_binding()
+    assert bound is not None
+    assert (await bound.capabilities()).browser_act is True
+    assert await bound.reload_surface() is True
+    await bound.aclose()
+    await bound.aclose()
+
+    requests = [json.loads(call["body"]) for call in calls if call.get("method") == "POST"]
+    assert requests[0] == {"version": 5}
+    assert requests[1] == {"version": 5}
+    assert requests[2]["bindingToken"] == binding_token
+    assert requests[2]["version"] == 5
+    assert requests[3] == {"version": 5, "bindingToken": binding_token}
+    assert len(requests) == 4
+    assert binding_token not in repr(bound)
+
+
+@pytest.mark.asyncio
+async def test_process_scoped_client_keeps_unbound_invocations_on_v4_after_v5_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binding_token = base64.urlsafe_b64encode(bytes(reversed(range(32)))).rstrip(b"=").decode()
+    capabilities = {
+        "version": 5,
+        "available": True,
+        "captureSelection": False,
+        "resolveAnnotationSelection": True,
+        "focusAnnotation": True,
+        "browserInspect": True,
+        "browserAct": True,
+        "screenshot": True,
+        "officeFlush": False,
+        "reloadSurface": True,
+        "bindCandidatePreview": True,
+        "restoreCanonicalPreview": True,
+    }
+    calls = _install_response_sequence(
+        monkeypatch,
+        [
+            {"ok": True, "value": capabilities},
+            {
+                "ok": True,
+                "value": {
+                    "version": 5,
+                    "bindingToken": binding_token,
+                    "capabilities": capabilities,
+                },
+            },
+            {"ok": True, "method": "reloadSurface", "value": {"reloaded": True}},
+            {"ok": True, "value": {"released": True}},
+        ],
+    )
+    client = DesktopArtifactBridgeClient(
+        endpoint="http://127.0.0.1:4321",
+        token=_token(),
+    )
+
+    bound = await client.acquire_binding()
+    assert bound is not None
+    assert await client.reload_surface() is True
+    await bound.aclose()
+
+    requests = [json.loads(call["body"]) for call in calls if call.get("method") == "POST"]
+    assert requests[2] == {
+        "version": 4,
+        "method": "reloadSurface",
+        "request": {"version": 4},
+    }
+    assert "bindingToken" not in requests[2]
+
+
+@pytest.mark.asyncio
+async def test_v5_acquire_validation_failure_releases_new_binding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binding_token = base64.urlsafe_b64encode(bytes(reversed(range(32)))).rstrip(b"=").decode()
+    capabilities = {
+        "version": 5,
+        "available": True,
+        "captureSelection": False,
+        "resolveAnnotationSelection": True,
+        "focusAnnotation": True,
+        "browserInspect": True,
+        "browserAct": True,
+        "screenshot": True,
+        "officeFlush": False,
+        "reloadSurface": True,
+        "bindCandidatePreview": True,
+        "restoreCanonicalPreview": True,
+    }
+    calls = _install_response_sequence(
+        monkeypatch,
+        [
+            {"ok": True, "value": capabilities},
+            {
+                "ok": True,
+                "value": {
+                    "version": 5,
+                    "bindingToken": binding_token,
+                    "capabilities": {**capabilities, "browserInspect": "invalid"},
+                },
+            },
+            {"ok": True, "value": {"released": True}},
+        ],
+    )
+    client = DesktopArtifactBridgeClient(
+        endpoint="http://127.0.0.1:4321",
+        token=_token(),
+    )
+
+    with pytest.raises(DesktopArtifactBridgeError, match="inspection capability"):
+        await client.acquire_binding()
+
+    requests = [json.loads(call["body"]) for call in calls if call.get("method") == "POST"]
+    assert requests[-1] == {"version": 5, "bindingToken": binding_token}
+
+
+@pytest.mark.asyncio
+async def test_turn_authority_cleanup_is_cancellation_safe_and_exactly_once() -> None:
+    started = asyncio.Event()
+    finish = asyncio.Event()
+    calls = 0
+
+    async def release() -> None:
+        nonlocal calls
+        calls += 1
+        started.set()
+        await finish.wait()
+
+    cleanup = TurnAuthorityCleanup(release)
+    first = asyncio.create_task(cleanup.aclose())
+    second = asyncio.create_task(cleanup.aclose())
+    await started.wait()
+    first.cancel()
+    finish.set()
+
+    results = await asyncio.gather(first, second, return_exceptions=True)
+    assert isinstance(results[0], asyncio.CancelledError)
+    assert results[1] is None
+    await cleanup.aclose()
+    assert calls == 1
 
 
 def test_environment_requires_desktop_and_exact_ipv4_loopback() -> None:

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -2932,9 +2932,13 @@ class TestSessionsSend:
             append_called.set()
             return await original_append(*args, **kwargs)
 
-        def observed_register(session_key: str, task: asyncio.Task) -> None:
+        def observed_register(
+            session_key: str,
+            task: asyncio.Task,
+            **kwargs: Any,
+        ) -> None:
             assert admission_active is True
-            original_register(session_key, task)
+            original_register(session_key, task, **kwargs)
 
         monkeypatch.setattr(registry, "admission", observed_admission)
         monkeypatch.setattr(registry, "register", observed_register)

--- a/tests/test_gateway/test_task_runtime_terminal_cleanup.py
+++ b/tests/test_gateway/test_task_runtime_terminal_cleanup.py
@@ -28,6 +28,7 @@ from opensquilla.engine.runtime import TurnRunner
 from opensquilla.gateway import task_runtime
 from opensquilla.gateway.auth import Principal
 from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.desktop_artifact_bridge import TurnAuthorityCleanup
 from opensquilla.gateway.routing import (
     RouteEnvelope,
     SourceKind,
@@ -107,6 +108,101 @@ def _make_storage() -> Any:
     storage.update_transcript_turn_context = update_turn_context
     storage.turn_context_updates = turn_context_updates
     return storage
+
+
+def _authority_envelope(
+    authority: TurnAuthorityCleanup,
+    session_key: str,
+) -> RouteEnvelope:
+    return replace(
+        _make_envelope(session_key),
+        runtime_services={
+            "desktop_artifact_bridge": object(),
+            "turn_authority_cleanup": authority,
+            "turn_cleanup_callbacks": [authority.aclose],
+            "durable_service": "kept",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_turn_authority_cleanup_runs_once_on_success_and_reservation_abort() -> None:
+    success_calls = 0
+    abort_calls = 0
+
+    async def release_success() -> None:
+        nonlocal success_calls
+        success_calls += 1
+
+    async def release_abort() -> None:
+        nonlocal abort_calls
+        abort_calls += 1
+
+    success_authority = TurnAuthorityCleanup(release_success)
+    runtime = _make_runtime()
+    success = await runtime.enqueue(
+        _authority_envelope(success_authority, "agent:main:webchat:authority-success"),
+        "success",
+    )
+    await runtime.wait(success.task_id, timeout=2.0)
+
+    abort_authority = TurnAuthorityCleanup(release_abort)
+    reservation = await runtime.reserve(
+        _authority_envelope(abort_authority, "agent:main:webchat:authority-abort"),
+        "abort",
+    )
+    await runtime.abort_reservation(reservation)
+    await runtime.abort_reservation(reservation)
+    await runtime.shutdown()
+
+    assert success_calls == 1
+    assert abort_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_turn_authority_cleanup_runs_once_when_activation_fails_before_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release_calls = 0
+
+    async def release() -> None:
+        nonlocal release_calls
+        release_calls += 1
+
+    runtime = _make_runtime()
+    authority = TurnAuthorityCleanup(release)
+
+    async def fail_activation(_reservation: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError("synthetic pre-boundary activation failure")
+
+    monkeypatch.setattr(runtime, "activate", fail_activation)
+
+    with pytest.raises(RuntimeError, match="pre-boundary activation failure"):
+        await runtime.enqueue(
+            _authority_envelope(
+                authority,
+                "agent:main:webchat:authority-activation-failure",
+            ),
+            "activation failure",
+        )
+
+    await authority.aclose()
+    await runtime.shutdown()
+
+    assert release_calls == 1
+    assert runtime._reservations_by_session == {}
+
+
+def test_reusable_route_envelope_strips_all_turn_authority() -> None:
+    async def release() -> None:
+        return None
+
+    authority = TurnAuthorityCleanup(release)
+    reusable = task_runtime._reusable_route_envelope(
+        _authority_envelope(authority, "agent:main:webchat:authority-cache")
+    )
+
+    assert reusable.runtime_services == {"durable_service": "kept"}
 
 
 def _make_runtime(

--- a/tests/test_live_long_task_case_driver.py
+++ b/tests/test_live_long_task_case_driver.py
@@ -780,6 +780,106 @@ def test_stop_count_requires_durable_webui_stop_outcomes() -> None:
     assert count == 1
 
 
+def test_terminal_history_evidence_waits_for_durable_assistant_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observations = iter(
+        [
+            (0, 0, 0, 0),
+            (18, 1, 0, 0),
+        ]
+    )
+    calls = 0
+
+    async def history_evidence(
+        _client: object,
+        *,
+        session_key: str,
+        assistant_marker: str,
+        user_marker: str = "",
+    ) -> tuple[int, int, int, int]:
+        nonlocal calls
+        calls += 1
+        assert session_key == "agent:main:webchat:synthetic"
+        assert assistant_marker == "synthetic complete"
+        assert user_marker == ""
+        return next(observations)
+
+    monkeypatch.setattr(driver, "_history_evidence", history_evidence)
+
+    class Client:
+        recv_calls = 0
+
+        async def recv_event(self, *, timeout: float) -> dict[str, object]:
+            self.recv_calls += 1
+            assert timeout > 0
+            return {"event": "history-settle"}
+
+    class Observation:
+        frames: list[dict[str, object]] = []
+
+        def consume(self, frame: dict[str, object]) -> None:
+            self.frames.append(frame)
+
+    client = Client()
+    observation = Observation()
+
+    result = asyncio.run(
+        driver._wait_for_assistant_history_evidence(
+            client,
+            observation,
+            session_key="agent:main:webchat:synthetic",
+            assistant_marker="synthetic complete",
+            deadline=driver.time.monotonic() + 1.0,
+        )
+    )
+
+    assert result == (18, 1, 0, 0)
+    assert calls == 2
+    assert client.recv_calls == 1
+    assert observation.frames == [{"event": "history-settle"}]
+
+
+def test_terminal_history_evidence_does_not_extend_case_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    async def history_evidence(
+        _client: object,
+        *,
+        session_key: str,
+        assistant_marker: str,
+        user_marker: str = "",
+    ) -> tuple[int, int, int, int]:
+        nonlocal calls
+        calls += 1
+        return (0, 0, 0, 0)
+
+    monkeypatch.setattr(driver, "_history_evidence", history_evidence)
+
+    class Client:
+        async def recv_event(self, *, timeout: float) -> dict[str, object]:
+            raise AssertionError(f"expired deadline waited for {timeout}")
+
+    class Observation:
+        def consume(self, frame: dict[str, object]) -> None:
+            raise AssertionError(f"expired deadline consumed {frame}")
+
+    result = asyncio.run(
+        driver._wait_for_assistant_history_evidence(
+            Client(),
+            Observation(),
+            session_key="agent:main:webchat:synthetic",
+            assistant_marker="synthetic complete",
+            deadline=driver.time.monotonic(),
+        )
+    )
+
+    assert result == (0, 0, 0, 0)
+    assert calls == 1
+
+
 def test_runtime_failure_preserves_physical_usage_and_cost_budget_evidence(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_skills/test_hub_management_service.py
+++ b/tests/test_skills/test_hub_management_service.py
@@ -2504,7 +2504,10 @@ async def test_rejected_drifted_reinstall_does_not_reload_or_advance_catalog(
     assert result.lifecycle.install_state.value == "drifted"
     assert loader.snapshot() is snapshot
     assert loader.snapshot().generation == snapshot.generation
-    current = loader.get_by_name("example-skill")
+    # get_by_name() may run its compatibility filesystem probe after 250 ms.
+    # Inspect the already-pinned live snapshot so scheduler delay cannot turn
+    # this transaction assertion into a separate external-drift refresh.
+    current = next(skill for skill in snapshot.skills if skill.name == "example-skill")
     assert current is published
     assert "Local drift." not in current.content
 

--- a/tests/test_skills/test_hub_transaction_process_gates.py
+++ b/tests/test_skills/test_hub_transaction_process_gates.py
@@ -180,6 +180,16 @@ def _wait_for_file(path: Path, process: subprocess.Popen[bytes]) -> None:
         time.sleep(0.01)
 
 
+def _release_lease_holder(process: subprocess.Popen[bytes]) -> None:
+    assert process.stdin is not None
+    process.stdin.close()
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+
+
 def test_gateway_profile_lease_blocks_offline_process_then_allows_install(
     tmp_path: Path,
 ) -> None:
@@ -189,7 +199,6 @@ def test_gateway_profile_lease_blocks_offline_process_then_allows_install(
     lockfile = profile_home / "skills-lock.json"
     journal = profile_home / "state" / "skill-transaction.json"
     ready = tmp_path / "lease-ready"
-    release = tmp_path / "lease-release"
     installed = tmp_path / "installed"
     environment = _worker_environment(state_root)
     holder = subprocess.Popen(
@@ -199,9 +208,9 @@ def test_gateway_profile_lease_blocks_offline_process_then_allows_install(
             "hold",
             str(profile_home),
             str(ready),
-            str(release),
         ],
         env=environment,
+        stdin=subprocess.PIPE,
     )
     try:
         _wait_for_file(ready, holder)
@@ -226,12 +235,7 @@ def test_gateway_profile_lease_blocks_offline_process_then_allows_install(
         assert not journal.exists()
         assert not (managed / "process-skill").exists()
     finally:
-        release.write_text("release", encoding="utf-8")
-        try:
-            holder.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            holder.kill()
-            holder.wait(timeout=5)
+        _release_lease_holder(holder)
     assert holder.returncode == 0
 
     succeeded = subprocess.run(
@@ -274,7 +278,6 @@ def test_unleased_build_services_does_not_sweep_another_process_reservation(
     rollback_reservation.mkdir(parents=True)
 
     ready = tmp_path / "lease-ready"
-    release = tmp_path / "lease-release"
     probe = tmp_path / "boot-probe.json"
     environment = _worker_environment(state_root)
     holder = subprocess.Popen(
@@ -284,9 +287,9 @@ def test_unleased_build_services_does_not_sweep_another_process_reservation(
             "hold",
             str(profile_home),
             str(ready),
-            str(release),
         ],
         env=environment,
+        stdin=subprocess.PIPE,
     )
     try:
         _wait_for_file(ready, holder)
@@ -309,12 +312,7 @@ def test_unleased_build_services_does_not_sweep_another_process_reservation(
         assert rollback_reservation.is_dir()
         assert "PROFILE_LEASE_REQUIRED" in probe.read_text(encoding="utf-8")
     finally:
-        release.write_text("release", encoding="utf-8")
-        try:
-            holder.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            holder.kill()
-            holder.wait(timeout=5)
+        _release_lease_holder(holder)
     assert holder.returncode == 0
 
 

--- a/tests/test_tools/test_document_browser_identity.py
+++ b/tests/test_tools/test_document_browser_identity.py
@@ -22,7 +22,7 @@ class _Bridge:
 
     async def capabilities(self) -> SimpleNamespace:
         return SimpleNamespace(
-            version=4,
+            version=5,
             browser_inspect=True,
             reload_surface=True,
             screenshot=True,
@@ -36,6 +36,7 @@ class _Bridge:
             active_preview_artifact_id=self._artifact_id,
             scope_id=self._scope_id,
             candidate_handle=self._candidate_handle,
+            binding_generation=1,
         )
 
     async def reload_surface(self, **_kwargs: object) -> bool:
@@ -76,7 +77,7 @@ class _ActionBridge(_Bridge):
 class _WireCapabilityBridge(_Bridge):
     async def capabilities(self) -> dict[str, object]:
         return {
-            "version": 4,
+            "version": 5,
             "available": True,
             "browserInspect": True,
             "browserAct": True,
@@ -172,6 +173,7 @@ async def test_candidate_inspect_requires_matching_active_surface_identity(
 
     assert result["status"] == "verification_passed"
     assert controller.verifications
+    assert "bindingGeneration" not in result
 
 
 @pytest.mark.asyncio
@@ -428,7 +430,7 @@ async def test_non_retryable_browser_control_result_closes_candidate_loop() -> N
 
 
 @pytest.mark.asyncio
-async def test_unavailable_candidate_preview_requires_explicit_discard() -> None:
+async def test_unavailable_candidate_preview_terminates_without_more_tools() -> None:
     call = ToolCall(
         tool_use_id="writer-preview-unavailable",
         tool_name="document_apply",
@@ -450,10 +452,13 @@ async def test_unavailable_candidate_preview_requires_explicit_discard() -> None
     projected = await dispatch_module._candidate_loop_effect_result(result, tool_call=call)
 
     assert projected.effect_outcome is not None
-    assert projected.effect_outcome.loop_action == "continue"
-    assert projected.effect_outcome.retry_policy == "same_turn"
+    assert projected.effect_outcome.loop_action == "finalize_without_tools"
+    assert projected.effect_outcome.retry_policy == "new_turn"
     assert projected.effect_outcome.outcome_code == "document_preview_unavailable"
-    assert json.loads(projected.content)["retry_allowed"] is True
+    payload = json.loads(projected.content)
+    assert payload["retry_allowed"] is False
+    assert payload["category"] == "DOCUMENT_PREVIEW_UNAVAILABLE"
+    assert projected.terminates_turn is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_tools/test_document_mutation_dispatch_outcomes.py
+++ b/tests/test_tools/test_document_mutation_dispatch_outcomes.py
@@ -8,6 +8,7 @@ import pytest
 
 from opensquilla.engine.types import ToolCall
 from opensquilla.tool_boundary import ToolResult
+from opensquilla.tools.builtin.document_browser import DocumentBridgeToolError
 from opensquilla.tools.builtin.document_format_adapters import DocumentMutationError
 from opensquilla.tools.dispatch import (
     _candidate_loop_effect_result,
@@ -201,6 +202,98 @@ async def test_candidate_finish_validation_error_returns_to_loop() -> None:
     assert projected.effect_outcome.retry_policy == "same_turn"
     assert projected.effect_outcome.loop_action == "continue"
     assert json.loads(projected.content)["retry_allowed"] is True
+
+
+@pytest.mark.asyncio
+async def test_typed_terminal_browser_loss_ends_after_one_failure() -> None:
+    candidate = _CandidateController("verification_failed")
+    context = _candidate_context(candidate)
+    call = ToolCall(
+        tool_use_id="inspect-terminal-loss",
+        tool_name="document_browser_inspect",
+        arguments={"scope": "document"},
+    )
+    result = ToolResult(
+        tool_use_id=call.tool_use_id,
+        tool_name=call.tool_name,
+        content="DOCUMENT_BROWSER_INSPECT_UNAVAILABLE: unavailable",
+        is_error=True,
+    )
+    exception = DocumentBridgeToolError(
+        "DOCUMENT_BROWSER_INSPECT_UNAVAILABLE: unavailable",
+        category="DOCUMENT_PREVIEW_UNAVAILABLE",
+        retry_policy="new_turn",
+        next_action="finalize_without_tools",
+        terminal_binding_loss=True,
+    )
+    token = current_tool_context.set(context)
+    try:
+        projected = await _candidate_loop_effect_result(
+            result,
+            tool_call=call,
+            exception=exception,
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert projected.effect_outcome is not None
+    assert projected.effect_outcome.retry_policy == "new_turn"
+    assert projected.effect_outcome.loop_action == "finalize_without_tools"
+    assert projected.terminates_turn is True
+    payload = json.loads(projected.content)
+    assert payload == {
+        "category": "DOCUMENT_PREVIEW_UNAVAILABLE",
+        "message_key": "document.previewUnavailable",
+        "next_action": "finalize_without_tools",
+        "outcome_code": "document_preview_unavailable",
+        "retry_allowed": False,
+        "retry_policy": "new_turn",
+        "status": "error",
+    }
+
+
+@pytest.mark.asyncio
+async def test_unknown_browser_action_requires_fresh_inspection() -> None:
+    candidate = _CandidateController("verification_failed")
+    context = _candidate_context(candidate)
+    context._artifact_browser_verification_token = "receipt-private"  # type: ignore[attr-defined]
+    context._artifact_browser_binding_generation = 7  # type: ignore[attr-defined]
+    call = ToolCall(
+        tool_use_id="action-result-unknown",
+        tool_name="document_browser_act",
+        arguments={"action": "click", "anchor": "opaque-anchor"},
+    )
+    result = ToolResult(
+        tool_use_id=call.tool_use_id,
+        tool_name=call.tool_name,
+        content="unknown",
+        is_error=True,
+    )
+    exception = DocumentBridgeToolError(
+        "DOCUMENT_ACTION_RESULT_UNKNOWN: inspect again",
+        category="DOCUMENT_ACTION_RESULT_UNKNOWN",
+        retry_policy="same_turn",
+        next_action="reinspect",
+        terminal_binding_loss=False,
+    )
+    token = current_tool_context.set(context)
+    try:
+        projected = await _candidate_loop_effect_result(
+            result,
+            tool_call=call,
+            exception=exception,
+        )
+    finally:
+        current_tool_context.reset(token)
+
+    assert projected.effect_outcome is not None
+    assert projected.effect_outcome.retry_policy == "same_turn"
+    assert projected.effect_outcome.loop_action == "continue"
+    assert context._artifact_browser_verification_token is None  # type: ignore[attr-defined]
+    assert context._artifact_browser_binding_generation is None  # type: ignore[attr-defined]
+    payload = json.loads(projected.content)
+    assert payload["category"] == "DOCUMENT_ACTION_RESULT_UNKNOWN"
+    assert payload["next_action"] == "reinspect"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add Desktop bridge v5 turn bindings that pin the exact native workbench surface, preserve the preview lease while detached from UI, and allow one deterministic recovery
- make Gateway terminal document failures structured, prevent repeated browser-tool loops, bind verification to the surface generation, and clean turn authority exactly once
- keep document tool details privacy-safe across RunTrace presentations, recover background-edit placeholders, and show a small unread `New` marker after a successful document update

## Focused validation

- `103 passed` across the changed Gateway and document-tool test files
- `162 passed` across the changed WebUI activity, RunTrace, workbench, header, and deliverable-indicator tests
- `vue-tsc --noEmit`
- WebUI architecture, security, theme, i18n, and design-token guards
- production WebUI artifact build and bundle guards
- Desktop TypeScript build, preview lease broker, native surface contract, and bridge loopback checks
- native Windows manual edit: document commit completed, preview refreshed, and the header `New` marker appeared

## Windows fixture limitation

- `test:desktop-workbench` reaches the Electron fixture and then fails before product assertions because Electron returns `ERR_FAILED` while loading the fixture's trusted `data:` URL; the same script fails identically in the original worktree
- `test:v1-html-agent-edit-e2e` exits during Electron renderer startup (`launch-failed`, exit 49) before the Gateway or document flow becomes reachable
- no retries, timeout increases, skipped assertions, or database migrations were added
