### PR TITLE
feat(channels): Hermes-style live streaming, tool progress and thinking bubble

### DIFF
--- a/src/opensquilla/channels/command_registry.py
+++ b/src/opensquilla/channels/command_registry.py
@@ -85,6 +85,14 @@ class CommandRegistry:
             context_factory(envelope),
         )
         reply_to = envelope.thread_id or envelope.channel_id
+        help_reply = _format_channel_help_reply(
+            name=name,
+            method=method,
+            res=res,
+            reply_to=reply_to,
+        )
+        if help_reply is not None:
+            return help_reply
         sandbox_reply = _format_channel_sandbox_reply(
             name=name,
             method=method,
@@ -112,6 +120,14 @@ class CommandRegistry:
         )
         if meta_reply is not None:
             return meta_reply
+        generic_reply = _format_channel_generic_reply(
+            name=name,
+            method=method,
+            res=res,
+            reply_to=reply_to,
+        )
+        if generic_reply is not None:
+            return generic_reply
         denied = bool(not res.ok and getattr(res.error, "code", "") == "UNAUTHORIZED")
         reason = "" if res.ok else f": {getattr(res.error, 'message', 'command failed')}"
         if res.ok:
@@ -127,6 +143,127 @@ class CommandRegistry:
             reply_to=envelope.thread_id or envelope.channel_id,
             metadata={"command": name, "method": method, "denied": denied},
         )
