### PR TITLE
Prepare OpenSquilla 0.5.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.5.4] - 2026-08-25
+
+### Added
+
+- Electron Desktop can import, inspect, version, edit, verify, and revert
+  single-file HTML documents. Element-scoped instructions can use the shared
+  Agent Loop, and the autonomous editing loop keeps candidate changes isolated
+  until an explicit commit.
+- Optional Python, Node.js, and Windows Git Bash Runtime Packs can be downloaded
+  from Sandbox settings through an immutable catalog. Downloads support resume,
+  cancellation, source fallback, integrity verification, removal, and cache
+  discard without modifying system-installed runtimes.
+- Each chat can now keep its own Direct, Router, or Ensemble strategy while the
+  global strategy remains the default for new chats. C3 can use the shared
+  multi-model fusion plan with resilient fixed-model fallback and independent
+  image routing.
+- The OpenSquilla technical report is available in English and Chinese PDF
+  editions, with the English edition also published on aiXiv.
+
 ### Changed
 
 - Fresh and managed TokenRhythm configurations now use DeepSeek V4 Flash 0731
@@ -13,6 +32,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   C2, and GLM 5.2 B5 fusion for C3. Existing custom inline tiers are not
   migrated, and the mixed-family preset continues to leave thinking levels
   unset.
+- Settings now use ten stable destinations, including combined Security &
+  Privacy controls and a first-level Memory page. Existing Settings deep links
+  continue through compatibility aliases.
+- Desktop installers are slimmer because optional developer runtimes are no
+  longer bundled. The Gateway and control console remain included, and users
+  can install only the Runtime Packs they need.
+
 ### Fixed
 
 - Desktop startup now shows monotonic, milestone-based progress without
@@ -22,6 +48,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   turn. Late provider or tool results are discarded, timed-out writes retain
   their timeout outcome, and committed file changes are recorded before the
   next turn can run.
+- Chat recovery now preserves activity order, router panels, live steering,
+  pending input, long-session scrolling, and durable turn commits across
+  reconnects and session switches. Large and image attachments use complete
+  routing capacity, and current-turn images are available to workspace tools.
+- Desktop and Gateway startup, process-tree cancellation, Windows Safe shell
+  execution, Windows installer progress, macOS Keychain recovery, CLI failure
+  exits, Skill catalog verification, prompt caching, usage accounting, and
+  provider fallback behavior are more reliable across supported platforms.
+
+### Security
+
+- HTML editing uses isolated preview surfaces, opaque mutation grants, atomic
+  revisions, and capability-gated document tools. Older or incomplete Desktop
+  bridges fail closed, while existing attachments and deliverables remain
+  readable and immutable.
+- Runtime Pack downloads are restricted to pinned sources and verified by exact
+  size and SHA-256 before safe extraction and activation. Failures remain local
+  to the requested component and do not block Gateway startup.
 
 ## [0.5.3] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Electron Desktop can import, inspect, version, edit, verify, and revert
-  single-file HTML documents. Element-scoped instructions can use the shared
-  Agent Loop, and the autonomous editing loop keeps candidate changes isolated
-  until an explicit commit.
+- Electron Desktop includes a beta for editing single-file HTML attachments and
+  deliverables. It provides preview, source, version, and change views plus
+  Agent-assisted candidate edits that users review before committing. Other
+  document formats and project-wide editing are not included.
 - Optional Python, Node.js, and Windows Git Bash Runtime Packs can be downloaded
   from Sandbox settings through an immutable catalog. Downloads support resume,
   cancellation, source fallback, integrity verification, removal, and cache
@@ -59,10 +59,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Security
 
