### PR TITLE
Isolate usage model detail expansion by session

### DIFF
--- a/opensquilla-webui/src/composables/usage/useUsageSessionRows.test.ts
+++ b/opensquilla-webui/src/composables/usage/useUsageSessionRows.test.ts
@@ -24,6 +24,7 @@ describe('useUsageSessionRows', () => {
       'Inspect the long-running launch readiness checklist and summarize risks',
     )
     expect(sortedRows.value[0].sessionKey).toBe('agent:main:webchat:private-id')
+    expect(sortedRows.value[0].rowIdentity).toBe('agent:main:webchat:private-id')
   })
 
   it('keeps rows with multiple models expandable', () => {
@@ -47,5 +48,69 @@ describe('useUsageSessionRows', () => {
     })
 
     expect(sortedRows.value[0].hasModelBreakdown).toBe(true)
+  })
+
+  it('keeps same-label deleted sessions independently expandable', () => {
+    const { sortedRows } = useUsageSessionRows({
+      visibleSessions: computed(() => [
+        {
+          sessionKey: '',
+          sessionId: 'deleted-session-a',
+          modelBreakdown: [{ model: 'provider/a' }, { model: 'provider/b' }],
+        },
+        {
+          sessionKey: '',
+          session_id: 'deleted-session-b',
+          modelBreakdown: [{ model: 'provider/a' }, { model: 'provider/b' }],
+        },
+      ]),
+      rangeHiddenHint: computed(() => ''),
+      sortCol: ref('updated_at'),
+      sortAsc: ref(false),
+      rowVal: (row, ...keys) => keys.map(key => row[key]).find(value => value != null),
+      numericRowVal: () => null,
+      sessionTimestamp: () => null,
+      relTime: () => '-',
+      sortVal: () => 0,
+      taskName: () => 'Untitled task',
+    })
+
+    expect(sortedRows.value.map(row => row.sessionLabel)).toEqual([
+      'Untitled task',
+      'Untitled task',
+    ])
+    expect(sortedRows.value.map(row => row.rowIdentity)).toEqual([
+      'deleted-session-a',
+      'deleted-session-b',
+    ])
+
+    const expandedSessions = new Set([sortedRows.value[0].rowIdentity])
+    expect(sortedRows.value.map(row => expandedSessions.has(row.rowIdentity))).toEqual([
+      true,
+      false,
+    ])
+  })
+
+  it('falls back to legacy non-empty session identities', () => {
+    const { sortedRows } = useUsageSessionRows({
+      visibleSessions: computed(() => [
+        { sessionKey: '', session: 'legacy-session' },
+        { key: 'legacy-key' },
+      ]),
+      rangeHiddenHint: computed(() => ''),
+      sortCol: ref('updated_at'),
+      sortAsc: ref(false),
+      rowVal: (row, ...keys) => keys.map(key => row[key]).find(value => value != null),
+      numericRowVal: () => null,
+      sessionTimestamp: () => null,
+      relTime: () => '-',
+      sortVal: () => 0,
+      taskName: () => 'Untitled task',
+    })
+
+    expect(sortedRows.value.map(row => row.rowIdentity)).toEqual([
+      'legacy-session',
+      'legacy-key',
+    ])
   })
 })

--- a/opensquilla-webui/src/composables/usage/useUsageSessionRows.ts
+++ b/opensquilla-webui/src/composables/usage/useUsageSessionRows.ts
@@ -4,6 +4,19 @@ import type { SessionRow, SortedRow } from '@/types/usage'
 
 const t = i18n.global.t
 
+function nonEmptyText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function usageRowIdentity(row: SessionRow, sessionKey: string, sessionLabel: string): string {
+  return nonEmptyText(sessionKey)
+    || nonEmptyText(row.sessionId)
+    || nonEmptyText(row.session_id)
+    || nonEmptyText(row.session)
+    || nonEmptyText(row.key)
+    || sessionLabel
+}
+
 export function useUsageSessionRows(options: {
   visibleSessions: ComputedRef<SessionRow[]>
   rangeHiddenHint: ComputedRef<string>
@@ -39,7 +52,7 @@ export function useUsageSessionRows(options: {
         raw: row,
         sessionKey,
         sessionLabel,
-        rowIdentity: sessionKey || sessionLabel,
+        rowIdentity: usageRowIdentity(row, sessionKey, sessionLabel),
         modified,
         inputTokens: options.numericRowVal(row, 'input_tokens', 'inputTokens'),
         outputTokens: options.numericRowVal(row, 'output_tokens', 'outputTokens'),

--- a/opensquilla-webui/src/types/usage.ts
+++ b/opensquilla-webui/src/types/usage.ts
@@ -1,6 +1,8 @@
 export interface SessionRow {
   session?: string
   sessionKey?: string
+  sessionId?: string
+  session_id?: string
   key?: string
   taskName?: string
   task_name?: string


### PR DESCRIPTION
## Scope
- Give each Usage session row a stable expansion identity.
- Preserve navigable session keys while using ledger session IDs for deleted or unavailable tasks.
- Add regression coverage for duplicate unnamed labels and legacy row shapes.

## Branch target
- main

## Linked issue
- None

## Release note status
- User-visible bug fix: expanding one unnamed Usage row no longer expands other unnamed rows.

## Verification
- Targeted WebUI unit tests: 18 passed.
- Full WebUI unit suite: 376 files and 4606 tests passed.
- WebUI typecheck and architecture guards passed.
- WebUI production build passed.
- Backend navigable-session-key contract test passed.
- GitNexus detect-changes risk: low; 0 execution flows affected.

## Safety and compatibility
- Frontend-only state identity change; no database, RPC, configuration, or persisted-state migration.
- Deleted historical tasks remain non-navigable.
- Platform-neutral across Linux, macOS, and Windows.

## Third-party origin
- None.