### PR TITLE
Persist historical router panel snapshots

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatMarkdownExport.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatMarkdownExport.test.ts
@@ -99,4 +99,31 @@ describe('buildChatMarkdown', () => {
 
     expect(markdown).toContain('NO_REPLY\nLiteral explanation')
   })
+
+  it('exports the authoritative routed model instead of inferring it from UI cells', () => {
+    const markdown = buildChatMarkdown({
+      title: 'Historical route',
+      exportedAt: '2026-08-25T00:00:00.000Z',
+      aiGeneratedLabel: 'AI generated',
+      messages: [{
+        displayRole: 'router',
+        roleLabel: 'Router',
+        text: '',
+        timeStr: '',
+        isRouterStrip: true,
+        routerSelectedModel: 'historical/authoritative-model',
+        winnerIdx: 0,
+        gridCells: [{
+          kind: 'real',
+          tier: 'c1',
+          tiers: ['c1'],
+          displayName: 'stale-model',
+          model: 'current/stale-model',
+        }],
+      } as ChatRenderedMessage],
+    })
+
+    expect(markdown).toContain('> Router selected historical/authoritative-model')
+    expect(markdown).not.toContain('current/stale-model')
+  })
 })

--- a/opensquilla-webui/src/composables/chat/useChatMarkdownExport.ts
+++ b/opensquilla-webui/src/composables/chat/useChatMarkdownExport.ts
@@ -56,7 +56,10 @@ export function buildChatMarkdown(options: BuildChatMarkdownOptions): string {
   for (const message of options.messages) {
     if (message.isRouterStrip) {
       const winner = message.gridCells?.[message.winnerIdx ?? -1]
-      if (winner) lines.push(`> Router selected ${winner.displayName || winner.model || winner.tier}`)
+      const selectedModel = String(message.routerSelectedModel || '').trim()
+      if (selectedModel || winner) {
+        lines.push(`> Router selected ${selectedModel || winner?.model || winner?.displayName || winner?.tier}`)
+      }
       continue
     }
     if (!['user', 'assistant', 'system', 'subagent', 'error'].includes(message.displayRole || message.role)) continue

--- a/opensquilla-webui/src/composables/chat/useChatRenderedMessages.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRenderedMessages.test.ts
@@ -880,6 +880,222 @@ describe('useChatRenderedMessages immutable route history', () => {
     expect(winner?.model).toBe('provider/original-model')
     expect(strip?.routerSource).toBe('classifier')
   })
+
+  it('restores the frozen candidate pool and lets the historical winner override it', () => {
+    const api = useChatRenderedMessages({
+      messages: ref<ChatMessage[]>([
+        { role: 'user', text: 'Historical question', ts: 1, turnId: 'turn-snapshot' },
+        {
+          role: 'assistant',
+          text: 'Historical answer',
+          ts: 2,
+          turnId: 'turn-snapshot',
+          restoredFromHistory: true,
+          usage: {
+            routed_tier: 'c1',
+            routed_model: 'historical/winner',
+            routing_source: 'classifier',
+            route_plan: {
+              version: 2,
+              tier: 'c1',
+              model: 'historical/winner',
+              source: 'classifier',
+              router_tier_snapshot: {
+                version: 1,
+                request_kind: 'text',
+                tiers: [
+                  { tier: 'c0', model: 'historical/fast', execution_kind: 'single_model' },
+                  { tier: 'c1', model: 'stale/conflict', execution_kind: 'ensemble' },
+                ],
+              },
+            },
+          },
+        },
+      ]),
+      sessionKey: ref('agent:main:webchat:snapshot'),
+      routerSlots: ref(['c0', 'c1']),
+      routerModels: ref({}),
+      routerTierConfigs: ref({
+        c0: { model: 'current/fast', supportsImage: false, imageOnly: false },
+        c1: { model: 'current/balanced', supportsImage: false, imageOnly: false },
+      }),
+      routerVisualEffectsEnabled: ref(true),
+      routerVisualMode: ref('real_candidates'),
+      renderMarkdown: text => text,
+      stripGeneratedArtifactMarkers: text => text,
+      stripTimePrefix: text => text,
+      isSubagentCompletionMessage: () => false,
+    })
+
+    const strip = api.renderedMessages.value.find(message => message.isRouterStrip)
+    expect(strip?.gridCells?.map(cell => cell.model)).toEqual([
+      'historical/fast',
+      'historical/winner',
+    ])
+    expect(strip?.gridCells?.[strip.winnerIdx ?? -1]).toMatchObject({
+      model: 'historical/winner',
+      executionKind: 'ensemble',
+    })
+    expect(strip?.routerSelectedModel).toBe('historical/winner')
+  })
+
+  it('rejects a damaged snapshot atomically and rebuilds with the historical winner', () => {
+    const api = useChatRenderedMessages({
+      messages: ref<ChatMessage[]>([
+        { role: 'user', text: 'Old question', ts: 1, turnId: 'turn-damaged' },
+        {
+          role: 'assistant',
+          text: 'Old answer',
+          ts: 2,
+          turnId: 'turn-damaged',
+          restoredFromHistory: true,
+          usage: {
+            routed_tier: 'c2',
+            routed_model: 'historical/winner',
+            routing_source: 'classifier',
+            route_plan: {
+              version: 2,
+              tier: 'c2',
+              model: 'historical/winner',
+              source: 'classifier',
+              router_tier_snapshot: {
+                version: 1,
+                request_kind: 'text',
+                tiers: [
+                  { tier: 'c0', model: 'damaged/one', execution_kind: 'single_model' },
+                  { tier: 't0', model: 'damaged/two', execution_kind: 'single_model' },
+                ],
+              },
+            },
+          },
+        },
+      ]),
+      sessionKey: ref('agent:main:webchat:damaged-snapshot'),
+      routerSlots: ref(['c0']),
+      routerModels: ref({}),
+      routerTierConfigs: ref({
+        c0: { model: 'current/fast', supportsImage: false, imageOnly: false },
+      }),
+      routerVisualEffectsEnabled: ref(true),
+      routerVisualMode: ref('real_candidates'),
+      renderMarkdown: text => text,
+      stripGeneratedArtifactMarkers: text => text,
+      stripTimePrefix: text => text,
+      isSubagentCompletionMessage: () => false,
+    })
+
+    const strip = api.renderedMessages.value.find(message => message.isRouterStrip)
+    expect(strip?.gridCells).toEqual(expect.arrayContaining([
+      expect.objectContaining({ model: 'current/fast' }),
+      expect.objectContaining({ model: 'historical/winner', tiers: ['c2'] }),
+    ]))
+    expect(strip?.gridCells?.some(cell => cell.model?.startsWith('damaged/'))).toBe(false)
+    expect(strip?.gridCells?.[strip.winnerIdx ?? -1]?.model).toBe('historical/winner')
+  })
+
+  it('shows only the historical winner when an old turn has no usable current pool', () => {
+    const api = useChatRenderedMessages({
+      messages: ref<ChatMessage[]>([
+        { role: 'user', text: 'Old question', ts: 1, turnId: 'turn-winner-only' },
+        {
+          role: 'assistant',
+          text: 'Old answer',
+          ts: 2,
+          turnId: 'turn-winner-only',
+          restoredFromHistory: true,
+          usage: {
+            routed_tier: 'c2',
+            routed_model: 'historical/only-winner',
+            routing_source: 'classifier',
+          },
+        },
+      ]),
+      sessionKey: ref('agent:main:webchat:winner-only'),
+      routerSlots: ref([]),
+      routerModels: ref({}),
+      routerTierConfigs: ref({}),
+      routerVisualEffectsEnabled: ref(true),
+      routerVisualMode: ref('real_candidates'),
+      renderMarkdown: text => text,
+      stripGeneratedArtifactMarkers: text => text,
+      stripTimePrefix: text => text,
+      isSubagentCompletionMessage: () => false,
+    })
+
+    const strip = api.renderedMessages.value.find(message => message.isRouterStrip)
+    expect(strip?.gridCells).toEqual([
+      expect.objectContaining({
+        tiers: ['c2'],
+        model: 'historical/only-winner',
+      }),
+    ])
+    expect(strip?.winnerIdx).toBe(0)
+  })
+
+  it('retains a valid live snapshot when an older done event omits it', () => {
+    const liveSnapshot = {
+      version: 1,
+      request_kind: 'text',
+      tiers: [
+        { tier: 'c0', model: 'frozen/fast', execution_kind: 'single_model' },
+        { tier: 'c1', model: 'frozen/winner', execution_kind: 'single_model' },
+      ],
+    }
+    const api = useChatRenderedMessages({
+      messages: ref<ChatMessage[]>([
+        { role: 'user', text: 'Live question', ts: 1, turnId: 'turn-live' },
+        {
+          role: 'router',
+          text: '',
+          ts: 2,
+          turnId: 'turn-live',
+          messageId: 'router-live',
+          provenanceKind: 'router_decision',
+          routerDecision: {
+            tier: 'c1',
+            model: 'frozen/winner',
+            source: 'classifier',
+            router_tier_snapshot: liveSnapshot,
+          },
+        },
+        {
+          role: 'assistant',
+          text: 'Done',
+          ts: 3,
+          turnId: 'turn-live',
+          messageId: 'assistant-live',
+          usage: {
+            routed_tier: 'c1',
+            routed_model: 'frozen/winner',
+            routing_source: 'classifier',
+            route_plan: {
+              version: 1,
+              tier: 'c1',
+              model: 'frozen/winner',
+              source: 'classifier',
+            },
+          },
+        },
+      ]),
+      sessionKey: ref('agent:main:webchat:live-snapshot'),
+      routerSlots: ref(['c0', 'c1']),
+      routerModels: ref({}),
+      routerTierConfigs: ref({
+        c0: { model: 'current/fast', supportsImage: false, imageOnly: false },
+        c1: { model: 'current/balanced', supportsImage: false, imageOnly: false },
+      }),
+      routerVisualEffectsEnabled: ref(true),
+      routerVisualMode: ref('real_candidates'),
+      renderMarkdown: text => text,
+      stripGeneratedArtifactMarkers: text => text,
+      stripTimePrefix: text => text,
+      isSubagentCompletionMessage: () => false,
+    })
+
+    const strip = api.renderedMessages.value.find(message => message.isRouterStrip)
+    expect(strip?.gridCells?.map(cell => cell.model)).toEqual(['frozen/fast', 'frozen/winner'])
+    expect(strip?.routerSettled).toBe(true)
+  })
 })
 
 describe('useChatRenderedMessages router visual mode', () => {

--- a/opensquilla-webui/src/composables/chat/useChatRenderedMessages.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRenderedMessages.ts
@@ -34,6 +34,7 @@ import {
   normalizeRouterTier,
   sortRouterTiers,
 } from '@/utils/chat/routerTiers'
+import { normalizeRouterTierSnapshot } from '@/utils/chat/routerTierSnapshot'
 import { clarifyRequestFromValue, userInputOutcomeFromValue } from '@/utils/chat/clarify'
 import type { RouterVisualMode } from '@/utils/chat/routerVisualMode'
 import type { ModelRoutingMode } from '@/types/modelRouting'
@@ -68,6 +69,8 @@ export interface NormalizedRouterDecision extends Record<string, unknown> {
   rollout_phase?: string
   accepted_routing_mode?: string
   acceptedRoutingMode?: string
+  router_tier_snapshot?: unknown
+  routerTierSnapshot?: unknown
 }
 
 export interface UseChatRenderedMessagesOptions {
@@ -423,7 +426,7 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
 
       const usageEnsemble = ensembleMetaFromMessage(msg)
       if (usageEnsemble) {
-        const usageRouterDecision = routerDecisionFromUsage(msg)
+        const usageRouterDecision = routerDecisionFromUsage(msg, turnRouterDecision)
         if (usageRouterDecision) turnRouterDecision = usageRouterDecision
         const inLiveTurn = options.isStreaming?.value === true && i > lastUserIdx
         const settledMessage = {
@@ -466,7 +469,13 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
         }
         prevRole = ''
       } else {
-        const usageRouterDecision = routerDecisionFromUsage(msg, inheritedSubagentRoute(msg))
+        const hasTurnUsage = Boolean(msg.routerUsage || msg.usage || msg.turn_usage)
+        const usageRouterDecision = routerDecisionFromUsage(
+          msg,
+          hasTurnUsage
+            ? turnRouterDecision || inheritedSubagentRoute(msg)
+            : inheritedSubagentRoute(msg),
+        )
         if (usageRouterDecision) {
           turnRouterDecision = usageRouterDecision
           const stripItem = renderedRouterStrip(
@@ -686,7 +695,19 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
   ): ChatRenderedMessage | null {
     const cells = routerDecisionCellsForRequest(decision, requestKind)
     const fixedSessionRoute = decision.source === 'session_model'
-    if (cells.length === 0 || (cells.length === 1 && !fixedSessionRoute)) return null
+    const snapshot = normalizeRouterTierSnapshot(
+      decision.router_tier_snapshot ?? decision.routerTierSnapshot,
+    )
+    const hasRequestSnapshot = snapshot?.request_kind === requestKind
+    if (
+      cells.length === 0
+      || (
+        cells.length === 1
+        && !fixedSessionRoute
+        && !hasRequestSnapshot
+        && currentRouterCandidatePoolAvailable(requestKind)
+      )
+    ) return null
     return {
       id: `router-turn-${turnIdx}`,
       role: 'router',
@@ -716,6 +737,7 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
       routerMode: 'squilla_router',
       gridCells: cells,
       winnerIdx: routerWinnerCellIndex(cells, decision.tier),
+      routerSelectedModel: String(decision.model || decision.routed_model || '').trim(),
       messageId: messageId || `${index}-router`,
     }
   }
@@ -1105,21 +1127,73 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
 
   function realRouterDecisionCellsForRequest(decision: NormalizedRouterDecision, requestKind: ChatRouterRequestKind): ChatRouterCell[] {
     const winnerTier = normalizeRouterTier(decision.tier)
+    const winnerModel = String(decision.model || decision.routed_model || '').trim()
+    const snapshot = normalizeRouterTierSnapshot(
+      decision.router_tier_snapshot ?? decision.routerTierSnapshot,
+    )
+    if (snapshot?.request_kind === requestKind) {
+      return routerCellsFromTierEntries(
+        snapshot.tiers.map(entry => ({
+          tier: entry.tier,
+          model: entry.model,
+          executionKind: entry.execution_kind,
+        })),
+        winnerTier,
+        winnerModel,
+        true,
+      )
+    }
+
     const configuredTiers = options.routerSlots.value.length
       ? options.routerSlots.value.map(normalizeRouterTier).filter(Boolean)
       : Object.keys(options.routerTierConfigs.value).map(normalizeRouterTier).filter(Boolean)
     if (winnerTier && !configuredTiers.includes(winnerTier)) configuredTiers.push(winnerTier)
     const sourceTiers = sortRouterTiers(configuredTiers.length ? configuredTiers : (winnerTier ? [winnerTier] : []))
-    const realByModel = new Map<string, ChatRouterCell>()
-
+    const entries: Array<{
+      tier: string
+      model: string
+      executionKind: 'single_model' | 'ensemble'
+    }> = []
     for (const tier of sourceTiers) {
       const tierConfig = routerTierConfig(tier)
       if (tier !== winnerTier && !routerTierMatchesRequestKind(tierConfig, requestKind)) continue
-      const model = tierConfig.model || options.routerModels.value[tier] || (tier === winnerTier ? String(decision.model || '') : '')
+      const model = tier === winnerTier && winnerModel
+        ? winnerModel
+        : tierConfig.model || options.routerModels.value[tier] || ''
       if (!model && tier !== winnerTier) continue
+      entries.push({
+        tier,
+        model,
+        executionKind: tierConfig.ensembleEnabled === true ? 'ensemble' : 'single_model',
+      })
+    }
+    return routerCellsFromTierEntries(entries, winnerTier, winnerModel, false)
+  }
+
+  function routerCellsFromTierEntries(
+    sourceEntries: Array<{
+      tier: string
+      model: string
+      executionKind: 'single_model' | 'ensemble'
+    }>,
+    winnerTier: string,
+    winnerModel: string,
+    preserveOrder: boolean,
+  ): ChatRouterCell[] {
+    const entries = sourceEntries.map(entry => ({ ...entry }))
+    const winnerEntry = entries.find(entry => entry.tier === winnerTier)
+    if (winnerEntry && winnerModel) {
+      winnerEntry.model = winnerModel
+    } else if (!winnerEntry && winnerTier && winnerModel) {
+      entries.push({ tier: winnerTier, model: winnerModel, executionKind: 'single_model' })
+    }
+
+    const realByModel = new Map<string, ChatRouterCell>()
+    for (const entry of entries) {
+      const { tier, model, executionKind } = entry
+      if (!model) continue
       const displayName = shortModelName(routerFxStripProvider(model)) || (tier === winnerTier ? 'selected model' : tier)
-      const executionKind = tierConfig.ensembleEnabled === true ? 'ensemble' : 'single_model'
-      const key = `${executionKind}:${displayName || model || `winner:${tier}`}`
+      const key = `${executionKind}:${model}`
       const existing = realByModel.get(key)
       if (existing) {
         existing.tiers = [...(existing.tiers || []), tier]
@@ -1134,9 +1208,10 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
         executionKind,
       })
     }
-
-    return Array.from(realByModel.values())
-      .sort((a, b) => (a.displayName || a.tier).localeCompare(b.displayName || b.tier))
+    const cells = Array.from(realByModel.values())
+    return preserveOrder
+      ? cells
+      : cells.sort((a, b) => (a.displayName || a.tier).localeCompare(b.displayName || b.tier))
   }
 
   function legacyRouterGridCells(realCells: ChatRouterCell[]): ChatRouterCell[] {
@@ -1165,6 +1240,18 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
   function routerTierMatchesRequestKind(tierConfig: ChatRouterTierConfig, requestKind: ChatRouterRequestKind): boolean {
     if (requestKind === 'image') return tierConfig.supportsImage || tierConfig.imageOnly
     return !tierConfig.imageOnly
+  }
+
+  function currentRouterCandidatePoolAvailable(requestKind: ChatRouterRequestKind): boolean {
+    const configuredTiers = options.routerSlots.value.length
+      ? options.routerSlots.value
+      : Object.keys(options.routerTierConfigs.value)
+    return configuredTiers.some((rawTier) => {
+      const tier = normalizeRouterTier(rawTier)
+      const config = routerTierConfig(tier)
+      const model = config.model || options.routerModels.value[tier] || ''
+      return Boolean(model && routerTierMatchesRequestKind(config, requestKind))
+    })
   }
 
   function normalizeMessageTimeline(msg: ChatMessage, ownerKey: string): ChatStreamTimelineItem[] {
@@ -1656,6 +1743,7 @@ export function normalizeRouterDecision(raw: unknown): NormalizedRouterDecision 
     tier,
     model: String(source.model || source.routed_model || ''),
     baseline_model: String(source.baseline_model || source.baselineModel || ''),
+    router_tier_snapshot: source.router_tier_snapshot ?? source.routerTierSnapshot,
   }
 }
 
@@ -1666,7 +1754,7 @@ function routerDecisionFromUsage(
   const usage = msg.routerUsage || msg.usage || msg.turn_usage
   if (!usage) return inheritedRoute
   if (usage.routing_source === 'none') return inheritedRoute
-  const routePlan = usage.route_plan
+  const routePlan = usage.route_plan || usage.routePlan
   const immutablePlan = (
     routePlan
     && typeof routePlan === 'object'
@@ -1681,6 +1769,20 @@ function routerDecisionFromUsage(
   const source = typeof immutablePlan?.source === 'string'
     ? immutablePlan.source
     : usage.routing_source || 'none'
+  const planHasSnapshot = Boolean(
+    immutablePlan
+    && (
+      Object.prototype.hasOwnProperty.call(immutablePlan, 'router_tier_snapshot')
+      || Object.prototype.hasOwnProperty.call(immutablePlan, 'routerTierSnapshot')
+    ),
+  )
+  const usageHasSnapshot = Object.prototype.hasOwnProperty.call(usage, 'router_tier_snapshot')
+    || Object.prototype.hasOwnProperty.call(usage, 'routerTierSnapshot')
+  const routerTierSnapshot = planHasSnapshot
+    ? immutablePlan?.router_tier_snapshot ?? immutablePlan?.routerTierSnapshot
+    : usageHasSnapshot
+      ? usage.router_tier_snapshot ?? usage.routerTierSnapshot
+      : inheritedRoute?.router_tier_snapshot ?? inheritedRoute?.routerTierSnapshot
   return normalizeRouterDecision({
     tier,
     model: immutablePlan?.model || usage.routed_model || usage.model || msg.model || '',
@@ -1692,6 +1794,7 @@ function routerDecisionFromUsage(
       : usage.routing_applied !== false,
     rollout_phase: usage.rollout_phase || 'full',
     accepted_routing_mode: msg.turnOutcome?.acceptedRoutingMode,
+    router_tier_snapshot: routerTierSnapshot,
   })
 }
 

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
@@ -1968,6 +1968,30 @@ describe('useChatRpcEventHandlers done usage attachment', () => {
         run_kind: 'goal',
         model_usage_breakdown: [{ model: 'z-ai/glm-5.2', role: 'aggregator' }],
         ensemble_trace: { profile: 'default', llm_request_count: 5 },
+        route_plan: {
+          version: 2,
+          tier: 'c1',
+          model: 'z-ai/glm-5.2',
+          router_tier_snapshot: {
+            version: 1,
+            request_kind: 'text',
+            tiers: [{
+              tier: 'c1',
+              model: 'z-ai/glm-5.2',
+              execution_kind: 'single_model',
+            }],
+          },
+        },
+        usage: {
+          model: 'z-ai/glm-5.2',
+          input_tokens: 10,
+          output_tokens: 1,
+          route_plan: {
+            version: 1,
+            tier: 'c1',
+            model: 'stale/nested-model',
+          },
+        },
         coverage_status: 'usage_unknown',
         usage_unknown: true,
         unknown_usage_events: 1,
@@ -1982,6 +2006,13 @@ describe('useChatRpcEventHandlers done usage attachment', () => {
         coverage_status: 'usage_unknown',
         usage_unknown: true,
         unknown_usage_events: 1,
+        route_plan: {
+          version: 2,
+          router_tier_snapshot: {
+            version: 1,
+            request_kind: 'text',
+          },
+        },
       })
       expect(messages.value[1].model).toBe('z-ai/glm-5.2')
       expect(messages.value[1].input_tokens).toBe(10)

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
@@ -208,6 +208,8 @@ type ChatDoneUsageFields = {
   model_call_segments?: ChatModelCallSegment[]
   modelCallSegments?: ChatModelCallSegment[]
   decision_id?: string
+  route_plan?: Record<string, unknown>
+  routePlan?: Record<string, unknown>
 }
 
 type ChatDoneUsagePayload = SessionDonePayload & ChatDoneUsageFields & {
@@ -1304,6 +1306,13 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
     }
     if (direct.ensembleTrace != null && usage.ensembleTrace == null) {
       usage.ensembleTrace = direct.ensembleTrace as never
+    }
+    const directRoutePlan = direct.route_plan ?? direct.routePlan
+    if (directRoutePlan != null) {
+      // The terminal event carries the canonical persisted RoutePlan. It must
+      // replace a smaller nested usage receipt so its tier snapshot wins over
+      // both live state and compatibility payloads.
+      usage.route_plan = directRoutePlan as Record<string, unknown>
     }
     for (const key of [
       'coverage_status',

--- a/opensquilla-webui/src/composables/chat/useChatSessionBootstrap.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionBootstrap.test.ts
@@ -555,6 +555,40 @@ describe('useChatSessionBootstrap', () => {
     expect(subscribeSession).toHaveBeenCalledTimes(2)
   })
 
+  it('recovers once when connected wins the disconnect-association race', async () => {
+    let resolveInterrupted!: (result: SessionSubscriptionOutcome) => void
+    let liveCalls = 0
+    const connectionClosed = new Error('connection closed')
+    const { api, subscribeSession } = createBootstrap({
+      subscribeSession: async () => {
+        liveCalls += 1
+        if (liveCalls === 1) {
+          return new Promise(resolve => {
+            resolveInterrupted = resolve
+          })
+        }
+        if (liveCalls === 2) {
+          return { ...UNAVAILABLE_FOR_TEST, error: connectionClosed }
+        }
+        return LIVE_READY
+      },
+    })
+
+    const run = api.startSessionBootstrap()
+    await vi.waitFor(() => expect(resolveInterrupted).toBeTypeOf('function'))
+
+    // RpcClient can emit disconnected while a superseded bootstrap is being
+    // cancelled, before this run becomes active. Its replacement handshake is
+    // still observable, so remember that connected socket while this phase is
+    // settling and recover if both old-generation attempts fail.
+    api.handleConnectionState('connected')
+    resolveInterrupted({ ...UNAVAILABLE_FOR_TEST, error: connectionClosed })
+    await run.live
+
+    await vi.waitFor(() => expect(api.livePhase.value).toBe('ready'))
+    expect(subscribeSession).toHaveBeenCalledTimes(3)
+  })
+
   it('does not grant repeated replacement sockets unbounded recovery budgets', async () => {
     let resolveInterrupted!: (result: SessionSubscriptionOutcome) => void
     const timeout = new RpcTimeoutError('sessions.messages.subscribe', 7_000)

--- a/opensquilla-webui/src/composables/chat/useChatSessionBootstrap.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionBootstrap.ts
@@ -648,13 +648,19 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
     }
     const replacementConnected = run.awaitingReplacementConnection
     run.awaitingReplacementConnection = false
-    if (replacementConnected && run.live.running) {
+    if (run.live.running) {
       const interruptedPhase = run.live
-      const resumeOnReplacement = () => {
+      const resumeOnReplacement = (outcome?: SessionSubscriptionOutcome) => {
+        const transportFailedAfterConnected = (
+          !replacementConnected
+          && requiresFreshLiveQueue(outcome?.error)
+        )
         if (
-          !isCurrent(run)
+          (!replacementConnected && !transportFailedAfterConnected)
+          || !isCurrent(run)
           || run.live !== interruptedPhase
           || interruptedPhase.running
+          || run.lateReplacementRecoveryUsed
           || (
             livePhase.value !== 'connecting'
             && livePhase.value !== 'degraded'
@@ -663,11 +669,15 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
         run.lateReplacementRecoveryUsed = true
         rearmCriticalQueue(run, false)
         // This is a continuation of the same outage, not a user-initiated
-        // retry. Preserve both the absolute deadline and attempts so repeated
-        // socket replacement cannot keep the UI in "connecting" forever.
+        // retry. Grant exactly one attempt on the authenticated socket. The
+        // connected event can win a route-switch race before the new run sees
+        // the matching disconnected event, so the interrupted phase may have
+        // already consumed both of its attempts on the retired generation.
+        // lateReplacementRecoveryUsed prevents later socket churn from
+        // repeatedly extending this recovery window.
         run.live = {
           ...liveRuntime(interruptedPhase.deadlineAt),
-          attempts: interruptedPhase.attempts,
+          attempts: 1,
           skipSnapshot: interruptedPhase.skipSnapshot,
         }
         run.live.promise = runLivePhase(run)
@@ -675,7 +685,10 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
       // The replacement handshake can finish before the interrupted subscribe
       // observes its cancellation. Resume exactly once after that old phase
       // settles instead of leaving the UI indefinitely in "connecting".
-      void interruptedPhase.promise.then(resumeOnReplacement, resumeOnReplacement)
+      void interruptedPhase.promise.then(
+        resumeOnReplacement,
+        () => resumeOnReplacement(),
+      )
       return publicRun(run)
     }
     if (!run.live.running && livePhase.value === 'degraded') {

--- a/opensquilla-webui/src/types/chat.ts
+++ b/opensquilla-webui/src/types/chat.ts
@@ -743,6 +743,8 @@ export interface ChatRenderedMessage {
   ensemble?: ChatEnsembleMeta
   gridCells?: ChatRouterCell[]
   winnerIdx?: number
+  /** Authoritative model from the historical routing decision, independent of UI cells. */
+  routerSelectedModel?: string
   parts?: import('./parts').ChatPart[]
   sources?: import('./parts').SourcePart[]
   statusHistory?: import('./parts').StatusPart[]

--- a/opensquilla-webui/src/types/rpc.ts
+++ b/opensquilla-webui/src/types/rpc.ts
@@ -795,6 +795,8 @@ export interface RouterDecisionPayload extends SessionEventPayload {
   source?: string
   routing_applied?: boolean
   decision?: unknown
+  router_tier_snapshot?: unknown
+  routerTierSnapshot?: unknown
 }
 
 /* ── LLM ensemble progress ─────────────────────────────────────────────

--- a/opensquilla-webui/src/utils/chat/routerTierSnapshot.test.ts
+++ b/opensquilla-webui/src/utils/chat/routerTierSnapshot.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeRouterTierSnapshot } from './routerTierSnapshot'
+
+describe('normalizeRouterTierSnapshot', () => {
+  it('normalizes legacy tier aliases in a complete v1 snapshot', () => {
+    expect(normalizeRouterTierSnapshot({
+      version: 1,
+      request_kind: 'text',
+      tiers: [{
+        tier: 't1',
+        provider: 'test-provider',
+        model: 'test/model',
+        execution_kind: 'ensemble',
+      }],
+    })).toEqual({
+      version: 1,
+      request_kind: 'text',
+      tiers: [{
+        tier: 'c1',
+        provider: 'test-provider',
+        model: 'test/model',
+        execution_kind: 'ensemble',
+      }],
+    })
+  })
+
+  it.each([
+    { version: 2, request_kind: 'text', tiers: [] },
+    { version: 1, request_kind: 'audio', tiers: [] },
+    {
+      version: 1,
+      request_kind: 'text',
+      tiers: [{ tier: 'c0', model: '', execution_kind: 'single_model' }],
+    },
+    {
+      version: 1,
+      request_kind: 'text',
+      tiers: [
+        { tier: 'c0', model: 'one', execution_kind: 'single_model' },
+        { tier: 't0', model: 'two', execution_kind: 'single_model' },
+      ],
+    },
+    {
+      version: 1,
+      request_kind: 'text',
+      tiers: [{ tier: 'c0', model: 'one', execution_kind: 'unknown' }],
+    },
+  ])('rejects the whole malformed snapshot %#', (snapshot) => {
+    expect(normalizeRouterTierSnapshot(snapshot)).toBeNull()
+  })
+})

--- a/opensquilla-webui/src/utils/chat/routerTierSnapshot.ts
+++ b/opensquilla-webui/src/utils/chat/routerTierSnapshot.ts
@@ -1,0 +1,65 @@
+import { IMAGE_TIER, TEXT_TIERS, normalizeRouterTier } from '@/utils/chat/routerTiers'
+
+export type RouterSnapshotRequestKind = 'text' | 'image'
+export type RouterSnapshotExecutionKind = 'single_model' | 'ensemble'
+
+export interface RouterTierSnapshotEntryV1 {
+  tier: string
+  provider?: string
+  model: string
+  execution_kind: RouterSnapshotExecutionKind
+}
+
+export interface RouterTierSnapshotV1 {
+  version: 1
+  request_kind: RouterSnapshotRequestKind
+  tiers: RouterTierSnapshotEntryV1[]
+}
+
+const ALLOWED_TIERS = new Set<string>([...TEXT_TIERS, IMAGE_TIER])
+const MAX_SNAPSHOT_TIERS = 8
+
+/** Atomically validate a persisted router candidate snapshot. */
+export function normalizeRouterTierSnapshot(value: unknown): RouterTierSnapshotV1 | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const source = value as Record<string, unknown>
+  if (source.version !== 1) return null
+  if (source.request_kind !== 'text' && source.request_kind !== 'image') return null
+  if (!Array.isArray(source.tiers) || source.tiers.length < 1 || source.tiers.length > MAX_SNAPSHOT_TIERS) {
+    return null
+  }
+
+  const seen = new Set<string>()
+  const tiers: RouterTierSnapshotEntryV1[] = []
+  for (const rawEntry of source.tiers) {
+    if (!rawEntry || typeof rawEntry !== 'object' || Array.isArray(rawEntry)) return null
+    const entry = rawEntry as Record<string, unknown>
+    const tier = normalizeRouterTier(entry.tier)
+    const model = typeof entry.model === 'string' ? entry.model.trim() : ''
+    const provider = entry.provider === undefined
+      ? undefined
+      : typeof entry.provider === 'string' ? entry.provider.trim() : null
+    const executionKind = entry.execution_kind
+    if (
+      !ALLOWED_TIERS.has(tier)
+      || seen.has(tier)
+      || !model
+      || provider === null
+      || provider === ''
+      || (executionKind !== 'single_model' && executionKind !== 'ensemble')
+    ) return null
+    seen.add(tier)
+    tiers.push({
+      tier,
+      ...(provider ? { provider } : {}),
+      model,
+      execution_kind: executionKind,
+    })
+  }
+
+  return {
+    version: 1,
+    request_kind: source.request_kind,
+    tiers,
+  }
+}

--- a/src/opensquilla/engine/route_plan.py
+++ b/src/opensquilla/engine/route_plan.py
@@ -9,9 +9,21 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 from opensquilla.provider.types import ModelCapabilities, ProviderRequestCorrelation
+from opensquilla.router_tiers import (
+    IMAGE_TIER,
+    TEXT_TIERS,
+    TierConfig,
+    effective_ensemble_selection_mode,
+    normalize_tier_id,
+    normalize_tier_mapping,
+    tier_ensemble_active,
+    tier_ensemble_execution,
+)
+
+_ROUTER_SNAPSHOT_TIER_ORDER = (*TEXT_TIERS, IMAGE_TIER)
 
 
 @dataclass(frozen=True, slots=True)
@@ -60,6 +72,42 @@ class RouteCapabilitySnapshot:
 
 
 @dataclass(frozen=True, slots=True)
+class RouterTierSnapshotEntry:
+    """One display-safe candidate from the accepted routing configuration."""
+
+    tier: str
+    provider: str
+    model: str
+    execution_kind: Literal["single_model", "ensemble"]
+
+    def as_dict(self) -> dict[str, Any]:
+        payload = {
+            "tier": self.tier,
+            "model": self.model,
+            "execution_kind": self.execution_kind,
+        }
+        if self.provider:
+            payload["provider"] = self.provider
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class RouterTierSnapshot:
+    """Versioned candidate pool frozen for one routed request."""
+
+    version: Literal[1]
+    request_kind: Literal["text", "image"]
+    tiers: tuple[RouterTierSnapshotEntry, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "request_kind": self.request_kind,
+            "tiers": [item.as_dict() for item in self.tiers],
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class RoutePlan:
     """One immutable router decision for one logical turn."""
 
@@ -75,9 +123,10 @@ class RoutePlan:
     prompt_policy: str
     fallback_chain: tuple[RouteFallback, ...]
     capabilities: RouteCapabilitySnapshot
+    router_tier_snapshot: RouterTierSnapshot | None = None
 
     def as_dict(self) -> dict[str, Any]:
-        return {
+        payload = {
             "version": self.version,
             "plan_id": self.plan_id,
             "turn_id": self.turn_id,
@@ -91,6 +140,9 @@ class RoutePlan:
             "fallback_chain": [item.as_dict() for item in self.fallback_chain],
             "capabilities": self.capabilities.as_dict(),
         }
+        if self.router_tier_snapshot is not None:
+            payload["router_tier_snapshot"] = self.router_tier_snapshot.as_dict()
+        return payload
 
 
 def _text(value: object) -> str:
@@ -192,6 +244,87 @@ def _thinking_snapshot(metadata: Mapping[str, Any], effective_thinking: object) 
     return _text(value)
 
 
+def _router_tier_snapshot(
+    config: Any,
+    metadata: Mapping[str, Any],
+    *,
+    winner_tier: object,
+    winner_provider: str,
+    winner_model: str,
+) -> RouterTierSnapshot | None:
+    """Freeze the candidate pool that was accepted for this logical turn."""
+
+    router = getattr(config, "squilla_router", None)
+    tiers = normalize_tier_mapping(getattr(router, "tiers", None))
+    normalized_winner = normalize_tier_id(winner_tier)
+    if not tiers or normalized_winner is None or not winner_model:
+        return None
+
+    request_kind: Literal["text", "image"] = (
+        "image"
+        if _text(metadata.get("routing_source")) == "image_route"
+        or bool(metadata.get("image_route_reason"))
+        or bool(metadata.get("router_vision_followup_needs_image"))
+        or normalized_winner == IMAGE_TIER
+        else "text"
+    )
+    shared_selection_mode = effective_ensemble_selection_mode(config)
+    ensemble = getattr(config, "llm_ensemble", None)
+    c3_fusion_active = bool(getattr(ensemble, "enabled", False)) or tier_ensemble_active(
+        tiers,
+        TEXT_TIERS[-1],
+    )
+
+    entries: list[RouterTierSnapshotEntry] = []
+    for tier in _ROUTER_SNAPSHOT_TIER_ORDER:
+        tier_config = TierConfig.from_value(tiers.get(tier))
+        if not tier_config.model:
+            continue
+        if request_kind == "image":
+            if not tier_config.supports_image:
+                continue
+            if tier == TEXT_TIERS[-1] and c3_fusion_active:
+                continue
+        elif tier_config.image_only or tier == IMAGE_TIER:
+            continue
+
+        selection_mode, _binding = tier_ensemble_execution(
+            tiers,
+            tier,
+            shared_selection_mode=shared_selection_mode,
+        )
+        entries.append(
+            RouterTierSnapshotEntry(
+                tier=tier,
+                provider=tier_config.provider,
+                model=tier_config.model,
+                execution_kind="ensemble" if selection_mode else "single_model",
+            )
+        )
+
+    winner_index = next(
+        (index for index, item in enumerate(entries) if item.tier == normalized_winner),
+        None,
+    )
+    winner_entry = RouterTierSnapshotEntry(
+        tier=normalized_winner,
+        provider=winner_provider,
+        model=winner_model,
+        execution_kind=(
+            entries[winner_index].execution_kind
+            if winner_index is not None
+            else "single_model"
+        ),
+    )
+    if winner_index is None:
+        entries.append(winner_entry)
+        entries.sort(key=lambda item: _ROUTER_SNAPSHOT_TIER_ORDER.index(item.tier))
+    else:
+        entries[winner_index] = winner_entry
+
+    return RouterTierSnapshot(version=1, request_kind=request_kind, tiers=tuple(entries))
+
+
 def pin_route_plan(
     turn: Any,
     *,
@@ -226,7 +359,7 @@ def pin_route_plan(
         if isinstance(value, list):
             fallback_candidates.extend(value)
     plan = RoutePlan(
-        version=1,
+        version=2,
         plan_id=turn_id,
         turn_id=turn_id,
         tier=tier,
@@ -245,6 +378,13 @@ def pin_route_plan(
         capabilities=_capability_snapshot(
             context_window=context_window,
             capabilities=capabilities,
+        ),
+        router_tier_snapshot=_router_tier_snapshot(
+            getattr(turn, "config", None),
+            metadata,
+            winner_tier=tier,
+            winner_provider=route_provider,
+            winner_model=route_model,
         ),
     )
     turn.route_plan = plan
@@ -308,6 +448,8 @@ __all__ = [
     "RouteCapabilitySnapshot",
     "RouteFallback",
     "RoutePlan",
+    "RouterTierSnapshot",
+    "RouterTierSnapshotEntry",
     "pin_route_plan",
     "record_execution_leg",
     "route_plan_snapshot",

--- a/src/opensquilla/engine/router_decision.py
+++ b/src/opensquilla/engine/router_decision.py
@@ -73,6 +73,11 @@ def build_router_decision_event(turn: TurnContext) -> RouterDecisionEvent | None
         thinking_mode = plan.thinking
         prompt_policy = plan.prompt_policy
         context_window = plan.capabilities.context_window or None
+        router_tier_snapshot = (
+            plan.router_tier_snapshot.as_dict()
+            if plan.router_tier_snapshot is not None
+            else None
+        )
     else:
         source = str(turn.metadata.get("routing_source") or "none")
         raw_routing_applied = turn.metadata.get("routing_applied")
@@ -83,6 +88,7 @@ def build_router_decision_event(turn: TurnContext) -> RouterDecisionEvent | None
         thinking_mode = str(turn.metadata.get("thinking_mode") or "")
         prompt_policy = str(turn.metadata.get("prompt_policy") or "")
         context_window = _resolve_context_window(model)
+        router_tier_snapshot = None
 
     return RouterDecisionEvent(
         tier=str(routed_tier),
@@ -99,4 +105,5 @@ def build_router_decision_event(turn: TurnContext) -> RouterDecisionEvent | None
         routing_applied=bool(routing_applied),
         rollout_phase=str(turn.metadata.get("rollout_phase") or "full"),
         context_window=context_window,
+        router_tier_snapshot=router_tier_snapshot,
     )

--- a/src/opensquilla/engine/types.py
+++ b/src/opensquilla/engine/types.py
@@ -438,6 +438,9 @@ class RouterDecisionEvent:
     routing_applied: bool = True
     rollout_phase: str = "full"
     context_window: int | None = None
+    # Display-safe, versioned candidate pool from the immutable RoutePlan.
+    # Appended for positional-construction and older consumer compatibility.
+    router_tier_snapshot: dict[str, Any] | None = None
 
 
 @dataclass

--- a/src/opensquilla/gateway/channel_dispatch.py
+++ b/src/opensquilla/gateway/channel_dispatch.py
@@ -2683,7 +2683,7 @@ def _artifact_event_payload(event: Any) -> dict[str, Any] | None:
 
 
 def _router_decision_payload(event: RouterDecisionEvent) -> dict[str, Any]:
-    return {
+    payload = {
         "tier": event.tier,
         "tier_index": event.tier_index,
         "model": event.model,
@@ -2699,6 +2699,9 @@ def _router_decision_payload(event: RouterDecisionEvent) -> dict[str, Any]:
         "rollout_phase": event.rollout_phase,
         "context_window": event.context_window,
     }
+    if event.router_tier_snapshot is not None:
+        payload["router_tier_snapshot"] = event.router_tier_snapshot
+    return payload
 
 
 def _terminal_generation_reset_text(event: AnswerGenerationResetEvent) -> str:

--- a/src/opensquilla/gateway/rpc_chat.py
+++ b/src/opensquilla/gateway/rpc_chat.py
@@ -118,6 +118,7 @@ _TURN_USAGE_PROJECTION_ALIASES = {
 _HISTORY_STRUCTURAL_RECEIPT_FIELDS = (
     ("model_usage_breakdown", "modelUsageBreakdown"),
     ("ensemble_trace", "ensembleTrace"),
+    ("route_plan", "routePlan"),
 )
 
 
@@ -132,6 +133,40 @@ def _history_structural_richness(value: object) -> tuple[int, int]:
     if isinstance(value, str):
         return (1, len(value)) if value.strip() else (0, 0)
     return (1, 0) if value is not None else (0, 0)
+
+
+def _history_route_plan_has_complete_snapshot(value: object) -> bool:
+    """Whether a route-plan candidate carries a minimally complete v1 snapshot."""
+
+    if not isinstance(value, Mapping):
+        return False
+    snapshot = value.get("router_tier_snapshot", value.get("routerTierSnapshot"))
+    if not isinstance(snapshot, Mapping):
+        return False
+    if snapshot.get("version") != 1 or snapshot.get("request_kind") not in {
+        "text",
+        "image",
+    }:
+        return False
+    tiers = snapshot.get("tiers")
+    if not isinstance(tiers, list) or not tiers:
+        return False
+    seen: set[str] = set()
+    for entry in tiers:
+        if not isinstance(entry, Mapping):
+            return False
+        tier = str(entry.get("tier") or "").strip().lower()
+        model = str(entry.get("model") or "").strip()
+        execution_kind = entry.get("execution_kind")
+        if (
+            not tier
+            or tier in seen
+            or not model
+            or execution_kind not in {"single_model", "ensemble"}
+        ):
+            return False
+        seen.add(tier)
+    return True
 
 
 def _clear_history_usage_for_indexes(
@@ -904,9 +939,21 @@ async def _project_missing_history_usage(
             if not candidates:
                 continue
             richest = candidates[0]
-            richest_score = _history_structural_richness(richest)
+            richest_score = (
+                int(
+                    snake_key == "route_plan"
+                    and _history_route_plan_has_complete_snapshot(richest)
+                ),
+                *_history_structural_richness(richest),
+            )
             for candidate in candidates[1:]:
-                candidate_score = _history_structural_richness(candidate)
+                candidate_score = (
+                    int(
+                        snake_key == "route_plan"
+                        and _history_route_plan_has_complete_snapshot(candidate)
+                    ),
+                    *_history_structural_richness(candidate),
+                )
                 if candidate_score > richest_score:
                     richest = candidate
                     richest_score = candidate_score

--- a/tests/test_contracts/test_session_event_wire.py
+++ b/tests/test_contracts/test_session_event_wire.py
@@ -95,6 +95,24 @@ def test_router_decision_payload_values_pass_through() -> None:
     assert payload["context_window"] == 128_000
 
 
+def test_router_decision_payload_passes_optional_tier_snapshot() -> None:
+    event = _synthetic_router_decision()
+    event.router_tier_snapshot = {
+        "version": 1,
+        "request_kind": "text",
+        "tiers": [
+            {
+                "tier": "c1",
+                "model": "test-provider/test-model",
+                "execution_kind": "single_model",
+            }
+        ],
+    }
+
+    payload = _router_decision_payload(event)
+    assert payload["router_tier_snapshot"] == event.router_tier_snapshot
+
+
 def test_ensemble_progress_payload_keys_are_frozen() -> None:
     event = EnsembleProgressEvent(
         event_type="proposer_done",

--- a/tests/test_engine/test_route_plan.py
+++ b/tests/test_engine/test_route_plan.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import FrozenInstanceError
+from types import SimpleNamespace
 
 import pytest
 
@@ -71,6 +72,8 @@ def test_route_plan_is_pinned_once_with_capability_snapshot() -> None:
     assert first.capabilities.context_window == 128_000
     assert first.capabilities.effective_max_tokens == 0
     assert first.capabilities.supports_reasoning is True
+    assert first.version == 2
+    assert first.router_tier_snapshot is None
 
     turn.metadata["routed_model"] = "must-not-replace-the-plan"
     second = pin_route_plan(
@@ -164,3 +167,153 @@ def test_route_plan_adds_deduplicated_selector_execution_candidates() -> None:
     ]
     assert plan.fallback_chain[-1].capabilities.context_window == 128_000
     assert plan.fallback_chain[-1].capabilities.supports_tools is True
+
+
+def test_route_plan_freezes_text_candidates_aliases_ensemble_and_winner() -> None:
+    turn = _turn()
+    turn.config = SimpleNamespace(
+        squilla_router=SimpleNamespace(
+            tiers={
+                "t0": {"provider": "provider-a", "model": "fast/model"},
+                "t1": {"provider": "provider-b", "model": "balanced/model"},
+                "c2": {"provider": "provider-c", "model": ""},
+                "c3": {
+                    "provider": "provider-d",
+                    "model": "quality/model",
+                    "ensemble_enabled": True,
+                },
+                "image_model": {
+                    "provider": "provider-image",
+                    "model": "image/model",
+                    "supports_image": True,
+                    "image_only": True,
+                },
+            }
+        ),
+        llm_ensemble=SimpleNamespace(
+            enabled=False,
+            selection_mode="custom_b5",
+            model_fields_set={"selection_mode"},
+        ),
+    )
+
+    plan = pin_route_plan(
+        turn,
+        turn_id="turn-snapshot-text",
+        provider="provider-c",
+        model="routed/model",
+        context_window=64_000,
+        capabilities=ModelCapabilities(),
+        effective_thinking=False,
+    )
+
+    assert plan is not None
+    snapshot = plan.as_dict()["router_tier_snapshot"]
+    assert snapshot == {
+        "version": 1,
+        "request_kind": "text",
+        "tiers": [
+            {
+                "tier": "c0",
+                "provider": "provider-a",
+                "model": "fast/model",
+                "execution_kind": "single_model",
+            },
+            {
+                "tier": "c1",
+                "provider": "provider-b",
+                "model": "balanced/model",
+                "execution_kind": "single_model",
+            },
+            {
+                "tier": "c2",
+                "provider": "provider-a",
+                "model": "routed/model",
+                "execution_kind": "single_model",
+            },
+            {
+                "tier": "c3",
+                "provider": "provider-d",
+                "model": "quality/model",
+                "execution_kind": "ensemble",
+            },
+        ],
+    }
+    assert turn.metadata["route_plan"]["router_tier_snapshot"] == snapshot
+
+    turn.config.squilla_router.tiers["t0"]["model"] = "changed/model"
+    assert plan.as_dict()["router_tier_snapshot"] == snapshot
+    event = build_router_decision_event(turn)
+    assert event is not None
+    assert event.router_tier_snapshot == snapshot
+
+
+def test_route_plan_freezes_only_executable_image_candidates() -> None:
+    turn = _turn()
+    turn.metadata.update(
+        {
+            "routed_tier": "image_model",
+            "routed_provider": "image-provider",
+            "routed_model": "image/winner",
+            "routing_source": "image_route",
+        }
+    )
+    turn.config = SimpleNamespace(
+        squilla_router=SimpleNamespace(
+            tiers={
+                "c0": {
+                    "provider": "vision-provider",
+                    "model": "vision/fallback",
+                    "supports_image": True,
+                },
+                "c1": {"provider": "text-provider", "model": "text/only"},
+                "c3": {
+                    "provider": "fusion-provider",
+                    "model": "vision/fusion-draft",
+                    "supports_image": True,
+                    "ensemble_enabled": True,
+                },
+                "image_model": {
+                    "provider": "old-image-provider",
+                    "model": "image/old-config",
+                    "supports_image": True,
+                    "image_only": True,
+                },
+            }
+        ),
+        llm_ensemble=SimpleNamespace(
+            enabled=False,
+            selection_mode="custom_b5",
+            model_fields_set={"selection_mode"},
+        ),
+    )
+
+    plan = pin_route_plan(
+        turn,
+        turn_id="turn-snapshot-image",
+        provider="image-provider",
+        model="image/winner",
+        context_window=32_000,
+        capabilities=ModelCapabilities(supports_vision=True),
+        effective_thinking=False,
+    )
+
+    assert plan is not None and plan.router_tier_snapshot is not None
+    assert plan.router_tier_snapshot.as_dict() == {
+        "version": 1,
+        "request_kind": "image",
+        "tiers": [
+            {
+                "tier": "c0",
+                "provider": "vision-provider",
+                "model": "vision/fallback",
+                "execution_kind": "single_model",
+            },
+            {
+                "tier": "image_model",
+                "provider": "image-provider",
+                "model": "image/winner",
+                "execution_kind": "single_model",
+            },
+        ],
+    }

--- a/tests/test_gateway/test_rpc_chat_history.py
+++ b/tests/test_gateway/test_rpc_chat_history.py
@@ -705,6 +705,27 @@ async def test_chat_history_keeps_richer_ensemble_receipt_on_terminal_duplicate(
         "final_request_role": "aggregator",
         "proposer_roles": ["proposer"],
     }
+    richer_route_plan = {
+        "version": 2,
+        "tier": "c2",
+        "model": "aggregator-model",
+        "router_tier_snapshot": {
+            "version": 1,
+            "request_kind": "text",
+            "tiers": [
+                {
+                    "tier": "c1",
+                    "model": "proposal-model",
+                    "execution_kind": "single_model",
+                },
+                {
+                    "tier": "c2",
+                    "model": "aggregator-model",
+                    "execution_kind": "ensemble",
+                },
+            ],
+        },
+    }
     try:
         with turn_context_scope({"turn_id": turn_id}):
             await manager.append_message(
@@ -719,6 +740,7 @@ async def test_chat_history_keeps_richer_ensemble_receipt_on_terminal_duplicate(
                     "cost_usd": 0.001,
                     "model_usage_breakdown": richer_breakdown,
                     "ensemble_trace": richer_trace,
+                    "route_plan": richer_route_plan,
                     "routing_source": "squilla_router",
                 },
             )
@@ -742,6 +764,26 @@ async def test_chat_history_keeps_richer_ensemble_receipt_on_terminal_duplicate(
                     "ensemble_trace": {
                         "final_request_role": "aggregator",
                         "physical_request_count": 1,
+                    },
+                    "route_plan": {
+                        "version": 2,
+                        "tier": "c2",
+                        "model": "aggregator-model",
+                        "fallback_chain": [
+                            {
+                                "tier": f"fallback-{index}",
+                                "provider": "large-stale-provider",
+                                "model": f"large-stale-model-{index}",
+                                "capabilities": {
+                                    "context_window": 128_000,
+                                    "supports_reasoning": True,
+                                    "supports_tools": True,
+                                    "supports_streaming": True,
+                                    "supports_vision": False,
+                                },
+                            }
+                            for index in range(8)
+                        ],
                     },
                 },
             )
@@ -802,6 +844,7 @@ async def test_chat_history_keeps_richer_ensemble_receipt_on_terminal_duplicate(
         assert usage["missing_cost_entries"] == 0
         assert usage["model_usage_breakdown"] == richer_breakdown
         assert usage["ensemble_trace"] == richer_trace
+        assert usage["route_plan"] == richer_route_plan
         assert usage["routing_source"] == "squilla_router"
     finally:
         await storage.close()

--- a/tests/test_gateway/test_rpc_sessions_fork.py
+++ b/tests/test_gateway/test_rpc_sessions_fork.py
@@ -162,6 +162,47 @@ async def test_fork_copies_transcript_and_marks_fork(dispatcher, ctx, manager):
 
 
 @pytest.mark.asyncio
+async def test_fork_preserves_router_snapshot_after_parent_deletion(dispatcher, ctx, manager):
+    await manager.create(PARENT_KEY, agent_id="main")
+    snapshot = {
+        "version": 1,
+        "request_kind": "text",
+        "tiers": [
+            {
+                "tier": "c1",
+                "model": "synthetic/model",
+                "execution_kind": "single_model",
+            }
+        ],
+    }
+    await manager.append_message(PARENT_KEY, "user", "question", token_count=1)
+    await manager.append_message(
+        PARENT_KEY,
+        "assistant",
+        "answer",
+        token_count=1,
+        turn_usage={
+            "route_plan": {
+                "version": 2,
+                "tier": "c1",
+                "model": "synthetic/model",
+                "router_tier_snapshot": snapshot,
+            }
+        },
+    )
+
+    fork_res = await dispatcher.dispatch("r1", "sessions.fork", {"key": PARENT_KEY}, ctx)
+    assert fork_res.ok is True
+    child_key = fork_res.payload["key"]
+    delete_res = await dispatcher.dispatch("r2", "sessions.delete", {"key": PARENT_KEY}, ctx)
+    assert delete_res.ok is True
+
+    child_entries = await manager.get_transcript(child_key)
+    assert child_entries[-1].turn_usage is not None
+    assert child_entries[-1].turn_usage["route_plan"]["router_tier_snapshot"] == snapshot
+
+
+@pytest.mark.asyncio
 async def test_fork_before_message_copies_only_prefix(dispatcher, ctx, manager):
     _first, middle, _final = await _seed_parent_with_markers(manager)
 


### PR DESCRIPTION
## Scope

Scope boundary: Persist a versioned per-turn router candidate snapshot, carry it through live and terminal events, render/export historical router decisions from that snapshot, and close the bounded Desktop startup recovery race exposed by the queue run.

Non-goals: No database migration, old-data backfill, routing execution change, UI badge for fallback records, or unbounded connection retry loop.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: This fixes directly reproduced historical panel consistency and Desktop connection-recovery defects without an existing issue.

## Release Note

Release note: Fixed historical model router panels changing after router configuration edits or gateway restarts, and prevented a recovered Desktop connection from remaining degraded after a startup subscription race.

## Tests

Ruff: Passed on affected Python files.

Pytest: 185 passed across route plans, router events, finalization, fallback selection, wire contracts, history recovery, and session forks.

Build: WebUI typecheck and all architecture/UI contract checks passed after rebasing onto current main.

Regression tests: added

Notes: WebUI unit suite passed all 377 files and 4633 tests. The focused RPC/session recovery suite passed 156 tests after the rebase. Mypy and git diff --check also passed. The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: yes

Surface: gateway and WebUI

Maintainer-only note: Verified in the local WebUI that distinct per-turn router candidate pools remain distinct after refresh. Queue failure evidence showed a healthy Gateway and authenticated replacement socket while the chat subscription remained degraded; the added regression covers that event-order race.

## Safety

The new shared protocol fields are optional and preserve existing field order and semantics. RoutePlan v1 and records without snapshots remain readable; malformed or unknown snapshots are rejected atomically and use the current-config fallback with the historical winner preserved. Desktop recovery receives only one additional subscription attempt after an authenticated connection and a transport-class failure; repeated socket churn cannot extend the budget. No secrets, local artifacts, transcripts, channel identifiers, or private fixtures are included. Both changes are platform-neutral.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No documentation changes are required.
- [x] No real secrets, local private paths, or private transcripts are included.
