### PR TITLE
Stabilize process-tree lifecycle checks

### DIFF
--- a/src/opensquilla/process_tree.py
+++ b/src/opensquilla/process_tree.py
@@ -41,6 +41,7 @@ from opensquilla.private_paths import apply_windows_private_dacl, create_windows
 log = logging.getLogger(__name__)
 
 _POLL_INTERVAL_SECONDS = 0.01
+_POSIX_EMPTY_CONFIRMATIONS_REQUIRED = 2
 _CONTROL_READY_TIMEOUT_SECONDS = 2.0
 _WINDOWS_FROZEN_READY_TIMEOUT_SECONDS = 5.0
 _WINDOWS_FROZEN_READY_RETRY_DELAY_SECONDS = 0.25
@@ -2307,7 +2308,8 @@ def _posix_group_members(pgid: int) -> tuple[int, ...] | None:
                 # Numeric /proc entries routinely disappear between listdir
                 # and open as unrelated processes exit. The anchor's own stat
                 # is mandatory; other vanished or malformed entries cannot be
-                # members of the final live snapshot.
+                # members of the final live snapshot. Consecutive empty
+                # confirmation below protects same-group fork/exit handoffs.
                 if int(name) == pgid:
                     return None
                 continue
@@ -2345,6 +2347,18 @@ def _posix_group_members(pgid: int) -> tuple[int, ...] | None:
     if not members or pgid not in members:
         return None
     return tuple(members)
+
+
+def _advance_posix_empty_confirmation(
+    previous: int,
+    members: tuple[int, ...] | None,
+    own_pid: int,
+    *,
+    captured_alive: bool,
+) -> int:
+    if members == (own_pid,) and not captured_alive:
+        return previous + 1
+    return 0
 
 
 def _run_posix_group_anchor(control_path_raw: str) -> int:
@@ -2429,14 +2443,19 @@ def _run_posix_group_anchor(control_path_raw: str) -> int:
         stdin_open = True
         poll_delay = _POLL_INTERVAL_SECONDS
         poll_cap = 0.25 if os.path.isdir("/proc") else 1.0
+        empty_confirmations = 0
         while True:
             members = _posix_group_members(pgid)
-            if (
-                members is not None
-                and len(members) == 1
-                and members[0] == own_pid
-                and not _captured_posix_processes_alive(captured)
-            ):
+            captured_alive = members == (own_pid,) and _captured_posix_processes_alive(
+                captured
+            )
+            empty_confirmations = _advance_posix_empty_confirmation(
+                empty_confirmations,
+                members,
+                own_pid,
+                captured_alive=captured_alive,
+            )
+            if empty_confirmations >= _POSIX_EMPTY_CONFIRMATIONS_REQUIRED:
                 try:
                     sys.stdout.buffer.write(_POSIX_ANCHOR_EMPTY)
                     sys.stdout.buffer.flush()

--- a/tests/functional/test_gateway_stop_process_tree_e2e.py
+++ b/tests/functional/test_gateway_stop_process_tree_e2e.py
@@ -88,6 +88,8 @@ class _StopProvider:
     async def _stream(self, call: int, messages: list[Message]) -> AsyncIterator[Any]:
         if call == 1:
             child_pid = self.evidence_dir / "child.pid"
+            leader_ready = self.evidence_dir / "leader-ready"
+            release_leader = self.evidence_dir / "release-leader"
             survived = self.evidence_dir / "descendant-survived"
             child_script = self.evidence_dir / "owned-child.py"
             parent_script = self.evidence_dir / "exited-parent.py"
@@ -96,9 +98,9 @@ class _StopProvider:
                 "import pathlib\n"
                 "import time\n"
                 f"pathlib.Path({str(child_pid)!r}).write_text(str(os.getpid()))\n"
-                "time.sleep(30)\n"
+                "time.sleep(120)\n"
                 f"pathlib.Path({str(survived)!r}).write_text('survived')\n"
-                "time.sleep(30)\n",
+                "time.sleep(120)\n",
                 encoding="utf-8",
             )
             # Keep the long-lived descendant in the same process tree without
@@ -110,17 +112,30 @@ class _StopProvider:
                 "import sys\n"
                 "import time\n"
                 f"child_pid = pathlib.Path({str(child_pid)!r})\n"
+                f"leader_ready = pathlib.Path({str(leader_ready)!r})\n"
+                f"release_leader = pathlib.Path({str(release_leader)!r})\n"
                 "subprocess.Popen(\n"
                 f"    [sys.executable, {str(child_script)!r}],\n"
                 "    stdin=subprocess.DEVNULL,\n"
                 "    stdout=subprocess.DEVNULL,\n"
                 "    stderr=subprocess.DEVNULL,\n"
                 ")\n"