-- HTML editing uses isolated preview surfaces, opaque mutation grants, atomic
-  revisions, and capability-gated document tools. Older or incomplete Desktop
-  bridges fail closed, while existing attachments and deliverables remain
-  readable and immutable.
+- The HTML editing beta uses isolated preview surfaces, opaque mutation grants,
+  atomic revisions, and capability-gated document tools. Older or incomplete
+  Desktop bridges fail closed, while existing attachments and deliverables
+  remain readable and immutable.
 - Runtime Pack downloads are restricted to pinned sources and verified by exact
   size and SHA-256 before safe extraction and activation. Failures remain local
   to the requested component and do not block Gateway startup.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -26,6 +26,29 @@ trailers.
 | [@ab2ence](https://github.com/ab2ence) | macOS Seatbelt backend execution, denial escalation, and release-candidate type-check cleanup. | [#46](https://github.com/opensquilla/opensquilla/pull/46), [`fb1e6225`](https://github.com/opensquilla/opensquilla/pull/46/commits/fb1e6225e4db9cb0801ea347a89c2066e3e0601b), [`f73ac3eb`](https://github.com/opensquilla/opensquilla/pull/46/commits/f73ac3eb0044c64c79cfd18f9ec03d1bba9128ff), [`cf3b046f`](https://github.com/opensquilla/opensquilla/pull/46/commits/cf3b046f42a42efc951320b0af80e9d066dcf7d2) |
 | [@kimjune01](https://github.com/kimjune01) | Provider stream timeout cleanup fix that prevents double-closing provider streams. | [#46](https://github.com/opensquilla/opensquilla/pull/46), [`06e3126d`](https://github.com/opensquilla/opensquilla/pull/46/commits/06e3126d8ebda4ad4cf349ca7be0d0804e0c008d) |
 
+## OpenSquilla 0.5.4
+
+The 0.5.4 release records new human contributor work after the 0.5.3 stable
+release. Commit links are included when an integration pull request preserved
+an original author whose GitHub identity was verified from the commit API.
+
+| Contributor | 0.5.4 contribution | Evidence |
+| --- | --- | --- |
+| [@AmirF194](https://github.com/AmirF194) | Restricted Zhipu reasoning-dialect behavior to the official API root. | [`ac33132e`](https://github.com/opensquilla/opensquilla/commit/ac33132e584bc45f1a1d4d126cc4d394fd8df8f3), [#1193](https://github.com/opensquilla/opensquilla/pull/1193) |
+| [@Kiuyor](https://github.com/Kiuyor) | Restored pasted Composer input when stale Windows IME state prevented Vue model synchronization. | [`c2bc8e57`](https://github.com/opensquilla/opensquilla/commit/c2bc8e57392539f5cf35a9d13de463792f383e07), [#1185](https://github.com/opensquilla/opensquilla/pull/1185) |
+| [@Liu-RK](https://github.com/Liu-RK) | Improved public release hygiene by removing obsolete generated upgrade artifacts. | [#1267](https://github.com/opensquilla/opensquilla/pull/1267) |
+| [@LiuXinchen1997](https://github.com/LiuXinchen1997) | Added the tier-level routing foundation incorporated into resilient C3 multi-model fusion. | [`b855538b`](https://github.com/opensquilla/opensquilla/pull/1199/commits/b855538bd0ddc30dcdff948882e363823f6d3114), [#1199](https://github.com/opensquilla/opensquilla/pull/1199) |
+| [@Sanjays2402](https://github.com/Sanjays2402) | Made the first session search query include already-existing sessions. | [#1214](https://github.com/opensquilla/opensquilla/pull/1214) |
+| [@ab2ence](https://github.com/ab2ence) | Added resilient C3 fusion and transactional Ensemble fallback, isolated provider-private state, enabled verified Qwen prompt caching, corrected zero-ledger display and continuation usage, and refined sidebar interactions. | [#1199](https://github.com/opensquilla/opensquilla/pull/1199), [#1226](https://github.com/opensquilla/opensquilla/pull/1226), [#1254](https://github.com/opensquilla/opensquilla/pull/1254), [#1270](https://github.com/opensquilla/opensquilla/pull/1270), [#1299](https://github.com/opensquilla/opensquilla/pull/1299), [#1300](https://github.com/opensquilla/opensquilla/pull/1300) |
+| [@freeaccount-create](https://github.com/freeaccount-create) | Made the `create_csv` tool schema compatible with Gemini. | [#1264](https://github.com/opensquilla/opensquilla/pull/1264) |
+| [@jiaoqingrui](https://github.com/jiaoqingrui) | Used the clearer token label in Ensemble traces. | [#1350](https://github.com/opensquilla/opensquilla/pull/1350) |
+| [@kriptoburak](https://github.com/kriptoburak) | Verified Skill digests through catalog paths. | [#1367](https://github.com/opensquilla/opensquilla/pull/1367) |
+| [@lifelmy](https://github.com/lifelmy) | Preserved routed per-model cost breakdowns in the CLI. | [#1215](https://github.com/opensquilla/opensquilla/pull/1215) |
+| [@lihongguang-0014](https://github.com/lihongguang-0014) | Improved chat continuity, streaming and steering recovery, attachment routing and workspace materialization, Desktop startup, task process ownership, session pagination, provider handling, and CLI reliability. | [#1179](https://github.com/opensquilla/opensquilla/pull/1179), [#1190](https://github.com/opensquilla/opensquilla/pull/1190), [#1195](https://github.com/opensquilla/opensquilla/pull/1195), [#1196](https://github.com/opensquilla/opensquilla/pull/1196), [#1252](https://github.com/opensquilla/opensquilla/pull/1252), [#1269](https://github.com/opensquilla/opensquilla/pull/1269), [#1303](https://github.com/opensquilla/opensquilla/pull/1303), [#1305](https://github.com/opensquilla/opensquilla/pull/1305), [#1307](https://github.com/opensquilla/opensquilla/pull/1307), [#1336](https://github.com/opensquilla/opensquilla/pull/1336), [#1342](https://github.com/opensquilla/opensquilla/pull/1342), [#1344](https://github.com/opensquilla/opensquilla/pull/1344), [#1355](https://github.com/opensquilla/opensquilla/pull/1355) |
+| [@openvictory](https://github.com/openvictory) | Added the English and Chinese technical report PDFs and announced them in the project READMEs. | [#1351](https://github.com/opensquilla/opensquilla/pull/1351) |
+| [@shixi-li](https://github.com/shixi-li) | Fixed Ensemble aggregator timeout fallback behavior. | [`7cc10609`](https://github.com/opensquilla/opensquilla/commit/7cc106093a2e9f24ccb2da977bbdcb1f64160e6e), [#1184](https://github.com/opensquilla/opensquilla/pull/1184) |
+| [@xfjsssq](https://github.com/xfjsssq) | Allowed unknown slash-prefixed text to be sent as a normal message. | [#1176](https://github.com/opensquilla/opensquilla/pull/1176) |
+
 ## OpenSquilla 0.5.3
 
 The 0.5.3 maintenance release records new human contributor work after the

--- a/README.de.md
+++ b/README.de.md
@@ -53,7 +53,7 @@ Provider-Schicht spricht mit TokenRhythm, OpenRouter, OpenAI, Anthropic, Ollama,
 DeepSeek, Gemini, Qwen/DashScope und über 20 weiteren LLM-Providern —
 ohne Änderung an deinem Code oder deinem Konfigurationsschema.
 
-OpenSquilla 0.5.3 ist die aktuelle stabile Version.
+OpenSquilla 0.5.4 ist die aktuelle stabile Version.
 
 Für aufgabenorientierte Produktdokumentation beginnst du am besten mit
 dem [OpenSquilla-Produktleitfaden](README.product.md) oder dem
@@ -79,10 +79,10 @@ Python-Wheel-Installationen verwenden versionsbehaftete Wheel-Dateinamen,
 weil die Installationsprogramme die im Wheel-Dateinamen eingebettete
 Version prüfen.
 
-Für den Desktop-Einsatz von 0.5.3 bevorzugst du die gepackten
+Für den Desktop-Einsatz von 0.5.4 bevorzugst du die gepackten
 Desktop-Installationsprogramme aus dem GitHub-Release:
-`OpenSquilla-0.5.3-mac-arm64.dmg` unter macOS und
-`OpenSquilla-0.5.3-win-x64.exe` unter Windows.
+`OpenSquilla-0.5.4-mac-arm64.dmg` unter macOS und
+`OpenSquilla-0.5.4-win-x64.exe` unter Windows.
 
 | Weg | Zielgruppe | Wann verwenden |
 | --- | --- | --- |
@@ -133,11 +133,11 @@ Installationslinks: [Git](https://git-scm.com/downloads) ·
 
 ### Desktop-Installationsprogramme
 
-Die 0.5.3-Desktop-Installationsprogramme bündeln die Vue-Steuerkonsole
+Die 0.5.4-Desktop-Installationsprogramme bündeln die Vue-Steuerkonsole
 und die Gateway-Runtime in einer Electron-Hülle.
 
-- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/OpenSquilla-0.5.3-mac-arm64.dmg>
-- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/OpenSquilla-0.5.3-win-x64.exe>
+- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/OpenSquilla-0.5.4-mac-arm64.dmg>
+- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/OpenSquilla-0.5.4-win-x64.exe>
 
 Für schnellere Downloads in Festlandchina verwende die direkten OSS-Download-Aliasse:
 - macOS Apple Silicon: <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-mac-arm64.dmg>
@@ -187,7 +187,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. OpenSquilla installieren** — derselbe Befehl auf jeder Plattform.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/opensquilla-0.5.3-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl"
 ```
 
 Damit wird das OpenSquilla-Wheel von der Release-URL installiert;
@@ -215,7 +215,7 @@ opensquilla gateway run
 
 Für eine vollständig festgelegte Installation verwende die
 versionsbehaftete Wheel-URL:
-`https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/opensquilla-0.5.3-py3-none-any.whl`.
+`https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl`.
 
 <a id="install-from-source"></a>
 

--- a/README.es.md
+++ b/README.es.md
@@ -44,7 +44,7 @@ OpenSquilla es un agente de IA con microkernel y eficiente en el uso de tokens. 
 
 Cada punto de entrada —Web UI, CLI y canales de chat— se ejecuta a través de ese mismo bucle, de modo que el envío de herramientas, los reintentos y el registro de decisiones se comportan de forma idéntica en todas partes. Una capa de proveedores conectable se comunica con TokenRhythm, OpenRouter, OpenAI, Anthropic, Ollama, DeepSeek, Gemini, Qwen/DashScope y más de 20 proveedores de LLM adicionales, sin ningún cambio en tu código ni en el esquema de configuración.
 
-OpenSquilla 0.5.3 es la versión estable actual.
+OpenSquilla 0.5.4 es la versión estable actual.
 
 Para documentación de producto orientada a tareas, comienza por la [Guía de producto de OpenSquilla](README.product.md) o el [índice de documentación](docs/README.md).
 
@@ -58,7 +58,7 @@ Los instaladores de escritorio y la instalación rápida desde terminal te ofrec
 
 Los comandos de instalación de versiones usan los recursos de release publicados en GitHub. Las instalaciones del wheel de Python usan nombres de archivo de wheel con versión, porque los instaladores validan la versión incrustada en el nombre del archivo del wheel.
 
-Para el uso de escritorio de 0.5.3, opta por los instaladores de escritorio empaquetados de la Release de GitHub: `OpenSquilla-0.5.3-mac-arm64.dmg` en macOS y `OpenSquilla-0.5.3-win-x64.exe` en Windows.
+Para el uso de escritorio de 0.5.4, opta por los instaladores de escritorio empaquetados de la Release de GitHub: `OpenSquilla-0.5.4-mac-arm64.dmg` en macOS y `OpenSquilla-0.5.4-win-x64.exe` en Windows.
 
 | Ruta | Público | Cuándo usarla |
 | --- | --- | --- |
@@ -91,10 +91,10 @@ Enlaces de instalación: [Git](https://git-scm.com/downloads) ·
 
 ### Instaladores de escritorio
 
-Los instaladores de escritorio de 0.5.3 empaquetan la consola de control de Vue y el runtime del gateway en una carcasa de Electron.
+Los instaladores de escritorio de 0.5.4 empaquetan la consola de control de Vue y el runtime del gateway en una carcasa de Electron.
 
-- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/OpenSquilla-0.5.3-mac-arm64.dmg>
-- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/OpenSquilla-0.5.3-win-x64.exe>
+- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/OpenSquilla-0.5.4-mac-arm64.dmg>
+- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/OpenSquilla-0.5.4-win-x64.exe>
 
 Para descargas más rápidas desde China continental, usa los alias de descarga directa de OSS:
 - macOS Apple Silicon: <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-mac-arm64.dmg>
@@ -136,7 +136,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. Instala OpenSquilla**: el mismo comando en todas las plataformas.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/opensquilla-0.5.3-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl"
 ```
 
 Esto instala el wheel de OpenSquilla desde la URL de la release y luego deja que `uv` descargue las dependencias declaradas por los extras seleccionados. El extra predeterminado `recommended` incluye dependencias del runtime de SquillaRouter como ONNX Runtime, LightGBM, NumPy y tokenizers, así que una primera instalación necesita acceso a la red salvo que esos wheels ya estén en caché. `uv` no instala runtimes nativos del sistema como `libomp` de macOS o el Visual C++ Redistributable de Windows; consulta [Solución de problemas](#troubleshooting) si el runtime del enrutador informa de un error de carga de biblioteca nativa.
@@ -152,7 +152,7 @@ opensquilla gateway run
 > Si no se encuentra `opensquilla` justo después de una instalación nueva con `uv`, abre una terminal nueva o vuelve a ejecutar la línea de PATH del paso 1.
 
 Para una instalación totalmente fijada, usa la URL del wheel con versión:
-`https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/opensquilla-0.5.3-py3-none-any.whl`.
+`https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl`.
 
 <a id="install-from-source"></a>
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -53,7 +53,7 @@ enfichable dialogue avec TokenRhythm, OpenRouter, OpenAI, Anthropic, Ollama, Dee
 Qwen/DashScope et plus de 20 autres fournisseurs de LLM, sans aucun changement dans
 votre code ni dans votre schéma de configuration.
 
-OpenSquilla 0.5.3 est la version stable actuelle.
+OpenSquilla 0.5.4 est la version stable actuelle.
 
 Pour une documentation produit orientée tâches, commencez par le
 [Guide produit OpenSquilla](README.product.md) ou par l'[index de la
@@ -78,9 +78,9 @@ GitHub publiées. Les installations de wheel Python utilisent des noms de fichie
 wheel versionnés, car les installateurs valident la version intégrée au nom de
 fichier du wheel.
 
-Pour un usage bureau en 0.5.3, préférez les installateurs de bureau empaquetés issus de la
-Release GitHub : `OpenSquilla-0.5.3-mac-arm64.dmg` sous macOS et
-`OpenSquilla-0.5.3-win-x64.exe` sous Windows.
+Pour un usage bureau en 0.5.4, préférez les installateurs de bureau empaquetés issus de la
+Release GitHub : `OpenSquilla-0.5.4-mac-arm64.dmg` sous macOS et
+`OpenSquilla-0.5.4-win-x64.exe` sous Windows.
 
 | Voie | Public | Quand l'utiliser |
 | --- | --- | --- |
@@ -129,11 +129,11 @@ Liens d'installation : [Git](https://git-scm.com/downloads) ·
 
 ### Installateurs de bureau
 
-Les installateurs de bureau 0.5.3 empaquettent la console de contrôle Vue et
+Les installateurs de bureau 0.5.4 empaquettent la console de contrôle Vue et
 l'environnement d'exécution de la passerelle dans une enveloppe Electron.
 
-- macOS Apple Silicon : <https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/OpenSquilla-0.5.3-mac-arm64.dmg>
-- Windows x64 : <https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/OpenSquilla-0.5.3-win-x64.exe>
+- macOS Apple Silicon : <https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/OpenSquilla-0.5.4-mac-arm64.dmg>
+- Windows x64 : <https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/OpenSquilla-0.5.4-win-x64.exe>
 
 Pour des téléchargements plus rapides depuis la Chine continentale, utilisez les alias de téléchargement direct OSS :
 - macOS Apple Silicon : <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-mac-arm64.dmg>
@@ -182,7 +182,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. Installer OpenSquilla** — la même commande sur toutes les plateformes.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/opensquilla-0.5.3-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl"
 ```
 
 Cela installe le wheel OpenSquilla depuis l'URL de release, puis laisse `uv`
@@ -207,7 +207,7 @@ opensquilla gateway run
 > nouveau terminal, ou réexécutez la ligne PATH de l'étape 1.
 
 Pour une installation entièrement épinglée, utilisez l'URL de wheel versionnée :
-`https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/opensquilla-0.5.3-py3-none-any.whl`.
+`https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl`.
 
 <a id="install-from-source"></a>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -44,7 +44,7 @@ OpenSquilla は、Token を効率的に使うマイクロカーネル AI Agent �
 
 すべての入口——Web UI、CLI、チャットチャネル——が同じループ上で動くため、ツールのディスパッチ、リトライ、判断ログの挙動はどこでも同一です。プラグイン可能なプロバイダ層は TokenRhythm、OpenRouter、OpenAI、Anthropic、Ollama、DeepSeek、Gemini、Qwen/DashScope をはじめとする 20 以上の LLM プロバイダと、あなたのコードや設定スキーマを変えることなくやり取りします。
 
-OpenSquilla 0.5.3 が現在の安定版リリースです。
+OpenSquilla 0.5.4 が現在の安定版リリースです。
 
 タスク指向の製品ドキュメントについては、[OpenSquilla 製品ガイド](README.product.md)または[ドキュメント索引](docs/README.md)から始めてください。
 
@@ -58,7 +58,7 @@ OpenSquilla は Windows、macOS、Linux で動作します。ご自身のユー�
 
 リリース版のインストールコマンドは、公開された GitHub リリースのアセットを使います。Python wheel のインストールでは、バージョン付きの wheel ファイル名を使います。インストーラーが wheel ファイル名に埋め込まれたバージョンを検証するためです。
 
-0.5.3 をデスクトップで使う場合は、GitHub リリースからパッケージ版デスクトップインストーラーを使うことをおすすめします。macOS では `OpenSquilla-0.5.3-mac-arm64.dmg`、Windows では `OpenSquilla-0.5.3-win-x64.exe` です。
+0.5.4 をデスクトップで使う場合は、GitHub リリースからパッケージ版デスクトップインストーラーを使うことをおすすめします。macOS では `OpenSquilla-0.5.4-mac-arm64.dmg`、Windows では `OpenSquilla-0.5.4-win-x64.exe` です。
 
 | 方法 | 対象 | 使うべき場面 |
 | --- | --- | --- |
@@ -91,10 +91,10 @@ macOS のターミナルインストールでは、SquillaRouter の LightGBM �
 
 ### デスクトップインストーラー
 
-0.5.3 のデスクトップインストーラーは、Vue 製コントロールコンソールとゲートウェイランタイムを Electron シェルにまとめています。
+0.5.4 のデスクトップインストーラーは、Vue 製コントロールコンソールとゲートウェイランタイムを Electron シェルにまとめています。
 
-- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/OpenSquilla-0.5.3-mac-arm64.dmg>
-- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/OpenSquilla-0.5.3-win-x64.exe>
+- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/OpenSquilla-0.5.4-mac-arm64.dmg>
+- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/OpenSquilla-0.5.4-win-x64.exe>
 
 中国本土からより高速にダウンロードするには、OSS の直接ダウンロード用エイリアスを使用してください。
 - macOS Apple Silicon: <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-mac-arm64.dmg>
@@ -131,7 +131,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. OpenSquilla をインストールする**——どのプラットフォームでも同じコマンドです。
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/opensquilla-0.5.3-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl"
 ```
 
 これはリリース URL から OpenSquilla wheel をインストールし、続いて `uv` が、選択した extra が宣言する依存関係をダウンロードします。デフォルトの `recommended` extra には、ONNX Runtime、LightGBM、NumPy、tokenizers といった SquillaRouter のランタイム依存関係が含まれるため、これらの wheel がすでにキャッシュされていない限り、初回インストールにはネットワークアクセスが必要です。`uv` は macOS の `libomp` や Windows の Visual C++ Redistributable のようなシステムネイティブのランタイムはインストールしません。ルーターランタイムがネイティブライブラリの読み込みエラーを報告した場合は、[トラブルシューティング](#troubleshooting)を参照してください。
@@ -147,7 +147,7 @@ opensquilla gateway run
 > 新規の `uv` インストール直後に `opensquilla` が見つからない場合は、新しいターミナルを開くか、ステップ 1 の PATH 設定の行を再実行してください。
 
 完全にバージョンを固定したインストールには、バージョン付きの wheel URL を使ってください:
-`https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/opensquilla-0.5.3-py3-none-any.whl`。
+`https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl`。
 
 <a id="install-from-source"></a>
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ TokenRhythm, OpenRouter, OpenAI, Anthropic, Ollama, DeepSeek, Gemini,
 Qwen/DashScope, and 20+ other LLM providers with no change to your code or config
 schema.
 
-OpenSquilla 0.5.3 is the current stable release.
+OpenSquilla 0.5.4 is the current stable release.
 
 For task-oriented product documentation, start with the
 [OpenSquilla Product Guide](README.product.md) or the
@@ -69,9 +69,9 @@ contain that console, so their users do **not** need Node.js or npm.
 Release install commands use published GitHub release assets. Python wheel installs use versioned wheel filenames because installers validate the version
 embedded in the wheel filename.
 
-For 0.5.3 desktop use, prefer the packaged desktop installers from
-the GitHub Release: `OpenSquilla-0.5.3-mac-arm64.dmg` on macOS and
-`OpenSquilla-0.5.3-win-x64.exe` on Windows.
+For 0.5.4 desktop use, prefer the packaged desktop installers from
+the GitHub Release: `OpenSquilla-0.5.4-mac-arm64.dmg` on macOS and
+`OpenSquilla-0.5.4-win-x64.exe` on Windows.
 
 | Path | Audience | When to use |
 | --- | --- | --- |
@@ -117,11 +117,11 @@ Install links: [Git](https://git-scm.com/downloads) ·
 
 ### Desktop installers
 
-The 0.5.3 desktop installers package the Vue control console and
+The 0.5.4 desktop installers package the Vue control console and
 gateway runtime in an Electron shell.
 
-- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/OpenSquilla-0.5.3-mac-arm64.dmg>
-- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/OpenSquilla-0.5.3-win-x64.exe>
+- macOS Apple Silicon: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/OpenSquilla-0.5.4-mac-arm64.dmg>
+- Windows x64: <https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/OpenSquilla-0.5.4-win-x64.exe>
 
 For faster Mainland China downloads, use the OSS direct-download aliases:
 - macOS Apple Silicon: <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-mac-arm64.dmg>
@@ -179,7 +179,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. Install OpenSquilla** — the same command on every platform.
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/opensquilla-0.5.3-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl"
 ```
 
 This installs the OpenSquilla wheel from the release URL, then lets
@@ -203,7 +203,7 @@ opensquilla gateway run
 > a new terminal, or re-run the PATH line from step 1.
 
 For a fully pinned install, use the versioned wheel URL:
-`https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/opensquilla-0.5.3-py3-none-any.whl`.
+`https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl`.
 
 ### Install from source
 
@@ -668,8 +668,8 @@ to allow inbound TCP on that port. Do not expose the gateway with
 **Docker**
 
 Prebuilt multi-arch images (`amd64`/`arm64`) are published to
-`ghcr.io/opensquilla/opensquilla` on release tags. 0.5.3 is published as
-both `v0.5.3` and the moving `latest` tag —
+`ghcr.io/opensquilla/opensquilla` on release tags. 0.5.4 is published as
+both `v0.5.4` and the moving `latest` tag —
 [`docs/docker.md`](docs/docker.md) is the full container guide
 (home servers and NAS, LAN exposure with token auth, upgrades):
 

--- a/README.product.md
+++ b/README.product.md
@@ -14,7 +14,7 @@ This guide is the product and usage entry point. The existing
 1. Install OpenSquilla:
 
    ```sh
-   uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/opensquilla-0.5.3-py3-none-any.whl"
+   uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl"
    ```
 
 2. Configure your provider:

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -47,7 +47,7 @@ OpenSquilla 是一个高效利用 Token 的微内核 AI Agent。本地模型路�
 Ollama、DeepSeek、Gemini、Qwen/DashScope 等 20 多个 LLM 提供商，无需改动你的代码或
 配置结构。
 
-OpenSquilla 0.5.3 是当前正式发布版本。
+OpenSquilla 0.5.4 是当前正式发布版本。
 
 如需面向任务的产品文档，请从
 [OpenSquilla 产品指南](README.product.md)或[文档索引](docs/README.md)开始。
@@ -63,8 +63,8 @@ OpenSquilla 可运行于 Windows、macOS 和 Linux。请选择与你的使用场
 发布版安装命令使用 GitHub 上已发布的 release 资源。Python wheel 安装使用带版本号的 wheel
 文件名，因为安装器会校验嵌入在 wheel 文件名中的版本号。
 
-对于 0.5.3 的桌面使用，建议从 GitHub Release 下载打包桌面安装包:macOS 上为
-`OpenSquilla-0.5.3-mac-arm64.dmg`，Windows 上为 `OpenSquilla-0.5.3-win-x64.exe`。
+对于 0.5.4 的桌面使用，建议从 GitHub Release 下载打包桌面安装包:macOS 上为
+`OpenSquilla-0.5.4-mac-arm64.dmg`，Windows 上为 `OpenSquilla-0.5.4-win-x64.exe`。
 
 | 安装方式 | 适合人群 | 何时使用 |
 | --- | --- | --- |
@@ -104,10 +104,10 @@ PowerShell 安装器会通过 `winget` 自动装好它；而**终端快速安装
 
 ### 桌面安装包
 
-0.5.3 桌面安装包将 Vue 控制台和网关运行时打包在一个 Electron 外壳中。
+0.5.4 桌面安装包将 Vue 控制台和网关运行时打包在一个 Electron 外壳中。
 
-- macOS Apple Silicon:<https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/OpenSquilla-0.5.3-mac-arm64.dmg>
-- Windows x64:<https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/OpenSquilla-0.5.3-win-x64.exe>
+- macOS Apple Silicon:<https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/OpenSquilla-0.5.4-mac-arm64.dmg>
+- Windows x64:<https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/OpenSquilla-0.5.4-win-x64.exe>
 
 中国大陆下载可直接使用 OSS 的固定安装包链接：
 
@@ -150,7 +150,7 @@ $env:Path = "$env:USERPROFILE\.local\bin;" + $env:Path
 **2. 安装 OpenSquilla**——所有平台命令相同。
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/opensquilla-0.5.3-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl"
 ```
 
 这会从 release URL 安装 OpenSquilla wheel，再由 `uv` 下载所选 extra 所声明的依赖。
@@ -171,7 +171,7 @@ opensquilla gateway run
 > PATH 设置命令。
 
 如需完全锁定版本的安装，请使用带版本号的 wheel URL:
-`https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/opensquilla-0.5.3-py3-none-any.whl`。
+`https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl`。
 
 <a id="install-from-source"></a>
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,7 +2,7 @@
 
 | Version | Tag | Date | Notes |
 |---|---|---|---|
-| 0.5.4 | v0.5.4 | 2026-08-25 | Stable: autonomous HTML editing, optional Runtime Packs, per-session routing, resilient C3 fusion, and cross-platform reliability |
+| 0.5.4 | v0.5.4 | 2026-08-25 | Stable: HTML document editing beta, optional Runtime Packs, per-session routing, resilient C3 fusion, and cross-platform reliability |
 | 0.5.3 | v0.5.3 | 2026-08-13 | Maintenance: durable Goals and follow-ups, resilient long-running chats, Skills and schedule workflows, safer recovery, and Web/Desktop refinements |
 | 0.5.2 | v0.5.2 | 2026-07-30 | Maintenance: same-turn steering, responsive startup and session history, safer recovery and usage accounting, and Desktop/provider/UI fixes |
 | 0.5.1 | v0.5.1 | 2026-07-29 | Maintenance: Full host/Cron reliability, Plan mode and project workspaces, artifact previews, desktop recovery, and provider/UI improvements |

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,7 @@
 
 | Version | Tag | Date | Notes |
 |---|---|---|---|
+| 0.5.4 | v0.5.4 | 2026-08-25 | Stable: autonomous HTML editing, optional Runtime Packs, per-session routing, resilient C3 fusion, and cross-platform reliability |
 | 0.5.3 | v0.5.3 | 2026-08-13 | Maintenance: durable Goals and follow-ups, resilient long-running chats, Skills and schedule workflows, safer recovery, and Web/Desktop refinements |
 | 0.5.2 | v0.5.2 | 2026-07-30 | Maintenance: same-turn steering, responsive startup and session history, safer recovery and usage accounting, and Desktop/provider/UI fixes |
 | 0.5.1 | v0.5.1 | 2026-07-29 | Maintenance: Full host/Cron reliability, Plan mode and project workspaces, artifact previews, desktop recovery, and provider/UI improvements |
@@ -31,7 +32,7 @@ updater metadata, the versioned Python wheel, and `SHA256SUMS`:
 - `SHA256SUMS`
 
 0.5.x preview releases are GitHub pre-releases and must not be marked as Latest;
-stable releases such as 0.5.3 are normal releases and may be marked Latest
+stable releases such as 0.5.4 are normal releases and may be marked Latest
 once verified.
 They do not publish Windows portable zips, Windows portable latest aliases,
 public wheelhouse zips, or separately branded macOS or Linux portable bundles.
@@ -102,9 +103,9 @@ already-installed Windows RC3 still requires a manual, in-place RC4 upgrade.
 
 README install commands must use tag-pinned URLs such as:
 
-- `https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/OpenSquilla-0.5.3-mac-arm64.dmg`
-- `https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/OpenSquilla-0.5.3-win-x64.exe`
-- `https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/opensquilla-0.5.3-py3-none-any.whl`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/OpenSquilla-0.5.4-mac-arm64.dmg`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/OpenSquilla-0.5.4-win-x64.exe`
+- `https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl`
 
 ## Release SOP
 
@@ -129,13 +130,13 @@ README install commands must use tag-pinned URLs such as:
    more time, then create the annotated tag on that exact SHA:
 
    ```sh
-   git tag -a v0.5.3 <verified-sha> -m "OpenSquilla 0.5.3"
-   git push origin v0.5.3
+   git tag -a v0.5.4 <verified-sha> -m "OpenSquilla 0.5.4"
+   git push origin v0.5.4
    ```
 
 8. Wait for both `.github/workflows/wheelhouse-release.yml` and
    `.github/workflows/docker-image.yml`. Review the draft GitHub Release. For
-   the `v0.5.3` stable, confirm it is not marked Pre-release, leave Latest
+   the `v0.5.4` stable, confirm it is not marked Pre-release, leave Latest
    unset until the maintainer explicitly confirms it at publish time, and
    confirm it contains only the Electron installers, updater metadata,
    versioned wheel, `SHA256SUMS`, plus GitHub's generated source archives. It
@@ -143,16 +144,16 @@ README install commands must use tag-pinned URLs such as:
    `OpenSquilla-windows-x64-portable.zip`.
 9. Verify GHCR before publishing broadly. For the first container release, make
    the newly created `ghcr.io/opensquilla/opensquilla` package public, then
-   confirm both `v0.5.3` and `latest` resolve to an amd64/arm64 manifest and
+   confirm both `v0.5.4` and `latest` resolve to an amd64/arm64 manifest and
    pass a gateway health smoke test.
 10. Publish the GitHub Release only after maintainer confirmation, then run the
    post-publish tag URL checks:
 
    ```sh
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/OpenSquilla-0.5.3-mac-arm64.dmg
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/OpenSquilla-0.5.3-win-x64.exe
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/opensquilla-0.5.3-py3-none-any.whl
-   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/SHA256SUMS
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/OpenSquilla-0.5.4-mac-arm64.dmg
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/OpenSquilla-0.5.4-win-x64.exe
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl
+   curl --fail --head --location https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/SHA256SUMS
    ```
 
 11. If a release tag is wrong before publication, stop and report its peeled
@@ -171,15 +172,15 @@ These checks cannot be fully proven by local artifact generation:
 
 - The tag exists on GitHub and matches `pyproject.toml`.
 - The release workflow can fetch hydrated Git LFS router assets.
-- The draft GitHub Release title is `OpenSquilla 0.5.3`.
-- Preview drafts are marked Pre-release and never Latest; the `v0.5.3`
+- The draft GitHub Release title is `OpenSquilla 0.5.4`.
+- Preview drafts are marked Pre-release and never Latest; the `v0.5.4`
   stable draft is not marked Pre-release, and Latest is applied only at
   publish after explicit maintainer confirmation.
 - Preview GitHub Releases contain the Electron installers, updater metadata,
   versioned wheel, and `SHA256SUMS` after `gh release upload --clobber`.
 - Preview GitHub Releases do not contain Windows portable zips or portable
   latest aliases.
-- The GHCR package is public, and `v0.5.3` plus `latest` expose both amd64
+- The GHCR package is public, and `v0.5.4` plus `latest` expose both amd64
   and arm64 images that pass the gateway health smoke test.
 - After a preview GitHub Release is published, the tag-pinned release asset URLs
   resolve.

--- a/desktop/electron/package-lock.json
+++ b/desktop/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensquilla/desktop-electron",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensquilla/desktop-electron",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "dependencies": {
         "electron-updater": "^6.6.2"
       },

--- a/desktop/electron/package.json
+++ b/desktop/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensquilla/desktop-electron",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "description": "Electron desktop shell for the OpenSquilla Control UI.",
   "repository": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ root release README with task-oriented guides.
 
 ## Surfaces and Operations
 
+- [`releases/0.5.4.md`](releases/0.5.4.md) - OpenSquilla 0.5.4 release notes.
 - [`releases/0.5.3.md`](releases/0.5.3.md) - OpenSquilla 0.5.3 release notes.
 - [`releases/0.5.2.md`](releases/0.5.2.md) - OpenSquilla 0.5.2 release notes.
 - [`releases/0.5.1.md`](releases/0.5.1.md) - OpenSquilla 0.5.1 release notes.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,7 +6,7 @@ automate OpenSquilla.
 Install the current release with the recommended integrations:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/opensquilla-0.5.3-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl"
 ```
 
 Run:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -30,7 +30,7 @@ Python, no Git, no build tools.
 
 Prebuilt multi-arch images are published to
 [`ghcr.io/opensquilla/opensquilla`](https://github.com/opensquilla/opensquilla/pkgs/container/opensquilla)
-for each release tag. The immutable `v0.5.3` tag identifies the 0.5.3 stable release, while
+for each release tag. The immutable `v0.5.4` tag identifies the 0.5.4 stable release, while
 `latest` follows the most recently pushed release tag, including previews and
 backports. If a backport moves `latest`, the newest release workflow is rerun to
 restore the intended ordering. If the release you want predates image
@@ -45,8 +45,8 @@ Create a directory for the deployment and write this `compose.yaml`:
 ```yaml
 services:
   gateway:
-    # Pin v0.5.3 for reproducibility; latest follows the most recent tag push.
-    image: ghcr.io/opensquilla/opensquilla:v0.5.3
+    # Pin v0.5.4 for reproducibility; latest follows the most recent tag push.
+    image: ghcr.io/opensquilla/opensquilla:v0.5.4
     environment:
       # In-container bind. Keep it 0.0.0.0 — what the network can reach is
       # decided by `ports` below, not by this value.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -12,7 +12,7 @@ UI, CLI, channels, and gateway control console.
 Install OpenSquilla with the MCP extra when you need this bridge:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/opensquilla-0.5.3-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl"
 ```
 
 Start the OpenSquilla gateway:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -176,7 +176,7 @@ opensquilla mcp-server run
 Install with:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/opensquilla-0.5.3-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended,mcp] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl"
 ```
 
 Use this when another MCP-capable client should access OpenSquilla-managed tools

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,7 +17,7 @@ UI, SquillaRouter, memory/search support, and safe local defaults.
 Install the current release wheel with the recommended extras:
 
 ```sh
-uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.3/opensquilla-0.5.3-py3-none-any.whl"
+uv tool install --python 3.12 "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl"
 ```
 
 The `recommended` extra includes SquillaRouter dependencies and memory/search

--- a/docs/releases/0.5.4.md
+++ b/docs/releases/0.5.4.md
@@ -3,11 +3,11 @@
 ## Overview
 
 OpenSquilla 0.5.4 is a feature and maintenance release for the 0.5 stable
-line. It adds autonomous, versioned HTML document editing in Electron Desktop,
-optional Runtime Packs with slimmer installers, per-chat model routing, and a
-more resilient C3 multi-model fusion path. It also improves chat continuity,
-Desktop startup and recovery, provider behavior, Skills, attachments, process
-lifecycle handling, and the Web interface.
+line. It introduces a beta for versioned, single-file HTML editing in Electron
+Desktop, optional Runtime Packs with slimmer installers, per-chat model routing,
+and a more resilient C3 multi-model fusion path. It also improves chat
+continuity, Desktop startup and recovery, provider behavior, Skills,
+attachments, process lifecycle handling, and the Web interface.
 
 Existing gateway configuration, chats, Agents, memory, and scheduled jobs stay
 in place. The Gateway applies additive database migrations automatically; no
@@ -17,23 +17,22 @@ installation, and restart OpenSquilla.
 
 ## ✨ What's Improved
 
-### Autonomous HTML document editing
+### HTML document editing beta
 
-Electron Desktop can now turn a single-file HTML attachment or deliverable into
-a versioned document workspace. Users can inspect Preview, Source, Versions,
-and Changes, select an element, attach an instruction, and let the shared Agent
-Loop propose and verify an edit.
+0.5.4 introduces an early beta for editing single-file HTML attachments and
+deliverables in Electron Desktop. It provides Preview, Source, Versions, and
+Changes views, selected-element instructions, and Agent-assisted candidate
+edits. The workflow is intended for evaluation and may still require manual
+source review, retry, or revert.
 
-- Candidate changes remain isolated until an explicit commit and are discarded
-  on cancellation or timeout.
-- Successful edits create one durable revision and change set, with whole-change
-  revert and restart recovery.
-- The autonomous loop can inspect the active preview, repair a candidate, and
-  finish by committing or discarding it without exposing arbitrary browser,
-  filesystem, or shell access.
-- Existing attachments and deliverables remain readable and immutable. Browser
-  clients and older Desktop bridges continue to view documents but fail closed
-  for native annotation editing.
+- The beta is limited to single-file UTF-8 HTML. It does not cover project
+  trees, Office or PDF documents, WYSIWYG editing, or collaborative editing.
+- Candidate changes remain separate until the user chooses to commit. Review
+  Preview and Changes before accepting an edit.
+- An Agent-assisted attempt may return no change or need another instruction;
+  committed changes can be reviewed by version and reverted as a whole.
+- Native element selection requires the current Electron bridge. Browser
+  clients and older Desktop bridges remain view-only for this beta.
 
 ### Runtime Packs and slimmer Desktop installers
 
@@ -163,9 +162,9 @@ the corresponding Runtime Pack from Sandbox settings after the upgrade.
 Existing chats keep working with older clients. Their per-chat routing mode is
 seeded from the current global strategy when first used by 0.5.4. New routing
 fields and commit receipts are additive, so clients that do not understand them
-may continue through their existing behavior. Native HTML annotation editing
-requires the complete current Electron bridge; older or browser-only clients
-remain view-only for that capability.
+may continue through their existing behavior. The HTML editing beta requires
+the complete current Electron bridge for native element selection; older or
+browser-only clients remain view-only for that capability.
 
 > [!IMPORTANT]
 > On Windows, users coming from RC3 or an older pre-Preview-4 build must not

--- a/docs/releases/0.5.4.md
+++ b/docs/releases/0.5.4.md
@@ -1,0 +1,234 @@
+# OpenSquilla 0.5.4
+
+## Overview
+
+OpenSquilla 0.5.4 is a feature and maintenance release for the 0.5 stable
+line. It adds autonomous, versioned HTML document editing in Electron Desktop,
+optional Runtime Packs with slimmer installers, per-chat model routing, and a
+more resilient C3 multi-model fusion path. It also improves chat continuity,
+Desktop startup and recovery, provider behavior, Skills, attachments, process
+lifecycle handling, and the Web interface.
+
+Existing gateway configuration, chats, Agents, memory, and scheduled jobs stay
+in place. The Gateway applies additive database migrations automatically; no
+manual data transfer is required. Users upgrading from 0.5.3 should quit the
+running Desktop app or gateway, install 0.5.4 directly over the current
+installation, and restart OpenSquilla.
+
+## ✨ What's Improved
+
+### Autonomous HTML document editing
+
+Electron Desktop can now turn a single-file HTML attachment or deliverable into
+a versioned document workspace. Users can inspect Preview, Source, Versions,
+and Changes, select an element, attach an instruction, and let the shared Agent
+Loop propose and verify an edit.
+
+- Candidate changes remain isolated until an explicit commit and are discarded
+  on cancellation or timeout.
+- Successful edits create one durable revision and change set, with whole-change
+  revert and restart recovery.
+- The autonomous loop can inspect the active preview, repair a candidate, and
+  finish by committing or discarding it without exposing arbitrary browser,
+  filesystem, or shell access.
+- Existing attachments and deliverables remain readable and immutable. Browser
+  clients and older Desktop bridges continue to view documents but fail closed
+  for native annotation editing.
+
+### Runtime Packs and slimmer Desktop installers
+
+- Python, Node.js, and Windows Git Bash are now optional Runtime Packs managed
+  from **Settings → Security & Privacy → Sandbox → Runtimes**. Installing a
+  component enables it automatically.
+- Downloads use an immutable catalog with GitHub and Beijing OSS source
+  fallback, exact integrity checks, resumable transfers, cancellation, removal,
+  and cache discard. System-installed runtimes are never modified or removed.
+- Desktop installers still include the Gateway and Vue control console but no
+  longer bundle developer runtimes, reducing installer size. The 0.5.3 bundled
+  runtimes are intentionally not migrated; install the Runtime Packs you need
+  after upgrading.
+
+### Model routing, Ensemble, and providers
+
+- Each chat can keep its own Direct, Router, or Ensemble strategy. The global
+  strategy remains the default for new chats, and existing chats adopt the
+  current global strategy atomically on first use.
+- C3 can use the shared multi-model fusion plan with resilient fixed-model
+  fallback, independent image routing, transactional tool attempts, and clearer
+  setup and activity presentation.
+- Fresh and managed TokenRhythm configurations use DeepSeek V4 Flash 0731 for
+  C0, DeepSeek V4 Pro 0813 for Direct and C1, Kimi K2.7 Code for C2, and GLM
+  5.2 B5 fusion for C3. Existing custom inline tiers are not migrated.
+- Qwen prompt caching, Zhipu reasoning endpoint matching, Gemini CSV schemas,
+  generic custom pricing, routed cost breakdowns, reasoning-only retries, and
+  Ensemble usage and fallback behavior are more reliable.
+
+### Chats, tasks, and attachments
+
+- Web chat confirms durable turn saves without delaying the answer or disabling
+  input. Activity ordering, router panels, steering boundaries, task ownership,
+  clocks, pending input, and scroll position recover more consistently across
+  reconnects and session switches.
+- Stop acknowledges promptly for provider and ordinary tool work while letting
+  in-flight filesystem mutations settle safely before the terminal turn is
+  published.
+- Large attachments use the complete request capacity during routing. Uploaded
+  images remain available to vision-capable models and are also materialized
+  for workspace tools.
+- Session history pagination, first-query session lookup, transcript reads,
+  prompt-cache continuity, slash-command input, Composer paste behavior, and
+  repeated-output handling have been hardened.
+
+### Desktop, Web, and platform reliability
+
+- Desktop startup is decoupled from Gateway readiness and now reports monotonic
+  milestones. Recovery starts faster, macOS Keychain failures have a guided
+  retry path, and Windows process-tree helpers and installer progress are more
+  reliable.
+- Settings are organized into ten stable destinations, including combined
+  Security & Privacy controls and a first-level Memory page. Existing Settings
+  deep links continue through compatibility aliases.
+- Sidebar interactions, long-session scrolling, Workbench resizing, activity
+  details, usage expansion, automation empty states, memory import, and global
+  controls are more consistent.
+- Windows Safe execution, process-tree cancellation, Gateway shutdown,
+  Skill-catalog digest verification, and CLI error exits now fail more
+  predictably across supported platforms.
+
+## Downloads
+
+Recommended desktop downloads:
+
+- macOS desktop installer: `OpenSquilla-0.5.4-mac-arm64.dmg`
+- macOS desktop zip: `OpenSquilla-0.5.4-mac-arm64.zip`
+- Windows desktop installer: `OpenSquilla-0.5.4-win-x64.exe`
+
+Users in Mainland China can use the stable direct installer links on the
+Alibaba Cloud OSS mirror:
+
+- macOS Apple Silicon: <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-mac-arm64.dmg>
+- Windows x64: <https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/OpenSquilla-win-x64.exe>
+
+Each alias is replaced only after the published release passes checksum
+verification. Versioned OSS and GitHub Release files remain available for
+pinned downloads.
+
+The Windows desktop installer is currently unsigned. See the
+[code signing policy](https://github.com/opensquilla/opensquilla/blob/v0.5.4/docs/code-signing-policy.md)
+before installation.
+
+Terminal and automation downloads:
+
+- Python wheel: `opensquilla-0.5.4-py3-none-any.whl`
+- Checksums: `SHA256SUMS`
+
+Updater metadata:
+
+- `latest-mac.yml`
+- `latest.yml`
+- `*.blockmap`
+
+No Windows Portable assets are published for 0.5.4. Existing 0.4.x Portable
+downloads remain on their original release pages as legacy sources; do not
+expect a 0.5.4 Portable zip or a Portable `/releases/latest/download/` alias.
+
+Privacy and third-party attribution are documented in
+[`PRIVACY.md`](https://github.com/opensquilla/opensquilla/blob/v0.5.4/PRIVACY.md)
+and
+[`THIRD_PARTY_NOTICES.md`](https://github.com/opensquilla/opensquilla/blob/v0.5.4/THIRD_PARTY_NOTICES.md).
+
+Container users can pull the multi-architecture gateway image:
+
+```sh
+docker pull ghcr.io/opensquilla/opensquilla:v0.5.4
+```
+
+The versioned image supports `linux/amd64` and `linux/arm64`. The moving
+`latest` tag follows the most recently verified release tag.
+
+## Upgrading from 0.5.3
+
+Quit the running Desktop app and gateway before upgrading. Back up the active
+profile first if you may need to recover or roll back.
+
+Install 0.5.4 directly over 0.5.3. Existing configuration, chats, Agents,
+memory, and scheduled tasks remain in the active profile. Additive database
+migrations run automatically when the Gateway starts.
+
+The 0.5.4 Desktop app uses optional Runtime Packs instead of the developer
+runtimes bundled in 0.5.3. Those old bundled runtimes are not copied into the
+new application. If a task needs managed Python, Node.js, or Git Bash, install
+the corresponding Runtime Pack from Sandbox settings after the upgrade.
+
+Existing chats keep working with older clients. Their per-chat routing mode is
+seeded from the current global strategy when first used by 0.5.4. New routing
+fields and commit receipts are additive, so clients that do not understand them
+may continue through their existing behavior. Native HTML annotation editing
+requires the complete current Electron bridge; older or browser-only clients
+remain view-only for that capability.
+
+> [!IMPORTANT]
+> On Windows, users coming from RC3 or an older pre-Preview-4 build must not
+> uninstall that build first: older uninstallers may delete
+> `%APPDATA%\OpenSquilla`. Back up that directory, then install 0.5.4 directly
+> over the existing installation. Preview 4, 0.5.0, 0.5.1, 0.5.2, 0.5.3, and
+> 0.5.4 installers preserve profile data during a normal uninstall.
+
+On macOS, drag the new app into Applications, eject the DMG, and open the
+Applications copy.
+
+CLI users can reinstall the published wheel over the current tool environment:
+
+```sh
+uv tool install --python 3.12 --force --reinstall-package opensquilla \
+  "opensquilla[recommended] @ https://github.com/opensquilla/opensquilla/releases/download/v0.5.4/opensquilla-0.5.4-py3-none-any.whl"
+```
+
+Non-user-initiated network observability can be disabled before startup with
+`OPENSQUILLA_PRIVACY_DISABLE_NETWORK_OBSERVABILITY=true` or:
+
+```toml
+[privacy]
+disable_network_observability = true
+```
+
+The compatibility variables `OPENSQUILLA_TELEMETRY_DISABLED=true` and
+`OPENSQUILLA_UPDATE_CHECK_DISABLED=true` remain honored.
+
+## Acknowledgements
+
+Thanks to the human contributors whose work is newly present in 0.5.4:
+
+- [@AmirF194](https://github.com/AmirF194) for tightening Zhipu reasoning
+  behavior to official API endpoints.
+- [@Kiuyor](https://github.com/Kiuyor) for restoring pasted Composer input
+  after stale IME composition state.
+- [@Liu-RK](https://github.com/Liu-RK) for improving public release repository
+  hygiene.
+- [@LiuXinchen1997](https://github.com/LiuXinchen1997) for the tier-level
+  routing foundation used by resilient C3 fusion.
+- [@Sanjays2402](https://github.com/Sanjays2402) for finding existing sessions
+  on the first search query.
+- [@ab2ence](https://github.com/ab2ence) for C3 fusion and Ensemble fallback,
+  provider-state isolation, Qwen prompt caching, usage accuracy, and sidebar
+  refinements.
+- [@freeaccount-create](https://github.com/freeaccount-create) for Gemini-safe
+  CSV tool schemas.
+- [@jiaoqingrui](https://github.com/jiaoqingrui) for clearer Ensemble trace
+  token labeling.
+- [@kriptoburak](https://github.com/kriptoburak) for Skill catalog-path digest
+  verification.
+- [@lifelmy](https://github.com/lifelmy) for preserving routed model cost
+  breakdowns in the CLI.
+- [@lihongguang-0014](https://github.com/lihongguang-0014) for extensive work on
+  chat continuity, steering, attachments, Desktop startup, process lifecycle,
+  session recovery, provider handling, and CLI reliability.
+- [@openvictory](https://github.com/openvictory) for publishing the technical
+  report PDFs and making them discoverable.
+- [@shixi-li](https://github.com/shixi-li) for safer Ensemble timeout fallback.
+- [@xfjsssq](https://github.com/xfjsssq) for allowing unknown slash-prefixed
+  text to be sent as an ordinary message.
+
+See
+[`CONTRIBUTORS.md`](https://github.com/opensquilla/opensquilla/blob/v0.5.4/CONTRIBUTORS.md)
+for the release attribution ledger and pull-request evidence.

--- a/install.ps1
+++ b/install.ps1
@@ -12,7 +12,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$defaultVersion = 'v0.5.3'
+$defaultVersion = 'v0.5.4'
 $repoSlug = if ($env:OPENSQUILLA_REPOSITORY) { $env:OPENSQUILLA_REPOSITORY } else { 'opensquilla/opensquilla' }
 $pythonVersion = if ($env:OPENSQUILLA_PYTHON_VERSION) { $env:OPENSQUILLA_PYTHON_VERSION } else { '3.12' }
 $originalPath = if ($env:Path) { $env:Path } else { '' }
@@ -94,7 +94,7 @@ function Test-ReleaseVersion {
 }
 
 if ($Version -notin @('latest', 'stable') -and -not (Test-ReleaseVersion $Version)) {
-    Write-Error "install.ps1: unsupported OPENSQUILLA_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v0.5.3. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
+    Write-Error "install.ps1: unsupported OPENSQUILLA_VERSION='$Version'. The release installer only supports latest, stable, or release versions like v0.5.4. Use git clone plus scripts/install_source.ps1 for main, dev, branch, or source installs."
     exit 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-default_version="v0.5.3"
+default_version="v0.5.4"
 repo_slug="${OPENSQUILLA_REPOSITORY:-opensquilla/opensquilla}"
 python_version="${OPENSQUILLA_PYTHON_VERSION:-3.12}"
 original_path="${PATH:-}"
@@ -18,10 +18,10 @@ cli_extras=""
 
 usage() {
     cat <<HELP
-Usage: bash install.sh [--version v0.5.3|latest] [--profile recommended|core] [--extras name[,name]]
+Usage: bash install.sh [--version v0.5.4|latest] [--profile recommended|core] [--extras name[,name]]
 
 Environment equivalents:
-  OPENSQUILLA_VERSION=v0.5.3
+  OPENSQUILLA_VERSION=v0.5.4
   OPENSQUILLA_INSTALL_PROFILE=recommended|core
   OPENSQUILLA_INSTALL_EXTRAS=matrix
   OPENSQUILLA_INSTALL_DRY_RUN=1
@@ -133,7 +133,7 @@ fi
 
 if [[ "${release_selector}" != "latest" && "${release_selector}" != "stable" ]] && ! is_release_version "${release_selector}"; then
     echo "install.sh: unsupported OPENSQUILLA_VERSION='${release_selector}'." >&2
-    echo "install.sh: the release installer only supports latest, stable, or release versions like v0.5.3." >&2
+    echo "install.sh: the release installer only supports latest, stable, or release versions like v0.5.4." >&2
     echo "install.sh: use git clone plus scripts/install_source.sh for main, dev, branch, or source installs." >&2
     exit 1
 fi

--- a/packages/opensquilla-tui-host/pyproject.toml
+++ b/packages/opensquilla-tui-host/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opensquilla-tui-host"
-version = "0.5.3"
+version = "0.5.4"
 description = "Self-contained OpenTUI companion host for OpenSquilla"
 license = "Apache-2.0"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opensquilla"
-version = "0.5.3"
+version = "0.5.4"
 description = "OpenSquilla — microkernel Python agent runtime with MCP-native tools and multi-channel messaging"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scripts/live_artifact_prompt_annotations_e2e.py
+++ b/scripts/live_artifact_prompt_annotations_e2e.py
@@ -2099,10 +2099,16 @@ class GatewayCertificationDriver:
     async def _wait_for_task(self, session_key: str, task_id: str) -> Mapping[str, Any]:
         deadline = time.monotonic() + self.timeout_seconds
         while time.monotonic() < deadline:
-            bootstrap = await self.client.call(
-                "sessions.bootstrap",
-                {"key": session_key, "limit": 100},
-            )
+            try:
+                bootstrap = await self.client.call(
+                    "sessions.bootstrap",
+                    {"key": session_key, "limit": 100},
+                )
+            except GatewayRPCError as exc:
+                if exc.code != "STORAGE_BUSY":
+                    raise
+                await asyncio.sleep(0.25)
+                continue
             tasks = bootstrap.get("tasks")
             if isinstance(tasks, list):
                 match = next(

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -6180,6 +6180,9 @@ class TestSessionsAbort:
         async def cancel_background(_session_key: str) -> int:
             return 0
 
+        async def session_tree_keys(_session_manager: Any, root_key: str) -> tuple[str, ...]:
+            return (root_key,)
+
         async def emit(*_args: Any, **_kwargs: Any) -> None:
             return None
 
@@ -6188,6 +6191,7 @@ class TestSessionsAbort:
             "opensquilla.gateway.subagent_announce.cancel_background_completion_for_session",
             cancel_background,
         )
+        monkeypatch.setattr(rpc_sessions, "_session_tree_keys", session_tree_keys)
         monkeypatch.setattr(rpc_sessions, "_emit_to_subscribers", emit)
         # The runtime cancellation intentionally never completes.  The
         # production handler must return on its shared budget, but a strict

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -12,7 +12,7 @@ RELEASE_PS1 = ROOT / "install.ps1"
 RELEASE_SH = ROOT / "install.sh"
 SOURCE_PS1 = ROOT / "scripts" / "install_source.ps1"
 SOURCE_SH = ROOT / "scripts" / "install_source.sh"
-CURRENT_RELEASE_TAG = "v0.5.3"
+CURRENT_RELEASE_TAG = "v0.5.4"
 
 
 def test_source_install_scripts_force_refresh_local_uv_tool_package() -> None:

--- a/tests/test_live_artifact_prompt_annotations_e2e.py
+++ b/tests/test_live_artifact_prompt_annotations_e2e.py
@@ -664,6 +664,65 @@ def test_certification_rejects_case_that_exceeds_its_pre_reserved_calls() -> Non
         asyncio.run(e2e._run_certification(OverrunningDriver(), hard_cap=64))
 
 
+@pytest.mark.asyncio
+async def test_wait_for_task_retries_transient_storage_busy(tmp_path: Path) -> None:
+    driver = e2e.GatewayCertificationDriver(
+        temp_root=tmp_path,
+        api_key="synthetic",
+        timeout_seconds=1.0,
+        provider_endpoint="http://127.0.0.1:9/v1",
+        preload_router=False,
+    )
+
+    class Client:
+        calls = 0
+
+        async def call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+            assert method == "sessions.bootstrap"
+            assert params == {"key": "agent:main:test", "limit": 100}
+            self.calls += 1
+            if self.calls == 1:
+                raise e2e.GatewayRPCError(
+                    method,
+                    code="STORAGE_BUSY",
+                    message="Session storage is temporarily busy. Retry this operation.",
+                )
+            return {"tasks": [{"task_id": "task-1", "status": "succeeded"}]}
+
+    client = Client()
+    driver.client = client
+
+    task = await driver._wait_for_task("agent:main:test", "task-1")
+
+    assert task["status"] == "succeeded"
+    assert client.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_wait_for_task_does_not_retry_other_rpc_errors(tmp_path: Path) -> None:
+    driver = e2e.GatewayCertificationDriver(
+        temp_root=tmp_path,
+        api_key="synthetic",
+        timeout_seconds=1.0,
+        provider_endpoint="http://127.0.0.1:9/v1",
+        preload_router=False,
+    )
+
+    class Client:
+        calls = 0
+
+        async def call(self, method: str, _params: dict[str, Any]) -> dict[str, Any]:
+            self.calls += 1
+            raise e2e.GatewayRPCError(method, code="FORBIDDEN", message="denied")
+
+    client = Client()
+    driver.client = client
+
+    with pytest.raises(e2e.GatewayRPCError, match="FORBIDDEN"):
+        await driver._wait_for_task("agent:main:test", "task-1")
+    assert client.calls == 1
+
+
 @pytest.mark.ci_serial
 @pytest.mark.asyncio
 async def test_owned_gateway_preflights_use_real_rpc_bridge_and_zero_provider_calls(

--- a/tests/test_onboarding/test_flow.py
+++ b/tests/test_onboarding/test_flow.py
@@ -1528,7 +1528,7 @@ def test_interactive_feishu_websocket_prompts_only_core_fields(tmp_path, monkeyp
     assert "uv tool install --python 3.12 --force" in normalized_out
     assert "opensquilla[recommended]" in normalized_out
     assert "https://github.com/opensquilla/opensquilla/releases/download/" in out
-    assert "v0.5.3" in out
+    assert "v0.5.4" in out
     assert "opensquilla.ai/install." not in normalized_out
     assert "uv sync --extra recommended" in normalized_out
     assert "--extra feishu" not in normalized_out

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -13,8 +13,8 @@ from pathlib import Path
 import pytest
 import yaml
 
-CURRENT_VERSION = "0.5.3"
-CURRENT_DESKTOP_VERSION = "0.5.3"
+CURRENT_VERSION = "0.5.4"
+CURRENT_DESKTOP_VERSION = "0.5.4"
 CURRENT_TAG = f"v{CURRENT_VERSION}"
 HISTORICAL_PREVIEW_VERSION = "0.2.0rc1"
 HISTORICAL_PREVIEW_TAG = f"v{HISTORICAL_PREVIEW_VERSION}"
@@ -1170,7 +1170,7 @@ def test_historical_040_release_notes_remain_available() -> None:
     assert "OpenSquilla-0.4.0-mac-arm64.dmg" in notes
 
 
-def test_current_release_notes_cover_goals_recovery_upgrade_and_containers() -> None:
+def test_current_release_notes_cover_documents_runtimes_upgrade_and_containers() -> None:
     notes = Path(f"docs/releases/{CURRENT_VERSION}.md").read_text(encoding="utf-8")
 
     assert "## Downloads" in notes
@@ -1178,23 +1178,23 @@ def test_current_release_notes_cover_goals_recovery_upgrade_and_containers() -> 
     assert f"OpenSquilla-{CURRENT_DESKTOP_VERSION}-mac-arm64.zip" in notes
     assert f"OpenSquilla-{CURRENT_DESKTOP_VERSION}-win-x64.exe" in notes
     assert f"opensquilla-{CURRENT_VERSION}-py3-none-any.whl" in notes
-    assert notes.index("### Durable Goals and long-running tasks") < notes.index(
-        "### Sessions, follow-ups, and history"
+    assert notes.index("### Autonomous HTML document editing") < notes.index(
+        "### Runtime Packs and slimmer Desktop installers"
     )
-    assert notes.index("### Chat and Desktop experience") < notes.index(
-        "### Skills, schedules, and providers"
+    assert notes.index("### Model routing, Ensemble, and providers") < notes.index(
+        "### Chats, tasks, and attachments"
     )
     assert notes.index("## ✨ What's Improved") < notes.index("## Downloads")
     assert "no\nmanual data transfer is required" in notes
     assert "Additive database\nmigrations run automatically" in notes
-    assert "durable across reconnects" in notes
-    assert "hidden detailed game prompt" in notes
-    assert "No Windows Portable assets are published for 0.5.3" in notes
-    assert "0.5.3 Portable zip" in notes
-    assert "## Upgrading from 0.5.2" in notes
+    assert "Candidate changes remain isolated" in notes
+    assert "The 0.5.3 bundled\n  runtimes are intentionally not migrated" in notes
+    assert "No Windows Portable assets are published for 0.5.4" in notes
+    assert "0.5.4 Portable zip" in notes
+    assert "## Upgrading from 0.5.3" in notes
     assert "must not\n> uninstall that build first" in notes
     assert r"%APPDATA%\OpenSquilla" in notes
-    assert "ghcr.io/opensquilla/opensquilla:v0.5.3" in notes
+    assert "ghcr.io/opensquilla/opensquilla:v0.5.4" in notes
     assert "`latest` tag follows the most recently verified release tag" in notes
     assert (
         "https://opensquilla-releases.oss-cn-beijing.aliyuncs.com/releases/latest/"
@@ -1209,21 +1209,20 @@ def test_current_release_notes_cover_goals_recovery_upgrade_and_containers() -> 
     assert "release gate" not in notes
     assert "## Acknowledgements" in notes
     for login in [
-        "@249469326i-lang",
-        "@HuaXiawithMoon",
+        "@AmirF194",
         "@Kiuyor",
-        "@LHMQ878",
         "@Liu-RK",
-        "@RickyYii",
-        "@Saul-Soul",
-        "@TUOXI293",
-        "@anujbolewar",
+        "@LiuXinchen1997",
+        "@Sanjays2402",
+        "@ab2ence",
         "@freeaccount-create",
-        "@iamasly",
         "@jiaoqingrui",
+        "@kriptoburak",
+        "@lifelmy",
         "@lihongguang-0014",
-        "@wade19990814-hue",
-        "@weiconghe",
+        "@openvictory",
+        "@shixi-li",
+        "@xfjsssq",
     ]:
         assert login in notes
     assert "CONTRIBUTORS.md" in notes
@@ -1236,30 +1235,29 @@ def test_docs_index_links_current_release_notes() -> None:
     assert "releases/0.4.0.md" in index
 
 
-def test_current_contributor_ledger_records_053_attribution() -> None:
+def test_current_contributor_ledger_records_054_attribution() -> None:
     ledger = Path("CONTRIBUTORS.md").read_text(encoding="utf-8")
-    section = ledger.split("## OpenSquilla 0.5.3", 1)[1].split("## OpenSquilla 0.5.2", 1)[0]
+    section = ledger.split("## OpenSquilla 0.5.4", 1)[1].split("## OpenSquilla 0.5.3", 1)[0]
 
     expected = {
-        "@249469326i-lang": "#1043",
-        "@HuaXiawithMoon": "#1155",
-        "@Kiuyor": "#1006",
-        "@LHMQ878": "#1058",
-        "@Liu-RK": "#1154",
-        "@RickyYii": "#1142",
-        "@Saul-Soul": "#1070",
-        "@TUOXI293": "#1024",
-        "@anujbolewar": "#957",
-        "@freeaccount-create": "#1153",
-        "@iamasly": "#994",
-        "@jiaoqingrui": "#968",
-        "@lihongguang-0014": "#1158",
-        "@wade19990814-hue": "#1135",
-        "@weiconghe": "#1123",
+        "@AmirF194": "#1193",
+        "@Kiuyor": "#1185",
+        "@Liu-RK": "#1267",
+        "@LiuXinchen1997": "#1199",
+        "@Sanjays2402": "#1214",
+        "@ab2ence": "#1300",
+        "@freeaccount-create": "#1264",
+        "@jiaoqingrui": "#1350",
+        "@kriptoburak": "#1367",
+        "@lifelmy": "#1215",
+        "@lihongguang-0014": "#1355",
+        "@openvictory": "#1351",
+        "@shixi-li": "#1184",
+        "@xfjsssq": "#1176",
     }
     for login, evidence in expected.items():
         assert login in section
         assert evidence in section
-    assert "#1025" in section
+    assert "#1179" in section
     assert "Codex" not in section
     assert "Claude Code" not in section

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -1178,7 +1178,7 @@ def test_current_release_notes_cover_documents_runtimes_upgrade_and_containers()
     assert f"OpenSquilla-{CURRENT_DESKTOP_VERSION}-mac-arm64.zip" in notes
     assert f"OpenSquilla-{CURRENT_DESKTOP_VERSION}-win-x64.exe" in notes
     assert f"opensquilla-{CURRENT_VERSION}-py3-none-any.whl" in notes
-    assert notes.index("### Autonomous HTML document editing") < notes.index(
+    assert notes.index("### HTML document editing beta") < notes.index(
         "### Runtime Packs and slimmer Desktop installers"
     )
     assert notes.index("### Model routing, Ensemble, and providers") < notes.index(
@@ -1187,7 +1187,8 @@ def test_current_release_notes_cover_documents_runtimes_upgrade_and_containers()
     assert notes.index("## ✨ What's Improved") < notes.index("## Downloads")
     assert "no\nmanual data transfer is required" in notes
     assert "Additive database\nmigrations run automatically" in notes
-    assert "Candidate changes remain isolated" in notes
+    assert "early beta" in notes
+    assert "limited to single-file UTF-8 HTML" in notes
     assert "The 0.5.3 bundled\n  runtimes are intentionally not migrated" in notes
     assert "No Windows Portable assets are published for 0.5.4" in notes
     assert "0.5.4 Portable zip" in notes

--- a/uv.lock
+++ b/uv.lock
@@ -1774,7 +1774,7 @@ wheels = [
 
 [[package]]
 name = "opensquilla"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Scope

- bump Python, Electron, TUI companion, installer, lockfile, and release-test metadata to 0.5.4
- add the 0.5.4 user-facing release notes and contributor attribution for work after v0.5.3
- advance README, quickstart, CLI, MCP, Docker, and release-SOP download pointers to the versioned 0.5.4 assets
- keep v0.5.3 as the signed-package upgrade and real-updater rehearsal baseline

Target branch: main

Linked issue: None

Release note status: added docs/releases/0.5.4.md and promoted the Unreleased changelog entries into 0.5.4.

## Verification

- uv run pytest tests/test_release_consistency.py tests/test_public_release_hygiene.py tests/test_install_scripts.py tests/test_onboarding/test_flow.py::test_interactive_feishu_websocket_prompts_only_core_fields -q — 64 passed, 2 skipped
- uv run pytest tests/test_release_consistency.py tests/test_public_release_hygiene.py -q — 47 passed
- uv run ruff check tests/test_release_consistency.py tests/test_install_scripts.py tests/test_onboarding/test_flow.py — passed
- uv lock --check — passed
- git diff --check and staged diff check — passed
- GitNexus pre-change and pre-commit analysis — LOW risk, no affected execution flows

## Safety and compatibility

- This PR changes release metadata, public documentation, installation pointers, attribution, and release-contract tests; it does not change runtime behavior.
- Existing configuration, chats, Agents, memory, scheduled jobs, and public protocol behavior are unchanged by this PR.
- The release notes document the already-merged additive migrations, per-chat routing compatibility, current-bridge requirement for native HTML annotation editing, slim-installer Runtime Pack transition, Windows in-place upgrade warning, and macOS installation path.
- The macOS and Windows upgrade workflows intentionally remain pinned to v0.5.3 as the previous stable baseline.
- No tag was created or moved, no release assets were built, and no GitHub Release was published.
- Do not merge until the tag-and-publish work can continue in the same release session, because main will advertise v0.5.4 immediately after merge.

Platform assessment: release metadata is platform-neutral. The published guidance and retained upgrade probes cover the distinct macOS and Windows packaging paths; Linux users continue through the versioned wheel or container image.

## Third-party origin

Third-party origin: none for this release-preparation change. Contributor evidence links to the GitHub pull requests and commits already present in the v0.5.3-to-main release range.
