### PR TITLE
Preserve packaged first-send probe across routes

### DIFF
--- a/desktop/electron/scripts/test-packaged-first-send-renderer.mjs
+++ b/desktop/electron/scripts/test-packaged-first-send-renderer.mjs
@@ -238,6 +238,38 @@ async function browserRpcSnapshot(page) {
   })
 }
 
+function installBrowserRpcProbe() {
+  const probe = { methods: {}, sends: [] }
+  Object.defineProperty(globalThis, '__opensquillaP15RpcProbe', {
+    configurable: false,
+    enumerable: false,
+    value: probe,
+    writable: false,
+  })
+  const originalSend = WebSocket.prototype.send
+  WebSocket.prototype.send = function opensquillaP15ObservedSend(data) {
+    try {
+      if (typeof data === 'string') {
+        const frame = JSON.parse(data)
+        if (frame?.type === 'req' && typeof frame.method === 'string') {
+          probe.methods[frame.method] = (probe.methods[frame.method] || 0) + 1
+          if (frame.method === 'chat.send') {
+            probe.sends.push({
+              message: typeof frame.params?.message === 'string' ? frame.params.message : '',
+              sessionKey: typeof frame.params?.sessionKey === 'string'
+                ? frame.params.sessionKey
+                : '',
+            })
+          }
+        }
+      }
+    } catch {
+      // The probe is diagnostic only; malformed/non-JSON frames stay intact.
+    }
+    return originalSend.call(this, data)
+  }
+}
+
 async function observedChatSendCount(page, message) {
   const snapshot = await browserRpcSnapshot(page)
   return snapshot.sends.filter((entry) => entry.message === message).length
@@ -371,40 +403,11 @@ try {
   })
   // Observe the renderer's own WebSocket without proxying it. Playwright's
   // routeWebSocket transparent proxy changes the ASGI accept sequence in a
-  // packaged Electron app. Patching the prototype in the settled document also
-  // covers the already-connected socket and avoids a reload racing Electron's
-  // main-process loadURL() promise.
-  await page.evaluate(() => {
-    const probe = { methods: {}, sends: [] }
-    Object.defineProperty(globalThis, '__opensquillaP15RpcProbe', {
-      configurable: false,
-      enumerable: false,
-      value: probe,
-      writable: false,
-    })
-    const originalSend = WebSocket.prototype.send
-    WebSocket.prototype.send = function opensquillaP15ObservedSend(data) {
-      try {
-        if (typeof data === 'string') {
-          const frame = JSON.parse(data)
-          if (frame?.type === 'req' && typeof frame.method === 'string') {
-            probe.methods[frame.method] = (probe.methods[frame.method] || 0) + 1
-            if (frame.method === 'chat.send') {
-              probe.sends.push({
-                message: typeof frame.params?.message === 'string' ? frame.params.message : '',
-                sessionKey: typeof frame.params?.sessionKey === 'string'
-                  ? frame.params.sessionKey
-                  : '',
-              })
-            }
-          }
-        }
-      } catch {
-        // The probe is diagnostic only; malformed/non-JSON frames stay intact.
-      }
-      return originalSend.call(this, data)
-    }
-  })
+  // packaged Electron app. Register the probe for later full-document route
+  // transitions, then patch the already-settled initial document directly.
+  // No reload can race Electron's main-process loadURL() promise.
+  await page.addInitScript(installBrowserRpcProbe)
+  await page.evaluate(installBrowserRpcProbe)
 
   for (let iteration = 1; iteration <= iterations; iteration += 1) {
     await page.setViewportSize(iteration % 2 === 1 ? WIDE_VIEWPORT : TIGHT_VIEWPORT)

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -122,11 +122,15 @@ def test_release_workflow_builds_desktop_installers() -> None:
         "timeout: INITIAL_GATEWAY_CONNECTION_TIMEOUT_MS" in first_send_gate
     )
     initial_connection = first_send_gate.index("timeout: INITIAL_GATEWAY_CONNECTION_TIMEOUT_MS")
-    probe_install = first_send_gate.index("await page.evaluate(() => {", initial_connection)
-    assert initial_connection < probe_install
-    assert "await page.addInitScript" not in first_send_gate
+    probe_install = first_send_gate.index(
+        "await page.addInitScript(installBrowserRpcProbe)", initial_connection
+    )
+    current_probe_install = first_send_gate.index(
+        "await page.evaluate(installBrowserRpcProbe)", probe_install
+    )
+    assert initial_connection < probe_install < current_probe_install
     assert "await page.reload" not in first_send_gate
-    assert "timeout: SEND_TIMEOUT_MS" in first_send_gate[probe_install:]
+    assert "timeout: SEND_TIMEOUT_MS" in first_send_gate[current_probe_install:]
     assert "PLAYWRIGHT_ELECTRON_SANDBOX_ERRORS" in first_send_gate
     assert "unexpectedRendererErrorCount" in first_send_gate
 


### PR DESCRIPTION
## Scope

Keep the packaged first-send WebSocket probe installed across full-document route transitions while avoiding a reload race during Electron startup.

## Branch target

main

## Linked issue

None

## Release note

No user-facing release note; release verification only.

## Verification

- Packaged macOS app: 2 iterations, 4 chat sends, 2 unique sessions, 4 provider requests
- 0 unexpected renderer errors
- 34 release consistency tests passed
- Node syntax check passed
- git diff check passed
- GitNexus change risk: low; no affected product execution flows

## Safety and compatibility

Test-harness-only change. Product runtime, persisted state, public APIs, platform behavior, and upgrade compatibility are unchanged. The release workflow runs the harness on Windows and macOS.

## Third-party origin

None.