### PR TITLE
Include runtime catalog in container builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ COPY scripts/verify_webui_artifact.py ./scripts/verify_webui_artifact.py
 COPY opensquilla-webui/ ./opensquilla-webui/
 COPY src/ ./src/
 COPY migrations/ ./migrations/
+COPY desktop/electron/runtime/runtime-pack-catalog.json ./desktop/electron/runtime/runtime-pack-catalog.json
 COPY --from=webui-builder \
     /build/src/opensquilla/gateway/static/dist/ \
     ./src/opensquilla/gateway/static/dist/

--- a/tests/test_ci/test_dockerignore_context.py
+++ b/tests/test_ci/test_dockerignore_context.py
@@ -12,6 +12,15 @@ import pytest
 _ROOT = Path(__file__).parents[2]
 
 
+def test_dockerfile_copies_runtime_catalog_required_by_wheel_build() -> None:
+    dockerfile = (_ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+    assert (
+        "COPY desktop/electron/runtime/runtime-pack-catalog.json "
+        "./desktop/electron/runtime/runtime-pack-catalog.json"
+    ) in dockerfile
+
+
 def _write(path: Path, contents: str = "probe\n") -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(contents, encoding="utf-8")


### PR DESCRIPTION
## Scope

- Copy the runtime pack catalog into the Docker build stage before Hatch prepares wheel metadata.
- Add a regression contract for the required Dockerfile input.

## Branch target

- `main`

## Linked issue

- None

## Release note status

- No user-facing release note required; this repairs the v0.5.4 container publication pipeline.

## Verification

- `uv run pytest -q tests/test_ci/test_dockerignore_context.py` (1 passed, 1 skipped because Docker E2E is opt-in)
- `uv run ruff check tests/test_ci/test_dockerignore_context.py`
- `git diff --check`

## Safety and compatibility

- Platform-neutral build-context fix; runtime behavior is unchanged.
- No persisted state, configuration, RPC, CLI, or client contract changes.

## Third-party origin

- None.