-                "deadline = time.monotonic() + 10\n"
-                "while not child_pid.exists() and time.monotonic() < deadline:\n"
+                "deadline = time.monotonic() + 45\n"
+                "while time.monotonic() < deadline:\n"
+                "    try:\n"
+                "        int(child_pid.read_text())\n"
+                "    except (FileNotFoundError, ValueError):\n"
+                "        time.sleep(0.05)\n"
+                "    else:\n"
+                "        break\n"
+                "else:\n"
+                "    raise RuntimeError('child did not publish its pid')\n"
+                "leader_ready.write_text('ready')\n"
+                "deadline = time.monotonic() + 45\n"
+                "while not release_leader.exists() and time.monotonic() < deadline:\n"
                 "    time.sleep(0.05)\n"
-                "if not child_pid.exists():\n"
-                "    raise RuntimeError('child did not publish its pid')\n",
+                "if not release_leader.exists():\n"
+                "    raise RuntimeError('leader release was not published')\n",
                 encoding="utf-8",
             )
             yield ToolUseStartEvent(
@@ -132,7 +147,7 @@ class _StopProvider:
                 tool_name="background_process",
                 arguments={
                     "command": _shell_command([sys.executable, str(parent_script)]),
-                    "timeout": 30,
+                    "timeout": 120,
                     "sandbox_permissions": "use_default",
                 },
             )
