### PR TITLE
Fix desktop package verification boundaries

### DIFF
--- a/desktop/electron/scripts/verify-package.mjs
+++ b/desktop/electron/scripts/verify-package.mjs
@@ -286,6 +286,14 @@ async function verifyRuntime(root, label, { platform, executeCommands }) {
   }
 }
 
+function sourceBetweenMarkers(source, startMarker, endMarker) {
+  const startIndex = source.indexOf(startMarker)
+  if (startIndex === -1) return ''
+  const endIndex = source.indexOf(endMarker, startIndex + startMarker.length)
+  if (endIndex === -1) return ''
+  return source.slice(startIndex, endIndex)
+}
+
 function verifyMainProcess(source, label) {
   for (const expected of [
     'gatewayStartPromise',
@@ -340,16 +348,22 @@ function verifyMainProcess(source, label) {
   if (source.includes('/control/chat/new') || source.includes('waitForControlUi')) {
     fail(`${label} main process still makes the Desktop document depend on Gateway Control UI`)
   }
-  const createWindowIndex = source.indexOf('async function createMainWindow')
-  const createWindowSource = createWindowIndex === -1
-    ? ''
-    : source.slice(createWindowIndex, createWindowIndex + 8_000)
+  const createWindowSource = sourceBetweenMarkers(
+    source,
+    'async function createMainWindow',
+    'function currentMainWindow',
+  )
   if (!createWindowSource.includes('loadURL(DESKTOP_RENDERER_URL)')) {
     fail(`${label} main window does not load the local Desktop renderer`)
   }
-  const waitIndex = source.indexOf('async function waitForGateway')
-  const waitSource = waitIndex === -1 ? '' : source.slice(waitIndex, waitIndex + 1_000)
-  if (!waitSource.includes('readinessCheck(url)') || waitSource.includes('healthCheck(url)')) {
+  const waitSource = sourceBetweenMarkers(
+    source,
+    'async function waitForGateway',
+    'function hasGatewayProcessExited',
+  )
+  const usesReadinessProbe = /readinessCheck\(\s*url(?:\s*,[^)]*)?\)/.test(waitSource)
+  const usesHealthProbe = /healthCheck\(\s*url(?:\s*,[^)]*)?\)/.test(waitSource)
+  if (!usesReadinessProbe || usesHealthProbe) {
     fail(`${label} gateway startup does not use the readiness endpoint`)
   }
 

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -2519,6 +2519,20 @@ def test_package_verifier_hard_fails_stale_runtime_and_boot_contract() -> None:
     ]:
         assert expected in verifier
 
+    assert "createWindowIndex + 8_000" not in verifier
+    assert "waitIndex + 1_000" not in verifier
+    assert re.search(
+        r"sourceBetweenMarkers\(\s*source,\s*'async function createMainWindow',"
+        r"\s*'function currentMainWindow',",
+        verifier,
+    )
+    assert re.search(
+        r"sourceBetweenMarkers\(\s*source,\s*'async function waitForGateway',"
+        r"\s*'function hasGatewayProcessExited',",
+        verifier,
+    )
+    assert r"readinessCheck\(\s*url(?:\s*,[^)]*)?\)" in verifier
+
 
 def test_packaged_session_recovery_gate_uses_installed_electron_and_real_gateway() -> None:
     package_json = json.loads(_read("desktop/electron/package.json"))


### PR DESCRIPTION
## Scope

Fix the release package verifier to inspect complete Electron functions by explicit source boundaries instead of fixed character windows. Accept the current readiness probe timeout argument while continuing to reject legacy health probes.

## Branch target

main

## Linked issue

None

## Release note

Internal 0.5.4 release pipeline repair; no user-facing release note.

## Verification

- 127 desktop startup contract tests passed
- Ruff passed
- TypeScript build passed
- Node syntax check passed
- Real package verifier no longer reports source or compiled main-process contract failures; the local run stops only on intentionally absent packaged runtime resources
- GitNexus change review: low risk, no affected execution flows

## Safety and compatibility

No runtime product behavior, persisted state, public API, or platform-specific application code changes. The verifier remains fail-closed when markers are missing and still checks source, compiled output, and app.asar on macOS and Windows.

## Third-party origin

None.