### PR TITLE
Fix duplicate router panels after reconnect

### DIFF
--- a/opensquilla-webui/e2e/long-task-resilience.spec.ts
+++ b/opensquilla-webui/e2e/long-task-resilience.spec.ts
@@ -11,6 +11,9 @@ import {
 const CONTROL_URL = '/control/'
 const SESSION_KEY = 'agent:main:webchat:e2e-long-task-resilience'
 const TASK_ID = 'task-e2e-long-running'
+const ROUTER_SESSION_KEY = 'agent:main:webchat:e2e-router-reconnect'
+const ROUTER_TASK_ID = 'task-e2e-router-reconnect'
+const ROUTER_TURN_ID = 'turn-e2e-router-reconnect'
 
 type RpcRequest = {
   id?: string | number
@@ -86,7 +89,7 @@ function eventFrame(event: string, payload: Record<string, unknown>) {
   return JSON.stringify({ type: 'event', event, payload })
 }
 
-function hello(methods: string[] = []) {
+function hello(methods: string[] = [], events: string[] = []) {
   return JSON.stringify({
     protocol: 3,
     policy: {
@@ -109,6 +112,7 @@ function hello(methods: string[] = []) {
         'session.event.provider_activity',
         'session.event.run_heartbeat',
         'session.event.done',
+        ...events,
       ],
     },
     auth: {
@@ -319,6 +323,193 @@ test.describe('0.5.0 long-task resilience', () => {
       page.getByText('First incremental token after restart.', { exact: true }),
     ).toBeVisible({ timeout: 2_000 })
     expect(performance.now() - firstTokenAt).toBeLessThanOrEqual(2_000)
+  })
+
+  test('keeps one router card across reconnect snapshot, done, and history refresh', async ({
+    page,
+  }) => {
+    test.setTimeout(30_000)
+    await preparePage(page)
+    await page.addInitScript(() => {
+      window.localStorage.setItem('opensquilla.routerVisualEffects', '1')
+    })
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+
+    const generation = 'generation-router-reconnect'
+    const sockets: WebSocketRoute[] = []
+    let initialSnapshotComplete = false
+    let settledHistory = false
+    const routerPayload = {
+      session_key: ROUTER_SESSION_KEY,
+      task_id: ROUTER_TASK_ID,
+      turn_id: ROUTER_TURN_ID,
+      stream_generation: generation,
+      stream_seq: 10,
+      tier: 'c1',
+      tier_index: 1,
+      model: 'deepseek/deepseek-v4-pro',
+      baseline_model: 'deepseek/deepseek-v4-pro',
+      source: 'squilla_router',
+      confidence: 0.8,
+      routing_applied: true,
+    }
+    const history = () => {
+      const messages: Array<Record<string, unknown>> = [{
+        role: 'user',
+        text: 'Build a long HTML document.',
+        id: 'router-reconnect-user',
+        message_id: 'router-reconnect-user',
+        timestamp: Math.floor(Date.now() / 1_000) - 10,
+        turn_context: { turn_id: ROUTER_TURN_ID },
+      }]
+      if (settledHistory) {
+        messages.push({
+          role: 'assistant',
+          text: 'The document is ready.',
+          id: 'router-reconnect-assistant',
+          message_id: 'router-reconnect-assistant',
+          timestamp: Math.floor(Date.now() / 1_000),
+          turn_context: { turn_id: ROUTER_TURN_ID },
+          usage: {
+            routed_tier: 'c1',
+            routed_model: 'deepseek/deepseek-v4-pro',
+            routing_source: 'squilla_router',
+            router_model_call_id: '1.0',
+            router_iteration: 1,
+          },
+        })
+      }
+      return { messages, has_more: false, canonical_complete: true }
+    }
+
+    await page.routeWebSocket(/\/ws$/, ws => {
+      const socketIndex = sockets.length
+      sockets.push(ws)
+      ws.send(eventFrame('connect.challenge', {}))
+      ws.onMessage(message => {
+        let frame: RpcRequest
+        try {
+          frame = JSON.parse(String(message)) as RpcRequest
+        } catch {
+          return
+        }
+        if (frame.type === 'ping') {
+          ws.send(JSON.stringify({ type: 'pong' }))
+          return
+        }
+        if (frame.type !== 'req') return
+        const method = String(frame.method || '')
+        if (method === 'connect') {
+          ws.send(hello([], [
+            'session.event.router_decision',
+            'session.event.turn_committed',
+          ]))
+          return
+        }
+        if (method === 'chat.history') {
+          ws.send(successResponse(frame.id, history()))
+          return
+        }
+        if (method === 'sessions.messages.snapshot') {
+          const replayRouter = socketIndex > 0 && !settledHistory
+          ws.send(successResponse(frame.id, {
+            key: ROUTER_SESSION_KEY,
+            task_id: settledHistory ? null : ROUTER_TASK_ID,
+            stream_generation: generation,
+            current_stream_seq: settledHistory ? 11 : replayRouter ? 10 : 9,
+            events: replayRouter
+              ? [{ event: 'session.event.router_decision', payload: routerPayload }]
+              : [],
+          }))
+          if (socketIndex === 0) initialSnapshotComplete = true
+          return
+        }
+        if (method === 'sessions.messages.subscribe') {
+          ws.send(successResponse(frame.id, {
+            subscribed: true,
+            replay_complete: true,
+            stream_generation: generation,
+            current_stream_seq: settledHistory ? 11 : socketIndex > 0 ? 10 : 9,
+            run_status: settledHistory ? 'idle' : 'running',
+            active_task: settledHistory
+              ? null
+              : { task_id: ROUTER_TASK_ID, status: 'running' },
+          }))
+          return
+        }
+        if (method === 'sessions.messages.hydrate') {
+          ws.send(successResponse(frame.id, {
+            hydration_complete: true,
+            stream_generation: generation,
+            current_stream_seq: settledHistory ? 11 : socketIndex > 0 ? 10 : 9,
+            run_status: settledHistory ? 'idle' : 'running',
+            active_task: settledHistory
+              ? null
+              : { task_id: ROUTER_TASK_ID, status: 'running' },
+          }))
+          return
+        }
+        if (method === 'config.get') {
+          ws.send(successResponse(frame.id, {
+            squilla_router: {
+              enabled: true,
+              rollout_phase: 'full',
+              tiers: {
+                c0: { model: 'openai/gpt-5.4-mini' },
+                c1: { model: 'deepseek/deepseek-v4-pro' },
+                c2: { model: 'z-ai/glm-5.2' },
+              },
+            },
+            permissions: {},
+            skills: {},
+          }))
+          return
+        }
+        if (method === 'models.routing.get') {
+          ws.send(successResponse(frame.id, { mode: 'router' }))
+          return
+        }
+        ws.send(successResponse(frame.id, basePayload(method)))
+      })
+    })
+
+    await page.goto(CONTROL_URL + 'chat?session=' + encodeURIComponent(ROUTER_SESSION_KEY))
+    await expect(page.locator('.conn-pill.connected')).toBeVisible({ timeout: 10_000 })
+    await expect.poll(() => initialSnapshotComplete).toBe(true)
+    sockets[0]!.send(eventFrame('session.event.router_decision', routerPayload))
+    await expect(page.locator('.router-fx')).toHaveCount(1)
+
+    await sockets[0]!.close({ code: 1012, reason: 'deterministic reconnect' })
+    await expect.poll(() => sockets.length, { timeout: 4_000 }).toBe(2)
+    await expect(page.locator('.conn-pill.connected')).toBeVisible({ timeout: 4_000 })
+    await expect(page.locator('.router-fx')).toHaveCount(1)
+
+    sockets[1]!.send(eventFrame('session.event.done', {
+      session_key: ROUTER_SESSION_KEY,
+      task_id: ROUTER_TASK_ID,
+      turn_id: ROUTER_TURN_ID,
+      stream_generation: generation,
+      stream_seq: 11,
+      reason: 'completed',
+      text: 'The document is ready.',
+      usage: {
+        model: 'deepseek/deepseek-v4-pro',
+        routed_tier: 'c1',
+        routed_model: 'deepseek/deepseek-v4-pro',
+        routing_source: 'squilla_router',
+        router_model_call_id: '1.0',
+        router_iteration: 1,
+      },
+    }))
+    await expect(page.locator('.router-fx')).toHaveCount(1)
+    await expect(page.locator('.router-fx[data-settled="true"]')).toHaveCount(1)
+    await expect(page.getByText('The document is ready.', { exact: true })).toBeVisible()
+
+    settledHistory = true
+    await page.reload()
+    await expect(page.locator('.conn-pill.connected')).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('.router-fx')).toHaveCount(1)
+    await expect(page.getByText('The document is ready.', { exact: true })).toHaveCount(1)
   })
 
   test('projects reasoning, Retry-After, retry, fallback, and stale progress without leaking errors', async ({

--- a/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.test.ts
@@ -39,6 +39,79 @@ function makeRuntime(
 }
 
 describe('router decision identity', () => {
+  it('reuses the live stream identity when the same decision is replayed from a snapshot', () => {
+    const { runtime, messagesRef } = makeRuntime([{
+      role: 'user',
+      text: 'q',
+      ts: 0,
+      turnId: 'turn-1',
+    }], true, 'squilla_router')
+
+    const decision = {
+      turn_id: 'turn-1',
+      tier: 'c1',
+      model: 'provider/first',
+      source: 'squilla_router',
+    }
+    runtime.queueRouterDecision({ ...decision, stream_seq: 10 })
+    runtime.queueRouterDecision(decision, 10)
+    runtime.flushPendingRouterDecision()
+
+    const routers = messagesRef.value.filter(message => message.role === 'router')
+    expect(routers).toHaveLength(1)
+    expect(routers[0]?.messageId).toBe('router-sess-10')
+  })
+
+  it('reuses one generated identity when a sequence-free decision is flushed later', () => {
+    const now = vi.spyOn(Date, 'now')
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(2_000)
+    try {
+      const { runtime, messagesRef } = makeRuntime([], true, 'squilla_router')
+
+      runtime.queueRouterDecision({
+        tier: 'c1',
+        model: 'provider/first',
+        source: 'squilla_router',
+      })
+      runtime.flushPendingRouterDecision()
+
+      const routers = messagesRef.value.filter(message => message.role === 'router')
+      expect(routers).toHaveLength(1)
+      expect(routers[0]?.messageId).toBe('router-sess-1000-1')
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it('keeps distinct sequence-free decisions unique inside the same millisecond', () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+    try {
+      const { runtime, messagesRef } = makeRuntime([], true, 'squilla_router')
+
+      runtime.queueRouterDecision({
+        tier: 'c1',
+        model: 'provider/first',
+        source: 'squilla_router',
+      })
+      runtime.flushPendingRouterDecision()
+      runtime.queueRouterDecision({
+        tier: 'c2',
+        model: 'provider/second',
+        source: 'squilla_router',
+      })
+      runtime.flushPendingRouterDecision()
+
+      const routers = messagesRef.value.filter(message => message.role === 'router')
+      expect(routers.map(message => message.messageId)).toEqual([
+        'router-sess-1000-1',
+        'router-sess-1000-2',
+      ])
+    } finally {
+      now.mockRestore()
+    }
+  })
+
   it('keeps emitted same-turn cards immutable and binds each physical call', () => {
     const { runtime, messagesRef } = makeRuntime([{
       role: 'user',

--- a/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.ts
@@ -28,7 +28,12 @@ export interface UseChatRouterDecisionRuntimeOptions {
 }
 
 export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRuntimeOptions) {
-  const pendingRouterDecision = ref<{ payload: RouterDecisionPayload; decision: NormalizedRouterDecision } | null>(null)
+  const pendingRouterDecision = ref<{
+    payload: RouterDecisionPayload
+    decision: NormalizedRouterDecision
+    messageId: string
+  } | null>(null)
+  let localRouterMessageSeq = 0
 
   // Router and ensemble events can arrive throughout a long streamed answer.
   // They should follow the live edge only while the reader has elected to stay
@@ -137,13 +142,31 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
     return true
   }
 
-  function appendRouterDecision(payload: RouterDecisionPayload, decision = normalizeRouterDecision(payload)) {
+  function validIdentityStreamSeq(value: unknown): number | null {
+    return typeof value === 'number' && Number.isSafeInteger(value) && value > 0
+      ? value
+      : null
+  }
+
+  function routerDecisionMessageId(
+    payload: RouterDecisionPayload,
+    identityStreamSeq?: number,
+  ): string {
+    const streamSeq = validIdentityStreamSeq(payload.stream_seq)
+      ?? validIdentityStreamSeq(identityStreamSeq)
+    if (streamSeq !== null) return `router-${options.sessionKey.value}-${streamSeq}`
+    localRouterMessageSeq += 1
+    return `router-${options.sessionKey.value}-${Date.now()}-${localRouterMessageSeq}`
+  }
+
+  function appendRouterDecision(
+    payload: RouterDecisionPayload,
+    decision: NormalizedRouterDecision,
+    messageId: string,
+  ) {
     if (!decision) return
     const turnId = payloadTurnId(payload)
     const acceptedDecision = freezeAcceptedRoutingMode(decision, turnId)
-    const messageId = payload?.stream_seq
-      ? `router-${options.sessionKey.value}-${payload.stream_seq}`
-      : `router-${options.sessionKey.value}-${Date.now()}`
     if (options.messages.value.some(message => message.messageId === messageId)) return
 
     options.messages.value.push({
@@ -158,7 +181,7 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
     scrollToBottomIfFollowing()
   }
 
-  function queueRouterDecision(payload: RouterDecisionPayload) {
+  function queueRouterDecision(payload: RouterDecisionPayload, identityStreamSeq?: number) {
     const normalizedDecision = normalizeRouterDecision(payload)
     if (!normalizedDecision) return
     const decision = freezeAcceptedRoutingMode(
@@ -169,15 +192,16 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
       const model = shortModelName(decision.model || decision.routed_model || '')
       options.setStreamActivity(model ? `Router selected · ${model}` : 'Router selected')
     }
-    pendingRouterDecision.value = { payload, decision }
-    appendRouterDecision(payload, decision)
+    const messageId = routerDecisionMessageId(payload, identityStreamSeq)
+    pendingRouterDecision.value = { payload, decision, messageId }
+    appendRouterDecision(payload, decision, messageId)
   }
 
   function flushPendingRouterDecision() {
     const pending = pendingRouterDecision.value
     if (!pending) return
     pendingRouterDecision.value = null
-    appendRouterDecision(pending.payload, pending.decision)
+    appendRouterDecision(pending.payload, pending.decision, pending.messageId)
   }
 
   function clearPendingRouterDecision() {

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.taskOwnership.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.taskOwnership.test.ts
@@ -481,6 +481,39 @@ describe('task ownership event races', () => {
     scope.stop()
   })
 
+  it('preserves the accepted router identity when a successor is replayed', () => {
+    const { api, options, activeStreamTaskId, scope } = makeHarness()
+
+    api.handlers.onTaskQueued({ task_id: 'task-B', session_key: SESSION })
+    api.handlers.onTaskRunning({ task_id: 'task-B', session_key: SESSION })
+    api.handlers.onRouterDecision({
+      task_id: 'task-B',
+      session_key: SESSION,
+      turn_id: 'turn-B',
+      stream_seq: 10,
+      tier: 'c1',
+      model: 'provider/first',
+      source: 'squilla_router',
+    })
+
+    expect(options.queueRouterDecision).not.toHaveBeenCalled()
+
+    api.handlers.onAny('session.event.done', {
+      task_id: 'task-A',
+      session_key: SESSION,
+      stream_seq: 11,
+      reason: 'completed',
+      text: 'complete A answer',
+    })
+
+    expect(activeStreamTaskId.value).toBe('task-B')
+    expect(options.queueRouterDecision).toHaveBeenCalledOnce()
+    const [payload, identityStreamSeq] = vi.mocked(options.queueRouterDecision).mock.calls[0]!
+    expect(payload).not.toHaveProperty('stream_seq')
+    expect(identityStreamSeq).toBe(10)
+    scope.stop()
+  })
+
   it('accepts a queued-only Stop terminal despite an empty render owner', () => {
     const { api, options, stream, activeStreamTaskId, taskOwnership, scope } = makeHarness()
     taskOwnership.noteTerminal('task-A')

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
@@ -72,6 +72,7 @@ function createHarness(options: {
   }
   const markEnsembleHandoff = vi.fn()
   const bindRouterDecisionToModelCall = vi.fn()
+  const queueRouterDecision = vi.fn()
   const schedulePendingDrainAfterTerminal = vi.fn()
   const scheduleHistorySync = vi.fn()
   const showCompactionToast = vi.fn()
@@ -109,7 +110,7 @@ function createHarness(options: {
     normalizeRunStatus: (status: string) => status,
     sessionRunStatus: options.sessionRunStatus || (() => ({ status: 'idle', label: 'Idle', task: null })),
     applySessionRunState,
-    queueRouterDecision: vi.fn(),
+    queueRouterDecision,
     bindRouterDecisionToModelCall,
     appendEnsembleProgress: vi.fn(),
     markEnsembleHandoff,
@@ -144,6 +145,7 @@ function createHarness(options: {
     applySessionRunState,
     markEnsembleHandoff,
     bindRouterDecisionToModelCall,
+    queueRouterDecision,
     schedulePendingDrainAfterTerminal,
     scheduleHistorySync,
     showCompactionToast,
@@ -534,6 +536,43 @@ describe('useChatRpcEventHandlers live snapshot restoration', () => {
       expect(stream.setAcceptedActivityOrder).toHaveBeenNthCalledWith(3, 12)
       expect(activeStreamTaskId.value).toBe('task-live')
       expect(lastStreamSeq.value).toBe(2400)
+    } finally {
+      stop()
+    }
+  })
+
+  it('keeps a snapshot router sequence as identity without replaying it through the cursor', () => {
+    const {
+      api,
+      lastStreamSeq,
+      queueRouterDecision,
+      stop,
+    } = createHarness()
+    try {
+      lastStreamSeq.value = 900
+      api.restoreLiveTurnSnapshot({
+        key: 'agent:main:test',
+        task_id: 'task-live',
+        current_stream_seq: 2_400,
+        events: [{
+          event: 'session.event.router_decision',
+          payload: {
+            session_key: 'agent:main:test',
+            task_id: 'task-live',
+            turn_id: 'turn-live',
+            stream_seq: 17,
+            tier: 'c1',
+            model: 'provider/first',
+            source: 'squilla_router',
+          },
+        }],
+      })
+
+      expect(queueRouterDecision).toHaveBeenCalledOnce()
+      const [payload, identityStreamSeq] = queueRouterDecision.mock.calls[0]!
+      expect(payload).not.toHaveProperty('stream_seq')
+      expect(identityStreamSeq).toBe(17)
+      expect(lastStreamSeq.value).toBe(2_400)
     } finally {
       stop()
     }

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
@@ -149,7 +149,7 @@ export interface UseChatRpcEventHandlersOptions {
   normalizeRunStatus: (status: string) => string
   sessionRunStatus: (source: ChatRunStatusSource | null | undefined) => ChatRunStatus
   applySessionRunState: (source: ChatRunStatusSource | null | undefined) => void
-  queueRouterDecision: (payload: RouterDecisionPayload) => void
+  queueRouterDecision: (payload: RouterDecisionPayload, identityStreamSeq?: number) => void
   bindRouterDecisionToModelCall?: (
     modelCallId: string,
     iteration?: number,
@@ -1027,10 +1027,14 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
       // Let the terminal own a shared cursor. A tracked compaction terminal may
       // still close its existing UI after task completion, but it must not move
       // the task cursor past the terminal that closed the stream.
-      const payload = entry.replayWithoutSeq || sharesTerminalSequence || maintenanceAfterTerminal
-        ? withoutBufferedStreamSeq(entry.payload)
-        : entry.payload
-      replayPendingStreamEvent({ event: entry.event, payload })
+      const replayWithoutSeq = Boolean(
+        entry.replayWithoutSeq || sharesTerminalSequence || maintenanceAfterTerminal,
+      )
+      replayPendingStreamEvent({
+        event: entry.event,
+        payload: entry.payload,
+        ...(replayWithoutSeq ? { replayWithoutSeq: true } : {}),
+      })
     }
   }
 
@@ -2128,7 +2132,7 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
     if (!acceptStreamSeq(payload)) return
     if (!stream.isStreaming.value) stream.startStreaming()
     recordActivityPhase('Selecting model', 'router:decided')
-    options.queueRouterDecision(payload)
+    options.queueRouterDecision(payload, replayActivityOrder)
   }
 
   function handleRpcEnsembleProgress(payload: EnsembleProgressPayload) {


### PR DESCRIPTION
## Summary
- preserve router decision identity when snapshots and buffered successor events replay without `stream_seq`
- reuse one stable message ID across queue/flush so reconnect snapshots remain idempotent
- keep legitimate retries, steer/ensemble calls, and same-millisecond sequence-free decisions distinct
- add deterministic unit and WebSocket reconnect coverage through done/usage settlement and history refresh

## Scope
- WebUI projection only
- no Gateway, RPC payload, SQLite, routing execution, billing, or rendered-message protocol changes

## Validation
- `npm run test:unit -- src/composables/chat/useChatRouterDecisionRuntime.test.ts src/composables/chat/useChatRpcEventHandlers.test.ts src/composables/chat/useChatRpcEventHandlers.taskOwnership.test.ts src/composables/chat/useChatRenderedMessages.test.ts` (184 passed)
- `npm run typecheck`
- `npm run build:artifact` (404 artifact files verified)
- targeted production-preview E2E: `keeps one router card across reconnect snapshot, done, and history refresh` (passed)
- remaining long-task resilience scenarios excluding the known main baseline case (4 passed)

## Upstream baseline note
The existing `projects reasoning, Retry-After, retry, fallback, and stale progress without leaking errors` E2E expects `Waiting for model` but currently renders `Working`. The same failure was reproduced with all six PR files stashed on clean `origin/main@72e7a9b76`, so it is not introduced by this change.