### PR TITLE
CI: serialize Windows shell process runtime tests

### DIFF
--- a/tests/test_ci/test_windows_test_shards.py
+++ b/tests/test_ci/test_windows_test_shards.py
@@ -319,6 +319,21 @@ def _function_decorators(path: Path, function_name: str) -> set[str]:
     raise AssertionError(f"missing test function: {path}:{function_name}")
 
 
+def test_windows_shell_process_runtime_is_marked_ci_serial() -> None:
+    path = Path("tests/test_sandbox/test_windows_shell_process_runtime.py")
+    parsed = ast.parse(path.read_text(encoding="utf-8"))
+
+    assert any(
+        isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "pytestmark"
+            for target in node.targets
+        )
+        and ast.unparse(node.value) == "pytest.mark.ci_serial"
+        for node in parsed.body
+    )
+
+
 def test_known_process_tree_flakes_are_marked_ci_serial() -> None:
     assert "pytest.mark.ci_serial" in _function_decorators(
         Path("tests/test_process_tree.py"),

--- a/tests/test_sandbox/test_windows_shell_process_runtime.py
+++ b/tests/test_sandbox/test_windows_shell_process_runtime.py
@@ -11,6 +11,8 @@ import pytest
 
 from opensquilla.tools.types import CallerKind, ToolContext, current_tool_context
 
+pytestmark = pytest.mark.ci_serial
+
 
 def _windows_runtime() -> SimpleNamespace:
     return SimpleNamespace(


### PR DESCRIPTION
## Summary

- Run the Windows shell process runtime test module in the existing ci_serial phase so real process-tree tests do not compete with the xdist bulk workers.
- Add a deterministic AST contract that keeps the module-level serial marker in place.
- Keep product timeouts, output assertions, and exit-code assertions unchanged.

## Context

- PR #1388 passed the foreground noop runtime test in PR CI but the same test reached the 60-second sandbox boundary in merge-group CI while running in the parallel Windows shard.
- The affected noop tests are introduced by #1388, so this main-based prerequisite marks their runtime module rather than weakening a test that is not yet present on main.

## Verification

- uv run ruff check tests/test_ci/test_windows_test_shards.py tests/test_sandbox/test_windows_shell_process_runtime.py
- uv run pytest tests/test_ci/test_windows_test_shards.py -q (46 passed, 1 skipped)
- uv run pytest tests/test_ci/test_windows_test_shards.py::test_windows_shell_process_runtime_is_marked_ci_serial tests/test_sandbox/test_windows_shell_process_runtime.py -q (39 passed)
- ci_serial collection: 38 collected; not ci_serial collection: 38 deselected
- Synthetic merge tree with #1388 contains the module marker and both noop foreground/background tests without conflicts