### PR TITLE
Extend OSS mirror workflow timeout to 60 minutes

### DIFF
--- a/.github/workflows/mirror-release-to-oss.yml
+++ b/.github/workflows/mirror-release-to-oss.yml
@@ -25,7 +25,7 @@ jobs:
   mirror-release-assets:
     name: Mirror release assets to Aliyun OSS
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       ALIYUN_OSS_BUCKET: ${{ vars.ALIYUN_OSS_BUCKET }}
       ALIYUN_OSS_PREFIX: ${{ vars.ALIYUN_OSS_PREFIX }}

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -703,6 +703,14 @@ def test_release_workflow_gates_built_and_downloaded_installers_on_profile_reten
     assert "verify-release-windows-upgrade.ps1" in windows_audit
 
 
+def test_release_mirror_allows_full_hour_for_cross_cloud_uploads() -> None:
+    workflow = yaml.safe_load(
+        Path(".github/workflows/mirror-release-to-oss.yml").read_text(encoding="utf-8")
+    )
+
+    assert workflow["jobs"]["mirror-release-assets"]["timeout-minutes"] == 60
+
+
 def test_release_workflow_prestages_draft_without_advancing_channels() -> None:
     workflow_text = Path(".github/workflows/wheelhouse-release.yml").read_text(
         encoding="utf-8"


### PR DESCRIPTION
## Scope
- increase the Aliyun OSS release mirror job timeout from 30 to 60 minutes
- add a release consistency regression test for the one-hour budget

## Branch target
- main

## Linked issue
- None

## Release note
- Not needed; CI/release infrastructure reliability only

## Verification
- uv run pytest tests/test_release_consistency.py tests/test_public_release_hygiene.py -q (48 passed)
- actionlint .github/workflows/mirror-release-to-oss.yml
- git diff --check
- GitNexus detect_changes: low risk, no affected execution flows

## Safety and compatibility
- no release assets, OSS paths, credentials, promotion logic, public interfaces, persisted state, or platform-specific runtime behavior change
- only the maximum GitHub Actions job duration changes

## Third-party origin
- None