### PR TITLE
Fix route-limited attachment history capacity admission

### DIFF
--- a/scripts/live_provider_profile_gateway_e2e.py
+++ b/scripts/live_provider_profile_gateway_e2e.py
@@ -11,12 +11,24 @@ not written to the output artifact.
 from __future__ import annotations
 
 import argparse
+import asyncio
+import base64
+import binascii
 import json
+import math
 import os
+import re
+import sqlite3
+import struct
 import subprocess
 import sys
 import tempfile
 import time
+import urllib.error
+import urllib.request
+import zlib
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
 from pathlib import Path
 from typing import Any
 
@@ -27,13 +39,23 @@ if str(REPO_ROOT) not in sys.path:
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
+from opensquilla.context_budget import CHARS_PER_TOKEN, ContextBudgetGovernor  # noqa: E402
+from opensquilla.engine.capacity_admission import (  # noqa: E402
+    MAX_THINKING_BUDGET_TOKENS,
+    model_has_request_capacity,
+)
 from opensquilla.engine.pricing import estimate_cost, resolve_model_price  # noqa: E402
 from opensquilla.gateway.config import GatewayConfig  # noqa: E402
+from opensquilla.provider.model_catalog import ModelCatalog  # noqa: E402
 from opensquilla.provider.preset_registry import (  # noqa: E402
     LEGACY_PROVIDER_PRESET_IDS,
     get_preset,
 )
 from opensquilla.provider.registry import get_provider_spec  # noqa: E402