@@ -162,7 +177,7 @@ class _StopProvider:
                 arguments={
                     "action": "wait",
                     "session_id": session_id,
-                    "timeout": 5,
+                    "timeout": 90,
                 },
             )
             yield DoneEvent(
@@ -445,6 +460,7 @@ async def test_stop_kills_leaderless_descendant_and_gateway_accepts_next_task(
         asyncio.get_running_loop().create_future()
     )
     descendant_identity: tuple[str, int] | None = None
+    release_leader = evidence / "release-leader"
     try:
         await _wait_for_health(port, process, gateway_log)
         await client.connect(f"ws://127.0.0.1:{port}/ws")
@@ -461,13 +477,15 @@ async def test_stop_kills_leaderless_descendant_and_gateway_accepts_next_task(
                     leader_wait_result.set_result(frame)
 
         first_turn = asyncio.create_task(consume_first())
-        await _wait_for_file(evidence / "child.pid")
+        await _wait_for_file(evidence / "leader-ready", timeout=60.0)
+        child_pid = evidence / "child.pid"
         descendant_identity = _open_process_liveness(
-            int((evidence / "child.pid").read_text(encoding="utf-8"))
+            int(child_pid.read_text(encoding="utf-8"))
         )
+        release_leader.write_text("release", encoding="utf-8")
         wait_frame = await asyncio.wait_for(
             asyncio.shield(leader_wait_result),
-            timeout=10.0,
+            timeout=30.0,
         )
         wait_payload = json.loads(str(wait_frame.get("result", "")))
         assert wait_frame.get("is_error") is False
@@ -494,6 +512,8 @@ async def test_stop_kills_leaderless_descendant_and_gateway_accepts_next_task(
         await _wait_for_health(port, process, gateway_log)
         assert process.poll() is None
     finally:
+        with contextlib.suppress(OSError):
+            release_leader.write_text("release", encoding="utf-8")
         if descendant_identity is not None:
             _close_process_liveness(descendant_identity)
         await client.close()

--- a/tests/test_gateway/test_rpc_workbench_resources.py
+++ b/tests/test_gateway/test_rpc_workbench_resources.py
@@ -36,6 +36,13 @@ from opensquilla.session.storage import SessionStorage
 SESSION_KEY = "agent:main:webchat:workbench-resources"
 
 
+async def _sqlite_total_changes(storage: SessionStorage) -> int:
+    async with storage.conn.execute("SELECT total_changes()") as cursor:
+        row = await cursor.fetchone()
+    assert row is not None
+    return int(row[0])
+
+
 def test_workbench_resource_method_scopes_are_fail_closed() -> None:
     assert METHOD_SCOPES["workbench.resources.list"] == READ_SCOPE
     assert METHOD_SCOPES["workbench.resources.get"] == READ_SCOPE
@@ -659,7 +666,7 @@ async def test_resource_reads_do_not_change_sqlite_rows(resource_env) -> None:
     )
     # Warm the additive schema seam once, exactly as Gateway boot does.
     await ArtifactSessionService.from_session_storage(env.storage)
-    changes_before = env.storage.conn.total_changes
+    changes_before = await _sqlite_total_changes(env.storage)
 
     listed = await _dispatch(
         env,
@@ -708,7 +715,7 @@ async def test_resource_reads_do_not_change_sqlite_rows(resource_env) -> None:
     assert legacy_fetched.error is None, legacy_fetched.error
     assert legacy_fetched.payload == fetched.payload
     assert previewed.error is None, previewed.error
-    assert env.storage.conn.total_changes == changes_before
+    assert await _sqlite_total_changes(env.storage) == changes_before
 
 
 @pytest.mark.asyncio
@@ -960,7 +967,7 @@ async def test_invalid_html_attachments_fail_closed_without_read_side_writes(res
         payload=b"",
         staged=True,
     )
-    changes_before_reads = env.storage.conn.total_changes
+    changes_before_reads = await _sqlite_total_changes(env.storage)
 
     expected_reasons = {
         str(invalid_encoding["attachment_id"]): "html_encoding_unsupported",
@@ -1009,7 +1016,7 @@ async def test_invalid_html_attachments_fail_closed_without_read_side_writes(res
         assert opened.payload["reasonCode"] == expected_reason
         assert opened.payload["resource"]["resource"]["id"] == attachment_id
 
-    assert env.storage.conn.total_changes == changes_before_reads
+    assert await _sqlite_total_changes(env.storage) == changes_before_reads
     service = await ArtifactSessionService.from_session_storage(env.storage)
     assert await service.list_documents(
         session_key=SESSION_KEY,
@@ -1153,7 +1160,7 @@ async def test_resource_inventory_preserves_inline_and_staged_attachment_occurre
     )
     assert list(transcript_dir.iterdir()) == [transcript_dir / sha]
 
-    changes_before_read = env.storage.conn.total_changes
+    changes_before_read = await _sqlite_total_changes(env.storage)
     listed = await _dispatch(
         env,
         "workbench.resources.list",
@@ -1195,7 +1202,7 @@ async def test_resource_inventory_preserves_inline_and_staged_attachment_occurre
     inline_url = inline_get.payload["resource"]["downloadUrl"]
     assert inline_url.startswith("data:text/html;base64,")
     assert base64.b64decode(inline_url.split(",", 1)[1], validate=True) == html
-    assert env.storage.conn.total_changes == changes_before_read
+    assert await _sqlite_total_changes(env.storage) == changes_before_read
 
     imported_first = await _import_attachment(
         env,
@@ -1386,7 +1393,7 @@ async def test_import_expected_hash_is_validated_and_bound_to_idempotency(
     )
     expected = hashlib.sha256(payload).hexdigest()
     service = await ArtifactSessionService.from_session_storage(env.storage)
-    changes_before_invalid = env.storage.conn.total_changes
+    changes_before_invalid = await _sqlite_total_changes(env.storage)
     base_params = {
         "sessionKey": SESSION_KEY,
         "source": {"type": "attachment", "id": attachment["attachment_id"]},
@@ -1405,7 +1412,7 @@ async def test_import_expected_hash_is_validated_and_bound_to_idempotency(
         rejected = await _dispatch(env, "documents.import", rejected_params)
         assert rejected.error is not None
         assert rejected.error.code == "INVALID_REQUEST"
-    assert env.storage.conn.total_changes == changes_before_invalid
+    assert await _sqlite_total_changes(env.storage) == changes_before_invalid
     assert await service.list_documents(
         session_key=SESSION_KEY,
         session_id=env.session.session_id,
@@ -1728,7 +1735,7 @@ async def test_publish_receipt_pins_immutable_revision_and_recovers_promotion(
     )
     document_id = imported["document"]["id"]
     revision_id = imported["revision"]["id"]
-    changes_before_missing_revision = env.storage.conn.total_changes
+    changes_before_missing_revision = await _sqlite_total_changes(env.storage)
     missing_revision = await _dispatch(
         env,
         "documents.publish",
@@ -1753,7 +1760,7 @@ async def test_publish_receipt_pins_immutable_revision_and_recovers_promotion(
     )
     assert mismatched_aliases.error is not None
     assert mismatched_aliases.error.code == "INVALID_REQUEST"
-    assert env.storage.conn.total_changes == changes_before_missing_revision
+    assert await _sqlite_total_changes(env.storage) == changes_before_missing_revision
 
     original_promote = ArtifactStore.promote_internal_ref
     failed_once = False

--- a/tests/test_process_tree.py
+++ b/tests/test_process_tree.py
@@ -401,12 +401,19 @@ async def test_posix_anchor_transport_failure_fails_closed() -> None:
 async def test_posix_anchor_outlives_leader_and_excludes_unrelated_group(tmp_path) -> None:
     child_pid = tmp_path / "owned-child.pid"
     owned_survived = tmp_path / "owned-survived"
+    owned_release = tmp_path / "owned-release"
     sibling_survived = tmp_path / "sibling-survived"
     child_script = (
-        "import os, pathlib, time; "
-        f"pathlib.Path({str(child_pid)!r}).write_text(str(os.getpid())); "
-        "time.sleep(0.8); "
-        f"pathlib.Path({str(owned_survived)!r}).write_text('survived')"
+        "import os\n"
+        "import pathlib\n"
+        "import time\n"
+        f"pathlib.Path({str(child_pid)!r}).write_text(str(os.getpid()))\n"
+        f"release = pathlib.Path({str(owned_release)!r})\n"
+        "deadline = time.monotonic() + 30\n"
+        "while not release.exists() and time.monotonic() < deadline:\n"
+        "    time.sleep(0.01)\n"
+        "if release.exists():\n"
+        f"    pathlib.Path({str(owned_survived)!r}).write_text('survived')\n"
     )
     parent_script = (
         "import subprocess, sys; "
@@ -438,11 +445,14 @@ async def test_posix_anchor_outlives_leader_and_excludes_unrelated_group(tmp_pat
         assert child_pid.exists()
         assert owner.is_active() is True
         assert await owner.terminate(graceful_timeout=0.2, kill_timeout=1.0)
+        owned_release.write_text("release", encoding="utf-8")
         await asyncio.wait_for(sibling.wait(), timeout=2.0)
         await asyncio.sleep(0.9)
         assert not owned_survived.exists()
         assert sibling_survived.exists()
     finally:
+        with contextlib.suppress(OSError):
+            owned_release.write_text("release", encoding="utf-8")
         if owner.is_active():
             await owner.terminate(graceful_timeout=0.1, kill_timeout=1.0)
         if sibling.returncode is None:
@@ -700,6 +710,62 @@ def test_posix_proc_ignores_unrelated_pid_disappearing_during_snapshot(
     monkeypatch.setattr("builtins.open", selective_open)
 
     assert process_tree._posix_group_members(123) == (123,)
+
+
+def test_posix_empty_confirmation_requires_consecutive_complete_snapshots() -> None:
+    confirmations = process_tree._advance_posix_empty_confirmation(
+        0,
+        (123,),
+        123,
+        captured_alive=False,
+    )
+    assert confirmations == 1
+
+    confirmations = process_tree._advance_posix_empty_confirmation(
+        confirmations,
+        None,
+        123,
+        captured_alive=False,
+    )
+    assert confirmations == 0
+
+    confirmations = process_tree._advance_posix_empty_confirmation(
+        confirmations,
+        (123,),
+        123,
+        captured_alive=True,
+    )
+    assert confirmations == 0
+
+    confirmations = process_tree._advance_posix_empty_confirmation(
+        confirmations,
+        (123,),
+        123,
+        captured_alive=False,
+    )
+    assert confirmations == 1
+    confirmations = process_tree._advance_posix_empty_confirmation(
+        confirmations,
+        (123, 456),
+        123,
+        captured_alive=False,
+    )
+    assert confirmations == 0
+
+    confirmations = process_tree._advance_posix_empty_confirmation(
+        confirmations,
+        (123,),
+        123,
+        captured_alive=False,
+    )
+    assert confirmations == 1
+    confirmations = process_tree._advance_posix_empty_confirmation(
+        confirmations,
+        (123,),
+        123,
+        captured_alive=False,
+    )
+    assert confirmations == 2
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Scope

- Require two consecutive complete anchor-only snapshots before a POSIX process owner closes, preventing a fork/exit handoff from being mistaken for an empty group.
- Make the real POSIX leader-exit regression deterministic with an explicit child release gate.
- Make the cross-platform Gateway Stop E2E use an explicit leader-ready/release-leader handshake, nested timeout budgets, and failure cleanup.

## Branch target

main

## Linked issue

None. Unblocks PR #1386 and PR #1387 after merge-queue process-tree flakes:
- https://github.com/opensquilla/opensquilla/actions/runs/32767403639/job/97560296405
- https://github.com/opensquilla/opensquilla/actions/runs/32770051792/job/97568436918
- https://github.com/opensquilla/opensquilla/actions/runs/32770051792/job/97568436956

## Release note status

Not required. This is internal process lifecycle correctness and CI reliability work with no user-facing API, configuration, or persisted-state change.

## Test results

- uv run --extra dev ruff check on all three changed files
- Full tests/test_process_tree.py: 67 passed, 7 skipped
- Formerly flaky real POSIX leader-exit regression: 20 consecutive passes
- Gateway/WebSocket Stop E2E: repeated passes, including after final timeout and cleanup review
- GitNexus compare audit: 3 changed files, low risk, no affected execution flows

## Safety notes

- Linux and macOS only delay empty-group notification by one successful poll; ownership scope and signal targets are unchanged.
- Windows product behavior is unchanged; the Windows adjustment is deterministic fixture orchestration and bounded failure cleanup.
- Existing installs, clients, config, database state, and public protocols are unaffected; no migration is required.

## Third-party origin

None.