+
+
+def _format_channel_help_reply(
+    *,
+    name: str,
+    method: str,
+    res: Any,
+    reply_to: str | None,
+) -> OutgoingMessage | None:
+    """Render the channel /help output from the status RPC payload.
+
+    The unified registry binds channel ``/help`` to the ``status`` RPC, whose
+    payload carries no command catalog. Fetching one here would need another
+    dispatcher round-trip, so instead render the static channel-surface
+    command list straight from the canonical registry — same source of truth
+    the ``commands.list_for_surface`` RPC uses.
+    """
+    if name != "help" or method != "status":
+        return None
+    lines = [
+        f"{cmd.name} — {cmd.description_for(Surface.CHANNEL)}"
+        for cmd in DEFAULT_REGISTRY.for_surface(Surface.CHANNEL)
+    ]
+    body = "\n".join(lines) if lines else "No commands available."
+    return OutgoingMessage(
+        content=f"Available commands:\n{body}",
+        reply_to=reply_to,
+        metadata={"command": name, "method": method, "denied": False},
+    )
+
+
+def _format_channel_generic_reply(
+    *,
+    name: str,
+    method: str,
+    res: Any,
+    reply_to: str | None,
+) -> OutgoingMessage | None:
+    """Render list/status RPC payloads that lack a dedicated formatter.
+
+    Several channel commands (``/model``, ``/status``, ``/skills``,
+    ``/memory``, ``/usage``) dispatch to RPC methods whose payload carries
+    the actual answer, but the shared dispatch path would otherwise collapse
+    them into a generic ``/{name} completed`` line. This formatter extracts
+    a compact, human-readable summary from the known payload shapes.
+    """
+    if not res.ok:
+        return None
+    payload = res.payload if isinstance(res.payload, dict) else {}
+    lines: list[str] = []
+
+    if method == "models.list":
+        for m in payload.get("models") or []:
+            mid = str(m.get("id") or m.get("name") or "?")
+            prov = str(m.get("provider") or "")
+            ctx = m.get("contextWindow")
+            ctx_s = f", {ctx}" if ctx else ""
+            lines.append(f"{mid} ({prov}{ctx_s})")
+        if not lines:
+            lines.append("No models available.")
+    elif method == "status":
+        st = str(payload.get("status") or "unknown")
+        ver = str(payload.get("version") or "?")
+        prov = str(payload.get("provider") or "?")
+        sessions = payload.get("active_sessions")
+        uptime = payload.get("uptime_ms")
+        parts = [f"status: {st}", f"version: {ver}", f"provider: {prov}"]
+        if sessions is not None:
+            parts.append(f"active_sessions: {sessions}")
+        if uptime:
+            parts.append(f"uptime: {int(uptime) // 1000}s")
+        lines.append(" | ".join(parts))
+    elif method == "skills.list":
+        for s in payload.get("skills") or []:
+            if isinstance(s, dict):
+                lines.append(str(s.get("name") or "?"))
+        if not lines:
+            lines.append("No skills loaded.")
+    elif method == "doctor.memory.status":
+        backend = str(payload.get("backend") or "none")
+        status = str(payload.get("status") or "?")
+        entry_count = payload.get("entryCount")
+        size_bytes = payload.get("sizeBytes")
+        parts = [f"backend: {backend}", f"status: {status}"]
+        if entry_count is not None:
+            parts.append(f"entries: {entry_count}")
+        if size_bytes:
+            parts.append(f"size: {int(size_bytes) // 1024}KB")
+        lines.append(" | ".join(parts))
+    elif method == "chat.history":
+        for m in payload.get("messages") or []:
+            if not isinstance(m, dict):
+                continue
+            role = str(m.get("role") or "?")
+            content = str(m.get("content") or m.get("text") or "")
+            content = content.replace("\n", " ")[:120]
+            lines.append(f"[{role}] {content}")
+        if not lines:
+            lines.append("No history.")
+    elif method == "usage.status":
+        parts = []
+        for key, label in (
+            ("totalTokens", "tokens"),
+            ("totalCostUsd", "cost_usd"),
+            ("totalCacheReadTokens", "cache_read"),
+            ("totalInputTokens", "input"),
+            ("totalOutputTokens", "output"),
+            ("activeSessions", "active_sessions"),
+        ):
+            val = payload.get(key)
+            if val is not None:
+                parts.append(f"{label}: {val}")
+        lines.append(" | ".join(parts) if parts else "No usage data.")
+
+    if not lines:
+        return None
+    return OutgoingMessage(
+        content="\n".join(lines),
+        reply_to=reply_to,
+        metadata={"command": name, "method": method, "denied": False},
+    )
 
 
 def _channel_command_params(

--- a/src/opensquilla/channels/telegram.py
+++ b/src/opensquilla/channels/telegram.py
@@ -24,6 +24,8 @@ from opensquilla.channels._attachment_io import (
 from opensquilla.channels._util import (
     ChannelAccessPolicy,
     EventDedupeCache,
+    FloodStrikeBackoff,
+    StreamThrottle,
     split_text_for_channel,
 )
 from opensquilla.channels.contract import (
@@ -70,6 +72,16 @@ _DEDUPE_SIZE = 4096
 _ALLOWED_UPDATES = ("message", "channel_post")
 # Telegram Bot API hard limit on sendMessage text length.
 _TELEGRAM_MAX_MESSAGE_CHARS = 4096
+
+
+def _telegram_text_exceeds(text: str) -> bool:
+    """True when *text* would exceed Telegram's 4096 UTF-16 unit cap.
+
+    Telegram measures message length in UTF-16 code units (astral chars such
+    as emoji count as two), matching ``split_text_for_channel`` with
+    ``ChannelLengthUnit.UTF16_UNITS`` used by ``send``.
+    """
+    return len(text.encode("utf-16-le")) // 2 > _TELEGRAM_MAX_MESSAGE_CHARS
 
 
 class TelegramApiError(RuntimeError):
@@ -171,6 +183,7 @@ class TelegramChannel:
             thread_reply=True,
             edit=True,
             delete=True,
+            streamed_message_replacement=True,
             transports=(self.config.transport_name,),
         )
 
@@ -780,6 +793,8 @@ class TelegramChannel:
         if not chat_id:
             raise ValueError("telegram.send requires chat_id via metadata, reply_to, or config")
         payload: dict[str, Any] = {"chat_id": str(chat_id), "text": message.content}
+        if message.metadata.get("disable_notification"):
+            payload["disable_notification"] = True
         thread_id = message.metadata.get("thread_id") or message.metadata.get("message_thread_id")
         if thread_id:
             payload["message_thread_id"] = _coerce_telegram_int(thread_id)
@@ -791,7 +806,20 @@ class TelegramChannel:
             payload["parse_mode"] = str(parse_mode)
         return payload
 
-    async def edit(self, message_id: str, content: str) -> None:
+    async def edit(self, message_id: str, content: str, *, chat_id: str | None = None) -> None:
+        if chat_id is not None and "|" not in message_id:
+            # Route kwargs from streaming_reply_kwargs carry the chat target
+            # explicitly (terminal reconcile path); keep the pipe-ref form
+            # authoritative when both are present.
+            await self._api(
+                "editMessageText",
+                {
+                    "chat_id": str(chat_id),
+                    "message_id": _coerce_telegram_int(message_id),
+                    "text": content,
+                },
+            )
+            return
         chat_id, raw_message_id = self._split_message_ref(message_id)
         await self._api(
             "editMessageText",
@@ -801,6 +829,110 @@ class TelegramChannel:
                 "text": content,
             },
         )
+
+    # ------------------------------------------------------------------
+    # Streaming (edit-throttled)
+    # ------------------------------------------------------------------
+
+    def streaming_reply_kwargs(self, inbound: IncomingMessage) -> dict[str, Any]:
+        """Route a streamed reply into the chat that triggered the turn.
+
+        Without this, ``send_streaming`` falls back to
+        ``config.default_chat_id`` and every streamed reply lands in one
+        static chat regardless of who asked.
+        """
+        kwargs: dict[str, Any] = {"chat_id": inbound.channel_id}
+        thread_id = inbound.metadata.get("thread_id") or inbound.metadata.get("message_thread_id")
+        if thread_id:
+            kwargs["thread_id"] = str(thread_id)
+        return kwargs
+
+    async def send_streaming(
+        self,
+        chunks: Any,
+        *,
+        chat_id: str | None = None,
+        thread_id: str | None = None,
+        update_interval_ms: int = 800,
+    ) -> str | None:
+        """Stream a message: post first chunk, ``editMessageText`` for the rest.
+
+        Telegram Bot API has no hard per-minute edit cap for this pattern, but
+        edits are network round trips; ``StreamThrottle`` coalesces micro-deltas
+        so at most one edit lands per ``update_interval_ms`` window and a
+        transient failure never loses accumulated text (next flush retries the
+        same snapshot).
+
+        The first chunk is sent as a fresh ``sendMessage``; subsequent chunks
+        rewrite that message in place. If the accumulated text would exceed
+        Telegram's 4096 UTF-16 cap, ``TelegramApiError`` is raised and the
+        dispatcher's relay falls back to the batch ``send`` path so the full
+        reply is still delivered (split into multiple messages by ``send``).
+
+        Returns the originating ``message_id`` (``<chat_id>|<message_id>``) or
+        ``None`` if the iterator was empty.
+        """
+        target = chat_id or self.config.default_chat_id
+        if not target:
+            raise RuntimeError("Telegram stream has no chat target")
+        target = str(target)
+        throttle = StreamThrottle(interval_s=update_interval_ms / 1000.0)
+        flood = FloodStrikeBackoff(cap=4, decay_s=30.0, adapter="telegram.stream")
+        resolved_chat: str | None = None
+        message_id: str | None = None
+
+        async def _post(text: str) -> None:
+            nonlocal resolved_chat, message_id
+            if _telegram_text_exceeds(text):
+                raise TelegramApiError(
+                    f"telegram.stream: text exceeds {_TELEGRAM_MAX_MESSAGE_CHARS} UTF-16 units"
+                )
+            payload: dict[str, Any] = {"chat_id": target, "text": text}
+            if thread_id:
+                payload["message_thread_id"] = _coerce_telegram_int(thread_id)
+            result = await self._api("sendMessage", payload)
+            resolved_chat = str(result.get("chat", {}).get("id", target))
+            raw_id = result.get("message_id")
+            message_id = str(raw_id) if raw_id is not None else None
+            flood.record_success()
+
+        async def _edit(text: str) -> None:
+            if _telegram_text_exceeds(text):
+                raise TelegramApiError(
+                    f"telegram.stream: text exceeds {_TELEGRAM_MAX_MESSAGE_CHARS} UTF-16 units"
+                )
+            if message_id is None or resolved_chat is None:
+                return
+            try:
+                await self._api(
+                    "editMessageText",
+                    {
+                        "chat_id": resolved_chat,
+                        "message_id": _coerce_telegram_int(message_id),
+                        "text": text,
+                    },
+                )
+                flood.record_success()
+            except TelegramApiError as exc:
+                if exc.error_code == 429 and exc.retry_after is not None:
+                    flood.record_429()
+                if flood.should_fallback():
+                    raise
+                # Single transient edit failure: accumulated text stays in the
+                # throttle so the next flush retries with the same snapshot.
+                log.warning(
+                    "channel.telegram.stream_edit_retry",
+                    error_code=exc.error_code,
+                    error=str(exc),
+                )
+
+        async for chunk in chunks:
+            throttle.add(chunk)
+            await throttle.maybe_flush(post=_post, edit=_edit)
+        await throttle.force_flush(post=_post, edit=_edit)
+        if message_id is None:
+            return None
+        return f"{resolved_chat or target}|{message_id}"
 
     async def delete(self, message_id: str) -> None:
         chat_id, raw_message_id = self._split_message_ref(message_id)

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -14,6 +14,7 @@ import contextlib
 import contextvars
 import copy
 import hashlib
+import weakref
 import inspect
 import json
 import math
@@ -739,6 +740,52 @@ def accepted_turn_config_scope(config: Any | None) -> Any:
         yield
     finally:
         _ACCEPTED_TURN_CONFIG.reset(token)
+
+
+# Real-time channel tool-progress registry: the active channel stream relay
+# per session registers here so the ToolHook path (fires synchronously at tool
+# execution time, unlike the transactional buffered ToolUse events) can push
+# status bubbles with Hermes-like latency.
+_CHANNEL_TOOL_PROGRESS_RELAYS: "weakref.WeakValueDictionary[str, Any]" = (
+    weakref.WeakValueDictionary()
+)
+
+
+def register_channel_tool_progress_relay(session_key: str, relay: Any) -> None:
+    if session_key:
+        _CHANNEL_TOOL_PROGRESS_RELAYS[session_key] = relay
+
+
+def _channel_tool_progress_hook(ctx: Any) -> Any:
+    """Return a ToolHook that mirrors tool start/end into the channel relay.
+
+    Only active when the turn's ToolContext is a channel caller with a live
+    relay registered for its session; otherwise None (zero-cost no-op).
+    """
+
+    if str(getattr(ctx, "caller_kind", "") or "") != "channel":
+        return None
+    # Keyed by channel id on both sides: the relay registers with
+    # inbound.channel_id and the ToolContext carries the same channel_id.
+    channel_id = str(getattr(ctx, "channel_id", "") or "")
+    relay = _CHANNEL_TOOL_PROGRESS_RELAYS.get(channel_id)
+    if relay is None:
+        return None
+
+    class _ChannelToolProgressHook:
+        def before_tool(self, call: Any) -> None:
+            try:
+                relay.notify_tool_start(call.tool_call)
+            except Exception:
+                pass
+
+        def after_tool(self, call: Any, outcome: Any) -> None:
+            try:
+                relay.notify_tool_end(call.tool_call, outcome)
+            except Exception:
+                pass
+
+    return _ChannelToolProgressHook()
 
 
 def _compute_route_input_savings_usd(
@@ -8016,10 +8063,18 @@ class TurnRunner:
                 or getattr(skill, "kind", "skill") != "meta"
             )
         }
