### PR TITLE
Stabilize HTML annotation proofs and picker rearming

### DIFF
--- a/desktop/electron/scripts/test-desktop-artifact-bridge-loopback.mjs
+++ b/desktop/electron/scripts/test-desktop-artifact-bridge-loopback.mjs
@@ -16,6 +16,10 @@ let bindingReleaseCount = 0
 const slowReloadGate = new Promise(resolve => { releaseSlowReload = resolve })
 const annotationDigest = 'b'.repeat(64)
 const annotationElementProof = 'c'.repeat(64)
+const annotationProofV2 = {
+  stableElementProofSha256: 'd'.repeat(64),
+  ancestorClassCommitments: ['e'.repeat(64), 'f'.repeat(64)],
+}
 const activePreviewArtifactId = 'art-loopback-preview'
 const annotationPath = JSON.stringify([
   ['', 'html', 1],
@@ -24,6 +28,7 @@ const annotationPath = JSON.stringify([
 ])
 const target = {
   capabilities: {
+    annotationProofV2: true,
     captureSelection: false,
     resolveAnnotationSelection: true,
     focusAnnotation: true,
@@ -43,6 +48,7 @@ const target = {
     elementPath: request.elementPath,
     ...(request.domSha256 === undefined ? {} : { domSha256: request.domSha256 }),
     elementProofSha256: request.elementProofSha256,
+    annotationProofV2,
     scopeId: 'synthetic:scope',
     rect: { x: 10, y: 20, width: 80, height: 24 },
   }),
@@ -118,6 +124,7 @@ assert.deepEqual(capabilities, {
     captureSelection: false,
     resolveAnnotationSelection: true,
     focusAnnotation: true,
+    annotationProofV2: true,
     browserInspect: false,
     browserAct: false,
     bindCandidatePreview: false,
@@ -181,6 +188,7 @@ assert.deepEqual(await resolvedAnnotationResponse.json(), {
     elementPath: annotationPath,
     domSha256: annotationDigest,
     elementProofSha256: annotationElementProof,
+    annotationProofV2,
     scopeId: 'synthetic:scope',
     rect: { x: 10, y: 20, width: 80, height: 24 },
   },
@@ -208,6 +216,7 @@ assert.deepEqual(await resolvedAnnotationWithoutDomResponse.json(), {
     tagName: 'button',
     elementPath: annotationPath,
     elementProofSha256: annotationElementProof,
+    annotationProofV2,
     scopeId: 'synthetic:scope',
     rect: { x: 10, y: 20, width: 80, height: 24 },
   },
@@ -224,6 +233,7 @@ const focusAnnotationResponse = await post('/v1/invoke', {
     tagName: 'button',
     elementPath: annotationPath,
     elementProofSha256: annotationElementProof,
+    annotationProofV2,
   },
 })
 assert.equal(focusAnnotationResponse.status, 200)
@@ -232,6 +242,26 @@ assert.deepEqual(await focusAnnotationResponse.json(), {
   method: 'focusAnnotation',
   value: { focused: true, activePreviewArtifactId },
 })
+
+const malformedFocusProofResponse = await post('/v1/invoke', {
+  version: 3,
+  method: 'focusAnnotation',
+  request: {
+    version: 3,
+    activePreviewArtifactId,
+    annotationId: 'annotation_loopback_invalid_v2',
+    scopeId: 'synthetic:scope',
+    tagName: 'button',
+    elementPath: annotationPath,
+    elementProofSha256: annotationElementProof,
+    annotationProofV2: {
+      ...annotationProofV2,
+      ancestorClassCommitments: [...annotationProofV2.ancestorClassCommitments].reverse(),
+    },
+  },
+})
+assert.equal(malformedFocusProofResponse.status, 200)
+assert.equal((await malformedFocusProofResponse.json()).code, 'invalid-request')
 
 const reloadResponse = await post('/v1/invoke', {
   version: 3,

--- a/desktop/electron/scripts/test-native-workbench-surface.mjs
+++ b/desktop/electron/scripts/test-native-workbench-surface.mjs
@@ -179,6 +179,16 @@ assert.match(
 )
 assert.match(
   nativeWorkbenchSurfaceRuntime,
+  /const rearmed = await this\.armAnnotationPicker\([\s\S]*?!rearmed\.ok[\s\S]*?code: 'ANNOTATION_REARM_FAILED'[\s\S]*?surfaceInstanceId: record\.surfaceInstanceId/,
+  'a rejected target must report a stable failure when its one-shot picker cannot rearm',
+)
+assert.match(
+  nativeWorkbenchSurfaceRuntime,
+  /surfaceInstanceId: randomUUID\(\)[\s\S]*?return \{ ok: true, surfaceInstanceId: record\.surfaceInstanceId \}/,
+  'surface creation must return the exact instance identity used to fence late picker events',
+)
+assert.match(
+  nativeWorkbenchSurfaceRuntime,
   /annotationRecordForCleanupRequest\(surfaceId\) \{[\s\S]*?record\.kind === 'artifact-preview'[\s\S]*?isArtifactBridgeProtocolVersion\(record\.version\)[\s\S]*?!record\.disposed/,
   'picker cleanup lookup must remain scoped to an undisposed artifact preview',
 )

--- a/desktop/electron/scripts/test-native-workbench-surface.mjs
+++ b/desktop/electron/scripts/test-native-workbench-surface.mjs
@@ -432,6 +432,12 @@ assert.deepEqual(
 )
 const selectionDigest = 'a'.repeat(64)
 const selectionElementProof = 'b'.repeat(64)
+const selectionStableElementProof = 'c'.repeat(64)
+const selectionAncestorClassCommitments = ['d'.repeat(64), 'e'.repeat(64)]
+const selectionProofV2 = {
+  stableElementProofSha256: selectionStableElementProof,
+  ancestorClassCommitments: selectionAncestorClassCommitments,
+}
 const activePreviewArtifactId = 'art-synthetic-preview'
 const selectionPath = JSON.stringify([
   ['', 'html', 1],
@@ -496,6 +502,63 @@ assert.deepEqual(
     elementProofSha256: selectionElementProof,
   },
 )
+assert.deepEqual(
+  parseDesktopArtifactFocusAnnotationRequest({
+    version: 3,
+    activePreviewArtifactId,
+    annotationId: 'annotation_v2',
+    scopeId: 'synthetic:scope',
+    tagName: 'button',
+    elementPath: selectionPath,
+    elementProofSha256: selectionElementProof,
+    annotationProofV2: selectionProofV2,
+  }),
+  {
+    version: 3,
+    activePreviewArtifactId,
+    annotationId: 'annotation_v2',
+    scopeId: 'synthetic:scope',
+    tagName: 'button',
+    elementPath: selectionPath,
+    elementProofSha256: selectionElementProof,
+    annotationProofV2: selectionProofV2,
+  },
+)
+for (const annotationProofV2 of [
+  {
+    ...selectionProofV2,
+    ancestorClassCommitments: [...selectionAncestorClassCommitments].reverse(),
+  },
+  {
+    ...selectionProofV2,
+    ancestorClassCommitments: [selectionAncestorClassCommitments[0], selectionAncestorClassCommitments[0]],
+  },
+  {
+    ...selectionProofV2,
+    ancestorClassCommitments: Array.from(
+      { length: 257 },
+      (_value, index) => index.toString(16).padStart(64, '0'),
+    ),
+  },
+  {
+    ...selectionProofV2,
+    unexpected: true,
+  },
+]) {
+  assert.throws(
+    () => parseDesktopArtifactFocusAnnotationRequest({
+      version: 3,
+      activePreviewArtifactId,
+      annotationId: 'annotation_invalid_v2',
+      scopeId: 'synthetic:scope',
+      tagName: 'button',
+      elementPath: selectionPath,
+      elementProofSha256: selectionElementProof,
+      annotationProofV2,
+    }),
+    /annotation proof-v2 is invalid/,
+  )
+}
 assert.throws(
   () => parseDesktopArtifactResolveAnnotationSelectionRequest({
     version: 3,
@@ -638,6 +701,7 @@ assert.deepEqual(
     tagName: 'button',
     elementPath: selectionPath,
     elementProofSha256: selectionElementProof,
+    annotationProofV2: selectionProofV2,
     rect: { x: 1, y: 2, width: 30, height: 20 },
     viewportWidth: 800,
     viewportHeight: 600,
@@ -646,6 +710,7 @@ assert.deepEqual(
     tagName: 'button',
     elementPath: selectionPath,
     elementProofSha256: selectionElementProof,
+    annotationProofV2: selectionProofV2,
     rect: { x: 1, y: 2, width: 30, height: 20 },
     viewportWidth: 800,
     viewportHeight: 600,
@@ -901,6 +966,7 @@ const controlledBridge = new DesktopArtifactBridge({
   getActiveTarget: () => ({
     isCurrent: () => true,
     capabilities: {
+      annotationProofV2: true,
       captureSelection: true,
       resolveAnnotationSelection: true,
       focusAnnotation: true,
@@ -969,6 +1035,7 @@ assert.deepEqual(controlledBridge.getCapabilities(), {
   captureSelection: true,
   resolveAnnotationSelection: true,
   focusAnnotation: true,
+  annotationProofV2: true,
   browserInspect: false,
   browserAct: false,
   bindCandidatePreview: false,

--- a/desktop/electron/scripts/test-native-workbench-surface.mjs
+++ b/desktop/electron/scripts/test-native-workbench-surface.mjs
@@ -673,6 +673,34 @@ assert.deepEqual(
   { version: 3, surfaceId: 'artifact:v3', annotationId: 'annotation_42' },
 )
 assert.deepEqual(
+  parseNativeWorkbenchAnnotationOverlayCloseRequest({
+    version: 3,
+    surfaceId: 'artifact:v3',
+    annotationId: 'annotation_42',
+    rearm: true,
+  }),
+  { version: 3, surfaceId: 'artifact:v3', annotationId: 'annotation_42', rearm: true },
+)
+assert.throws(
+  () => parseNativeWorkbenchAnnotationOverlayCloseRequest({
+    version: 3,
+    surfaceId: 'artifact:v3',
+    annotationId: 'annotation_42',
+    rearm: false,
+  }),
+  /overlay close request is invalid/,
+)
+assert.throws(
+  () => parseNativeWorkbenchAnnotationOverlayCloseRequest({
+    version: 3,
+    surfaceId: 'artifact:v3',
+    annotationId: 'annotation_42',
+    rearm: true,
+    unexpected: true,
+  }),
+  /overlay close request is invalid/,
+)
+assert.deepEqual(
   parseNativeWorkbenchAnnotationOverlayMessage({
     version: 1,
     type: 'draft-changed',

--- a/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
+++ b/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
@@ -1134,7 +1134,21 @@ try {
       await v3Contents.executeJavaScript(`(() => {
         window.__annotationPageClicks = 0
         window.__annotationPreviewKeys = 0
-        document.getElementById('font-probe').addEventListener(
+        document.body.classList.add('fixture-source-shell')
+        const annotationTarget = document.getElementById('font-probe')
+        // Keep the click target above the concurrently playing media fixture.
+        // Chromium may resize the video after metadata arrives, otherwise a
+        // coordinate click can intermittently select the video instead.
+        const annotationTargetRect = annotationTarget.getBoundingClientRect()
+        annotationTarget.style.cssText += [
+          'position:absolute',
+          'z-index:2147483647',
+          'left:' + (window.scrollX + annotationTargetRect.x) + 'px',
+          'top:' + (window.scrollY + annotationTargetRect.y) + 'px',
+          'width:' + annotationTargetRect.width + 'px',
+          'height:' + annotationTargetRect.height + 'px',
+        ].join(';')
+        annotationTarget.addEventListener(
           'click',
           () => { window.__annotationPageClicks += 1 },
         )
@@ -1192,6 +1206,16 @@ try {
         throw new Error(`DOM annotation selection was rejected: ${JSON.stringify(annotationSelectedEvent)}`)
       }
       const selected = annotationSelectedEvent.detail.selection
+      if (selected.tagName !== 'div') {
+        throw new Error(`The annotation click selected ${selected.tagName} instead of font-probe.`)
+      }
+      const annotationSourceProofV2 = structuredClone(
+        manager.surfaces.get('artifact:v3-bridge')?.annotationCandidate?.annotationProofV2,
+      )
+      if (!annotationSourceProofV2) {
+        throw new Error('The internal annotation proof-v2 was not retained.')
+      }
+      const annotationSelectionHidesProofV2 = !('annotationProofV2' in selected)
       const annotationPageClicks = await v3Contents.executeJavaScript(
         'Number(window.__annotationPageClicks || 0)',
       )
@@ -1199,6 +1223,9 @@ try {
       // must not invalidate its source-backed authorization proof.
       await v3Contents.executeJavaScript(
         "document.getElementById('lottie-probe').setAttribute('data-runtime-state', 'ready')",
+      )
+      await v3Contents.executeJavaScript(
+        "document.body.classList.add('fixture-runtime-visible')",
       )
       const resolvedSelection = await v3BridgeTarget.resolveAnnotationSelection(
         {
@@ -1210,6 +1237,14 @@ try {
           elementProofSha256: selected.elementProofSha256,
         },
         new AbortController().signal,
+      )
+      const annotationAncestorClassAdditionAccepted = Boolean(
+        resolvedSelection.annotationProofV2
+        && resolvedSelection.annotationProofV2.stableElementProofSha256
+          === annotationSourceProofV2.stableElementProofSha256
+        && annotationSourceProofV2.ancestorClassCommitments.every(commitment => (
+          resolvedSelection.annotationProofV2.ancestorClassCommitments.includes(commitment)
+        )),
       )
       const annotationWrongArtifactResolveRejected =
         await v3BridgeTarget.resolveAnnotationSelection(
@@ -1706,6 +1741,7 @@ try {
           tagName: selected.tagName,
           elementPath: selected.elementPath,
           elementProofSha256: selected.elementProofSha256,
+          annotationProofV2: annotationSourceProofV2,
         },
         new AbortController().signal,
       )
@@ -1720,6 +1756,7 @@ try {
           tagName: selected.tagName,
           elementPath: selected.elementPath,
           elementProofSha256: selected.elementProofSha256,
+          annotationProofV2: annotationSourceProofV2,
         },
         new AbortController().signal,
       ).then(() => false, () => true)
@@ -1732,6 +1769,7 @@ try {
           tagName: selected.tagName,
           elementPath: selected.elementPath,
           elementProofSha256: selected.elementProofSha256,
+          annotationProofV2: annotationSourceProofV2,
         },
         new AbortController().signal,
       ).then(() => false, () => true)
@@ -1747,6 +1785,7 @@ try {
           tagName: selected.tagName,
           elementPath: selected.elementPath,
           elementProofSha256: selected.elementProofSha256,
+          annotationProofV2: annotationSourceProofV2,
         },
         new AbortController().signal,
       ).then(() => false, () => true)
@@ -1765,12 +1804,79 @@ try {
           tagName: selected.tagName,
           elementPath: selected.elementPath,
           elementProofSha256: selected.elementProofSha256,
+          annotationProofV2: annotationSourceProofV2,
         },
         new AbortController().signal,
       ).then(() => false, () => true)
       await v3Contents.executeJavaScript(
         "document.body.removeAttribute('data-ancestor-mismatch')",
       )
+      const focusWithSourceProof = overrides => v3BridgeTarget.focusAnnotation(
+        {
+          version: 3,
+          activePreviewArtifactId,
+          annotationId: 'annotation_electron_fixture',
+          scopeId: 'synthetic:v3-bridge',
+          tagName: selected.tagName,
+          elementPath: selected.elementPath,
+          elementProofSha256: selected.elementProofSha256,
+          annotationProofV2: annotationSourceProofV2,
+          ...overrides,
+        },
+        new AbortController().signal,
+      )
+      await v3Contents.executeJavaScript(
+        "document.body.classList.remove('fixture-source-shell')",
+      )
+      const annotationAncestorClassRemovalRejected = await focusWithSourceProof()
+        .then(() => false, () => true)
+      await v3Contents.executeJavaScript(`(() => {
+        document.body.classList.add('fixture-source-shell')
+        document.body.classList.remove('fixture-runtime-replacement')
+      })()`)
+      await v3Contents.executeJavaScript(`(() => {
+        document.body.classList.remove('fixture-source-shell')
+        document.body.classList.add('fixture-runtime-replacement')
+      })()`)
+      const annotationAncestorClassReplacementRejected = await focusWithSourceProof()
+        .then(() => false, () => true)
+      await v3Contents.executeJavaScript(`(() => {
+        document.body.classList.remove('fixture-runtime-replacement')
+        document.body.classList.add('fixture-source-shell')
+      })()`)
+      await v3Contents.executeJavaScript(
+        "document.body.setAttribute('id', 'fixture-runtime-id')",
+      )
+      const annotationAncestorIdMismatchRejected = await focusWithSourceProof()
+        .then(() => false, () => true)
+      await v3Contents.executeJavaScript("document.body.removeAttribute('id')")
+      await v3Contents.executeJavaScript(
+        "document.body.setAttribute('style', 'opacity: 0.99')",
+      )
+      const annotationAncestorStyleMismatchRejected = await focusWithSourceProof()
+        .then(() => false, () => true)
+      await v3Contents.executeJavaScript("document.body.removeAttribute('style')")
+      await v3Contents.executeJavaScript(
+        "document.getElementById('font-probe').classList.add('fixture-selected-runtime')",
+      )
+      const annotationSelectedClassMismatchRejected = await focusWithSourceProof()
+        .then(() => false, () => true)
+      await v3Contents.executeJavaScript(
+        "document.getElementById('font-probe').removeAttribute('class')",
+      )
+      const mismatchedElementPath = JSON.stringify(
+        JSON.parse(selected.elementPath).map((segment, index, segments) => (
+          index === segments.length - 1
+            ? [segment[0], segment[1], segment[2] + 1]
+            : segment
+        )),
+      )
+      const annotationPathMismatchRejected = await focusWithSourceProof({
+        elementPath: mismatchedElementPath,
+      }).then(() => false, () => true)
+      const annotationTagMismatchRejected = await focusWithSourceProof({
+        tagName: 'span',
+      }).then(() => false, () => true)
       const annotationRefocus = await v3BridgeTarget.focusAnnotation(
         {
           version: 3,
@@ -1780,6 +1886,7 @@ try {
           tagName: selected.tagName,
           elementPath: selected.elementPath,
           elementProofSha256: selected.elementProofSha256,
+          annotationProofV2: annotationSourceProofV2,
         },
         new AbortController().signal,
       )
@@ -1804,6 +1911,10 @@ try {
         annotationId: 'annotation_fallback_fixture',
       })
       const annotationPreviewRestoredAfterFallback = v3View.getVisible()
+      await v3Contents.executeJavaScript(`(() => {
+        document.body.removeAttribute('class')
+        document.getElementById('font-probe').removeAttribute('style')
+      })()`)
       const annotationGoldenEventsBefore = events.length
       const annotationGoldenPicker = await manager.setArtifactAnnotationMode({
         version: 3,
@@ -2693,6 +2804,7 @@ try {
         v3BridgeCapabilities,
         v3AnnotationCapabilities,
         annotationPicker,
+        annotationSelectionHidesProofV2,
         annotationUnrelatedNodeCount,
         annotationSelected: {
           tagName: selected.tagName,
@@ -2703,6 +2815,7 @@ try {
         },
         annotationPageClicks,
         resolvedSelection,
+        annotationAncestorClassAdditionAccepted,
         annotationWrongArtifactResolveRejected,
         annotationOverlayResult,
         annotationOverlaySecurity,
@@ -2744,6 +2857,13 @@ try {
         annotationWrongArtifactFocusRejected,
         annotationDomMismatchRejected,
         annotationAncestorMismatchRejected,
+        annotationAncestorClassRemovalRejected,
+        annotationAncestorClassReplacementRejected,
+        annotationAncestorIdMismatchRejected,
+        annotationAncestorStyleMismatchRejected,
+        annotationSelectedClassMismatchRejected,
+        annotationPathMismatchRejected,
+        annotationTagMismatchRejected,
         annotationRefocus,
         annotationFallbackShow,
         annotationFallbackEvent,
@@ -3036,6 +3156,7 @@ try {
       captureSelection: false,
       resolveAnnotationSelection: true,
       focusAnnotation: true,
+      annotationProofV2: true,
       browserInspect: false,
       browserAct: false,
       bindCandidatePreview: false,
@@ -3057,6 +3178,11 @@ try {
     overlayCopyVersion: 1,
   })
   assert.equal(result.annotationPicker.ok, true)
+  assert.equal(
+    result.annotationSelectionHidesProofV2,
+    true,
+    'annotation-selected must not expose the internal proof-v2 to WebUI',
+  )
   assert.equal(
     result.annotationUnrelatedNodeCount,
     50010,
@@ -3222,6 +3348,18 @@ try {
   assert.equal(result.annotationWrongArtifactFocusRejected, true)
   assert.equal(result.annotationDomMismatchRejected, true)
   assert.equal(result.annotationAncestorMismatchRejected, true)
+  assert.equal(
+    result.annotationAncestorClassAdditionAccepted,
+    true,
+    'adding an ancestor class must preserve the source proof while returning refreshed commitments',
+  )
+  assert.equal(result.annotationAncestorClassRemovalRejected, true)
+  assert.equal(result.annotationAncestorClassReplacementRejected, true)
+  assert.equal(result.annotationAncestorIdMismatchRejected, true)
+  assert.equal(result.annotationAncestorStyleMismatchRejected, true)
+  assert.equal(result.annotationSelectedClassMismatchRejected, true)
+  assert.equal(result.annotationPathMismatchRejected, true)
+  assert.equal(result.annotationTagMismatchRejected, true)
   assert.deepEqual(result.annotationRefocus, {
     focused: true,
     activePreviewArtifactId: 'art-synthetic-v3-bridge',

--- a/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
+++ b/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
@@ -1532,6 +1532,33 @@ try {
         && manager.surfaces.get('artifact:v3-bridge')?.annotationCandidate === null
       const annotationRearmEventsBefore = events.length
       const annotationPickerRearm = annotationOverlayAcknowledgement
+      const annotationRejectedSelectionDiagnosticsBefore = annotationLifecycleDiagnostics.length
+      const annotationRejectedSelectionRecord = manager.surfaces.get('artifact:v3-bridge')
+      if (!annotationRejectedSelectionRecord) {
+        throw new Error('The annotation surface disappeared before rejected-selection recovery.')
+      }
+      // A CSS pseudo-element can produce an inspectNodeRequested backend id
+      // which cannot be resolved to a supported Element in the isolated
+      // world. Exercise the same rejection path deterministically, then prove
+      // the next real click is still captured by the picker below.
+      await manager.handleAnnotationNodeSelected(
+        annotationRejectedSelectionRecord,
+        Number.MAX_SAFE_INTEGER,
+      )
+      const annotationRejectedSelectionDiagnostics = annotationLifecycleDiagnostics.slice(
+        annotationRejectedSelectionDiagnosticsBefore,
+      )
+      const annotationRejectedSelectionRecovery = {
+        blocked: events.slice(annotationRearmEventsBefore).some(event =>
+          event.surfaceId === 'artifact:v3-bridge'
+          && event.type === 'blocked-action'
+          && event.detail?.action === 'annotation-picker'),
+        rejected: annotationRejectedSelectionDiagnostics.some(entry =>
+          entry.phase === 'selection-rejected'),
+        rearmed: annotationRejectedSelectionDiagnostics.some(entry => entry.phase === 'armed')
+          && annotationRejectedSelectionRecord.annotationPickerActive === true,
+        candidateCleared: annotationRejectedSelectionRecord.annotationCandidate === null,
+      }
       const annotationPageClicksBeforeRearm = await v3Contents.executeJavaScript(
         'Number(window.__annotationPageClicks || 0)',
       )
@@ -3012,6 +3039,7 @@ try {
         annotationOverlayClosedAfterAcknowledgement,
         annotationAtomicHandoffPendingState,
         annotationPickerRearm,
+        annotationRejectedSelectionRecovery,
         annotationRearmOverlayResult,
         annotationRearmCopy,
         annotationRearmLayout,
@@ -3529,6 +3557,12 @@ try {
     body: 'Retain this body after a failed handoff.',
   })
   assert.equal(result.annotationAtomicFailureRetry.ok, true)
+  assert.deepEqual(result.annotationRejectedSelectionRecovery, {
+    blocked: true,
+    rejected: true,
+    rearmed: true,
+    candidateCleared: true,
+  })
   assert.equal(
     result.annotationLifecycleDiagnostics.some(entry => entry.phase === 'close-start'),
     true,

--- a/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
+++ b/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
@@ -1517,28 +1517,42 @@ try {
         surfaceId: 'artifact:v3-bridge',
         enabled: true,
       })
-      const annotationRearmDocument = await v3Contents.debugger.sendCommand('DOM.getDocument', {
-        depth: -1,
-        pierce: false,
-      })
-      const annotationRearmNode = await v3Contents.debugger.sendCommand('DOM.querySelector', {
-        nodeId: annotationRearmDocument.root.nodeId,
-        selector: '#font-probe',
-      })
-      const annotationRearmDescription = await v3Contents.debugger.sendCommand(
-        'DOM.describeNode',
-        { nodeId: annotationRearmNode.nodeId },
+      const annotationPageClicksBeforeRearm = await v3Contents.executeJavaScript(
+        'Number(window.__annotationPageClicks || 0)',
       )
-      await manager.handleAnnotationNodeSelected(
-        manager.surfaces.get('artifact:v3-bridge'),
-        annotationRearmDescription.node.backendNodeId,
-      )
+      v3Contents.focus()
+      await v3Contents.debugger.sendCommand('Input.dispatchMouseEvent', {
+        type: 'mouseMoved',
+        x: annotationX,
+        y: annotationY,
+        button: 'none',
+      })
+      await v3Contents.debugger.sendCommand('Input.dispatchMouseEvent', {
+        type: 'mousePressed',
+        x: annotationX,
+        y: annotationY,
+        button: 'left',
+        clickCount: 1,
+      })
+      await v3Contents.debugger.sendCommand('Input.dispatchMouseEvent', {
+        type: 'mouseReleased',
+        x: annotationX,
+        y: annotationY,
+        button: 'left',
+        clickCount: 1,
+      })
       const annotationRearmSelectionEvent = await waitFor(
         () => events.slice(annotationRearmEventsBefore).find(event =>
           event.surfaceId === 'artifact:v3-bridge'
           && event.type === 'annotation-selected'),
         'rearmed annotation selection',
       )
+      const annotationPageClicksAfterRearm = await v3Contents.executeJavaScript(
+        'Number(window.__annotationPageClicks || 0)',
+      )
+      if (annotationPageClicksAfterRearm !== annotationPageClicksBeforeRearm) {
+        throw new Error('The rearmed annotation picker leaked the click to the preview page.')
+      }
       const annotationRearmSelection = annotationRearmSelectionEvent.detail.selection
       const annotationRearmOverlayResult = await manager.showArtifactAnnotationOverlay({
         version: 3,
@@ -3376,6 +3390,8 @@ try {
   )
   assert.equal(result.annotationPostconditionFailure.ok, false)
   assert.deepEqual(result.annotationRollbackCommands, [
+    ['Overlay.setInspectMode', 'none', true],
+    ['Overlay.hideHighlight', null, false],
     ['Overlay.setInspectMode', 'searchForNode', true],
     ['Overlay.setInspectMode', 'none', true],
     ['Overlay.hideHighlight', null, false],

--- a/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
+++ b/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
@@ -118,7 +118,7 @@ const server = createServer((request, response) => {
         #gsap-probe { width: 20px; height: 20px; background: rgb(20, 80, 200); }
         #lottie-probe { width: 100px; height: 100px; }
       </style>
-      <div id="font-probe">Synthetic font preview</div>
+      <div id="font-probe" class="fixture-source-target">Synthetic font preview</div>
       <div id="gsap-probe"></div>
       <div id="lottie-probe"></div>
       <canvas id="canvas-probe" width="8" height="8"></canvas>
@@ -2059,11 +2059,25 @@ try {
       await v3Contents.executeJavaScript(
         "document.getElementById('font-probe').classList.add('fixture-selected-runtime')",
       )
-      const annotationSelectedClassMismatchRejected = await focusWithSourceProof()
-        .then(() => false, () => true)
+      const annotationSelectedClassAdditionAccepted = await focusWithSourceProof()
+        .then(result => result.focused === true, () => false)
       await v3Contents.executeJavaScript(
-        "document.getElementById('font-probe').removeAttribute('class')",
+        "document.getElementById('font-probe').classList.remove('fixture-source-target')",
       )
+      const annotationSelectedClassRemovalRejected = await focusWithSourceProof()
+        .then(() => false, () => true)
+      await v3Contents.executeJavaScript(`(() => {
+        const target = document.getElementById('font-probe')
+        target.classList.remove('fixture-selected-runtime')
+        target.classList.add('fixture-runtime-replacement')
+      })()`)
+      const annotationSelectedClassReplacementRejected = await focusWithSourceProof()
+        .then(() => false, () => true)
+      await v3Contents.executeJavaScript(`(() => {
+        const target = document.getElementById('font-probe')
+        target.classList.remove('fixture-runtime-replacement')
+        target.classList.add('fixture-source-target')
+      })()`)
       const mismatchedElementPath = JSON.stringify(
         JSON.parse(selected.elementPath).map((segment, index, segments) => (
           index === segments.length - 1
@@ -3070,7 +3084,9 @@ try {
         annotationAncestorClassReplacementRejected,
         annotationAncestorIdMismatchRejected,
         annotationAncestorStyleMismatchRejected,
-        annotationSelectedClassMismatchRejected,
+        annotationSelectedClassAdditionAccepted,
+        annotationSelectedClassRemovalRejected,
+        annotationSelectedClassReplacementRejected,
         annotationPathMismatchRejected,
         annotationTagMismatchRejected,
         annotationRefocus,
@@ -3603,7 +3619,13 @@ try {
   assert.equal(result.annotationAncestorClassReplacementRejected, true)
   assert.equal(result.annotationAncestorIdMismatchRejected, true)
   assert.equal(result.annotationAncestorStyleMismatchRejected, true)
-  assert.equal(result.annotationSelectedClassMismatchRejected, true)
+  assert.equal(
+    result.annotationSelectedClassAdditionAccepted,
+    true,
+    'adding a selected-element class must preserve the source proof',
+  )
+  assert.equal(result.annotationSelectedClassRemovalRejected, true)
+  assert.equal(result.annotationSelectedClassReplacementRejected, true)
   assert.equal(result.annotationPathMismatchRejected, true)
   assert.equal(result.annotationTagMismatchRejected, true)
   assert.deepEqual(result.annotationRefocus, {

--- a/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
+++ b/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
@@ -841,21 +841,11 @@ try {
         return await waitForTrustedAnnotationInput(overlay, probe, expectedValue, label)
       }
 
-      async function closeAnnotationOverlayAndDrain(request, label) {
-        const record = manager.surfaces.get(request.surfaceId)
-        const candidate = record?.annotationCandidate ?? null
-        const result = manager.closeArtifactAnnotationOverlay(request)
-        if (record && candidate) {
-          // Closing stops the interval synchronously, but a geometry CDP call
-          // that already started may still finish through its stale-selection
-          // cleanup. Do not let that cleanup cancel the next picker rearm.
-          await waitFor(async () => {
-            if (candidate.geometryRefreshPending) return false
-            await record.cdpQueue
-            return !candidate.geometryRefreshPending && record.annotationCandidate === null
-          }, `${label} geometry cleanup`)
-        }
-        return result
+      function closeAnnotationOverlayImmediately(request) {
+        // Do not drain a retired geometry read before continuing. The product
+        // contract must fence that stale continuation from the newly armed
+        // picker, including when the next click arrives immediately.
+        return manager.closeArtifactAnnotationOverlay(request)
       }
 
       // WebContents.isFocused() is only meaningful while the Electron app owns
@@ -1502,11 +1492,11 @@ try {
         const textarea = document.getElementById('annotation-body')
         textarea.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
       })()`)
-      const annotationOverlayAcknowledgement = await closeAnnotationOverlayAndDrain({
+      const annotationOverlayAcknowledgement = await closeAnnotationOverlayImmediately({
         version: 3,
         surfaceId: 'artifact:v3-bridge',
         annotationId: 'annotation_electron_fixture',
-      }, 'trusted annotation acknowledgement')
+      })
       const annotationOverlayClosedAfterAcknowledgement =
         !annotationOverlay.view.getVisible()
         && annotationOverlay.binding === null
@@ -1669,20 +1659,53 @@ try {
           && event.detail?.body === 'Rearmed input\n'),
         'reused trusted overlay IME state reset',
       )
-      const annotationRearmOverlayClose = await closeAnnotationOverlayAndDrain({
+      const retiredGeometryCandidate = manager.surfaces
+        .get('artifact:v3-bridge')?.annotationCandidate
+      const rearmCdpCommand = manager.cdpCommand.bind(manager)
+      let releaseRetiredGeometry = null
+      manager.cdpCommand = async (record, method, params) => {
+        const result = await rearmCdpCommand(record, method, params)
+        if (
+          releaseRetiredGeometry === null
+          && method === 'Runtime.callFunctionOn'
+          && params?.returnByValue === true
+          && params?.awaitPromise !== true
+        ) {
+          await new Promise(resolve => {
+            releaseRetiredGeometry = resolve
+          })
+        }
+        return result
+      }
+      await waitFor(
+        () => typeof releaseRetiredGeometry === 'function',
+        'in-flight retired annotation geometry read',
+      )
+      const annotationRearmOverlayClose = await closeAnnotationOverlayImmediately({
         version: 3,
         surfaceId: 'artifact:v3-bridge',
         annotationId: 'annotation_rearmed_fixture',
-      }, 'rearmed annotation acknowledgement')
-      const annotationRearmFocusCycles = []
-      const annotationRearmCycleCount = fixture.stressMode ? 8 : 4
-      for (let cycle = 0; cycle < annotationRearmCycleCount; cycle += 1) {
-        const cycleEventsBefore = events.length
-        const cyclePicker = await manager.setArtifactAnnotationMode({
+      })
+      const annotationRearmAfterRetiredGeometry =
+        await manager.setArtifactAnnotationMode({
           version: 3,
           surfaceId: 'artifact:v3-bridge',
           enabled: true,
         })
+      manager.cdpCommand = rearmCdpCommand
+      releaseRetiredGeometry()
+      await waitFor(
+        () => retiredGeometryCandidate?.geometryRefreshPending === false,
+        'retired annotation geometry completion',
+      )
+      const annotationRetiredGeometryDidNotCancelRearm =
+        annotationRearmAfterRetiredGeometry.ok
+        && manager.surfaces.get('artifact:v3-bridge')?.annotationPickerActive === true
+      const annotationRearmFocusCycles = []
+      const annotationRearmCycleCount = fixture.stressMode ? 8 : 4
+      let cyclePicker = annotationRearmAfterRetiredGeometry
+      for (let cycle = 0; cycle < annotationRearmCycleCount; cycle += 1) {
+        const cycleEventsBefore = events.length
         const cyclePageClicksBefore = await v3Contents.executeJavaScript(
           'Number(window.__annotationPageClicks || 0)',
         )
@@ -1745,11 +1768,18 @@ try {
           value: cycleInputState.value,
         })
         const cycleFocusState = cycleInputState
-        const cycleClose = await closeAnnotationOverlayAndDrain({
+        const cycleClose = await closeAnnotationOverlayImmediately({
           version: 3,
           surfaceId: 'artifact:v3-bridge',
           annotationId: cycleAnnotationId,
-        }, `annotation rearm close cycle ${cycle + 1}`)
+        })
+        const cycleNextPicker = cycle + 1 < annotationRearmCycleCount
+          ? await manager.setArtifactAnnotationMode({
+              version: 3,
+              surfaceId: 'artifact:v3-bridge',
+              enabled: true,
+            })
+          : null
         annotationRearmFocusCycles.push({
           picker: cyclePicker.ok,
           overlay: cycleOverlayResult.ok,
@@ -1757,6 +1787,7 @@ try {
           typedValue: cycleInputState.value,
           closed: cycleClose.ok,
         })
+        cyclePicker = cycleNextPicker
       }
       const v3Record = manager.surfaces.get('artifact:v3-bridge')
       const annotationScrollBeforeFocus = await v3Contents.executeJavaScript('window.scrollY')
@@ -2875,6 +2906,7 @@ try {
         annotationRearmShiftEnterDidNotSubmit,
         annotationRearmSubmitAfterInterruptedComposition,
         annotationRearmOverlayClose,
+        annotationRetiredGeometryDidNotCancelRearm,
         annotationRearmFocusCycles,
         annotationFocus,
         annotationScrollBeforeFocus,
@@ -3344,6 +3376,7 @@ try {
   assert.equal(result.annotationRearmShiftEnterDidNotSubmit, true)
   assert.equal(result.annotationRearmSubmitAfterInterruptedComposition, true)
   assert.equal(result.annotationRearmOverlayClose.ok, true)
+  assert.equal(result.annotationRetiredGeometryDidNotCancelRearm, true)
   assert.equal(result.annotationRearmFocusCycles.length, result.stressMode ? 8 : 4)
   assert.equal(
     result.annotationRearmFocusCycles.every(cycle =>

--- a/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
+++ b/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
@@ -570,6 +570,7 @@ try {
       const Manager = globalThis.__opensquillaNativeWorkbenchSurfaceManager
       if (!Manager) throw new Error('The native Workbench manager fixture was not installed.')
       const events = []
+      const annotationLifecycleDiagnostics = []
       const owner = new BrowserWindow({
         show: true,
         width: 900,
@@ -587,6 +588,7 @@ try {
       const previewPinReleases = []
       let manager
       manager = new Manager({
+        annotationAudit: entry => annotationLifecycleDiagnostics.push(entry),
         getPrivilegedGatewayUrl: () => fixture.privilegedGatewayUrl,
         getWindow: () => owner,
         emit: event => {
@@ -1478,7 +1480,7 @@ try {
         && annotationOverlay.binding?.annotationId === 'annotation_electron_fixture'
         && manager.surfaces.get('artifact:v3-bridge')?.annotationCandidate?.selection.selectionId
           === selected.selectionId
-      const annotationWrongAcknowledgement = manager.closeArtifactAnnotationOverlay({
+      const annotationWrongAcknowledgement = await manager.closeArtifactAnnotationOverlay({
         version: 3,
         surfaceId: 'artifact:v3-bridge',
         annotationId: 'annotation_wrong_fixture',
@@ -1492,21 +1494,44 @@ try {
         const textarea = document.getElementById('annotation-body')
         textarea.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
       })()`)
-      const annotationOverlayAcknowledgement = await closeAnnotationOverlayImmediately({
+      const atomicHandoffCdpCommand = manager.cdpCommand.bind(manager)
+      let releaseAtomicHandoff = null
+      manager.cdpCommand = async (record, method, params) => {
+        if (
+          releaseAtomicHandoff === null
+          && method === 'Overlay.setInspectMode'
+          && params?.mode === 'searchForNode'
+        ) {
+          await new Promise(resolve => {
+            releaseAtomicHandoff = resolve
+          })
+        }
+        return await atomicHandoffCdpCommand(record, method, params)
+      }
+      const annotationOverlayAcknowledgementPromise = closeAnnotationOverlayImmediately({
         version: 3,
         surfaceId: 'artifact:v3-bridge',
         annotationId: 'annotation_electron_fixture',
+        rearm: true,
       })
+      await waitFor(
+        () => typeof releaseAtomicHandoff === 'function',
+        'blocked atomic annotation handoff',
+      )
+      const annotationAtomicHandoffPendingState = {
+        editorVisible: annotationOverlay.view.getVisible(),
+        editorBound: annotationOverlay.binding?.annotationId === 'annotation_electron_fixture',
+        previewHidden: !manager.surfaces.get('artifact:v3-bridge')?.view.getVisible(),
+      }
+      releaseAtomicHandoff()
+      const annotationOverlayAcknowledgement = await annotationOverlayAcknowledgementPromise
+      manager.cdpCommand = atomicHandoffCdpCommand
       const annotationOverlayClosedAfterAcknowledgement =
         !annotationOverlay.view.getVisible()
         && annotationOverlay.binding === null
         && manager.surfaces.get('artifact:v3-bridge')?.annotationCandidate === null
       const annotationRearmEventsBefore = events.length
-      const annotationPickerRearm = await manager.setArtifactAnnotationMode({
-        version: 3,
-        surfaceId: 'artifact:v3-bridge',
-        enabled: true,
-      })
+      const annotationPickerRearm = annotationOverlayAcknowledgement
       const annotationPageClicksBeforeRearm = await v3Contents.executeJavaScript(
         'Number(window.__annotationPageClicks || 0)',
       )
@@ -1702,7 +1727,7 @@ try {
         annotationRearmAfterRetiredGeometry.ok
         && manager.surfaces.get('artifact:v3-bridge')?.annotationPickerActive === true
       const annotationRearmFocusCycles = []
-      const annotationRearmCycleCount = fixture.stressMode ? 8 : 4
+      const annotationRearmCycleCount = fixture.stressMode ? 50 : 8
       let cyclePicker = annotationRearmAfterRetiredGeometry
       for (let cycle = 0; cycle < annotationRearmCycleCount; cycle += 1) {
         const cycleEventsBefore = events.length
@@ -1768,27 +1793,116 @@ try {
           value: cycleInputState.value,
         })
         const cycleFocusState = cycleInputState
+        const cycleSubmitEventsBefore = events.length
+        await annotationOverlay.view.webContents.executeJavaScript(
+          "document.querySelector('button[type=submit]').click()",
+        )
+        const cycleSubmit = await waitFor(
+          () => events.slice(cycleSubmitEventsBefore).find(event =>
+            event.type === 'annotation-submit'
+            && event.detail?.annotationId === cycleAnnotationId
+            && event.detail?.body === cycleBody),
+          `annotation rearm submit cycle ${cycle + 1}`,
+        )
         const cycleClose = await closeAnnotationOverlayImmediately({
           version: 3,
           surfaceId: 'artifact:v3-bridge',
           annotationId: cycleAnnotationId,
+          rearm: true,
         })
-        const cycleNextPicker = cycle + 1 < annotationRearmCycleCount
-          ? await manager.setArtifactAnnotationMode({
-              version: 3,
-              surfaceId: 'artifact:v3-bridge',
-              enabled: true,
-            })
-          : null
+        const cycleNextPicker = cycleClose
         annotationRearmFocusCycles.push({
           picker: cyclePicker.ok,
           overlay: cycleOverlayResult.ok,
           ...cycleFocusState,
           typedValue: cycleInputState.value,
+          submitted: Boolean(cycleSubmit),
           closed: cycleClose.ok,
         })
         cyclePicker = cycleNextPicker
       }
+      const atomicFailureEventsBefore = events.length
+      v3Contents.focus()
+      await v3Contents.debugger.sendCommand('Input.dispatchMouseEvent', {
+        type: 'mouseMoved',
+        x: annotationX,
+        y: annotationY,
+        button: 'none',
+      })
+      await v3Contents.debugger.sendCommand('Input.dispatchMouseEvent', {
+        type: 'mousePressed',
+        x: annotationX,
+        y: annotationY,
+        button: 'left',
+        clickCount: 1,
+      })
+      await v3Contents.debugger.sendCommand('Input.dispatchMouseEvent', {
+        type: 'mouseReleased',
+        x: annotationX,
+        y: annotationY,
+        button: 'left',
+        clickCount: 1,
+      })
+      const atomicFailureSelectionEvent = await waitFor(
+        () => events.slice(atomicFailureEventsBefore).find(event =>
+          event.surfaceId === 'artifact:v3-bridge'
+          && event.type === 'annotation-selected'),
+        'atomic annotation failure selection',
+      )
+      const annotationAtomicFailureId = 'annotation_atomic_failure_fixture'
+      const annotationAtomicFailureOverlay = await manager.showArtifactAnnotationOverlay({
+        version: 3,
+        surfaceId: 'artifact:v3-bridge',
+        selectionId: atomicFailureSelectionEvent.detail.selection.selectionId,
+        annotationId: annotationAtomicFailureId,
+        initialBody: 'Retain this body after a failed handoff.',
+      })
+      await restoreTrustedAnnotationInputFocus(
+        annotationOverlay,
+        'atomic annotation failure editor focus',
+      )
+      const atomicFailureCdpCommand = manager.cdpCommand.bind(manager)
+      let rejectAtomicArm = true
+      manager.cdpCommand = async (record, method, params) => {
+        if (
+          rejectAtomicArm
+          && method === 'Overlay.setInspectMode'
+          && params?.mode === 'searchForNode'
+        ) {
+          rejectAtomicArm = false
+          throw new Error('Synthetic atomic picker activation failure')
+        }
+        return await atomicFailureCdpCommand(record, method, params)
+      }
+      const annotationAtomicFailureResult = await manager.closeArtifactAnnotationOverlay({
+        version: 3,
+        surfaceId: 'artifact:v3-bridge',
+        annotationId: annotationAtomicFailureId,
+        rearm: true,
+      })
+      manager.cdpCommand = atomicFailureCdpCommand
+      const annotationAtomicFailureRetained = {
+        editorVisible: annotationOverlay.view.getVisible(),
+        editorBound: annotationOverlay.binding?.annotationId === annotationAtomicFailureId,
+        previewVisible: Boolean(manager.surfaces.get('artifact:v3-bridge')?.view.getVisible()),
+        candidateRetained: manager.surfaces
+          .get('artifact:v3-bridge')?.annotationCandidate?.selection.selectionId
+          === atomicFailureSelectionEvent.detail.selection.selectionId,
+        body: await annotationOverlay.view.webContents.executeJavaScript(
+          "document.getElementById('annotation-body').value",
+        ),
+      }
+      const annotationAtomicFailureRetry = await manager.closeArtifactAnnotationOverlay({
+        version: 3,
+        surfaceId: 'artifact:v3-bridge',
+        annotationId: annotationAtomicFailureId,
+        rearm: true,
+      })
+      const annotationAtomicStopAfterCycles = await manager.setArtifactAnnotationMode({
+        version: 3,
+        surfaceId: 'artifact:v3-bridge',
+        enabled: false,
+      })
       const v3Record = manager.surfaces.get('artifact:v3-bridge')
       const annotationScrollBeforeFocus = await v3Contents.executeJavaScript('window.scrollY')
       const annotationFocus = await v3BridgeTarget.focusAnnotation(
@@ -1964,7 +2078,7 @@ try {
         'trusted annotation overlay fallback event',
       )
       const annotationPreviewHiddenForFallback = !v3View.getVisible()
-      const annotationFallbackClose = manager.closeArtifactAnnotationOverlay({
+      const annotationFallbackClose = await manager.closeArtifactAnnotationOverlay({
         version: 3,
         surfaceId: 'artifact:v3-bridge',
         annotationId: 'annotation_fallback_fixture',
@@ -2896,6 +3010,7 @@ try {
         annotationOverlayRetainedAfterWrongAcknowledgement,
         annotationOverlayAcknowledgement,
         annotationOverlayClosedAfterAcknowledgement,
+        annotationAtomicHandoffPendingState,
         annotationPickerRearm,
         annotationRearmOverlayResult,
         annotationRearmCopy,
@@ -2908,6 +3023,12 @@ try {
         annotationRearmOverlayClose,
         annotationRetiredGeometryDidNotCancelRearm,
         annotationRearmFocusCycles,
+        annotationAtomicFailureOverlay,
+        annotationAtomicFailureResult,
+        annotationAtomicFailureRetained,
+        annotationAtomicFailureRetry,
+        annotationAtomicStopAfterCycles,
+        annotationLifecycleDiagnostics,
         annotationFocus,
         annotationScrollBeforeFocus,
         annotationScrollAfterFocus,
@@ -3236,6 +3357,7 @@ try {
     picker: true,
     trustedOverlay: true,
     overlayCopyVersion: 1,
+    atomicCloseRearm: true,
   })
   assert.equal(result.annotationPicker.ok, true)
   assert.equal(
@@ -3343,6 +3465,11 @@ try {
   assert.equal(result.annotationOverlayRetainedAfterWrongAcknowledgement, true)
   assert.equal(result.annotationOverlayAcknowledgement.ok, true)
   assert.equal(result.annotationOverlayClosedAfterAcknowledgement, true)
+  assert.deepEqual(result.annotationAtomicHandoffPendingState, {
+    editorVisible: true,
+    editorBound: true,
+    previewHidden: true,
+  })
   assert.equal(result.annotationPickerRearm.ok, true)
   assert.equal(result.annotationRearmOverlayResult.ok, true)
   assert.deepEqual(result.annotationRearmCopy, {
@@ -3377,7 +3504,7 @@ try {
   assert.equal(result.annotationRearmSubmitAfterInterruptedComposition, true)
   assert.equal(result.annotationRearmOverlayClose.ok, true)
   assert.equal(result.annotationRetiredGeometryDidNotCancelRearm, true)
-  assert.equal(result.annotationRearmFocusCycles.length, result.stressMode ? 8 : 4)
+  assert.equal(result.annotationRearmFocusCycles.length, result.stressMode ? 50 : 8)
   assert.equal(
     result.annotationRearmFocusCycles.every(cycle =>
       cycle.picker
@@ -3385,10 +3512,34 @@ try {
       && cycle.editorFocused
       && cycle.ownerFocused
       && cycle.nativeFocused
+      && cycle.submitted
       && cycle.closed
       && cycle.typedValue.includes('中文输入')),
     true,
     'trusted annotation editor must survive repeated close/rearm/IME cycles',
+  )
+  assert.equal(result.annotationAtomicStopAfterCycles.ok, true)
+  assert.equal(result.annotationAtomicFailureOverlay.ok, true)
+  assert.equal(result.annotationAtomicFailureResult.ok, false)
+  assert.deepEqual(result.annotationAtomicFailureRetained, {
+    editorVisible: true,
+    editorBound: true,
+    previewVisible: true,
+    candidateRetained: true,
+    body: 'Retain this body after a failed handoff.',
+  })
+  assert.equal(result.annotationAtomicFailureRetry.ok, true)
+  assert.equal(
+    result.annotationLifecycleDiagnostics.some(entry => entry.phase === 'close-start'),
+    true,
+  )
+  assert.equal(
+    result.annotationLifecycleDiagnostics.some(entry => entry.phase === 'armed'),
+    true,
+  )
+  assert.equal(
+    result.annotationLifecycleDiagnostics.some(entry => entry.phase === 'selection-emitted'),
+    true,
   )
   assert.deepEqual(result.annotationFocus, {
     focused: true,

--- a/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
+++ b/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
@@ -1559,6 +1559,51 @@ try {
           && annotationRejectedSelectionRecord.annotationPickerActive === true,
         candidateCleared: annotationRejectedSelectionRecord.annotationCandidate === null,
       }
+      const annotationRearmFailureEventsBefore = events.length
+      const annotationRearmFailureCdpCommand = manager.cdpCommand.bind(manager)
+      let rejectAutomaticRearm = true
+      manager.cdpCommand = async (record, method, params) => {
+        if (
+          rejectAutomaticRearm
+          && method === 'Overlay.setInspectMode'
+          && params?.mode === 'searchForNode'
+        ) {
+          rejectAutomaticRearm = false
+          throw new Error('synthetic automatic picker rearm failure')
+        }
+        return await annotationRearmFailureCdpCommand(record, method, params)
+      }
+      await manager.handleAnnotationNodeSelected(
+        annotationRejectedSelectionRecord,
+        Number.MAX_SAFE_INTEGER,
+      )
+      manager.cdpCommand = annotationRearmFailureCdpCommand
+      const annotationRearmFailureEvent = events
+        .slice(annotationRearmFailureEventsBefore)
+        .find(event => event.surfaceId === 'artifact:v3-bridge'
+          && event.type === 'blocked-action'
+          && event.detail?.action === 'annotation-picker'
+          && event.detail?.code === 'ANNOTATION_REARM_FAILED'
+          && event.detail?.surfaceInstanceId
+            === annotationRejectedSelectionRecord.surfaceInstanceId)
+      const annotationPickerInactiveAfterRearmFailure =
+        annotationRejectedSelectionRecord.annotationPickerActive === false
+      const annotationPickerRecoveryAfterRearmFailure =
+        await manager.setArtifactAnnotationMode({
+          version: 3,
+          surfaceId: 'artifact:v3-bridge',
+          enabled: true,
+        })
+      const annotationRejectedSelectionRearmFailure = {
+        reported: Boolean(annotationRearmFailureEvent),
+        reasonStable: annotationRearmFailureEvent?.detail?.reason
+          === 'annotation-picker-rearm-failed',
+        rawErrorHidden: !events.slice(annotationRearmFailureEventsBefore).some(event =>
+          JSON.stringify(event).includes('synthetic automatic picker rearm failure')),
+        inactiveBeforeRecovery: annotationPickerInactiveAfterRearmFailure,
+        recovered: annotationPickerRecoveryAfterRearmFailure.ok
+          && annotationRejectedSelectionRecord.annotationPickerActive === true,
+      }
       const annotationPageClicksBeforeRearm = await v3Contents.executeJavaScript(
         'Number(window.__annotationPageClicks || 0)',
       )
@@ -3054,6 +3099,7 @@ try {
         annotationAtomicHandoffPendingState,
         annotationPickerRearm,
         annotationRejectedSelectionRecovery,
+        annotationRejectedSelectionRearmFailure,
         annotationRearmOverlayResult,
         annotationRearmCopy,
         annotationRearmLayout,
@@ -3578,6 +3624,13 @@ try {
     rejected: true,
     rearmed: true,
     candidateCleared: true,
+  })
+  assert.deepEqual(result.annotationRejectedSelectionRearmFailure, {
+    reported: true,
+    reasonStable: true,
+    rawErrorHidden: true,
+    inactiveBeforeRecovery: true,
+    recovered: true,
   })
   assert.equal(
     result.annotationLifecycleDiagnostics.some(entry => entry.phase === 'close-start'),

--- a/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
+++ b/desktop/electron/scripts/test-native-workbench-v2-electron.mjs
@@ -1675,7 +1675,7 @@ try {
         annotationId: 'annotation_rearmed_fixture',
       }, 'rearmed annotation acknowledgement')
       const annotationRearmFocusCycles = []
-      const annotationRearmCycleCount = fixture.stressMode ? 3 : 1
+      const annotationRearmCycleCount = fixture.stressMode ? 8 : 4
       for (let cycle = 0; cycle < annotationRearmCycleCount; cycle += 1) {
         const cycleEventsBefore = events.length
         const cyclePicker = await manager.setArtifactAnnotationMode({
@@ -1683,28 +1683,42 @@ try {
           surfaceId: 'artifact:v3-bridge',
           enabled: true,
         })
-        const cycleDocument = await v3Contents.debugger.sendCommand('DOM.getDocument', {
-          depth: -1,
-          pierce: false,
-        })
-        const cycleNode = await v3Contents.debugger.sendCommand('DOM.querySelector', {
-          nodeId: cycleDocument.root.nodeId,
-          selector: '#font-probe',
-        })
-        const cycleDescription = await v3Contents.debugger.sendCommand(
-          'DOM.describeNode',
-          { nodeId: cycleNode.nodeId },
+        const cyclePageClicksBefore = await v3Contents.executeJavaScript(
+          'Number(window.__annotationPageClicks || 0)',
         )
-        await manager.handleAnnotationNodeSelected(
-          manager.surfaces.get('artifact:v3-bridge'),
-          cycleDescription.node.backendNodeId,
-        )
+        v3Contents.focus()
+        await v3Contents.debugger.sendCommand('Input.dispatchMouseEvent', {
+          type: 'mouseMoved',
+          x: annotationX,
+          y: annotationY,
+          button: 'none',
+        })
+        await v3Contents.debugger.sendCommand('Input.dispatchMouseEvent', {
+          type: 'mousePressed',
+          x: annotationX,
+          y: annotationY,
+          button: 'left',
+          clickCount: 1,
+        })
+        await v3Contents.debugger.sendCommand('Input.dispatchMouseEvent', {
+          type: 'mouseReleased',
+          x: annotationX,
+          y: annotationY,
+          button: 'left',
+          clickCount: 1,
+        })
         const cycleSelectionEvent = await waitFor(
           () => events.slice(cycleEventsBefore).find(event =>
             event.surfaceId === 'artifact:v3-bridge'
             && event.type === 'annotation-selected'),
           `annotation rearm selection cycle ${cycle + 1}`,
         )
+        const cyclePageClicksAfter = await v3Contents.executeJavaScript(
+          'Number(window.__annotationPageClicks || 0)',
+        )
+        if (cyclePageClicksAfter !== cyclePageClicksBefore) {
+          throw new Error(`Annotation rearm cycle ${cycle + 1} leaked the click to the page.`)
+        }
         const cycleAnnotationId = `annotation_rearm_stress_${cycle + 1}`
         const cycleOverlayResult = await manager.showArtifactAnnotationOverlay({
           version: 3,
@@ -3330,7 +3344,7 @@ try {
   assert.equal(result.annotationRearmShiftEnterDidNotSubmit, true)
   assert.equal(result.annotationRearmSubmitAfterInterruptedComposition, true)
   assert.equal(result.annotationRearmOverlayClose.ok, true)
-  assert.equal(result.annotationRearmFocusCycles.length, result.stressMode ? 3 : 1)
+  assert.equal(result.annotationRearmFocusCycles.length, result.stressMode ? 8 : 4)
   assert.equal(
     result.annotationRearmFocusCycles.every(cycle =>
       cycle.picker

--- a/desktop/electron/src/desktop-artifact-bridge-contract.ts
+++ b/desktop/electron/src/desktop-artifact-bridge-contract.ts
@@ -41,7 +41,7 @@ export interface DesktopArtifactBridgeCapabilities {
   captureSelection: boolean
   resolveAnnotationSelection: boolean
   focusAnnotation: boolean
-  /** Additive proof for runtime-only class additions on non-selected ancestors. */
+  /** Additive proof for runtime-only class additions along the selected element path. */
   annotationProofV2?: true
   browserInspect: boolean
   /** True only while a v4 offline candidate preview is bound to the surface. */

--- a/desktop/electron/src/desktop-artifact-bridge-contract.ts
+++ b/desktop/electron/src/desktop-artifact-bridge-contract.ts
@@ -41,6 +41,8 @@ export interface DesktopArtifactBridgeCapabilities {
   captureSelection: boolean
   resolveAnnotationSelection: boolean
   focusAnnotation: boolean
+  /** Additive proof for runtime-only class additions on non-selected ancestors. */
+  annotationProofV2?: true
   browserInspect: boolean
   /** True only while a v4 offline candidate preview is bound to the surface. */
   browserAct: boolean
@@ -88,6 +90,11 @@ interface DesktopArtifactBridgeRequestBase {
   version: DesktopArtifactBridgeProtocolVersion
 }
 
+export interface DesktopArtifactAnnotationProofV2 {
+  stableElementProofSha256: string
+  ancestorClassCommitments: string[]
+}
+
 export type DesktopArtifactCaptureSelectionRequest = DesktopArtifactBridgeRequestBase
 
 export interface DesktopArtifactResolveAnnotationSelectionRequest
@@ -108,6 +115,7 @@ export interface DesktopArtifactFocusAnnotationRequest
   tagName: string
   elementPath: string
   elementProofSha256: string
+  annotationProofV2?: DesktopArtifactAnnotationProofV2
 }
 
 export type DesktopArtifactBrowserInspectScope =
@@ -245,6 +253,7 @@ export interface DesktopArtifactResolvedAnnotationSelection {
   elementPath: string
   domSha256?: string
   elementProofSha256: string
+  annotationProofV2?: DesktopArtifactAnnotationProofV2
   scopeId: string
   rect: {
     x: number
@@ -455,6 +464,37 @@ function parseActivePreviewArtifactId(value: unknown): string {
   return value
 }
 
+export function parseDesktopArtifactAnnotationProofV2(
+  value: unknown,
+): DesktopArtifactAnnotationProofV2 {
+  const proof = objectRecord(value)
+  const commitments = proof?.ancestorClassCommitments
+  if (
+    !proof
+    || Object.keys(proof).some(key => ![
+      'stableElementProofSha256',
+      'ancestorClassCommitments',
+    ].includes(key))
+    || typeof proof.stableElementProofSha256 !== 'string'
+    || !/^[a-f0-9]{64}$/.test(proof.stableElementProofSha256)
+    || !Array.isArray(commitments)
+    || commitments.length > 256
+    || commitments.some(commitment => (
+      typeof commitment !== 'string'
+      || !/^[a-f0-9]{64}$/.test(commitment)
+    ))
+    || commitments.some((commitment, index) => (
+      index > 0 && commitments[index - 1] >= commitment
+    ))
+  ) {
+    throw new Error('The Desktop artifact annotation proof-v2 is invalid.')
+  }
+  return {
+    stableElementProofSha256: proof.stableElementProofSha256,
+    ancestorClassCommitments: [...commitments],
+  }
+}
+
 export function parseDesktopArtifactCaptureSelectionRequest(
   value: unknown,
 ): DesktopArtifactCaptureSelectionRequest {
@@ -517,6 +557,7 @@ export function parseDesktopArtifactFocusAnnotationRequest(
       'tagName',
       'elementPath',
       'elementProofSha256',
+      'annotationProofV2',
     ],
     'annotation focus',
   )
@@ -544,6 +585,13 @@ export function parseDesktopArtifactFocusAnnotationRequest(
     tagName: request.tagName,
     elementPath: parseAnnotationElementPath(request.elementPath),
     elementProofSha256: request.elementProofSha256,
+    ...(request.annotationProofV2 === undefined
+      ? {}
+      : {
+          annotationProofV2: parseDesktopArtifactAnnotationProofV2(
+            request.annotationProofV2,
+          ),
+        }),
   }
 }
 

--- a/desktop/electron/src/desktop-artifact-bridge.ts
+++ b/desktop/electron/src/desktop-artifact-bridge.ts
@@ -59,7 +59,9 @@ type DesktopArtifactBridgeHandler<M extends DesktopArtifactBridgeMethod> = (
 export interface DesktopArtifactBridgeTarget {
   /** Protocol negotiated by the active native surface, when known. */
   protocolVersion?: DesktopArtifactBridgeProtocolVersion
-  capabilities: Partial<Record<DesktopArtifactBridgeMethod, boolean>>
+  capabilities: Partial<Record<DesktopArtifactBridgeMethod, boolean>> & {
+    annotationProofV2?: boolean
+  }
   isCurrent(): boolean
   captureSelection?: DesktopArtifactBridgeHandler<'captureSelection'>
   resolveAnnotationSelection?: DesktopArtifactBridgeHandler<'resolveAnnotationSelection'>
@@ -156,6 +158,7 @@ export class DesktopArtifactBridge {
       captureSelection: this.methodAvailable(target, 'captureSelection'),
       resolveAnnotationSelection: this.methodAvailable(target, 'resolveAnnotationSelection'),
       focusAnnotation: this.methodAvailable(target, 'focusAnnotation'),
+      ...(target.capabilities.annotationProofV2 === true ? { annotationProofV2: true } : {}),
       browserInspect: requestedVersion === DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION && this.methodAvailable(target, 'browserInspect'),
       browserAct: requestedVersion === DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION && this.methodAvailable(target, 'browserAct'),
       bindCandidatePreview: requestedVersion === DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION && this.methodAvailable(target, 'bindCandidatePreview'),
@@ -245,6 +248,7 @@ export class DesktopArtifactBridge {
       captureSelection: available('captureSelection'),
       resolveAnnotationSelection: available('resolveAnnotationSelection'),
       focusAnnotation: available('focusAnnotation'),
+      ...(target.capabilities.annotationProofV2 === true ? { annotationProofV2: true } : {}),
       browserInspect: available('browserInspect'),
       browserAct: available('browserAct'),
       screenshot: available('screenshot'),

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -669,6 +669,10 @@ const artifactPreviewLeaseBroker = new ArtifactPreviewLeaseBroker({
 })
 
 const nativeWorkbenchSurfaces = new NativeWorkbenchSurfaceManager({
+  annotationAudit: entry => desktopLog(
+    'native_workbench_annotation_picker_lifecycle',
+    { ...entry },
+  ),
   forceArtifactPreviewsOffline: process.env.OPENSQUILLA_PREVIEW_FORCE_OFFLINE === '1',
   getPrivilegedGatewayUrl: () => (
     gatewayState.status === 'ready' && gatewayState.url
@@ -11268,10 +11272,10 @@ ipcMain.handle('desktop:workbench:annotation:show-overlay', async (event, payloa
     return { ok: false, message: error instanceof Error ? error.message : String(error) }
   }
 })
-ipcMain.handle('desktop:workbench:annotation:close-overlay', (event, payload: unknown) => {
+ipcMain.handle('desktop:workbench:annotation:close-overlay', async (event, payload: unknown) => {
   if (!trustedControlUiIpc(event)) throw new Error('Untrusted artifact annotation request.')
   try {
-    return nativeWorkbenchSurfaces.closeArtifactAnnotationOverlay(
+    return await nativeWorkbenchSurfaces.closeArtifactAnnotationOverlay(
       parseNativeWorkbenchAnnotationOverlayCloseRequest(payload),
     )
   } catch (error) {

--- a/desktop/electron/src/native-workbench-annotation-contract.ts
+++ b/desktop/electron/src/native-workbench-annotation-contract.ts
@@ -26,6 +26,7 @@ export interface NativeWorkbenchAnnotationCapabilities {
   picker: boolean
   trustedOverlay: boolean
   overlayCopyVersion?: 1
+  atomicCloseRearm?: true
   reason?: string
 }
 
@@ -60,6 +61,7 @@ export interface NativeWorkbenchAnnotationOverlayCloseRequest {
   version: NativeWorkbenchAnnotationProtocolVersion
   surfaceId: string
   annotationId?: string
+  rearm?: true
 }
 
 export interface NativeWorkbenchAnnotationRect {
@@ -246,9 +248,12 @@ export function parseNativeWorkbenchAnnotationOverlayCloseRequest(
 ): NativeWorkbenchAnnotationOverlayCloseRequest {
   const request = parseExactRequest(
     value,
-    ['version', 'surfaceId', 'annotationId'],
+    ['version', 'surfaceId', 'annotationId', 'rearm'],
     'overlay close',
   )
+  if (request.rearm !== undefined && request.rearm !== true) {
+    throw new Error('The native Workbench annotation overlay close request is invalid.')
+  }
   return {
     version: request.version as NativeWorkbenchAnnotationProtocolVersion,
     surfaceId: parseNativeWorkbenchSurfaceId(request.surfaceId),
@@ -260,6 +265,7 @@ export function parseNativeWorkbenchAnnotationOverlayCloseRequest(
             'annotation',
           ),
         }),
+    ...(request.rearm === true ? { rearm: true as const } : {}),
   }
 }
 

--- a/desktop/electron/src/native-workbench-annotation-contract.ts
+++ b/desktop/electron/src/native-workbench-annotation-contract.ts
@@ -1,4 +1,8 @@
 import {
+  parseDesktopArtifactAnnotationProofV2,
+  type DesktopArtifactAnnotationProofV2,
+} from './desktop-artifact-bridge-contract.js'
+import {
   NATIVE_WORKBENCH_PROTOCOL_VERSION_V3,
   NATIVE_WORKBENCH_PROTOCOL_VERSION_V4,
   parseNativeWorkbenchSurfaceId,
@@ -81,6 +85,7 @@ export interface NativeWorkbenchAnnotationSelection {
 
 export interface NativeWorkbenchAnnotationSelectionCandidate
   extends Omit<NativeWorkbenchAnnotationSelection, 'selectionId'> {
+  annotationProofV2?: DesktopArtifactAnnotationProofV2
   viewportWidth: number
   viewportHeight: number
 }
@@ -305,6 +310,7 @@ export function parseNativeWorkbenchAnnotationSelection(
       'elementPath',
       'domSha256',
       'elementProofSha256',
+      'annotationProofV2',
       'rect',
       'viewportWidth',
       'viewportHeight',
@@ -336,6 +342,13 @@ export function parseNativeWorkbenchAnnotationSelection(
     elementPath: selection.elementPath,
     ...(selection.domSha256 === undefined ? {} : { domSha256: selection.domSha256 }),
     elementProofSha256: selection.elementProofSha256,
+    ...(selection.annotationProofV2 === undefined
+      ? {}
+      : {
+          annotationProofV2: parseDesktopArtifactAnnotationProofV2(
+            selection.annotationProofV2,
+          ),
+        }),
     rect: {
       x: rect.x as number,
       y: rect.y as number,

--- a/desktop/electron/src/native-workbench-surface-contract.ts
+++ b/desktop/electron/src/native-workbench-surface-contract.ts
@@ -225,6 +225,8 @@ export interface NativeWorkbenchSurfaceEvent {
     requestingOrigin?: string
     mediaTypes?: string[]
     action?: string
+    code?: string
+    surfaceInstanceId?: string
     targetUrl?: string
     annotationId?: string
     body?: string

--- a/desktop/electron/src/native-workbench-surface.ts
+++ b/desktop/electron/src/native-workbench-surface.ts
@@ -2771,7 +2771,12 @@ export class NativeWorkbenchSurfaceManager {
       ) return
       candidate.geometryRefreshPending = true
       void this.refreshAnnotationGeometry(record, candidate).catch(() => {
-        void this.cancelAnnotationInteraction(record, 'selection-stale', true)
+        // Closing an editor can release its candidate while this CDP read is
+        // still in flight. Never let that retired read cancel a picker that a
+        // newer close/rearm transaction has already installed.
+        if (record.annotationCandidate === candidate) {
+          void this.cancelAnnotationInteraction(record, 'selection-stale', true)
+        }
       }).finally(() => {
         candidate.geometryRefreshPending = false
       })

--- a/desktop/electron/src/native-workbench-surface.ts
+++ b/desktop/electron/src/native-workbench-surface.ts
@@ -85,6 +85,7 @@ function artifactHtmlCsp(allowRemoteResources: boolean): string {
 
 interface NativeWorkbenchSurfaceRecord {
   id: string
+  surfaceInstanceId: string
   version: NativeWorkbenchCreateRequest['version']
   kind: NativeWorkbenchCreateRequest['kind']
   mode: NativeWorkbenchPreviewMode
@@ -1004,6 +1005,7 @@ export interface NativeWorkbenchSurfaceResult {
   code?: string
   retryable?: boolean
   message?: string
+  surfaceInstanceId?: string
 }
 
 export interface NativeWorkbenchAnnotationLifecycleDiagnostic {
@@ -1329,6 +1331,7 @@ export class NativeWorkbenchSurfaceManager {
     )
     const record: NativeWorkbenchSurfaceRecord = {
       id: request.surfaceId,
+      surfaceInstanceId: randomUUID(),
       version: request.version,
       kind: request.kind,
       mode,
@@ -1454,7 +1457,7 @@ export class NativeWorkbenchSurfaceManager {
       if (record.crashed) {
         return { ok: false, message: 'The native Workbench surface renderer failed.' }
       }
-      return { ok: true }
+      return { ok: true, surfaceInstanceId: record.surfaceInstanceId }
     } catch (error) {
       this.failRecord(record, 'error', { message: errorMessage(error) })
       await this.destroyRecord(record)
@@ -3780,7 +3783,21 @@ export class NativeWorkbenchSurfaceManager {
       // surface generation. A concurrent Stop, navigation, hide, or replace
       // advances the epoch and prevents this recovery from reactivating it.
       const rearmEpoch = ++record.annotationPickerEpoch
-      await this.armAnnotationPicker(record, rearmEpoch, generation, null)
+      const rearmed = await this.armAnnotationPicker(record, rearmEpoch, generation, null)
+      if (
+        !rearmed.ok
+        && this.annotationPickerTransitionIsCurrent(record, rearmEpoch, generation, null)
+      ) {
+        // Do not expose the raw CDP failure. WebUI uses this stable signal to
+        // clear its optimistic armed state and invoke the existing one-shot
+        // bounded recovery instead of leaving a pressed but inert toolbar.
+        this.emit(record, 'blocked-action', {
+          action: 'annotation-picker',
+          code: 'ANNOTATION_REARM_FAILED',
+          reason: 'annotation-picker-rearm-failed',
+          surfaceInstanceId: record.surfaceInstanceId,
+        })
+      }
     } finally {
       if (!retainedObjectGroup) {
         await this.cdpCommand(record, 'Runtime.releaseObjectGroup', { objectGroup })

--- a/desktop/electron/src/native-workbench-surface.ts
+++ b/desktop/electron/src/native-workbench-surface.ts
@@ -1011,7 +1011,7 @@ export interface NativeWorkbenchSurfaceResult {
 }
 
 export interface NativeWorkbenchAnnotationLifecycleDiagnostic {
-  phase: 'close-start' | 'arm-start' | 'armed' | 'cancelled' | 'failed' | 'selection-emitted'
+  phase: 'close-start' | 'arm-start' | 'armed' | 'cancelled' | 'failed' | 'selection-emitted' | 'selection-rejected'
   outcome: 'started' | 'succeeded' | 'cancelled' | 'failed'
   reason: NativeWorkbenchAnnotationLifecycleReason
   elapsedMs: number
@@ -1034,6 +1034,7 @@ type NativeWorkbenchAnnotationLifecycleReason =
   | 'candidate-preview-bound'
   | 'candidate-preview-restored'
   | 'selection-stale'
+  | 'selection-rejected'
   | 'debugger-detached'
   | 'surface-reloaded'
   | 'surface-navigation'
@@ -1054,6 +1055,7 @@ const NATIVE_WORKBENCH_ANNOTATION_LIFECYCLE_REASONS = new Set<string>([
   'candidate-preview-bound',
   'candidate-preview-restored',
   'selection-stale',
+  'selection-rejected',
   'debugger-detached',
   'surface-reloaded',
   'surface-navigation',
@@ -3665,7 +3667,7 @@ export class NativeWorkbenchSurfaceManager {
     backendNodeId: number,
   ): Promise<void> {
     if (!record.annotationPickerActive || !this.isActiveAnnotationRecord(record)) return
-    record.annotationPickerEpoch += 1
+    const pickerEpoch = ++record.annotationPickerEpoch
     record.annotationPickerActive = false
     const generation = record.annotationDocumentGeneration
     // Chromium exits inspect mode as part of dispatching inspectNodeRequested.
@@ -3757,11 +3759,32 @@ export class NativeWorkbenchSurfaceManager {
       )
       this.emit(record, 'annotation-selected', { selection })
     } catch (error) {
+      const selectionIsCurrent = this.annotationPickerTransitionIsCurrent(
+        record,
+        pickerEpoch,
+        generation,
+        null,
+      )
+      if (!selectionIsCurrent) return
       this.clearAnnotationCandidate(record)
+      this.auditAnnotationPicker(
+        record,
+        'selection-rejected',
+        'failed',
+        'selection-rejected',
+      )
       this.emit(record, 'blocked-action', {
         action: 'annotation-picker',
         reason: errorMessage(error).slice(0, 200),
       })
+      // Chromium inspect mode is one-shot: even an unsupported node (for
+      // example a page-wide CSS pseudo-element) consumes searchForNode before
+      // the isolated inspector can reject it. Keep the user's annotation
+      // intent alive by installing a fresh picker, fenced to this exact
+      // surface generation. A concurrent Stop, navigation, hide, or replace
+      // advances the epoch and prevents this recovery from reactivating it.
+      const rearmEpoch = ++record.annotationPickerEpoch
+      await this.armAnnotationPicker(record, rearmEpoch, generation, null)
     } finally {
       if (!retainedObjectGroup) {
         await this.cdpCommand(record, 'Runtime.releaseObjectGroup', { objectGroup })

--- a/desktop/electron/src/native-workbench-surface.ts
+++ b/desktop/electron/src/native-workbench-surface.ts
@@ -50,6 +50,7 @@ import {
   type NativeWorkbenchSurfaceRectRequest,
 } from './native-workbench-surface-contract.js'
 import type {
+  DesktopArtifactAnnotationProofV2,
   DesktopArtifactBrowserActRequest,
   DesktopArtifactBrowserActResult,
   DesktopArtifactBrowserInspectRequest,
@@ -195,6 +196,7 @@ interface NativeWorkbenchBrowserAnchor {
 
 interface NativeWorkbenchAnnotationCandidate {
   selection: NativeWorkbenchAnnotationSelection
+  annotationProofV2?: DesktopArtifactAnnotationProofV2
   viewportWidth: number
   viewportHeight: number
   documentGeneration: number
@@ -202,6 +204,25 @@ interface NativeWorkbenchAnnotationCandidate {
   objectId: string
   geometryTimer: NodeJS.Timeout | null
   geometryRefreshPending: boolean
+}
+
+type AnnotationProofV2MismatchReason =
+  | 'proof-v2-unavailable'
+  | 'stable-proof-mismatch'
+  | 'ancestor-class-token-removed'
+
+function annotationProofV2MismatchReason(
+  expected: DesktopArtifactAnnotationProofV2 | undefined,
+  runtime: DesktopArtifactAnnotationProofV2 | undefined,
+): AnnotationProofV2MismatchReason | null {
+  if (!expected || !runtime) return 'proof-v2-unavailable'
+  if (expected.stableElementProofSha256 !== runtime.stableElementProofSha256) {
+    return 'stable-proof-mismatch'
+  }
+  const runtimeCommitments = new Set(runtime.ancestorClassCommitments)
+  return expected.ancestorClassCommitments.every(commitment => (
+    runtimeCommitments.has(commitment)
+  )) ? null : 'ancestor-class-token-removed'
 }
 
 interface NativeWorkbenchAnnotationOverlayBinding {
@@ -357,6 +378,8 @@ const NATIVE_WORKBENCH_ANNOTATION_INSPECT_FUNCTION = `function () {
   }
   const segments = []
   const proofTokens = []
+  const stableProofTokens = []
+  const ancestorClassTokens = []
   let current = selected
   while (current) {
     if (segments.length >= 128) return { ok: false, reason: 'path-too-deep' }
@@ -376,6 +399,20 @@ const NATIVE_WORKBENCH_ANNOTATION_INSPECT_FUNCTION = `function () {
       attribute.value,
     ]).sort(compareJsonKeysByCodePoint)
     proofTokens.unshift([namespace, tagName, index, attributes])
+    if (current === selected) {
+      stableProofTokens.unshift([namespace, tagName, index, attributes])
+    } else {
+      stableProofTokens.unshift([
+        namespace,
+        tagName,
+        index,
+        attributes.filter(attribute => !(attribute[0] === '' && attribute[1] === 'class')),
+      ])
+      const tokens = attributes
+        .filter(attribute => attribute[0] === '' && attribute[1] === 'class')
+        .flatMap(attribute => attribute[2].split(/[\\t\\n\\f\\r ]+/).filter(Boolean))
+      ancestorClassTokens.unshift(Array.from(new Set(tokens)))
+    }
     current = current.parentElement
   }
   const elementPath = JSON.stringify(segments)
@@ -388,26 +425,69 @@ const NATIVE_WORKBENCH_ANNOTATION_INSPECT_FUNCTION = `function () {
   if (proofEncoded.byteLength > 4194304) {
     return { ok: false, reason: 'element-proof-too-large' }
   }
+  const stableProofEncoded = new TextEncoder().encode(
+    stableProofTokens.map(token => JSON.stringify(token)).join('\\n'),
+  )
+  let proofV2Available = true
+  let ancestorClassTokenBytes = 0
+  let ancestorClassTokenCount = 0
+  const ancestorClassCommitmentInputs = []
+  for (let depth = 0; depth < ancestorClassTokens.length; depth += 1) {
+    for (const token of ancestorClassTokens[depth]) {
+      ancestorClassTokenCount += 1
+      ancestorClassTokenBytes += new TextEncoder().encode(token).byteLength
+      ancestorClassCommitmentInputs.push([depth, token])
+    }
+  }
+  if (ancestorClassTokenCount > 256 || ancestorClassTokenBytes > 65536) {
+    proofV2Available = false
+  }
 
   const rect = selected.getBoundingClientRect()
   const viewport = window.visualViewport
-  return crypto.subtle.digest('SHA-256', proofEncoded).then(elementProofBuffer => ({
-    ok: true,
-    tagName: (selected.localName || selected.tagName || '').toLowerCase(),
-    elementPath,
-    elementProofSha256: Array.from(
-      new Uint8Array(elementProofBuffer),
-      byte => byte.toString(16).padStart(2, '0'),
-    ).join(''),
-    rect: {
-      x: rect.x,
-      y: rect.y,
-      width: rect.width,
-      height: rect.height,
-    },
-    viewportWidth: viewport ? viewport.width : window.innerWidth,
-    viewportHeight: viewport ? viewport.height : window.innerHeight,
-  }))
+  const toHex = buffer => Array.from(
+    new Uint8Array(buffer),
+    byte => byte.toString(16).padStart(2, '0'),
+  ).join('')
+  return Promise.all([
+    crypto.subtle.digest('SHA-256', proofEncoded),
+    crypto.subtle.digest('SHA-256', stableProofEncoded),
+  ]).then(async ([elementProofBuffer, stableElementProofBuffer]) => {
+    const stableElementProofSha256 = toHex(stableElementProofBuffer)
+    let annotationProofV2
+    if (proofV2Available) {
+      const commitmentBuffers = await Promise.all(
+        ancestorClassCommitmentInputs.map(([depth, token]) => crypto.subtle.digest(
+          'SHA-256',
+          new TextEncoder().encode(JSON.stringify([
+            'opensquilla.annotation.ancestor-class.v2',
+            stableElementProofSha256,
+            depth,
+            token,
+          ])),
+        )),
+      )
+      annotationProofV2 = {
+        stableElementProofSha256,
+        ancestorClassCommitments: Array.from(new Set(commitmentBuffers.map(toHex))).sort(),
+      }
+    }
+    return {
+      ok: true,
+      tagName: (selected.localName || selected.tagName || '').toLowerCase(),
+      elementPath,
+      elementProofSha256: toHex(elementProofBuffer),
+      ...(annotationProofV2 ? { annotationProofV2 } : {}),
+      rect: {
+        x: rect.x,
+        y: rect.y,
+        width: rect.width,
+        height: rect.height,
+      },
+      viewportWidth: viewport ? viewport.width : window.innerWidth,
+      viewportHeight: viewport ? viewport.height : window.innerHeight,
+    }
+  })
 }`
 
 // Geometry refresh deliberately avoids re-running the element proof. The full
@@ -1654,6 +1734,7 @@ export class NativeWorkbenchSurfaceManager {
         : NATIVE_WORKBENCH_PROTOCOL_VERSION_V4,
       isCurrent: () => this.isActiveArtifactBridgeRecord(record),
       capabilities: {
+        annotationProofV2: true,
         captureSelection: false,
         resolveAnnotationSelection: (
           record.kind === 'artifact-preview'
@@ -1766,6 +1847,9 @@ export class NativeWorkbenchSurfaceManager {
           elementPath: candidate.selection.elementPath,
           ...(request.domSha256 === undefined ? {} : { domSha256: request.domSha256 }),
           elementProofSha256: candidate.selection.elementProofSha256,
+          ...(candidate.annotationProofV2 === undefined
+            ? {}
+            : { annotationProofV2: candidate.annotationProofV2 }),
           scopeId: record.scopeId,
           rect: { ...candidate.selection.rect },
         }
@@ -2599,11 +2683,25 @@ export class NativeWorkbenchSurfaceManager {
         throw new Error('The selected preview element is no longer editable.')
       }
       const current = parseNativeWorkbenchAnnotationSelection(raw)
-      if (
-        current.tagName !== candidate.selection.tagName
-        || current.elementPath !== candidate.selection.elementPath
-        || current.elementProofSha256 !== candidate.selection.elementProofSha256
-      ) throw new Error('The preview DOM changed after the element was selected.')
+      const strictProofMatches = (
+        current.elementProofSha256 === candidate.selection.elementProofSha256
+      )
+      if (current.tagName !== candidate.selection.tagName) {
+        throw new Error('The preview DOM changed after selection (tag-mismatch).')
+      }
+      if (current.elementPath !== candidate.selection.elementPath) {
+        throw new Error('The preview DOM changed after selection (path-mismatch).')
+      }
+      if (!strictProofMatches) {
+        const mismatchReason = annotationProofV2MismatchReason(
+          candidate.annotationProofV2,
+          current.annotationProofV2,
+        )
+        if (mismatchReason) {
+          throw new Error(`The preview DOM changed after selection (${mismatchReason}).`)
+        }
+      }
+      candidate.annotationProofV2 = current.annotationProofV2
       this.applyAnnotationGeometry(record, candidate, current)
     } catch (error) {
       if (record.annotationCandidate === candidate) this.clearAnnotationCandidate(record)
@@ -3111,11 +3209,26 @@ export class NativeWorkbenchSurfaceManager {
         throw new Error('The annotation element could not be inspected safely.')
       }
       const selection = parseNativeWorkbenchAnnotationSelection(inspected.result?.value)
-      if (
-        selection.tagName !== request.tagName
-        || selection.elementPath !== request.elementPath
-        || selection.elementProofSha256 !== request.elementProofSha256
-      ) throw new Error('The preview DOM no longer matches the annotation anchor.')
+      const strictProofMatches = (
+        selection.elementProofSha256 === request.elementProofSha256
+      )
+      if (selection.tagName !== request.tagName) {
+        throw new Error('The preview DOM no longer matches the annotation anchor (tag-mismatch).')
+      }
+      if (selection.elementPath !== request.elementPath) {
+        throw new Error('The preview DOM no longer matches the annotation anchor (path-mismatch).')
+      }
+      if (!strictProofMatches) {
+        const mismatchReason = annotationProofV2MismatchReason(
+          request.annotationProofV2,
+          selection.annotationProofV2,
+        )
+        if (mismatchReason) {
+          throw new Error(
+            `The preview DOM no longer matches the annotation anchor (${mismatchReason}).`,
+          )
+        }
+      }
       const described = await this.cdpCommand(record, 'DOM.describeNode', {
         objectId: selectedObjectId,
       }) as { node?: { backendNodeId?: unknown } }
@@ -3336,6 +3449,9 @@ export class NativeWorkbenchSurfaceManager {
       }
       record.annotationCandidate = {
         selection,
+        ...(candidate.annotationProofV2 === undefined
+          ? {}
+          : { annotationProofV2: candidate.annotationProofV2 }),
         viewportWidth: candidate.viewportWidth,
         viewportHeight: candidate.viewportHeight,
         documentGeneration: generation,

--- a/desktop/electron/src/native-workbench-surface.ts
+++ b/desktop/electron/src/native-workbench-surface.ts
@@ -400,20 +400,16 @@ const NATIVE_WORKBENCH_ANNOTATION_INSPECT_FUNCTION = `function () {
       attribute.value,
     ]).sort(compareJsonKeysByCodePoint)
     proofTokens.unshift([namespace, tagName, index, attributes])
-    if (current === selected) {
-      stableProofTokens.unshift([namespace, tagName, index, attributes])
-    } else {
-      stableProofTokens.unshift([
-        namespace,
-        tagName,
-        index,
-        attributes.filter(attribute => !(attribute[0] === '' && attribute[1] === 'class')),
-      ])
-      const tokens = attributes
-        .filter(attribute => attribute[0] === '' && attribute[1] === 'class')
-        .flatMap(attribute => attribute[2].split(/[\\t\\n\\f\\r ]+/).filter(Boolean))
-      ancestorClassTokens.unshift(Array.from(new Set(tokens)))
-    }
+    stableProofTokens.unshift([
+      namespace,
+      tagName,
+      index,
+      attributes.filter(attribute => !(attribute[0] === '' && attribute[1] === 'class')),
+    ])
+    const tokens = attributes
+      .filter(attribute => attribute[0] === '' && attribute[1] === 'class')
+      .flatMap(attribute => attribute[2].split(/[\\t\\n\\f\\r ]+/).filter(Boolean))
+    ancestorClassTokens.unshift(Array.from(new Set(tokens)))
     current = current.parentElement
   }
   const elementPath = JSON.stringify(segments)

--- a/desktop/electron/src/native-workbench-surface.ts
+++ b/desktop/electron/src/native-workbench-surface.ts
@@ -1540,6 +1540,22 @@ export class NativeWorkbenchSurfaceManager {
       }
     }
     this.clearAnnotationCandidate(record)
+    // Chromium normally exits inspect mode before dispatching
+    // Overlay.inspectNodeRequested, but that transition is not a reliable
+    // re-arm boundary on Windows. A later searchForNode command can resolve
+    // successfully while ordinary page clicks still pass through to the
+    // document. Make every enable an idempotent clean-arm transaction so the
+    // UI never advertises an active picker that Chromium did not install.
+    record.annotationPickerActive = false
+    const resetFailure = await this.clearAnnotationInspectState(record, true)
+    if (resetFailure) {
+      return {
+        ok: false,
+        code: 'ANNOTATION_UNAVAILABLE',
+        retryable: true,
+        message: resetFailure,
+      }
+    }
     record.annotationPickerActive = true
     try {
       await this.cdpCommand(record, 'Overlay.setInspectMode', {

--- a/desktop/electron/src/native-workbench-surface.ts
+++ b/desktop/electron/src/native-workbench-surface.ts
@@ -129,6 +129,7 @@ interface NativeWorkbenchSurfaceRecord {
   annotationFallbackActive: boolean
   annotationFocusTimer: NodeJS.Timeout | null
   annotationPickerActive: boolean
+  annotationPickerEpoch: number
   /** True only after the current v4 preview navigation reaches did-finish-load. */
   browserDocumentReady: boolean
   /** Set by CDP Runtime.exceptionThrown until the next successful navigation. */
@@ -1009,7 +1010,70 @@ export interface NativeWorkbenchSurfaceResult {
   message?: string
 }
 
+export interface NativeWorkbenchAnnotationLifecycleDiagnostic {
+  phase: 'close-start' | 'arm-start' | 'armed' | 'cancelled' | 'failed' | 'selection-emitted'
+  outcome: 'started' | 'succeeded' | 'cancelled' | 'failed'
+  reason: NativeWorkbenchAnnotationLifecycleReason
+  elapsedMs: number
+  pickerEpoch: number
+  generation: number
+  webContentsId: number
+  current: boolean
+  visible: boolean
+  cdpReady: boolean
+}
+
+type NativeWorkbenchAnnotationLifecycleReason =
+  | 'requested'
+  | 'completed'
+  | 'superseded'
+  | 'reset-failed'
+  | 'activate-failed'
+  | 'preview-hide-failed'
+  | 'picker-cancelled'
+  | 'candidate-preview-bound'
+  | 'candidate-preview-restored'
+  | 'selection-stale'
+  | 'debugger-detached'
+  | 'surface-reloaded'
+  | 'surface-navigation'
+  | 'surface-redirect'
+  | 'surface-hidden'
+  | 'surface-closed'
+  | 'surface-failed'
+  | 'lifecycle-cancelled'
+
+const NATIVE_WORKBENCH_ANNOTATION_LIFECYCLE_REASONS = new Set<string>([
+  'requested',
+  'completed',
+  'superseded',
+  'reset-failed',
+  'activate-failed',
+  'preview-hide-failed',
+  'picker-cancelled',
+  'candidate-preview-bound',
+  'candidate-preview-restored',
+  'selection-stale',
+  'debugger-detached',
+  'surface-reloaded',
+  'surface-navigation',
+  'surface-redirect',
+  'surface-hidden',
+  'surface-closed',
+  'surface-failed',
+  'lifecycle-cancelled',
+])
+
+function nativeWorkbenchAnnotationLifecycleReason(
+  reason: string,
+): NativeWorkbenchAnnotationLifecycleReason {
+  return NATIVE_WORKBENCH_ANNOTATION_LIFECYCLE_REASONS.has(reason)
+    ? reason as NativeWorkbenchAnnotationLifecycleReason
+    : 'lifecycle-cancelled'
+}
+
 export interface NativeWorkbenchSurfaceManagerOptions {
+  annotationAudit?(entry: NativeWorkbenchAnnotationLifecycleDiagnostic): void
   authenticationTimeoutMs?: number
   getPrivilegedGatewayUrl?(): string | null
   getWindow(): BrowserWindow | null
@@ -1204,7 +1268,14 @@ export class NativeWorkbenchSurfaceManager {
     activePreviewArtifactId: string | null = null,
   ): Promise<NativeWorkbenchSurfaceResult> {
     const pending = this.surfaces.get(request.surfaceId)
-    if (pending) this.cancelPendingAuthentication(pending)
+    if (pending) {
+      // Fence an in-flight atomic picker arm before waiting behind any queued
+      // surface work. The eventual destroy still performs authoritative CDP
+      // cleanup; this synchronous epoch bump only prevents a late arm result
+      // from becoming current during replacement.
+      pending.annotationPickerEpoch += 1
+      this.cancelPendingAuthentication(pending)
+    }
     return await this.queueSurfaceOperation(
       request.surfaceId,
       () => this.createSurfaceNow(request, activePreviewArtifactId),
@@ -1326,6 +1397,7 @@ export class NativeWorkbenchSurfaceManager {
       annotationFallbackActive: false,
       annotationFocusTimer: null,
       annotationPickerActive: false,
+      annotationPickerEpoch: 0,
       browserDocumentReady: false,
       browserRuntimeException: false,
       offlineRealmGuardInstalled: false,
@@ -1445,6 +1517,7 @@ export class NativeWorkbenchSurfaceManager {
         picker: false,
         trustedOverlay: false,
         overlayCopyVersion: 1,
+        atomicCloseRearm: true,
         reason: 'No active protocol-v4 HTML artifact preview is available.',
       }
     }
@@ -1455,6 +1528,7 @@ export class NativeWorkbenchSurfaceManager {
         picker: false,
         trustedOverlay: false,
         overlayCopyVersion: 1,
+        atomicCloseRearm: true,
         reason: 'The isolated DOM inspector is unavailable.',
       }
     }
@@ -1473,6 +1547,7 @@ export class NativeWorkbenchSurfaceManager {
         picker: true,
         trustedOverlay: false,
         overlayCopyVersion: 1,
+        atomicCloseRearm: true,
         reason: 'The trusted annotation editor is unavailable.',
       }
     }
@@ -1482,6 +1557,143 @@ export class NativeWorkbenchSurfaceManager {
       picker: true,
       trustedOverlay: true,
       overlayCopyVersion: 1,
+      atomicCloseRearm: true,
+    }
+  }
+
+  private annotationPickerTransitionIsCurrent(
+    record: NativeWorkbenchSurfaceRecord,
+    pickerEpoch: number,
+    documentGeneration: number,
+    binding: NativeWorkbenchAnnotationOverlayBinding | null,
+  ): boolean {
+    if (
+      record.annotationPickerEpoch !== pickerEpoch
+      || record.annotationDocumentGeneration !== documentGeneration
+      || this.surfaces.get(record.id) !== record
+      || this.activeSurfaceId !== record.id
+      || record.kind !== 'artifact-preview'
+      || record.activePreviewArtifactId === null
+      || record.disposed
+      || record.crashed
+      || !record.visibleRequested
+      || !record.rect
+      || record.owner.isDestroyed()
+      || !this.ownerCanShowSurfaces(record.owner)
+      || record.view.webContents.isDestroyed()
+      || !record.cdpReady
+      || !record.view.webContents.debugger.isAttached()
+    ) return false
+    return binding === null || this.activeAnnotationOverlayBinding(record) === binding
+  }
+
+  private auditAnnotationPicker(
+    record: NativeWorkbenchSurfaceRecord,
+    phase: NativeWorkbenchAnnotationLifecycleDiagnostic['phase'],
+    outcome: NativeWorkbenchAnnotationLifecycleDiagnostic['outcome'],
+    reason: string,
+    startedAt = Date.now(),
+  ): void {
+    try {
+      this.options.annotationAudit?.({
+        phase,
+        outcome,
+        reason: nativeWorkbenchAnnotationLifecycleReason(reason),
+        elapsedMs: Math.max(0, Date.now() - startedAt),
+        pickerEpoch: record.annotationPickerEpoch,
+        generation: record.annotationDocumentGeneration,
+        webContentsId: record.view.webContents.id,
+        current: this.surfaces.get(record.id) === record && !record.disposed && !record.crashed,
+        visible: record.view.getVisible(),
+        cdpReady: record.cdpReady && record.view.webContents.debugger.isAttached(),
+      })
+    } catch {
+      // Diagnostics must never change picker lifecycle semantics.
+    }
+  }
+
+  private async armAnnotationPicker(
+    record: NativeWorkbenchSurfaceRecord,
+    pickerEpoch: number,
+    documentGeneration: number,
+    binding: NativeWorkbenchAnnotationOverlayBinding | null,
+  ): Promise<NativeWorkbenchSurfaceResult> {
+    const startedAt = Date.now()
+    this.auditAnnotationPicker(record, 'arm-start', 'started', 'requested', startedAt)
+    record.annotationPickerActive = false
+    const resetFailure = await this.clearAnnotationInspectState(record, true)
+    if (!this.annotationPickerTransitionIsCurrent(
+      record,
+      pickerEpoch,
+      documentGeneration,
+      binding,
+    )) {
+      this.auditAnnotationPicker(record, 'cancelled', 'cancelled', 'superseded', startedAt)
+      return {
+        ok: false,
+        code: 'ANNOTATION_UNAVAILABLE',
+        retryable: true,
+        message: 'The annotation picker was cancelled before it became active.',
+      }
+    }
+    if (resetFailure) {
+      this.auditAnnotationPicker(record, 'failed', 'failed', 'reset-failed', startedAt)
+      return {
+        ok: false,
+        code: 'ANNOTATION_UNAVAILABLE',
+        retryable: true,
+        message: resetFailure,
+      }
+    }
+    record.annotationPickerActive = true
+    try {
+      await this.cdpCommand(record, 'Overlay.setInspectMode', {
+        mode: 'searchForNode',
+        highlightConfig: NATIVE_WORKBENCH_ANNOTATION_HIGHLIGHT_CONFIG,
+      })
+      const transitionCurrent = this.annotationPickerTransitionIsCurrent(
+        record,
+        pickerEpoch,
+        documentGeneration,
+        binding,
+      )
+      if (
+        !record.annotationPickerActive
+        || !transitionCurrent
+      ) {
+        // A postcondition failure on this exact epoch means Chromium may have
+        // accepted searchForNode while the manager cannot advertise it as
+        // armed. Roll that inspect mode back. A superseded epoch must not run
+        // this cleanup because it could disable the replacement picker.
+        if (transitionCurrent && record.annotationPickerEpoch === pickerEpoch) {
+          await this.clearAnnotationInspectState(record, true)
+        }
+        this.auditAnnotationPicker(record, 'cancelled', 'cancelled', 'superseded', startedAt)
+        return {
+          ok: false,
+          code: 'ANNOTATION_UNAVAILABLE',
+          retryable: true,
+          message: 'The annotation picker was cancelled before it became active.',
+        }
+      }
+      this.auditAnnotationPicker(record, 'armed', 'succeeded', 'completed', startedAt)
+      return { ok: true }
+    } catch (error) {
+      if (record.annotationPickerEpoch === pickerEpoch) {
+        record.annotationPickerActive = false
+      }
+      const cleanupFailure = record.annotationPickerEpoch === pickerEpoch
+        ? await this.clearAnnotationInspectState(record, true)
+        : null
+      this.auditAnnotationPicker(record, 'failed', 'failed', 'activate-failed', startedAt)
+      return {
+        ok: false,
+        code: 'ANNOTATION_UNAVAILABLE',
+        retryable: true,
+        message: cleanupFailure
+          ? `${errorMessage(error)} ${cleanupFailure}`
+          : errorMessage(error),
+      }
     }
   }
 
@@ -1546,38 +1758,13 @@ export class NativeWorkbenchSurfaceManager {
     // successfully while ordinary page clicks still pass through to the
     // document. Make every enable an idempotent clean-arm transaction so the
     // UI never advertises an active picker that Chromium did not install.
-    record.annotationPickerActive = false
-    const resetFailure = await this.clearAnnotationInspectState(record, true)
-    if (resetFailure) {
-      return {
-        ok: false,
-        code: 'ANNOTATION_UNAVAILABLE',
-        retryable: true,
-        message: resetFailure,
-      }
-    }
-    record.annotationPickerActive = true
-    try {
-      await this.cdpCommand(record, 'Overlay.setInspectMode', {
-        mode: 'searchForNode',
-        highlightConfig: NATIVE_WORKBENCH_ANNOTATION_HIGHLIGHT_CONFIG,
-      })
-      if (!this.isActiveAnnotationRecord(record) || !record.annotationPickerActive) {
-        throw new Error('The annotation picker was cancelled before it became active.')
-      }
-      return { ok: true }
-    } catch (error) {
-      record.annotationPickerActive = false
-      const cleanupFailure = await this.clearAnnotationInspectState(record, true)
-      return {
-        ok: false,
-        code: 'ANNOTATION_UNAVAILABLE',
-        retryable: true,
-        message: cleanupFailure
-          ? `${errorMessage(error)} ${cleanupFailure}`
-          : errorMessage(error),
-      }
-    }
+    const pickerEpoch = ++record.annotationPickerEpoch
+    return await this.armAnnotationPicker(
+      record,
+      pickerEpoch,
+      record.annotationDocumentGeneration,
+      null,
+    )
   }
 
   async showArtifactAnnotationOverlay(
@@ -1678,9 +1865,9 @@ export class NativeWorkbenchSurfaceManager {
     }
   }
 
-  closeArtifactAnnotationOverlay(
+  async closeArtifactAnnotationOverlay(
     request: NativeWorkbenchAnnotationOverlayCloseRequest,
-  ): NativeWorkbenchSurfaceResult {
+  ): Promise<NativeWorkbenchSurfaceResult> {
     const record = this.surfaces.get(request.surfaceId)
     if (!record || record.disposed) {
       return {
@@ -1703,6 +1890,85 @@ export class NativeWorkbenchSurfaceManager {
         retryable: true,
         message: 'The trusted annotation editor changed.',
       }
+    }
+    if (request.rearm === true) {
+      const candidate = record.annotationCandidate
+      if (
+        !overlay
+        || !binding
+        || !candidate
+        || binding.record !== record
+        || candidate.documentGeneration !== record.annotationDocumentGeneration
+        || !record.cdpReady
+        || !record.view.webContents.debugger.isAttached()
+        || this.activeSurfaceId !== record.id
+        || !record.visibleRequested
+        || !record.rect
+      ) {
+        return {
+          ok: false,
+          code: 'ANNOTATION_UNAVAILABLE',
+          retryable: true,
+          message: 'The trusted annotation editor cannot rearm the picker.',
+        }
+      }
+      const startedAt = Date.now()
+      const documentGeneration = record.annotationDocumentGeneration
+      const pickerEpoch = ++record.annotationPickerEpoch
+      this.auditAnnotationPicker(record, 'close-start', 'started', 'requested', startedAt)
+      this.stopAnnotationGeometryWatcher(candidate)
+      try {
+        record.view.webContents.setAudioMuted(true)
+        record.view.setVisible(false)
+        overlay.view.setVisible(this.ownerCanShowSurfaces(record.owner))
+      } catch {
+        this.startAnnotationGeometryWatcher(record, candidate)
+        this.auditAnnotationPicker(record, 'failed', 'failed', 'preview-hide-failed', startedAt)
+        return {
+          ok: false,
+          code: 'ANNOTATION_UNAVAILABLE',
+          retryable: true,
+          message: 'The preview could not enter the annotation handoff state.',
+        }
+      }
+      const armed = await this.armAnnotationPicker(
+        record,
+        pickerEpoch,
+        documentGeneration,
+        binding,
+      )
+      if (!armed.ok) {
+        if (
+          this.surfaces.get(record.id) === record
+          && !record.disposed
+          && !record.crashed
+          && this.activeAnnotationOverlayBinding(record) === binding
+          && record.annotationCandidate === candidate
+        ) {
+          this.setPhysicalVisibility(record, this.ownerCanShowSurfaces(record.owner))
+          this.startAnnotationGeometryWatcher(record, candidate)
+        }
+        return armed
+      }
+      if (!this.annotationPickerTransitionIsCurrent(
+        record,
+        pickerEpoch,
+        documentGeneration,
+        binding,
+      )) {
+        this.auditAnnotationPicker(record, 'cancelled', 'cancelled', 'superseded', startedAt)
+        return {
+          ok: false,
+          code: 'ANNOTATION_UNAVAILABLE',
+          retryable: true,
+          message: 'The annotation picker handoff was superseded.',
+        }
+      }
+      this.closeAnnotationOverlayBinding(overlay, false)
+      record.annotationFallbackActive = false
+      this.clearAnnotationCandidate(record)
+      this.setPhysicalVisibility(record, this.ownerCanShowSurfaces(record.owner))
+      return { ok: true }
     }
     if (overlay) this.closeAnnotationOverlayBinding(overlay, false)
     record.annotationFallbackActive = false
@@ -3399,6 +3665,7 @@ export class NativeWorkbenchSurfaceManager {
     backendNodeId: number,
   ): Promise<void> {
     if (!record.annotationPickerActive || !this.isActiveAnnotationRecord(record)) return
+    record.annotationPickerEpoch += 1
     record.annotationPickerActive = false
     const generation = record.annotationDocumentGeneration
     // Chromium exits inspect mode as part of dispatching inspectNodeRequested.
@@ -3482,6 +3749,12 @@ export class NativeWorkbenchSurfaceManager {
         geometryRefreshPending: false,
       }
       retainedObjectGroup = true
+      this.auditAnnotationPicker(
+        record,
+        'selection-emitted',
+        'succeeded',
+        'completed',
+      )
       this.emit(record, 'annotation-selected', { selection })
     } catch (error) {
       this.clearAnnotationCandidate(record)
@@ -3505,6 +3778,8 @@ export class NativeWorkbenchSurfaceManager {
     // Fence delayed focus cleanup synchronously. Navigation and destruction
     // intentionally do not wait for this async routine before tearing down the
     // child renderer, so a prior timer must not outlive the surface generation.
+    const startedAt = Date.now()
+    record.annotationPickerEpoch += 1
     const inspectModeMayBeActive = record.annotationPickerActive
     if (record.annotationFocusTimer) clearTimeout(record.annotationFocusTimer)
     record.annotationFocusTimer = null
@@ -3533,6 +3808,13 @@ export class NativeWorkbenchSurfaceManager {
       && !record.view.webContents.isDestroyed()
       && record.view.webContents.debugger.isAttached()
     ) record.annotationPickerActive = true
+    this.auditAnnotationPicker(
+      record,
+      cleanupFailure ? 'failed' : 'cancelled',
+      cleanupFailure ? 'failed' : 'cancelled',
+      cleanupFailure ? 'reset-failed' : reason,
+      startedAt,
+    )
     return cleanupFailure
   }
 
@@ -3998,7 +4280,13 @@ export class NativeWorkbenchSurfaceManager {
 
   async destroySurface(surfaceId: string): Promise<NativeWorkbenchSurfaceResult> {
     const pending = this.surfaces.get(surfaceId)
-    if (pending) this.cancelPendingAuthentication(pending)
+    if (pending) {
+      // destroyAll and ordinary close share this queue-external fence so a
+      // blocked searchForNode cannot complete successfully while disposal is
+      // waiting for earlier work on the same surface.
+      pending.annotationPickerEpoch += 1
+      this.cancelPendingAuthentication(pending)
+    }
     return await this.queueSurfaceOperation(
       surfaceId,
       () => this.destroySurfaceNow(surfaceId),

--- a/opensquilla-webui/src/components/workbench/AppWorkbench.annotationStatus.test.ts
+++ b/opensquilla-webui/src/components/workbench/AppWorkbench.annotationStatus.test.ts
@@ -30,6 +30,19 @@ describe('AppWorkbench annotation mode status', () => {
     expect(appWorkbenchSource).toContain("? 'workbench-annotation-mode-status'")
   })
 
+  it('marks the annotation action as beta without changing its accessible label', () => {
+    expect(appWorkbenchSource).toContain(
+      "v-if=\"toolbarItem.id === 'toggle-annotation-mode'\"",
+    )
+    expect(appWorkbenchSource).toContain('class="app-workbench__action-beta"')
+    expect(appWorkbenchSource).toMatch(
+      /app-workbench__action-beta[\s\S]*aria-hidden="true"[\s\S]*>\s*β\s*<\/span>/,
+    )
+    expect(appWorkbenchSource).toMatch(
+      /\.app-workbench__action-beta\s*\{[\s\S]*font-size: 7px;[\s\S]*opacity: 0\.58;/,
+    )
+  })
+
   it('uses the workbench container width and preserves fixed-size toolbar actions', () => {
     expect(appWorkbenchSource).toContain('@container (max-width: 520px)')
     expect(appWorkbenchSource).toMatch(

--- a/opensquilla-webui/src/components/workbench/AppWorkbench.vue
+++ b/opensquilla-webui/src/components/workbench/AppWorkbench.vue
@@ -128,6 +128,13 @@
           @click="performPanelAction(item, toolbarItem.id)"
         >
           <Icon :name="toolbarItem.icon" :size="15" aria-hidden="true" />
+          <span
+            v-if="toolbarItem.id === 'toggle-annotation-mode'"
+            class="app-workbench__action-beta"
+            aria-hidden="true"
+          >
+            β
+          </span>
         </button>
       </template>
     </template>
@@ -1411,6 +1418,7 @@ onBeforeUnmount(() => {
 }
 
 .app-workbench__action {
+  position: relative;
   display: inline-flex;
   width: 30px;
   height: 30px;
@@ -1423,6 +1431,18 @@ onBeforeUnmount(() => {
   background: transparent;
   color: var(--text-dim);
   cursor: pointer;
+}
+
+.app-workbench__action-beta {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  color: currentColor;
+  font-size: 7px;
+  font-weight: 600;
+  line-height: 1;
+  opacity: 0.58;
+  pointer-events: none;
 }
 
 .app-workbench__switcher {

--- a/opensquilla-webui/src/components/workbench/ArtifactDocumentPanel.test.ts
+++ b/opensquilla-webui/src/components/workbench/ArtifactDocumentPanel.test.ts
@@ -529,6 +529,11 @@ describe('ArtifactDocumentPanel', () => {
       type: 'artifact-annotation-fallback-submit',
       payload: { annotationId: 'annotation-1', body: 'Updated draft' },
     })
+    dialog?.querySelector<HTMLButtonElement>('button[type="button"]')?.click()
+    expect(onWorkbenchEvent).toHaveBeenCalledWith({
+      type: 'artifact-annotation-fallback-cancel',
+      payload: { annotationId: 'annotation-1', reason: 'user-cancelled' },
+    })
     mounted.unmount()
   })
 

--- a/opensquilla-webui/src/components/workbench/ArtifactDocumentPanel.vue
+++ b/opensquilla-webui/src/components/workbench/ArtifactDocumentPanel.vue
@@ -438,7 +438,10 @@ function cancelAnnotationFallback() {
   if (!props.annotationFallback) return
   emit('workbench-event', {
     type: 'artifact-annotation-fallback-cancel',
-    payload: { annotationId: props.annotationFallback.annotationId },
+    payload: {
+      annotationId: props.annotationFallback.annotationId,
+      reason: 'user-cancelled',
+    },
   })
 }
 const documentFeatures = computed(() => props.documentFeatures)

--- a/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.test.ts
+++ b/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.test.ts
@@ -3144,8 +3144,11 @@ describe('artifact Workbench provider', () => {
     // A typed, recoverable selection rejection stays visible and actionable;
     // it must not open an editor or silently release the rearmed one-shot mode.
     expect(renderState.annotationMode).toBe(true)
+    const createCountBeforeChangedSelection = createAnnotation.mock.calls.length
+    const rearmCountBeforeChangedSelection = setMode.mock.calls.length
     rejectNextCreate = Object.assign(new Error('selected element changed'), {
-      code: 'ARTIFACT_ELEMENT_CHANGED',
+      code: 'DOCUMENT_CHANGED',
+      accepted: false,
     })
     await runtime.handleNativeSurfaceEvent?.({
       version: 3,
@@ -3162,6 +3165,7 @@ describe('artifact Workbench provider', () => {
         },
       },
     }, item)
+    expect(createAnnotation).toHaveBeenCalledTimes(createCountBeforeChangedSelection + 1)
     expect(showOverlay).toHaveBeenCalledOnce()
     expect(renderState.annotationFallback).toBeNull()
     expect(renderState.annotationMode).toBe(true)
@@ -3169,6 +3173,11 @@ describe('artifact Workbench provider', () => {
       'workbench.artifactAnnotation.elementChanged',
       { tone: 'warn', duration: 12_000 },
     )
+    expect(pushToast).not.toHaveBeenCalledWith(
+      'workbench.artifactAnnotation.createFailed',
+      expect.anything(),
+    )
+    expect(setMode).toHaveBeenCalledTimes(rearmCountBeforeChangedSelection + 1)
     expect(setMode.mock.calls.map(([request]) => request.enabled)).toEqual([
       true,
       false,
@@ -3178,6 +3187,7 @@ describe('artifact Workbench provider', () => {
 
     // The recovered picker accepts a local proof after unrelated runtime DOM
     // changes, without a whole-DOM hash or an extra toolbar toggle.
+    const rearmCountBeforeRecoveredSelection = setMode.mock.calls.length
     await runtime.handleNativeSurfaceEvent?.({
       version: 3,
       surfaceId: item.id,
@@ -3202,6 +3212,7 @@ describe('artifact Workbench provider', () => {
       },
     }))
     expect(showOverlay).toHaveBeenCalledTimes(2)
+    expect(setMode).toHaveBeenCalledTimes(rearmCountBeforeRecoveredSelection)
 
     // If the scoped surface disappears while closing the trusted editor, the
     // persisted draft remains valid. Acknowledge the vanished overlay, rebuild

--- a/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.test.ts
+++ b/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.test.ts
@@ -155,7 +155,12 @@ async function createAnnotationDraftHarness(
   const setSurfaceRect = vi.fn(async () => ({ ok: true as const }))
   const setAnnotationMode = vi.fn(async (
     _request: Parameters<NonNullable<NativeWorkbenchApi['setArtifactAnnotationMode']>>[0],
-  ) => ({ ok: true as const }))
+  ): Promise<NativeWorkbenchSurfaceResult> => ({ ok: true }))
+  const createSurface = vi.fn(async (): Promise<NativeWorkbenchSurfaceResult> => ({
+    ok: true,
+    surfaceInstanceId: 'surface-instance-current',
+  }))
+  const destroySurface = vi.fn(async (): Promise<NativeWorkbenchSurfaceResult> => ({ ok: true }))
   const pushToast = vi.fn()
   const lease = {
     version: 1 as const,
@@ -216,10 +221,10 @@ async function createAnnotationDraftHarness(
       status: 204,
       payload: undefined,
     })),
-    createSurface: vi.fn(async () => ({ ok: true as const })),
+    createSurface,
     setSurfaceRect,
     activateSurface: vi.fn(async () => ({ ok: true as const })),
-    destroySurface: vi.fn(async () => ({ ok: true as const })),
+    destroySurface,
     onSurfaceEvent: vi.fn(() => () => undefined),
   }
   const renderState: Record<string, unknown> = {}
@@ -310,8 +315,10 @@ async function createAnnotationDraftHarness(
     beginOverlayEdit,
     closeOverlay,
     completeOverlayEdit,
+    createSurface,
     createAnnotation,
     discardAnnotation,
+    destroySurface,
     item,
     pushToast,
     releaseOverlayEdit,
@@ -553,6 +560,231 @@ describe('artifact Workbench provider', () => {
     expect(harness.showOverlay).toHaveBeenCalledTimes(2)
   })
 
+  it.each([
+    {
+      name: 'submit',
+      event: (annotationId: string) => ({
+        version: 3 as const,
+        surfaceId: 'artifact:artifact-1',
+        type: 'annotation-submit' as const,
+        detail: { annotationId, body: 'Recover the expired atomic handoff.' },
+      }),
+    },
+    {
+      name: 'cancel',
+      event: (annotationId: string) => ({
+        version: 3 as const,
+        surfaceId: 'artifact:artifact-1',
+        type: 'annotation-cancel' as const,
+        detail: { annotationId, reason: 'user-cancelled' },
+      }),
+    },
+  ])('rearms through the bounded path when atomic $name finds an expired surface', async ({
+    name,
+    event,
+  }) => {
+    const harness = await createAnnotationDraftHarness({ ok: true }, true)
+    const setModeCallsBeforeClose = harness.setAnnotationMode.mock.calls.length
+    const createCallsBeforeClose = harness.createSurface.mock.calls.length
+    harness.closeOverlay.mockResolvedValueOnce({
+      ok: false,
+      code: 'PREVIEW_CAPABILITY_EXPIRED',
+      retryable: true,
+    })
+    harness.setAnnotationMode
+      .mockResolvedValueOnce({
+        ok: false,
+        code: 'PREVIEW_CAPABILITY_EXPIRED',
+        retryable: true,
+      })
+      .mockResolvedValueOnce({ ok: true })
+
+    await harness.runtime.handleNativeSurfaceEvent?.(
+      event(harness.annotationId),
+      harness.item,
+    )
+
+    expect(harness.releaseOverlayEdit).toHaveBeenCalledOnce()
+    const recoveryModeCalls = harness.setAnnotationMode.mock.calls
+      .slice(setModeCallsBeforeClose)
+      .map(([request]) => request.enabled)
+    expect(recoveryModeCalls[0]).toBe(true)
+    expect(recoveryModeCalls).toContain(false)
+    expect(recoveryModeCalls[recoveryModeCalls.length - 1]).toBe(true)
+    expect(harness.createSurface).toHaveBeenCalledTimes(createCallsBeforeClose + 1)
+    expect(harness.pushToast).not.toHaveBeenCalledWith(
+      'workbench.artifactAnnotation.closeFailed',
+      expect.anything(),
+    )
+    if (name === 'submit') {
+      expect(harness.completeOverlayEdit).toHaveBeenCalledOnce()
+      expect(harness.discardAnnotation).not.toHaveBeenCalled()
+    } else {
+      expect(harness.completeOverlayEdit).not.toHaveBeenCalled()
+      expect(harness.discardAnnotation).toHaveBeenCalledOnce()
+    }
+  })
+
+  it('recovers once when rejected-target automatic rearm reports a stable failure', async () => {
+    const harness = await createAnnotationDraftHarness({ ok: true }, true)
+    await harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'annotation-submit',
+      detail: {
+        annotationId: harness.annotationId,
+        body: 'Finish the first editor before testing picker recovery.',
+      },
+    }, harness.item)
+    const modeCallsBeforeFailure = harness.setAnnotationMode.mock.calls.length
+
+    await harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'blocked-action',
+      detail: {
+        action: 'annotation-picker',
+        code: 'ANNOTATION_REARM_FAILED',
+        reason: 'annotation-picker-rearm-failed',
+        surfaceInstanceId: 'surface-instance-current',
+      },
+    }, harness.item)
+
+    expect(harness.setAnnotationMode).toHaveBeenCalledTimes(modeCallsBeforeFailure + 1)
+    expect(harness.renderState).toMatchObject({
+      annotationMode: true,
+      annotationModeStopping: false,
+    })
+    await harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'annotation-selected',
+      detail: {
+        selection: {
+          selectionId: 'selection-after-rearm-failure',
+          tagName: 'button',
+          elementPath: '[["","button",2]]',
+          elementProofSha256: 'd'.repeat(64),
+          rect: { x: 40, y: 2, width: 30, height: 20 },
+        },
+      },
+    }, harness.item)
+    expect(harness.createAnnotation).toHaveBeenCalledTimes(2)
+  })
+
+  it('fails closed when rejected-target picker recovery also fails', async () => {
+    const harness = await createAnnotationDraftHarness({ ok: true }, true)
+    await harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'annotation-submit',
+      detail: {
+        annotationId: harness.annotationId,
+        body: 'Finish the editor before the terminal recovery failure.',
+      },
+    }, harness.item)
+    harness.setAnnotationMode.mockResolvedValue({
+      ok: false,
+      code: 'ANNOTATION_UNAVAILABLE',
+      retryable: true,
+    })
+
+    await harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'blocked-action',
+      detail: {
+        action: 'annotation-picker',
+        code: 'ANNOTATION_REARM_FAILED',
+        surfaceInstanceId: 'surface-instance-current',
+      },
+    }, harness.item)
+
+    expect(harness.renderState.annotationMode).toBe(false)
+    expect(harness.pushToast).toHaveBeenCalledWith(
+      'workbench.artifactAnnotation.unavailable',
+      { tone: 'danger' },
+    )
+  })
+
+  it('ignores a rejected-target rearm failure from a replaced surface instance', async () => {
+    const harness = await createAnnotationDraftHarness({ ok: true }, true)
+    await harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'annotation-submit',
+      detail: {
+        annotationId: harness.annotationId,
+        body: 'Close the editor before the stale event arrives.',
+      },
+    }, harness.item)
+    const modeCallsBeforeStaleEvent = harness.setAnnotationMode.mock.calls.length
+
+    await harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'blocked-action',
+      detail: {
+        action: 'annotation-picker',
+        code: 'ANNOTATION_REARM_FAILED',
+        surfaceInstanceId: 'surface-instance-retired',
+      },
+    }, harness.item)
+
+    expect(harness.setAnnotationMode).toHaveBeenCalledTimes(modeCallsBeforeStaleEvent)
+    expect(harness.renderState.annotationMode).toBe(true)
+  })
+
+  it.each(['rejected', 'threw'] as const)(
+    'restores the surface identity when native destruction is %s',
+    async (failure) => {
+      const harness = await createAnnotationDraftHarness({ ok: true }, true)
+      await harness.runtime.handleNativeSurfaceEvent?.({
+        version: 3,
+        surfaceId: harness.item.id,
+        type: 'annotation-submit',
+        detail: {
+          annotationId: harness.annotationId,
+          body: 'Close the editor before testing failed surface release.',
+        },
+      }, harness.item)
+      if (failure === 'rejected') {
+        harness.destroySurface.mockResolvedValueOnce({ ok: false })
+      } else {
+        harness.destroySurface.mockRejectedValueOnce(new Error('synthetic destroy failure'))
+      }
+      const internal = harness.runtime as unknown as {
+        releaseNativeSurface(clearResource: boolean): Promise<boolean>
+      }
+      await expect(internal.releaseNativeSurface(false)).resolves.toBe(false)
+      await harness.runtime.handleSurfaceRect?.({
+        itemId: harness.item.id,
+        x: 300,
+        y: 40,
+        width: 600,
+        height: 500,
+        visible: true,
+      }, harness.item)
+      await harness.runtime.performAction?.('toggle-annotation-mode', harness.item)
+      const modeCallsBeforeMatchingEvent = harness.setAnnotationMode.mock.calls.length
+
+      await harness.runtime.handleNativeSurfaceEvent?.({
+        version: 3,
+        surfaceId: harness.item.id,
+        type: 'blocked-action',
+        detail: {
+          action: 'annotation-picker',
+          code: 'ANNOTATION_REARM_FAILED',
+          surfaceInstanceId: 'surface-instance-current',
+        },
+      }, harness.item)
+
+      expect(harness.setAnnotationMode).toHaveBeenCalledTimes(
+        modeCallsBeforeMatchingEvent + 1,
+      )
+    },
+  )
+
   it('keeps the trusted editor and draft ownership when atomic rearm fails', async () => {
     const harness = await createAnnotationDraftHarness({ ok: true }, true)
     harness.closeOverlay
@@ -615,7 +847,7 @@ describe('artifact Workbench provider', () => {
     expect(harness.releaseOverlayEdit).toHaveBeenCalledOnce()
   })
 
-  it('does not reactivate annotation mode from a late atomic close result after stop', async () => {
+  it('preserves a submitted draft when Stop supersedes an atomic close', async () => {
     const harness = await createAnnotationDraftHarness({ ok: true }, true)
     let finishClose: (() => void) | null = null
     harness.closeOverlay.mockImplementationOnce(async () => {
@@ -641,6 +873,15 @@ describe('artifact Workbench provider', () => {
 
     await harness.runtime.performAction?.('toggle-annotation-mode', harness.item)
     expect(harness.renderState.annotationMode).toBe(false)
+    await harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'annotation-cancel',
+      detail: {
+        annotationId: harness.annotationId,
+        reason: 'picker-cancelled',
+      },
+    }, harness.item)
     const resolveClose: unknown = finishClose
     if (typeof resolveClose !== 'function') throw new Error('atomic close is not pending')
     resolveClose()
@@ -650,10 +891,72 @@ describe('artifact Workbench provider', () => {
     expect(harness.renderState.annotationModeStopping).toBe(false)
     expect(harness.completeOverlayEdit).not.toHaveBeenCalled()
     expect(harness.releaseOverlayEdit).not.toHaveBeenCalled()
+    expect(harness.updateAnnotation).toHaveBeenCalledOnce()
+    expect(harness.renderState.annotationFallback).toMatchObject({
+      annotationId: harness.annotationId,
+      body: 'Do not resurrect a stopped picker.',
+      reason: 'picker-cancelled',
+    })
     expect(harness.setAnnotationMode.mock.calls.map(([request]) => request.enabled)).toEqual([
       true,
       false,
     ])
+  })
+
+  it('clears discarded ownership when Stop supersedes an atomic cancel', async () => {
+    const harness = await createAnnotationDraftHarness({ ok: true }, true)
+    let finishClose: (() => void) | null = null
+    harness.closeOverlay.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        finishClose = resolve
+      })
+      return {
+        ok: false,
+        code: 'ANNOTATION_UNAVAILABLE',
+        retryable: true,
+      }
+    })
+    const pendingCancel = harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'annotation-cancel',
+      detail: { annotationId: harness.annotationId, reason: 'user-cancelled' },
+    }, harness.item)
+    await vi.waitFor(() => expect(harness.closeOverlay).toHaveBeenCalledOnce())
+
+    await harness.runtime.performAction?.('toggle-annotation-mode', harness.item)
+    await harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'annotation-cancel',
+      detail: { annotationId: harness.annotationId, reason: 'picker-cancelled' },
+    }, harness.item)
+    const resolveClose: unknown = finishClose
+    if (typeof resolveClose !== 'function') throw new Error('atomic close is not pending')
+    resolveClose()
+    await pendingCancel
+
+    expect(harness.discardAnnotation).toHaveBeenCalledOnce()
+    expect(harness.releaseOverlayEdit).toHaveBeenCalledOnce()
+    expect(harness.renderState.annotationFallback).toBeNull()
+    expect(harness.renderState.annotationMode).toBe(false)
+
+    await harness.runtime.performAction?.('toggle-annotation-mode', harness.item)
+    await harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'annotation-selected',
+      detail: {
+        selection: {
+          selectionId: 'selection-after-cancel-stop',
+          tagName: 'button',
+          elementPath: '[["","button",2]]',
+          elementProofSha256: 'e'.repeat(64),
+          rect: { x: 40, y: 2, width: 30, height: 20 },
+        },
+      },
+    }, harness.item)
+    expect(harness.createAnnotation).toHaveBeenCalledTimes(2)
   })
 
   it('does not expose a Desktop native-open diagnostic in the toast', async () => {

--- a/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.test.ts
+++ b/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.test.ts
@@ -30,6 +30,7 @@ const artifact: ArtifactPayload = {
 }
 
 afterEach(() => {
+  vi.useRealTimers()
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
 })
@@ -90,7 +91,406 @@ async function createNativeRuntimeHarness(
   }
 }
 
+async function createAnnotationDraftHarness(
+  showOverlayResult: NativeWorkbenchSurfaceResult = { ok: true },
+) {
+  const legacy = createLegacyArtifactWorkspace(artifact, 'session-a')
+  const workspace = {
+    ...legacy,
+    source: 'document-api' as const,
+    document: {
+      ...legacy.document,
+      documentId: 'document-1',
+      headRevisionId: 'revision-1',
+      capabilities: {
+        ...legacy.document.capabilities,
+        preview: true,
+        edit: true,
+        source: true,
+        promptAnnotations: false,
+      },
+    },
+  }
+  const createAnnotation = vi.fn(async (request: {
+    annotationId: string
+    sessionKey: string
+    documentId: string
+    revisionId: string
+  }) => ({
+    annotationId: request.annotationId,
+    sessionKey: request.sessionKey,
+    sessionId: null,
+    sessionEpoch: null,
+    documentId: request.documentId,
+    documentName: 'preview.html',
+    revisionId: request.revisionId,
+    generation: 1,
+    anchorId: 'anchor-1',
+    body: '',
+    status: 'draft' as const,
+    freshness: 'fresh' as const,
+    staleReason: null,
+    stateRevision: 1,
+    tagName: 'button',
+    locator: {},
+    quote: '<button>',
+    sourceExcerpt: null,
+    sentMessageId: null,
+    sentTurnId: null,
+    sentOrder: null,
+    createdAt: 1,
+    updatedAt: 1,
+    schemaVersion: 1,
+  }))
+  const updateAnnotation = vi.fn(async (_annotationId: string, _body: string) => null)
+  const discardAnnotation = vi.fn(async (_annotationId: string) => true)
+  const beginOverlayEdit = vi.fn()
+  const completeOverlayEdit = vi.fn()
+  const releaseOverlayEdit = vi.fn()
+  const closeOverlay = vi.fn(async (): Promise<NativeWorkbenchSurfaceResult> => ({ ok: true }))
+  const showOverlay = vi.fn(async (
+    _request: Parameters<NonNullable<NativeWorkbenchApi['showArtifactAnnotationOverlay']>>[0],
+  ): Promise<NativeWorkbenchSurfaceResult> => showOverlayResult)
+  const setSurfaceRect = vi.fn(async () => ({ ok: true as const }))
+  const pushToast = vi.fn()
+  const lease = {
+    version: 1 as const,
+    lease_id: 'apl-annotation-focused',
+    effective_mode: 'full' as const,
+    launch_url: 'http://p-0123456789abcdef0123456789abcdef.localhost:48721/index.html',
+    entrypoint: 'index.html',
+    expires_at: '2099-01-01T00:00:00Z',
+    preview_origin: 'http://p-0123456789abcdef0123456789abcdef.localhost:48721',
+    idle_timeout_seconds: 28_800,
+    source: {
+      kind: 'single_file' as const,
+      collection_status: 'not_applicable' as const,
+      file_count: 1,
+      total_bytes: 128,
+      warning_codes: [],
+    },
+  }
+  const nativeApi: NativeWorkbenchApi = {
+    getCapabilities: vi.fn(async () => ({
+      protocolVersions: [3] as Array<3>,
+      modes: ['full', 'offline'] as Array<'full' | 'offline'>,
+      maxSurfaces: 8,
+    })),
+    getArtifactAnnotationCapabilities: vi.fn(async () => ({
+      version: 3 as const,
+      available: true,
+      picker: true,
+      trustedOverlay: true,
+      overlayCopyVersion: 1 as const,
+    })),
+    setArtifactAnnotationMode: vi.fn(async () => ({ ok: true as const })),
+    showArtifactAnnotationOverlay: showOverlay,
+    closeArtifactAnnotationOverlay: closeOverlay,
+    screenshot: vi.fn(async () => ({
+      ok: true as const,
+      method: 'screenshot' as const,
+      value: {
+        mime: 'image/png' as const,
+        data: new Uint8Array([137, 80, 78, 71]),
+        width: 320,
+        height: 180,
+      },
+    })),
+    createArtifactPreviewLease: vi.fn(async () => ({
+      ok: true as const,
+      status: 201,
+      payload: lease,
+    })),
+    renewArtifactPreviewLease: vi.fn(async () => ({
+      ok: true as const,
+      status: 200,
+      payload: { version: 1 as const, lease_id: lease.lease_id, expires_at: lease.expires_at },
+    })),
+    revokeArtifactPreviewLease: vi.fn(async () => ({
+      ok: true as const,
+      status: 204,
+      payload: undefined,
+    })),
+    createSurface: vi.fn(async () => ({ ok: true as const })),
+    setSurfaceRect,
+    activateSurface: vi.fn(async () => ({ ok: true as const })),
+    destroySurface: vi.fn(async () => ({ ok: true as const })),
+    onSurfaceEvent: vi.fn(() => () => undefined),
+  }
+  const renderState: Record<string, unknown> = {}
+  const item = createArtifactPreviewWorkbenchItem({
+    artifact,
+    nativeHtml: true,
+    sessionKey: 'session-a',
+  })
+  const definition = createArtifactWorkbenchDefinitions({
+    artifactDocuments: {
+      load: vi.fn(async () => undefined),
+      snapshot: vi.fn(() => ({
+        key: 'fixture',
+        loading: false,
+        loaded: true,
+        stale: false,
+        error: null,
+        workspace,
+      })),
+      headArtifact: vi.fn(() => artifact),
+    },
+    promptAnnotations: {
+      create: createAnnotation,
+      update: updateAnnotation,
+      discard: discardAnnotation,
+      beginOverlayEdit,
+      completeOverlayEdit,
+      releaseOverlayEdit,
+      setActiveDocument: vi.fn(),
+    },
+    authToken: () => 'synthetic-token',
+    baseOrigin: 'http://127.0.0.1:18791',
+    confirmRemoteResources: vi.fn(async () => true),
+    currentSessionId: () => 'session-a',
+    openArtifact: vi.fn(),
+    platform: {
+      id: 'desktop',
+      capabilities: { canOpenArtifactsNatively: true },
+      files: {},
+    } as unknown as Platform,
+    previewLeasesEnabled: true,
+    pushToast,
+    t: key => key,
+  }).find(candidate => candidate.kind === 'artifact-preview')!
+  const runtime = await definition.createRuntime!(item, {
+    nativeWorkbenchApi: nativeApi,
+    getRenderState: () => renderState,
+    updateRenderState: patch => Object.assign(renderState, patch),
+    isItemOpen: () => true,
+    setExpanded: vi.fn(),
+    reportError: vi.fn(),
+  })
+
+  workspace.document.capabilities.promptAnnotations = true
+  workspace.document.capabilities.manualEdit = true
+  workspace.document.capabilities.selectionContext = true
+  workspace.document.capabilities.agentEdit = true
+  await runtime.resume?.(item)
+  await runtime.handleSurfaceRect?.({
+    itemId: item.id,
+    x: 300,
+    y: 40,
+    width: 600,
+    height: 500,
+    visible: true,
+  }, item)
+  await runtime.performAction?.('toggle-annotation-mode', item)
+  await runtime.handleNativeSurfaceEvent?.({
+    version: 3,
+    surfaceId: item.id,
+    type: 'annotation-selected',
+    detail: {
+      selection: {
+        selectionId: 'selection-focused',
+        tagName: 'button',
+        elementPath: '[["","button",1]]',
+        elementProofSha256: 'b'.repeat(64),
+        domSha256: 'a'.repeat(64),
+        rect: { x: 1, y: 2, width: 30, height: 20 },
+      },
+    },
+  }, item)
+  const annotationId = String(showOverlay.mock.calls[0]?.[0].annotationId || '')
+  expect(annotationId).not.toBe('')
+
+  return {
+    annotationId,
+    beginOverlayEdit,
+    closeOverlay,
+    completeOverlayEdit,
+    discardAnnotation,
+    item,
+    pushToast,
+    releaseOverlayEdit,
+    renderState,
+    runtime,
+    setSurfaceRect,
+    updateAnnotation,
+  }
+}
+
 describe('artifact Workbench provider', () => {
+  it.each([
+    'surface-hidden',
+    'surface-navigation',
+    'surface-reloaded',
+    'surface-closed',
+    'picker-cancelled',
+  ])('flushes a pending annotation before %s and keeps one fallback draft', async (reason) => {
+    vi.useFakeTimers()
+    const harness = await createAnnotationDraftHarness()
+
+    await harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'annotation-draft-change',
+      detail: { annotationId: harness.annotationId, body: 'Keep this lifecycle draft.' },
+    }, harness.item)
+    await vi.advanceTimersByTimeAsync(249)
+    expect(harness.updateAnnotation).not.toHaveBeenCalled()
+
+    let finishUpdate: (() => void) | null = null
+    harness.updateAnnotation.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        finishUpdate = resolve
+      })
+      return null
+    })
+    const cancel = {
+      version: 3 as const,
+      surfaceId: harness.item.id,
+      type: 'annotation-cancel' as const,
+      detail: { annotationId: harness.annotationId, reason },
+    }
+    const pendingCancel = harness.runtime.handleNativeSurfaceEvent?.(cancel, harness.item)
+    expect(harness.updateAnnotation).toHaveBeenCalledOnce()
+    await harness.runtime.handleNativeSurfaceEvent?.(cancel, harness.item)
+    const resolveUpdate: unknown = finishUpdate
+    if (typeof resolveUpdate !== 'function') throw new Error('annotation update is not pending')
+    resolveUpdate()
+    await pendingCancel
+
+    expect(harness.updateAnnotation).toHaveBeenCalledOnce()
+    expect(harness.updateAnnotation).toHaveBeenCalledWith(
+      harness.annotationId,
+      'Keep this lifecycle draft.',
+    )
+    expect(harness.discardAnnotation).not.toHaveBeenCalled()
+    expect(harness.releaseOverlayEdit).not.toHaveBeenCalled()
+    expect(harness.renderState.annotationFallback).toMatchObject({
+      annotationId: harness.annotationId,
+      body: 'Keep this lifecycle draft.',
+      reason,
+    })
+    expect(harness.setSurfaceRect).toHaveBeenLastCalledWith(
+      expect.objectContaining({ surfaceId: harness.item.id, visible: false }),
+    )
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(harness.updateAnnotation).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the local body, screenshot, and fallback when lifecycle flush fails', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:focused-annotation-preview')
+    const revokeScreenshotUrl = vi.spyOn(URL, 'revokeObjectURL')
+      .mockImplementation(() => undefined)
+    const harness = await createAnnotationDraftHarness({
+      ok: false,
+      code: 'PREVIEW_RENDERER_FAILED',
+      retryable: true,
+    })
+    harness.updateAnnotation.mockRejectedValueOnce(new Error('synthetic update failure'))
+
+    await harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'annotation-draft-change',
+      detail: { annotationId: harness.annotationId, body: 'Retry this saved-locally body.' },
+    }, harness.item)
+    await harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'annotation-cancel',
+      detail: { annotationId: harness.annotationId, reason: 'surface-reloaded' },
+    }, harness.item)
+
+    expect(harness.updateAnnotation).toHaveBeenCalledOnce()
+    expect(harness.discardAnnotation).not.toHaveBeenCalled()
+    expect(harness.releaseOverlayEdit).not.toHaveBeenCalled()
+    expect(harness.renderState.annotationFallback).toMatchObject({
+      annotationId: harness.annotationId,
+      body: 'Retry this saved-locally body.',
+      reason: 'surface-reloaded',
+      screenshotUrl: 'blob:focused-annotation-preview',
+    })
+    expect(revokeScreenshotUrl).not.toHaveBeenCalled()
+    expect(harness.pushToast).toHaveBeenCalledWith(
+      'workbench.artifactAnnotation.updateFailed',
+      { tone: 'danger' },
+    )
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(harness.updateAnnotation).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    { label: 'unknown', reason: 'future-surface-transition' },
+    { label: 'missing', reason: undefined },
+  ])('treats an $label annotation cancel reason as a recoverable interruption', async ({ reason }) => {
+    vi.useFakeTimers()
+    const harness = await createAnnotationDraftHarness()
+
+    await harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'annotation-draft-change',
+      detail: { annotationId: harness.annotationId, body: 'Preserve a future reason.' },
+    }, harness.item)
+    await harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'annotation-cancel',
+      detail: {
+        annotationId: harness.annotationId,
+        ...(reason ? { reason } : {}),
+      },
+    }, harness.item)
+
+    expect(harness.updateAnnotation).toHaveBeenCalledWith(
+      harness.annotationId,
+      'Preserve a future reason.',
+    )
+    expect(harness.discardAnnotation).not.toHaveBeenCalled()
+    expect(harness.renderState.annotationFallback).toMatchObject({
+      annotationId: harness.annotationId,
+      body: 'Preserve a future reason.',
+      reason: reason || 'lifecycle-interrupted',
+    })
+  })
+
+  it('discards an explicit user cancellation exactly once', async () => {
+    vi.useFakeTimers()
+    const harness = await createAnnotationDraftHarness()
+    harness.closeOverlay
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: true })
+
+    await harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'annotation-draft-change',
+      detail: { annotationId: harness.annotationId, body: 'Discard only by intent.' },
+    }, harness.item)
+    const cancel = {
+      version: 3 as const,
+      surfaceId: harness.item.id,
+      type: 'annotation-cancel' as const,
+      detail: { annotationId: harness.annotationId, reason: 'user-cancelled' },
+    }
+    await harness.runtime.handleNativeSurfaceEvent?.(cancel, harness.item)
+    await harness.runtime.handleNativeSurfaceEvent?.(cancel, harness.item)
+
+    expect(harness.discardAnnotation).toHaveBeenCalledOnce()
+    expect(harness.discardAnnotation).toHaveBeenCalledWith(harness.annotationId)
+    expect(harness.closeOverlay).toHaveBeenCalledTimes(2)
+    expect(harness.updateAnnotation).not.toHaveBeenCalled()
+    expect(harness.completeOverlayEdit).not.toHaveBeenCalled()
+    expect(harness.releaseOverlayEdit).toHaveBeenCalledOnce()
+    expect(harness.renderState.annotationFallback).toBeNull()
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(harness.updateAnnotation).not.toHaveBeenCalled()
+    expect(harness.discardAnnotation).toHaveBeenCalledOnce()
+  })
+
   it('does not expose a Desktop native-open diagnostic in the toast', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response('<p>fixture</p>', {
       status: 200,
@@ -3143,7 +3543,7 @@ describe('artifact Workbench provider', () => {
     resolveDeferredDiscard = null
     const pendingOldCancel = runtime.handleComponentEvent?.({
       type: 'artifact-annotation-fallback-cancel',
-      payload: { annotationId: newSubmitAnnotationId },
+      payload: { annotationId: newSubmitAnnotationId, reason: 'user-cancelled' },
     }, item)
     await vi.waitFor(() => expect(resolveDeferredDiscard).toBeTypeOf('function'))
     workspace.document.headRevisionId = 'revision-5'

--- a/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.test.ts
+++ b/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.test.ts
@@ -93,6 +93,7 @@ async function createNativeRuntimeHarness(
 
 async function createAnnotationDraftHarness(
   showOverlayResult: NativeWorkbenchSurfaceResult = { ok: true },
+  atomicCloseRearm = false,
 ) {
   const legacy = createLegacyArtifactWorkspace(artifact, 'session-a')
   const workspace = {
@@ -152,6 +153,9 @@ async function createAnnotationDraftHarness(
     _request: Parameters<NonNullable<NativeWorkbenchApi['showArtifactAnnotationOverlay']>>[0],
   ): Promise<NativeWorkbenchSurfaceResult> => showOverlayResult)
   const setSurfaceRect = vi.fn(async () => ({ ok: true as const }))
+  const setAnnotationMode = vi.fn(async (
+    _request: Parameters<NonNullable<NativeWorkbenchApi['setArtifactAnnotationMode']>>[0],
+  ) => ({ ok: true as const }))
   const pushToast = vi.fn()
   const lease = {
     version: 1 as const,
@@ -182,8 +186,9 @@ async function createAnnotationDraftHarness(
       picker: true,
       trustedOverlay: true,
       overlayCopyVersion: 1 as const,
+      ...(atomicCloseRearm ? { atomicCloseRearm: true as const } : {}),
     })),
-    setArtifactAnnotationMode: vi.fn(async () => ({ ok: true as const })),
+    setArtifactAnnotationMode: setAnnotationMode,
     showArtifactAnnotationOverlay: showOverlay,
     closeArtifactAnnotationOverlay: closeOverlay,
     screenshot: vi.fn(async () => ({
@@ -305,13 +310,16 @@ async function createAnnotationDraftHarness(
     beginOverlayEdit,
     closeOverlay,
     completeOverlayEdit,
+    createAnnotation,
     discardAnnotation,
     item,
     pushToast,
     releaseOverlayEdit,
     renderState,
     runtime,
+    setAnnotationMode,
     setSurfaceRect,
+    showOverlay,
     updateAnnotation,
   }
 }
@@ -489,6 +497,163 @@ describe('artifact Workbench provider', () => {
     await vi.advanceTimersByTimeAsync(1_000)
     expect(harness.updateAnnotation).not.toHaveBeenCalled()
     expect(harness.discardAnnotation).toHaveBeenCalledOnce()
+  })
+
+  it('atomically closes and rearms after submit without a second mode or rect request', async () => {
+    const harness = await createAnnotationDraftHarness({ ok: true }, true)
+    const setModeCallsBeforeSubmit = harness.setAnnotationMode.mock.calls.length
+    const rectCallsBeforeSubmit = harness.setSurfaceRect.mock.calls.length
+
+    await harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'annotation-submit',
+      detail: {
+        annotationId: harness.annotationId,
+        body: 'Make the next edit immediately selectable.',
+      },
+    }, harness.item)
+
+    expect(harness.updateAnnotation).toHaveBeenCalledWith(
+      harness.annotationId,
+      'Make the next edit immediately selectable.',
+    )
+    expect(harness.closeOverlay).toHaveBeenCalledWith({
+      version: 3,
+      surfaceId: harness.item.id,
+      annotationId: harness.annotationId,
+      rearm: true,
+    })
+    expect(harness.completeOverlayEdit).toHaveBeenCalledOnce()
+    expect(harness.releaseOverlayEdit).toHaveBeenCalledOnce()
+    expect(harness.setAnnotationMode).toHaveBeenCalledTimes(setModeCallsBeforeSubmit)
+    expect(harness.setSurfaceRect).toHaveBeenCalledTimes(rectCallsBeforeSubmit)
+    expect(harness.renderState).toMatchObject({
+      annotationMode: true,
+      annotationModeStopping: false,
+    })
+
+    await harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'annotation-selected',
+      detail: {
+        selection: {
+          selectionId: 'selection-next',
+          tagName: 'button',
+          elementPath: '[["","button",2]]',
+          elementProofSha256: 'c'.repeat(64),
+          domSha256: 'a'.repeat(64),
+          rect: { x: 40, y: 2, width: 30, height: 20 },
+        },
+      },
+    }, harness.item)
+
+    expect(harness.createAnnotation).toHaveBeenCalledTimes(2)
+    expect(harness.showOverlay).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the trusted editor and draft ownership when atomic rearm fails', async () => {
+    const harness = await createAnnotationDraftHarness({ ok: true }, true)
+    harness.closeOverlay
+      .mockResolvedValueOnce({
+        ok: false,
+        code: 'ANNOTATION_UNAVAILABLE',
+        retryable: true,
+      })
+      .mockResolvedValueOnce({ ok: true })
+
+    const submit = {
+      version: 3 as const,
+      surfaceId: harness.item.id,
+      type: 'annotation-submit' as const,
+      detail: {
+        annotationId: harness.annotationId,
+        body: 'Keep this body while the picker is unavailable.',
+      },
+    }
+    await harness.runtime.handleNativeSurfaceEvent?.(submit, harness.item)
+
+    expect(harness.closeOverlay).toHaveBeenCalledOnce()
+    expect(harness.closeOverlay).toHaveBeenLastCalledWith(expect.objectContaining({ rearm: true }))
+    expect(harness.completeOverlayEdit).not.toHaveBeenCalled()
+    expect(harness.releaseOverlayEdit).not.toHaveBeenCalled()
+    expect(harness.pushToast).toHaveBeenCalledWith(
+      'workbench.artifactAnnotation.closeFailed',
+      { tone: 'danger', duration: 9000 },
+    )
+
+    await harness.runtime.handleNativeSurfaceEvent?.(submit, harness.item)
+
+    expect(harness.closeOverlay).toHaveBeenCalledTimes(2)
+    expect(harness.completeOverlayEdit).toHaveBeenCalledOnce()
+    expect(harness.releaseOverlayEdit).toHaveBeenCalledOnce()
+  })
+
+  it('discards once while retrying an atomic cancel handoff', async () => {
+    const harness = await createAnnotationDraftHarness({ ok: true }, true)
+    harness.closeOverlay
+      .mockResolvedValueOnce({
+        ok: false,
+        code: 'ANNOTATION_UNAVAILABLE',
+        retryable: true,
+      })
+      .mockResolvedValueOnce({ ok: true })
+    const cancel = {
+      version: 3 as const,
+      surfaceId: harness.item.id,
+      type: 'annotation-cancel' as const,
+      detail: { annotationId: harness.annotationId, reason: 'user-cancelled' },
+    }
+
+    await harness.runtime.handleNativeSurfaceEvent?.(cancel, harness.item)
+    await harness.runtime.handleNativeSurfaceEvent?.(cancel, harness.item)
+
+    expect(harness.discardAnnotation).toHaveBeenCalledOnce()
+    expect(harness.closeOverlay).toHaveBeenCalledTimes(2)
+    expect(harness.closeOverlay).toHaveBeenLastCalledWith(expect.objectContaining({ rearm: true }))
+    expect(harness.releaseOverlayEdit).toHaveBeenCalledOnce()
+  })
+
+  it('does not reactivate annotation mode from a late atomic close result after stop', async () => {
+    const harness = await createAnnotationDraftHarness({ ok: true }, true)
+    let finishClose: (() => void) | null = null
+    harness.closeOverlay.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        finishClose = resolve
+      })
+      return {
+        ok: false,
+        code: 'ANNOTATION_UNAVAILABLE',
+        retryable: true,
+      }
+    })
+    const pendingSubmit = harness.runtime.handleNativeSurfaceEvent?.({
+      version: 3,
+      surfaceId: harness.item.id,
+      type: 'annotation-submit',
+      detail: {
+        annotationId: harness.annotationId,
+        body: 'Do not resurrect a stopped picker.',
+      },
+    }, harness.item)
+    await vi.waitFor(() => expect(harness.closeOverlay).toHaveBeenCalledOnce())
+
+    await harness.runtime.performAction?.('toggle-annotation-mode', harness.item)
+    expect(harness.renderState.annotationMode).toBe(false)
+    const resolveClose: unknown = finishClose
+    if (typeof resolveClose !== 'function') throw new Error('atomic close is not pending')
+    resolveClose()
+    await pendingSubmit
+
+    expect(harness.renderState.annotationMode).toBe(false)
+    expect(harness.renderState.annotationModeStopping).toBe(false)
+    expect(harness.completeOverlayEdit).not.toHaveBeenCalled()
+    expect(harness.releaseOverlayEdit).not.toHaveBeenCalled()
+    expect(harness.setAnnotationMode.mock.calls.map(([request]) => request.enabled)).toEqual([
+      true,
+      false,
+    ])
   })
 
   it('does not expose a Desktop native-open diagnostic in the toast', async () => {

--- a/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.ts
+++ b/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.ts
@@ -337,6 +337,11 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
   private annotationOverlayId = ''
   private annotationOverlayBody = ''
   private annotationOverlayOperation: symbol | null = null
+  private annotationOverlayDeferredCancel: {
+    attempt: number
+    annotationId: string
+    reason: string
+  } | null = null
   private annotationOverlayDiscarded: {
     attempt: number
     annotationId: string
@@ -360,6 +365,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
   private leaseRenewTimer: ReturnType<typeof setInterval> | null = null
   private readonly nativeRecoveryAttemptedKeys = new Set<string>()
   private nativeRecoveryInFlight: Promise<void> | null = null
+  private nativeSurfaceInstanceId = ''
   private defaultMode: WorkbenchPreviewMode
   private mode: WorkbenchPreviewMode
   private nativeProtocolVersion: NativeWorkbenchProtocolVersion = 1
@@ -1175,6 +1181,22 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
             }
           : {}),
       })
+      if (
+        event.detail?.action === 'annotation-picker'
+        && event.detail?.code === 'ANNOTATION_REARM_FAILED'
+        && event.detail?.surfaceInstanceId === this.nativeSurfaceInstanceId
+      ) {
+        // An unsupported target consumes Chromium's one-shot inspect mode.
+        // Desktop normally reinstalls it before reporting the rejection. If
+        // that reinstall fails, never leave the toolbar claiming the picker
+        // is armed; use the existing single bounded capability recovery path.
+        this.annotationPickerArmed = false
+        if (
+          this.annotationMode
+          && !this.annotationOverlayId
+          && !this.annotationSelectionPending
+        ) await this.setAnnotationMode(true)
+      }
     } else if (event.type === 'capability-expired') {
       await this.replaceLeasePreview()
     } else if (event.type === 'unresponsive') {
@@ -1488,7 +1510,12 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
     generation: number
     surfaceId: string
     annotationId: string
-  }, rearm = false): Promise<{ ok: boolean; code?: string; retryable?: boolean }> {
+  }, rearm = false): Promise<{
+    ok: boolean
+    code?: string
+    retryable?: boolean
+    rearmed?: boolean
+  }> {
     const close = this.context.nativeWorkbenchApi?.closeArtifactAnnotationOverlay
     if (!close) return { ok: false }
     try {
@@ -1505,11 +1532,15 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
           || (!rearm && result.code === 'ANNOTATION_UNAVAILABLE'))
       ) {
         // The scoped surface is already gone, so its trusted overlay is gone
-        // too. Treat close as acknowledged; after local cleanup the normal
-        // rearm path rebuilds the current surface once and retries the picker.
-        return { ok: true }
+        // too. Treat only the close as acknowledged. In particular, an
+        // atomic close did not rearm a picker on the vanished surface; after
+        // local cleanup the normal path must rebuild and arm the replacement.
+        return { ok: true, rearmed: false }
       }
-      return result
+      return {
+        ...result,
+        rearmed: rearm && result.ok,
+      }
     } catch {
       return {
         ok: false,
@@ -1533,6 +1564,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
     this.annotationOverlayOperation = operation
     const atomicRearm = this.annotationAtomicCloseRearm && this.annotationMode
     const modeOperation = this.annotationModeOperation
+    let bodyFlushed = false
     try {
       // A prior cancel may already have durably discarded this draft while a
       // native close failed. It cannot be resurrected; only retry that close.
@@ -1541,6 +1573,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
       if (!alreadyDiscarded) {
         this.annotationOverlayBody = body
         if (!await this.flushAnnotationBody(annotationId, body)) return
+        bodyFlushed = true
         if (!this.annotationOverlayFenceCurrent(fence)) return
       }
       const closed = await this.closeAnnotationOverlay(fence, atomicRearm)
@@ -1555,7 +1588,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
       }
       this.options.promptAnnotations?.completeOverlayEdit?.(annotationId)
       if (!this.clearAnnotationOverlayState(fence)) return
-      if (atomicRearm) {
+      if (atomicRearm && closed.rearmed === true) {
         if (
           modeOperation === this.annotationModeOperation
           && this.annotationMode
@@ -1578,12 +1611,27 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
       if (this.annotationOverlayOperation === operation) {
         this.annotationOverlayOperation = null
       }
+      await this.reconcileDeferredAnnotationCancel(fence, bodyFlushed)
     }
   }
 
   private async handleAnnotationCancel(annotationId: string, reason: string) {
     const fence = this.annotationOverlayFence(annotationId)
-    if (!fence || this.annotationOverlayOperation) return
+    if (!fence) return
+    if (this.annotationOverlayOperation) {
+      // Desktop lifecycle cancellation may race an update/discard and its
+      // atomic close acknowledgement. Queue the exact ownership fence instead
+      // of dropping the event; otherwise Desktop can close the editor while
+      // WebUI permanently retains an unreachable annotationOverlayId.
+      if (reason !== 'user-cancelled') {
+        this.annotationOverlayDeferredCancel = {
+          attempt: fence.attempt,
+          annotationId: fence.annotationId,
+          reason: reason || 'lifecycle-interrupted',
+        }
+      }
+      return
+    }
     if (reason !== 'user-cancelled') {
       // Desktop also uses annotation-cancel to report that the trusted editor
       // was interrupted by surface/navigation lifecycle. Only the explicit
@@ -1645,7 +1693,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
         return
       }
       if (!this.clearAnnotationOverlayState(fence)) return
-      if (atomicRearm) {
+      if (atomicRearm && closed.rearmed === true) {
         if (
           modeOperation === this.annotationModeOperation
           && this.annotationMode
@@ -1664,7 +1712,40 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
       if (this.annotationOverlayOperation === operation) {
         this.annotationOverlayOperation = null
       }
+      await this.reconcileDeferredAnnotationCancel(fence)
     }
+  }
+
+  private async reconcileDeferredAnnotationCancel(fence: {
+    attempt: number
+    generation: number
+    surfaceId: string
+    annotationId: string
+  }, bodyAlreadyFlushed = false) {
+    const deferred = this.annotationOverlayDeferredCancel
+    if (
+      !deferred
+      || deferred.attempt !== fence.attempt
+      || deferred.annotationId !== fence.annotationId
+    ) return
+    this.annotationOverlayDeferredCancel = null
+    if (!this.annotationOverlayFenceCurrent(fence)) return
+
+    const discarded = this.annotationOverlayDiscarded?.attempt === fence.attempt
+      && this.annotationOverlayDiscarded.annotationId === fence.annotationId
+    if (discarded) {
+      if (this.clearAnnotationOverlayState(fence)) await this.syncSurfaceRect()
+      return
+    }
+
+    const body = this.annotationOverlayBody
+    this.preserveAnnotationFallback(deferred.reason)
+    await Promise.all([
+      bodyAlreadyFlushed
+        ? Promise.resolve(true)
+        : this.flushAnnotationBody(fence.annotationId, body),
+      this.hideNativeSurfaceForAnnotationFallback(),
+    ])
   }
 
   private clearAnnotationOverlayState(expected?: {
@@ -1682,6 +1763,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
     const annotationId = this.annotationOverlayId
     this.annotationUpdateTimer = null
     this.annotationOverlayOperation = null
+    this.annotationOverlayDeferredCancel = null
     this.annotationOverlayDiscarded = null
     this.annotationOverlayAttempt += 1
     this.annotationOverlayId = ''
@@ -1825,6 +1907,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
     const generation = this.generation + 1
     this.generation = generation
     this.createdSurface = true
+    this.nativeSurfaceInstanceId = ''
     this.context.updateRenderState({
       missingResources: resource.hasRelativeResources,
       nativeSurfaceState: 'loading',
@@ -1864,6 +1947,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
       )
       return
     }
+    this.nativeSurfaceInstanceId = result.surfaceInstanceId || ''
     await this.syncSurfaceRect()
     if (generation !== this.generation || !this.createdSurface) return
     // Desktop only advertises the picker for the active, visible v3 surface.
@@ -2129,6 +2213,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
     }
     const generation = ++this.generation
     this.createdSurface = true
+    this.nativeSurfaceInstanceId = ''
     this.agentEditReleaseObserved = false
     this.context.updateRenderState({
       agentEditInProgress: false,
@@ -2156,6 +2241,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
     if (generation !== this.generation) return
     if (!result.ok) {
       this.createdSurface = false
+      this.nativeSurfaceInstanceId = ''
       if (result.code === 'AGENT_EDIT_IN_PROGRESS') {
         await this.releaseLease()
         this.context.updateRenderState({
@@ -2171,6 +2257,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
       }
       throw surfaceError('Failed to create the native Workbench surface', result.message)
     }
+    this.nativeSurfaceInstanceId = result.surfaceInstanceId || ''
     if (!await this.syncSurfaceRect()) return
     if (generation !== this.generation || !this.createdSurface) return
     // createSurface resolves only after the native preview has loaded its
@@ -2636,7 +2723,9 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
     // stale rect event incorrectly report "surface no longer exists" and tear
     // down the replacement as well.
     const hadSurface = this.createdSurface
+    const surfaceInstanceId = this.nativeSurfaceInstanceId
     this.createdSurface = false
+    this.nativeSurfaceInstanceId = ''
     const overlayId = this.annotationOverlayId
     const preserveModeIntent = this.annotationModeRestorePending || this.annotationMode
     let preserveAnnotationFallback = false
@@ -2714,12 +2803,18 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
         // Keep the record logically owned when Desktop rejected destruction;
         // callers are allowed to retry the cleanup. Do not resurrect it if a
         // newer create/release transition already advanced the generation.
-        if (this.generation === releaseGeneration) this.createdSurface = hadSurface
+        if (this.generation === releaseGeneration) {
+          this.createdSurface = hadSurface
+          this.nativeSurfaceInstanceId = surfaceInstanceId
+        }
         return false
       }
       return true
     } catch {
-      if (this.generation === releaseGeneration) this.createdSurface = hadSurface
+      if (this.generation === releaseGeneration) {
+        this.createdSurface = hadSurface
+        this.nativeSurfaceInstanceId = surfaceInstanceId
+      }
       return false
     }
   }

--- a/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.ts
+++ b/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.ts
@@ -571,6 +571,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
         : {}
       await this.handleAnnotationCancel(
         typeof payload.annotationId === 'string' ? payload.annotationId : '',
+        typeof payload.reason === 'string' ? payload.reason : '',
       )
       return
     }
@@ -1099,7 +1100,10 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
         event.detail?.body || '',
       )
     } else if (event.type === 'annotation-cancel') {
-      await this.handleAnnotationCancel(event.detail?.annotationId || '')
+      await this.handleAnnotationCancel(
+        event.detail?.annotationId || '',
+        event.detail?.reason || '',
+      )
     } else if (event.type === 'annotation-overlay-fallback') {
       const annotationId = event.detail?.annotationId || this.annotationOverlayId
       if (!annotationId || annotationId !== this.annotationOverlayId) return
@@ -1555,9 +1559,30 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
     }
   }
 
-  private async handleAnnotationCancel(annotationId: string) {
+  private async handleAnnotationCancel(annotationId: string, reason: string) {
     const fence = this.annotationOverlayFence(annotationId)
     if (!fence || this.annotationOverlayOperation) return
+    if (reason !== 'user-cancelled') {
+      // Desktop also uses annotation-cancel to report that the trusted editor
+      // was interrupted by surface/navigation lifecycle. Only the explicit
+      // button reason is destructive; every other (including future or
+      // missing) reason must keep the durable draft and its local recovery UI.
+      const operation = Symbol('annotation-interrupted')
+      this.annotationOverlayOperation = operation
+      try {
+        const body = this.annotationOverlayBody
+        this.preserveAnnotationFallback(reason || 'lifecycle-interrupted')
+        await Promise.all([
+          this.flushAnnotationBody(annotationId, body),
+          this.hideNativeSurfaceForAnnotationFallback(),
+        ])
+      } finally {
+        if (this.annotationOverlayOperation === operation) {
+          this.annotationOverlayOperation = null
+        }
+      }
+      return
+    }
     const operation = Symbol('annotation-cancel')
     this.annotationOverlayOperation = operation
     try {

--- a/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.ts
+++ b/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.ts
@@ -1404,6 +1404,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
           { tone: 'warn' },
         )
       } else if ([
+        'DOCUMENT_CHANGED',
         'ARTIFACT_ELEMENT_CHANGED',
         // Older Gateways used the whole-DOM name for the same recoverable
         // selection rejection. Keep the UX actionable during upgrades.

--- a/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.ts
+++ b/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.ts
@@ -328,6 +328,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
   private annotationMode = false
   private annotationModeRestorePending = false
   private annotationOverlayCopyVersion: 0 | 1 = 0
+  private annotationAtomicCloseRearm = false
   private annotationPickerArmed = false
   private annotationModeOperation = 0
   private annotationSelectionAttempt = 0
@@ -1487,7 +1488,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
     generation: number
     surfaceId: string
     annotationId: string
-  }): Promise<{ ok: boolean; code?: string; retryable?: boolean }> {
+  }, rearm = false): Promise<{ ok: boolean; code?: string; retryable?: boolean }> {
     const close = this.context.nativeWorkbenchApi?.closeArtifactAnnotationOverlay
     if (!close) return { ok: false }
     try {
@@ -1495,12 +1496,13 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
         version: this.nativeArtifactProtocolVersion(),
         surfaceId: fence.surfaceId,
         annotationId: fence.annotationId,
+        ...(rearm && this.annotationAtomicCloseRearm ? { rearm: true as const } : {}),
       })
       if (
         !result.ok
         && result.retryable === true
         && (result.code === 'PREVIEW_CAPABILITY_EXPIRED'
-          || result.code === 'ANNOTATION_UNAVAILABLE')
+          || (!rearm && result.code === 'ANNOTATION_UNAVAILABLE'))
       ) {
         // The scoped surface is already gone, so its trusted overlay is gone
         // too. Treat close as acknowledged; after local cleanup the normal
@@ -1529,6 +1531,8 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
     if (!fence || !body.trim() || this.annotationOverlayOperation) return
     const operation = Symbol('annotation-submit')
     this.annotationOverlayOperation = operation
+    const atomicRearm = this.annotationAtomicCloseRearm && this.annotationMode
+    const modeOperation = this.annotationModeOperation
     try {
       // A prior cancel may already have durably discarded this draft while a
       // native close failed. It cannot be resurrected; only retry that close.
@@ -1539,14 +1543,31 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
         if (!await this.flushAnnotationBody(annotationId, body)) return
         if (!this.annotationOverlayFenceCurrent(fence)) return
       }
-      const closed = await this.closeAnnotationOverlay(fence)
+      const closed = await this.closeAnnotationOverlay(fence, atomicRearm)
       if (!this.annotationOverlayFenceCurrent(fence)) return
       if (!closed.ok) {
+        if (atomicRearm && (
+          modeOperation !== this.annotationModeOperation
+          || !this.annotationMode
+        )) return
         this.showAnnotationCloseFailure()
         return
       }
       this.options.promptAnnotations?.completeOverlayEdit?.(annotationId)
       if (!this.clearAnnotationOverlayState(fence)) return
+      if (atomicRearm) {
+        if (
+          modeOperation === this.annotationModeOperation
+          && this.annotationMode
+        ) {
+          this.annotationPickerArmed = true
+          this.context.updateRenderState({
+            annotationMode: true,
+            annotationModeStopping: false,
+          })
+        }
+        return
+      }
       await this.syncSurfaceRect()
       // Adding one draft only completes that element's editor. Keep the
       // explicit annotation session active so the user can select more page
@@ -1586,6 +1607,8 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
     }
     const operation = Symbol('annotation-cancel')
     this.annotationOverlayOperation = operation
+    const atomicRearm = this.annotationAtomicCloseRearm && this.annotationMode
+    const modeOperation = this.annotationModeOperation
     try {
       if (this.annotationUpdateTimer) {
         clearTimeout(this.annotationUpdateTimer)
@@ -1611,13 +1634,30 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
       }
       // Explicit close is the native acknowledgement. Until it succeeds the
       // trusted editor remains visible and owns the opaque selection.
-      const closed = await this.closeAnnotationOverlay(fence)
+      const closed = await this.closeAnnotationOverlay(fence, atomicRearm)
       if (!this.annotationOverlayFenceCurrent(fence)) return
       if (!closed.ok) {
+        if (atomicRearm && (
+          modeOperation !== this.annotationModeOperation
+          || !this.annotationMode
+        )) return
         this.showAnnotationCloseFailure()
         return
       }
       if (!this.clearAnnotationOverlayState(fence)) return
+      if (atomicRearm) {
+        if (
+          modeOperation === this.annotationModeOperation
+          && this.annotationMode
+        ) {
+          this.annotationPickerArmed = true
+          this.context.updateRenderState({
+            annotationMode: true,
+            annotationModeStopping: false,
+          })
+        }
+        return
+      }
       await this.syncSurfaceRect()
       await this.rearmAnnotationPickerIfNeeded()
     } finally {
@@ -1871,6 +1911,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
       || !nativeApi.closeArtifactAnnotationOverlay
     ) {
       this.annotationOverlayCopyVersion = 0
+      this.annotationAtomicCloseRearm = false
       const preserveRestoreIntent = this.annotationModeRestorePending
       this.annotationModeOperation += 1
       this.annotationSelectionAttempt += 1
@@ -1889,6 +1930,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
       const capability = await nativeApi.getArtifactAnnotationCapabilities()
       if (expectedGeneration !== this.generation || !this.createdSurface) return false
       this.annotationOverlayCopyVersion = capability.overlayCopyVersion === 1 ? 1 : 0
+      this.annotationAtomicCloseRearm = capability.atomicCloseRearm === true
       const available = (capability.version === 3 || capability.version === 4)
         && capability.available
         && capability.picker !== false
@@ -1930,6 +1972,7 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
     } catch {
       if (expectedGeneration !== this.generation || !this.createdSurface) return false
       this.annotationOverlayCopyVersion = 0
+      this.annotationAtomicCloseRearm = false
       const preserveRestoreIntent = this.annotationModeRestorePending
       this.annotationModeOperation += 1
       this.annotationSelectionAttempt += 1

--- a/opensquilla-webui/src/platform/desktop.ts
+++ b/opensquilla-webui/src/platform/desktop.ts
@@ -191,6 +191,10 @@ function normalizeNativeSurfaceEvent(payload: unknown): NativeWorkbenchSurfaceEv
           : {}),
         ...(typeof rawDetail.action === 'string' ? { action: rawDetail.action } : {}),
         ...(typeof rawDetail.code === 'string' ? { code: rawDetail.code } : {}),
+        ...(typeof rawDetail.surfaceInstanceId === 'string'
+          && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(rawDetail.surfaceInstanceId)
+          ? { surfaceInstanceId: rawDetail.surfaceInstanceId }
+          : {}),
       }
     : undefined
   return {

--- a/opensquilla-webui/src/platform/desktop.ts
+++ b/opensquilla-webui/src/platform/desktop.ts
@@ -307,6 +307,7 @@ function desktopNativeWorkbenchApi(api: OpenSquillaDesktopApi): NativeWorkbenchA
                 ? { trustedOverlay: raw.trustedOverlay }
                 : {}),
               ...(raw.overlayCopyVersion === 1 ? { overlayCopyVersion: 1 as const } : {}),
+              ...(raw.atomicCloseRearm === true ? { atomicCloseRearm: true as const } : {}),
               ...(typeof raw.reason === 'string' ? { reason: raw.reason } : {}),
             }
           },

--- a/opensquilla-webui/src/platform/native-workbench.test.ts
+++ b/opensquilla-webui/src/platform/native-workbench.test.ts
@@ -174,6 +174,7 @@ describe('native Workbench platform bridge', () => {
         picker: true,
         trustedOverlay: true,
         overlayCopyVersion: 1,
+        atomicCloseRearm: true,
       }),
       setArtifactAnnotationMode: setMode,
       showArtifactAnnotationOverlay: showOverlay,
@@ -188,6 +189,7 @@ describe('native Workbench platform bridge', () => {
       picker: true,
       trustedOverlay: true,
       overlayCopyVersion: 1,
+      atomicCloseRearm: true,
     })
     await expect(native.screenshot?.({ version: 3 })).resolves.toEqual({
       ok: true,

--- a/opensquilla-webui/src/platform/native-workbench.test.ts
+++ b/opensquilla-webui/src/platform/native-workbench.test.ts
@@ -231,9 +231,19 @@ describe('native Workbench platform bridge', () => {
       type: 'annotation-draft-change',
       detail: { annotationId: '../invalid', body: 'x'.repeat(16 * 1024 + 1) },
     })
+    emit?.({
+      version: 3,
+      surfaceId: 'artifact:fixture',
+      type: 'blocked-action',
+      detail: {
+        action: 'annotation-picker',
+        code: 'ANNOTATION_REARM_FAILED',
+        surfaceInstanceId: 'surface-instance-current',
+      },
+    })
 
-    expect(listener).toHaveBeenCalledOnce()
-    expect(listener).toHaveBeenCalledWith({
+    expect(listener).toHaveBeenCalledTimes(2)
+    expect(listener).toHaveBeenNthCalledWith(1, {
       version: 3,
       surfaceId: 'artifact:fixture',
       type: 'annotation-selected',
@@ -245,6 +255,16 @@ describe('native Workbench platform bridge', () => {
           elementProofSha256: 'b'.repeat(64),
           rect: { x: 1, y: 2, width: 30, height: 40 },
         },
+      },
+    })
+    expect(listener).toHaveBeenNthCalledWith(2, {
+      version: 3,
+      surfaceId: 'artifact:fixture',
+      type: 'blocked-action',
+      detail: {
+        action: 'annotation-picker',
+        code: 'ANNOTATION_REARM_FAILED',
+        surfaceInstanceId: 'surface-instance-current',
       },
     })
   })

--- a/opensquilla-webui/src/platform/types.ts
+++ b/opensquilla-webui/src/platform/types.ts
@@ -238,6 +238,7 @@ export interface NativeArtifactAnnotationCapabilities {
   picker?: boolean
   trustedOverlay?: boolean
   overlayCopyVersion?: 1
+  atomicCloseRearm?: true
   reason?: string
 }
 
@@ -270,6 +271,7 @@ export interface NativeArtifactAnnotationOverlayCloseRequest {
   version: 3 | 4
   surfaceId: string
   annotationId?: string
+  rearm?: true
 }
 
 export interface NativeArtifactScreenshotRequest {

--- a/opensquilla-webui/src/platform/types.ts
+++ b/opensquilla-webui/src/platform/types.ts
@@ -320,6 +320,7 @@ export interface NativeWorkbenchSurfaceResult {
   code?: string
   retryable?: boolean
   message?: string
+  surfaceInstanceId?: string
 }
 
 export type NativeWorkbenchSurfaceEventType =
@@ -357,6 +358,7 @@ export interface NativeWorkbenchSurfaceEvent {
     canGoForward?: boolean
     action?: string
     code?: string
+    surfaceInstanceId?: string
     message?: string
     path?: string
     reason?: string

--- a/src/opensquilla/artifact_session/html_anchors.py
+++ b/src/opensquilla/artifact_session/html_anchors.py
@@ -205,7 +205,7 @@ class HtmlAnchorChangedError(ValueError):
 
 @dataclass(frozen=True, slots=True)
 class ElementProofV2:
-    """Bounded proof that tolerates additive ancestor class tokens only."""
+    """Bounded proof that tolerates additive class tokens on the element path."""
 
     stable_element_proof_sha256: str
     ancestor_class_commitments: tuple[str, ...]
@@ -548,11 +548,12 @@ def canonical_element_proof_v2(
     """Return the bounded v2 element proof, or ``None`` when it is too large.
 
     The stable digest keeps the v1 path and attribute serialization, except
-    that an unnamespaced ``class`` attribute is omitted from non-selected
-    ancestors.  Each ancestor class token is committed separately so a source
-    token may be reordered, duplicated, or joined by additive runtime tokens,
-    while removal/replacement and moving a token to another depth still fail
-    closed.  No token or partial commitment set is returned on overflow.
+    that an unnamespaced ``class`` attribute is omitted from every element on
+    the path, including the selected element.  Each class token is committed
+    separately so a source token may be reordered, duplicated, or joined by
+    additive runtime tokens, while removal/replacement and moving a token to
+    another depth still fail closed.  No token or partial commitment set is
+    returned on overflow.
     """
 
     ancestors: list[etree._Element] = []
@@ -569,30 +570,28 @@ def canonical_element_proof_v2(
     stable_tokens: list[str] = []
     ancestor_class_tokens: set[tuple[int, str]] = set()
     class_token_bytes = 0
-    selected_depth = len(ancestors) - 1
     for depth, element in enumerate(ancestors):
         namespace, tag_name = _element_name(element)
         attributes = _normalized_element_attributes(element)
-        if depth != selected_depth:
-            stable_attributes: list[list[str]] = []
-            for attribute in attributes:
-                if attribute[0] == "" and attribute[1] == "class":
-                    for token in _ASCII_CLASS_WHITESPACE_RE.split(attribute[2]):
-                        if not token:
-                            continue
-                        depth_token = (depth, token)
-                        if depth_token in ancestor_class_tokens:
-                            continue
-                        class_token_bytes += len(token.encode("utf-8"))
-                        ancestor_class_tokens.add(depth_token)
-                        if (
-                            len(ancestor_class_tokens) > MAX_ANCESTOR_CLASS_COMMITMENTS
-                            or class_token_bytes > MAX_ANCESTOR_CLASS_TOKEN_BYTES
-                        ):
-                            return None
-                    continue
-                stable_attributes.append(attribute)
-            attributes = stable_attributes
+        stable_attributes: list[list[str]] = []
+        for attribute in attributes:
+            if attribute[0] == "" and attribute[1] == "class":
+                for token in _ASCII_CLASS_WHITESPACE_RE.split(attribute[2]):
+                    if not token:
+                        continue
+                    depth_token = (depth, token)
+                    if depth_token in ancestor_class_tokens:
+                        continue
+                    class_token_bytes += len(token.encode("utf-8"))
+                    ancestor_class_tokens.add(depth_token)
+                    if (
+                        len(ancestor_class_tokens) > MAX_ANCESTOR_CLASS_COMMITMENTS
+                        or class_token_bytes > MAX_ANCESTOR_CLASS_TOKEN_BYTES
+                    ):
+                        return None
+                continue
+            stable_attributes.append(attribute)
+        attributes = stable_attributes
         stable_tokens.append(
             json.dumps(
                 [

--- a/src/opensquilla/artifact_session/html_anchors.py
+++ b/src/opensquilla/artifact_session/html_anchors.py
@@ -25,6 +25,11 @@ SOURCE_OFFSET_ENCODING = "unicode-code-point"
 MAX_SEMANTIC_PROFILE_BYTES = 4 * 1024
 MAX_CONTEXT_BYTES = 8 * 1024
 MAX_CANDIDATE_SOURCE_BYTES = 16 * 1024
+MAX_ANCESTOR_CLASS_COMMITMENTS = 256
+MAX_ANCESTOR_CLASS_TOKEN_BYTES = 64 * 1024
+
+_ANCESTOR_CLASS_COMMITMENT_DOMAIN = "opensquilla.annotation.ancestor-class.v2"
+_ASCII_CLASS_WHITESPACE_RE = re.compile(r"[\t\n\f\r ]+")
 
 _SAFE_ATTRIBUTES = (
     "id",
@@ -196,6 +201,14 @@ def _parse_elements(source: str) -> tuple[_Element, ...]:
 
 class HtmlAnchorChangedError(ValueError):
     """The browser selection no longer identifies the immutable HTML source."""
+
+
+@dataclass(frozen=True, slots=True)
+class ElementProofV2:
+    """Bounded proof that tolerates additive ancestor class tokens only."""
+
+    stable_element_proof_sha256: str
+    ancestor_class_commitments: tuple[str, ...]
 
 
 _HTML_NAMESPACE = "http://www.w3.org/1999/xhtml"
@@ -527,6 +540,94 @@ def canonical_element_proof_sha256(
     return hashlib.sha256("\n".join(tokens).encode("utf-8")).hexdigest()
 
 
+def canonical_element_proof_v2(
+    root: etree._Element,
+    *,
+    selected: etree._Element,
+) -> ElementProofV2 | None:
+    """Return the bounded v2 element proof, or ``None`` when it is too large.
+
+    The stable digest keeps the v1 path and attribute serialization, except
+    that an unnamespaced ``class`` attribute is omitted from non-selected
+    ancestors.  Each ancestor class token is committed separately so a source
+    token may be reordered, duplicated, or joined by additive runtime tokens,
+    while removal/replacement and moving a token to another depth still fail
+    closed.  No token or partial commitment set is returned on overflow.
+    """
+
+    ancestors: list[etree._Element] = []
+    current: etree._Element | None = selected
+    while current is not None:
+        ancestors.append(current)
+        if current is root:
+            break
+        current = current.getparent()
+    if not ancestors or ancestors[-1] is not root:
+        raise ValueError("The selected element is outside the canonical DOM")
+    ancestors.reverse()
+
+    stable_tokens: list[str] = []
+    ancestor_class_tokens: set[tuple[int, str]] = set()
+    class_token_bytes = 0
+    selected_depth = len(ancestors) - 1
+    for depth, element in enumerate(ancestors):
+        namespace, tag_name = _element_name(element)
+        attributes = _normalized_element_attributes(element)
+        if depth != selected_depth:
+            stable_attributes: list[list[str]] = []
+            for attribute in attributes:
+                if attribute[0] == "" and attribute[1] == "class":
+                    for token in _ASCII_CLASS_WHITESPACE_RE.split(attribute[2]):
+                        if not token:
+                            continue
+                        depth_token = (depth, token)
+                        if depth_token in ancestor_class_tokens:
+                            continue
+                        class_token_bytes += len(token.encode("utf-8"))
+                        ancestor_class_tokens.add(depth_token)
+                        if (
+                            len(ancestor_class_tokens) > MAX_ANCESTOR_CLASS_COMMITMENTS
+                            or class_token_bytes > MAX_ANCESTOR_CLASS_TOKEN_BYTES
+                        ):
+                            return None
+                    continue
+                stable_attributes.append(attribute)
+            attributes = stable_attributes
+        stable_tokens.append(
+            json.dumps(
+                [
+                    namespace,
+                    tag_name,
+                    _element_nth_of_type(element),
+                    attributes,
+                ],
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+        )
+
+    stable_digest = hashlib.sha256("\n".join(stable_tokens).encode("utf-8")).hexdigest()
+    commitments = {
+        hashlib.sha256(
+            json.dumps(
+                [
+                    _ANCESTOR_CLASS_COMMITMENT_DOMAIN,
+                    stable_digest,
+                    depth,
+                    token,
+                ],
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+        for depth, token in ancestor_class_tokens
+    }
+    return ElementProofV2(
+        stable_element_proof_sha256=stable_digest,
+        ancestor_class_commitments=tuple(sorted(commitments)),
+    )
+
+
 def parse_element_path(value: str) -> tuple[tuple[str, str, int], ...]:
     """Validate the canonical browser element path wire representation."""
 
@@ -592,6 +693,23 @@ def canonical_selection_proofs(source: str, *, element_path: str) -> tuple[str, 
     selected = canonical_element_at_path(root, element_path)
     dom_sha256 = canonical_browser_dom_digest(root, source=source)
     return dom_sha256, canonical_element_proof_sha256(root, selected=selected)
+
+
+def canonical_selection_proof_v2(
+    source: str,
+    *,
+    element_path: str,
+) -> ElementProofV2 | None:
+    """Safely derive the bounded v2 proof for one canonical source path."""
+
+    parser = lxml_html.HTMLParser(recover=True, no_network=True)
+    try:
+        root = lxml_html.document_fromstring(source, parser=parser)
+    except (etree.ParserError, ValueError) as exc:
+        raise ValueError("The canonical HTML source cannot be parsed safely") from exc
+    _normalize_browser_html_dom(root, source=source)
+    selected = canonical_element_at_path(root, element_path)
+    return canonical_element_proof_v2(root, selected=selected)
 
 
 def _canonical_element_path(root: etree._Element, selected: etree._Element) -> str:
@@ -701,6 +819,7 @@ def canonical_opening_anchor(
     element_path: str,
     expected_element_proof_sha256: str,
     expected_tag_name: str,
+    expected_element_proof_v2: ElementProofV2 | None = None,
 ) -> tuple[dict[str, Any], str, dict[str, Any]]:
     """Verify a browser selection and produce the shared source anchor shape."""
 
@@ -719,7 +838,17 @@ def canonical_opening_anchor(
         raise HtmlAnchorChangedError("selection tag no longer matches the source")
     actual_element_proof_sha256 = canonical_element_proof_sha256(root, selected=selected)
     if actual_element_proof_sha256 != expected_element_proof_sha256:
-        raise HtmlAnchorChangedError("selection proof no longer matches the source")
+        actual_element_proof_v2 = canonical_element_proof_v2(root, selected=selected)
+        if (
+            expected_element_proof_v2 is None
+            or actual_element_proof_v2 is None
+            or actual_element_proof_v2.stable_element_proof_sha256
+            != expected_element_proof_v2.stable_element_proof_sha256
+            or not set(actual_element_proof_v2.ancestor_class_commitments).issubset(
+                expected_element_proof_v2.ancestor_class_commitments
+            )
+        ):
+            raise HtmlAnchorChangedError("selection proof no longer matches the source")
     start, start_tag_end, _opening_tag_name = _opening_span_for_element(
         source,
         root=root,
@@ -1166,6 +1295,7 @@ def contextual_candidate(
 
 __all__ = [
     "ContextualCandidate",
+    "ElementProofV2",
     "HtmlAnchorChangedError",
     "HtmlAnchorResolution",
     "MAX_CONTEXT_BYTES",
@@ -1174,7 +1304,9 @@ __all__ = [
     "canonical_browser_dom_digest",
     "canonical_element_at_path",
     "canonical_element_proof_sha256",
+    "canonical_element_proof_v2",
     "canonical_opening_anchor",
+    "canonical_selection_proof_v2",
     "canonical_selection_proofs",
     "canonical_selection_context_for_locator",
     "contextual_candidate",

--- a/src/opensquilla/gateway/desktop_artifact_bridge.py
+++ b/src/opensquilla/gateway/desktop_artifact_bridge.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass
 from typing import Any, Final, Literal, cast
 from urllib.parse import urlsplit
 
+from opensquilla.artifact_session.html_anchors import ElementProofV2
+
 DESKTOP_ARTIFACT_BRIDGE_URL_ENV: Final = "OPENSQUILLA_DESKTOP_ARTIFACT_BRIDGE_URL"
 DESKTOP_ARTIFACT_BRIDGE_TOKEN_ENV: Final = "OPENSQUILLA_DESKTOP_ARTIFACT_BRIDGE_TOKEN"
 DESKTOP_ARTIFACT_BRIDGE_PROTOCOL_VERSION: Final = 5
@@ -173,6 +175,7 @@ class DesktopArtifactBridgeCapabilities:
     reload_surface: bool
     bind_candidate_preview: bool
     restore_canonical_preview: bool
+    annotation_proof_v2: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -192,6 +195,7 @@ class DesktopArtifactResolvedAnnotationSelection:
     dom_sha256: str | None
     element_proof_sha256: str
     scope_id: str
+    annotation_proof_v2: ElementProofV2 | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -257,6 +261,55 @@ def _boolean(value: object, *, label: str) -> bool:
     return value
 
 
+def _annotation_proof_v2(value: object) -> ElementProofV2:
+    payload = _record(value, label="annotation proof-v2 response")
+    if set(payload) != {"stableElementProofSha256", "ancestorClassCommitments"}:
+        raise DesktopArtifactBridgeError(
+            "invalid-response", "The Desktop bridge annotation proof-v2 is invalid."
+        )
+    stable_digest = payload.get("stableElementProofSha256")
+    raw_commitments = payload.get("ancestorClassCommitments")
+    if (
+        not isinstance(stable_digest, str)
+        or not _SHA256_RE.fullmatch(stable_digest)
+        or not isinstance(raw_commitments, list)
+        or len(raw_commitments) > 256
+        or any(
+            not isinstance(commitment, str) or not _SHA256_RE.fullmatch(commitment)
+            for commitment in raw_commitments
+        )
+        or raw_commitments != sorted(set(raw_commitments))
+    ):
+        raise DesktopArtifactBridgeError(
+            "invalid-response", "The Desktop bridge annotation proof-v2 is invalid."
+        )
+    return ElementProofV2(
+        stable_element_proof_sha256=stable_digest,
+        ancestor_class_commitments=tuple(raw_commitments),
+    )
+
+
+def _annotation_proof_v2_payload(value: ElementProofV2) -> dict[str, object]:
+    stable_digest = value.stable_element_proof_sha256
+    commitments = value.ancestor_class_commitments
+    if (
+        not isinstance(stable_digest, str)
+        or not _SHA256_RE.fullmatch(stable_digest)
+        or not isinstance(commitments, tuple)
+        or len(commitments) > 256
+        or any(
+            not isinstance(commitment, str) or not _SHA256_RE.fullmatch(commitment)
+            for commitment in commitments
+        )
+        or list(commitments) != sorted(set(commitments))
+    ):
+        raise ValueError("Desktop artifact annotation proof-v2 is invalid")
+    return {
+        "stableElementProofSha256": stable_digest,
+        "ancestorClassCommitments": list(commitments),
+    }
+
+
 def _parse_capabilities(value: object) -> DesktopArtifactBridgeCapabilities:
     payload = _record(value, label="capabilities response")
     remote_version = payload.get("version")
@@ -301,6 +354,11 @@ def _parse_capabilities(value: object) -> DesktopArtifactBridgeCapabilities:
                 label="canonical preview restore capability",
             )
             if "restoreCanonicalPreview" in payload
+            else False
+        ),
+        annotation_proof_v2=(
+            _boolean(payload.get("annotationProofV2"), label="annotation proof-v2 capability")
+            if "annotationProofV2" in payload
             else False
         ),
     )
@@ -574,6 +632,11 @@ class DesktopArtifactBridgeClient:
         scope_id = _optional_string(
             value.get("scopeId"), label="annotation scope", max_chars=512
         )
+        annotation_proof_v2 = (
+            _annotation_proof_v2(value["annotationProofV2"])
+            if "annotationProofV2" in value
+            else None
+        )
         if (
             response_active_preview_artifact_id != active_preview_artifact_id
             or response_selection_id != selection_id
@@ -609,6 +672,7 @@ class DesktopArtifactBridgeClient:
             dom_sha256=dom_sha256,
             element_proof_sha256=element_proof_sha256,
             scope_id=scope_id,
+            annotation_proof_v2=annotation_proof_v2,
         )
 
     async def focus_annotation(
@@ -620,6 +684,7 @@ class DesktopArtifactBridgeClient:
         tag_name: str,
         element_path: str,
         element_proof_sha256: str,
+        annotation_proof_v2: ElementProofV2 | None = None,
         deadline_ms: int = 2_000,
     ) -> bool:
         if not isinstance(active_preview_artifact_id, str) or not _ARTIFACT_ID_RE.fullmatch(
@@ -642,16 +707,19 @@ class DesktopArtifactBridgeClient:
             element_proof_sha256
         ):
             raise ValueError("Desktop artifact annotation element proof is invalid")
+        request: dict[str, object] = {
+            "activePreviewArtifactId": active_preview_artifact_id,
+            "annotationId": annotation_id,
+            "scopeId": scope_id,
+            "tagName": tag_name,
+            "elementPath": element_path,
+            "elementProofSha256": element_proof_sha256,
+        }
+        if annotation_proof_v2 is not None:
+            request["annotationProofV2"] = _annotation_proof_v2_payload(annotation_proof_v2)
         value = await self._call(
             "focusAnnotation",
-            {
-                "activePreviewArtifactId": active_preview_artifact_id,
-                "annotationId": annotation_id,
-                "scopeId": scope_id,
-                "tagName": tag_name,
-                "elementPath": element_path,
-                "elementProofSha256": element_proof_sha256,
-            },
+            request,
             deadline_ms=deadline_ms,
         )
         if value != {

--- a/src/opensquilla/gateway/rpc_artifact_editing.py
+++ b/src/opensquilla/gateway/rpc_artifact_editing.py
@@ -45,7 +45,9 @@ from opensquilla.artifact_session import (
     ArtifactNotFoundError as ArtifactSessionNotFoundError,
 )
 from opensquilla.artifact_session.html_anchors import (
+    ElementProofV2,
     HtmlAnchorChangedError,
+    canonical_selection_proof_v2,
     remap_html_anchor,
     target_projection,
 )
@@ -113,6 +115,8 @@ _HTML_TAG_NAME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9:-]{0,127}$")
 _OPAQUE_ANNOTATION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 _SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 _SOURCE_OFFSET_ENCODING = "unicode-code-point"
+
+
 class _OpeningTagCollector(HTMLParser):
     """Collect canonical source opening-tag spans with raw spelling intact."""
 
@@ -575,6 +579,7 @@ def _canonical_opening_anchor(
     element_path: str,
     expected_element_proof_sha256: str,
     expected_tag_name: str,
+    expected_element_proof_v2: ElementProofV2 | None = None,
 ) -> tuple[dict[str, Any], str, dict[str, Any]]:
     try:
         return shared_canonical_opening_anchor(
@@ -582,9 +587,18 @@ def _canonical_opening_anchor(
             element_path=element_path,
             expected_element_proof_sha256=expected_element_proof_sha256,
             expected_tag_name=expected_tag_name,
+            expected_element_proof_v2=expected_element_proof_v2,
         )
     except HtmlAnchorChangedError as exc:
-        raise artifact_product_error(ArtifactProductErrorCode.DOCUMENT_CHANGED) from exc
+        raise logged_artifact_product_error(
+            ArtifactProductErrorCode.DOCUMENT_CHANGED,
+            exc,
+            operation="prompt_annotations.verify_source_selection",
+            retryable=False,
+            reason_code="selection_proof_changed",
+            verification_stage="source-anchor",
+            proof_mode="v2" if expected_element_proof_v2 is not None else "v1",
+        ) from exc
 
 
 # Compatibility aliases for tests and older internal imports. Production
@@ -1938,13 +1952,23 @@ async def _trusted_annotation_selection(
     element_path: str,
     dom_sha256: str | None,
     element_proof_sha256: str,
-) -> None:
+) -> ElementProofV2 | None:
     bridge = get_desktop_artifact_bridge_client()
     if bridge is None or not hasattr(bridge, "resolve_annotation_selection"):
         raise artifact_product_error(
             ArtifactProductErrorCode.ANNOTATION_UNAVAILABLE,
             reason_code="preview_unavailable",
         )
+    annotation_proof_v2_capable = False
+    capabilities = getattr(bridge, "capabilities", None)
+    if callable(capabilities):
+        try:
+            advertised = await capabilities(deadline_ms=2_000)
+            annotation_proof_v2_capable = getattr(advertised, "annotation_proof_v2", False) is True
+        except (DesktopArtifactBridgeError, TypeError, ValueError):
+            # Capability probing is additive. Its absence/failure keeps the
+            # established strict-v1 path available but can never enable v2.
+            annotation_proof_v2_capable = False
     try:
         resolved = await bridge.resolve_annotation_selection(
             active_preview_artifact_id=active_preview_artifact_id,
@@ -1976,6 +2000,27 @@ async def _trusted_annotation_selection(
             ArtifactProductErrorCode.ANNOTATION_UNAVAILABLE,
             reason_code="preview_changed",
         )
+    if not annotation_proof_v2_capable:
+        return None
+    resolved_v2 = getattr(resolved, "annotation_proof_v2", None)
+    if resolved_v2 is None:
+        return None
+    if (
+        not isinstance(resolved_v2, ElementProofV2)
+        or not _SHA256_RE.fullmatch(resolved_v2.stable_element_proof_sha256)
+        or len(resolved_v2.ancestor_class_commitments) > 256
+        or any(
+            not _SHA256_RE.fullmatch(commitment)
+            for commitment in resolved_v2.ancestor_class_commitments
+        )
+        or list(resolved_v2.ancestor_class_commitments)
+        != sorted(set(resolved_v2.ancestor_class_commitments))
+    ):
+        raise artifact_product_error(
+            ArtifactProductErrorCode.ANNOTATION_UNAVAILABLE,
+            reason_code="preview_changed",
+        )
+    return resolved_v2
 
 
 async def _scoped_prompt_annotation(
@@ -2045,7 +2090,11 @@ async def _idempotent_prompt_annotation_create(
         or anchor.revision_id != revision_id
         or locator_tag_name != tag_name
         or context.get("element_path") != element_path
-        or context.get("element_proof_sha256") != element_proof_sha256
+        or context.get(
+            "selection_element_proof_sha256",
+            context.get("element_proof_sha256"),
+        )
+        != element_proof_sha256
     ):
         raise artifact_product_error(ArtifactProductErrorCode.ANNOTATION_BUSY)
     return annotation, anchor
@@ -2161,7 +2210,7 @@ async def _handle_prompt_annotation_create(
             ArtifactProductErrorCode.RESOURCE_UNSUPPORTED,
             reason_code="annotation_unsupported",
         )
-    await _trusted_annotation_selection(
+    trusted_element_proof_v2 = await _trusted_annotation_selection(
         session_key=session_key,
         active_preview_artifact_id=revision.artifact_id,
         selection_id=selection_id,
@@ -2182,7 +2231,13 @@ async def _handle_prompt_annotation_create(
         element_path=element_path,
         expected_element_proof_sha256=element_proof_sha256,
         expected_tag_name=tag_name,
+        expected_element_proof_v2=trusted_element_proof_v2,
     )
+    # The canonical element proof remains in ``element_proof_sha256``. Keep
+    # the exact renderer-selected v1 proof separately so an accepted v2 create
+    # can replay a lost response without consuming another native candidate.
+    # V2 commitments are deliberately never persisted.
+    anchor_context["selection_element_proof_sha256"] = element_proof_sha256
 
     try:
         anchor, annotation = await service.create_prompt_annotation_with_anchor(
@@ -2316,6 +2371,20 @@ async def _handle_prompt_annotation_focus(
         or not _HTML_TAG_NAME_RE.fullmatch(tag_name)
     ):
         raise artifact_product_error(ArtifactProductErrorCode.ANNOTATION_UNAVAILABLE)
+    annotation_proof_v2: ElementProofV2 | None = None
+    capabilities = getattr(bridge, "capabilities", None)
+    if callable(capabilities):
+        try:
+            advertised = await capabilities(deadline_ms=2_000)
+            if getattr(advertised, "annotation_proof_v2", False) is True:
+                annotation_proof_v2 = canonical_selection_proof_v2(
+                    current_source,
+                    element_path=element_path,
+                )
+        except (DesktopArtifactBridgeError, TypeError, ValueError):
+            # Keep old Desktop shells on the strict-v1 focus request. A v2
+            # proof is never sent without an affirmative current capability.
+            annotation_proof_v2 = None
     try:
         focused = await bridge.focus_annotation(
             annotation_id=annotation.annotation_id,
@@ -2324,6 +2393,11 @@ async def _handle_prompt_annotation_focus(
             tag_name=tag_name.lower(),
             element_path=element_path,
             element_proof_sha256=element_proof_sha256,
+            **(
+                {"annotation_proof_v2": annotation_proof_v2}
+                if annotation_proof_v2 is not None
+                else {}
+            ),
             deadline_ms=2_000,
         )
     except (DesktopArtifactBridgeError, ValueError) as exc:

--- a/tests/test_artifact_session/test_html_anchors.py
+++ b/tests/test_artifact_session/test_html_anchors.py
@@ -129,14 +129,14 @@ def test_canonical_selection_proofs_safely_parse_source_and_path() -> None:
     assert len(proof) == 64
 
 
-def test_element_proof_v2_accepts_only_additive_reordered_ancestor_classes() -> None:
+def test_element_proof_v2_accepts_only_additive_reordered_path_classes() -> None:
     source = (
         '<main class="shell base" id="app"><section class="card reveal">'
         '<span class="leaf" id="target">Leaf</span></section></main>'
     )
     runtime = (
         '<main class="ready base shell shell" id="app">'
-        '<section class="visible reveal card"><span class="leaf" id="target">'
+        '<section class="visible reveal card"><span class="active leaf leaf" id="target">'
         "Leaf</span></section></main>"
     )
     element_path = json.dumps(
@@ -174,27 +174,29 @@ def test_element_proof_v2_accepts_only_additive_reordered_ancestor_classes() -> 
     [
         # Removing/replacing a source class token is not additive.
         '<main class="shell" id="app" data-state="source" style="color:red">'
-        '<span id="target">Leaf</span></main>',
+        '<span id="target" class="selected base">Leaf</span></main>',
         '<main class="shell other" id="app" data-state="source" style="color:red">'
-        '<span id="target">Leaf</span></main>',
+        '<span id="target" class="selected base">Leaf</span></main>',
         # All non-class ancestor attributes remain strict, including style.
         '<main class="shell base" id="changed" data-state="source" style="color:red">'
-        '<span id="target">Leaf</span></main>',
+        '<span id="target" class="selected base">Leaf</span></main>',
         '<main class="shell base" id="app" data-state="changed" style="color:red">'
-        '<span id="target">Leaf</span></main>',
+        '<span id="target" class="selected base">Leaf</span></main>',
         '<main class="shell base" id="app" data-state="source" style="color:blue">'
+        '<span id="target" class="selected base">Leaf</span></main>',
+        # Removing/replacing a selected-element source class is not additive.
+        '<main class="shell base" id="app" data-state="source" style="color:red">'
         '<span id="target">Leaf</span></main>',
-        # The selected element keeps its complete attribute identity.
         '<main class="shell base" id="app" data-state="source" style="color:red">'
-        '<span id="target" class="selected">Leaf</span></main>',
+        '<span id="target" class="changed">Leaf</span></main>',
         '<main class="shell base" id="app" data-state="source" style="color:red">'
-        '<span id="target" style="opacity:.5">Leaf</span></main>',
+        '<span id="target" class="selected base" style="opacity:.5">Leaf</span></main>',
     ],
 )
 def test_element_proof_v2_rejects_non_additive_or_non_class_changes(runtime: str) -> None:
     source = (
         '<main class="shell base" id="app" data-state="source" style="color:red">'
-        '<span id="target">Leaf</span></main>'
+        '<span id="target" class="selected base">Leaf</span></main>'
     )
     element_path = json.dumps(
         [["", "html", 1], ["", "body", 1], ["", "main", 1], ["", "span", 1]],

--- a/tests/test_artifact_session/test_html_anchors.py
+++ b/tests/test_artifact_session/test_html_anchors.py
@@ -7,9 +7,13 @@ import pytest
 from lxml import html as lxml_html  # type: ignore[import-untyped]
 
 from opensquilla.artifact_session.html_anchors import (
+    ElementProofV2,
+    HtmlAnchorChangedError,
     canonical_element_at_path,
     canonical_element_proof_sha256,
+    canonical_element_proof_v2,
     canonical_opening_anchor,
+    canonical_selection_proof_v2,
     canonical_selection_proofs,
     contextual_candidate,
     enrich_anchor_context,
@@ -123,6 +127,109 @@ def test_canonical_selection_proofs_safely_parse_source_and_path() -> None:
 
     assert len(dom_sha256) == 64
     assert len(proof) == 64
+
+
+def test_element_proof_v2_accepts_only_additive_reordered_ancestor_classes() -> None:
+    source = (
+        '<main class="shell base" id="app"><section class="card reveal">'
+        '<span class="leaf" id="target">Leaf</span></section></main>'
+    )
+    runtime = (
+        '<main class="ready base shell shell" id="app">'
+        '<section class="visible reveal card"><span class="leaf" id="target">'
+        "Leaf</span></section></main>"
+    )
+    element_path = json.dumps(
+        [
+            ["", "html", 1],
+            ["", "body", 1],
+            ["", "main", 1],
+            ["", "section", 1],
+            ["", "span", 1],
+        ],
+        separators=(",", ":"),
+    )
+    source_v1 = canonical_selection_proofs(source, element_path=element_path)[1]
+    runtime_v1 = canonical_selection_proofs(runtime, element_path=element_path)[1]
+    source_v2 = canonical_selection_proof_v2(source, element_path=element_path)
+    runtime_v2 = canonical_selection_proof_v2(runtime, element_path=element_path)
+
+    assert source_v1 != runtime_v1
+    assert source_v2 is not None and runtime_v2 is not None
+    assert source_v2.stable_element_proof_sha256 == runtime_v2.stable_element_proof_sha256
+    assert set(source_v2.ancestor_class_commitments) < set(runtime_v2.ancestor_class_commitments)
+    locator, opening, _context = canonical_opening_anchor(
+        source,
+        element_path=element_path,
+        expected_element_proof_sha256=runtime_v1,
+        expected_tag_name="span",
+        expected_element_proof_v2=runtime_v2,
+    )
+    assert opening == '<span class="leaf" id="target">'
+    assert locator["tag_name"] == "span"
+
+
+@pytest.mark.parametrize(
+    "runtime",
+    [
+        # Removing/replacing a source class token is not additive.
+        '<main class="shell" id="app" data-state="source" style="color:red">'
+        '<span id="target">Leaf</span></main>',
+        '<main class="shell other" id="app" data-state="source" style="color:red">'
+        '<span id="target">Leaf</span></main>',
+        # All non-class ancestor attributes remain strict, including style.
+        '<main class="shell base" id="changed" data-state="source" style="color:red">'
+        '<span id="target">Leaf</span></main>',
+        '<main class="shell base" id="app" data-state="changed" style="color:red">'
+        '<span id="target">Leaf</span></main>',
+        '<main class="shell base" id="app" data-state="source" style="color:blue">'
+        '<span id="target">Leaf</span></main>',
+        # The selected element keeps its complete attribute identity.
+        '<main class="shell base" id="app" data-state="source" style="color:red">'
+        '<span id="target" class="selected">Leaf</span></main>',
+        '<main class="shell base" id="app" data-state="source" style="color:red">'
+        '<span id="target" style="opacity:.5">Leaf</span></main>',
+    ],
+)
+def test_element_proof_v2_rejects_non_additive_or_non_class_changes(runtime: str) -> None:
+    source = (
+        '<main class="shell base" id="app" data-state="source" style="color:red">'
+        '<span id="target">Leaf</span></main>'
+    )
+    element_path = json.dumps(
+        [["", "html", 1], ["", "body", 1], ["", "main", 1], ["", "span", 1]],
+        separators=(",", ":"),
+    )
+    runtime_v1 = canonical_selection_proofs(runtime, element_path=element_path)[1]
+    runtime_v2 = canonical_selection_proof_v2(runtime, element_path=element_path)
+    assert runtime_v2 is not None
+
+    with pytest.raises(HtmlAnchorChangedError, match="selection proof"):
+        canonical_opening_anchor(
+            source,
+            element_path=element_path,
+            expected_element_proof_sha256=runtime_v1,
+            expected_tag_name="span",
+            expected_element_proof_v2=runtime_v2,
+        )
+
+
+def test_element_proof_v2_is_all_or_nothing_at_aggregate_limits() -> None:
+    root = lxml_html.document_fromstring("<main><span>Leaf</span></main>")
+    main = root.xpath("//main")[0]
+    selected = root.xpath("//span")[0]
+
+    main.set("class", " ".join(f"token-{index}" for index in range(257)))
+    assert canonical_element_proof_v2(root, selected=selected) is None
+
+    main.set("class", "x" * (64 * 1024 + 1))
+    assert canonical_element_proof_v2(root, selected=selected) is None
+
+    # Duplicate tokens are semantic duplicates, not partial commitments.
+    main.set("class", "\t".join(["same"] * 128))
+    proof = canonical_element_proof_v2(root, selected=selected)
+    assert isinstance(proof, ElementProofV2)
+    assert len(proof.ancestor_class_commitments) == 1
 
 
 def test_remap_never_chooses_first_ambiguous_candidate() -> None:

--- a/tests/test_artifact_session/test_html_anchors.py
+++ b/tests/test_artifact_session/test_html_anchors.py
@@ -173,24 +173,40 @@ def test_element_proof_v2_accepts_only_additive_reordered_path_classes() -> None
     "runtime",
     [
         # Removing/replacing a source class token is not additive.
-        '<main class="shell" id="app" data-state="source" style="color:red">'
-        '<span id="target" class="selected base">Leaf</span></main>',
-        '<main class="shell other" id="app" data-state="source" style="color:red">'
-        '<span id="target" class="selected base">Leaf</span></main>',
+        (
+            '<main class="shell" id="app" data-state="source" style="color:red">'
+            + '<span id="target" class="selected base">Leaf</span></main>'
+        ),
+        (
+            '<main class="shell other" id="app" data-state="source" style="color:red">'
+            + '<span id="target" class="selected base">Leaf</span></main>'
+        ),
         # All non-class ancestor attributes remain strict, including style.
-        '<main class="shell base" id="changed" data-state="source" style="color:red">'
-        '<span id="target" class="selected base">Leaf</span></main>',
-        '<main class="shell base" id="app" data-state="changed" style="color:red">'
-        '<span id="target" class="selected base">Leaf</span></main>',
-        '<main class="shell base" id="app" data-state="source" style="color:blue">'
-        '<span id="target" class="selected base">Leaf</span></main>',
+        (
+            '<main class="shell base" id="changed" data-state="source" style="color:red">'
+            + '<span id="target" class="selected base">Leaf</span></main>'
+        ),
+        (
+            '<main class="shell base" id="app" data-state="changed" style="color:red">'
+            + '<span id="target" class="selected base">Leaf</span></main>'
+        ),
+        (
+            '<main class="shell base" id="app" data-state="source" style="color:blue">'
+            + '<span id="target" class="selected base">Leaf</span></main>'
+        ),
         # Removing/replacing a selected-element source class is not additive.
-        '<main class="shell base" id="app" data-state="source" style="color:red">'
-        '<span id="target">Leaf</span></main>',
-        '<main class="shell base" id="app" data-state="source" style="color:red">'
-        '<span id="target" class="changed">Leaf</span></main>',
-        '<main class="shell base" id="app" data-state="source" style="color:red">'
-        '<span id="target" class="selected base" style="opacity:.5">Leaf</span></main>',
+        (
+            '<main class="shell base" id="app" data-state="source" style="color:red">'
+            + '<span id="target">Leaf</span></main>'
+        ),
+        (
+            '<main class="shell base" id="app" data-state="source" style="color:red">'
+            + '<span id="target" class="changed">Leaf</span></main>'
+        ),
+        (
+            '<main class="shell base" id="app" data-state="source" style="color:red">'
+            + '<span id="target" class="selected base" style="opacity:.5">Leaf</span></main>'
+        ),
     ],
 )
 def test_element_proof_v2_rejects_non_additive_or_non_class_changes(runtime: str) -> None:

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -2572,7 +2572,10 @@ def test_offline_document_workbench_gate_composes_owned_gateway_and_real_electro
     assert "OPENSQUILLA_WORKBENCH_E2E_MODE || 'stress'" in native
     assert "const annotationGeometryDeltas = fixture.stressMode" in native
     assert "? [96, -24, 24, -32, 32]" in native
-    assert "const annotationRearmCycleCount = fixture.stressMode ? 3 : 1" in native
+    assert "const annotationRearmCycleCount = fixture.stressMode ? 50 : 8" in native
+    assert "rearm: true" in native
+    assert "annotationAtomicHandoffPendingState" in native
+    assert "annotationAtomicFailureRetained" in native
     assert "restoreTrustedAnnotationInputFocus" in native
     assert "state.ownerFocused" in native
     assert "&& state.nativeFocused" in native

--- a/tests/test_gateway/test_desktop_artifact_bridge.py
+++ b/tests/test_gateway/test_desktop_artifact_bridge.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 
+from opensquilla.artifact_session.html_anchors import ElementProofV2
 from opensquilla.gateway import desktop_artifact_bridge as bridge_module
 from opensquilla.gateway.desktop_artifact_bridge import (
     DESKTOP_ARTIFACT_BRIDGE_TOKEN_ENV,
@@ -406,6 +407,7 @@ async def test_capabilities_uses_authenticated_fixed_endpoint(
     assert capabilities.screenshot is True
     assert capabilities.office_flush is False
     assert capabilities.reload_surface is True
+    assert capabilities.annotation_proof_v2 is False
     request = calls[1]
     assert request["method"] == "POST"
     assert request["path"] == "/v1/capabilities"
@@ -416,12 +418,46 @@ async def test_capabilities_uses_authenticated_fixed_endpoint(
 
 
 @pytest.mark.asyncio
+async def test_capabilities_accepts_optional_annotation_proof_v2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_response(
+        monkeypatch,
+        {
+            "ok": True,
+            "value": {
+                "version": 5,
+                "available": True,
+                "captureSelection": True,
+                "resolveAnnotationSelection": True,
+                "focusAnnotation": True,
+                "browserInspect": True,
+                "browserAct": True,
+                "screenshot": True,
+                "officeFlush": True,
+                "reloadSurface": True,
+                "annotationProofV2": True,
+            },
+        },
+    )
+    client = DesktopArtifactBridgeClient(endpoint="http://127.0.0.1:1234", token=_token())
+
+    capabilities = await client.capabilities()
+
+    assert capabilities.annotation_proof_v2 is True
+
+
+@pytest.mark.asyncio
 async def test_resolve_annotation_selection_is_typed_and_requires_exact_echo(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     active_preview_artifact_id = "art-bridge-fixture"
     digest = "a" * 64
     element_proof = "c" * 64
+    proof_v2 = ElementProofV2(
+        stable_element_proof_sha256="d" * 64,
+        ancestor_class_commitments=("1" * 64, "2" * 64),
+    )
     element_path = json.dumps(
         [["", "html", 1], ["", "body", 1], ["", "button", 2]],
         separators=(",", ":"),
@@ -438,6 +474,10 @@ async def test_resolve_annotation_selection_is_typed_and_requires_exact_echo(
                 "elementPath": element_path,
                 "domSha256": digest,
                 "elementProofSha256": element_proof,
+                "annotationProofV2": {
+                    "stableElementProofSha256": proof_v2.stable_element_proof_sha256,
+                    "ancestorClassCommitments": list(proof_v2.ancestor_class_commitments),
+                },
                 "scopeId": "agent:fixture:webchat:fixture",
                 "rect": {"x": 10, "y": 20, "width": 80, "height": 24},
             },
@@ -460,6 +500,7 @@ async def test_resolve_annotation_selection_is_typed_and_requires_exact_echo(
     assert resolved.element_path == element_path
     assert resolved.dom_sha256 == digest
     assert resolved.element_proof_sha256 == element_proof
+    assert resolved.annotation_proof_v2 == proof_v2
     assert resolved.scope_id == "agent:fixture:webchat:fixture"
     request = json.loads(calls[1]["body"])
     assert request == {
@@ -559,6 +600,106 @@ async def test_resolve_annotation_selection_is_typed_and_requires_exact_echo(
             element_proof_sha256="not-a-proof",
         )
     assert mismatched_calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "proof_v2",
+    [
+        {"stableElementProofSha256": "d" * 64},
+        {
+            "stableElementProofSha256": "d" * 64,
+            "ancestorClassCommitments": ["2" * 64, "1" * 64],
+        },
+        {
+            "stableElementProofSha256": "d" * 64,
+            "ancestorClassCommitments": ["1" * 64, "1" * 64],
+        },
+        {
+            "stableElementProofSha256": "d" * 64,
+            "ancestorClassCommitments": ["1" * 64] * 257,
+        },
+        {
+            "stableElementProofSha256": "not-a-digest",
+            "ancestorClassCommitments": [],
+        },
+    ],
+)
+async def test_resolve_annotation_selection_rejects_partial_or_unbounded_proof_v2(
+    monkeypatch: pytest.MonkeyPatch,
+    proof_v2: dict[str, object],
+) -> None:
+    artifact_id = "art-proof-v2-malformed"
+    element_path = json.dumps(
+        [["", "html", 1], ["", "body", 1], ["", "button", 1]],
+        separators=(",", ":"),
+    )
+    _install_response(
+        monkeypatch,
+        {
+            "ok": True,
+            "method": "resolveAnnotationSelection",
+            "value": {
+                "activePreviewArtifactId": artifact_id,
+                "selectionId": "selection-proof-v2",
+                "tagName": "button",
+                "elementPath": element_path,
+                "elementProofSha256": "a" * 64,
+                "annotationProofV2": proof_v2,
+                "scopeId": "agent:fixture:webchat:fixture",
+                "rect": {"x": 1, "y": 2, "width": 3, "height": 4},
+            },
+        },
+    )
+    client = DesktopArtifactBridgeClient(endpoint="http://127.0.0.1:4321", token=_token())
+
+    with pytest.raises(DesktopArtifactBridgeError, match="proof-v2"):
+        await client.resolve_annotation_selection(
+            active_preview_artifact_id=artifact_id,
+            selection_id="selection-proof-v2",
+            tag_name="button",
+            element_path=element_path,
+            element_proof_sha256="a" * 64,
+        )
+
+
+@pytest.mark.asyncio
+async def test_focus_annotation_sends_proof_v2_only_when_supplied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact_id = "art-focus-proof-v2"
+    element_path = json.dumps(
+        [["", "html", 1], ["", "body", 1], ["", "section", 1]],
+        separators=(",", ":"),
+    )
+    proof_v2 = ElementProofV2(
+        stable_element_proof_sha256="d" * 64,
+        ancestor_class_commitments=("1" * 64,),
+    )
+    calls = _install_response(
+        monkeypatch,
+        {
+            "ok": True,
+            "method": "focusAnnotation",
+            "value": {"focused": True, "activePreviewArtifactId": artifact_id},
+        },
+    )
+    client = DesktopArtifactBridgeClient(endpoint="http://127.0.0.1:4321", token=_token())
+
+    assert await client.focus_annotation(
+        active_preview_artifact_id=artifact_id,
+        annotation_id="annotation-proof-v2",
+        scope_id="agent:fixture:webchat:fixture",
+        tag_name="section",
+        element_path=element_path,
+        element_proof_sha256="a" * 64,
+        annotation_proof_v2=proof_v2,
+    )
+    request = json.loads(calls[1]["body"])["request"]
+    assert request["annotationProofV2"] == {
+        "stableElementProofSha256": "d" * 64,
+        "ancestorClassCommitments": ["1" * 64],
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway/test_rpc_artifact_editing.py
+++ b/tests/test_gateway/test_rpc_artifact_editing.py
@@ -24,9 +24,11 @@ from opensquilla.artifact_session import (
     MutationAttemptStatus,
 )
 from opensquilla.artifact_session.html_anchors import (
+    ElementProofV2,
     canonical_browser_dom_digest,
     canonical_element_at_path,
     canonical_element_proof_sha256,
+    canonical_selection_proof_v2,
 )
 from opensquilla.artifacts import (
     ArtifactBundle,
@@ -128,6 +130,10 @@ def _annotation_proofs(html: str, element_path: str) -> tuple[str, str]:
         selected=selected,
     )
     return dom_sha256, element_proof_sha256
+
+
+def _annotation_proof_v2(html: str, element_path: str) -> ElementProofV2 | None:
+    return canonical_selection_proof_v2(html, element_path=element_path)
 
 
 async def _annotation_row_counts(env) -> tuple[int, int, int]:
@@ -287,8 +293,18 @@ async def test_prompt_annotation_create_replay_does_not_reuse_native_candidate(
 
 
 class _EchoAnnotationBridge:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        annotation_proof_v2: ElementProofV2 | None = None,
+        proof_v2_capable: bool = False,
+    ) -> None:
         self.resolve_calls: list[dict[str, object]] = []
+        self.annotation_proof_v2 = annotation_proof_v2
+        self.proof_v2_capable = proof_v2_capable
+
+    async def capabilities(self, **_kwargs):
+        return SimpleNamespace(annotation_proof_v2=self.proof_v2_capable)
 
     async def resolve_annotation_selection(self, **kwargs):
         self.resolve_calls.append(kwargs)
@@ -300,6 +316,7 @@ class _EchoAnnotationBridge:
             dom_sha256=kwargs["dom_sha256"],
             element_proof_sha256=kwargs["element_proof_sha256"],
             scope_id=SESSION_KEY,
+            annotation_proof_v2=self.annotation_proof_v2,
         )
 
 
@@ -553,6 +570,286 @@ async def test_prompt_annotation_accepts_unrelated_runtime_dom_mutation(
     assert anchor_context["semantic_profile_v1"]["normalized_text"] == "Title"
     assert "dom_sha256" not in anchor_context
     assert await _annotation_row_counts(env) == (1, 1, 1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "runtime_html",
+    [
+        (
+            '<main class="shell base ready" id="app" data-state="source" '
+            'style="color:red"><section class="card reveal visible" data-zone="hero">'
+            '<span class="leaf" style="opacity:1">Leaf</span></section></main>'
+        ),
+        (
+            '<main class="base shell" id="app" data-state="source" style="color:red">'
+            '<section class="reveal card" data-zone="hero">'
+            '<span class="leaf" style="opacity:1">Leaf</span></section></main>'
+        ),
+        (
+            '<main class="shell base shell" id="app" data-state="source" '
+            'style="color:red"><section class="card reveal reveal" data-zone="hero">'
+            '<span class="leaf" style="opacity:1">Leaf</span></section></main>'
+        ),
+    ],
+    ids=("add", "reorder", "duplicates"),
+)
+async def test_prompt_annotation_v2_accepts_additive_ancestor_class_mutations(
+    artifact_editing_env,
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_html: str,
+) -> None:
+    env = artifact_editing_env
+    source_html = (
+        '<main class="shell base" id="app" data-state="source" style="color:red">'
+        '<section class="card reveal" data-zone="hero">'
+        '<span class="leaf" style="opacity:1">Leaf</span></section></main>'
+    )
+    _ref, document = await _adopt_html(env, source_html.encode())
+    element_path = json.dumps(
+        [
+            ["", "html", 1],
+            ["", "body", 1],
+            ["", "main", 1],
+            ["", "section", 1],
+            ["", "span", 1],
+        ],
+        separators=(",", ":"),
+    )
+    runtime_dom_sha256, runtime_v1 = _annotation_proofs(runtime_html, element_path)
+    source_v1 = _annotation_proofs(source_html, element_path)[1]
+    runtime_v2 = _annotation_proof_v2(runtime_html, element_path)
+    assert source_v1 != runtime_v1
+    assert runtime_v2 is not None
+
+    bridge = _EchoAnnotationBridge(
+        annotation_proof_v2=runtime_v2,
+        proof_v2_capable=True,
+    )
+    monkeypatch.setattr(
+        artifact_editing_rpc,
+        "get_desktop_artifact_bridge_client",
+        lambda: bridge,
+    )
+    params = {
+        "annotationId": "annotation-v2-accepted",
+        "sessionKey": SESSION_KEY,
+        "documentId": document["id"],
+        "revisionId": document["headRevisionId"],
+        "selection": {
+            "selectionId": "selection-v2-accepted",
+            "tagName": "span",
+            "elementPath": element_path,
+            "domSha256": runtime_dom_sha256,
+            "elementProofSha256": runtime_v1,
+        },
+        "body": "Update the leaf.",
+    }
+    created = await _dispatch(env, "artifacts.prompt_annotations.create", params)
+
+    assert created.error is None, created.error
+    context = created.payload["annotation"]["anchor"]["context"]
+    assert context["element_proof_sha256"] == source_v1
+    assert context["selection_element_proof_sha256"] == runtime_v1
+    assert not any("commitment" in key for key in context)
+    assert await _annotation_row_counts(env) == (1, 1, 1)
+
+    # Lost-response recovery uses the exact selected v1 proof stored in the
+    # anchor context and never asks Desktop to consume the candidate twice.
+    monkeypatch.setattr(
+        artifact_editing_rpc,
+        "get_desktop_artifact_bridge_client",
+        lambda: object(),
+    )
+    replayed = await _dispatch(env, "artifacts.prompt_annotations.create", params)
+    assert replayed.error is None, replayed.error
+    assert replayed.payload == created.payload
+    assert len(bridge.resolve_calls) == 1
+    assert await _annotation_row_counts(env) == (1, 1, 1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "runtime_html",
+    [
+        (
+            '<main class="shell" id="app" data-state="source" style="color:red">'
+            '<section class="card reveal" data-zone="hero"><span class="leaf" '
+            'style="opacity:1">Leaf</span></section></main>'
+        ),
+        (
+            '<main class="shell other" id="app" data-state="source" style="color:red">'
+            '<section class="card reveal" data-zone="hero"><span class="leaf" '
+            'style="opacity:1">Leaf</span></section></main>'
+        ),
+        (
+            '<main class="shell base" id="changed" data-state="source" style="color:red">'
+            '<section class="card reveal" data-zone="hero"><span class="leaf" '
+            'style="opacity:1">Leaf</span></section></main>'
+        ),
+        (
+            '<main class="shell base" id="app" data-state="changed" style="color:red">'
+            '<section class="card reveal" data-zone="hero"><span class="leaf" '
+            'style="opacity:1">Leaf</span></section></main>'
+        ),
+        (
+            '<main class="shell base" id="app" data-state="source" style="color:blue">'
+            '<section class="card reveal" data-zone="hero"><span class="leaf" '
+            'style="opacity:1">Leaf</span></section></main>'
+        ),
+        (
+            '<main class="shell base" id="app" data-state="source" style="color:red">'
+            '<section class="card reveal" data-zone="hero"><span class="leaf changed" '
+            'style="opacity:1">Leaf</span></section></main>'
+        ),
+        (
+            '<main class="shell base" id="app" data-state="source" style="color:red">'
+            '<section class="card reveal" data-zone="hero"><span class="leaf" '
+            'style="opacity:.5">Leaf</span></section></main>'
+        ),
+    ],
+    ids=(
+        "remove-class",
+        "replace-class",
+        "ancestor-id",
+        "ancestor-data",
+        "ancestor-style",
+        "selected-class",
+        "selected-style",
+    ),
+)
+async def test_prompt_annotation_v2_rejects_non_additive_identity_changes_without_writes(
+    artifact_editing_env,
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_html: str,
+) -> None:
+    env = artifact_editing_env
+    source_html = (
+        '<main class="shell base" id="app" data-state="source" style="color:red">'
+        '<section class="card reveal" data-zone="hero">'
+        '<span class="leaf" style="opacity:1">Leaf</span></section></main>'
+    )
+    _ref, document = await _adopt_html(env, source_html.encode())
+    element_path = json.dumps(
+        [
+            ["", "html", 1],
+            ["", "body", 1],
+            ["", "main", 1],
+            ["", "section", 1],
+            ["", "span", 1],
+        ],
+        separators=(",", ":"),
+    )
+    runtime_dom_sha256, runtime_v1 = _annotation_proofs(runtime_html, element_path)
+    runtime_v2 = _annotation_proof_v2(runtime_html, element_path)
+    assert runtime_v2 is not None
+    bridge = _EchoAnnotationBridge(
+        annotation_proof_v2=runtime_v2,
+        proof_v2_capable=True,
+    )
+    monkeypatch.setattr(
+        artifact_editing_rpc,
+        "get_desktop_artifact_bridge_client",
+        lambda: bridge,
+    )
+
+    rejected = await _dispatch(
+        env,
+        "artifacts.prompt_annotations.create",
+        {
+            "annotationId": "annotation-v2-rejected",
+            "sessionKey": SESSION_KEY,
+            "documentId": document["id"],
+            "revisionId": document["headRevisionId"],
+            "selection": {
+                "selectionId": "selection-v2-rejected",
+                "tagName": "span",
+                "elementPath": element_path,
+                "domSha256": runtime_dom_sha256,
+                "elementProofSha256": runtime_v1,
+            },
+            "body": "This must not persist.",
+        },
+    )
+
+    assert rejected.error is not None
+    assert rejected.error.code == "DOCUMENT_CHANGED"
+    assert len(bridge.resolve_calls) == 1
+    assert await _annotation_row_counts(env) == (0, 0, 0)
+
+
+@pytest.mark.asyncio
+async def test_prompt_annotation_v2_requires_capability_and_complete_bounded_evidence(
+    artifact_editing_env,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    env = artifact_editing_env
+    source_html = '<main class="shell base"><span id="leaf">Leaf</span></main>'
+    runtime_html = '<main class="shell base visible"><span id="leaf">Leaf</span></main>'
+    _ref, document = await _adopt_html(env, source_html.encode())
+    element_path = json.dumps(
+        [["", "html", 1], ["", "body", 1], ["", "main", 1], ["", "span", 1]],
+        separators=(",", ":"),
+    )
+    runtime_dom_sha256, runtime_v1 = _annotation_proofs(runtime_html, element_path)
+    runtime_v2 = _annotation_proof_v2(runtime_html, element_path)
+    assert runtime_v2 is not None
+    params = {
+        "annotationId": "annotation-v2-no-capability",
+        "sessionKey": SESSION_KEY,
+        "documentId": document["id"],
+        "revisionId": document["headRevisionId"],
+        "selection": {
+            "selectionId": "selection-v2-no-capability",
+            "tagName": "span",
+            "elementPath": element_path,
+            "domSha256": runtime_dom_sha256,
+            "elementProofSha256": runtime_v1,
+        },
+        "body": "No capability means strict v1.",
+    }
+
+    bridge = _EchoAnnotationBridge(
+        annotation_proof_v2=runtime_v2,
+        proof_v2_capable=False,
+    )
+    monkeypatch.setattr(
+        artifact_editing_rpc,
+        "get_desktop_artifact_bridge_client",
+        lambda: bridge,
+    )
+    no_capability = await _dispatch(env, "artifacts.prompt_annotations.create", params)
+    assert no_capability.error is not None
+    assert no_capability.error.code == "DOCUMENT_CHANGED"
+    assert await _annotation_row_counts(env) == (0, 0, 0)
+
+    bridge = _EchoAnnotationBridge(
+        annotation_proof_v2=SimpleNamespace(
+            stable_element_proof_sha256=runtime_v2.stable_element_proof_sha256,
+            ancestor_class_commitments=runtime_v2.ancestor_class_commitments,
+        ),  # type: ignore[arg-type]
+        proof_v2_capable=True,
+    )
+    monkeypatch.setattr(
+        artifact_editing_rpc,
+        "get_desktop_artifact_bridge_client",
+        lambda: bridge,
+    )
+    malformed = await _dispatch(
+        env,
+        "artifacts.prompt_annotations.create",
+        {
+            **params,
+            "annotationId": "annotation-v2-malformed",
+            "selection": {
+                **params["selection"],
+                "selectionId": "selection-v2-malformed",
+            },
+        },
+    )
+    assert malformed.error is not None
+    assert malformed.error.code == "ANNOTATION_UNAVAILABLE"
+    assert await _annotation_row_counts(env) == (0, 0, 0)
 
 
 @pytest.mark.asyncio
@@ -2301,6 +2598,10 @@ async def test_prompt_annotation_selection_is_revalidated_and_persisted_as_ancho
     class FakeBridge:
         def __init__(self) -> None:
             self.focus_calls: list[dict[str, object]] = []
+            self.proof_v2_capable = False
+
+        async def capabilities(self, **_kwargs):
+            return SimpleNamespace(annotation_proof_v2=self.proof_v2_capable)
 
         async def resolve_annotation_selection(self, **kwargs):
             return SimpleNamespace(
@@ -2375,6 +2676,25 @@ async def test_prompt_annotation_selection_is_revalidated_and_persisted_as_ancho
             "deadline_ms": 2_000,
         }
     ]
+    fake_bridge.proof_v2_capable = True
+    focused_v2 = await _dispatch(
+        env,
+        "artifacts.prompt_annotations.focus",
+        {"sessionKey": SESSION_KEY, "annotationId": annotation["id"]},
+    )
+    assert focused_v2.error is None, focused_v2.error
+    expected_proof_v2 = canonical_selection_proof_v2(html, element_path=element_path)
+    assert expected_proof_v2 is not None
+    assert fake_bridge.focus_calls[1] == {
+        "annotation_id": annotation["id"],
+        "scope_id": SESSION_KEY,
+        "active_preview_artifact_id": _ref.id,
+        "tag_name": "section",
+        "element_path": element_path,
+        "element_proof_sha256": element_proof_sha256,
+        "annotation_proof_v2": expected_proof_v2,
+        "deadline_ms": 2_000,
+    }
     listed = await _dispatch(
         env,
         "artifacts.prompt_annotations.list",
@@ -2412,7 +2732,7 @@ async def test_prompt_annotation_selection_is_revalidated_and_persisted_as_ancho
     assert discarded_focus.error is not None
     assert discarded_focus.error.code == "ANNOTATION_UNAVAILABLE"
     assert discarded_focus.error.details == {"reasonCode": "not_draft"}
-    assert len(fake_bridge.focus_calls) == 1
+    assert len(fake_bridge.focus_calls) == 2
 
 
 @pytest.mark.asyncio
@@ -2735,6 +3055,41 @@ def test_element_proof_sha256_cross_runtime_golden() -> None:
     # ordering, and non-BMP values.
     assert element_proof_sha256 == (
         "26992606963b33b7d475a826bf0a48ae802e9ac7bfe43ed5cab3aa97b7f0c5c8"
+    )
+
+
+def test_element_proof_v2_cross_runtime_golden() -> None:
+    html = (
+        '<main class="shell α" data-label="😀">'
+        '<svg class="icon ready" viewBox="0 0 10 10">'
+        '<path aria-label="星😀" d="M0 0"></path></svg></main>'
+    )
+    element_path = json.dumps(
+        [
+            ["", "html", 1],
+            ["", "body", 1],
+            ["", "main", 1],
+            ["http://www.w3.org/2000/svg", "svg", 1],
+            ["http://www.w3.org/2000/svg", "path", 1],
+        ],
+        separators=(",", ":"),
+    )
+
+    proof_v2 = canonical_selection_proof_v2(html, element_path=element_path)
+
+    # Shared with Electron: stable v1-shaped tokens omit only unnamespaced
+    # ancestor class attributes; commitments hash the compact domain-separated
+    # JSON tuple and are de-duplicated then sorted as lowercase hex.
+    assert proof_v2 == ElementProofV2(
+        stable_element_proof_sha256=(
+            "26992606963b33b7d475a826bf0a48ae802e9ac7bfe43ed5cab3aa97b7f0c5c8"
+        ),
+        ancestor_class_commitments=(
+            "15ccaf87c7fc343055d0b26eedd8b4830f0e3fe8ad35783e45b743a1feba5662",
+            "32e98037d3929ef4440d88c8fbe4e03df5a9159c9657a234eff2da68dee0ea3a",
+            "5e65b9071e1268e5fc08d9b713c1220aef8fa800878b794f40b1c6e642ce9144",
+            "f5b127210b5887563e205dc9aaf0fc773e081149ae9f2b6dfb16321db5c8ab0f",
+        ),
     )
 
 

--- a/tests/test_gateway/test_rpc_artifact_editing.py
+++ b/tests/test_gateway/test_rpc_artifact_editing.py
@@ -231,7 +231,7 @@ async def test_prompt_annotation_create_replay_does_not_reuse_native_candidate(
     monkeypatch.setattr(
         artifact_editing_rpc,
         "get_desktop_artifact_bridge_client",
-        lambda: object(),
+        object,
     )
     replayed = await _dispatch(env, "artifacts.prompt_annotations.create", params)
     assert replayed.error is None, replayed.error

--- a/tests/test_gateway/test_rpc_artifact_editing.py
+++ b/tests/test_gateway/test_rpc_artifact_editing.py
@@ -591,10 +591,15 @@ async def test_prompt_annotation_accepts_unrelated_runtime_dom_mutation(
             'style="color:red"><section class="card reveal reveal" data-zone="hero">'
             '<span class="leaf" style="opacity:1">Leaf</span></section></main>'
         ),
+        (
+            '<main class="shell base" id="app" data-state="source" style="color:red">'
+            '<section class="card reveal" data-zone="hero">'
+            '<span class="visible leaf leaf" style="opacity:1">Leaf</span></section></main>'
+        ),
     ],
-    ids=("add", "reorder", "duplicates"),
+    ids=("ancestor-add", "reorder", "duplicates", "selected-add"),
 )
-async def test_prompt_annotation_v2_accepts_additive_ancestor_class_mutations(
+async def test_prompt_annotation_v2_accepts_additive_path_class_mutations(
     artifact_editing_env,
     monkeypatch: pytest.MonkeyPatch,
     runtime_html: str,
@@ -699,7 +704,12 @@ async def test_prompt_annotation_v2_accepts_additive_ancestor_class_mutations(
         ),
         (
             '<main class="shell base" id="app" data-state="source" style="color:red">'
-            '<section class="card reveal" data-zone="hero"><span class="leaf changed" '
+            '<section class="card reveal" data-zone="hero"><span '
+            'style="opacity:1">Leaf</span></section></main>'
+        ),
+        (
+            '<main class="shell base" id="app" data-state="source" style="color:red">'
+            '<section class="card reveal" data-zone="hero"><span class="changed" '
             'style="opacity:1">Leaf</span></section></main>'
         ),
         (
@@ -714,7 +724,8 @@ async def test_prompt_annotation_v2_accepts_additive_ancestor_class_mutations(
         "ancestor-id",
         "ancestor-data",
         "ancestor-style",
-        "selected-class",
+        "selected-class-remove",
+        "selected-class-replace",
         "selected-style",
     ),
 )

--- a/tests/test_provider_final_request_proof.py
+++ b/tests/test_provider_final_request_proof.py
@@ -8,6 +8,7 @@ import httpx
 
 from opensquilla.provider import anthropic as anthropic_module
 from opensquilla.provider import openai as openai_module
+from opensquilla.provider import request_proof as request_proof_module
 from opensquilla.provider.anthropic import AnthropicProvider
 from opensquilla.provider.openai import OpenAIProvider
 from opensquilla.provider.types import (
@@ -46,6 +47,17 @@ def _anthropic_sse_body(events: list[dict[str, Any]]) -> bytes:
         parts.append(f"event: {event['type']}\n".encode())
         parts.append(f"data: {json.dumps(event)}\n\n".encode())
     return b"".join(parts)
+
+
+def _use_deterministic_token_estimator(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        request_proof_module,
+        "_serialized_token_estimate",
+        lambda serialized_payload: (
+            max(1, (len(serialized_payload) + 3) // 4),
+            "synthetic_tokenizer",
+        ),
+    )
 
 
 def test_openai_final_request_proof_blocks_oversized_send(monkeypatch: Any) -> None:
@@ -388,6 +400,7 @@ def test_openai_final_request_proof_compacts_adapter_payload_with_tools(
     monkeypatch.setenv("OPENSQUILLA_PROVIDER_COMPACTION_PROTECT_RECENT_RESULTS", "0")
     monkeypatch.setenv("OPENSQUILLA_PROVIDER_COMPACTION_PROTECT_ERROR_RESULTS", "0")
     monkeypatch.setenv("OPENSQUILLA_PROVIDER_COMPACTION_PROTECT_UNRESOLVED_RESULTS", "0")
+    _use_deterministic_token_estimator(monkeypatch)
     requests: list[httpx.Request] = []
     payloads: list[dict[str, Any]] = []
     proofs: list[dict[str, Any]] = []
@@ -478,6 +491,7 @@ def test_anthropic_final_request_proof_compacts_adapter_payload_with_tools(
     monkeypatch.setenv("OPENSQUILLA_PROVIDER_COMPACTION_PROTECT_RECENT_RESULTS", "0")
     monkeypatch.setenv("OPENSQUILLA_PROVIDER_COMPACTION_PROTECT_ERROR_RESULTS", "0")
     monkeypatch.setenv("OPENSQUILLA_PROVIDER_COMPACTION_PROTECT_UNRESOLVED_RESULTS", "0")
+    _use_deterministic_token_estimator(monkeypatch)
     requests: list[httpx.Request] = []
     payloads: list[dict[str, Any]] = []
     proofs: list[dict[str, Any]] = []


### PR DESCRIPTION
## Scope

Scope boundary: Stabilize trusted HTML annotation selection, overlay handoff, and repeated picker rearming across Desktop, WebUI, and Gateway.
Non-goals: No model-provider behavior, database schema, document_finish, verification token, revision, or automatic retry changes.

## Branch

Base branch: main
Target exception: N/A

## Issue

Linked issue: None
If None, reason: Regression was diagnosed and reproduced from the reported desktop sessions; no issue was supplied.

## Release Note

Release note: Fixed HTML annotations sometimes ignoring the first or later element click, especially after animated class changes or rapid consecutive annotations.

## Tests

Ruff: Focused Python suite passed.
Pytest: 233 passed.
Build: WebUI typecheck and architecture/security/theme/i18n guards passed; Desktop TypeScript build passed.
Regression tests: added
Notes:
- WebUI focused: 65 passed.
- Native Workbench static contract passed.
- Desktop artifact bridge loopback passed.
- The real-Electron fixture is currently blocked before annotation assertions by an environment-level ERR_FAILED while loading the unchanged fixture owner page.

## Maintainer Live Check

Maintainer live check: yes
Surface: browser
Maintainer-only note: Run the Windows packaged annotation smoke once the fixture owner-page bootstrap is healthy.

## Safety

Proof v2, atomic close/rearm, and surface instance identity are additive optional fields. Old Desktop/Gateway paths remain compatible. Malformed or stale selection and rearm states remain fail-closed. No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or tests/_private/ contents are included.

## Third-Party Origin

Third-party origin: none
Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.

## Summary

- tolerate additive runtime CSS classes in trusted annotation proofs while still rejecting class removal, replacement, structural drift, and non-class identity changes
- make overlay submit/cancel and the next Chromium picker arm an epoch-fenced handoff
- preserve interrupted drafts and recover expired or replaced surfaces without stale events mutating the replacement
- report and recover one-shot picker rearm failures without exposing raw CDP diagnostics
