### PR TITLE
fix(windows): pin Windows PowerShell 5.1 for sandbox upgrade-migration ACL

### DIFF
--- a/src/opensquilla/sandbox/upgrade_migration.py
+++ b/src/opensquilla/sandbox/upgrade_migration.py
@@ -1,4 +1,4 @@
-﻿"""Idempotent direct-update migration for legacy sandbox state."""
+"""Idempotent direct-update migration for legacy sandbox state."""
 
 from __future__ import annotations
 
@@ -428,36 +428,56 @@ def _acl_path_hash(path: Path) -> str:
     return hashlib.sha256(str(path).encode("utf-8")).hexdigest()
 
 
-def _windows_powershell_exe() -> str:
-    """Return the absolute path to Windows PowerShell 5.1 (powershell.exe).
+def _windows_powershell_exe() -> str | None:
+    """Return the absolute path to Windows PowerShell 5.1, or ``None``.
 
-    The ACL migration script relies on .NET Framework-only APIs such as
+    The ACL migration script depends on .NET Framework-only APIs such as
     ``[System.IO.Directory]::SetAccessControl`` and
     ``[System.IO.File]::SetAccessControl``, which do not exist in PowerShell 7
-    (.NET Core / ``pwsh``). On systems where ``pwsh`` is installed, a bare
-    ``powershell`` on PATH may resolve to ``pwsh``, or be shadowed by a
-    ``powershell.exe`` alias that points at ``pwsh``. Pin the well-known
-    Windows PowerShell location instead of trusting PATH lookup.
+    (.NET Core / ``pwsh``). ``pwsh`` frequently shadows a bare ``powershell``
+    PATH lookup on hosts that install it, which is exactly the failure this
+    guards against. Instead of trusting PATH, pin the well-known Windows
+    PowerShell install locations. Those canonical paths are always Windows
+    PowerShell 5.1 on a supported Windows host, so returning them is itself the
+    verification that we invoke 5.1 rather than a PATH-resolved ``pwsh``.
+
+    Returns ``None`` only when neither known location exists, so callers fail
+    loudly instead of silently invoking an unverified PATH binary.
     """
     system_root = os.environ.get("SystemRoot", r"C:\Windows")
     candidates = (
+        # SysNative is the Wow64 redirector view used by 32-bit processes to
+        # reach the native 64-bit System32 directory.
         os.path.join(system_root, "SysNative", "WindowsPowerShell", "v1.0", "powershell.exe"),
         os.path.join(system_root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),
     )
     for candidate in candidates:
         if os.path.exists(candidate):
             return candidate
-    # Last resort: assume PATH resolves to Windows PowerShell 5.1, not pwsh.
-    return "powershell"
+    return None
 
 
 def _windows_acl_shells() -> tuple[str, ...]:
-    # Windows PowerShell 5.1 is required for the .NET Framework-only SetAccessControl
-    # APIs used by the ACL script; pwsh (.NET Core) must only be a fallback.
+    """Resolve the PowerShell shells used for Windows ACL hardening.
+
+    Windows PowerShell 5.1 (the .NET Framework build) is required for the
+    ``SetAccessControl`` APIs the ACL script depends on, so it is preferred.
+    ``pwsh`` (.NET Core) can only be a last-resort fallback: it will usually
+    fail the script's verification, and that failure is surfaced rather than
+    masked. If neither a trusted Windows PowerShell 5.1 nor ``pwsh`` is
+    available, fail explicitly so the missing dependency is diagnosable instead
+    of being hidden behind a PATH-resolved binary that may not be 5.1.
+    """
     preferred = _windows_powershell_exe()
     fallback = shutil.which("pwsh")
     shells = tuple(item for item in (preferred, fallback) if item is not None)
-    return shells or (preferred,)
+    if not shells:
+        raise RuntimeError(
+            "Windows PowerShell 5.1 was not found at the expected system "
+            "locations (System32/SysNative WindowsPowerShell v1.0) and no pwsh "
+            "fallback is on PATH; cannot harden upgrade snapshot ACLs."
+        )
+    return shells
 
 
 def _protect_windows_acl_batch(

--- a/src/opensquilla/sandbox/upgrade_migration.py
+++ b/src/opensquilla/sandbox/upgrade_migration.py
@@ -1,4 +1,4 @@
-"""Idempotent direct-update migration for legacy sandbox state."""
+﻿"""Idempotent direct-update migration for legacy sandbox state."""
 
 from __future__ import annotations
 
@@ -428,11 +428,36 @@ def _acl_path_hash(path: Path) -> str:
     return hashlib.sha256(str(path).encode("utf-8")).hexdigest()
 
 
+def _windows_powershell_exe() -> str:
+    """Return the absolute path to Windows PowerShell 5.1 (powershell.exe).
+
+    The ACL migration script relies on .NET Framework-only APIs such as
+    ``[System.IO.Directory]::SetAccessControl`` and
+    ``[System.IO.File]::SetAccessControl``, which do not exist in PowerShell 7
+    (.NET Core / ``pwsh``). On systems where ``pwsh`` is installed, a bare
+    ``powershell`` on PATH may resolve to ``pwsh``, or be shadowed by a
+    ``powershell.exe`` alias that points at ``pwsh``. Pin the well-known
+    Windows PowerShell location instead of trusting PATH lookup.
+    """
+    system_root = os.environ.get("SystemRoot", r"C:\Windows")
+    candidates = (
+        os.path.join(system_root, "SysNative", "WindowsPowerShell", "v1.0", "powershell.exe"),
+        os.path.join(system_root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),
+    )
+    for candidate in candidates:
+        if os.path.exists(candidate):
+            return candidate
+    # Last resort: assume PATH resolves to Windows PowerShell 5.1, not pwsh.
+    return "powershell"
+
+
 def _windows_acl_shells() -> tuple[str, ...]:
-    preferred = shutil.which("pwsh")
-    fallback = shutil.which("powershell")
+    # Windows PowerShell 5.1 is required for the .NET Framework-only SetAccessControl
+    # APIs used by the ACL script; pwsh (.NET Core) must only be a fallback.
+    preferred = _windows_powershell_exe()
+    fallback = shutil.which("pwsh")
     shells = tuple(item for item in (preferred, fallback) if item is not None)
-    return shells or ("powershell",)
+    return shells or (preferred,)
 
 
 def _protect_windows_acl_batch(

--- a/tests/test_sandbox/test_windows_acl_shell_selection.py
+++ b/tests/test_sandbox/test_windows_acl_shell_selection.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+from opensquilla.sandbox import upgrade_migration as module
+
+WINPS_SYSTEM32 = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+WINPS_SYSNATIVE = r"C:\Windows\SysNative\WindowsPowerShell\v1.0\powershell.exe"
+PWSH = r"C:\Program Files\PowerShell\7\pwsh.exe"
+
+
+def _patch_exists(monkeypatch: pytest.MonkeyPatch, *, system32: bool, sysnative: bool) -> None:
+    def fake_exists(path: str) -> bool:
+        if system32 and path == WINPS_SYSTEM32:
+            return True
+        if sysnative and path == WINPS_SYSNATIVE:
+            return True
+        return False
+
+    monkeypatch.setattr(module.os.path, "exists", fake_exists)
+
+
+def _patch_which(monkeypatch: pytest.MonkeyPatch, *, pwsh: bool) -> None:
+    def fake_which(name: str) -> str | None:
+        if pwsh and name == "pwsh":
+            return PWSH
+        return None
+
+    monkeypatch.setattr(module.shutil, "which", fake_which)
+
+
+def test_selects_system32_windows_powershell_on_64bit(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 64-bit process: the SysNative redirector is invisible, so System32 wins.
+    _patch_exists(monkeypatch, system32=True, sysnative=False)
+    _patch_which(monkeypatch, pwsh=True)
+    assert module._windows_powershell_exe() == WINPS_SYSTEM32
+    assert module._windows_acl_shells() == (WINPS_SYSTEM32, PWSH)
+
+
+def test_selects_sysnative_windows_powershell_on_32bit(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 32-bit process: SysNative redirects to the native 64-bit directory.
+    _patch_exists(monkeypatch, system32=False, sysnative=True)
+    _patch_which(monkeypatch, pwsh=True)
+    assert module._windows_powershell_exe() == WINPS_SYSNATIVE
+    assert module._windows_acl_shells() == (WINPS_SYSNATIVE, PWSH)
+
+
+def test_missing_system_paths_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Neither canonical location exists. We must NOT silently resolve a bare
+    # "powershell" from PATH, which a co-installed pwsh can shadow.
+    _patch_exists(monkeypatch, system32=False, sysnative=False)
+    _patch_which(monkeypatch, pwsh=False)
+    assert module._windows_powershell_exe() is None
+
+
+def test_path_only_pwsh_falls_back_to_pwsh(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Windows PowerShell 5.1 absent, only pwsh on PATH: pwsh is the fallback.
+    _patch_exists(monkeypatch, system32=False, sysnative=False)
+    _patch_which(monkeypatch, pwsh=True)
+    assert module._windows_powershell_exe() is None
+    assert module._windows_acl_shells() == (PWSH,)
+
+
+def test_both_unavailable_raises_diagnosable_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No trusted Windows PowerShell 5.1 and no pwsh: fail loudly, not silently.
+    _patch_exists(monkeypatch, system32=False, sysnative=False)
+    _patch_which(monkeypatch, pwsh=False)
+    with pytest.raises(RuntimeError, match="Windows PowerShell 5.1"):
+        module._windows_acl_shells()
+
+
+def test_preferred_shell_failure_falls_back_at_runtime(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    # The runtime loop must try the preferred Windows PowerShell 5.1 first and
+    # fall back to pwsh only when the preferred invocation fails for a
+    # retryable reason, then succeed.
+    entry = tmp_path / "snapshot"
+    entry.mkdir()
+    monkeypatch.setattr(module, "_windows_acl_shells", lambda: (WINPS_SYSTEM32, PWSH))
+
+    calls: list[str] = []
+
+    class _Completed:
+        def __init__(self, returncode: int, stdout: bytes = b"", stderr: bytes = b"") -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def fake_run(cmd, **_kwargs):
+        calls.append(cmd[0])
+        if cmd[0] == WINPS_SYSTEM32:
+            return _Completed(1, stdout=b"", stderr=b"securityprivilege required")
+        entries = ((entry, True),)
+        result = {
+            "count": len(entries),
+            "ids": [str(i) for i in range(len(entries))],
+            "pathUtf8Base64": [
+                base64.b64encode(str(p).encode("utf-8")).decode("ascii") for p, _ in entries
+            ],
+            "pathHashes": [module._acl_path_hash(p) for p, _ in entries],
+        }
+        return _Completed(0, stdout=json.dumps(result).encode("ascii"))
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    module._protect_windows_acl_batch(((entry, True),), windows_user_sid="S-1-5-21-1")
+    assert calls == [WINPS_SYSTEM32, PWSH]


### PR DESCRIPTION
## Summary

On Windows, the gateway crashes at startup during sandbox upgrade migration. The ACL-protection step invokes `[System.IO.Directory]::SetAccessControl`, a .NET Framework API that exists only in **Windows PowerShell 5.1**. The code currently resolves the shell through `_windows_acl_shells()`, which prefers `pwsh` (PowerShell 7 / .NET Core). PowerShell 7 does not implement `SetAccessControl`, so the subprocess fails and the gateway aborts with `RuntimeError: migration_failed_manual_recovery_required`.

This is deterministic on machines where `powershell` on PATH resolves to PowerShell 7 — for example when `C:\Program Files\PowerShell\7` precedes `C:\Windows\System32\WindowsPowerShell\v1.0` in PATH.

## Root cause

`src/opensquilla/sandbox/upgrade_migration.py` — `_windows_acl_shells()` returns `[pwsh, powershell]`, and the ACL protection script depends on a .NET Framework-only API. The runtime that actually executes the script is therefore not guaranteed to be Windows PowerShell 5.1.

Observed error (gateway.log):
```
File "opensquilla\gateway\boot.py", line 3788, in build_services
  ...
RuntimeError: migration_failed_manual_recovery_required
Caused by: cannot protect upgrade snapshot path: ...
Method invocation failed because [System.IO.Directory] does not contain a method named 'SetAccessControl'
```

## Fix

- Add `_windows_powershell_exe()` that resolves the Windows PowerShell 5.1 executable from `SystemRoot` (`SysNative`/`System32` → `WindowsPowerShell\v1.0\powershell.exe`), with a `pwsh` fallback.
- Use it as the preferred shell for the ACL invocation so the .NET Framework runtime is guaranteed regardless of how `powershell` resolves on the host.

## Test plan

- On a host where `powershell` → PowerShell 7: gateway no longer crashes during `build_services` / sandbox upgrade migration.
- `_protect_private_path` now executes `SetAccessControl` successfully (verified against Windows PowerShell 5.1).

## Notes

This is a distinct root cause from the existing Windows/PowerShell integration issues (sandbox first-run blocking, Full Host Access argv escaping). The common theme is that Windows PowerShell invocation should explicitly pin the version/path rather than rely on bare `powershell`/`pwsh` resolution.