+        # Real-time tool progress: fan tool start/end into the ambient channel
+        # stream sink. The buffered ToolUse events in the public stream are
+        # transactional (committed only after the provider round is validated),
+        # so they arrive in bursts at round end; the ToolHook path fires
+        # synchronously at execution time, which is the latency users see in
+        # Hermes-style status bubbles.
+        channel_progress_hook = _channel_tool_progress_hook(ctx)
         tool_handler = build_tool_handler(
             self._tool_registry,
             ctx,
             known_skill_names=known_skill_names,
+            tool_hooks=(channel_progress_hook,) if channel_progress_hook else None,
         )
         return tool_defs, tool_handler
 

--- a/src/opensquilla/gateway/channel_dispatch.py
+++ b/src/opensquilla/gateway/channel_dispatch.py
@@ -2250,6 +2250,21 @@ _STREAM_RELAY_DEFAULT_COALESCE_MS = 0.0
 _STREAM_RELAY_DEFAULT_COALESCE_CHARS = 0
 
 
+def _channel_tool_progress_enabled(channel: Any, config: Any) -> bool:
+    """Hermes-style per-tool-call status bubbles (opt-out via channel config).
+
+    Enabled by default for adapters that can send messages; disable with
+    ``[channels] tool_progress = false`` in config.toml.
+    """
+
+    if not callable(getattr(channel, "send", None)):
+        return False
+    channels_cfg = getattr(config, "channels", None) if config is not None else None
+    if isinstance(channels_cfg, dict):
+        return bool(channels_cfg.get("tool_progress", True))
+    return bool(getattr(channels_cfg, "tool_progress", True))
+
+
 def _resolve_stream_relay_coalesce(config: Any) -> tuple[float, int]:
     """Return ``(window_seconds, char_threshold)`` for stream relay batching.
 
@@ -2306,6 +2321,97 @@ class _RuntimeChannelStreamRelay:
         coalesce_window_s, coalesce_chars = _resolve_stream_relay_coalesce(config)
         self._coalesce_window_s = coalesce_window_s
         self._coalesce_chars = coalesce_chars
+        # Hermes-style tool progress: one silent status message per tool call,
+        # edited in place per tool_use_id so a long turn shows live activity
+        # instead of one silent bubble (see _maybe_notify_tool_progress).
+        self._tool_status_ids: dict[str, str] = {}
+        self._tool_notify_enabled = _channel_tool_progress_enabled(channel, config)
+
+    def _tool_progress_text(
+        self, *, tool_name: str, tool_use_id: str, arguments: Any, done: bool, is_error: bool
+    ) -> str:
+        args_preview = ""
+        if isinstance(arguments, dict):
+            for key in ("command", "path", "pattern", "query", "url", "file_path", "name"):
+                val = arguments.get(key)
+                if isinstance(val, str) and val.strip():
+                    args_preview = val.strip().splitlines()[0][:80]
+                    break
+        suffix = f" `{args_preview}`" if args_preview else ""
+        if done:
+            return f"{'✗' if is_error else '✓'} {tool_name}{suffix}"
+        return f"⚙ {tool_name}{suffix}"
+
+    async def _send_tool_status(
+        self, *, tool_use_id: str, text: str, reply_to: str | None
+    ) -> str | None:
+        """Send (or edit) one silent status bubble; returns its message ref."""
+
+        send = getattr(self._channel, "send", None)
+        if not callable(send):
+            return None
+        existing = self._tool_status_ids.get(tool_use_id)
+        if existing is not None:
+            edit = getattr(self._channel, "edit", None)
+            if callable(edit):
+                try:
+                    await edit(existing, text, chat_id=reply_to)
+                    return existing
+                except Exception:
+                    self._tool_status_ids.pop(tool_use_id, None)
+        outgoing = OutgoingMessage(
+            content=text,
+            reply_to=reply_to,
+            metadata={"disable_notification": True},
+        )
+        try:
+            result = await send(outgoing)
+        except Exception:
+            return None
+        ref: str | None = None
+        if isinstance(result, str) and result:
+            ref = result
+        elif isinstance(result, dict):
+            inner = result.get("result") if isinstance(result.get("result"), dict) else {}
+            chat_raw = result.get("chat") or inner.get("chat") or {}
+            chat = chat_raw.get("id") if isinstance(chat_raw, dict) else chat_raw
+            msg_id = result.get("message_id") or inner.get("message_id")
+            if msg_id is not None:
+                ref = f"{chat or reply_to}|{msg_id}"
+        if ref:
+            self._tool_status_ids[tool_use_id] = ref
+            return ref
+        return None
+
+    async def _maybe_notify_tool_progress(self, event: Any) -> None:
+        if not self._tool_notify_enabled:
+            return
+        meta = getattr(self._inbound, "metadata", None) or {}
+        thread = meta.get("thread_id") or meta.get("message_thread_id")
+        reply_to = thread or getattr(self._inbound, "channel_id", None)
+        if isinstance(event, ToolUseEndEvent):
+            text = self._tool_progress_text(
+                tool_name=event.tool_name,
+                tool_use_id=event.tool_use_id,
+                arguments=event.arguments,
+                done=True,
+                is_error=False,
+            )
+            await self._send_tool_status(
+                tool_use_id=event.tool_use_id, text=text, reply_to=reply_to
+            )
+        elif isinstance(event, ToolResultEvent):
+            if getattr(event, "is_error", False):
+                text = self._tool_progress_text(
+                    tool_name=event.tool_name,
+                    tool_use_id=event.tool_use_id,
+                    arguments=getattr(event, "arguments", None),
+                    done=True,
+                    is_error=True,
+                )
+                await self._send_tool_status(
+                    tool_use_id=event.tool_use_id, text=text, reply_to=reply_to
+                )
 
     @classmethod
     def maybe_create(
@@ -2315,7 +2421,20 @@ class _RuntimeChannelStreamRelay:
         task_runtime: Any,
         config: Any = None,
     ) -> _RuntimeChannelStreamRelay | None:
-        if not resolve_channel_stream_policy(channel).relay_stream:
+        policy = resolve_channel_stream_policy(channel)
+        log.warning(
+            "channel_dispatch.relay_diag",
+            channel_type=type(channel).__name__,
+            policy_mode=policy.mode,
+            relay_stream=policy.relay_stream,
+            has_send_streaming=callable(getattr(channel, "send_streaming", None)),
+            has_enqueue=callable(getattr(task_runtime, "enqueue", None)),
+            enqueue_accepts_sink=(
+                callable(getattr(task_runtime, "enqueue", None))
+                and _accepts_keyword_arg(task_runtime.enqueue, "stream_event_sink")
+            ),
+        )
+        if not policy.relay_stream:
             return None
         enqueue = getattr(task_runtime, "enqueue", None)
         if not callable(enqueue) or not _accepts_keyword_arg(enqueue, "stream_event_sink"):
@@ -2428,6 +2547,7 @@ class _RuntimeChannelStreamRelay:
                 return
 
     async def emit(self, event: Any) -> None:
+        await self._maybe_notify_tool_progress(event)
         artifact = _artifact_event_payload(event)
         if artifact is not None:
             self._artifacts.append(artifact)

--- a/src/opensquilla/gateway/channel_dispatch.py
+++ b/src/opensquilla/gateway/channel_dispatch.py
@@ -2321,11 +2321,18 @@ class _RuntimeChannelStreamRelay:
         coalesce_window_s, coalesce_chars = _resolve_stream_relay_coalesce(config)
         self._coalesce_window_s = coalesce_window_s
         self._coalesce_chars = coalesce_chars
-        # Hermes-style tool progress: one silent status message per tool call,
-        # edited in place per tool_use_id so a long turn shows live activity
-        # instead of one silent bubble (see _maybe_notify_tool_progress).
+        # Hermes-style tool progress: one silent, accumulating status message
+        # edited in place as the turn runs (see notify_tool_start/end and the
+        # thinking feed in emit()). Lines: "⚙ tool `arg`" -> "✓/✗ ...", plus
+        # "💬 <last thinking sentence>" interleaved.
         self._tool_status_ids: dict[str, str] = {}
         self._tool_notify_enabled = _channel_tool_progress_enabled(channel, config)
+        # Accumulating progress bubble (Hermes-style single editable message).
+        self._progress_lines: list[str] = []
+        self._progress_ref: str | None = None
+        self._progress_last_edit = 0.0
+        self._progress_edit_interval = 1.5
+        self._progress_lock = asyncio.Lock()
 
     def _tool_progress_text(
         self, *, tool_name: str, tool_use_id: str, arguments: Any, done: bool, is_error: bool
@@ -2342,76 +2349,120 @@ class _RuntimeChannelStreamRelay:
             return f"{'✗' if is_error else '✓'} {tool_name}{suffix}"
         return f"⚙ {tool_name}{suffix}"
 
-    async def _send_tool_status(
-        self, *, tool_use_id: str, text: str, reply_to: str | None
-    ) -> str | None:
-        """Send (or edit) one silent status bubble; returns its message ref."""
-
-        send = getattr(self._channel, "send", None)
-        if not callable(send):
-            return None
-        existing = self._tool_status_ids.get(tool_use_id)
-        if existing is not None:
-            edit = getattr(self._channel, "edit", None)
-            if callable(edit):
-                try:
-                    await edit(existing, text, chat_id=reply_to)
-                    return existing
-                except Exception:
-                    self._tool_status_ids.pop(tool_use_id, None)
-        outgoing = OutgoingMessage(
-            content=text,
-            reply_to=reply_to,
-            metadata={"disable_notification": True},
-        )
-        try:
-            result = await send(outgoing)
-        except Exception:
-            return None
-        ref: str | None = None
-        if isinstance(result, str) and result:
-            ref = result
-        elif isinstance(result, dict):
-            inner = result.get("result") if isinstance(result.get("result"), dict) else {}
-            chat_raw = result.get("chat") or inner.get("chat") or {}
-            chat = chat_raw.get("id") if isinstance(chat_raw, dict) else chat_raw
-            msg_id = result.get("message_id") or inner.get("message_id")
-            if msg_id is not None:
-                ref = f"{chat or reply_to}|{msg_id}"
-        if ref:
-            self._tool_status_ids[tool_use_id] = ref
-            return ref
-        return None
-
-    async def _maybe_notify_tool_progress(self, event: Any) -> None:
-        if not self._tool_notify_enabled:
-            return
+    def _progress_reply_to(self) -> str | None:
         meta = getattr(self._inbound, "metadata", None) or {}
         thread = meta.get("thread_id") or meta.get("message_thread_id")
-        reply_to = thread or getattr(self._inbound, "channel_id", None)
-        if isinstance(event, ToolUseEndEvent):
-            text = self._tool_progress_text(
-                tool_name=event.tool_name,
-                tool_use_id=event.tool_use_id,
-                arguments=event.arguments,
-                done=True,
-                is_error=False,
-            )
-            await self._send_tool_status(
-                tool_use_id=event.tool_use_id, text=text, reply_to=reply_to
-            )
-        elif isinstance(event, ToolResultEvent):
-            if getattr(event, "is_error", False):
-                text = self._tool_progress_text(
-                    tool_name=event.tool_name,
-                    tool_use_id=event.tool_use_id,
-                    arguments=getattr(event, "arguments", None),
-                    done=True,
-                    is_error=True,
+        return thread or getattr(self._inbound, "channel_id", None)
+
+    async def _append_progress_line(self, line: str, *, replace_last: bool = False) -> None:
+        """Append (or update) one line in the accumulating progress bubble.
+
+        Hermes-style presentation: a single silent message, edited at most
+        once per ``_progress_edit_interval`` seconds, mirroring a CLI's
+        scrolling transcript of interleaved tool lines and thinking lines.
+        """
+
+        if not self._tool_notify_enabled:
+            return
+        async with self._progress_lock:
+            if replace_last and self._progress_lines:
+                self._progress_lines[-1] = line
+            else:
+                self._progress_lines.append(line)
+            await self._flush_progress(force=False)
+
+    async def _flush_progress(self, *, force: bool) -> None:
+        """Render the accumulated lines; throttled edit-in-place."""
+
+        now = asyncio.get_event_loop().time()
+        if not force and (now - self._progress_last_edit) < self._progress_edit_interval:
+            return
+        text = "\n".join(self._progress_lines[-30:])  # cap like Hermes' bubble split
+        send = getattr(self._channel, "send", None)
+        edit = getattr(self._channel, "edit", None)
+        reply_to = self._progress_reply_to()
+        try:
+            if self._progress_ref is not None and callable(edit):
+                await edit(self._progress_ref, text, chat_id=reply_to)
+            elif callable(send):
+                outgoing = OutgoingMessage(
+                    content=text,
+                    reply_to=reply_to,
+                    metadata={"disable_notification": True},
                 )
-                await self._send_tool_status(
-                    tool_use_id=event.tool_use_id, text=text, reply_to=reply_to
-                )
+                result = await send(outgoing)
+                ref: str | None = None
+                if isinstance(result, str) and result:
+                    ref = result
+                elif isinstance(result, dict):
+                    inner = result.get("result") if isinstance(result.get("result"), dict) else {}
+                    chat_raw = result.get("chat") or inner.get("chat") or {}
+                    chat = chat_raw.get("id") if isinstance(chat_raw, dict) else chat_raw
+                    msg_id = result.get("message_id") or inner.get("message_id")
+                    if msg_id is not None:
+                        ref = f"{chat or reply_to}|{msg_id}"
+                if ref:
+                    self._progress_ref = ref
+            self._progress_last_edit = now
+        except Exception:
+            # Lost bubble is cosmetic; reset so the next flush sends fresh.
+            self._progress_ref = None
+
+    def notify_tool_start(self, tool_call: Any) -> None:
+        """Real-time ToolHook target (sync): tool is about to execute."""
+
+        if not self._tool_notify_enabled:
+            return
+        text = self._tool_progress_text(
+            tool_name=str(getattr(tool_call, "tool_name", "?")),
+            tool_use_id="",
+            arguments=getattr(tool_call, "arguments", None),
+            done=False,
+            is_error=False,
+        )
+        try:
+            asyncio.get_running_loop().create_task(
+                self._append_progress_line(text)
+            )
+        except RuntimeError:
+            pass
+
+    def notify_tool_end(self, tool_call: Any, outcome: Any) -> None:
+        """Real-time ToolHook target (sync): tool finished (ok or error)."""
+
+        if not self._tool_notify_enabled:
+            return
+        is_error = getattr(outcome, "exception", None) is not None
+        result = getattr(outcome, "result", None)
+        if not is_error and result is not None and getattr(result, "is_error", False):
+            is_error = True
+        text = self._tool_progress_text(
+            tool_name=str(getattr(tool_call, "tool_name", "?")),
+            tool_use_id="",
+            arguments=getattr(tool_call, "arguments", None),
+            done=True,
+            is_error=is_error,
+        )
+        try:
+            asyncio.get_running_loop().create_task(
+                self._append_progress_line(text, replace_last=True)
+            )
+        except RuntimeError:
+            pass
+
+    def notify_thinking(self, text: str) -> None:
+        """Live thinking delta (from the unbuffered sink path in emit())."""
+
+        if not self._tool_notify_enabled or not text:
+            return
+        snippet = " ".join(text.split()[:30])
+        line = f"💬 {snippet}"
+        try:
+            asyncio.get_running_loop().create_task(
+                self._append_progress_line(line, replace_last=True)
+            )
+        except RuntimeError:
+            pass
 
     @classmethod
     def maybe_create(
@@ -2459,6 +2510,15 @@ class _RuntimeChannelStreamRelay:
 
         if self._task is None and not self._closed:
             self._task = asyncio.create_task(self._run())
+            try:
+                from opensquilla.engine.runtime import register_channel_tool_progress_relay
+
+                register_channel_tool_progress_relay(
+                    str(getattr(self._inbound, "channel_id", "") or ""),
+                    self,
+                )
+            except Exception:
+                pass
 
     async def _run(self) -> Any:
         reply_kwargs = _streaming_reply_kwargs(self._channel, self._inbound)
@@ -2547,7 +2607,12 @@ class _RuntimeChannelStreamRelay:
                 return
 
     async def emit(self, event: Any) -> None:
-        await self._maybe_notify_tool_progress(event)
+        # Live thinking deltas are unbuffered through this sink; mirror them
+        # into the progress bubble (Hermes-style 💬 lines between tool lines).
+        if self._tool_notify_enabled:
+            kind = getattr(event, "kind", None)
+            if kind == "thinking" and isinstance(getattr(event, "text", ""), str):
+                self.notify_thinking(event.text)
         artifact = _artifact_event_payload(event)
         if artifact is not None:
             self._artifacts.append(artifact)


### PR DESCRIPTION
## Summary

Channel (Telegram etc.) turns currently go silent during execution: text streams only at the end in one burst, tool calls are invisible until the turn completes, and there is no live reasoning view. This PR brings the channel surface to parity with a CLI/Hermes-like experience:

- **Live text streaming** (`send_streaming` on the Telegram adapter): first chunk posts a message, subsequent deltas edit it in place with `StreamThrottle` coalescing and flood backoff; falls back to batched `send` on failure or 4096-overflow so no content is lost.
- **Edit reconcile fix**: `streaming_reply_kwargs` routes replies to the originating chat; `edit()` accepts the explicit `chat_id` kwarg so terminal snapshot replacement no longer fails with `TypeError` (`stream_terminal_reconcile_failed`).
- **Hermes-style progress bubble**: one silent, accumulating status message per turn (edited ~every 1.5s) interleaving:
  - tool lines via the `ToolHook` path (`before_tool`/`after_tool` fire synchronously at execution time — the public ToolUse events are transactional/buffered, hence unusable for live progress): `⚙ tool arg` → `✓`/`✗`
  - thinking lines from the unbuffered stream sink: `💬 <latest reasoning snippet>`
- **Runtime registry** (weak-ref, keyed by channel id) binds the active channel relay to the turn's `ToolContext`; non-channel callers (CLI/cron) get a zero-cost no-op hook.
- Opt-out via `[channels] tool_progress = false` in config.toml.

## Testing

- Offline unit simulation of the full notify chain: thinking → tool start → tool end interleaving, accumulating edits, error marking, ref extraction from Telegram `sendMessage` responses.
- Live-validated against a real Telegram channel turn with multi-tool loops.
- Verified CLI path unaffected (hook resolves to `None` for non-channel callers).

Fixes the "silent until done" channel UX reported by users watching long tool loops.
