### PR TITLE
Keep sidebar hover previews anchored for long titles

### DIFF
--- a/opensquilla-webui/e2e/sidebar-hover-geometry.spec.ts
+++ b/opensquilla-webui/e2e/sidebar-hover-geometry.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from '@playwright/test'
+import { readFileSync } from 'node:fs'
+
+const sidebarCss = [
+  new URL('../src/assets/base.css', import.meta.url),
+  new URL('../src/styles/control-visual-system.css', import.meta.url),
+  new URL('../src/styles/apple-modern.css', import.meta.url),
+].map(url => readFileSync(url, 'utf8')).join('\n')
+
+const longTitle = [
+  '请执行一项 Deep Research 任务：分析 Fortinet 的长期经营表现、竞争格局与估值风险，',
+  'including-an-intentionally-long-unbroken-segment-that-must-not-expand-the-sidebar-row',
+].join('')
+
+for (const sidebarWidth of [260, 420]) {
+  for (const depth of [0, 2]) {
+    test(`long title keeps a bounded hover anchor at ${sidebarWidth}px and depth ${depth}`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: 1280, height: 900 })
+      await page.setContent(`<!doctype html>
+        <style>
+          :root {
+            --sp-1: 4px;
+            --sp-2: 8px;
+            --radius-md: 8px;
+            --dur-fast: 0s;
+            --sidebar-bg: #222;
+            --sidebar-text: #ddd;
+            --sidebar-text-strong: #fff;
+            --sidebar-item-hover: #333;
+            --font-sans: sans-serif;
+          }
+          ${sidebarCss}
+          #app { --sidebar-width: ${sidebarWidth}px; }
+        </style>
+        <div id="app">
+          <nav class="sidebar docked">
+            <div class="sidebar-section sidebar-history">
+              <div class="sidebar-history-list">
+                <div class="sidebar-group">
+                  <div class="sidebar-group__body">
+                    <div class="sidebar-group__content">
+                      <div
+                        class="sidebar-history-row"
+                        data-session-key="long-title"
+                        style="--row-depth: ${depth}"
+                      >
+                        <button class="sidebar-history-item" type="button">
+                          <span class="sidebar-history-title">${longTitle}</span>
+                        </button>
+                        <div class="sidebar-row-menu-wrap">
+                          <button class="sidebar-row-menu-btn" type="button">⋯</button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </nav>
+        </div>
+      `)
+
+      const geometry = await page.evaluate(() => {
+        const body = document.querySelector<HTMLElement>('.sidebar-group__body')!
+        const content = document.querySelector<HTMLElement>('.sidebar-group__content')!
+        const row = document.querySelector<HTMLElement>('.sidebar-history-row')!
+        const title = document.querySelector<HTMLElement>('.sidebar-history-title')!
+        const bodyRect = body.getBoundingClientRect()
+        const contentRect = content.getBoundingClientRect()
+        const rowRect = row.getBoundingClientRect()
+        const preview = document.createElement('div')
+        preview.className = 'sidebar-session-preview'
+        preview.style.left = `${rowRect.right + 8}px`
+        preview.style.top = `${rowRect.top}px`
+        preview.textContent = 'Preview'
+        document.body.appendChild(preview)
+        const previewRect = preview.getBoundingClientRect()
+        const titleStyle = getComputedStyle(title)
+
+        return {
+          bodyWidth: bodyRect.width,
+          contentWidth: contentRect.width,
+          bodyRight: bodyRect.right,
+          rowRight: rowRect.right,
+          previewGap: previewRect.left - rowRect.right,
+          titleClientWidth: title.clientWidth,
+          titleScrollWidth: title.scrollWidth,
+          titleOverflow: titleStyle.overflow,
+          titleTextOverflow: titleStyle.textOverflow,
+          titleWhiteSpace: titleStyle.whiteSpace,
+        }
+      })
+
+      expect(geometry.contentWidth).toBeLessThanOrEqual(geometry.bodyWidth + 1)
+      expect(geometry.rowRight).toBeLessThanOrEqual(geometry.bodyRight + 1)
+      expect(Math.abs(geometry.previewGap - 8)).toBeLessThanOrEqual(1)
+      expect(geometry.titleScrollWidth).toBeGreaterThan(geometry.titleClientWidth)
+      expect(geometry.titleOverflow).toBe('hidden')
+      expect(geometry.titleTextOverflow).toBe('ellipsis')
+      expect(geometry.titleWhiteSpace).toBe('nowrap')
+    })
+  }
+}