+from opensquilla.provider.request_proof import estimate_provider_media_tokens  # noqa: E402
+from opensquilla.session.compaction import estimate_entry_model_replay_tokens  # noqa: E402
+from opensquilla.session.manager import SessionManager  # noqa: E402
+from opensquilla.session.storage import SessionStorage  # noqa: E402
 from scripts.live_harness_security import (  # noqa: E402
     child_environment,
     classify_failure,
@@ -85,6 +107,26 @@ TEXT_PROFILE_SLOTS = ("c0", "c1", "c2", "c3")
 LIVE_AGENT_MAX_ITERATIONS = 6
 LIVE_AGENT_RUNTIME_TIMEOUT_SECONDS = 75.0
 LIVE_TURN_HARD_DEADLINE_SECONDS = 90.0
+ATTACHMENT_CAPACITY_OPT_IN_ENV = "OPENSQUILLA_LIVE_TOKENRHYTHM_ATTACHMENT_CAPACITY"
+ATTACHMENT_CAPACITY_PROVIDER = "tokenrhythm"
+ATTACHMENT_CAPACITY_MODEL = "kimi-k2.6"
+ATTACHMENT_CAPACITY_BASE_CONTEXT_WINDOW_TOKENS = 1_000_000
+# Kimi may return provider-billed reasoning tokens even when the request turns
+# explicit thinking off. A real 64-token gate consumed 63 reasoning tokens and
+# truncated before its completion marker, so use the same bounded smoke floor
+# as the TokenRhythm profile matrix. The prompt still requests a short answer.
+ATTACHMENT_CAPACITY_MAX_OUTPUT_TOKENS = 4_096
+ATTACHMENT_CAPACITY_PROVIDER_TIMEOUT_SECONDS = 60.0
+ATTACHMENT_CAPACITY_AGENT_TIMEOUT_SECONDS = 75.0
+ATTACHMENT_CAPACITY_TOTAL_TIMEOUT_SECONDS = 120.0
+ATTACHMENT_CAPACITY_GATEWAY_READY_TIMEOUT_SECONDS = 45.0
+ATTACHMENT_CAPACITY_GATEWAY_SHUTDOWN_TIMEOUT_SECONDS = 15.0
+# The shared polling helper can spend up to three seconds in its final history
+# read plus its half-second interval after its own deadline check.
+ATTACHMENT_CAPACITY_ASSISTANT_POLL_OVERRUN_SECONDS = 4.0
+ATTACHMENT_CAPACITY_MIN_RAW_MARGIN_TOKENS = 4_096
+ATTACHMENT_CAPACITY_EXPECTED_HISTORY_TURNS = 1
+ATTACHMENT_CAPACITY_EXPECTED_MEDIA_BLOCKS = 3
 _PUBLIC_RESULT_KEYS = frozenset(
     {
         "provider",
@@ -96,6 +138,85 @@ _PUBLIC_RESULT_KEYS = frozenset(
         "latency_ms",
     }
 )
+_PUBLIC_USAGE_KEYS = frozenset(
+    {
+        "billed_cost",
+        "cache_write_tokens",
+        "cached_tokens",
+        "cachedTokens",
+        "compaction_count",
+        "configured_max_output_tokens",
+        "cost_source",
+        "decoded_history_bytes",
+        "history_image_count",
+        "history_turn_count",
+        "input_tokens",
+        "last_history_image_count",
+        "models",
+        "output_tokens",
+        "physical_request_count",
+        "physical_response_count",
+        "projected_media_fits_at_max_thinking",
+        "projected_media_tokens",
+        "provider_proof_effective_token_budget",
+        "provider_proof_estimated_tokens",
+        "provider_proof_fits",
+        "provider_proof_media_blocks",
+        "raw_history_estimated_tokens",
+        "raw_history_fits_at_zero_thinking",
+        "reasoning_tokens",
+        "reasoningTokens",
+        "route_max_history_turns",
+        "router_admission_token_limit",
+        "router_max_thinking_admission_token_limit",
+        "source",
+        "totalCostUsd",
+        "totalInputTokens",
+        "totalOutputTokens",
+        "totalTokens",
+    }
+)
+_PUBLIC_COST_KEYS = frozenset(
+    {
+        "billing_scope",
+        "cache_read_per_m",
+        "cache_write_per_m",
+        "cost_source",
+        "estimate_basis",
+        "input_per_m",
+        "opensquilla_estimate",
+        "opensquilla_estimated_cost_usd",
+        "output_per_m",
+        "price_source",
+        "provider_billed",
+        "provider_billed_cost_usd",
+        "raw_gateway_usage_billed_cost_usd",
+        "source",
+    }
+)
+_PUBLIC_USAGE_BOOLEAN_KEYS = frozenset(
+    {
+        "projected_media_fits_at_max_thinking",
+        "provider_proof_fits",
+        "raw_history_fits_at_zero_thinking",
+    }
+)
+_PUBLIC_USAGE_STRING_KEYS = frozenset({"cost_source", "source"})
+_PUBLIC_USAGE_STRING_LIST_KEYS = frozenset({"models"})
+_PUBLIC_USAGE_NUMERIC_KEYS = (
+    _PUBLIC_USAGE_KEYS
+    - _PUBLIC_USAGE_BOOLEAN_KEYS
+    - _PUBLIC_USAGE_STRING_KEYS
+    - _PUBLIC_USAGE_STRING_LIST_KEYS
+)
+_PUBLIC_COST_STRING_KEYS = frozenset(
+    {"billing_scope", "cost_source", "estimate_basis", "price_source", "source"}
+)
+_PUBLIC_COST_NUMERIC_KEYS = _PUBLIC_COST_KEYS - _PUBLIC_COST_STRING_KEYS
+_PUBLIC_STATUS_VALUES = frozenset({"passed", "failed", "skipped"})
+_PUBLIC_TEXT_LIMIT = 256
+_PUBLIC_ACCOUNTING_TEXT_LIMIT = 128
+_PUBLIC_MODEL_LIST_LIMIT = 16
 
 TIER_CASES = [
     {
@@ -147,8 +268,7 @@ def _marker_component(value: str) -> str:
 
 def _case_marker(provider: str, slot: str, case_id: str) -> str:
     return (
-        f"E2E_{_marker_component(provider)}_"
-        f"{_marker_component(slot)}_{_marker_component(case_id)}"
+        f"E2E_{_marker_component(provider)}_{_marker_component(slot)}_{_marker_component(case_id)}"
     )
 
 
@@ -229,7 +349,7 @@ def _render_tier_overrides(tiers: dict[str, dict[str, Any]] | None) -> str:
     if not tiers:
         return ""
     lines: list[str] = []
-    for slot in TEXT_PROFILE_SLOTS:
+    for slot in (*TEXT_PROFILE_SLOTS, "image_model"):
         cfg = tiers.get(slot)
         if not isinstance(cfg, dict):
             continue
@@ -262,6 +382,12 @@ def _write_config(
     default_tier: str = "c1",
     tier_overrides: dict[str, dict[str, Any]] | None = None,
     llm_thinking: str | None = None,
+    agent_max_iterations: int = LIVE_AGENT_MAX_ITERATIONS,
+    llm_request_timeout_seconds: float = 90.0,
+    agent_runtime_timeout_seconds: float = LIVE_AGENT_RUNTIME_TIMEOUT_SECONDS,
+    turn_hard_deadline_seconds: float = LIVE_TURN_HARD_DEADLINE_SECONDS,
+    model_context_window_tokens: int | None = None,
+    model_supports_vision_override: str | None = None,
 ) -> None:
     tier_override_toml = _render_tier_overrides(tier_overrides)
     llm_thinking_toml = (
@@ -273,13 +399,33 @@ def _write_config(
     tier_profile_toml = (
         f'tier_profile = "{provider}"' if provider in LEGACY_PROVIDER_PRESET_IDS else ""
     )
+    model_override_fields: dict[str, dict[str, Any]] = {}
+    if model_context_window_tokens is not None:
+        model_override_fields.setdefault(model, {})["context_window"] = max(
+            1,
+            int(model_context_window_tokens),
+        )
+    if model_supports_vision_override is not None:
+        model_override_fields.setdefault(model_supports_vision_override, {})[
+            "supports_vision"
+        ] = True
+    model_override_lines: list[str] = []
+    for override_model, fields in model_override_fields.items():
+        model_override_lines.extend(
+            (
+                "",
+                f"[models.{_toml_value(provider)}.{_toml_value(override_model)}]",
+                *(f"{key} = {_toml_value(value)}" for key, value in fields.items()),
+            )
+        )
+    model_override_toml = "\n".join(model_override_lines)
     path.write_text(
         f"""
 host = "127.0.0.1"
 debug = false
-llm_request_timeout_seconds = 90
-agent_runtime_timeout_seconds = {LIVE_AGENT_RUNTIME_TIMEOUT_SECONDS}
-agent_max_iterations = {LIVE_AGENT_MAX_ITERATIONS}
+llm_request_timeout_seconds = {llm_request_timeout_seconds}
+agent_runtime_timeout_seconds = {agent_runtime_timeout_seconds}
+agent_max_iterations = {agent_max_iterations}
 agent_max_provider_retries = 0
 
 [auth]
@@ -299,10 +445,13 @@ profile = "minimal"
 deny = ["*"]
 
 [task_runtime]
-turn_hard_deadline_s = {LIVE_TURN_HARD_DEADLINE_SECONDS}
+turn_hard_deadline_s = {turn_hard_deadline_seconds}
 
 [memory]
 source = "state"
+
+[naming]
+enabled = false
 
 [llm]
 provider = "{provider}"
@@ -326,11 +475,662 @@ complaint_upgrade_enabled = true
 complaint_upgrade_steps = 1
 require_router_runtime = true
 {tier_override_toml}
+{model_override_toml}
 """.strip()
         + "\n",
         encoding="utf-8",
     )
     os.chmod(path, 0o600)
+
+
+def _tokenrhythm_attachment_tiers() -> dict[str, dict[str, Any]]:
+    preset = get_preset(ATTACHMENT_CAPACITY_PROVIDER)
+    if preset is None:
+        raise RuntimeError("TokenRhythm preset is unavailable")
+    tiers = preset.tier_defaults()
+    image_tier = tiers.get("image_model")
+    if not isinstance(image_tier, dict):
+        raise RuntimeError("TokenRhythm preset has no image_model tier")
+    if image_tier.get("model") != ATTACHMENT_CAPACITY_MODEL:
+        raise RuntimeError("TokenRhythm image_model does not match the verified live fixture")
+    unsafe_fallback_slots = [
+        slot
+        for slot in TEXT_PROFILE_SLOTS
+        if not isinstance(tiers.get(slot), dict)
+        or tiers[slot].get("supports_image") is not False
+    ]
+    if unsafe_fallback_slots:
+        raise RuntimeError(
+            "TokenRhythm attachment gate requires every text fallback to be explicitly "
+            "non-vision before any live request"
+        )
+    return tiers
+
+
+def _attachment_capacity_admission_token_limit(
+    *,
+    thinking_budget_tokens: int = 0,
+) -> int:
+    """Return the exact input ceiling used by this special gate's config."""
+
+    catalog = ModelCatalog()
+    context_window = catalog.resolve_context_window(
+        ATTACHMENT_CAPACITY_MODEL,
+        ATTACHMENT_CAPACITY_PROVIDER,
+    )
+    governor = ContextBudgetGovernor.from_values(
+        context_window_tokens=context_window,
+        max_output_tokens=ATTACHMENT_CAPACITY_MAX_OUTPUT_TOKENS,
+        thinking_budget_tokens=thinking_budget_tokens,
+        context_overflow_threshold=0.85,
+    )
+    return max(
+        1,
+        governor.snapshot().provider_request_max_chars // CHARS_PER_TOKEN,
+    )
+
+
+def _attachment_capacity_request_fits(
+    request_input_tokens: int,
+    *,
+    thinking_budget_tokens: int,
+) -> bool:
+    """Run the production admission predicate with the special gate's limits."""
+
+    return model_has_request_capacity(
+        provider=ATTACHMENT_CAPACITY_PROVIDER,
+        model=ATTACHMENT_CAPACITY_MODEL,
+        material_tokens=max(0, int(request_input_tokens)),
+        request_input_tokens=max(0, int(request_input_tokens)),
+        thinking_budget_tokens=max(0, int(thinking_budget_tokens)),
+        max_output_override_tokens=ATTACHMENT_CAPACITY_MAX_OUTPUT_TOKENS,
+    )
+
+
+def _png_chunk(kind: bytes, payload: bytes) -> bytes:
+    checksum = binascii.crc32(kind)
+    checksum = binascii.crc32(payload, checksum) & 0xFFFFFFFF
+    return struct.pack(">I", len(payload)) + kind + payload + struct.pack(">I", checksum)
+
+
+def _deterministic_png(width: int, height: int, *, seed: int) -> bytes:
+    """Build a valid, deterministic RGB PNG without optional image libraries."""
+
+    if width <= 0 or height <= 0:
+        raise ValueError("PNG dimensions must be positive")
+    state = seed & 0xFFFFFFFF
+    rows = bytearray()
+    for _row in range(height):
+        rows.append(0)
+        for _column in range(width * 3):
+            state = (1_664_525 * state + 1_013_904_223) & 0xFFFFFFFF
+            rows.append((state >> 24) & 0xFF)
+    header = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    return b"".join(
+        (
+            b"\x89PNG\r\n\x1a\n",
+            _png_chunk(b"IHDR", header),
+            _png_chunk(b"IDAT", zlib.compress(bytes(rows), level=0)),
+            _png_chunk(b"IEND", b""),
+        )
+    )
+
+
+def _inline_image(name: str, payload: bytes) -> dict[str, str]:
+    return {
+        "type": "image/png",
+        "name": name,
+        "data": base64.b64encode(payload).decode("ascii"),
+    }
+
+
+def _inline_history_envelope(text: str, images: list[dict[str, str]]) -> str:
+    return json.dumps(
+        {"text": text, "attachments": images},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def _upload_inline_attachment(
+    *,
+    port: int,
+    attachment: dict[str, str],
+    timeout: float,
+) -> str:
+    payload = base64.b64decode(attachment["data"], validate=True)
+    boundary = f"----OpenSquillaAttachmentCapacity{time.time_ns():x}"
+    filename = attachment.get("name") or "current.png"
+    media_type = attachment.get("type") or "application/octet-stream"
+    prefix = (
+        f"--{boundary}\r\n"
+        f'Content-Disposition: form-data; name="file"; filename="{filename}"\r\n'
+        f"Content-Type: {media_type}\r\n\r\n"
+    ).encode()
+    body = prefix + payload + f"\r\n--{boundary}--\r\n".encode("ascii")
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}/api/v1/files/upload",
+        data=body,
+        headers={
+            "Content-Type": f"multipart/form-data; boundary={boundary}",
+            "Content-Length": str(len(body)),
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+        result = json.loads(response.read().decode("utf-8"))
+    file_uuid = result.get("file_uuid") if isinstance(result, dict) else None
+    if not isinstance(file_uuid, str) or not file_uuid.startswith("u-"):
+        raise RuntimeError("attachment upload did not return a valid file_uuid")
+    return file_uuid
+
+
+def _attachment_capacity_fixture() -> dict[str, Any]:
+    """Return isolated synthetic history whose raw envelope falsely exceeds admission."""
+
+    admission_limit = _attachment_capacity_admission_token_limit(thinking_budget_tokens=0)
+    max_thinking_admission_limit = _attachment_capacity_admission_token_limit(
+        thinking_budget_tokens=MAX_THINKING_BUDGET_TOKENS
+    )
+    oldest_width = 128
+    fixture: dict[str, Any] | None = None
+    while oldest_width <= 512:
+        payloads = [
+            _deterministic_png(oldest_width, oldest_width, seed=11),
+            _deterministic_png(48, 48, seed=22),
+            _deterministic_png(48, 48, seed=33),
+            _deterministic_png(116, 116, seed=44),
+        ]
+        images = [
+            _inline_image("history-1.png", payloads[0]),
+            _inline_image("history-2.png", payloads[1]),
+            _inline_image("history-3a.png", payloads[2]),
+            _inline_image("history-3b.png", payloads[3]),
+        ]
+        turns = [
+            {
+                "user": _inline_history_envelope("Historical image turn one.", [images[0]]),
+                "assistant": "Historical answer one.",
+            },
+            {
+                "user": _inline_history_envelope("Historical image turn two.", [images[1]]),
+                "assistant": "Historical answer two.",
+            },
+            {
+                "user": _inline_history_envelope(
+                    "Historical image turn three.",
+                    [images[2], images[3]],
+                ),
+                "assistant": "Historical answer three.",
+            },
+        ]
+        estimator_output = StringIO()
+        with redirect_stdout(estimator_output), redirect_stderr(estimator_output):
+            raw_tokens = sum(
+                estimate_entry_model_replay_tokens({"content": turn[role]})
+                for turn in turns
+                for role in ("user", "assistant")
+            )
+        retained_media_tokens = sum(
+            estimate_provider_media_tokens("image", len(payload)) for payload in payloads[2:]
+        )
+        current_payload = _deterministic_png(71, 71, seed=55)
+        projected_media_tokens = retained_media_tokens + estimate_provider_media_tokens(
+            "image", len(current_payload)
+        )
+        raw_fits = _attachment_capacity_request_fits(
+            raw_tokens,
+            thinking_budget_tokens=0,
+        )
+        projected_fits_at_max_thinking = _attachment_capacity_request_fits(
+            projected_media_tokens,
+            thinking_budget_tokens=MAX_THINKING_BUDGET_TOKENS,
+        )
+        fixture = {
+            "turns": turns,
+            "current_attachment": _inline_image("current.png", current_payload),
+            "excluded_base64": [images[0]["data"], images[1]["data"]],
+            "retained_base64": [images[2]["data"], images[3]["data"]],
+            "metrics": {
+                "history_turn_count": len(turns),
+                "history_image_count": len(images),
+                "last_history_image_count": 2,
+                "raw_history_estimated_tokens": raw_tokens,
+                "router_admission_token_limit": admission_limit,
+                "router_max_thinking_admission_token_limit": (max_thinking_admission_limit),
+                "projected_media_tokens": projected_media_tokens,
+                "configured_max_output_tokens": (ATTACHMENT_CAPACITY_MAX_OUTPUT_TOKENS),
+                "raw_history_fits_at_zero_thinking": raw_fits,
+                "projected_media_fits_at_max_thinking": (projected_fits_at_max_thinking),
+                "decoded_history_bytes": sum(len(payload) for payload in payloads),
+            },
+        }
+        if (
+            not raw_fits
+            and projected_fits_at_max_thinking
+            and raw_tokens >= admission_limit + ATTACHMENT_CAPACITY_MIN_RAW_MARGIN_TOKENS
+        ):
+            break
+        oldest_width += 32
+    if fixture is None or (
+        fixture["metrics"]["raw_history_estimated_tokens"]
+        < admission_limit + ATTACHMENT_CAPACITY_MIN_RAW_MARGIN_TOKENS
+        or fixture["metrics"]["raw_history_fits_at_zero_thinking"] is not False
+    ):
+        raise RuntimeError("unable to construct an over-admission attachment fixture")
+    if (
+        fixture["metrics"]["projected_media_tokens"] >= max_thinking_admission_limit
+        or fixture["metrics"]["projected_media_fits_at_max_thinking"] is not True
+    ):
+        raise RuntimeError("attachment fixture media projection is not safely below admission")
+    return fixture
+
+
+async def _seed_attachment_capacity_history_async(
+    state_dir: Path,
+    session_key: str,
+    fixture: dict[str, Any],
+) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    storage = SessionStorage(str(state_dir / "sessions.db"))
+    await storage.connect()
+    manager = SessionManager(storage, inject_time_prefix=False)
+    try:
+        await manager.create(
+            session_key=session_key,
+            agent_id="main",
+            display_name="TokenRhythm attachment capacity live fixture",
+            model_routing_mode="router",
+        )
+        for turn in fixture["turns"]:
+            await manager.append_message(session_key, "user", turn["user"])
+            await manager.append_message(session_key, "assistant", turn["assistant"])
+    finally:
+        await storage.close()
+
+
+def _seed_attachment_capacity_history(
+    state_dir: Path,
+    session_key: str,
+    fixture: dict[str, Any],
+) -> None:
+    asyncio.run(_seed_attachment_capacity_history_async(state_dir, session_key, fixture))
+
+
+def _attachment_capacity_session_metrics(state_dir: Path, session_key: str) -> dict[str, Any]:
+    connection = sqlite3.connect(state_dir / "sessions.db")
+    try:
+        row = connection.execute(
+            "SELECT session_id, compaction_count, input_tokens, output_tokens FROM sessions "
+            "WHERE session_key = ?",
+            (session_key,),
+        ).fetchone()
+        usage_row = (
+            connection.execute(
+                "SELECT COUNT(*), COALESCE(SUM(CASE WHEN status = 'finalized' THEN 1 "
+                "ELSE 0 END), 0) FROM usage_events WHERE session_id = ?",
+                (row[0],),
+            ).fetchone()
+            if row is not None
+            else None
+        )
+        unknown_reasons = (
+            connection.execute(
+                "SELECT unknown_reason FROM usage_events WHERE session_id = ? "
+                "AND status = 'unknown' ORDER BY started_at_ms, event_id",
+                (row[0],),
+            ).fetchall()
+            if row is not None
+            else []
+        )
+    finally:
+        connection.close()
+    if row is None:
+        return {
+            "compaction_count": -1,
+            "session_input_tokens": 0,
+            "session_output_tokens": 0,
+            "physical_request_count": -1,
+            "physical_response_count": -1,
+        }
+    physical_failure_kind = None
+    for (unknown_reason,) in reversed(unknown_reasons):
+        prefix, separator, safe_code = str(unknown_reason or "").partition(":")
+        if prefix != "provider_error" or not separator:
+            continue
+        physical_failure_kind = _attachment_capacity_safe_failure_kind(safe_code)
+        if physical_failure_kind is not None:
+            break
+    return {
+        "compaction_count": int(row[1] or 0),
+        "session_input_tokens": int(row[2] or 0),
+        "session_output_tokens": int(row[3] or 0),
+        "physical_request_count": int((usage_row or (0, 0))[0] or 0),
+        "physical_response_count": int((usage_row or (0, 0))[1] or 0),
+        "physical_failure_kind": physical_failure_kind,
+    }
+
+
+def _provider_proof_from_logs(paths: list[Path]) -> dict[str, Any]:
+    """Extract only scalar proof evidence; never retain the surrounding raw log line."""
+
+    proof: dict[str, Any] = {}
+    for path in paths:
+        if not path.is_file():
+            continue
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            if "provider.request_proof" not in line:
+                continue
+            current: dict[str, Any] = {}
+            for field in (
+                "estimated_tokens",
+                "effective_proof_token_budget",
+            ):
+                match = re.search(rf"\b{field}=(\d+)", line)
+                if match:
+                    current[field] = int(match.group(1))
+            match = re.search(r"\bmedia_blocks_reserved=(\d+)", line)
+            if match:
+                current["media_blocks"] = int(match.group(1))
+            match = re.search(r"\bfits=(True|False|true|false)", line)
+            if match:
+                current["fits"] = match.group(1).lower() == "true"
+            if current:
+                proof = current
+    return proof
+
+
+def _request_projection_evidence(
+    request: dict[str, Any],
+    fixture: dict[str, Any],
+) -> dict[str, Any]:
+    payload = request.get("payload") or {}
+    messages = payload.get("messages") or []
+    if not isinstance(messages, list):
+        messages = []
+    history_texts: set[str] = set()
+    for turn in fixture.get("turns") or []:
+        if not isinstance(turn, dict):
+            continue
+        try:
+            envelope = json.loads(str(turn.get("user") or ""))
+        except (json.JSONDecodeError, ValueError):
+            continue
+        text = envelope.get("text") if isinstance(envelope, dict) else None
+        if isinstance(text, str) and text:
+            history_texts.add(text)
+
+    def _message_text_parts(message: dict[str, Any]) -> list[str]:
+        content = message.get("content")
+        if isinstance(content, str):
+            return [content]
+        if not isinstance(content, list):
+            return []
+        return [
+            str(block.get("text") or "")
+            for block in content
+            if isinstance(block, dict)
+            and block.get("type") == "text"
+            and isinstance(block.get("text"), str)
+        ]
+
+    history_user_turns = sum(
+        1
+        for message in messages
+        if isinstance(message, dict)
+        and message.get("role") == "user"
+        and any(
+            history_text in text_part
+            for text_part in _message_text_parts(message)
+            for history_text in history_texts
+        )
+    )
+
+    typed_image_payloads: list[str] = []
+    text_parts: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        text_parts.extend(_message_text_parts(message))
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "image":
+                continue
+            data = block.get("data")
+            if not isinstance(data, str):
+                source = block.get("source")
+                data = source.get("data") if isinstance(source, dict) else None
+            if isinstance(data, str):
+                typed_image_payloads.append(data)
+
+    serialized = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    excluded_absent = all(value not in serialized for value in fixture["excluded_base64"])
+    expected_payloads = [
+        *fixture["retained_base64"],
+        fixture["current_attachment"]["data"],
+    ]
+    expected_present = sorted(typed_image_payloads) == sorted(expected_payloads)
+    expected_media_text_absent = all(
+        expected not in text_part
+        for expected in expected_payloads
+        for text_part in text_parts
+    )
+    return {
+        "history_user_turn_count": history_user_turns,
+        "media_blocks": len(typed_image_payloads),
+        "excluded_old_media_absent": excluded_absent,
+        "expected_media_present": expected_present,
+        "expected_media_text_absent": expected_media_text_absent,
+    }
+
+
+def _attachment_capacity_safe_failure_kind(raw_code: object) -> str | None:
+    if not isinstance(raw_code, str | int) or isinstance(raw_code, bool):
+        return None
+    code = str(raw_code).strip().lower().replace("-", "_")
+    if not code or not code.isascii() or len(code) > 64:
+        return None
+    if code in {
+        "401",
+        "authentication",
+        "provider_auth_invalid",
+        "auth_invalid",
+    }:
+        return "auth"
+    if code in {
+        "402",
+        "provider_insufficient_credits",
+        "insufficient_credits",
+        "insufficient_quota",
+        "usage_limit_reached",
+    }:
+        return "balance"
+    if code in {"403", "permission"}:
+        return "not-entitled"
+    if code in {
+        "404",
+        "not_found",
+        "provider_model_not_found",
+        "model_not_found",
+    }:
+        return "model-unavailable"
+    if code in {
+        "429",
+        "rate_limit",
+        "provider_rate_limited",
+        "rate_limited",
+    }:
+        return "rate-limit"
+    numeric_status = int(code) if code.isdigit() and len(code) == 3 else None
+    if (
+        numeric_status == 408
+        or (numeric_status is not None and 500 <= numeric_status <= 599)
+        or code
+        in {
+            "transport",
+            "unavailable",
+            "provider_provider_overloaded",
+            "provider_overloaded",
+            "provider_transport_transient",
+            "transport_transient",
+            "provider_retry_after_deadline",
+            "request_error",
+            "response_incomplete",
+            "timeout",
+        }
+    ):
+        return "transport"
+    return None
+
+
+def _attachment_capacity_llm_error_failure_kind(
+    errors: list[dict[str, Any]],
+) -> str | None:
+    """Classify only the bounded error codes retained by turn-call logging.
+
+    Provider prose is deliberately absent from ``llm_error`` records.  The
+    nested ``error.code`` is already projected through
+    ``safe_provider_failure_code`` and is therefore the authoritative safe
+    signal when the HTTP/UI surface has collapsed an upstream failure to a
+    generic task error.
+    """
+
+    for row in reversed(errors):
+        payload = row.get("payload")
+        if not isinstance(payload, dict):
+            continue
+        error = payload.get("error")
+        if not isinstance(error, dict):
+            continue
+        failure_kind = _attachment_capacity_safe_failure_kind(error.get("code"))
+        if failure_kind is not None:
+            return failure_kind
+    return None
+
+
+_ATTACHMENT_CAPACITY_HTTP_ERROR_RE = re.compile(
+    r"provider\.chat_http_error\b.*?\bstatus_code=(\d{3})\b"
+)
+
+
+def _attachment_capacity_provider_http_statuses(paths: list[Path]) -> list[int]:
+    """Extract only allowlisted HTTP status scalars from captured provider logs."""
+
+    statuses: list[int] = []
+    for path in paths:
+        if not path.is_file():
+            continue
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            match = _ATTACHMENT_CAPACITY_HTTP_ERROR_RE.search(line)
+            if match is None:
+                continue
+            status = int(match.group(1))
+            if 400 <= status <= 599 and status not in statuses:
+                statuses.append(status)
+    return statuses
+
+
+def _evaluate_attachment_capacity_evidence(
+    *,
+    records: list[dict[str, Any]],
+    decisions: list[dict[str, Any]],
+    session_key: str,
+    fixture: dict[str, Any],
+    session_metrics: dict[str, Any],
+    proof: dict[str, Any],
+    turn_error: str | None,
+    provider_http_statuses: list[int] | None = None,
+) -> dict[str, Any]:
+    session_records = [row for row in records if row.get("session_key") == session_key]
+    requests = [row for row in session_records if row.get("kind") == "llm_request"]
+    responses = [row for row in session_records if row.get("kind") == "llm_response"]
+    errors = [row for row in session_records if row.get("kind") == "llm_error"]
+    request = requests[0] if len(requests) == 1 else {}
+    response = responses[0] if len(responses) == 1 else {}
+    projection = _request_projection_evidence(request, fixture) if request else {}
+    decision = _decision_for_session(decisions, session_key=session_key)
+    router_step = _router_step_from_decision(decision)
+    response_usage = (response.get("payload") or {}).get("usage") or {}
+    request_model = str(request.get("model") or "")
+    response_model = str(response_usage.get("model") or "")
+    input_tokens = int(response_usage.get("input_tokens") or 0)
+    output_tokens = int(response_usage.get("output_tokens") or 0)
+    physical_request_count = int(
+        session_metrics.get("physical_request_count", len(requests))
+    )
+    physical_response_count = int(
+        session_metrics.get("physical_response_count", len(responses))
+    )
+    ok = all(
+        (
+            not turn_error,
+            len(requests) == 1,
+            len(responses) == 1,
+            not errors,
+            request.get("provider") == ATTACHMENT_CAPACITY_PROVIDER,
+            response.get("provider") == ATTACHMENT_CAPACITY_PROVIDER,
+            request_model == ATTACHMENT_CAPACITY_MODEL,
+            response_model == ATTACHMENT_CAPACITY_MODEL,
+            router_step.get("routing_source") == "image_route",
+            decision.get("image_route_reason") == "current_turn",
+            projection.get("history_user_turn_count") == ATTACHMENT_CAPACITY_EXPECTED_HISTORY_TURNS,
+            projection.get("media_blocks") == ATTACHMENT_CAPACITY_EXPECTED_MEDIA_BLOCKS,
+            projection.get("excluded_old_media_absent") is True,
+            projection.get("expected_media_present") is True,
+            projection.get("expected_media_text_absent") is True,
+            session_metrics.get("compaction_count") == 0,
+            physical_request_count == 1,
+            physical_response_count == 1,
+            proof.get("fits") is True,
+            proof.get("media_blocks") == ATTACHMENT_CAPACITY_EXPECTED_MEDIA_BLOCKS,
+            input_tokens > 0,
+            output_tokens > 0,
+        )
+    )
+    failure_text = turn_error or ""
+    if not failure_text and not ok:
+        failure_text = "attachment capacity live evidence invariant failed"
+    failure_kind = None
+    if not ok:
+        ledger_failure_kind = session_metrics.get("physical_failure_kind")
+        if isinstance(ledger_failure_kind, str):
+            failure_kind = ledger_failure_kind
+        for status in reversed(provider_http_statuses or []):
+            if failure_kind is not None:
+                break
+            failure_kind = _attachment_capacity_safe_failure_kind(status)
+            if failure_kind is not None:
+                break
+        if failure_kind is None:
+            failure_kind = _attachment_capacity_llm_error_failure_kind(errors)
+        if failure_kind is None:
+            # OpenSquilla error refs are opaque correlation IDs. Strip only
+            # the fixed terminal suffix so digits such as ``404`` inside a
+            # random ref cannot masquerade as an HTTP status.
+            classification_text = re.sub(
+                r"\s+\(ref:\s*[0-9a-fA-F]{8}\)\s*$",
+                "",
+                failure_text,
+            )
+            failure_kind = classify_failure(classification_text)
+    return {
+        "ok": ok,
+        "failure_kind": failure_kind,
+        "actual_model": request_model,
+        "actual_request_model": request_model,
+        "actual_response_model": response_model,
+        "request_count": len(requests),
+        "response_count": len(responses),
+        "request_projection": projection,
+        "router_step": router_step,
+        "decision": {
+            "image_route_reason": decision.get("image_route_reason"),
+        },
+        "usage": response_usage,
+        "proof": proof,
+    }
 
 
 def _first_record(records: list[dict[str, Any]], *, session_key: str, kind: str) -> dict[str, Any]:
@@ -379,9 +1179,7 @@ def _estimate_cost(
 ) -> dict[str, Any]:
     input_tokens = int(usage.get("input_tokens") or usage.get("prompt_tokens") or 0)
     output_tokens = int(usage.get("output_tokens") or usage.get("completion_tokens") or 0)
-    cache_read_tokens = int(
-        usage.get("cache_read_tokens") or usage.get("cached_tokens") or 0
-    )
+    cache_read_tokens = int(usage.get("cache_read_tokens") or usage.get("cached_tokens") or 0)
     cache_write_tokens = int(usage.get("cache_write_tokens") or 0)
     resolved = resolve_model_price(model, provider or "")
     estimate_result = estimate_cost(
@@ -534,9 +1332,10 @@ def _run_gateway_case_batch_in_temp(
 
     stdout_path = tmp_path / "gateway.stdout.log"
     stderr_path = tmp_path / "gateway.stderr.log"
-    with stdout_path.open("w", encoding="utf-8") as stdout_file, stderr_path.open(
-        "w", encoding="utf-8"
-    ) as stderr_file:
+    with (
+        stdout_path.open("w", encoding="utf-8") as stdout_file,
+        stderr_path.open("w", encoding="utf-8") as stderr_file,
+    ):
         proc = subprocess.Popen(
             [
                 sys.executable,
@@ -565,9 +1364,7 @@ def _run_gateway_case_batch_in_temp(
                 for case in cases:
                     slot = str(case.get("slot") or case.get("tier") or default_tier)
                     marker = _case_marker(provider, slot, str(case["id"]))
-                    session_key = (
-                        f"profile-e2e:{provider}:{case['id']}:{int(time.time() * 1000)}"
-                    )
+                    session_key = f"profile-e2e:{provider}:{case['id']}:{int(time.time() * 1000)}"
                     message = case["message"].format(marker=marker)
                     try:
                         accepted = _post_json(
@@ -700,8 +1497,8 @@ def _run_gateway_case_batch(
     """Run one isolated batch and always remove raw Gateway artifacts."""
 
     tmp_path = Path(tempfile.mkdtemp(prefix=f"opensquilla-{provider}-profile-e2e-"))
-    os.chmod(tmp_path, 0o700)
     try:
+        os.chmod(tmp_path, 0o700)
         return _run_gateway_case_batch_in_temp(
             provider=provider,
             api_key=api_key,
@@ -714,6 +1511,311 @@ def _run_gateway_case_batch(
             default_tier=default_tier,
             tier_overrides=tier_overrides,
             llm_thinking=llm_thinking,
+            tmp_path=tmp_path,
+        )
+    finally:
+        scan_and_remove_temporary_tree(tmp_path, (api_key,))
+
+
+def _attachment_capacity_remaining_timeout(
+    deadline: float,
+    cap_seconds: float,
+    *,
+    overrun_reserve_seconds: float = 0.0,
+) -> float:
+    """Return a bounded positive wait without extending an absolute deadline."""
+
+    remaining = deadline - time.monotonic() - max(0.0, overrun_reserve_seconds)
+    if remaining <= 0:
+        return 0.0
+    return min(max(0.0, cap_seconds), remaining)
+
+
+def _wait_for_attachment_gateway_ready(
+    proc: subprocess.Popen[Any],
+    port: int,
+    *,
+    timeout_seconds: float,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Wait for completed Gateway boot, not merely the live process probe."""
+
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            return None, f"gateway exited early with code {proc.returncode} before readiness"
+        remaining = deadline - time.monotonic()
+        try:
+            with urllib.request.urlopen(  # noqa: S310 - loopback readiness probe
+                f"http://127.0.0.1:{port}/ready",
+                timeout=min(1.0, max(0.05, remaining)),
+            ) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            if isinstance(payload, dict) and payload.get("ready") is True:
+                return payload, None
+        except (
+            urllib.error.URLError,
+            TimeoutError,
+            json.JSONDecodeError,
+            UnicodeDecodeError,
+        ):
+            # Startup probes may fail transiently; retry within the fixed deadline.
+            pass
+        time.sleep(min(0.25, max(0.0, deadline - time.monotonic())))
+    return None, "gateway did not become ready before timeout"
+
+
+def _run_tokenrhythm_attachment_capacity_in_temp(
+    *,
+    api_key: str,
+    base_url: str,
+    tmp_path: Path,
+    synthetic_vision_capability_override: bool = False,
+) -> dict[str, Any]:
+    total_deadline = time.monotonic() + ATTACHMENT_CAPACITY_TOTAL_TIMEOUT_SECONDS
+    # The shared shutdown helper has a hard 10-second terminate wait followed
+    # by a 5-second kill wait. All active readiness/submit/reply waits must end
+    # before this work deadline so shutdown cannot push the gate past 120s.
+    work_deadline = total_deadline - ATTACHMENT_CAPACITY_GATEWAY_SHUTDOWN_TIMEOUT_SECONDS
+    fixture = _attachment_capacity_fixture()
+    tiers = _tokenrhythm_attachment_tiers()
+    state_dir = tmp_path / "state"
+    session_state_dir = state_dir / "state"
+    turn_log_dir = tmp_path / "turn-calls"
+    user_state_dir = tmp_path / "user-state"
+    log_dir = tmp_path / "logs"
+    for directory in (turn_log_dir, user_state_dir, log_dir):
+        directory.mkdir(mode=0o700)
+    session_key = f"agent:main:webchat:attachment-capacity-{int(time.time() * 1000)}"
+    _seed_attachment_capacity_history(session_state_dir, session_key, fixture)
+
+    config_path = tmp_path / "gateway.toml"
+    _write_config(
+        config_path,
+        ATTACHMENT_CAPACITY_PROVIDER,
+        base_url,
+        str(tiers["c1"]["model"]),
+        max_tokens=ATTACHMENT_CAPACITY_MAX_OUTPUT_TOKENS,
+        tier_overrides=tiers,
+        agent_max_iterations=1,
+        llm_request_timeout_seconds=ATTACHMENT_CAPACITY_PROVIDER_TIMEOUT_SECONDS,
+        agent_runtime_timeout_seconds=ATTACHMENT_CAPACITY_AGENT_TIMEOUT_SECONDS,
+        turn_hard_deadline_seconds=ATTACHMENT_CAPACITY_AGENT_TIMEOUT_SECONDS,
+        model_context_window_tokens=ATTACHMENT_CAPACITY_BASE_CONTEXT_WINDOW_TOKENS,
+        model_supports_vision_override=(
+            ATTACHMENT_CAPACITY_MODEL if synthetic_vision_capability_override else None
+        ),
+    )
+    port = _free_port()
+    provider_spec = get_provider_spec(ATTACHMENT_CAPACITY_PROVIDER)
+    env = child_environment(
+        ATTACHMENT_CAPACITY_PROVIDER,
+        {provider_spec.env_key: api_key},
+        base_environment=os.environ,
+    )
+    isolated_home = str(user_state_dir)
+    env["HOME"] = isolated_home
+    env["USERPROFILE"] = isolated_home
+    env["PYTHONPATH"] = str(SRC_DIR) + os.pathsep + env.get("PYTHONPATH", "")
+    env["OPENSQUILLA_GATEWAY_CONFIG_PATH"] = str(config_path)
+    env["OPENSQUILLA_STATE_DIR"] = str(state_dir)
+    env["OPENSQUILLA_USER_STATE_DIR"] = str(user_state_dir)
+    env["OPENSQUILLA_LOG_DIR"] = str(log_dir)
+    env["OPENSQUILLA_TEST_PROFILE_LOCK_ROOT"] = "1"
+    env["OPENSQUILLA_MEMORY_DREAM_DISABLED"] = "1"
+    env["OPENSQUILLA_TURN_CALL_LOG"] = "1"
+    env["OPENSQUILLA_TURN_CALL_LOG_DIR"] = str(turn_log_dir)
+
+    stdout_path = tmp_path / "gateway.stdout.log"
+    stderr_path = tmp_path / "gateway.stderr.log"
+    records: list[dict[str, Any]] = []
+    decisions: list[dict[str, Any]] = []
+    proof: dict[str, Any] = {}
+    provider_http_statuses: list[int] = []
+    health: dict[str, Any] | None = None
+    turn_error: str | None = None
+    assistant: dict[str, Any] | None = None
+    with (
+        stdout_path.open("w", encoding="utf-8") as stdout_file,
+        stderr_path.open("w", encoding="utf-8") as stderr_file,
+    ):
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "opensquilla.cli.main",
+                "gateway",
+                "run",
+                "--port",
+                str(port),
+                "--bind",
+                "127.0.0.1",
+            ],
+            cwd=tmp_path,
+            env=env,
+            stdout=stdout_file,
+            stderr=stderr_file,
+            text=True,
+        )
+        try:
+            readiness_timeout = _attachment_capacity_remaining_timeout(
+                work_deadline,
+                ATTACHMENT_CAPACITY_GATEWAY_READY_TIMEOUT_SECONDS,
+            )
+            if readiness_timeout < ATTACHMENT_CAPACITY_GATEWAY_READY_TIMEOUT_SECONDS:
+                turn_error = "total deadline exhausted before gateway readiness wait"
+            else:
+                health, turn_error = _wait_for_attachment_gateway_ready(
+                    proc,
+                    port,
+                    timeout_seconds=readiness_timeout,
+                )
+            if turn_error is None:
+                marker = "ATTACHMENT_CAPACITY_LIVE_OK"
+                upload_timeout = _attachment_capacity_remaining_timeout(
+                    work_deadline,
+                    10.0,
+                )
+                if upload_timeout <= 0:
+                    turn_error = "total deadline exhausted before attachment submit"
+                else:
+                    current_attachment = fixture["current_attachment"]
+                    file_uuid = _upload_inline_attachment(
+                        port=port,
+                        attachment=current_attachment,
+                        timeout=upload_timeout,
+                    )
+                    submit_timeout = _attachment_capacity_remaining_timeout(
+                        work_deadline,
+                        10.0,
+                    )
+                    if submit_timeout <= 0:
+                        turn_error = "total deadline exhausted before attachment submit"
+                    else:
+                        _post_json(
+                            f"http://127.0.0.1:{port}/api/chat",
+                            {
+                                "sessionKey": session_key,
+                                "message": (
+                                    "请简短描述当前图片，不要调用工具，最后单独输出 "
+                                    + marker
+                                    + "。"
+                                ),
+                                "attachments": [
+                                    {
+                                        "file_uuid": file_uuid,
+                                        "mime": current_attachment["type"],
+                                        "name": current_attachment["name"],
+                                    }
+                                ],
+                            },
+                            timeout=submit_timeout,
+                        )
+            if turn_error is None:
+                reply_timeout = _attachment_capacity_remaining_timeout(
+                    work_deadline,
+                    ATTACHMENT_CAPACITY_AGENT_TIMEOUT_SECONDS,
+                    overrun_reserve_seconds=(ATTACHMENT_CAPACITY_ASSISTANT_POLL_OVERRUN_SECONDS),
+                )
+                if reply_timeout <= 0:
+                    turn_error = "total deadline exhausted before assistant reply wait"
+                else:
+                    assistant, _history, turn_error = _wait_for_assistant_reply(
+                        port=port,
+                        session_key=session_key,
+                        previous_assistant_count=len(fixture["turns"]),
+                        timeout_seconds=reply_timeout,
+                    )
+                if turn_error is None and marker not in str((assistant or {}).get("text") or ""):
+                    turn_error = "assistant reply did not contain the bounded completion marker"
+        except Exception as exc:  # noqa: BLE001 - compact, sanitized live diagnostic
+            turn_error = f"{type(exc).__name__}: {exc}"
+        finally:
+            _stop_gateway(proc)
+            stdout_file.flush()
+            stderr_file.flush()
+            records = _read_turn_call_records(turn_log_dir)
+            decisions = _read_decision_records(tmp_path)
+            provider_log_paths = [stdout_path, stderr_path, log_dir / "debug.log"]
+            proof = _provider_proof_from_logs(provider_log_paths)
+            provider_http_statuses = _attachment_capacity_provider_http_statuses(
+                provider_log_paths
+            )
+
+    session_metrics = _attachment_capacity_session_metrics(session_state_dir, session_key)
+    evidence = _evaluate_attachment_capacity_evidence(
+        records=records,
+        decisions=decisions,
+        session_key=session_key,
+        fixture=fixture,
+        session_metrics=session_metrics,
+        proof=proof,
+        turn_error=turn_error,
+        provider_http_statuses=provider_http_statuses,
+    )
+    response = _first_record(records, session_key=session_key, kind="llm_response")
+    response_payload = response.get("payload") or {}
+    usage = _accounting_usage_fields(response_payload.get("usage") or {})
+    usage.update(
+        {
+            **fixture["metrics"],
+            "provider_proof_estimated_tokens": proof.get("estimated_tokens"),
+            "provider_proof_effective_token_budget": proof.get("effective_proof_token_budget"),
+            "provider_proof_media_blocks": proof.get("media_blocks"),
+            # Usage-ledger starts are committed immediately before each
+            # physical provider dispatch, including selector fallback legs.
+            # This is stronger than the outer llm_request turn-call record,
+            # which counts one logical Agent call around the whole selector.
+            "physical_request_count": session_metrics["physical_request_count"],
+            "physical_response_count": session_metrics["physical_response_count"],
+            "compaction_count": session_metrics["compaction_count"],
+            "route_max_history_turns": evidence["request_projection"].get(
+                "history_user_turn_count"
+            ),
+            "provider_proof_fits": proof.get("fits"),
+        }
+    )
+    actual_request_model = str(evidence.get("actual_request_model") or "")
+    actual_response_model = str(evidence.get("actual_response_model") or "")
+    case = {
+        "ok": evidence["ok"],
+        "failure_kind": evidence["failure_kind"],
+        "expected_model": ATTACHMENT_CAPACITY_MODEL,
+        "actual_request_model": actual_request_model,
+        "actual_response_model": actual_response_model,
+        "usage": usage,
+        "cost": _estimate_cost(
+            actual_request_model,
+            response_payload.get("usage") or {},
+            provider=ATTACHMENT_CAPACITY_PROVIDER,
+        ),
+        "latency_ms": int(response_payload.get("duration_ms") or 0),
+    }
+    result = {
+        "provider": ATTACHMENT_CAPACITY_PROVIDER,
+        "ok": evidence["ok"],
+        "provider_ok": evidence["ok"],
+        "models_covered": [actual_request_model] if evidence["ok"] else [],
+        "failure_kinds": [evidence["failure_kind"]] if evidence["failure_kind"] else [],
+        "cases": [case],
+        "usage_from_turn_logs": usage,
+        "health": health or {},
+        "error": turn_error,
+    }
+    return sanitize_report(result, (api_key,))
+
+
+def _run_tokenrhythm_attachment_capacity(api_key: str) -> dict[str, Any]:
+    requested_base_url = os.environ.get("TOKENRHYTHM_BASE_URL", "").strip()
+    base_url = registry_endpoint(
+        ATTACHMENT_CAPACITY_PROVIDER,
+        requested_base_url or None,
+    )
+    tmp_path = Path(tempfile.mkdtemp(prefix="opensquilla-tokenrhythm-attachment-capacity-"))
+    try:
+        os.chmod(tmp_path, 0o700)
+        return _run_tokenrhythm_attachment_capacity_in_temp(
+            api_key=api_key,
+            base_url=base_url,
             tmp_path=tmp_path,
         )
     finally:
@@ -739,13 +1841,9 @@ def _run_provider(provider: str, *, max_tokens: int, timeout_seconds: float) -> 
             "env_key": spec.env_key,
             "base_url": base_url,
             "key_present": False,
-            "tier_profile": (
-                provider if provider in LEGACY_PROVIDER_PRESET_IDS else None
-            ),
+            "tier_profile": (provider if provider in LEGACY_PROVIDER_PRESET_IDS else None),
             "tier_mode": (
-                "legacy_profile"
-                if provider in LEGACY_PROVIDER_PRESET_IDS
-                else "inline_preset"
+                "legacy_profile" if provider in LEGACY_PROVIDER_PRESET_IDS else "inline_preset"
             ),
             "tier_models": {slot: cfg.get("model") for slot, cfg in slot_targets.items()},
             "profile_slots_covered": [],
@@ -763,9 +1861,7 @@ def _run_provider(provider: str, *, max_tokens: int, timeout_seconds: float) -> 
         max_tokens=max_tokens,
         timeout_seconds=timeout_seconds,
         case_mode="natural_router",
-        tier_overrides=(
-            tiers if provider not in LEGACY_PROVIDER_PRESET_IDS else None
-        ),
+        tier_overrides=(tiers if provider not in LEGACY_PROVIDER_PRESET_IDS else None),
     )
     all_cases = list(natural.get("cases") or [])
     coverage_batches: list[dict[str, Any]] = []
@@ -773,9 +1869,7 @@ def _run_provider(provider: str, *, max_tokens: int, timeout_seconds: float) -> 
         target_case = {
             "slot": missing_slot,
             "id": f"coverage_{missing_slot}",
-            "message": (
-                "不要调用工具，请只回复一句中文短句并包含 {marker}。"
-            ),
+            "message": ("不要调用工具，请只回复一句中文短句并包含 {marker}。"),
         }
         batch = _run_gateway_case_batch(
             provider=provider,
@@ -803,9 +1897,7 @@ def _run_provider(provider: str, *, max_tokens: int, timeout_seconds: float) -> 
         - {""}
     )
     natural_cases = [row for row in all_cases if row.get("case_mode") == "natural_router"]
-    coverage_cases = [
-        row for row in all_cases if row.get("case_mode") == "coverage_compensation"
-    ]
+    coverage_cases = [row for row in all_cases if row.get("case_mode") == "coverage_compensation"]
     provider_ok = not missing_slots and any(
         row.get("case_mode") == "natural_router" and row.get("assistant_excerpt")
         for row in all_cases
@@ -822,9 +1914,7 @@ def _run_provider(provider: str, *, max_tokens: int, timeout_seconds: float) -> 
         "key_present": bool(api_key),
         "tier_profile": provider if provider in LEGACY_PROVIDER_PRESET_IDS else None,
         "tier_mode": (
-            "legacy_profile"
-            if provider in LEGACY_PROVIDER_PRESET_IDS
-            else "inline_preset"
+            "legacy_profile" if provider in LEGACY_PROVIDER_PRESET_IDS else "inline_preset"
         ),
         "tier_models": {slot: cfg.get("model") for slot, cfg in slot_targets.items()},
         "profile_slots_covered": covered_slots,
@@ -851,20 +1941,22 @@ def _public_provider_result(result: dict[str, Any]) -> dict[str, Any]:
     """Drop raw prompts, replies, session ids, endpoints, and diagnostics."""
 
     cases = [
-        {
-            "provider": str(result.get("provider") or ""),
-            "model": str(
-                row.get("actual_response_model")
-                or row.get("actual_request_model")
-                or row.get("expected_model")
-                or ""
-            ),
-            "status": "passed" if row.get("ok") is True else "failed",
-            "failure_class": row.get("failure_kind"),
-            "usage": row.get("usage") or {},
-            "cost": row.get("cost") or {},
-            "latency_ms": int(row.get("latency_ms") or 0),
-        }
+        _project_public_result(
+            {
+                "provider": str(result.get("provider") or ""),
+                "model": str(
+                    row.get("actual_response_model")
+                    or row.get("actual_request_model")
+                    or row.get("expected_model")
+                    or ""
+                ),
+                "status": "passed" if row.get("ok") is True else "failed",
+                "failure_class": row.get("failure_kind"),
+                "usage": row.get("usage") or {},
+                "cost": row.get("cost") or {},
+                "latency_ms": int(row.get("latency_ms") or 0),
+            }
+        )
         for row in result.get("cases") or []
         if isinstance(row, dict)
     ]
@@ -896,22 +1988,105 @@ def _project_public_result(row: dict[str, Any]) -> dict[str, Any]:
     """Project one in-memory case onto the persisted report contract."""
 
     status = str(row.get("status") or "failed")
+    if status not in _PUBLIC_STATUS_VALUES:
+        status = "failed"
     failure_class = row.get("failure_class")
     if status == "passed":
         failure_class = None
     elif failure_class is None:
         failure_class = "implementation"
-    usage = row.get("usage")
-    cost = row.get("cost")
+    raw_usage = row.get("usage")
+    raw_cost = row.get("cost")
+    usage = _project_public_accounting(raw_usage, usage=True)
+    cost = _project_public_accounting(raw_cost, usage=False)
     return {
-        "provider": str(row.get("provider") or ""),
-        "model": str(row.get("model") or ""),
+        "provider": _bounded_public_text(row.get("provider"), limit=_PUBLIC_TEXT_LIMIT),
+        "model": _bounded_public_text(row.get("model"), limit=_PUBLIC_TEXT_LIMIT),
         "status": status,
-        "failure_class": str(failure_class) if failure_class is not None else None,
-        "usage": dict(usage) if isinstance(usage, dict) else {},
-        "cost": dict(cost) if isinstance(cost, dict) else {},
+        "failure_class": (
+            _bounded_public_text(failure_class, limit=_PUBLIC_ACCOUNTING_TEXT_LIMIT)
+            or "implementation"
+            if failure_class is not None
+            else None
+        ),
+        "usage": usage,
+        "cost": cost,
         "latency_ms": int(row.get("latency_ms") or 0),
     }
+
+
+def _bounded_public_text(value: object, *, limit: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    if not value or len(value) > limit:
+        return ""
+    if any(ord(char) < 0x20 or ord(char) == 0x7F for char in value):
+        return ""
+    return value
+
+
+def _is_public_number(value: object) -> bool:
+    if not isinstance(value, int | float) or isinstance(value, bool) or value < 0:
+        return False
+    try:
+        return math.isfinite(float(value))
+    except (OverflowError, ValueError):
+        return False
+
+
+def _project_public_accounting(raw: object, *, usage: bool) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return {}
+    numeric_keys = _PUBLIC_USAGE_NUMERIC_KEYS if usage else _PUBLIC_COST_NUMERIC_KEYS
+    string_keys = _PUBLIC_USAGE_STRING_KEYS if usage else _PUBLIC_COST_STRING_KEYS
+    boolean_keys = _PUBLIC_USAGE_BOOLEAN_KEYS if usage else frozenset()
+    string_list_keys = _PUBLIC_USAGE_STRING_LIST_KEYS if usage else frozenset()
+    projected: dict[str, Any] = {}
+    for raw_key, value in raw.items():
+        if not isinstance(raw_key, str):
+            continue
+        if value is None and raw_key in numeric_keys | string_keys:
+            projected[raw_key] = None
+        elif raw_key in numeric_keys and _is_public_number(value):
+            projected[raw_key] = value
+        elif raw_key in boolean_keys and isinstance(value, bool):
+            projected[raw_key] = value
+        elif raw_key in string_keys:
+            safe_text = _bounded_public_text(value, limit=_PUBLIC_ACCOUNTING_TEXT_LIMIT)
+            if safe_text:
+                projected[raw_key] = safe_text
+        elif raw_key in string_list_keys and isinstance(value, list):
+            if len(value) <= _PUBLIC_MODEL_LIST_LIMIT:
+                safe_values = [
+                    _bounded_public_text(item, limit=_PUBLIC_TEXT_LIMIT) for item in value
+                ]
+                if all(safe_values) and len(safe_values) == len(value):
+                    projected[raw_key] = safe_values
+    return projected
+
+
+def _public_accounting_value_is_valid(key: str, value: object, *, usage: bool) -> bool:
+    numeric_keys = _PUBLIC_USAGE_NUMERIC_KEYS if usage else _PUBLIC_COST_NUMERIC_KEYS
+    string_keys = _PUBLIC_USAGE_STRING_KEYS if usage else _PUBLIC_COST_STRING_KEYS
+    boolean_keys = _PUBLIC_USAGE_BOOLEAN_KEYS if usage else frozenset()
+    string_list_keys = _PUBLIC_USAGE_STRING_LIST_KEYS if usage else frozenset()
+    if value is None:
+        return key in numeric_keys | string_keys
+    if key in numeric_keys:
+        return _is_public_number(value)
+    if key in boolean_keys:
+        return isinstance(value, bool)
+    if key in string_keys:
+        return bool(_bounded_public_text(value, limit=_PUBLIC_ACCOUNTING_TEXT_LIMIT))
+    if key in string_list_keys:
+        return (
+            isinstance(value, list)
+            and len(value) <= _PUBLIC_MODEL_LIST_LIMIT
+            and all(
+                bool(_bounded_public_text(item, limit=_PUBLIC_TEXT_LIMIT)) for item in value
+            )
+        )
+    return False
 
 
 def _assert_public_report_schema(report: Any) -> None:
@@ -922,13 +2097,36 @@ def _assert_public_report_schema(report: Any) -> None:
     for index, row in enumerate(report):
         if not isinstance(row, dict) or set(row) != _PUBLIC_RESULT_KEYS:
             raise RuntimeError(f"public live report row {index} has an invalid field set")
-        if not all(isinstance(row[field], str) for field in ("provider", "model", "status")):
+        provider = _bounded_public_text(row["provider"], limit=_PUBLIC_TEXT_LIMIT)
+        model = row["model"]
+        if (
+            not provider
+            or not isinstance(model, str)
+            or (model and not _bounded_public_text(model, limit=_PUBLIC_TEXT_LIMIT))
+            or row["status"] not in _PUBLIC_STATUS_VALUES
+        ):
             raise RuntimeError(f"public live report row {index} has an invalid identity")
-        if row["failure_class"] is not None and not isinstance(row["failure_class"], str):
+        if row["failure_class"] is not None and not _bounded_public_text(
+            row["failure_class"], limit=_PUBLIC_ACCOUNTING_TEXT_LIMIT
+        ):
             raise RuntimeError(f"public live report row {index} has an invalid failure class")
         if not isinstance(row["usage"], dict) or not isinstance(row["cost"], dict):
             raise RuntimeError(f"public live report row {index} has invalid accounting fields")
-        if isinstance(row["latency_ms"], bool) or not isinstance(row["latency_ms"], int | float):
+        if not set(row["usage"]).issubset(_PUBLIC_USAGE_KEYS):
+            raise RuntimeError(f"public live report row {index} has invalid usage fields")
+        if not set(row["cost"]).issubset(_PUBLIC_COST_KEYS):
+            raise RuntimeError(f"public live report row {index} has invalid cost fields")
+        if not all(
+            _public_accounting_value_is_valid(key, value, usage=True)
+            for key, value in row["usage"].items()
+        ):
+            raise RuntimeError(f"public live report row {index} has invalid usage values")
+        if not all(
+            _public_accounting_value_is_valid(key, value, usage=False)
+            for key, value in row["cost"].items()
+        ):
+            raise RuntimeError(f"public live report row {index} has invalid cost values")
+        if not _is_public_number(row["latency_ms"]):
             raise RuntimeError(f"public live report row {index} has an invalid latency")
 
 
@@ -954,9 +2152,7 @@ def _public_report_rows(raw_results: list[dict[str, Any]]) -> list[dict[str, Any
                             ),
                             "status": "passed" if ok else "failed",
                             "failure_class": (
-                                None
-                                if ok
-                                else str(case.get("failure_kind") or "implementation")
+                                None if ok else str(case.get("failure_kind") or "implementation")
                             ),
                             "usage": case.get("usage") or {},
                             "cost": case.get("cost") or {},
@@ -1024,6 +2220,16 @@ def _emit_main_diagnostics(
     print(redact_text(message, secrets), file=sys.stderr)
 
 
+def _discard_live_report_output(output: Path) -> bool:
+    """Best-effort removal for a failed run without masking its first error."""
+
+    try:
+        output.unlink(missing_ok=True)
+    except OSError:
+        return False
+    return True
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--providers", nargs="+", default=DEFAULT_PROVIDERS)
@@ -1031,51 +2237,106 @@ def main() -> int:
     parser.add_argument("--max-tokens", type=int, default=64)
     parser.add_argument("--timeout-seconds", type=float, default=120.0)
     parser.add_argument("--no-env-file", action="store_true")
+    parser.add_argument(
+        "--attachment-capacity",
+        action="store_true",
+        help="run only the isolated TokenRhythm attachment-capacity live gate",
+    )
+    parser.add_argument(
+        "--confirm-live-cost",
+        action="store_true",
+        help="confirm that the selected live gate may make its bounded provider call",
+    )
     args = parser.parse_args()
     output = Path(args.output)
     if not is_temporary_report_path(output):
         parser.error("--output must be inside the system temporary directory")
+    if output.exists():
+        if output.is_symlink() or not output.is_file():
+            parser.error("--output must name a regular file")
+        try:
+            output.unlink()
+        except OSError:
+            parser.error("--output could not be cleared before the live run")
     if not 32 <= args.max_tokens <= 64:
         parser.error("--max-tokens must be between 32 and 64")
 
-    if not args.no_env_file and os.environ.get("OPENSQUILLA_LIVE_DISABLE_DOTENV") != "1":
+    if args.attachment_capacity:
+        if not args.confirm_live_cost:
+            parser.error("--attachment-capacity requires --confirm-live-cost")
+        if os.environ.get(ATTACHMENT_CAPACITY_OPT_IN_ENV) != "1":
+            parser.error(f"--attachment-capacity requires {ATTACHMENT_CAPACITY_OPT_IN_ENV}=1")
+        if not os.environ.get("TOKENRHYTHM_API_KEY", "").strip():
+            parser.error("--attachment-capacity requires TOKENRHYTHM_API_KEY in the environment")
+
+    if (
+        not args.attachment_capacity
+        and not args.no_env_file
+        and os.environ.get("OPENSQUILLA_LIVE_DISABLE_DOTENV") != "1"
+    ):
         _load_env_quietly()
-    secrets = {
-        name: os.environ.get(name, "")
-        for name in provider_secret_names()
-        if os.environ.get(name)
-    }
+    secrets: dict[str, str] = {}
+    for name in provider_secret_names():
+        raw_value = os.environ.get(name, "")
+        if not raw_value:
+            continue
+        secrets[name] = raw_value
+        stripped_value = raw_value.strip()
+        if stripped_value and stripped_value != raw_value:
+            secrets[f"{name}:stripped"] = stripped_value
+    attachment_api_key = (
+        os.environ.get("TOKENRHYTHM_API_KEY", "").strip()
+        if args.attachment_capacity
+        else ""
+    )
     try:
-        raw_results = [
-            _run_provider(
-                provider,
-                max_tokens=args.max_tokens,
-                timeout_seconds=args.timeout_seconds,
-            )
-            for provider in args.providers
-        ]
-    except (OSError, RuntimeError, ValueError) as exc:
-        output.unlink(missing_ok=True)
+        if args.attachment_capacity:
+            raw_results = [_run_tokenrhythm_attachment_capacity(attachment_api_key)]
+        else:
+            raw_results = [
+                _run_provider(
+                    provider,
+                    max_tokens=args.max_tokens,
+                    timeout_seconds=args.timeout_seconds,
+                )
+                for provider in args.providers
+            ]
+    except Exception as exc:  # noqa: BLE001 - live harness must fail closed
+        removed = _discard_live_report_output(output)
+        cleanup_suffix = "" if removed else "; incomplete output removal also failed"
         print(
-            redact_text(f"provider profile gateway matrix failed: {exc}", secrets),
+            redact_text(
+                f"provider profile gateway matrix failed: {exc}{cleanup_suffix}",
+                secrets,
+            ),
             file=sys.stderr,
         )
         return 2
-    summaries = [_public_provider_result(result) for result in raw_results]
-    all_ok = all(result.get("status") == "passed" for result in summaries)
-    payload = _public_report_rows(raw_results)
-    _emit_main_diagnostics(summaries, payload, secrets)
+    finally:
+        if args.attachment_capacity:
+            # This can only clear the harness process. The caller must also
+            # remove its exported value and rotate a credential exposed during
+            # an investigation.
+            os.environ.pop("TOKENRHYTHM_API_KEY", None)
     try:
+        summaries = [_public_provider_result(result) for result in raw_results]
+        all_ok = all(result.get("status") == "passed" for result in summaries)
+        payload = _public_report_rows(raw_results)
+        _emit_main_diagnostics(summaries, payload, secrets)
         payload = sanitize_report(payload, secrets)
         if report_contains_secret(payload, secrets):
             raise RuntimeError("refusing to write a report containing provider credentials")
         payload = write_safe_report(output, payload, secrets)
         _assert_public_report_schema(payload)
-    except (OSError, RuntimeError, ValueError) as exc:
-        output.unlink(missing_ok=True)
-        print(redact_text(f"unable to write live report: {exc}", secrets), file=sys.stderr)
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    except Exception as exc:  # noqa: BLE001 - no traceback or stale report on failure
+        removed = _discard_live_report_output(output)
+        cleanup_suffix = "" if removed else "; incomplete output removal also failed"
+        print(
+            redact_text(f"unable to write live report: {exc}{cleanup_suffix}", secrets),
+            file=sys.stderr,
+        )
         return 2
-    print(json.dumps(payload, ensure_ascii=False, indent=2))
     return 0 if all_ok else 1
 
 

--- a/src/opensquilla/engine/history.py
+++ b/src/opensquilla/engine/history.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
 import json
-from collections.abc import Mapping
-from dataclasses import dataclass
+from collections.abc import Callable, Collection, Mapping, Sequence
+from dataclasses import dataclass, field
 from typing import Any
 
 from opensquilla.execution_status import (
@@ -17,6 +19,7 @@ from opensquilla.provider import (
     ContentBlockToolUse,
     Message,
 )
+from opensquilla.provider.types import ContentBlockDocument, ContentBlockImage
 from opensquilla.silent_reply import sanitize_historical_silent_reply
 
 _SYNTHETIC_USER_PREFIXES = (
@@ -25,6 +28,306 @@ _SYNTHETIC_USER_PREFIXES = (
     "[Request context for this turn]",
     "[Runtime context for this turn]",
 )
+
+
+@dataclass(frozen=True)
+class HistoryReplayEntryProjection:
+    """One transcript row projected into provider-visible replay material.
+
+    ``content`` is deliberately hidden from ``repr`` because it may contain
+    user text or an in-memory typed media block.  Callers can also represent
+    non-message transcript records without teaching this module about session
+    persistence: legacy summaries and terminal notices are accumulated on the
+    returned :class:`HistoryReplayProjection` instead.
+    """
+
+    role: str | None = None
+    content: Any = field(default="", repr=False)
+    tool_calls: list[dict[str, Any]] | None = field(default=None, repr=False)
+    reasoning_content: str | None = field(default=None, repr=False)
+    turn_context: Mapping[str, Any] | None = field(default=None, repr=False)
+    legacy_summary_marker: str | None = field(default=None, repr=False)
+    terminal_notice: str | None = field(default=None, repr=False)
+    estimate_complete: bool = True
+    persisted_token_count: int = 0
+    raw_token_floor_applies: bool = True
+    # ``None`` preserves the prior state, matching ignored/system rows.  A
+    # terminal notice uses ``False`` so positional current-user trimming does
+    # not remove a prompt that is no longer the transcript tail.
+    last_entry_was_user: bool | None = None
+
+
+@dataclass(frozen=True)
+class HistoryReplayMessageProvenance:
+    """Private transcript-row provenance for one reconstructed message."""
+
+    entry_index: int | None = field(default=None, repr=False)
+    estimate_complete: bool = field(default=True, repr=False)
+    persisted_token_count: int = field(default=0, repr=False)
+    raw_token_floor_applies: bool = field(default=True, repr=False)
+
+
+@dataclass(frozen=True)
+class HistoryReplayProjection:
+    """Side-effect-free reconstruction of a transcript replay slice."""
+
+    messages: tuple[Message, ...] = field(default=(), repr=False)
+    message_provenance: tuple[HistoryReplayMessageProvenance, ...] = field(
+        default=(),
+        repr=False,
+    )
+    legacy_summary_markers: tuple[str, ...] = field(default=(), repr=False)
+    terminal_notices: tuple[str, ...] = field(default=(), repr=False)
+    estimate_complete: bool = True
+
+
+@dataclass(frozen=True)
+class HistoryReplayCapacityProjection:
+    """Media-aware capacity projection for a reconstructed history slice."""
+
+    messages: tuple[Message, ...] = field(default=(), repr=False)
+    estimated_tokens: int = 0
+    message_count: int = 0
+    media_block_count: int = 0
+    media_reserve_tokens: int = 0
+    estimate_complete: bool = True
+
+
+def project_history_replay(
+    entries: Sequence[Any],
+    *,
+    excluded_entry_indexes: Collection[int] = (),
+    trim_last_user: bool = True,
+    bound_slice_applied: bool = False,
+    entry_projector: Callable[[Any, int], HistoryReplayEntryProjection],
+) -> HistoryReplayProjection:
+    """Reconstruct the exact pre-current transcript message sequence.
+
+    The caller owns persistence-specific decoding through ``entry_projector``;
+    this function owns the replay invariants shared by history loading and
+    router admission: bound/queued exclusions, persisted tool reconstruction,
+    positional current-user trimming, and terminal-notice placement.  Inputs
+    are never mutated.
+    """
+
+    excluded = set(excluded_entry_indexes)
+    messages: list[Message] = []
+    message_provenance: list[HistoryReplayMessageProvenance] = []
+    legacy_summary_markers: list[str] = []
+    terminal_notices: dict[str, HistoryReplayMessageProvenance] = {}
+    estimate_complete = True
+    last_entry_was_user = False
+
+    for entry_index, entry in enumerate(entries):
+        if entry_index in excluded:
+            # Mirrors the queued-send loader: a skipped bound/future user is
+            # not the replay tail and therefore disables positional trimming.
+            last_entry_was_user = False
+            continue
+
+        projected = entry_projector(entry, entry_index)
+        estimate_complete = estimate_complete and projected.estimate_complete
+        if projected.legacy_summary_marker is not None:
+            legacy_summary_markers.append(projected.legacy_summary_marker)
+        if projected.terminal_notice is not None:
+            terminal_notices.setdefault(
+                projected.terminal_notice,
+                HistoryReplayMessageProvenance(
+                    entry_index=entry_index,
+                    estimate_complete=projected.estimate_complete,
+                    persisted_token_count=max(0, projected.persisted_token_count),
+                    raw_token_floor_applies=projected.raw_token_floor_applies,
+                ),
+            )
+        if projected.role in {"user", "assistant"}:
+            reconstructed = reconstruct_messages_from_entry(
+                projected.role,
+                projected.content,
+                projected.tool_calls,
+                projected.reasoning_content,
+                turn_context=projected.turn_context,
+            )
+            messages.extend(reconstructed)
+            message_provenance.extend(
+                HistoryReplayMessageProvenance(
+                    entry_index=entry_index,
+                    estimate_complete=projected.estimate_complete,
+                    persisted_token_count=max(0, projected.persisted_token_count),
+                    raw_token_floor_applies=projected.raw_token_floor_applies,
+                )
+                for _message in reconstructed
+            )
+        if projected.last_entry_was_user is not None:
+            last_entry_was_user = projected.last_entry_was_user
+
+    if (
+        not bound_slice_applied
+        and trim_last_user
+        and last_entry_was_user
+        and messages
+        and messages[-1].role == "user"
+    ):
+        messages.pop()
+        message_provenance.pop()
+
+    unique_notices = tuple(terminal_notices)
+    messages.extend(Message(role="assistant", content=notice) for notice in unique_notices)
+    message_provenance.extend(terminal_notices[notice] for notice in unique_notices)
+    return HistoryReplayProjection(
+        messages=tuple(messages),
+        message_provenance=tuple(message_provenance),
+        legacy_summary_markers=tuple(legacy_summary_markers),
+        terminal_notices=unique_notices,
+        estimate_complete=estimate_complete,
+    )
+
+
+def project_history_replay_capacity(
+    projection: HistoryReplayProjection,
+    *,
+    max_history_turns: int = 0,
+) -> HistoryReplayCapacityProjection:
+    """Estimate replay tokens after the route's real history-tail policy.
+
+    Typed media is replaced by a bounded placeholder before tokenization and
+    pays the same decoded-byte reserve used by provider request proof.  Plain
+    dictionaries (including arbitrary JSON/data URLs in tool arguments) are
+    intentionally *not* recognized as media and remain fully tokenized.
+    Invalid or unsupported typed media keeps its raw conservative projection
+    and marks the result incomplete so admission fails closed.
+    """
+
+    from opensquilla.contracts.attachments import IMAGE_ATTACHMENT_MIMES
+    from opensquilla.provider.request_proof import estimate_provider_media_tokens
+    from opensquilla.session.tokenizer import estimate_tokens
+
+    messages = list(projection.messages)
+    provenance = list(projection.message_provenance)
+    if messages and not provenance:
+        # Compatibility for internal callers that construct a projection by
+        # hand. Runtime-built projections always carry row provenance.
+        provenance = [
+            HistoryReplayMessageProvenance(
+                estimate_complete=projection.estimate_complete,
+            )
+            for _ in range(len(messages))
+        ]
+    provenance_shape_complete = len(provenance) == len(messages)
+    if not provenance_shape_complete:
+        provenance = [
+            HistoryReplayMessageProvenance(estimate_complete=False)
+            for _ in range(len(messages))
+        ]
+    if max_history_turns > 0:
+        retained_indexes = _limit_turn_retained_indexes(messages, max_history_turns)
+        messages = [messages[index] for index in retained_indexes]
+        provenance = [provenance[index] for index in retained_indexes]
+    messages, retained_indexes = _repair_tool_pairing_with_retained_indexes(messages)
+    provenance = [provenance[index] for index in retained_indexes]
+
+    media_block_count = 0
+    media_reserve_tokens = 0
+    estimate_complete = provenance_shape_complete and all(
+        item.estimate_complete for item in provenance
+    )
+
+    def _project_value(value: Any) -> Any:
+        nonlocal media_block_count, media_reserve_tokens, estimate_complete
+
+        media_kind: str | None = None
+        if isinstance(value, ContentBlockImage):
+            if (
+                value.source_type != "base64"
+                or value.media_type not in IMAGE_ATTACHMENT_MIMES
+            ):
+                estimate_complete = False
+            else:
+                media_kind = "image"
+        elif isinstance(value, ContentBlockDocument):
+            if value.source_type != "base64" or value.media_type != "application/pdf":
+                estimate_complete = False
+            else:
+                media_kind = "pdf"
+
+        if media_kind is not None:
+            try:
+                decoded_bytes = len(base64.b64decode(value.data, validate=True))
+            except (binascii.Error, ValueError):
+                estimate_complete = False
+            else:
+                reserve = estimate_provider_media_tokens(media_kind, decoded_bytes)
+                media_block_count += 1
+                media_reserve_tokens += reserve
+                dumped = value.model_dump(mode="json", exclude_none=True)
+                dumped["data"] = (
+                    f"[history_{media_kind}_omitted: {len(value.data)} chars]"
+                )
+                return dumped
+
+        if isinstance(value, list | tuple):
+            return [_project_value(item) for item in value]
+        if isinstance(value, dict):
+            # Do not infer media from untyped user/tool JSON.
+            return {str(key): _project_value(item) for key, item in value.items()}
+        model_fields = getattr(type(value), "model_fields", None)
+        if isinstance(model_fields, dict):
+            projected_model: dict[str, Any] = {}
+            for name in model_fields:
+                item = getattr(value, name, None)
+                if item is not None:
+                    projected_model[str(name)] = _project_value(item)
+            return projected_model
+        return value
+
+    payload: list[Any] = []
+    entry_estimates: dict[tuple[str, int], int] = {}
+    entry_media_reserves: dict[tuple[str, int], int] = {}
+    entry_token_floors: dict[tuple[str, int], int] = {}
+    for message_index, (message, source) in enumerate(zip(messages, provenance, strict=True)):
+        media_before = media_reserve_tokens
+        projected_message = _project_value(message)
+        payload.append(projected_message)
+        serialized_message = json.dumps(
+            projected_message,
+            ensure_ascii=False,
+            sort_keys=True,
+            default=str,
+        )
+        message_tokens = estimate_tokens(serialized_message)
+        message_media_reserve = media_reserve_tokens - media_before
+        source_key = (
+            ("entry", source.entry_index)
+            if source.entry_index is not None
+            else ("message", message_index)
+        )
+        entry_estimates[source_key] = entry_estimates.get(source_key, 0) + message_tokens
+        entry_media_reserves[source_key] = (
+            entry_media_reserves.get(source_key, 0) + message_media_reserve
+        )
+        if source.raw_token_floor_applies:
+            entry_token_floors[source_key] = max(
+                entry_token_floors.get(source_key, 0),
+                max(0, source.persisted_token_count),
+            )
+
+    adjusted_entry_tokens = sum(
+        max(tokens, entry_token_floors.get(source_key, 0))
+        + entry_media_reserves.get(source_key, 0)
+        for source_key, tokens in entry_estimates.items()
+    )
+    serialized_tokens = 0
+    if payload:
+        serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)
+        serialized_tokens = estimate_tokens(serialized) + media_reserve_tokens
+    estimated_tokens = max(serialized_tokens, adjusted_entry_tokens)
+    return HistoryReplayCapacityProjection(
+        messages=tuple(messages),
+        estimated_tokens=max(0, estimated_tokens),
+        message_count=len(messages),
+        media_block_count=media_block_count,
+        media_reserve_tokens=max(0, media_reserve_tokens),
+        estimate_complete=estimate_complete,
+    )
 
 
 @dataclass(frozen=True)
@@ -145,6 +448,19 @@ def limit_turns(messages: list[Message], max_turns: int) -> list[Message]:
     return messages[cut_index:]
 
 
+def _limit_turn_retained_indexes(
+    messages: list[Message],
+    max_turns: int,
+) -> tuple[int, ...]:
+    """Return source indexes for the suffix retained by ``limit_turns``."""
+
+    limited = limit_turns(messages, max_turns)
+    if limited is messages:
+        return tuple(range(len(messages)))
+    start = len(messages) - len(limited)
+    return tuple(range(start, len(messages)))
+
+
 def _extract_tool_use_ids(content: Any) -> set[str]:
     """Extract tool_use IDs from message content."""
     ids: set[str] = set()
@@ -195,8 +511,10 @@ def _dedupe_tool_result_blocks(content: Any) -> tuple[Any, bool]:
     return next_content, changed
 
 
-def repair_tool_pairing(messages: list[Message]) -> list[Message]:
-    """Remove messages with malformed tool_use/tool_result adjacency.
+def _repair_tool_pairing_with_retained_indexes(
+    messages: list[Message],
+) -> tuple[list[Message], tuple[int, ...]]:
+    """Repair tool pairing and return indexes retained from ``messages``.
 
     OpenAI-compatible providers require an assistant message with tool calls to
     be followed immediately by tool result messages for every requested
@@ -204,10 +522,12 @@ def repair_tool_pairing(messages: list[Message]) -> list[Message]:
     ordinary user/context messages between the call and result still make the
     provider request invalid.
 
-    Returns original list reference if no repairs needed.
+    Returns the original list reference if no repairs are needed. The private
+    index sidecar lets capacity accounting discard provenance for messages that
+    this repair removes without changing the public repair API.
     """
     if not messages:
-        return messages
+        return messages, ()
 
     valid_tool_call_indices: set[int] = set()
     valid_tool_result_indices: set[int] = set()
@@ -237,6 +557,7 @@ def repair_tool_pairing(messages: list[Message]) -> list[Message]:
             valid_tool_result_indices.update(result_indices)
 
     repaired: list[Message] = []
+    retained_indexes: list[int] = []
     changed = False
     for index, message in enumerate(messages):
         use_ids = _extract_tool_use_ids(message.content)
@@ -260,8 +581,18 @@ def repair_tool_pairing(messages: list[Message]) -> list[Message]:
                 changed = True
 
         repaired.append(message)
+        retained_indexes.append(index)
 
-    return messages if not changed else repaired
+    if not changed:
+        return messages, tuple(range(len(messages)))
+    return repaired, tuple(retained_indexes)
+
+
+def repair_tool_pairing(messages: list[Message]) -> list[Message]:
+    """Remove messages with malformed tool_use/tool_result adjacency."""
+
+    repaired, _retained_indexes = _repair_tool_pairing_with_retained_indexes(messages)
+    return repaired
 
 
 def _coerce_tool_input(raw: Any) -> dict[str, Any]:

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -19,6 +19,7 @@ import json
 import math
 import os
 import platform
+import re
 import time
 import uuid
 from collections import deque
@@ -27,6 +28,7 @@ from collections.abc import (
     AsyncIterator,
     Awaitable,
     Callable,
+    Collection,
     Hashable,
     Mapping,
     Sequence,
@@ -175,6 +177,9 @@ from opensquilla.engine.turn_runner.harness import (
     _TurnRunnerTurnMemoryCaptureAdapter,
     _TurnRunnerUsageTelemetryAdapter,
     create_turn_execution_context,
+)
+from opensquilla.engine.turn_runner.prompt_assembler_stage import (
+    RouterHistoryReplayRequest,
 )
 from opensquilla.engine.turn_runner.stream_consumer_stage import (
     _could_be_human_silent_reply_prefix,
@@ -8981,6 +8986,7 @@ class TurnRunner:
         skill_catalog: Any | None = None,
         usage_execution_context: UsageExecutionContext | None = None,
         provider_request_correlation: ProviderRequestCorrelation | None = None,
+        router_history_replay_request: RouterHistoryReplayRequest | None = None,
     ) -> tuple[Any, Any]:
         """Run the pre-turn pipeline and re-resolve provider if model changed.
 
@@ -9373,6 +9379,31 @@ class TurnRunner:
         if not planning_turn and not restricted_tool_boundary:
             pipeline_steps.insert(-4, meta_command_launch)
         turn = await run_pipeline(turn, pipeline_steps)
+        if router_history_replay_request is not None:
+            history_capacity = await self._router_history_capacity_for_request(
+                session_key,
+                router_history_replay_request,
+                max_history_turns=self._route_history_turn_limit(turn.metadata),
+                preserve_image_attachments=(
+                    turn.metadata.get("image_route_reason")
+                    in {"current_turn", "gate_history"}
+                ),
+                reachable_provider_kinds=self._route_capacity_provider_kinds(
+                    turn,
+                    initial_provider_config=initial_provider_config,
+                ),
+            )
+            turn.metadata["routing_history_capacity_estimated_tokens"] = max(
+                0,
+                int(history_capacity.get("history_capacity_estimated_tokens") or 0),
+            )
+            turn.metadata["routing_history_capacity_message_count"] = max(
+                0,
+                int(history_capacity.get("history_capacity_message_count") or 0),
+            )
+            turn.metadata["routing_history_capacity_estimate_complete"] = (
+                history_capacity.get("history_capacity_estimate_complete") is True
+            )
         # Capacity admission is safety-critical: it runs at the finalized
         # prompt/tool boundary outside the generic fail-open pipeline wrapper.
         # An unexpected estimator failure must stop the turn rather than leave
@@ -9865,6 +9896,407 @@ class TurnRunner:
 
         return turn, provider
 
+    @staticmethod
+    def _route_history_turn_limit(metadata: Mapping[str, Any]) -> int:
+        raw = metadata.get("route_max_history_turns")
+        if isinstance(raw, bool):
+            return 0
+        if isinstance(raw, int):
+            return max(0, raw)
+        if isinstance(raw, str):
+            try:
+                return max(0, int(raw))
+            except ValueError:
+                return 0
+        return 0
+
+    @staticmethod
+    def _route_capacity_provider_kinds(
+        turn: Any,
+        *,
+        initial_provider_config: Any | None,
+    ) -> frozenset[str] | None:
+        """Return provider-native history kinds reachable by this routed turn."""
+
+        providers: set[str] = set()
+
+        def _add(value: Any) -> None:
+            provider = str(value or "").strip().lower()
+            if provider:
+                providers.add(provider)
+
+        active_provider = getattr(initial_provider_config, "provider", "")
+        _add(active_provider)
+        metadata = getattr(turn, "metadata", {}) or {}
+        _add(metadata.get("routed_provider"))
+        for key in ("router_fallback_chain", "selector_execution_chain"):
+            rows = metadata.get(key)
+            if not isinstance(rows, list):
+                continue
+            for row in rows:
+                if isinstance(row, Mapping):
+                    _add(row.get("provider"))
+
+        router_cfg = getattr(getattr(turn, "config", None), "squilla_router", None)
+        if bool(getattr(router_cfg, "cross_provider_tiers", False)):
+            tiers = getattr(router_cfg, "tiers", None)
+            requires_image = metadata.get("image_route_reason") in {
+                "current_turn",
+                "gate_history",
+            }
+            if isinstance(tiers, Mapping):
+                for raw_tier in tiers.values():
+                    if not isinstance(raw_tier, Mapping):
+                        continue
+                    if requires_image and not bool(raw_tier.get("supports_image", False)):
+                        continue
+                    if not requires_image and bool(raw_tier.get("image_only", False)):
+                        continue
+                    _add(raw_tier.get("provider") or active_provider)
+
+        # Unknown/legacy selector shapes retain the previous conservative
+        # all-provider behavior instead of silently omitting a reachable state.
+        return frozenset(providers) if providers else None
+
+    @staticmethod
+    def _attachment_history_capacity_projection(
+        content: str,
+        *,
+        preserve_image_attachments: bool,
+        media_root: Path | None,
+        session_id: str | None,
+    ) -> tuple[bool, bool, bool]:
+        """Classify an attachment envelope and prove its replay when required.
+
+        Ordinary JSON is not treated as an attachment envelope and remains a
+        conservative text input. The result is ``(recognized, valid,
+        estimate_complete)``. Invalid recognized envelopes remain raw text;
+        only a valid envelope may replace its persisted raw-token floor.
+        """
+
+        if not content or not content.lstrip().startswith("{"):
+            return False, True, True
+        try:
+            parsed = json.loads(content)
+        except (json.JSONDecodeError, ValueError):
+            return False, True, True
+        if not isinstance(parsed, dict) or "text" not in parsed:
+            return False, True, True
+        if not isinstance(parsed.get("text"), str):
+            return True, False, False
+        attachments = parsed.get("attachments") or []
+        if not isinstance(attachments, list):
+            return True, False, False
+        for attachment in attachments:
+            if not isinstance(attachment, dict):
+                return True, False, False
+            media_type = (
+                attachment.get("type")
+                or attachment.get("mime")
+                or attachment.get("media_type")
+            )
+            if (
+                not isinstance(media_type, str)
+                or media_type not in _ALLOWED_ENGINE_MEDIA_TYPES
+            ):
+                return True, False, False
+            data = attachment.get("data")
+            sha_ref = attachment.get("sha256_ref")
+            missing_reason = attachment.get("missing_reason")
+            data_text = data if isinstance(data, str) and data else None
+            sha_ref_text = sha_ref if isinstance(sha_ref, str) and sha_ref else None
+            has_missing_reason = isinstance(missing_reason, str) and bool(missing_reason)
+            if not (data_text is not None or sha_ref_text is not None or has_missing_reason):
+                return True, False, False
+            if data_text is not None:
+                try:
+                    base64.b64decode(data_text, validate=True)
+                except (binascii.Error, ValueError):
+                    return True, False, False
+            if not preserve_image_attachments or media_type not in _IMAGE_ATTACHMENT_MIMES:
+                continue
+            if data_text is not None:
+                continue
+            if sha_ref_text is None:
+                # A persisted missing_reason-only record intentionally replays
+                # as an unavailable marker and needs no media hydration.
+                continue
+            if media_root is None or not session_id:
+                return True, True, False
+            raw_size = attachment.get("size")
+            size = raw_size if isinstance(raw_size, int) else -1
+            label = attachment.get("name")
+            if not isinstance(label, str) or not label.strip():
+                label = "image"
+            try:
+                ref = make_attachment_ref(
+                    sha256=sha_ref_text,
+                    name=label,
+                    mime=media_type,
+                    size=size,
+                    session_id=session_id,
+                    source="transcript",
+                )
+                read_attachment_ref_bytes(ref, media_root=media_root)
+            except (OSError, ValueError):
+                return True, True, False
+        return True, True, True
+
+    @staticmethod
+    def _attachment_history_residual_token_floor(
+        content: str,
+        projected_content: Any,
+        persisted_token_count: int,
+    ) -> int:
+        """Remove only replayed inline-image data from a persisted raw floor.
+
+        A transcript token_count is row-scoped, so clearing it wholesale can
+        also discount ordinary text, PDF bytes, or a legacy provider-usage
+        surplus. Replace the exact canonical ``data`` JSON values for images
+        that became typed blocks, then subtract only that measured delta.
+        Failure to locate every value keeps the original conservative floor.
+        """
+
+        raw_tokens = estimate_tokens(content)
+        raw_floor = max(0, persisted_token_count, raw_tokens)
+        if not isinstance(projected_content, list):
+            return raw_floor
+        from opensquilla.provider.types import ContentBlockImage
+
+        typed_image_count = sum(
+            isinstance(block, ContentBlockImage) and block.source_type == "base64"
+            for block in projected_content
+        )
+        if typed_image_count <= 0:
+            return raw_floor
+        try:
+            parsed = json.loads(content)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return raw_floor
+        if not isinstance(parsed, dict):
+            return raw_floor
+        attachments = parsed.get("attachments") or []
+        if not isinstance(attachments, list):
+            return raw_floor
+        inline_image_data = [
+            attachment["data"]
+            for attachment in attachments
+            if isinstance(attachment, dict)
+            and (
+                attachment.get("type")
+                or attachment.get("mime")
+                or attachment.get("media_type")
+            )
+            in _IMAGE_ATTACHMENT_MIMES
+            and isinstance(attachment.get("data"), str)
+            and bool(attachment.get("data"))
+        ]
+        if not inline_image_data or typed_image_count < len(inline_image_data):
+            return raw_floor
+
+        residual = content
+        for data in set(inline_image_data):
+            encoded_data = json.dumps(data, ensure_ascii=False)
+            placeholder = json.dumps(
+                f"[history_image_omitted: {len(data)} chars]",
+                ensure_ascii=False,
+            )
+            pattern = re.compile(r'("data"\s*:\s*)' + re.escape(encoded_data))
+            expected_replacements = inline_image_data.count(data)
+            if len(pattern.findall(residual)) != expected_replacements:
+                return raw_floor
+            residual, replacements = pattern.subn(
+                lambda match: match.group(1) + placeholder,
+                residual,
+            )
+            if replacements != expected_replacements:
+                return raw_floor
+
+        residual_tokens = estimate_tokens(residual)
+        image_data_delta = max(0, raw_tokens - residual_tokens)
+        return max(0, residual_tokens, persisted_token_count - image_data_delta)
+
+    def _project_history_replay(
+        self,
+        entries: Sequence[Any],
+        *,
+        excluded_entry_indexes: Collection[int],
+        trim_last_user: bool,
+        bound_slice_applied: bool,
+        image_replay_entry_indexes: Collection[int] = (),
+        media_root: Path | None = None,
+        session_id: str | None = None,
+        materialize_historical_attachments: bool = False,
+        workspace_dir: str | Path | None = None,
+        historical_materializer: AttachmentWorkspaceMaterializer | None = None,
+        restricted_turn: bool = False,
+        require_capacity_proof: bool = False,
+    ) -> Any:
+        """Project transcript rows through the same replay decoder for all consumers."""
+
+        from opensquilla.engine.history import (
+            HistoryReplayEntryProjection,
+            project_history_replay,
+        )
+
+        image_indexes = set(image_replay_entry_indexes)
+
+        def _entry_projector(entry: Any, entry_index: int) -> HistoryReplayEntryProjection:
+            role = getattr(entry, "role", None)
+            raw_content = getattr(entry, "content", None) or ""
+            raw_token_count = getattr(entry, "token_count", None)
+            if isinstance(raw_token_count, bool):
+                persisted_token_count = 0
+            else:
+                try:
+                    persisted_token_count = max(0, int(raw_token_count or 0))
+                except (TypeError, ValueError):
+                    persisted_token_count = 0
+            if (
+                role == "system"
+                and isinstance(raw_content, str)
+                and raw_content.startswith(_CONTEXT_SUMMARY_MARKER)
+            ):
+                return HistoryReplayEntryProjection(
+                    legacy_summary_marker=(
+                        None
+                        if restricted_turn
+                        else _strip_context_summary_marker(raw_content)
+                    )
+                )
+            subagent_notice = _subagent_terminal_history_notice(entry)
+            if subagent_notice is not None:
+                return HistoryReplayEntryProjection(
+                    terminal_notice=subagent_notice,
+                    persisted_token_count=persisted_token_count,
+                    last_entry_was_user=False,
+                )
+            if role not in {"user", "assistant"}:
+                return HistoryReplayEntryProjection()
+
+            estimate_complete = True
+            raw_token_floor_applies = True
+            if raw_content and role == "user":
+                preserve_image = entry_index in image_indexes
+                recognized = False
+                valid = True
+                if require_capacity_proof:
+                    recognized, valid, estimate_complete = (
+                        self._attachment_history_capacity_projection(
+                            raw_content,
+                            preserve_image_attachments=preserve_image,
+                            media_root=media_root,
+                            session_id=session_id,
+                        )
+                    )
+                if (
+                    require_capacity_proof
+                    and recognized
+                    and (not valid or not estimate_complete)
+                ):
+                    # Do not partially unpack unproven attachment envelopes:
+                    # retaining their raw JSON/base64 is the conservative view.
+                    projected_content = raw_content
+                else:
+                    projected_content = self._maybe_unpack_attachments(
+                        raw_content,
+                        preserve_image_attachments=preserve_image,
+                        materialize_historical_attachments=(
+                            materialize_historical_attachments
+                        ),
+                        media_root=media_root,
+                        session_id=session_id,
+                        workspace_dir=workspace_dir,
+                        historical_materializer=historical_materializer,
+                    )
+                if require_capacity_proof and recognized and valid:
+                    persisted_token_count = (
+                        self._attachment_history_residual_token_floor(
+                            raw_content,
+                            projected_content,
+                            persisted_token_count,
+                        )
+                    )
+            elif raw_content and role == "assistant":
+                projected_content = self._maybe_unpack_assistant_artifacts(raw_content)
+            else:
+                projected_content = raw_content
+            turn_context = getattr(entry, "turn_context", None)
+            return HistoryReplayEntryProjection(
+                role=role,
+                content=projected_content,
+                tool_calls=getattr(entry, "tool_calls", None),
+                reasoning_content=getattr(entry, "reasoning_content", None),
+                turn_context=(turn_context if isinstance(turn_context, dict) else None),
+                estimate_complete=estimate_complete,
+                persisted_token_count=persisted_token_count,
+                raw_token_floor_applies=raw_token_floor_applies,
+                last_entry_was_user=role == "user",
+            )
+
+        return project_history_replay(
+            entries,
+            excluded_entry_indexes=excluded_entry_indexes,
+            trim_last_user=trim_last_user,
+            bound_slice_applied=bound_slice_applied,
+            entry_projector=_entry_projector,
+        )
+
+    async def _router_history_capacity_for_request(
+        self,
+        session_key: str,
+        request: RouterHistoryReplayRequest,
+        *,
+        max_history_turns: int,
+        preserve_image_attachments: bool,
+        reachable_provider_kinds: Collection[str] | None = None,
+    ) -> dict[str, Any]:
+        """Resolve a turn-local replay request after the router selects a route."""
+
+        if self._session_manager is None:
+            return {
+                "history_capacity_estimated_tokens": 0,
+                "history_capacity_message_count": 0,
+                "history_capacity_estimate_complete": True,
+            }
+        try:
+            get_transcript = getattr(self._session_manager, "get_transcript", None)
+            if not callable(get_transcript):
+                return {"history_capacity_estimate_complete": False}
+            snapshot = request.transcript_snapshot
+            if snapshot is not None:
+                entries = list(await snapshot.get_entries())
+            else:
+                transcript = get_transcript(session_key)
+                if inspect.isawaitable(transcript):
+                    transcript = await transcript
+                entries = list(transcript or [])
+
+            bound_index: int | None = None
+            if request.bound_user_message_id is not None:
+                for index, entry in enumerate(entries):
+                    if getattr(entry, "message_id", None) == request.bound_user_message_id:
+                        bound_index = index
+                        break
+            return await self._router_history_capacity_context(
+                session_key,
+                entries,
+                exclude_last_user=request.exclude_last_user,
+                bound_user_message_id=request.bound_user_message_id,
+                bound_index=bound_index,
+                max_history_turns=max_history_turns,
+                preserve_image_attachments=preserve_image_attachments,
+                reachable_provider_kinds=reachable_provider_kinds,
+            )
+        except Exception as exc:  # noqa: BLE001 - capacity admission fails closed
+            # Never serialize the exception: storage/provider errors may echo
+            # transcript or attachment material.
+            log.warning(
+                "turn_runner.router_capacity_projection_failed",
+                error_type=type(exc).__name__,
+            )
+            return {"history_capacity_estimate_complete": False}
+
     async def _router_history_capacity_context(
         self,
         session_key: str,
@@ -9873,8 +10305,11 @@ class TurnRunner:
         exclude_last_user: bool,
         bound_user_message_id: str | None,
         bound_index: int | None,
+        max_history_turns: int = 0,
+        preserve_image_attachments: bool = False,
+        reachable_provider_kinds: Collection[str] | None = None,
     ) -> dict[str, Any]:
-        """Measure the pre-current replay projection for attachment routing."""
+        """Measure the route-specific pre-current replay projection."""
 
         excluded_user_indexes: set[int] = set()
         if bound_index is not None:
@@ -9890,37 +10325,52 @@ class TurnRunner:
         ):
             excluded_user_indexes.add(len(entries) - 1)
 
-        from opensquilla.session.compaction import estimate_entry_model_replay_tokens
-
-        capacity_tokens = 0
-        capacity_message_count = 0
-        legacy_summary_markers: list[str] = []
-        for index, entry in enumerate(entries):
-            if index in excluded_user_indexes:
-                continue
-            role = getattr(entry, "role", None)
-            content = getattr(entry, "content", None)
-            if (
-                role == "system"
-                and isinstance(content, str)
-                and content.startswith(_CONTEXT_SUMMARY_MARKER)
-            ):
-                legacy_summary_markers.append(_strip_context_summary_marker(content))
-                continue
-            if role not in {"user", "assistant"}:
-                continue
-            capacity_tokens += estimate_entry_model_replay_tokens(entry)
-            tool_calls = getattr(entry, "tool_calls", None)
-            capacity_message_count += 1 + (
-                2 * len(tool_calls) if isinstance(tool_calls, list) else 0
+        image_replay_entry_indexes: set[int] = set()
+        replay_session_id: str | None = None
+        if preserve_image_attachments:
+            router_cfg = getattr(self._turn_config(), "squilla_router", None)
+            lookback = int(
+                getattr(router_cfg, "vision_history_lookback_turns", 3) or 0
             )
+            if lookback > 0:
+                user_entry_indexes = [
+                    index
+                    for index, entry in enumerate(entries)
+                    if index not in excluded_user_indexes
+                    and getattr(entry, "role", None) == "user"
+                    and isinstance(getattr(entry, "content", None), str)
+                    and bool(str(getattr(entry, "content", "")).strip())
+                ]
+                image_replay_entry_indexes = set(user_entry_indexes[-lookback:])
+                replay_session_id = await self._resolve_session_id_for_log(session_key)
+                if replay_session_id is None:
+                    replay_session_id = session_key
+
+        replay = self._project_history_replay(
+            entries,
+            excluded_entry_indexes=excluded_user_indexes,
+            trim_last_user=exclude_last_user,
+            bound_slice_applied=bool(excluded_user_indexes),
+            image_replay_entry_indexes=image_replay_entry_indexes,
+            media_root=self._attachment_media_root(),
+            session_id=replay_session_id,
+            require_capacity_proof=True,
+        )
+        from opensquilla.engine.history import project_history_replay_capacity
+
+        capacity = project_history_replay_capacity(
+            replay,
+            max_history_turns=max_history_turns,
+        )
+        legacy_summary_markers = list(replay.legacy_summary_markers)
 
         summaries: list[Any] = []
         context_states: list[Any] = []
         get_summaries = getattr(self._session_manager, "get_summaries", None)
         get_context_states = getattr(self._session_manager, "get_context_states", None)
-        capacity_estimate_complete = (
-            bound_user_message_id is None or bound_index is not None
+        capacity_estimate_complete = bool(
+            capacity.estimate_complete
+            and (bound_user_message_id is None or bound_index is not None)
         )
         try:
             pending: list[Any] = []
@@ -9957,12 +10407,28 @@ class TurnRunner:
                 1 if rendered else 0,
             )
 
-        best_compaction_tokens, best_compaction_messages = _summary_projection()
+        portable_summary_tokens, portable_summary_messages = _summary_projection()
+        # A provider without a native checkpoint sees the route-limited
+        # transcript plus the portable request-context summary.
+        capacity_tokens = capacity.estimated_tokens + portable_summary_tokens
+        capacity_message_count = capacity.message_count + portable_summary_messages
+        capacity_envelope_score = capacity_tokens + (8 * capacity_message_count)
         provider_kinds = {
             str(getattr(state, "provider", "") or "").strip()
             for state in context_states
             if str(getattr(state, "provider", "") or "").strip()
         }
+        if reachable_provider_kinds is not None:
+            reachable = {
+                str(provider or "").strip().lower()
+                for provider in reachable_provider_kinds
+                if str(provider or "").strip()
+            }
+            provider_kinds = {
+                provider_kind
+                for provider_kind in provider_kinds
+                if provider_kind.lower() in reachable
+            }
         for provider_kind in provider_kinds:
             native_context = build_provider_compaction_context(
                 context_states=context_states,
@@ -9970,28 +10436,45 @@ class TurnRunner:
             )
             if not native_context.messages:
                 continue
-            payload = [
-                message.model_dump(mode="json", exclude_none=True)
-                for message in native_context.messages
-            ]
-            projected_tokens = estimate_tokens(
-                json.dumps(
-                    payload,
-                    ensure_ascii=False,
-                    sort_keys=True,
-                    default=str,
-                )
+            # Match _load_history + Agent exactly: native provider state is
+            # prepended before max_history_turns and tool-pair repair apply.
+            # Limiting transcript first and then adding native state would
+            # retain a checkpoint that the actual provider request discards.
+            from opensquilla.engine.history import (
+                HistoryReplayMessageProvenance,
+                HistoryReplayProjection,
+            )
+
+            native_replay = HistoryReplayProjection(
+                messages=tuple(native_context.messages) + replay.messages,
+                message_provenance=(
+                    tuple(
+                        HistoryReplayMessageProvenance()
+                        for _message in native_context.messages
+                    )
+                    + replay.message_provenance
+                ),
+                legacy_summary_markers=replay.legacy_summary_markers,
+                terminal_notices=replay.terminal_notices,
+                estimate_complete=replay.estimate_complete,
+            )
+            provider_capacity = project_history_replay_capacity(
+                native_replay,
+                max_history_turns=max_history_turns,
             )
             residual_tokens, residual_messages = _summary_projection(
                 native_context.covered_through_ids
             )
-            provider_view_tokens = projected_tokens + residual_tokens
-            provider_view_messages = len(native_context.messages) + residual_messages
-            if provider_view_tokens > best_compaction_tokens:
-                best_compaction_tokens = provider_view_tokens
-                best_compaction_messages = provider_view_messages
-        capacity_tokens += best_compaction_tokens
-        capacity_message_count += best_compaction_messages
+            provider_view_tokens = provider_capacity.estimated_tokens + residual_tokens
+            provider_view_messages = provider_capacity.message_count + residual_messages
+            provider_view_score = provider_view_tokens + (8 * provider_view_messages)
+            if provider_view_score > capacity_envelope_score:
+                capacity_tokens = provider_view_tokens
+                capacity_message_count = provider_view_messages
+                capacity_envelope_score = provider_view_score
+            capacity_estimate_complete = bool(
+                capacity_estimate_complete and provider_capacity.estimate_complete
+            )
 
         return {
             "history_capacity_estimated_tokens": max(0, capacity_tokens),
@@ -12707,12 +13190,10 @@ class TurnRunner:
             else await self._session_manager.get_transcript(session_key)
         )
 
-        from opensquilla.engine.history import reconstruct_messages_from_entry
         from opensquilla.provider import Message
 
         history: list[Message] = []
         summary_markers: list[str] = []
-        subagent_terminal_notices: list[str] = []
         emergency_overrides = getattr(self, "_emergency_compaction_overrides", {})
         emergency_override = (
             None
@@ -12801,7 +13282,6 @@ class TurnRunner:
             attachment_replay_session_id = await self._resolve_session_id_for_log(session_key)
             if attachment_replay_session_id is None:
                 attachment_replay_session_id = session_key
-        last_entry_was_user = False
         history_materializer: AttachmentWorkspaceMaterializer | None = None
         if materialize_historical_attachments and workspace_dir and attachment_replay_session_id:
             # One instance per history load so first-materialization replays
@@ -12812,76 +13292,21 @@ class TurnRunner:
                 materializable_mimes=None,
                 disk_budget_bytes=workspace_attachment_budget_from_config(self._config),
             )
-        for entry_index, entry in enumerate(transcript):
-            if entry_index in bound_skip_indexes:
-                # The bound current prompt (re-appended by the caller) and any
-                # later still-queued user prompt are excluded from history.
-                last_entry_was_user = False
-                continue
-            if (
-                entry.role == "system"
-                and entry.content
-                and entry.content.startswith(_CONTEXT_SUMMARY_MARKER)
-            ):
-                if not restricted_turn:
-                    summary_markers.append(_strip_context_summary_marker(entry.content))
-                continue
-            subagent_notice = _subagent_terminal_history_notice(entry)
-            if subagent_notice is not None:
-                subagent_terminal_notices.append(subagent_notice)
-                last_entry_was_user = False
-                continue
-            if entry.role not in ("user", "assistant"):
-                continue
-            raw_content = entry.content or ""
-            # User messages may carry attachment envelopes; assistant messages
-            # may carry artifact metadata. Both become text-only safe markers
-            # for model-context replay.
-            if raw_content and entry.role == "user":
-                content: Any = self._maybe_unpack_attachments(
-                    raw_content,
-                    preserve_image_attachments=entry_index in image_replay_entry_indexes,
-                    materialize_historical_attachments=materialize_historical_attachments,
-                    media_root=self._attachment_media_root(),
-                    session_id=attachment_replay_session_id,
-                    workspace_dir=workspace_dir,
-                    historical_materializer=history_materializer,
-                )
-            elif raw_content and entry.role == "assistant":
-                content = self._maybe_unpack_assistant_artifacts(raw_content)
-            else:
-                content = raw_content
-            history.extend(
-                reconstruct_messages_from_entry(
-                    entry.role,
-                    content,
-                    entry.tool_calls,
-                    getattr(entry, "reasoning_content", None),
-                    turn_context=(
-                        getattr(entry, "turn_context", None)
-                        if isinstance(getattr(entry, "turn_context", None), dict)
-                        else None
-                    ),
-                )
-            )
-            last_entry_was_user = entry.role == "user"
-        # Strip the caller-appended user turn only when the transcript really
-        # ended on a user entry; an assistant entry that reconstructs into
-        # assistant + user(tool_result) must keep its tool_result tail. When the
-        # id-bound slice already excluded the current prompt, skip the positional
-        # pop entirely.
-        if (
-            not bound_slice_applied
-            and trim_last_user
-            and last_entry_was_user
-            and history
-            and history[-1].role == "user"
-        ):
-            history.pop()
-        history.extend(
-            Message(role="assistant", content=notice)
-            for notice in dict.fromkeys(subagent_terminal_notices)
+        replay = self._project_history_replay(
+            transcript,
+            excluded_entry_indexes=bound_skip_indexes,
+            trim_last_user=trim_last_user,
+            bound_slice_applied=bound_slice_applied,
+            image_replay_entry_indexes=image_replay_entry_indexes,
+            media_root=self._attachment_media_root(),
+            session_id=attachment_replay_session_id,
+            materialize_historical_attachments=materialize_historical_attachments,
+            workspace_dir=workspace_dir,
+            historical_materializer=history_materializer,
+            restricted_turn=restricted_turn,
         )
+        history = list(replay.messages)
+        summary_markers.extend(replay.legacy_summary_markers)
         if restricted_turn:
             # Context states, durable summaries, and legacy summary markers
             # were produced before this turn's restricted provider projection.

--- a/src/opensquilla/engine/turn_runner/harness.py
+++ b/src/opensquilla/engine/turn_runner/harness.py
@@ -310,6 +310,7 @@ class _TurnRunnerPipelineExecutionAdapter(PipelineExecutionPort):
             "skill_catalog": request.skill_catalog,
             "usage_execution_context": request.usage_execution_context,
             "provider_request_correlation": request.provider_request_correlation,
+            "router_history_replay_request": request.router_history_replay_request,
         }
         accepted_kwargs = {
             name: value

--- a/src/opensquilla/engine/turn_runner/prompt_assembler_stage.py
+++ b/src/opensquilla/engine/turn_runner/prompt_assembler_stage.py
@@ -51,6 +51,24 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 @dataclass(frozen=True)
+class RouterHistoryReplayRequest:
+    """Turn-local replay inputs consumed only after routing has completed.
+
+    This object must never enter ``TurnContext.metadata``: it can retain a
+    transcript snapshot whose rows include user content and inline media.
+    Every field is hidden from ``repr`` so recording test doubles and error
+    reports cannot accidentally render those rows.
+    """
+
+    exclude_last_user: bool = field(repr=False)
+    bound_user_message_id: str | None = field(default=None, repr=False)
+    transcript_snapshot: TurnTranscriptSnapshot[Any] | None = field(
+        default=None,
+        repr=False,
+    )
+
+
+@dataclass(frozen=True)
 class RunPipelineRequest:
     """Typed input for ``PipelineExecutionPort.run_pipeline``.
 
@@ -94,6 +112,10 @@ class RunPipelineRequest:
     skill_catalog: Any | None = None
     usage_execution_context: Any | None = None
     provider_request_correlation: ProviderRequestCorrelation | None = field(
+        default=None,
+        repr=False,
+    )
+    router_history_replay_request: RouterHistoryReplayRequest | None = field(
         default=None,
         repr=False,
     )
@@ -423,7 +445,11 @@ class PromptAssemblerStage:
                 inp.history_has_persisted_user or inp.persist_input
             ),
             "bound_user_message_id": inp.bound_user_message_id,
-            "include_capacity": bool(inp.attachments),
+            # Capacity is route-dependent (notably max_history_turns for image
+            # routes), so only semantic/sticky context is fetched here.  The
+            # opaque request below lets _run_pipeline project capacity after
+            # routing without putting transcript rows in metadata.
+            "include_capacity": False,
         }
         if inp.transcript_snapshot is not None:
             router_context_kwargs["transcript_snapshot"] = inp.transcript_snapshot
@@ -524,6 +550,17 @@ class PromptAssemblerStage:
             skill_catalog=(None if restricted_tool_boundary else inp.skill_catalog),
             usage_execution_context=inp.usage_execution_context,
             provider_request_correlation=inp.provider_request_correlation,
+            router_history_replay_request=(
+                RouterHistoryReplayRequest(
+                    exclude_last_user=(
+                        inp.history_has_persisted_user or inp.persist_input
+                    ),
+                    bound_user_message_id=inp.bound_user_message_id,
+                    transcript_snapshot=inp.transcript_snapshot,
+                )
+                if inp.attachments
+                else None
+            ),
         )
         turn, provider = await self._pipeline_executor.run_pipeline(request)
 

--- a/tests/functional/test_gateway_attachment_history_e2e.py
+++ b/tests/functional/test_gateway_attachment_history_e2e.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
 import json
 import uuid
 from collections.abc import AsyncIterator
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import httpx
@@ -47,6 +49,7 @@ from opensquilla.provider.types import (
 )
 from opensquilla.session.manager import SessionManager
 from opensquilla.session.storage import SessionStorage
+from opensquilla.token_estimation import estimate_tokens
 
 _PNG_BYTES = (
     b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
@@ -55,9 +58,10 @@ _PNG_BYTES = (
     b"\x01\x00\x18\xdd\x8d\xb0\x00\x00\x00\x00IEND\xaeB`\x82"
 )
 
-_TEXT_MODEL = "test/text"
-_GATE_MODEL = "test/gate"
-_VISION_MODEL = "test/vision"
+_PROVIDER_ID = "tokenrhythm"
+_TEXT_MODEL = "deepseek-v4-pro-0813"
+_GATE_MODEL = "deepseek-v4-flash-0731"
+_VISION_MODEL = "kimi-k2.6"
 _TURN_TERMINAL_EVENT_TIMEOUT_SECONDS = 30.0
 _TURN_TASK_DRAIN_TIMEOUT_SECONDS = 10.0
 
@@ -84,7 +88,7 @@ class _RecordingProvider:
 
 
 class _RecordingSelector:
-    active_provider_id = "openrouter"
+    active_provider_id = _PROVIDER_ID
 
     def __init__(
         self,
@@ -96,6 +100,13 @@ class _RecordingSelector:
 
     def clone(self) -> _RecordingSelector:
         return _RecordingSelector(self.providers, self.model)
+
+    @property
+    def current_config(self) -> SimpleNamespace:
+        return SimpleNamespace(provider=_PROVIDER_ID, model=self.model)
+
+    def remaining_chain(self) -> list[SimpleNamespace]:
+        return [self.current_config]
 
     def override_model(self, model: str) -> None:
         self.model = model
@@ -120,22 +131,24 @@ class _FakeModelCatalog:
         model_id: str,  # noqa: ARG002
         *,
         user_override: int = 0,
-        provider: str = "openrouter",  # noqa: ARG002
+        provider: str = _PROVIDER_ID,  # noqa: ARG002
     ) -> int:
         return user_override if user_override > 0 else 1024
 
     def resolve_context_window(
         self,
-        model_id: str,  # noqa: ARG002
+        model_id: str,
         *,
-        provider: str = "openrouter",  # noqa: ARG002
+        provider: str = _PROVIDER_ID,  # noqa: ARG002
     ) -> int:
-        return 8192
+        # Mirror the live TokenRhythm shape: the stable text/base consumer has
+        # a much larger durable-history window than the one-turn image route.
+        return 1_000_000 if model_id == _TEXT_MODEL else 128_000
 
     def get_capabilities(
         self,
         model_id: str,
-        provider_name: str = "openrouter",  # noqa: ARG002
+        provider_name: str = _PROVIDER_ID,  # noqa: ARG002
         base_url: str = "",  # noqa: ARG002
     ) -> ModelCapabilities:
         return ModelCapabilities(supports_vision=model_id == _VISION_MODEL)
@@ -144,7 +157,7 @@ class _FakeModelCatalog:
         self,
         model_id: str,
         *,
-        provider_name: str = "openrouter",  # noqa: ARG002
+        provider_name: str = _PROVIDER_ID,  # noqa: ARG002
         base_url: str = "",  # noqa: ARG002
     ) -> str:
         return "supported" if model_id == _VISION_MODEL else "unsupported"
@@ -217,28 +230,28 @@ def _configure_gateway(tmp_path: Path) -> GatewayConfig:
     config.squilla_router.vision_followup_gate_tier = "c0"
     config.squilla_router.tiers = {
         "c0": {
-            "provider": "openrouter",
+            "provider": _PROVIDER_ID,
             "model": _GATE_MODEL,
             "supports_image": False,
         },
         "c1": {
-            "provider": "openrouter",
+            "provider": _PROVIDER_ID,
             "model": _TEXT_MODEL,
             "supports_image": False,
         },
         "image_model": {
-            "provider": "openrouter",
+            "provider": _PROVIDER_ID,
             "model": _VISION_MODEL,
             "supports_image": True,
             "image_only": True,
         },
     }
     config.squilla_router.default_tier = "c1"
-    config.llm.provider = "openrouter"
+    config.llm.provider = _PROVIDER_ID
     config.llm.model = _TEXT_MODEL
-    # Synthetic model ids are absent from the production catalog. Declare the
-    # deployment contract exercised by this end-to-end fixture explicitly.
-    config.llm.context_window_tokens = 128_000
+    # Synthetic model ids are absent from the production catalog; the fake
+    # catalog above declares their per-deployment windows explicitly.
+    config.llm.context_window_tokens = 0
     return config
 
 
@@ -346,6 +359,36 @@ def _event_payloads(sink: _EventSink, event_name: str) -> list[dict[str, Any]]:
 
 def _file_uuid_attachment(file_uuid: str) -> dict[str, str]:
     return {"file_uuid": file_uuid, "mime": "image/png", "name": "first.png"}
+
+
+def _deterministic_png_payload(*, seed: str, size: int = 80_000) -> bytes:
+    """Return stable high-entropy PNG-like bytes for capacity regression fixtures."""
+
+    payload = bytearray(_PNG_BYTES)
+    counter = 0
+    while len(payload) < size:
+        payload.extend(hashlib.sha256(f"{seed}:{counter}".encode()).digest())
+        counter += 1
+    return bytes(payload[:size])
+
+
+def _inline_image_envelope(text: str, *payloads: bytes) -> str:
+    return json.dumps(
+        {
+            "text": text,
+            "attachments": [
+                {
+                    "type": "image/png",
+                    "name": f"legacy-{index}.png",
+                    "size": len(payload),
+                    "data": base64.b64encode(payload).decode("ascii"),
+                }
+                for index, payload in enumerate(payloads, start=1)
+            ],
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
 
 
 @pytest.fixture
@@ -599,6 +642,169 @@ async def test_gateway_upload_history_image_replays_through_squilla_router_gate_
         bootstrap_configs[-1].max_history_turns
         == config.squilla_router.vision_history_lookback_turns
     )
+
+
+@pytest.mark.asyncio
+async def test_gateway_current_image_capacity_uses_route_limited_media_history(
+    _e2e_stack: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy inline images must not create a false Router capacity rejection."""
+
+    manager: SessionManager = _e2e_stack["manager"]
+    runner: TurnRunner = _e2e_stack["runner"]
+    subscription_manager: SubscriptionManager = _e2e_stack["subscription_manager"]
+    sink: _EventSink = _e2e_stack["sink"]
+    text_provider: _RecordingProvider = _e2e_stack["text_provider"]
+    gate_provider: _RecordingProvider = _e2e_stack["gate_provider"]
+    vision_provider: _RecordingProvider = _e2e_stack["vision_provider"]
+    bootstrap_configs: list[AgentConfig] = _e2e_stack["bootstrap_configs"]
+    key = "agent:main:attachment-capacity-replay"
+    preflight_calls = 0
+    router_capacity_calls: list[dict[str, Any]] = []
+
+    run_preflight = runner._maybe_preflight_compact
+
+    async def _record_preflight(*args: Any, **kwargs: Any) -> None:
+        nonlocal preflight_calls
+        preflight_calls += 1
+        await run_preflight(*args, **kwargs)
+
+    # Exercise the real preflight boundary. The stable text/base deployment has
+    # a 1M window while the image route has 128k, so this synthetic history is
+    # raw-overflowing for Router admission but naturally below durable
+    # compaction pressure, matching the live TokenRhythm topology.
+    monkeypatch.setattr(runner, "_maybe_preflight_compact", _record_preflight)
+    project_router_capacity = runner._router_history_capacity_for_request
+
+    async def _record_router_capacity(
+        session_key: str,
+        request: Any,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        result = await project_router_capacity(session_key, request, **kwargs)
+        router_capacity_calls.append({**kwargs, "result": dict(result)})
+        return result
+
+    monkeypatch.setattr(
+        runner,
+        "_router_history_capacity_for_request",
+        _record_router_capacity,
+    )
+    session = await manager.create(session_key=key, agent_id="main")
+    subscription_manager.subscribe_messages(sink.conn_id, key)
+
+    payloads = [
+        _deterministic_png_payload(seed=f"legacy-{index}") for index in range(4)
+    ]
+    envelopes = [
+        _inline_image_envelope("legacy turn one", payloads[0]),
+        _inline_image_envelope("legacy turn two", payloads[1]),
+        _inline_image_envelope("legacy turn three", payloads[2], payloads[3]),
+    ]
+    assert sum(estimate_tokens(envelope) for envelope in envelopes) > 100_000
+    for index, envelope in enumerate(envelopes, start=1):
+        await manager.append_message(key, "user", envelope)
+        await manager.append_message(key, "assistant", f"legacy answer {index}")
+
+    file_uuid = await _upload_png(_e2e_stack["app"])
+    event_count_before = len(sink.events)
+    await _send_session_turn(
+        ctx=_e2e_stack["ctx"],
+        key=key,
+        sink=sink,
+        message="Describe only the current image.",
+        attachments=[_file_uuid_attachment(file_uuid)],
+    )
+
+    assert len(text_provider.calls) == 0
+    assert len(gate_provider.calls) == 0
+    assert len(vision_provider.calls) == 1
+    assert not any(
+        event == "session.event.error"
+        for event, _payload in sink.events[event_count_before:]
+    )
+
+    sent_messages = vision_provider.calls[0]["messages"]
+    historical_users = [
+        message
+        for message in sent_messages[:-1]
+        if message.role == "user" and _message_has_image(message)
+    ]
+    assert len(historical_users) == 1
+    decoded_images = [
+        base64.b64decode(block.data, validate=True)
+        for message in sent_messages
+        for block in _message_image_blocks(message)
+    ]
+    assert payloads[0] not in decoded_images
+    assert payloads[1] not in decoded_images
+    assert payloads[2] in decoded_images
+    assert payloads[3] in decoded_images
+    assert _PNG_BYTES in decoded_images
+
+    # The provider may receive typed image blocks, but legacy envelope/base64
+    # must never survive as text in the projected history.
+    legacy_data = {
+        base64.b64encode(payload).decode("ascii") for payload in payloads
+    }
+    for message in sent_messages:
+        text_parts: list[str] = []
+        if isinstance(message.content, str):
+            text_parts.append(message.content)
+        elif isinstance(message.content, list):
+            text_parts.extend(
+                block.text
+                for block in message.content
+                if isinstance(block, ContentBlockText)
+            )
+        projected_text = "\n".join(text_parts)
+        assert '"attachments":' not in projected_text
+        assert all(data not in projected_text for data in legacy_data)
+
+    projected_history_parts: list[str] = []
+    replayed_legacy_user_turns = 0
+    for message in sent_messages[:-1]:
+        message_parts: list[str] = []
+        if isinstance(message.content, str):
+            message_parts.append(message.content)
+        elif isinstance(message.content, list):
+            message_parts.extend(
+                block.text
+                for block in message.content
+                if isinstance(block, ContentBlockText)
+            )
+        projected_history_parts.extend(message_parts)
+        if message.role == "user" and "legacy turn" in "\n".join(message_parts):
+            replayed_legacy_user_turns += 1
+    projected_history_text = "\n".join(projected_history_parts)
+    assert replayed_legacy_user_turns == 1
+    assert "legacy turn one" not in projected_history_text
+    assert "legacy turn two" not in projected_history_text
+    assert "legacy answer 1" not in projected_history_text
+    assert "legacy answer 2" not in projected_history_text
+    assert "legacy turn three" in projected_history_text
+    assert "legacy answer 3" in projected_history_text
+
+    router_events = _event_payloads(sink, "session.event.router_decision")
+    assert router_events[-1]["source"] == "image_route"
+    assert router_events[-1]["model"] == _VISION_MODEL
+    done_events = _event_payloads(sink, "session.event.done")
+    assert done_events[-1]["image_route_reason"] == "current_turn"
+    assert bootstrap_configs[-1].max_history_turns == 1
+    assert len(router_capacity_calls) == 1
+    assert router_capacity_calls[0]["max_history_turns"] == 1
+    assert router_capacity_calls[0]["preserve_image_attachments"] is True
+    assert router_capacity_calls[0]["reachable_provider_kinds"] == frozenset(
+        {_PROVIDER_ID}
+    )
+    assert router_capacity_calls[0]["result"]["history_capacity_message_count"] == 2
+    assert router_capacity_calls[0]["result"]["history_capacity_estimate_complete"] is True
+    assert preflight_calls == 1
+    persisted = await manager.get_session(key)
+    assert persisted is not None
+    assert persisted.session_id == session.session_id
+    assert persisted.compaction_count == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/test_turn_prompt_binding.py
+++ b/tests/test_engine/test_turn_prompt_binding.py
@@ -12,6 +12,7 @@ replies are kept — with a positional-trim fallback when no id is supplied.
 
 from __future__ import annotations
 
+import base64
 import json
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
@@ -21,9 +22,26 @@ from unittest.mock import MagicMock
 import pytest
 
 from opensquilla.engine import Agent, AgentConfig
+from opensquilla.engine.history import (
+    HistoryReplayProjection,
+    project_history_replay_capacity,
+)
 from opensquilla.engine.runtime import TurnRunner
+from opensquilla.engine.turn_runner.prompt_assembler_stage import (
+    RouterHistoryReplayRequest,
+)
+from opensquilla.engine.turn_runner.transcript_snapshot import TurnTranscriptSnapshot
 from opensquilla.gateway.config import GatewayConfig
-from opensquilla.provider import ChatConfig, DoneEvent, Message, TextDeltaEvent
+from opensquilla.provider import (
+    ChatConfig,
+    ContentBlockToolResult,
+    ContentBlockToolUse,
+    DoneEvent,
+    Message,
+    TextDeltaEvent,
+)
+from opensquilla.provider.request_proof import estimate_provider_media_tokens
+from opensquilla.session.compaction import estimate_entry_model_replay_tokens
 from opensquilla.session.context_view import (
     build_compaction_context_records,
     build_provider_compaction_context,
@@ -129,6 +147,24 @@ def _history_user_texts(messages: list[Message]) -> list[str]:
         for m in messages[:-1]
         if m.role == "user" and isinstance(m.content, str)
     ]
+
+
+def _inline_images(text: str, *payloads: bytes) -> str:
+    return json.dumps(
+        {
+            "text": text,
+            "attachments": [
+                {
+                    "type": "image/png",
+                    "name": f"image-{index}.png",
+                    "size": len(payload),
+                    "data": base64.b64encode(payload).decode("ascii"),
+                }
+                for index, payload in enumerate(payloads, start=1)
+            ],
+        },
+        separators=(",", ":"),
+    )
 
 
 async def _run_and_capture(
@@ -351,6 +387,578 @@ async def test_router_capacity_does_not_double_count_bound_attachment_across_com
 
 
 @pytest.mark.asyncio
+async def test_router_capacity_projects_inline_images_after_route() -> None:
+    manager = _FakeSessionManager()
+    key = "agent:main:router-capacity-inline-images"
+    await manager.create(key)
+    payloads = [bytes(range(256)) * 100, bytes(reversed(range(256))) * 100]
+    envelope = _inline_images("inspect both images", *payloads)
+    historical_user = await manager.append_message(key, "user", envelope)
+    await manager.append_message(key, "assistant", "historical answer")
+    current = await manager.append_message(key, "user", "current image turn")
+    entries = await manager.get_transcript(key)
+
+    context = await _new_runner(manager)._router_history_capacity_context(
+        key,
+        entries,
+        exclude_last_user=True,
+        bound_user_message_id=current.message_id,
+        bound_index=2,
+        max_history_turns=1,
+        preserve_image_attachments=True,
+    )
+
+    raw_tokens = estimate_entry_model_replay_tokens(historical_user)
+    media_reserve = sum(
+        estimate_provider_media_tokens("image", len(payload)) for payload in payloads
+    )
+    assert context["history_capacity_estimate_complete"] is True
+    assert context["history_capacity_message_count"] == 2
+    assert media_reserve <= context["history_capacity_estimated_tokens"] < raw_tokens
+
+    text_route_context = await _new_runner(manager)._router_history_capacity_context(
+        key,
+        entries,
+        exclude_last_user=True,
+        bound_user_message_id=current.message_id,
+        bound_index=2,
+        max_history_turns=1,
+        preserve_image_attachments=False,
+    )
+    assert text_route_context["history_capacity_estimate_complete"] is True
+    assert text_route_context["history_capacity_estimated_tokens"] >= raw_tokens
+
+    ordinary_json = json.dumps(
+        {
+            "payload": "ordinary application data",
+            "preview_url": (
+                "data:image/png;base64," + base64.b64encode(payloads[0]).decode("ascii")
+            ),
+            "attachments": [
+                {
+                    "type": "image/png",
+                    "data": base64.b64encode(payloads[0]).decode("ascii"),
+                }
+            ],
+        },
+        separators=(",", ":"),
+    )
+    manager._transcripts[key] = [
+        _TranscriptEntry(
+            role="user",
+            content=ordinary_json,
+            message_id="ordinary-json",
+        ),
+        current,
+    ]
+    ordinary_entries = await manager.get_transcript(key)
+    ordinary_context = await _new_runner(manager)._router_history_capacity_context(
+        key,
+        ordinary_entries,
+        exclude_last_user=True,
+        bound_user_message_id=current.message_id,
+        bound_index=1,
+        max_history_turns=1,
+        preserve_image_attachments=True,
+    )
+    assert ordinary_context["history_capacity_estimate_complete"] is True
+    assert ordinary_context["history_capacity_estimated_tokens"] >= estimate_tokens(
+        ordinary_json
+    )
+
+
+def test_router_capacity_does_not_discount_tool_argument_data_url() -> None:
+    data_url = "data:image/png;base64," + base64.b64encode(bytes(range(256)) * 80).decode(
+        "ascii"
+    )
+    projection = HistoryReplayProjection(
+        messages=(
+            Message(role="user", content="inspect tool input"),
+            Message(
+                role="assistant",
+                content=[
+                    ContentBlockToolUse(
+                        id="tool-data-url",
+                        name="inspect",
+                        input={"preview_url": data_url},
+                    )
+                ],
+            ),
+            Message(
+                role="user",
+                content=[
+                    ContentBlockToolResult(
+                        tool_use_id="tool-data-url",
+                        content="done",
+                    )
+                ],
+            ),
+        )
+    )
+
+    capacity = project_history_replay_capacity(projection)
+
+    assert capacity.estimate_complete is True
+    assert capacity.media_block_count == 0
+    assert capacity.media_reserve_tokens == 0
+    assert capacity.estimated_tokens >= estimate_tokens(data_url)
+
+
+@pytest.mark.asyncio
+async def test_router_capacity_applies_route_history_limit_and_bound_slice() -> None:
+    manager = _FakeSessionManager()
+    key = "agent:main:router-capacity-route-limit"
+    await manager.create(key)
+    await manager.append_message(key, "user", "first user " + "x" * 8_000)
+    await manager.append_message(key, "assistant", "first answer " + "a" * 8_000)
+    await manager.append_message(key, "user", "second user " + "y" * 4_000)
+    await manager.append_message(key, "assistant", "second answer " + "b" * 4_000)
+    current = await manager.append_message(key, "user", "bound current " + "c" * 40_000)
+    await manager.append_message(key, "user", "queued future " + "q" * 40_000)
+    entries = await manager.get_transcript(key)
+    runner = _new_runner(manager)
+
+    async def project(max_history_turns: int) -> dict[str, Any]:
+        return await runner._router_history_capacity_context(
+            key,
+            entries,
+            exclude_last_user=True,
+            bound_user_message_id=current.message_id,
+            bound_index=4,
+            max_history_turns=max_history_turns,
+            preserve_image_attachments=False,
+        )
+
+    unlimited = await project(0)
+    one_turn = await project(1)
+    two_turns = await project(2)
+
+    assert unlimited["history_capacity_estimate_complete"] is True
+    assert one_turn["history_capacity_estimate_complete"] is True
+    assert two_turns["history_capacity_estimate_complete"] is True
+    assert unlimited["history_capacity_message_count"] == 4
+    assert one_turn["history_capacity_message_count"] == 2
+    assert two_turns["history_capacity_message_count"] == 4
+    assert one_turn["history_capacity_estimated_tokens"] < two_turns[
+        "history_capacity_estimated_tokens"
+    ]
+    assert two_turns["history_capacity_estimated_tokens"] == unlimited[
+        "history_capacity_estimated_tokens"
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "attachment",
+    [
+        {
+            "type": "image/png",
+            "name": "broken.png",
+            "data": "this is not valid base64 ***",
+        },
+        {
+            "type": "application/x-unknown",
+            "name": "unknown.bin",
+            "data": base64.b64encode(b"unknown").decode("ascii"),
+        },
+        {
+            "type": "image/png",
+            "name": "missing.png",
+            "size": 1,
+            "sha256_ref": "0" * 64,
+        },
+    ],
+    ids=["invalid-base64", "unknown-mime", "missing-sha256-ref"],
+)
+async def test_router_capacity_invalid_inline_image_fails_closed(
+    attachment: dict[str, Any],
+) -> None:
+    manager = _FakeSessionManager()
+    key = "agent:main:router-capacity-invalid-inline"
+    await manager.create(key)
+    invalid = json.dumps(
+        {
+            "text": "broken historical image",
+            "attachments": [attachment],
+        },
+        separators=(",", ":"),
+    )
+    await manager.append_message(key, "user", invalid)
+    await manager.append_message(key, "assistant", "historical answer")
+    current = await manager.append_message(key, "user", "current image turn")
+    entries = await manager.get_transcript(key)
+
+    context = await _new_runner(manager)._router_history_capacity_context(
+        key,
+        entries,
+        exclude_last_user=True,
+        bound_user_message_id=current.message_id,
+        bound_index=2,
+        max_history_turns=1,
+        preserve_image_attachments=True,
+    )
+
+    assert context["history_capacity_estimate_complete"] is False
+
+
+@pytest.mark.asyncio
+async def test_router_capacity_only_fails_closed_for_invalid_media_retained_by_route() -> None:
+    manager = _FakeSessionManager()
+    key = "agent:main:router-capacity-invalid-route-tail"
+    await manager.create(key)
+    invalid = json.dumps(
+        {
+            "text": "broken historical image",
+            "attachments": [
+                {
+                    "type": "image/png",
+                    "name": "broken.png",
+                    "data": "this is not valid base64 ***",
+                }
+            ],
+        },
+        separators=(",", ":"),
+    )
+    current = _TranscriptEntry(role="user", content="current", message_id="current")
+    runner = _new_runner(manager)
+
+    async def project(entries: list[_TranscriptEntry]) -> dict[str, Any]:
+        manager._transcripts[key] = entries
+        return await runner._router_history_capacity_context(
+            key,
+            entries,
+            exclude_last_user=True,
+            bound_user_message_id=current.message_id,
+            bound_index=len(entries) - 1,
+            max_history_turns=1,
+            preserve_image_attachments=True,
+        )
+
+    cropped_invalid = await project(
+        [
+            _TranscriptEntry("user", invalid, "old-broken"),
+            _TranscriptEntry("assistant", "old answer", "old-answer"),
+            _TranscriptEntry("user", "recent valid turn", "recent-valid"),
+            _TranscriptEntry("assistant", "recent answer", "recent-answer"),
+            current,
+        ]
+    )
+    retained_invalid = await project(
+        [
+            _TranscriptEntry("user", "old valid turn", "old-valid"),
+            _TranscriptEntry("assistant", "old answer", "old-answer"),
+            _TranscriptEntry("user", invalid, "recent-broken"),
+            _TranscriptEntry("assistant", "recent answer", "recent-answer"),
+            current,
+        ]
+    )
+
+    assert cropped_invalid["history_capacity_message_count"] == 2
+    assert cropped_invalid["history_capacity_estimate_complete"] is True
+    assert retained_invalid["history_capacity_message_count"] == 2
+    assert retained_invalid["history_capacity_estimate_complete"] is False
+
+
+@pytest.mark.asyncio
+async def test_router_capacity_accepts_retained_missing_reason_marker() -> None:
+    manager = _FakeSessionManager()
+    key = "agent:main:router-capacity-missing-reason"
+    await manager.create(key)
+    missing = json.dumps(
+        {
+            "text": "inspect the unavailable image",
+            "attachments": [
+                {
+                    "type": "image/png",
+                    "name": "lost.png",
+                    "missing_reason": "attachment persistence disabled",
+                }
+            ],
+        },
+        separators=(",", ":"),
+    )
+    await manager.append_message(key, "user", missing)
+    await manager.append_message(key, "assistant", "historical answer")
+    current = await manager.append_message(key, "user", "current image turn")
+    entries = await manager.get_transcript(key)
+    runner = _new_runner(manager)
+
+    replay = runner._project_history_replay(
+        entries,
+        excluded_entry_indexes={2},
+        trim_last_user=True,
+        bound_slice_applied=True,
+        image_replay_entry_indexes={0},
+        media_root=runner._attachment_media_root(),
+        session_id=key,
+        require_capacity_proof=True,
+    )
+    context = await runner._router_history_capacity_context(
+        key,
+        entries,
+        exclude_last_user=True,
+        bound_user_message_id=current.message_id,
+        bound_index=2,
+        max_history_turns=1,
+        preserve_image_attachments=True,
+    )
+
+    marker = "[historical attachment omitted: lost.png (image/png)]"
+    marker_count = sum(
+        message.content.count(marker)
+        for message in replay.messages
+        if isinstance(message.content, str)
+    )
+    assert marker_count == 1
+    assert replay.estimate_complete is True
+    assert context["history_capacity_message_count"] == 2
+    assert context["history_capacity_estimate_complete"] is True
+
+
+@pytest.mark.asyncio
+async def test_router_capacity_preserves_plain_token_floor_but_clears_inline_media_floor() -> None:
+    manager = _FakeSessionManager()
+    key = "agent:main:router-capacity-token-floor"
+    await manager.create(key)
+    current = _TranscriptEntry(role="user", content="current", message_id="current")
+    runner = _new_runner(manager)
+    high_floor = 50_000
+
+    async def project(historical: _TranscriptEntry) -> dict[str, Any]:
+        entries = [
+            historical,
+            _TranscriptEntry("assistant", "short answer", f"{historical.message_id}-answer"),
+            current,
+        ]
+        manager._transcripts[key] = entries
+        return await runner._router_history_capacity_context(
+            key,
+            entries,
+            exclude_last_user=True,
+            bound_user_message_id=current.message_id,
+            bound_index=2,
+            max_history_turns=1,
+            preserve_image_attachments=True,
+        )
+
+    plain = await project(
+        _TranscriptEntry(
+            "user",
+            "small ordinary history row",
+            "plain",
+            token_count=high_floor,
+        )
+    )
+    inline_envelope = _inline_images(
+        "image history row",
+        bytes(range(256)) * 120,
+    )
+    inline_raw_floor = estimate_tokens(inline_envelope)
+    inline_media = await project(
+        _TranscriptEntry(
+            "user",
+            inline_envelope,
+            "inline-media",
+            token_count=inline_raw_floor,
+        )
+    )
+
+    assert plain["history_capacity_estimated_tokens"] >= high_floor
+    assert inline_media["history_capacity_estimate_complete"] is True
+    assert inline_media["history_capacity_estimated_tokens"] < inline_raw_floor
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("persist_raw_floor", [False, True])
+async def test_router_capacity_mixed_envelope_discounts_only_typed_image_data(
+    persist_raw_floor: bool,
+) -> None:
+    manager = _FakeSessionManager()
+    key = "agent:main:router-capacity-mixed-image-document"
+    await manager.create(key)
+    image_data = base64.b64encode(bytes(range(256)) * 120).decode("ascii")
+    document_data = base64.b64encode(bytes(reversed(range(256))) * 80).decode("ascii")
+    envelope = json.dumps(
+        {
+            "text": "inspect the image and document",
+            "attachments": [
+                {"type": "image/png", "name": "image.png", "data": image_data},
+                {"type": "application/pdf", "name": "document.pdf", "data": document_data},
+            ],
+        },
+        separators=(",", ":"),
+    )
+    raw_floor = estimate_tokens(envelope)
+    historical = _TranscriptEntry(
+        "user",
+        envelope,
+        "mixed-history",
+        token_count=raw_floor if persist_raw_floor else None,
+    )
+    answer = _TranscriptEntry("assistant", "answer", "mixed-answer")
+    current = _TranscriptEntry("user", "current", "current")
+    entries = [historical, answer, current]
+    manager._transcripts[key] = entries
+
+    context = await _new_runner(manager)._router_history_capacity_context(
+        key,
+        entries,
+        exclude_last_user=True,
+        bound_user_message_id=current.message_id,
+        bound_index=2,
+        max_history_turns=1,
+        preserve_image_attachments=True,
+    )
+
+    # The image data becomes a typed media block, while the PDF base64 remains
+    # in the conservative residual token floor for this mixed row.
+    residual_envelope = envelope.replace(
+        json.dumps(image_data),
+        json.dumps(f"[history_image_omitted: {len(image_data)} chars]"),
+    )
+    expected_image_reserve = estimate_provider_media_tokens(
+        "image",
+        len(base64.b64decode(image_data, validate=True)),
+    )
+    assert context["history_capacity_estimate_complete"] is True
+    assert (
+        estimate_tokens(residual_envelope) + expected_image_reserve
+        <= context["history_capacity_estimated_tokens"]
+    )
+    assert context["history_capacity_estimated_tokens"] < raw_floor
+
+
+@pytest.mark.asyncio
+async def test_router_capacity_projection_exception_fails_closed_at_request_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _FakeSessionManager()
+    key = "agent:main:router-capacity-projection-error"
+    await manager.create(key)
+    current = await manager.append_message(key, "user", "current")
+    runner = _new_runner(manager)
+
+    async def fail_projection(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("synthetic projection failure with private content")
+
+    monkeypatch.setattr(runner, "_router_history_capacity_context", fail_projection)
+    context = await runner._router_history_capacity_for_request(
+        key,
+        RouterHistoryReplayRequest(
+            exclude_last_user=True,
+            bound_user_message_id=current.message_id,
+        ),
+        max_history_turns=1,
+        preserve_image_attachments=True,
+    )
+
+    assert context == {"history_capacity_estimate_complete": False}
+
+
+@pytest.mark.asyncio
+async def test_router_capacity_request_resolves_bound_and_queued_users_from_snapshot() -> None:
+    manager = _FakeSessionManager()
+    key = "agent:main:router-capacity-request-snapshot"
+    await manager.create(key)
+    prior_user = _TranscriptEntry("user", "prior user", "prior-user")
+    prior_answer = _TranscriptEntry("assistant", "prior answer", "prior-answer")
+    bound = _TranscriptEntry("user", "bound current " + "b" * 20_000, "bound")
+    queued = _TranscriptEntry("user", "queued future " + "q" * 20_000, "queued")
+
+    async def load_snapshot() -> list[_TranscriptEntry]:
+        return [prior_user, prior_answer, bound, queued]
+
+    snapshot = TurnTranscriptSnapshot(load_snapshot)
+    context = await _new_runner(manager)._router_history_capacity_for_request(
+        key,
+        RouterHistoryReplayRequest(
+            exclude_last_user=True,
+            bound_user_message_id=bound.message_id,
+            transcript_snapshot=snapshot,
+        ),
+        max_history_turns=1,
+        preserve_image_attachments=False,
+        reachable_provider_kinds={"tokenrhythm"},
+    )
+
+    assert snapshot.load_count == 1
+    assert context["history_capacity_estimate_complete"] is True
+    assert context["history_capacity_message_count"] == 2
+    assert context["history_capacity_estimated_tokens"] < estimate_tokens(bound.content)
+
+
+@pytest.mark.asyncio
+async def test_router_capacity_request_snapshot_read_failure_is_incomplete() -> None:
+    manager = _FakeSessionManager()
+    key = "agent:main:router-capacity-request-snapshot-failure"
+    await manager.create(key)
+
+    async def fail_snapshot() -> list[_TranscriptEntry]:
+        raise RuntimeError("private transcript read failure")
+
+    context = await _new_runner(manager)._router_history_capacity_for_request(
+        key,
+        RouterHistoryReplayRequest(
+            exclude_last_user=True,
+            transcript_snapshot=TurnTranscriptSnapshot(fail_snapshot),
+        ),
+        max_history_turns=1,
+        preserve_image_attachments=True,
+    )
+
+    assert context == {"history_capacity_estimate_complete": False}
+
+
+def test_router_capacity_route_tail_repairs_tool_pairing() -> None:
+    projection = HistoryReplayProjection(
+        messages=(
+            Message(role="user", content="old turn"),
+            Message(
+                role="assistant",
+                content=[ContentBlockToolUse(id="old", name="lookup", input={})],
+            ),
+            Message(role="user", content="retained turn"),
+            Message(
+                role="user",
+                content=[ContentBlockToolResult(tool_use_id="old", content="old result")],
+            ),
+            Message(
+                role="assistant",
+                content=[ContentBlockToolUse(id="retained", name="lookup", input={})],
+            ),
+            Message(
+                role="user",
+                content=[
+                    ContentBlockToolResult(
+                        tool_use_id="retained",
+                        content="retained result",
+                    )
+                ],
+            ),
+        )
+    )
+
+    capacity = project_history_replay_capacity(projection, max_history_turns=1)
+    use_ids = {
+        block.id
+        for message in capacity.messages
+        if isinstance(message.content, list)
+        for block in message.content
+        if isinstance(block, ContentBlockToolUse)
+    }
+    result_ids = {
+        block.tool_use_id
+        for message in capacity.messages
+        if isinstance(message.content, list)
+        for block in message.content
+        if isinstance(block, ContentBlockToolResult)
+    }
+
+    assert capacity.message_count == 3
+    assert use_ids == result_ids == {"retained"}
+
+
+@pytest.mark.asyncio
 async def test_router_capacity_adds_native_state_and_uncovered_portable_summary() -> None:
     manager = _FakeSessionManager()
     key = "agent:main:router-capacity-mixed-compaction"
@@ -407,6 +1015,101 @@ async def test_router_capacity_adds_native_state_and_uncovered_portable_summary(
     ) + estimate_tokens(rendered_residual)
     assert context["history_capacity_estimated_tokens"] == expected
     assert context["history_capacity_message_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_router_capacity_limits_native_state_with_combined_provider_replay() -> None:
+    manager = _FakeSessionManager()
+    key = "agent:main:router-capacity-native-route-tail"
+    node = await manager.create(key)
+    await manager.append_message(key, "user", "old user " + "u" * 8_000)
+    await manager.append_message(key, "assistant", "old answer " + "a" * 8_000)
+    await manager.append_message(key, "user", "recent user")
+    await manager.append_message(key, "assistant", "recent answer")
+    current = await manager.append_message(key, "user", "current")
+    entries = await manager.get_transcript(key)
+    runner = _new_runner(manager)
+
+    without_native = await runner._router_history_capacity_context(
+        key,
+        entries,
+        exclude_last_user=True,
+        bound_user_message_id=current.message_id,
+        bound_index=4,
+        max_history_turns=1,
+    )
+    manager._context_states[key] = [
+        SessionContextState(
+            session_id=node.session_id,
+            session_key=key,
+            provider="anthropic",
+            model="synthetic-model",
+            state_kind="anthropic_compaction_block",
+            payload={"content": "native checkpoint " + "n" * 20_000},
+            covered_through_id=2,
+            portable=False,
+            cacheable=True,
+        )
+    ]
+
+    with_native = await runner._router_history_capacity_context(
+        key,
+        entries,
+        exclude_last_user=True,
+        bound_user_message_id=current.message_id,
+        bound_index=4,
+        max_history_turns=1,
+    )
+
+    # _load_history prepends native state before Agent.limit_turns. The older
+    # native assistant checkpoint is therefore cropped together with the old
+    # transcript turn and must not be added back by Router admission.
+    assert with_native == without_native
+    assert with_native["history_capacity_message_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_router_capacity_ignores_unreachable_provider_native_state() -> None:
+    manager = _FakeSessionManager()
+    key = "agent:main:router-capacity-unreachable-native"
+    node = await manager.create(key)
+    await manager.append_message(key, "user", "history")
+    await manager.append_message(key, "assistant", "answer")
+    current = await manager.append_message(key, "user", "current")
+    entries = await manager.get_transcript(key)
+    manager._context_states[key] = [
+        SessionContextState(
+            session_id=node.session_id,
+            session_key=key,
+            provider="anthropic",
+            model="synthetic-model",
+            state_kind="anthropic_compaction_block",
+            payload={"content": "stale native checkpoint " + "n" * 20_000},
+            covered_through_id=0,
+            portable=False,
+            cacheable=True,
+        )
+    ]
+    runner = _new_runner(manager)
+
+    async def project(reachable: set[str]) -> dict[str, Any]:
+        return await runner._router_history_capacity_context(
+            key,
+            entries,
+            exclude_last_user=True,
+            bound_user_message_id=current.message_id,
+            bound_index=2,
+            reachable_provider_kinds=reachable,
+        )
+
+    tokenrhythm_view = await project({"tokenrhythm"})
+    anthropic_view = await project({"anthropic"})
+
+    assert tokenrhythm_view["history_capacity_message_count"] == 2
+    assert anthropic_view["history_capacity_message_count"] == 3
+    assert anthropic_view["history_capacity_estimated_tokens"] > tokenrhythm_view[
+        "history_capacity_estimated_tokens"
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/turn_runner/test_prompt_assembler_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_prompt_assembler_stage_unit.py
@@ -76,6 +76,7 @@ class _RecordingRouterContext:
     context: dict[str, Any] = field(default_factory=dict)
     calls: list[tuple[str, bool]] = field(default_factory=list)
     bound_user_message_ids: list[str | None] = field(default_factory=list)
+    include_capacity_flags: list[bool] = field(default_factory=list)
     transcript_snapshots: list[Any | None] = field(default_factory=list)
 
     async def fetch_router_context(
@@ -89,6 +90,7 @@ class _RecordingRouterContext:
     ):
         self.calls.append((session_key, exclude_last_user))
         self.bound_user_message_ids.append(bound_user_message_id)
+        self.include_capacity_flags.append(include_capacity)
         self.transcript_snapshots.append(transcript_snapshot)
         return dict(self.context)
 
@@ -447,6 +449,33 @@ async def test_prompt_assembler_forwards_turn_transcript_snapshot() -> None:
     await stage.run(_make_input(transcript_snapshot=transcript_snapshot))
 
     assert router_context.transcript_snapshots == [transcript_snapshot]
+
+
+@pytest.mark.asyncio
+async def test_attachment_prompt_carries_repr_safe_router_replay_request() -> None:
+    router_context = _RecordingRouterContext()
+    executor = _RecordingPipelineExecutor(turn=_make_turn(), provider=_StubProvider())
+    stage = _make_stage(router=router_context, executor=executor)
+    transcript_snapshot = SimpleNamespace(private_history="history-secret")
+
+    await stage.run(
+        _make_input(
+            attachments=[{"type": "image/png", "data": "current-secret"}],
+            bound_user_message_id="msg-bound",
+            transcript_snapshot=transcript_snapshot,
+        )
+    )
+
+    request = executor.requests[0]
+    replay_request = request.router_history_replay_request
+    assert router_context.include_capacity_flags == [False]
+    assert replay_request is not None
+    assert replay_request.exclude_last_user is True
+    assert replay_request.bound_user_message_id == "msg-bound"
+    assert replay_request.transcript_snapshot is transcript_snapshot
+    assert repr(replay_request) == "RouterHistoryReplayRequest()"
+    assert "history-secret" not in repr(request)
+    assert "current-secret" not in repr(request.router_history_replay_request)
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_provider_profile_gateway_e2e.py
+++ b/tests/test_live_provider_profile_gateway_e2e.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import http.server
 import importlib.util
 import json
 import os
+import sqlite3
 import sys
+import threading
 import tomllib
 from pathlib import Path
 
@@ -462,8 +465,18 @@ def test_public_provider_summary_excludes_raw_turn_material() -> None:
             {
                 "ok": True,
                 "actual_response_model": "gpt-4.1-mini",
-                "usage": {"input_tokens": 2, "output_tokens": 1},
-                "cost": {"opensquilla_estimated_cost_usd": 0.00001},
+                "usage": {
+                    "input_tokens": 2,
+                    "output_tokens": 1,
+                    "models": [{"prompt": "nested-must-not-report"}],
+                    "source": {"session_key": "nested-must-not-report"},
+                    "session_key": "must-not-report",
+                },
+                "cost": {
+                    "opensquilla_estimated_cost_usd": 0.00001,
+                    "source": {"prompt": "nested-must-not-report"},
+                    "prompt": "must-not-report",
+                },
                 "latency_ms": 9,
                 "assistant_excerpt": "must not leave memory boundary",
                 "session_key": "must-not-report",
@@ -489,9 +502,29 @@ def test_public_provider_summary_excludes_raw_turn_material() -> None:
     final_serialized = json.dumps(final_rows)
     assert "cases" not in final_serialized
     assert "session_key" not in final_serialized
+    assert "prompt" not in final_serialized
+    assert "nested-must-not-report" not in final_serialized
     with pytest.raises(RuntimeError, match="invalid field set"):
         e2e._assert_public_report_schema(  # noqa: SLF001
             [{**final_rows[0], "session_key": "forbidden"}]
+        )
+    with pytest.raises(RuntimeError, match="invalid usage values"):
+        e2e._assert_public_report_schema(  # noqa: SLF001
+            [
+                {
+                    **final_rows[0],
+                    "usage": {"input_tokens": {"session_key": "forbidden"}},
+                }
+            ]
+        )
+    with pytest.raises(RuntimeError, match="invalid cost values"):
+        e2e._assert_public_report_schema(  # noqa: SLF001
+            [
+                {
+                    **final_rows[0],
+                    "cost": {"source": {"prompt": "forbidden"}},
+                }
+            ]
         )
 
 
@@ -543,3 +576,1194 @@ def test_gateway_main_writes_and_prints_only_exact_public_rows(
     captured = capsys.readouterr()
     assert json.loads(captured.out) == payload
     assert "coverage" in captured.err
+
+
+def test_gateway_main_catches_unexpected_runner_error_and_redacts_stripped_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output = tmp_path / "unexpected-runner-error.json"
+    output.write_text("stale report", encoding="utf-8")
+    stripped_key = "synthetic-stripped-provider-key"
+    monkeypatch.setenv("OPENAI_API_KEY", f"  {stripped_key}  ")
+
+    def fail_runner(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise TypeError(f"synthetic unexpected failure: {stripped_key}")
+
+    monkeypatch.setattr(e2e, "_run_provider", fail_runner)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "live_provider_profile_gateway_e2e.py",
+            "--providers",
+            "openai",
+            "--no-env-file",
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert e2e.main() == 2
+    assert not output.exists()
+    captured = capsys.readouterr()
+    assert stripped_key not in captured.err
+    assert "[REDACTED]" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_gateway_main_catches_projection_error_and_removes_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output = tmp_path / "projection-error.json"
+    monkeypatch.setattr(
+        e2e,
+        "_run_provider",
+        lambda *_args, **_kwargs: {
+            "provider": "openai",
+            "ok": True,
+            "models_covered": ["gpt-4.1-mini"],
+            "failure_kinds": [],
+            "cases": [],
+        },
+    )
+
+    def fail_projection(_results: object) -> list[dict[str, object]]:
+        raise AttributeError("synthetic projection failure")
+
+    monkeypatch.setattr(e2e, "_public_report_rows", fail_projection)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "live_provider_profile_gateway_e2e.py",
+            "--providers",
+            "openai",
+            "--no-env-file",
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert e2e.main() == 2
+    assert not output.exists()
+    captured = capsys.readouterr()
+    assert "unable to write live report" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_gateway_main_rejects_directory_output_before_running(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "report-directory"
+    output.mkdir()
+    monkeypatch.setattr(
+        e2e,
+        "_run_provider",
+        lambda *_args, **_kwargs: pytest.fail("runner must not start for directory output"),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "live_provider_profile_gateway_e2e.py",
+            "--providers",
+            "openai",
+            "--no-env-file",
+            "--output",
+            str(output),
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        e2e.main()
+    assert output.is_dir()
+
+
+def test_attachment_capacity_fixture_is_over_raw_admission_but_media_bounded() -> None:
+    fixture = e2e._attachment_capacity_fixture()  # noqa: SLF001
+    metrics = fixture["metrics"]
+
+    assert metrics["history_turn_count"] == 3
+    assert metrics["history_image_count"] == 4
+    assert metrics["last_history_image_count"] == 2
+    assert (
+        metrics["raw_history_estimated_tokens"]
+        >= metrics["router_admission_token_limit"] + e2e.ATTACHMENT_CAPACITY_MIN_RAW_MARGIN_TOKENS
+    )
+    assert (
+        metrics["configured_max_output_tokens"]
+        == e2e.ATTACHMENT_CAPACITY_MAX_OUTPUT_TOKENS
+    )
+    assert metrics[
+        "router_admission_token_limit"
+    ] == e2e._attachment_capacity_admission_token_limit(  # noqa: SLF001
+        thinking_budget_tokens=0,
+    )
+    assert metrics[
+        "router_max_thinking_admission_token_limit"
+    ] == e2e._attachment_capacity_admission_token_limit(  # noqa: SLF001
+        thinking_budget_tokens=e2e.MAX_THINKING_BUDGET_TOKENS,
+    )
+    assert metrics["raw_history_fits_at_zero_thinking"] is False
+    assert metrics["projected_media_fits_at_max_thinking"] is True
+    assert not e2e._attachment_capacity_request_fits(  # noqa: SLF001
+        metrics["raw_history_estimated_tokens"],
+        thinking_budget_tokens=0,
+    )
+    assert e2e._attachment_capacity_request_fits(  # noqa: SLF001
+        metrics["projected_media_tokens"],
+        thinking_budget_tokens=e2e.MAX_THINKING_BUDGET_TOKENS,
+    )
+    assert (
+        metrics["projected_media_tokens"]
+        < metrics["router_max_thinking_admission_token_limit"]
+        < metrics["router_admission_token_limit"]
+    )
+    image_counts = [len(json.loads(turn["user"])["attachments"]) for turn in fixture["turns"]]
+    assert image_counts == [1, 1, 2]
+    assert fixture["current_attachment"]["type"] == "image/png"
+    assert fixture["current_attachment"]["data"]
+
+
+def test_attachment_capacity_seed_uses_only_isolated_session_state(tmp_path: Path) -> None:
+    fixture = e2e._attachment_capacity_fixture()  # noqa: SLF001
+    state_dir = tmp_path / "isolated-state"
+    session_key = "agent:main:webchat:offline-attachment-capacity"
+
+    e2e._seed_attachment_capacity_history(state_dir, session_key, fixture)  # noqa: SLF001
+
+    connection = sqlite3.connect(state_dir / "sessions.db")
+    try:
+        rows = connection.execute(
+            "SELECT role, content FROM transcript_entries WHERE session_key = ? ORDER BY id",
+            (session_key,),
+        ).fetchall()
+        session_state = connection.execute(
+            "SELECT compaction_count, model_routing_mode FROM sessions WHERE session_key = ?",
+            (session_key,),
+        ).fetchone()
+    finally:
+        connection.close()
+    assert [row[0] for row in rows] == ["user", "assistant"] * 3
+    assert [row[1] for row in rows] == [
+        value for turn in fixture["turns"] for value in (turn["user"], turn["assistant"])
+    ]
+    assert session_state == (0, "router")
+
+
+def test_attachment_capacity_config_is_single_call_and_includes_image_tier(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "gateway.toml"
+    tiers = e2e._tokenrhythm_attachment_tiers()  # noqa: SLF001
+
+    e2e._write_config(  # noqa: SLF001
+        config_path,
+        "tokenrhythm",
+        "https://tokenrhythm.studio/v1",
+        tiers["c1"]["model"],
+        max_tokens=e2e.ATTACHMENT_CAPACITY_MAX_OUTPUT_TOKENS,
+        tier_overrides=tiers,
+        agent_max_iterations=1,
+        llm_request_timeout_seconds=e2e.ATTACHMENT_CAPACITY_PROVIDER_TIMEOUT_SECONDS,
+        agent_runtime_timeout_seconds=e2e.ATTACHMENT_CAPACITY_AGENT_TIMEOUT_SECONDS,
+        turn_hard_deadline_seconds=e2e.ATTACHMENT_CAPACITY_AGENT_TIMEOUT_SECONDS,
+        model_context_window_tokens=e2e.ATTACHMENT_CAPACITY_BASE_CONTEXT_WINDOW_TOKENS,
+        model_supports_vision_override=e2e.ATTACHMENT_CAPACITY_MODEL,
+    )
+
+    data = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert data["agent_max_iterations"] == 1
+    assert data["agent_max_provider_retries"] == 0
+    assert data["llm"]["max_tokens"] == e2e.ATTACHMENT_CAPACITY_MAX_OUTPUT_TOKENS
+    assert data["llm_request_timeout_seconds"] == 60.0
+    assert data["agent_runtime_timeout_seconds"] == 75.0
+    assert data["task_runtime"]["turn_hard_deadline_s"] == 75.0
+    assert data["naming"]["enabled"] is False
+    assert data["squilla_router"]["tiers"]["image_model"] == tiers["image_model"]
+    assert data["squilla_router"]["tiers"]["image_model"]["model"] == "kimi-k2.6"
+    assert all(tiers[slot]["supports_image"] is False for slot in e2e.TEXT_PROFILE_SLOTS)
+    assert (
+        data["models"]["tokenrhythm"]["deepseek-v4-pro-0813"]["context_window"]
+        == e2e.ATTACHMENT_CAPACITY_BASE_CONTEXT_WINDOW_TOKENS
+    )
+    assert data["models"]["tokenrhythm"]["kimi-k2.6"]["supports_vision"] is True
+
+
+def test_attachment_capacity_runner_reaches_provider_through_real_gateway(
+    tmp_path: Path,
+) -> None:
+    requests: list[dict[str, object]] = []
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+        def do_POST(self) -> None:  # noqa: N802 - stdlib handler contract
+            if self.path.rstrip("/") != "/v1/chat/completions":
+                self.send_error(404)
+                return
+            length = int(self.headers.get("content-length") or "0")
+            payload = json.loads(self.rfile.read(length))
+            requests.append(payload)
+            model = str(payload.get("model") or "kimi-k2.6")
+            chunks = [
+                {
+                    "model": model,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "role": "assistant",
+                                "content": "Synthetic image reply.\nATTACHMENT_CAPACITY_LIVE_OK",
+                            },
+                            "finish_reason": None,
+                        }
+                    ],
+                },
+                {
+                    "model": model,
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 100, "completion_tokens": 5},
+                },
+            ]
+            body = b"".join(
+                f"data: {json.dumps(chunk, separators=(',', ':'))}\n\n".encode()
+                for chunk in chunks
+            ) + b"data: [DONE]\n\n"
+            self.send_response(200)
+            self.send_header("content-type", "text/event-stream")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    try:
+        result = e2e._run_tokenrhythm_attachment_capacity_in_temp(  # noqa: SLF001
+            api_key="synthetic-attachment-capacity-key",
+            base_url=f"http://{host}:{port}/v1",
+            tmp_path=tmp_path,
+            synthetic_vision_capability_override=True,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert result["ok"] is True, result
+    assert len(requests) == 1
+    assert requests[0]["model"] == "kimi-k2.6"
+    case = result["cases"][0]
+    assert case["usage"]["physical_request_count"] == 1
+    assert case["usage"]["physical_response_count"] == 1
+    assert case["usage"]["compaction_count"] == 0
+    assert case["usage"]["provider_proof_fits"] is True
+
+
+@pytest.mark.parametrize(
+    ("status_code", "provider_message", "expected_failure"),
+    [
+        (401, "invalid api key", "auth"),
+        (429, "rate limit exceeded", "rate-limit"),
+        (503, "service temporarily unavailable", "transport"),
+    ],
+)
+def test_attachment_capacity_runner_bounds_provider_http_failures_to_one_call(
+    tmp_path: Path,
+    status_code: int,
+    provider_message: str,
+    expected_failure: str,
+) -> None:
+    requests: list[dict[str, object]] = []
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+        def do_POST(self) -> None:  # noqa: N802 - stdlib handler contract
+            if self.path.rstrip("/") != "/v1/chat/completions":
+                self.send_error(404)
+                return
+            length = int(self.headers.get("content-length") or "0")
+            requests.append(json.loads(self.rfile.read(length)))
+            body = json.dumps(
+                {
+                    "error": {
+                        "message": provider_message,
+                        "type": "synthetic_provider_error",
+                        "code": status_code,
+                    }
+                },
+                separators=(",", ":"),
+            ).encode()
+            self.send_response(status_code)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    try:
+        result = e2e._run_tokenrhythm_attachment_capacity_in_temp(  # noqa: SLF001
+            api_key="synthetic-attachment-capacity-key",
+            base_url=f"http://{host}:{port}/v1",
+            tmp_path=tmp_path,
+            synthetic_vision_capability_override=True,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert result["ok"] is False
+    assert len(requests) == 1
+    case = result["cases"][0]
+    assert case["failure_kind"] == expected_failure
+    assert case["usage"]["physical_request_count"] == 1
+    assert case["usage"]["physical_response_count"] == 0
+    assert case["usage"]["compaction_count"] == 0
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_failure", "expected_response_count"),
+    [
+        ("empty", "implementation", 0),
+        ("truncated", "implementation", 0),
+        ("marker_missing", "implementation", 1),
+        ("timeout", "transport", 0),
+    ],
+)
+def test_attachment_capacity_runner_fails_closed_for_stream_faults(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mode: str,
+    expected_failure: str,
+    expected_response_count: int,
+) -> None:
+    requests: list[dict[str, object]] = []
+    if mode == "timeout":
+        monkeypatch.setattr(e2e, "ATTACHMENT_CAPACITY_PROVIDER_TIMEOUT_SECONDS", 1.0)
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+        def do_POST(self) -> None:  # noqa: N802 - stdlib handler contract
+            if self.path.rstrip("/") != "/v1/chat/completions":
+                self.send_error(404)
+                return
+            length = int(self.headers.get("content-length") or "0")
+            payload = json.loads(self.rfile.read(length))
+            requests.append(payload)
+            model = str(payload.get("model") or "kimi-k2.6")
+            if mode == "timeout":
+                threading.Event().wait(2.5)
+            if mode == "empty":
+                body = b""
+            elif mode == "truncated":
+                body = b'data: {"model":"kimi-k2.6","choices":['
+            else:
+                chunks = [
+                    {
+                        "model": model,
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {
+                                    "role": "assistant",
+                                    "content": (
+                                        "Synthetic reply without the required marker."
+                                        if mode == "marker_missing"
+                                        else "Synthetic delayed reply.\nATTACHMENT_CAPACITY_LIVE_OK"
+                                    ),
+                                },
+                                "finish_reason": None,
+                            }
+                        ],
+                    },
+                    {
+                        "model": model,
+                        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                        "usage": {"prompt_tokens": 100, "completion_tokens": 5},
+                    },
+                ]
+                body = b"".join(
+                    f"data: {json.dumps(chunk, separators=(',', ':'))}\n\n".encode()
+                    for chunk in chunks
+                ) + b"data: [DONE]\n\n"
+            self.send_response(200)
+            self.send_header("content-type", "text/event-stream")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            try:
+                self.wfile.write(body)
+            except (BrokenPipeError, ConnectionResetError):
+                # Fault cases intentionally let the client close the synthetic stream.
+                pass
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    try:
+        result = e2e._run_tokenrhythm_attachment_capacity_in_temp(  # noqa: SLF001
+            api_key="synthetic-attachment-capacity-key",
+            base_url=f"http://{host}:{port}/v1",
+            tmp_path=tmp_path,
+            synthetic_vision_capability_override=True,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert result["ok"] is False
+    assert len(requests) == 1
+    case = result["cases"][0]
+    assert case["failure_kind"] == expected_failure
+    assert case["usage"]["physical_request_count"] == 1
+    assert case["usage"]["physical_response_count"] == expected_response_count
+    assert case["usage"]["compaction_count"] == 0
+    assert "synthetic-attachment-capacity-key" not in json.dumps(result)
+
+
+def test_attachment_capacity_absolute_deadline_never_forces_a_positive_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(e2e.time, "monotonic", lambda: 100.0)
+
+    assert e2e._attachment_capacity_remaining_timeout(100.0, 75.0) == 0.0  # noqa: SLF001
+    assert e2e._attachment_capacity_remaining_timeout(99.0, 75.0) == 0.0  # noqa: SLF001
+    assert e2e._attachment_capacity_remaining_timeout(110.0, 75.0) == 10.0  # noqa: SLF001
+    assert (  # noqa: SLF001
+        e2e._attachment_capacity_remaining_timeout(
+            110.0,
+            75.0,
+            overrun_reserve_seconds=4.0,
+        )
+        == 6.0
+    )
+    assert (
+        e2e.ATTACHMENT_CAPACITY_TOTAL_TIMEOUT_SECONDS
+        - e2e.ATTACHMENT_CAPACITY_GATEWAY_SHUTDOWN_TIMEOUT_SECONDS
+        == 105.0
+    )
+
+
+def test_attachment_capacity_always_removes_raw_tree_after_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    raw_root = tmp_path / "opensquilla-tokenrhythm-attachment-capacity-failure"
+
+    def fake_mkdtemp(*, prefix: str) -> str:
+        assert prefix == "opensquilla-tokenrhythm-attachment-capacity-"
+        raw_root.mkdir()
+        return str(raw_root)
+
+    def fake_inner(**kwargs):
+        root = kwargs["tmp_path"]
+        (root / "turn-calls").mkdir()
+        (root / "turn-calls" / "raw.jsonl").write_text("synthetic raw trace")
+        raise RuntimeError("synthetic attachment failure")
+
+    monkeypatch.setattr(e2e.tempfile, "mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(e2e, "_run_tokenrhythm_attachment_capacity_in_temp", fake_inner)
+
+    with pytest.raises(RuntimeError, match="synthetic attachment failure"):
+        e2e._run_tokenrhythm_attachment_capacity("synthetic-cleanup-key")  # noqa: SLF001
+
+    assert not raw_root.exists()
+
+
+def test_attachment_capacity_removes_raw_tree_when_initial_chmod_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    raw_root = tmp_path / "opensquilla-tokenrhythm-attachment-capacity-chmod"
+    cleanup_calls: list[Path] = []
+
+    def fake_mkdtemp(*, prefix: str) -> str:
+        assert prefix == "opensquilla-tokenrhythm-attachment-capacity-"
+        raw_root.mkdir()
+        return str(raw_root)
+
+    def fail_chmod(_path: object, _mode: int) -> None:
+        raise PermissionError("synthetic chmod failure")
+
+    def fake_cleanup(path: object, _secrets: object) -> None:
+        cleanup_calls.append(Path(path))
+        raw_root.rmdir()
+
+    monkeypatch.setattr(e2e.tempfile, "mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(e2e.os, "chmod", fail_chmod)
+    monkeypatch.setattr(e2e, "scan_and_remove_temporary_tree", fake_cleanup)
+
+    with pytest.raises(PermissionError, match="synthetic chmod failure"):
+        e2e._run_tokenrhythm_attachment_capacity("synthetic-cleanup-key")  # noqa: SLF001
+
+    assert cleanup_calls == [raw_root]
+    assert not raw_root.exists()
+
+
+def _attachment_capacity_evidence_records(
+    fixture: dict[str, object],
+    session_key: str,
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    retained = fixture["retained_base64"]
+    assert isinstance(retained, list)
+    current = fixture["current_attachment"]
+    assert isinstance(current, dict)
+    request = {
+        "session_key": session_key,
+        "kind": "llm_request",
+        "provider": "tokenrhythm",
+        "model": "kimi-k2.6",
+        "payload": {
+            "messages": [
+                {"role": "system", "content": "bounded system"},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Historical image turn three."},
+                        {"type": "image", "data": retained[0]},
+                        {"type": "image", "data": retained[1]},
+                    ],
+                },
+                {"role": "assistant", "content": "history answer"},
+                {
+                    "role": "user",
+                    "content": "[Request context for this turn]\nsynthetic context",
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "image", "data": current["data"]}],
+                },
+            ],
+            "config": {"model": "kimi-k2.6"},
+        },
+    }
+    response = {
+        "session_key": session_key,
+        "kind": "llm_response",
+        "provider": "tokenrhythm",
+        "model": "kimi-k2.6",
+        "payload": {
+            "usage": {
+                "model": "kimi-k2.6",
+                "input_tokens": 123,
+                "output_tokens": 7,
+            }
+        },
+    }
+    decision = {
+        "session_key": session_key,
+        "image_route_reason": "current_turn",
+        "pipeline_steps": [
+            {
+                "step_name": "apply_squilla_router",
+                "routing_source": "image_route",
+                "routed_tier": "image_model",
+            }
+        ],
+    }
+    return [request, response], [decision]
+
+
+@pytest.mark.parametrize("physical_request_count", [0, 1, 2])
+def test_attachment_capacity_evidence_enforces_zero_or_one_call_boundary(
+    physical_request_count: int,
+) -> None:
+    fixture = e2e._attachment_capacity_fixture()  # noqa: SLF001
+    session_key = "agent:main:webchat:offline-evidence"
+    records, decisions = _attachment_capacity_evidence_records(fixture, session_key)
+    request = records[0]
+    records = records[1:]
+    records[:0] = [request for _ in range(physical_request_count)]
+
+    evidence = e2e._evaluate_attachment_capacity_evidence(  # noqa: SLF001
+        records=records,
+        decisions=decisions,
+        session_key=session_key,
+        fixture=fixture,
+        session_metrics={"compaction_count": 0},
+        proof={
+            "fits": True,
+            "estimated_tokens": 1000,
+            "effective_proof_token_budget": 80_000,
+            "media_blocks": 3,
+        },
+        turn_error=None,
+    )
+
+    assert evidence["request_count"] == physical_request_count
+    assert evidence["ok"] is (physical_request_count == 1)
+    if physical_request_count == 1:
+        assert evidence["response_count"] == 1
+        assert evidence["actual_request_model"] == "kimi-k2.6"
+        assert evidence["actual_response_model"] == "kimi-k2.6"
+        assert evidence["request_projection"] == {
+            "history_user_turn_count": 1,
+            "media_blocks": 3,
+            "excluded_old_media_absent": True,
+            "expected_media_present": True,
+            "expected_media_text_absent": True,
+        }
+
+
+@pytest.mark.parametrize("compaction_count", [0, 1])
+def test_attachment_capacity_evidence_requires_no_compaction(
+    compaction_count: int,
+) -> None:
+    fixture = e2e._attachment_capacity_fixture()  # noqa: SLF001
+    session_key = "agent:main:webchat:offline-compaction-evidence"
+    records, decisions = _attachment_capacity_evidence_records(fixture, session_key)
+
+    evidence = e2e._evaluate_attachment_capacity_evidence(  # noqa: SLF001
+        records=records,
+        decisions=decisions,
+        session_key=session_key,
+        fixture=fixture,
+        session_metrics={"compaction_count": compaction_count},
+        proof={
+            "fits": True,
+            "estimated_tokens": 1000,
+            "effective_proof_token_budget": 80_000,
+            "media_blocks": 3,
+        },
+        turn_error=None,
+    )
+
+    assert evidence["ok"] is (compaction_count == 0)
+
+
+@pytest.mark.parametrize(
+    ("turn_error", "expected_failure"),
+    [
+        ("HTTP 401 unauthorized", "auth"),
+        ("insufficient balance", "balance"),
+        ("HTTP 403 forbidden", "not-entitled"),
+        ("model kimi-k2.6 not found (404)", "model-unavailable"),
+        ("HTTP 429 rate limit", "rate-limit"),
+        ("HTTP 503 service unavailable", "transport"),
+        ("provider request timed out", "transport"),
+        (
+            "Error: The model provider returned an invalid response. "
+            "(ref: 40471b87)",
+            "implementation",
+        ),
+        ("assistant completion marker missing", "implementation"),
+    ],
+)
+def test_attachment_capacity_failure_taxonomy_is_preserved(
+    turn_error: str,
+    expected_failure: str,
+) -> None:
+    fixture = e2e._attachment_capacity_fixture()  # noqa: SLF001
+    session_key = "agent:main:webchat:offline-failure-taxonomy"
+    records, decisions = _attachment_capacity_evidence_records(fixture, session_key)
+
+    evidence = e2e._evaluate_attachment_capacity_evidence(  # noqa: SLF001
+        records=records,
+        decisions=decisions,
+        session_key=session_key,
+        fixture=fixture,
+        session_metrics={"compaction_count": 0},
+        proof={"fits": True, "media_blocks": 3},
+        turn_error=turn_error,
+    )
+
+    assert evidence["ok"] is False
+    assert evidence["failure_kind"] == expected_failure
+
+
+@pytest.mark.parametrize(
+    ("safe_code", "expected_failure"),
+    [
+        ("401", "auth"),
+        ("provider_auth_invalid", "auth"),
+        ("402", "balance"),
+        ("provider_insufficient_credits", "balance"),
+        ("403", "not-entitled"),
+        ("404", "model-unavailable"),
+        ("provider_model_not_found", "model-unavailable"),
+        ("429", "rate-limit"),
+        ("provider_rate_limited", "rate-limit"),
+        ("rate_limit", "rate-limit"),
+        ("408", "transport"),
+        ("501", "transport"),
+        ("599", "transport"),
+        ("503", "transport"),
+        ("transport", "transport"),
+        ("unavailable", "transport"),
+        ("authentication", "auth"),
+        ("not_found", "model-unavailable"),
+        ("permission", "not-entitled"),
+        ("provider_overloaded", "transport"),
+        ("provider_transport_transient", "transport"),
+        ("request_error", "transport"),
+        ("timeout", "transport"),
+    ],
+)
+def test_attachment_capacity_failure_taxonomy_uses_safe_llm_error_code(
+    safe_code: str,
+    expected_failure: str,
+) -> None:
+    fixture = e2e._attachment_capacity_fixture()  # noqa: SLF001
+    session_key = "agent:main:webchat:offline-safe-error-code"
+    records, decisions = _attachment_capacity_evidence_records(fixture, session_key)
+    records.append(
+        {
+            "session_key": session_key,
+            "kind": "llm_error",
+            "provider": "tokenrhythm",
+            "model": "kimi-k2.6",
+            "payload": {
+                "error": {
+                    "code": safe_code,
+                    "code_chars": len(safe_code),
+                    "message_chars": 123,
+                }
+            },
+        }
+    )
+
+    evidence = e2e._evaluate_attachment_capacity_evidence(  # noqa: SLF001
+        records=records,
+        decisions=decisions,
+        session_key=session_key,
+        fixture=fixture,
+        session_metrics={"compaction_count": 0},
+        proof={"fits": True, "media_blocks": 3},
+        turn_error="The task failed before it could finish.",
+    )
+
+    assert evidence["ok"] is False
+    assert evidence["failure_kind"] == expected_failure
+
+
+@pytest.mark.parametrize(
+    "broken_invariant",
+    [
+        "llm_error",
+        "routing_source",
+        "image_route_reason",
+        "proof_fits",
+        "proof_media_count",
+        "input_usage",
+        "output_usage",
+        "old_media_leak",
+        "retained_media_as_text",
+    ],
+)
+def test_attachment_capacity_evidence_rejects_each_safety_invariant(
+    broken_invariant: str,
+) -> None:
+    fixture = e2e._attachment_capacity_fixture()  # noqa: SLF001
+    session_key = "agent:main:webchat:offline-broken-invariant"
+    records, decisions = _attachment_capacity_evidence_records(fixture, session_key)
+    proof = {"fits": True, "media_blocks": 3}
+
+    request = records[0]
+    response = records[1]
+    if broken_invariant == "llm_error":
+        records.append(
+            {
+                "session_key": session_key,
+                "kind": "llm_error",
+                "provider": "tokenrhythm",
+                "model": "kimi-k2.6",
+            }
+        )
+    elif broken_invariant == "routing_source":
+        decisions[0]["pipeline_steps"][0]["routing_source"] = "classifier"
+    elif broken_invariant == "image_route_reason":
+        decisions[0]["image_route_reason"] = "gate_history"
+    elif broken_invariant == "proof_fits":
+        proof["fits"] = False
+    elif broken_invariant == "proof_media_count":
+        proof["media_blocks"] = 2
+    elif broken_invariant == "input_usage":
+        response["payload"]["usage"]["input_tokens"] = 0
+    elif broken_invariant == "output_usage":
+        response["payload"]["usage"]["output_tokens"] = 0
+    elif broken_invariant == "old_media_leak":
+        request["payload"]["messages"][0]["content"] += fixture["excluded_base64"][0]
+    elif broken_invariant == "retained_media_as_text":
+        request["payload"]["messages"][1]["content"] = "".join(
+            fixture["retained_base64"]
+        )
+
+    evidence = e2e._evaluate_attachment_capacity_evidence(  # noqa: SLF001
+        records=records,
+        decisions=decisions,
+        session_key=session_key,
+        fixture=fixture,
+        session_metrics={"compaction_count": 0},
+        proof=proof,
+        turn_error=None,
+    )
+
+    assert evidence["ok"] is False
+    assert evidence["failure_kind"] == "implementation"
+
+
+def test_attachment_capacity_waits_for_ready_not_only_live(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payloads = iter(({"ready": False}, {"ready": True, "status": "ready"}))
+    urls: list[str] = []
+
+    class Proc:
+        returncode = None
+
+        @staticmethod
+        def poll() -> None:
+            return None
+
+    class Response:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._body = json.dumps(payload).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return self._body
+
+    def fake_urlopen(url: str, *, timeout: float) -> Response:
+        assert timeout > 0
+        urls.append(url)
+        return Response(next(payloads))
+
+    monkeypatch.setattr(e2e.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(e2e.time, "sleep", lambda _seconds: None)
+
+    ready, error = e2e._wait_for_attachment_gateway_ready(  # noqa: SLF001
+        Proc(),  # type: ignore[arg-type]
+        49152,
+        timeout_seconds=1.0,
+    )
+
+    assert error is None
+    assert ready == {"ready": True, "status": "ready"}
+    assert urls == ["http://127.0.0.1:49152/ready"] * 2
+
+
+def test_attachment_capacity_readiness_reports_early_gateway_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Proc:
+        returncode = 17
+
+        @staticmethod
+        def poll() -> int:
+            return 17
+
+    monkeypatch.setattr(
+        e2e.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: pytest.fail("readiness must stop after process exit"),
+    )
+
+    ready, error = e2e._wait_for_attachment_gateway_ready(  # noqa: SLF001
+        Proc(),  # type: ignore[arg-type]
+        49152,
+        timeout_seconds=1.0,
+    )
+
+    assert ready is None
+    assert error == "gateway exited early with code 17 before readiness"
+
+
+def test_attachment_capacity_readiness_times_out_when_ready_stays_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Clock:
+        value = -0.1
+
+        def __call__(self) -> float:
+            self.value += 0.1
+            return self.value
+
+    class Proc:
+        returncode = None
+
+        @staticmethod
+        def poll() -> None:
+            return None
+
+    class Response:
+        @staticmethod
+        def __enter__():
+            return Response()
+
+        @staticmethod
+        def __exit__(*_args: object) -> None:
+            return None
+
+        @staticmethod
+        def read() -> bytes:
+            return b'{"ready":false}'
+
+    monkeypatch.setattr(e2e.time, "monotonic", Clock())
+    monkeypatch.setattr(e2e.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        e2e.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: Response(),
+    )
+
+    ready, error = e2e._wait_for_attachment_gateway_ready(  # noqa: SLF001
+        Proc(),  # type: ignore[arg-type]
+        49152,
+        timeout_seconds=0.5,
+    )
+
+    assert ready is None
+    assert error == "gateway did not become ready before timeout"
+
+
+def test_attachment_capacity_upload_rejects_invalid_file_uuid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Response:
+        @staticmethod
+        def __enter__():
+            return Response()
+
+        @staticmethod
+        def __exit__(*_args: object) -> None:
+            return None
+
+        @staticmethod
+        def read() -> bytes:
+            return b'{"file_uuid":"not-an-upload-id"}'
+
+    monkeypatch.setattr(
+        e2e.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: Response(),
+    )
+
+    with pytest.raises(RuntimeError, match="valid file_uuid"):
+        e2e._upload_inline_attachment(  # noqa: SLF001
+            port=49152,
+            attachment=e2e._attachment_capacity_fixture()["current_attachment"],  # noqa: SLF001
+            timeout=1.0,
+        )
+
+
+@pytest.mark.parametrize(
+    ("request_model", "response_model"),
+    [
+        ("", "kimi-k2.6"),
+        ("wrong-model", "kimi-k2.6"),
+        ("kimi-k2.6", ""),
+        ("kimi-k2.6", "wrong-model"),
+    ],
+)
+def test_attachment_capacity_requires_independent_request_and_response_models(
+    request_model: str,
+    response_model: str,
+) -> None:
+    fixture = e2e._attachment_capacity_fixture()  # noqa: SLF001
+    session_key = "agent:main:webchat:offline-model-evidence"
+    records, decisions = _attachment_capacity_evidence_records(fixture, session_key)
+    records[0]["model"] = request_model
+    response_usage = records[1]["payload"]["usage"]
+    assert isinstance(response_usage, dict)
+    response_usage["model"] = response_model
+
+    evidence = e2e._evaluate_attachment_capacity_evidence(  # noqa: SLF001
+        records=records,
+        decisions=decisions,
+        session_key=session_key,
+        fixture=fixture,
+        session_metrics={"compaction_count": 0},
+        proof={"fits": True, "media_blocks": 3},
+        turn_error=None,
+    )
+
+    assert evidence["actual_request_model"] == request_model
+    assert evidence["actual_response_model"] == response_model
+    assert evidence["ok"] is False
+
+
+def test_attachment_capacity_proof_parser_keeps_only_scalar_evidence(tmp_path: Path) -> None:
+    log_path = tmp_path / "debug.log"
+    log_path.write_text(
+        "provider.request_proof estimated_tokens=37720 "
+        "effective_proof_token_budget=87704 media_blocks_reserved=3 fits=True "
+        "top_contributors=['must-not-survive']\n",
+        encoding="utf-8",
+    )
+
+    proof = e2e._provider_proof_from_logs([log_path])  # noqa: SLF001
+
+    assert proof == {
+        "estimated_tokens": 37_720,
+        "effective_proof_token_budget": 87_704,
+        "media_blocks": 3,
+        "fits": True,
+    }
+    assert "must-not-survive" not in json.dumps(proof)
+
+
+def test_attachment_capacity_http_error_parser_keeps_only_unique_status_scalars(
+    tmp_path: Path,
+) -> None:
+    stdout = tmp_path / "gateway.stdout.log"
+    debug = tmp_path / "debug.log"
+    stdout.write_text(
+        "provider.chat_http_error provider='tokenrhythm' model='kimi-k2.6' "
+        "status_code=429 response_body_chars=88\n"
+        "unrelated status_code=401\n"
+        "provider.chat_http_error status_code=399\n",
+        encoding="utf-8",
+    )
+    debug.write_text(
+        "provider.chat_http_error provider='tokenrhythm' model='kimi-k2.6' "
+        "status_code=429 response_body_chars=88\n"
+        "provider.chat_http_error provider='tokenrhythm' model='kimi-k2.6' "
+        "status_code=503 response_body_chars=100\n",
+        encoding="utf-8",
+    )
+
+    statuses = e2e._attachment_capacity_provider_http_statuses(  # noqa: SLF001
+        [stdout, debug, tmp_path / "missing.log"]
+    )
+
+    assert statuses == [429, 503]
+
+
+@pytest.mark.parametrize(
+    ("confirm", "opt_in", "key", "expected"),
+    [
+        (False, "1", "synthetic-key", "--confirm-live-cost"),
+        (True, None, "synthetic-key", e2e.ATTACHMENT_CAPACITY_OPT_IN_ENV),
+        (True, "1", None, "TOKENRHYTHM_API_KEY"),
+    ],
+)
+def test_attachment_capacity_main_requires_all_three_live_gates(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    confirm: bool,
+    opt_in: str | None,
+    key: str | None,
+    expected: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output = tmp_path / "attachment-capacity.json"
+    argv = [
+        "live_provider_profile_gateway_e2e.py",
+        "--attachment-capacity",
+        "--output",
+        str(output),
+    ]
+    if confirm:
+        argv.append("--confirm-live-cost")
+    monkeypatch.setattr(sys, "argv", argv)
+    if opt_in is None:
+        monkeypatch.delenv(e2e.ATTACHMENT_CAPACITY_OPT_IN_ENV, raising=False)
+    else:
+        monkeypatch.setenv(e2e.ATTACHMENT_CAPACITY_OPT_IN_ENV, opt_in)
+    if key is None:
+        monkeypatch.delenv("TOKENRHYTHM_API_KEY", raising=False)
+    else:
+        monkeypatch.setenv("TOKENRHYTHM_API_KEY", key)
+    monkeypatch.setattr(
+        e2e,
+        "_run_tokenrhythm_attachment_capacity",
+        lambda _api_key: pytest.fail("live runner must not start before every gate passes"),
+    )
+
+    with pytest.raises(SystemExit):
+        e2e.main()
+
+    assert expected in capsys.readouterr().err
+    assert not output.exists()
+
+
+def test_attachment_capacity_main_runs_only_single_tokenrhythm_scenario(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output = tmp_path / "attachment-capacity.json"
+    synthetic_key = "synthetic-attachment-live-key"
+    captured: list[str] = []
+    monkeypatch.setenv(e2e.ATTACHMENT_CAPACITY_OPT_IN_ENV, "1")
+    monkeypatch.setenv("TOKENRHYTHM_API_KEY", synthetic_key)
+    monkeypatch.setattr(
+        e2e,
+        "_load_env_quietly",
+        lambda *_args, **_kwargs: pytest.fail("attachment gate must not load .env"),
+    )
+    monkeypatch.setattr(
+        e2e,
+        "_run_provider",
+        lambda *_args, **_kwargs: pytest.fail("attachment gate must not run c0-c3 matrix"),
+    )
+
+    def fake_attachment_run(api_key: str) -> dict[str, object]:
+        captured.append(api_key)
+        return {
+            "provider": "tokenrhythm",
+            "ok": True,
+            "models_covered": ["kimi-k2.6"],
+            "failure_kinds": [],
+            "cases": [
+                {
+                    "ok": True,
+                    "actual_request_model": "kimi-k2.6",
+                    "actual_response_model": "kimi-k2.6",
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 5,
+                        "physical_request_count": 1,
+                        "compaction_count": 0,
+                        "provider_proof_fits": True,
+                    },
+                    "cost": {"opensquilla_estimated_cost_usd": 0.001},
+                    "latency_ms": 12,
+                }
+            ],
+        }
+
+    monkeypatch.setattr(e2e, "_run_tokenrhythm_attachment_capacity", fake_attachment_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "live_provider_profile_gateway_e2e.py",
+            "--attachment-capacity",
+            "--confirm-live-cost",
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert e2e.main() == 0
+    assert captured == [synthetic_key]
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload[0]["provider"] == "tokenrhythm"
+    assert payload[0]["model"] == "kimi-k2.6"
+    assert payload[0]["usage"]["physical_request_count"] == 1
+    assert "TOKENRHYTHM_API_KEY" not in os.environ
+    rendered = output.read_text(encoding="utf-8") + capsys.readouterr().out
+    assert synthetic_key not in rendered


### PR DESCRIPTION
## Scope

Scope boundary:

- Defer SquillaRouter history-capacity admission until routing has selected the actual route.
- Project the route-limited replay/history/media shape that the provider request will use.
- Add deterministic regression coverage and an opt-in TokenRhythm attachment-capacity live gate.

Non-goals:

- No changes to transcript persistence, the generic estimator, durable/preflight compaction policy, provider adapters, RPC/UI, Windows noop shell behavior, WebSocket backpressure, or async-generator cleanup.
- Attachment-only durable-compaction behavior remains out of scope.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Reproduced from a live OpenSquilla attachment session; no public issue was supplied.

## Release Note

Release note: Fix image attachment turns being rejected by Router capacity admission even though their route-limited provider replay fits.

## Tests

Ruff: `uv run ruff check src tests` — passed.

Pytest:

- Router/attachment regression group: 276 passed, 2 skipped.
- Compaction regression group: 267 passed, 2 skipped.
- Provider-proof group: 114 passed.
- Focused migration set: 172 passed (including opaque error-ref taxonomy regression).
- Attachment-capacity live-gate safety suite: 73 passed.

Build:

- `uv run mypy src/opensquilla --show-error-codes` — passed (977 source files).
- WebUI typecheck, architecture checks, security checks, and production build — passed.

Regression tests: added

Notes:

- The default test path remains offline, deterministic, credential-free, and safe for forks.
- Local complete Windows shards were also exercised. Remaining local failures were host capability/baseline conditions: Windows long paths disabled, symlink privilege unavailable, missing `sh`/`python3`, and the protected `.codex` worktree-path policy. Hosted Windows and Ubuntu PR CI remain authoritative.
- A manual real-provider WebUI smoke routed the image turn to `tokenrhythm/kimi-k2.6`, produced provider proof `fits=true`, kept `compaction_count=0`, and did not reproduce `LargeContextCapacityError`.
- The dedicated opt-in `--attachment-capacity` TokenRhythm live gate passed with the internal 4096 output setting: `tokenrhythm/kimi-k2.6`, one physical request/response, `route_max_history_turns=1`, three media blocks, `provider-proof fits=true`, and `compaction_count=0`.
- The controlled fixture proved the regression boundary: raw history estimate 240,589 exceeded the 197,118 Router admission limit, while the routed provider proof estimated 6,498 tokens against a 193,022 effective budget.
- Live usage was 2,913 input tokens and 202 output tokens; latency was 8,530 ms and provider-billed cost was USD 0.003496559.
- The live harness hardening in this PR restricts public reports to an allowlist and removes temporary reports/profile data after secret scans.

## Maintainer Live Check

Maintainer live check: yes

Surface: provider | gateway

Maintainer-only note: The manual WebUI smoke and the isolated 4096 attachment-capacity live gate both passed. Contributors are not expected to provide secrets or run credentialed checks.

## Safety

No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are committed. The live harness reads credentials only from process environment, avoids argv/report persistence, scans outputs, and cleans temporary state.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
