### PR TITLE
Align packaged first-send startup budget

### DIFF
--- a/desktop/electron/scripts/test-packaged-first-send-renderer.mjs
+++ b/desktop/electron/scripts/test-packaged-first-send-renderer.mjs
@@ -10,9 +10,11 @@ import {
   requiredOption,
   waitFor,
 } from './packaged-smoke-helpers.mjs'
+import { DESKTOP_GATEWAY_STARTUP_TIMEOUT_MS } from '../dist/gateway-lifecycle.js'
 
 const DEFAULT_ITERATIONS = 20
 const SEND_TIMEOUT_MS = 45_000
+const INITIAL_GATEWAY_CONNECTION_TIMEOUT_MS = DESKTOP_GATEWAY_STARTUP_TIMEOUT_MS + SEND_TIMEOUT_MS
 const HEADER_IDENTITY_ATTRIBUTE = 'data-opensquilla-first-send-identity'
 const HEADER_IDENTITY_SETTLE_MS = 250
 const FORBIDDEN_RENDERER_ERROR = /(?:emitsOptions|\bexposed\b|nextSibling|getNextHostNode|Teleport\.process|\[ErrorBoundary\])/i
@@ -401,7 +403,11 @@ try {
     const header = page.locator('#app-route-header [data-testid="chat-header-actions"]')
     await page.locator('.conn-pill.connected').waitFor({
       state: 'visible',
-      timeout: SEND_TIMEOUT_MS,
+      // The local renderer is intentionally visible before profile inspection
+      // and Gateway cold start complete. Preserve the runtime's full startup
+      // budget on the first iteration; later reconnects keep the strict send
+      // timeout used by every other interaction in this gate.
+      timeout: iteration === 1 ? INITIAL_GATEWAY_CONNECTION_TIMEOUT_MS : SEND_TIMEOUT_MS,
     })
     await composer.waitFor({ state: 'visible', timeout: SEND_TIMEOUT_MS })
     // The packaged app can expose its initial draft URL before Vue has mounted

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -113,6 +113,15 @@ def test_release_workflow_builds_desktop_installers() -> None:
     assert "await page.mouse.move(1, 1)" in first_send_gate
     assert "rendererErrors" in first_send_gate
     assert "consoleErrorMessages" in first_send_gate
+    assert "DESKTOP_GATEWAY_STARTUP_TIMEOUT_MS" in first_send_gate
+    assert (
+        "INITIAL_GATEWAY_CONNECTION_TIMEOUT_MS = "
+        "DESKTOP_GATEWAY_STARTUP_TIMEOUT_MS + SEND_TIMEOUT_MS"
+    ) in first_send_gate
+    assert (
+        "timeout: iteration === 1 ? INITIAL_GATEWAY_CONNECTION_TIMEOUT_MS : SEND_TIMEOUT_MS"
+        in first_send_gate
+    )
 
 
 def test_release_workflow_runs_v053_windows_upgrade_checks_on_server_2022() -> None:


### PR DESCRIPTION
## Scope

Give the packaged first-send release gate the full documented Desktop Gateway cold-start budget for its initial connection. Keep the existing 45-second timeout for all later reconnects and every send/receipt assertion.

## Branch target

main

## Linked issue

None

## Release note

Internal 0.5.4 release gate repair; no user-facing release note.

## Verification

- 34 release consistency tests passed
- Electron TypeScript build passed
- Ruff passed
- Node syntax check passed
- GitNexus change review: low risk, no affected execution flows

## Safety and compatibility

No product runtime, persisted state, public API, or package content changes. The gate remains offline and fail-closed; only the first connection wait now matches the product's supported cold-start window on Windows and macOS.

## Third-party origin

None.