--- a/opensquilla-webui/src/components/SidebarConversations.workspaces.test.ts
+++ b/opensquilla-webui/src/components/SidebarConversations.workspaces.test.ts
@@ -396,6 +396,30 @@ describe('SidebarConversations project workspaces', () => {
     expect(row?.querySelector('.sidebar-history-item')?.getAttribute('title')).toBeNull()
   })
 
+  it('keeps a long mixed-language title and tooltip relationship intact', async () => {
+    const title = '请执行一项 Deep Research 任务：分析 Fortinet 的长期经营表现与竞争格局'
+    const { host } = await mountSidebar([projectRow(), taskRow({ title })])
+    const row = host.querySelector<HTMLElement>(
+      '[data-session-key="agent:main:webchat:task-a"]',
+    )
+    Object.defineProperty(row, 'getBoundingClientRect', {
+      value: () => ({ left: 12, right: 280, top: 40 }),
+    })
+
+    row?.dispatchEvent(new MouseEvent('mouseenter'))
+    await nextTick()
+
+    const trigger = row?.querySelector('.sidebar-history-item')
+    const preview = document.body.querySelector('.sidebar-session-preview')
+    expect(row?.querySelector('.sidebar-history-title')?.textContent).toBe(title)
+    expect(preview?.querySelector('.sidebar-session-preview__title')?.textContent).toBe(title)
+    expect(preview?.querySelector('.sidebar-session-preview__time')?.textContent).not.toBe('')
+    expect(preview?.querySelector('[data-testid="sidebar-session-project"]')?.textContent)
+      .toContain('Project A')
+    expect(trigger?.getAttribute('aria-describedby')).toBe('sidebar-session-preview')
+    expect(preview?.getAttribute('role')).toBe('tooltip')
+  })
+
   it('keeps the hover card but omits the project row for an unbound session', async () => {
     const { host } = await mountSidebar([
       taskRow({

--- a/opensquilla-webui/src/styles/control-visual-system.css
+++ b/opensquilla-webui/src/styles/control-visual-system.css
@@ -781,6 +781,7 @@ summary.control-row--divider:focus-visible {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  min-width: 0;
 }
 
 /* Subagent indent: a left rail mirrors the console list's nested look. The


### PR DESCRIPTION
## Scope

Scope boundary: Constrain sidebar conversation content so long unbroken titles cannot move the hover-card anchor beyond the visible sidebar, and add deterministic component and browser geometry regressions.

Non-goals: No changes to hover-card positioning logic, Teleport behavior, card dimensions, scrolling/resizing behavior, persistence, RPC, or public interfaces.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: The defect was supplied directly with a desktop screenshot and no issue number.

## Release Note

Release note: NONE

## Tests

Ruff: N/A (frontend-only change)

Pytest: N/A (frontend-only change)

Build: `cd opensquilla-webui && npm run build` passed

Regression tests: added

Notes:

- `npm run test:unit -- --run src/components/SidebarSessionHoverCard.test.ts src/components/SidebarConversations.workspaces.test.ts` — 29 passed
- `npm run test:e2e -- e2e/sidebar-hover-geometry.spec.ts` — 4 passed
- `npm run typecheck` — passed
- Browser geometry coverage includes 260px and 420px sidebars plus top-level and nested conversations.
- The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

The deterministic Chromium geometry regression exercises the real sidebar CSS. A packaged macOS Desktop check at 100%/120% zoom remains suitable as release acceptance, but is not required for the implementation test path.

## Safety

This is a platform-neutral CSS layout constraint plus synthetic offline tests. It adds no dependencies, HTML rendering paths, network access, secrets, user data, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, or non-public fixtures. Existing installs, persisted state, desktop clients, and public interfaces are unaffected.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [ ] Documentation updated (not needed; behavior is restored without changing a public contract)
