### PR TITLE
Decouple nightly health from merge CI

### DIFF
--- a/.github/scripts/ci_attestation.py
+++ b/.github/scripts/ci_attestation.py
@@ -268,10 +268,8 @@ def create_attestation(
 
     if plan_basis not in {"change_set", "full_fallback"}:
         raise AttestationError("evidence plan basis is invalid")
-    if plan_basis == "full_fallback" and (
-        source_event != "merge_group" or evidence_kind != "root"
-    ):
-        raise AttestationError("full-fallback evidence must be a root merge-group run")
+    if plan_basis == "full_fallback" and evidence_kind != "root":
+        raise AttestationError("full-fallback evidence must be a root run")
 
     suites = sorted({item for item in successful_suites if item}) or ["ci-result"]
     execution_digests = dict(sorted((suite_execution_digests or {}).items()))
@@ -739,10 +737,8 @@ def _validate_canonical_source_plan(
     plan_basis = attestation.get("plan_basis")
     evidence_kind = attestation.get("evidence_kind")
     if plan_basis == "full_fallback":
-        if source_event != "merge_group" or evidence_kind != "root":
-            raise AttestationError(
-                "full-fallback evidence must be a root merge-group run"
-            )
+        if evidence_kind != "root":
+            raise AttestationError("full-fallback evidence must be a root run")
         changed_paths = [".ci/run-all"]
     elif plan_basis != "change_set":
         raise AttestationError("evidence plan basis is invalid")
@@ -896,6 +892,8 @@ def validate_candidate(
     if match_kind == "exact":
         if tested_tree_sha != queue_tree_sha:
             raise AttestationError("attestation tested tree does not match the queue")
+        if tested_base_sha != queue_base_sha:
+            raise AttestationError("attestation tested base does not match the queue")
     elif match_kind == "composed":
         if reconstructed_queue_tree != queue_tree_sha:
             raise AttestationError("pull request head and queue base do not reconstruct queue tree")
@@ -1017,23 +1015,6 @@ def verify_queue(
         if queue_policy != base_policy:
             raise AttestationError("CI policy changed relative to the queue base")
 
-        nightly_details: dict[str, object] = {}
-        nightly_healthy, nightly_reason = verify_nightly_health(
-            repo=repo,
-            repository=repository,
-            token=token,
-            api_url=api_url,
-            details=nightly_details,
-        )
-        details.update(
-            nightly_healthy=str(nightly_healthy).lower(),
-            nightly_reason=nightly_reason,
-            nightly_run_id=nightly_details.get("source_run_id", ""),
-            nightly_age_seconds=nightly_details.get("age_seconds", ""),
-        )
-        if not nightly_healthy:
-            raise AttestationError(f"nightly health check failed: {nightly_reason}")
-
         pull_request_number = _queue_pr_number(merge_group)
         current_pull_request = _request_json(
             f"{api_url}/repos/{repository}/pulls/{pull_request_number}", token
@@ -1125,7 +1106,16 @@ def verify_queue(
                 tested_tree = _require_sha(
                     attestation.get("tested_tree_sha"), "attested tree SHA"
                 )
-                match_kind = "exact" if tested_tree == queue_tree_sha else "composed"
+                if tested_tree != queue_tree_sha:
+                    raise AttestationError(
+                        "only exact-tree pull request evidence may be reused"
+                    )
+                if attestation.get("source_event") != "pull_request":
+                    raise AttestationError(
+                        "only pull request evidence may be reused by the queue"
+                    )
+                if attestation.get("evidence_kind") != "root":
+                    raise AttestationError("only root evidence may be reused by the queue")
                 validate_candidate(
                     attestation=attestation,
                     run=run,
@@ -1133,61 +1123,33 @@ def verify_queue(
                     queue_tree_sha=queue_tree_sha,
                     queue_base_sha=queue_base_sha,
                     queue_policy_digest=queue_policy,
-                    match_kind=match_kind,
+                    match_kind="exact",
                     current_pull_request=current_pull_request,
                     reconstructed_queue_tree=reconstructed_tree,
                     repo=repo,
                 )
-                if attestation.get("source_event") == "pull_request":
-                    attested_number = attestation.get("pull_request_number")
-                    attested_head = _require_sha(
-                        attestation.get("head_sha"), "attested head SHA"
+                attested_number = attestation.get("pull_request_number")
+                attested_head = _require_sha(
+                    attestation.get("head_sha"), "attested head SHA"
+                )
+                if attested_number != pull_request_number:
+                    raise AttestationError("evidence belongs to another pull request")
+                latest_run_id = _latest_pr_run_id(
+                    api_url=api_url,
+                    repository=repository,
+                    token=token,
+                    pull_request_number=pull_request_number,
+                    head_sha=attested_head,
+                    head_ref=str(attestation.get("head_ref", "")),
+                )
+                if latest_run_id != run_id:
+                    raise AttestationError(
+                        "evidence workflow run is not the latest authoritative PR run"
                     )
-                    if attested_number != pull_request_number:
-                        raise AttestationError("evidence belongs to another pull request")
-                    latest_run_id = _latest_pr_run_id(
-                        api_url=api_url,
-                        repository=repository,
-                        token=token,
-                        pull_request_number=pull_request_number,
-                        head_sha=attested_head,
-                        head_ref=str(attestation.get("head_ref", "")),
-                    )
-                    if latest_run_id != run_id:
-                        raise AttestationError(
-                            "evidence workflow run is not the latest authoritative PR run"
-                        )
-                combined_smoke_suites: tuple[str, ...] = ()
-                if match_kind == "composed":
-                    if attestation.get("source_event") != "pull_request":
-                        raise AttestationError(
-                            "only pull request evidence may be composed across a base advance"
-                        )
-                    if not _wait_for_base_successful_ci(
-                        api_url=api_url,
-                        repository=repository,
-                        token=token,
-                        queue_base_sha=queue_base_sha,
-                    ):
-                        raise AttestationError("queue base evidence is not green")
-                    safe, composition_reason, combined_smoke_suites = _composition_is_safe(
-                        repo=repo,
-                        attestation=attestation,
-                        queue_base_sha=queue_base_sha,
-                    )
-                    if not safe:
-                        raise AttestationError(composition_reason)
-                    details["reason_code"] = "reusable_base_advance"
-                    reason = f"composed trusted PR/base evidence: {composition_reason}"
-                else:
-                    details["reason_code"] = "reusable_exact"
-                    reason = "matching trusted exact-tree CI evidence"
+                details["reason_code"] = "reusable_exact"
+                reason = "matching trusted exact-base, exact-tree PR CI evidence"
                 details.update(
-                    artifact_name=(
-                        f"ci-evidence-v2-tree-{queue_tree_sha}"
-                        if match_kind == "exact"
-                        else f"ci-evidence-v2-pr-{pull_request_number}-{current_head_sha}"
-                    ),
+                    artifact_name=f"ci-evidence-v2-tree-{queue_tree_sha}",
                     source_root_issued_at=attestation.get("root_issued_at", ""),
                     source_lineage=json.dumps(
                         attestation.get("lineage", []), separators=(",", ":")
@@ -1201,9 +1163,7 @@ def verify_queue(
                         sort_keys=True,
                         separators=(",", ":"),
                     ),
-                    combined_smoke_suites=_canonical_suite_json(
-                        combined_smoke_suites
-                    ),
+                    combined_smoke_suites=_canonical_suite_json(),
                 )
                 return True, reason, run_id
             except (AttestationError, OSError, ValueError, zipfile.BadZipFile) as exc:
@@ -1513,10 +1473,6 @@ def _verify_queue_command(args: argparse.Namespace) -> int:
                 "source_suite_execution_digests", "{}"
             ),
             "combined_smoke_suites": details.get("combined_smoke_suites", "[]"),
-            "nightly_healthy": details.get("nightly_healthy", "false"),
-            "nightly_reason": details.get("nightly_reason", ""),
-            "nightly_run_id": details.get("nightly_run_id", ""),
-            "nightly_age_seconds": details.get("nightly_age_seconds", ""),
         },
     )
     print(f"reusable={str(reusable).lower()} reason={reason}")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,6 @@ jobs:
       source_planner_digest: ${{ steps.verify.outputs.source_planner_digest }}
       source_suite_execution_digests: ${{ steps.verify.outputs.source_suite_execution_digests }}
       combined_smoke_suites: ${{ steps.verify.outputs.combined_smoke_suites || '[]' }}
-      nightly_healthy: ${{ steps.verify.outputs.nightly_healthy || 'false' }}
-      nightly_reason: ${{ steps.verify.outputs.nightly_reason }}
-      nightly_run_id: ${{ steps.verify.outputs.nightly_run_id }}
-      nightly_age_seconds: ${{ steps.verify.outputs.nightly_age_seconds }}
     steps:
       - name: Validate optimization mode
         id: mode
@@ -100,10 +96,6 @@ jobs:
           QUEUE_HEAD_SHA: ${{ steps.verify.outputs.queue_head_sha }}
           QUEUE_TREE_SHA: ${{ steps.verify.outputs.queue_tree_sha }}
           COMBINED_SMOKE_SUITES: ${{ steps.verify.outputs.combined_smoke_suites || '[]' }}
-          NIGHTLY_HEALTHY: ${{ steps.verify.outputs.nightly_healthy || 'false' }}
-          NIGHTLY_REASON: ${{ steps.verify.outputs.nightly_reason }}
-          NIGHTLY_RUN_ID: ${{ steps.verify.outputs.nightly_run_id }}
-          NIGHTLY_AGE_SECONDS: ${{ steps.verify.outputs.nightly_age_seconds }}
         shell: bash
         run: |
           {
@@ -116,7 +108,6 @@ jobs:
             echo "- Artifact: \`${ARTIFACT_NAME}\`"
             echo "- Queue base/head/tree: \`${QUEUE_BASE_SHA}\` / \`${QUEUE_HEAD_SHA}\` / \`${QUEUE_TREE_SHA}\`"
             echo "- Combined-tree domain smokes: \`${COMBINED_SMOKE_SUITES}\`"
-            echo "- Nightly health: \`${NIGHTLY_HEALTHY}\` (${NIGHTLY_REASON}; run \`${NIGHTLY_RUN_ID}\`, age \`${NIGHTLY_AGE_SECONDS}s\`)"
             if [[ -n "${SOURCE_RUN_ID}" ]]; then
               echo "- Source run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}"
             fi
@@ -135,6 +126,7 @@ jobs:
       ${{ always()
           && (github.event_name != 'merge_group'
               || (vars.CI_OPTIMIZATION_MODE || 'enforce') != 'enforce'
+              || needs.queue-attestation.result != 'success'
               || needs.queue-attestation.outputs.reusable != 'true')
           && (github.event_name != 'push'
               || (vars.CI_OPTIMIZATION_MODE || 'enforce') != 'enforce') }}
@@ -158,8 +150,6 @@ jobs:
       toolchain_artifact_changed: ${{ steps.classify.outputs.toolchain_artifact_changed }}
       full_required: ${{ steps.classify.outputs.full_required }}
       pytest_targets: ${{ steps.classify.outputs.pytest_targets }}
-      nightly_healthy: ${{ steps.nightly.outputs.healthy || 'true' }}
-      nightly_reason: ${{ steps.nightly.outputs.reason }}
       required_suites: ${{ steps.plan.outputs.required_suites }}
       desktop_matrix: ${{ steps.plan.outputs.desktop_matrix }}
       python_matrix: ${{ steps.plan.outputs.python_matrix }}
@@ -173,17 +163,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Verify fresh full-nightly health
-        id: nightly
-        if: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && env.CI_OPTIMIZATION_MODE != 'legacy' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: >-
-          python3 .github/scripts/ci_attestation.py verify-nightly-health
-          --repository "${GITHUB_REPOSITORY}"
-          --api-url "${GITHUB_API_URL}"
-          --github-output "${GITHUB_OUTPUT}"
 
       - name: List changed files
         shell: bash
@@ -199,13 +178,7 @@ jobs:
               ;;
           esac
 
-          if [[ ("${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "merge_group") \
-                && "${CI_OPTIMIZATION_MODE}" != "legacy" \
-                && "${{ steps.nightly.outputs.healthy || 'false' }}" != "true" ]]; then
-            echo "Fresh full-nightly evidence is unavailable; running the full fail-closed matrix." >&2
-            printf '.ci/run-all\n' > "${changed_files}"
-          else
-            case "${{ github.event_name }}" in
+          case "${{ github.event_name }}" in
             pull_request)
               if [[ "${CI_OPTIMIZATION_MODE}" == "legacy" ]]; then
                 printf '.ci/run-all\n' > "${changed_files}"
@@ -234,8 +207,7 @@ jobs:
             *)
               printf '.ci/run-all\n' > "${changed_files}"
               ;;
-            esac
-          fi
+          esac
 
           echo "Changed files:"
           sed 's/^/  /' "${changed_files}"
@@ -281,18 +253,12 @@ jobs:
 
       - name: Summarize merge-group fallback decision
         if: ${{ github.event_name == 'merge_group' }}
-        env:
-          FULL_REQUIRED: ${{ steps.classify.outputs.full_required }}
         shell: bash
         run: |
-          decision="queue_diff_targeted"
-          if [[ "${FULL_REQUIRED}" == "true" ]]; then
-            decision="full_fail_closed"
-          fi
           {
             echo "## Merge queue fallback"
             echo
-            echo "- Decision: \`${decision}\`"
+            echo "- Decision: \`full_fail_closed\`"
           } >> "${GITHUB_STEP_SUMMARY}"
 
   workflow-lint:
@@ -1838,6 +1804,7 @@ jobs:
         if: >-
           ${{ (github.event_name == 'merge_group'
                && (vars.CI_OPTIMIZATION_MODE || 'enforce') == 'enforce'
+               && needs.queue-attestation.result == 'success'
                && needs.queue-attestation.outputs.reusable == 'true')
               || (github.event_name == 'push'
                   && (vars.CI_OPTIMIZATION_MODE || 'enforce') == 'enforce') }}
@@ -1879,6 +1846,7 @@ jobs:
         if: >-
           ${{ !((github.event_name == 'merge_group'
                  && (vars.CI_OPTIMIZATION_MODE || 'enforce') == 'enforce'
+                 && needs.queue-attestation.result == 'success'
                  && needs.queue-attestation.outputs.reusable == 'true')
                 || (github.event_name == 'push'
                     && (vars.CI_OPTIMIZATION_MODE || 'enforce') == 'enforce')) }}
@@ -1890,6 +1858,7 @@ jobs:
         if: >-
           ${{ !((github.event_name == 'merge_group'
                  && (vars.CI_OPTIMIZATION_MODE || 'enforce') == 'enforce'
+                 && needs.queue-attestation.result == 'success'
                  && needs.queue-attestation.outputs.reusable == 'true')
                 || (github.event_name == 'push'
                     && (vars.CI_OPTIMIZATION_MODE || 'enforce') == 'enforce')) }}
@@ -1932,6 +1901,7 @@ jobs:
         id: attestation
         if: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && env.CI_OPTIMIZATION_MODE != 'legacy' }}
         env:
+          QUEUE_RESULT: ${{ needs.queue-attestation.result }}
           QUEUE_REUSABLE: ${{ needs.queue-attestation.outputs.reusable }}
           SOURCE_RUN_ID: ${{ needs.queue-attestation.outputs.source_run_id }}
           SOURCE_ROOT_ISSUED_AT: ${{ needs.queue-attestation.outputs.source_root_issued_at }}
@@ -1939,12 +1909,32 @@ jobs:
           SOURCE_SUCCESSFUL_SUITES: ${{ needs.queue-attestation.outputs.source_successful_suites }}
           SOURCE_PLANNER_DIGEST: ${{ needs.queue-attestation.outputs.source_planner_digest }}
           SOURCE_SUITE_EXECUTION_DIGESTS: ${{ needs.queue-attestation.outputs.source_suite_execution_digests }}
+          PLANNED_SUCCESSFUL_SUITES: ${{ needs.classify-changes.outputs.required_suites }}
+          PLANNED_PLANNER_DIGEST: ${{ needs.classify-changes.outputs.planner_digest }}
+          PLANNED_SUITE_EXECUTION_DIGESTS: ${{ needs.classify-changes.outputs.suite_execution_digests }}
+          PLANNED_PLATFORM_MATRIX: ${{ needs.classify-changes.outputs.platform_matrix }}
+          PLANNED_FULL_FALLBACK: ${{ needs.classify-changes.outputs.planner_full_fallback }}
         shell: bash
         run: |
           set -euo pipefail
+          plan_args=()
+          if [[ -n "${PLANNED_SUCCESSFUL_SUITES}" ]]; then
+            plan_basis="change_set"
+            if [[ "${PLANNED_FULL_FALLBACK}" == "true" ]]; then
+              plan_basis="full_fallback"
+            fi
+            plan_args=(
+              --successful-suites "${PLANNED_SUCCESSFUL_SUITES}"
+              --planner-digest "${PLANNED_PLANNER_DIGEST}"
+              --suite-execution-digests "${PLANNED_SUITE_EXECUTION_DIGESTS}"
+              --platform-matrix "${PLANNED_PLATFORM_MATRIX}"
+              --plan-basis "${plan_basis}"
+            )
+          fi
           source_args=()
           if [[ "${GITHUB_EVENT_NAME}" == "merge_group" \
                 && "${CI_OPTIMIZATION_MODE}" == "enforce" \
+                && "${QUEUE_RESULT}" == "success" \
                 && "${QUEUE_REUSABLE}" == "true" ]]; then
             source_args=(
               --source-run-id "${SOURCE_RUN_ID}"
@@ -1961,6 +1951,7 @@ jobs:
             --optimization-mode "${CI_OPTIMIZATION_MODE}" \
             --output "${RUNNER_TEMP}/ci-attestation.json" \
             --github-output "${GITHUB_OUTPUT}" \
+            "${plan_args[@]}" \
             "${source_args[@]}"
 
       - name: Upload tree-indexed CI evidence v2

--- a/tests/test_ci/test_ci_attestation.py
+++ b/tests/test_ci/test_ci_attestation.py
@@ -99,7 +99,7 @@ def test_verify_queue_details_default_combined_smoke_to_empty_json(
     assert details["combined_smoke_suites"] == "[]"
 
 
-def test_verify_queue_command_emits_canonical_combined_smoke_output(
+def test_verify_queue_command_emits_fail_closed_outputs(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -109,10 +109,10 @@ def test_verify_queue_command_emits_canonical_combined_smoke_output(
 
     def fake_verify_queue(**kwargs: Any) -> tuple[bool, str, int]:
         kwargs["details"].update(
-            reason_code="reusable_base_advance",
-            combined_smoke_suites='["python-targeted"]',
+            reason_code="reusable_exact",
+            combined_smoke_suites="[]",
         )
-        return True, "trusted overlap", 123
+        return True, "trusted exact evidence", 123
 
     monkeypatch.setenv("GH_TOKEN", "synthetic-token")
     monkeypatch.setitem(
@@ -136,8 +136,10 @@ def test_verify_queue_command_emits_canonical_combined_smoke_output(
         for line in output_path.read_text(encoding="utf-8").splitlines()
     )
     assert outputs["reusable"] == "true"
-    assert outputs["reason_code"] == "reusable_base_advance"
-    assert outputs["combined_smoke_suites"] == '["python-targeted"]'
+    assert outputs["reason_code"] == "reusable_exact"
+    assert outputs["combined_smoke_suites"] == "[]"
+    assert "nightly_healthy" not in outputs
+    assert "nightly_reason" not in outputs
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -199,7 +201,12 @@ def _seed_suite_execution_input_fixtures(repo: Path) -> None:
 
 
 def _merge_preview_repo(
-    tmp_path: Path, *, advance_base: bool = False, change_ci_executor: bool = False
+    tmp_path: Path,
+    *,
+    advance_base: bool = False,
+    change_ci_executor: bool = False,
+    full_plan_change: bool = False,
+    feature_path: str = "src/example.py",
 ) -> tuple[Path, str, str, str]:
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -216,13 +223,18 @@ def _merge_preview_repo(
         _write(repo, relative, Path(relative).read_text(encoding="utf-8"))
     _write(repo, "pyproject.toml", "[project]\nname='fixture'\nversion='0'\n")
     _write(repo, "src/example.py", "BASE = True\n")
+    if feature_path != "src/example.py":
+        _write(repo, feature_path, "BASE = True\n")
     _seed_suite_execution_input_fixtures(repo)
     _git(repo, "add", ".")
     _git(repo, "commit", "-m", "base")
 
     _git(repo, "switch", "-c", "feature")
-    _write(repo, "src/example.py", "BASE = True\nFEATURE = True\n")
-    _git(repo, "add", "src/example.py")
+    _write(repo, feature_path, "BASE = True\nFEATURE = True\n")
+    _git(repo, "add", feature_path)
+    if full_plan_change:
+        _write(repo, "pyproject.toml", "[project]\nname='fixture'\nversion='1'\n")
+        _git(repo, "add", "pyproject.toml")
     if change_ci_executor:
         _write(repo, ".github/scripts/windows_test_shards.py", "TEST_SHARDS = 2\n")
         _git(repo, "add", ".github/scripts/windows_test_shards.py")
@@ -402,6 +414,45 @@ def test_create_command_records_full_merge_group_root_plan(tmp_path: Path) -> No
     )
 
 
+def test_pull_request_root_evidence_records_planner_full_fallback(
+    tmp_path: Path,
+) -> None:
+    repo, base_sha, head_sha, merge_sha = _merge_preview_repo(
+        tmp_path,
+        feature_path="docs/feature.md",
+        full_plan_change=True,
+    )
+    event = _event(base_sha, head_sha, merge_sha)
+    full_plan = _evidence_metadata(repo, [".ci/run-all"])
+
+    attestation = create_attestation(
+        repo=repo,
+        repository="opensquilla/opensquilla",
+        event=event,
+        workflow_run_id=123,
+        workflow_run_attempt=1,
+        workflow_ref="opensquilla/opensquilla/.github/workflows/ci.yml@refs/pull/42/merge",
+        optimization_mode="enforce",
+        plan_basis="full_fallback",
+        **full_plan,
+    )
+
+    assert attestation["source_event"] == "pull_request"
+    assert attestation["evidence_kind"] == "root"
+    assert attestation["plan_basis"] == "full_fallback"
+    assert attestation["successful_suites"] == full_plan["successful_suites"]
+    validate_candidate(
+        attestation=attestation,
+        run=_run(attestation),
+        repository="opensquilla/opensquilla",
+        queue_tree_sha=str(attestation["tested_tree_sha"]),
+        queue_base_sha=base_sha,
+        queue_policy_digest=str(attestation["trust_policy_digest"]),
+        current_pull_request={"number": 42, **event["pull_request"]},
+        repo=repo,
+    )
+
+
 def test_create_attestation_uses_tested_base_when_event_base_is_stale(
     tmp_path: Path,
 ) -> None:
@@ -537,6 +588,65 @@ def test_validate_candidate_rejects_non_green_or_mismatched_runs(tmp_path: Path)
     )
 
 
+@pytest.mark.parametrize(
+    ("mismatch", "expected_reason"),
+    (
+        ("policy", "trust_policy_digest"),
+        ("run-attempt", "run_attempt"),
+        ("planner-digest", "planner digest"),
+        ("execution-digest", "execution digest"),
+        ("platform-matrix", "platform matrix"),
+    ),
+)
+def test_validate_candidate_rejects_independent_evidence_contract_mismatches(
+    tmp_path: Path,
+    mismatch: str,
+    expected_reason: str,
+) -> None:
+    repo, base_sha, head_sha, merge_sha = _merge_preview_repo(tmp_path)
+    event = _event(base_sha, head_sha, merge_sha)
+    attestation = create_attestation(
+        repo=repo,
+        repository="opensquilla/opensquilla",
+        event=event,
+        workflow_run_id=123,
+        workflow_run_attempt=1,
+        workflow_ref="opensquilla/opensquilla/.github/workflows/ci.yml@refs/pull/42/merge",
+        optimization_mode="enforce",
+        **_evidence_metadata(repo),
+    )
+    tampered = json.loads(json.dumps(attestation))
+    run = _run(tampered)
+    queue_policy_digest = str(attestation["trust_policy_digest"])
+
+    if mismatch == "policy":
+        queue_policy_digest = "f" * 64
+    elif mismatch == "run-attempt":
+        run["run_attempt"] = 2
+    elif mismatch == "planner-digest":
+        tampered["planner_digest"] = "f" * 64
+    elif mismatch == "execution-digest":
+        suite = next(iter(tampered["suite_execution_digests"]))
+        tampered["suite_execution_digests"][suite] = "f" * 64
+    elif mismatch == "platform-matrix":
+        assert tampered["platform_matrix"]
+        tampered["platform_matrix"] = tampered["platform_matrix"][:-1]
+    else:  # pragma: no cover - the parametrization is exhaustive
+        raise AssertionError(f"unknown mismatch: {mismatch}")
+
+    with pytest.raises(AttestationError, match=expected_reason):
+        validate_candidate(
+            attestation=tampered,
+            run=run,
+            repository="opensquilla/opensquilla",
+            queue_tree_sha=str(tampered["tested_tree_sha"]),
+            queue_base_sha=base_sha,
+            queue_policy_digest=queue_policy_digest,
+            current_pull_request={"number": 42, **event["pull_request"]},
+            repo=repo,
+        )
+
+
 def test_validate_candidate_rejects_self_reported_incomplete_suite_coverage(
     tmp_path: Path,
 ) -> None:
@@ -606,6 +716,85 @@ def test_validate_candidate_rejects_expired_root_evidence(tmp_path: Path) -> Non
                 "number": 42,
                 **_event(base_sha, head_sha, merge_sha)["pull_request"],
             },
+        )
+
+
+def test_validate_candidate_accepts_ttl_boundary_and_rejects_future_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo, base_sha, head_sha, merge_sha = _merge_preview_repo(tmp_path)
+    event = _event(base_sha, head_sha, merge_sha)
+    attestation = create_attestation(
+        repo=repo,
+        repository="opensquilla/opensquilla",
+        event=event,
+        workflow_run_id=123,
+        workflow_run_attempt=1,
+        workflow_ref="opensquilla/opensquilla/.github/workflows/ci.yml@refs/pull/42/merge",
+        optimization_mode="enforce",
+        **_evidence_metadata(repo),
+    )
+    fixed_now = datetime(2026, 8, 25, 12, 0, tzinfo=UTC)
+
+    class FrozenDateTime(datetime):
+        @classmethod
+        def now(cls, tz: Any = None) -> datetime:
+            if tz is None:
+                return fixed_now.replace(tzinfo=None)
+            return fixed_now.astimezone(tz)
+
+    monkeypatch.setitem(validate_candidate.__globals__, "datetime", FrozenDateTime)
+    current_pr = {"number": 42, **event["pull_request"]}
+    attestation["root_issued_at"] = (fixed_now - timedelta(hours=72)).isoformat()
+
+    validate_candidate(
+        attestation=attestation,
+        run=_run(attestation),
+        repository="opensquilla/opensquilla",
+        queue_tree_sha=str(attestation["tested_tree_sha"]),
+        queue_base_sha=base_sha,
+        queue_policy_digest=str(attestation["trust_policy_digest"]),
+        current_pull_request=current_pr,
+    )
+
+    attestation["root_issued_at"] = (fixed_now + timedelta(seconds=301)).isoformat()
+    with pytest.raises(AttestationError, match="future"):
+        validate_candidate(
+            attestation=attestation,
+            run=_run(attestation),
+            repository="opensquilla/opensquilla",
+            queue_tree_sha=str(attestation["tested_tree_sha"]),
+            queue_base_sha=base_sha,
+            queue_policy_digest=str(attestation["trust_policy_digest"]),
+            current_pull_request=current_pr,
+        )
+
+
+def test_validate_candidate_rejects_exact_tree_from_different_base(
+    tmp_path: Path,
+) -> None:
+    repo, base_sha, head_sha, merge_sha = _merge_preview_repo(tmp_path)
+    event = _event(base_sha, head_sha, merge_sha)
+    attestation = create_attestation(
+        repo=repo,
+        repository="opensquilla/opensquilla",
+        event=event,
+        workflow_run_id=123,
+        workflow_run_attempt=1,
+        workflow_ref="opensquilla/opensquilla/.github/workflows/ci.yml@refs/pull/42/merge",
+        optimization_mode="enforce",
+        **_evidence_metadata(repo),
+    )
+
+    with pytest.raises(AttestationError, match="tested base"):
+        validate_candidate(
+            attestation=attestation,
+            run=_run(attestation),
+            repository="opensquilla/opensquilla",
+            queue_tree_sha=str(attestation["tested_tree_sha"]),
+            queue_base_sha="f" * 40,
+            queue_policy_digest=str(attestation["trust_policy_digest"]),
+            current_pull_request={"number": 42, **event["pull_request"]},
         )
 
 
@@ -900,7 +1089,19 @@ def _verify_composed_fixture(
     monkeypatch.setitem(
         verify_queue.__globals__,
         "verify_nightly_health",
-        lambda **_kwargs: (True, "latest full nightly is green and fresh"),
+        lambda **_kwargs: pytest.fail(
+            "queue verification must not inspect nightly health"
+        ),
+    )
+    monkeypatch.setitem(
+        verify_queue.__globals__,
+        "_wait_for_base_successful_ci",
+        lambda **_kwargs: pytest.fail("queue verification must not compose base evidence"),
+    )
+    monkeypatch.setitem(
+        verify_queue.__globals__,
+        "_composition_is_safe",
+        lambda **_kwargs: pytest.fail("queue verification must not compose evidence"),
     )
     details: dict[str, object] = {}
     reusable, reason, source_run = verify_queue(
@@ -915,7 +1116,7 @@ def _verify_composed_fixture(
     return reusable, reason, source_run, details
 
 
-def test_verify_queue_rejects_python_targeted_overlap(
+def test_verify_queue_rejects_composed_python_evidence(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -931,12 +1132,12 @@ def test_verify_queue_rejects_python_targeted_overlap(
     )
 
     assert reusable is False
-    assert "unsupported source suites: python-targeted" in reason
+    assert "only exact-tree pull request evidence" in reason
     assert source_run is None
     assert details["combined_smoke_suites"] == "[]"
 
 
-def test_verify_queue_disjoint_composition_has_no_combined_smoke_suites(
+def test_verify_queue_rejects_disjoint_base_advance_composition(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -944,20 +1145,20 @@ def test_verify_queue_disjoint_composition_has_no_combined_smoke_suites(
         tmp_path, base_delta_path="docs/queue.md"
     )
 
-    reusable, _reason, source_run, details = _verify_composed_fixture(
+    reusable, reason, source_run, details = _verify_composed_fixture(
         repo=repo,
         attestation=attestation,
         queue_base=queue_base,
         monkeypatch=monkeypatch,
     )
 
-    assert reusable is True
-    assert source_run == 123
-    assert details["reason_code"] == "reusable_base_advance"
+    assert reusable is False
+    assert "only exact-tree pull request evidence" in reason
+    assert source_run is None
     assert details["combined_smoke_suites"] == "[]"
 
 
-def test_verify_queue_rejects_overlap_outside_combined_smoke_trust_root(
+def test_verify_queue_rejects_composed_full_python_evidence(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -975,7 +1176,7 @@ def test_verify_queue_rejects_overlap_outside_combined_smoke_trust_root(
     )
 
     assert reusable is False
-    assert "unsupported source suites: python-full" in reason
+    assert "only exact-tree pull request evidence" in reason
     assert source_run is None
     assert details["combined_smoke_suites"] == "[]"
 
@@ -988,10 +1189,26 @@ def test_squash_binding_reconstructs_the_tested_tree(tmp_path: Path) -> None:
     ) == _git(repo, "rev-parse", "HEAD^{tree}")
 
 
-def test_verify_queue_reuses_only_exact_trusted_evidence(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    ("full_plan_change", "paths", "plan_basis"),
+    (
+        (False, ["docs/feature.md"], "change_set"),
+        (True, [".ci/run-all"], "full_fallback"),
+    ),
+    ids=("targeted", "full"),
+)
+def test_verify_queue_reuses_only_exact_trusted_evidence_without_nightly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    full_plan_change: bool,
+    paths: list[str],
+    plan_basis: str,
 ) -> None:
-    repo, base_sha, head_sha, merge_sha = _merge_preview_repo(tmp_path)
+    repo, base_sha, head_sha, merge_sha = _merge_preview_repo(
+        tmp_path,
+        feature_path="docs/feature.md",
+        full_plan_change=full_plan_change,
+    )
     event = _event(base_sha, head_sha, merge_sha)
     attestation = create_attestation(
         repo=repo,
@@ -1001,13 +1218,17 @@ def test_verify_queue_reuses_only_exact_trusted_evidence(
         workflow_run_attempt=1,
         workflow_ref="opensquilla/opensquilla/.github/workflows/ci.yml@refs/pull/42/merge",
         optimization_mode="shadow",
-        **_evidence_metadata(repo),
+        plan_basis=plan_basis,
+        **_evidence_metadata(repo, paths),
     )
     run = _run(attestation)
     run["created_at"] = "2026-08-20T00:00:00Z"
     current_pr = {"number": 42, **event["pull_request"]}
+    api_calls: list[str] = []
+    latest_runs = [run]
 
     def fake_json(url: str, _token: str) -> dict[str, Any]:
+        api_calls.append(url)
         if "actions/artifacts" in url:
             return {
                 "artifacts": [
@@ -1024,7 +1245,7 @@ def test_verify_queue_reuses_only_exact_trusted_evidence(
         if "/pulls/42" in url:
             return current_pr
         if "actions/workflows/ci.yml/runs" in url:
-            return {"workflow_runs": [run]}
+            return {"workflow_runs": latest_runs}
         return run
 
     monkeypatch.setitem(verify_queue.__globals__, "_request_json", fake_json)
@@ -1034,7 +1255,9 @@ def test_verify_queue_reuses_only_exact_trusted_evidence(
     monkeypatch.setitem(
         verify_queue.__globals__,
         "verify_nightly_health",
-        lambda **_kwargs: (True, "latest full nightly is green and fresh"),
+        lambda **_kwargs: pytest.fail(
+            "queue verification must not inspect nightly health"
+        ),
     )
 
     details: dict[str, object] = {}
@@ -1049,12 +1272,29 @@ def test_verify_queue_reuses_only_exact_trusted_evidence(
     )
 
     assert reusable is True
-    assert reason == "matching trusted exact-tree CI evidence"
+    assert reason == "matching trusted exact-base, exact-tree PR CI evidence"
     assert source_run == 123
     assert details["reason_code"] == "reusable_exact"
     assert details["candidate_count"] == 1
     assert details["artifact_name"].startswith("ci-evidence-v2-tree-")
     assert details["combined_smoke_suites"] == "[]"
+    assert all("event=schedule" not in url for url in api_calls)
+
+    newer_run = {**run, "id": 124, "created_at": "2026-08-21T00:00:00Z"}
+    latest_runs.insert(0, newer_run)
+    reusable, reason, source_run = verify_queue(
+        repo=repo,
+        repository="opensquilla/opensquilla",
+        event=event,
+        token="synthetic-token",
+        api_url="https://api.github.com",
+        current_run_id=1000,
+    )
+
+    assert reusable is False
+    assert "latest authoritative PR run" in reason
+    assert source_run is None
+    latest_runs[:] = [run]
 
     _write(repo, ".github/workflows/ci.yml", "name: Changed CI\n")
     _git(repo, "add", ".github/workflows/ci.yml")
@@ -1071,6 +1311,90 @@ def test_verify_queue_reuses_only_exact_trusted_evidence(
 
     assert reusable is False
     assert "CI policy changed" in reason
+    assert source_run is None
+
+
+@pytest.mark.parametrize(
+    ("evidence_kind", "source_event", "lineage", "expected_reason"),
+    (
+        ("derived", "pull_request", [456], "only root evidence"),
+        ("root", "pull_request", [456], "root evidence must not have lineage"),
+        ("root", "merge_group", [], "only pull request evidence"),
+    ),
+    ids=("derived", "root-with-lineage", "merge-group-source"),
+)
+def test_verify_queue_rejects_non_root_pr_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    evidence_kind: str,
+    source_event: str,
+    lineage: list[int],
+    expected_reason: str,
+) -> None:
+    repo, base_sha, head_sha, merge_sha = _merge_preview_repo(tmp_path)
+    event = _event(base_sha, head_sha, merge_sha)
+    attestation = create_attestation(
+        repo=repo,
+        repository="opensquilla/opensquilla",
+        event=event,
+        workflow_run_id=123,
+        workflow_run_attempt=1,
+        workflow_ref="opensquilla/opensquilla/.github/workflows/ci.yml@refs/pull/42/merge",
+        optimization_mode="enforce",
+        **_evidence_metadata(repo),
+    )
+    attestation.update(
+        evidence_kind=evidence_kind,
+        source_event=source_event,
+        lineage=lineage,
+    )
+    archive = _archive(attestation)
+    run = _run(attestation)
+    current_pr = {"number": 42, **event["pull_request"]}
+
+    def fake_json(url: str, _token: str) -> dict[str, Any]:
+        if "actions/artifacts" in url:
+            return {
+                "artifacts": [
+                    {
+                        "id": 1,
+                        "expired": False,
+                        "size_in_bytes": len(archive),
+                        "created_at": "2026-08-20T00:00:00Z",
+                        "archive_download_url": "https://api.github.com/artifact.zip",
+                        "workflow_run": {"id": 123},
+                    }
+                ]
+            }
+        if "/pulls/42" in url:
+            return current_pr
+        if url.endswith("/actions/runs/123"):
+            return run
+        raise AssertionError(f"unexpected API request: {url}")
+
+    monkeypatch.setitem(verify_queue.__globals__, "_request_json", fake_json)
+    monkeypatch.setitem(
+        verify_queue.__globals__, "_request_bytes", lambda _url, _token: archive
+    )
+    monkeypatch.setitem(
+        verify_queue.__globals__,
+        "verify_nightly_health",
+        lambda **_kwargs: pytest.fail(
+            "queue verification must not inspect nightly health"
+        ),
+    )
+
+    reusable, reason, source_run = verify_queue(
+        repo=repo,
+        repository="opensquilla/opensquilla",
+        event=event,
+        token="synthetic-token",
+        api_url="https://api.github.com",
+        current_run_id=999,
+    )
+
+    assert reusable is False
+    assert expected_reason in reason
     assert source_run is None
 
 
@@ -1142,7 +1466,9 @@ def test_verify_queue_skips_full_depth_lineage_and_uses_root_candidate(
     monkeypatch.setitem(
         verify_queue.__globals__,
         "verify_nightly_health",
-        lambda **_kwargs: (True, "latest full nightly is green and fresh"),
+        lambda **_kwargs: pytest.fail(
+            "queue verification must not inspect nightly health"
+        ),
     )
 
     reusable, reason, source_run = verify_queue(
@@ -1155,7 +1481,7 @@ def test_verify_queue_skips_full_depth_lineage_and_uses_root_candidate(
     )
 
     assert reusable is True
-    assert reason == "matching trusted exact-tree CI evidence"
+    assert reason == "matching trusted exact-base, exact-tree PR CI evidence"
     assert source_run == 123
 
 

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -220,6 +220,8 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     )
     assert 'printf \'.ci/run-all\\n\' > "${changed_files}"' in merge_group_case
     assert "git diff --name-only" not in merge_group_case
+    assert "queue_diff_targeted" not in text
+    assert "full_fail_closed" in text
     assert (
         'git diff --no-renames --name-only "${before}" "${after}" > "${changed_files}"'
         in text
@@ -242,10 +244,16 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     assert ".github/scripts/check_ci_results.py" in text
     assert "code_changed" not in text
     assert "workflow_changed" not in text
-    assert text.count(
-        '"${{ github.event_name }}" == "pull_request" || '
-        '"${{ github.event_name }}" == "merge_group"'
-    ) == 3
+    assert "Verify fresh full-nightly health" not in text
+    assert "verify-nightly-health" not in text
+    assert "steps.nightly" not in text
+    assert "nightly_healthy" not in text
+    pull_request_case = text.split("            pull_request)", 1)[1].split(
+        "              ;;", 1
+    )[0]
+    assert "github.event.pull_request.base.sha" in pull_request_case
+    assert "github.event.pull_request.head.sha" in pull_request_case
+    assert "nightly" not in pull_request_case.lower()
 
 
 def test_ci_fast_paths_keep_the_required_check_and_fail_closed() -> None:
@@ -266,12 +274,21 @@ def test_ci_fast_paths_keep_the_required_check_and_fail_closed() -> None:
     assert jobs["queue-attestation"]["outputs"]["combined_smoke_suites"] == (
         "${{ steps.verify.outputs.combined_smoke_suites || '[]' }}"
     )
+    assert not any(
+        name.startswith("nightly_") for name in jobs["queue-attestation"]["outputs"]
+    )
     assert jobs["classify-changes"]["needs"] == "queue-attestation"
     assert jobs["classify-changes"]["outputs"]["planner_full_fallback"] == (
         "${{ steps.plan.outputs.full_fallback }}"
     )
     assert "always()" in jobs["classify-changes"]["if"]
     assert "github.event_name != 'merge_group'" in jobs["classify-changes"]["if"]
+    assert "needs.queue-attestation.result != 'success'" in (
+        jobs["classify-changes"]["if"]
+    )
+    assert not any(
+        name.startswith("nightly_") for name in jobs["classify-changes"]["outputs"]
+    )
     classify_consumers = {
         job_name: job
         for job_name, job in jobs.items()
@@ -303,6 +320,7 @@ def test_ci_fast_paths_keep_the_required_check_and_fail_closed() -> None:
     assert jobs["main-canary"]["name"] == (
         "Queue/main installation and offline gateway canary"
     )
+    assert "needs.queue-attestation.result == 'success'" in jobs["main-canary"]["if"]
     assert "test_gateway_silent_reply_process_e2e.py" in str(jobs["main-canary"])
     assert all(
         step.get("name") != "Run overlapping Python domain smoke"
@@ -313,6 +331,93 @@ def test_ci_fast_paths_keep_the_required_check_and_fail_closed() -> None:
         jobs["ci-result"]
     )
     assert "ci-nightly-health-v1" in str(jobs["ci-result"])
+    ci_result_steps = jobs["ci-result"]["steps"]
+    fast_path = next(
+        step
+        for step in ci_result_steps
+        if step.get("name") == "Accept verified queue or main fast path"
+    )
+    setup_python = next(
+        step for step in ci_result_steps if step.get("name") == "Set up Python"
+    )
+    result_gate = next(
+        step
+        for step in ci_result_steps
+        if step.get("name") == "Check required CI results"
+    )
+    for condition in (fast_path["if"], setup_python["if"], result_gate["if"]):
+        assert "needs.queue-attestation.result == 'success'" in condition
+        assert "needs.queue-attestation.outputs.reusable == 'true'" in condition
+    attestation = next(
+        step
+        for step in ci_result_steps
+        if step.get("name") == "Create trusted CI evidence v2"
+    )
+    assert attestation["env"]["QUEUE_RESULT"] == (
+        "${{ needs.queue-attestation.result }}"
+    )
+    assert attestation["env"]["PLANNED_SUCCESSFUL_SUITES"] == (
+        "${{ needs.classify-changes.outputs.required_suites }}"
+    )
+    assert attestation["env"]["PLANNED_FULL_FALLBACK"] == (
+        "${{ needs.classify-changes.outputs.planner_full_fallback }}"
+    )
+    assert '"${QUEUE_RESULT}" == "success"' in attestation["run"]
+    assert '--successful-suites "${PLANNED_SUCCESSFUL_SUITES}"' in attestation["run"]
+    assert '--plan-basis "${plan_basis}"' in attestation["run"]
+    assert ci_result_steps.index(fast_path) < ci_result_steps.index(attestation)
+    assert ci_result_steps.index(result_gate) < ci_result_steps.index(attestation)
+    assert '"${MAIN_CANARY_RESULT}" != "success"' in fast_path["run"]
+    assert "exit 1" in fast_path["run"]
+    assert "always()" not in attestation["if"]
+    assert "failure()" not in attestation["if"]
+    assert "cancelled()" not in attestation["if"]
+
+
+@pytest.mark.parametrize(
+    ("queue_result", "queue_reusable", "canary_result", "expected_code"),
+    (
+        ("success", "true", "success", 0),
+        ("failure", "true", "success", 1),
+        ("success", "false", "success", 1),
+        ("success", "true", "failure", 1),
+        ("success", "true", "cancelled", 1),
+        ("success", "true", "skipped", 1),
+        ("success", "true", "", 1),
+    ),
+)
+def test_ci_queue_fast_path_shell_fails_closed(
+    queue_result: str,
+    queue_reusable: str,
+    canary_result: str,
+    expected_code: int,
+) -> None:
+    jobs = _workflow("ci.yml")["jobs"]
+    fast_path = next(
+        step
+        for step in jobs["ci-result"]["steps"]
+        if step.get("name") == "Accept verified queue or main fast path"
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "GITHUB_EVENT_NAME": "merge_group",
+            "QUEUE_RESULT": queue_result,
+            "QUEUE_REUSABLE": queue_reusable,
+            "QUEUE_REASON": "synthetic evidence decision",
+            "MAIN_CANARY_RESULT": canary_result,
+        }
+    )
+
+    completed = subprocess.run(
+        [_bash_executable(), "-euo", "pipefail", "-c", fast_path["run"]],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == expected_code
 
 
 def test_skill_hub_contract_uses_classifier_gate_without_changing_required_names() -> None:


### PR DESCRIPTION
## Scope

Scope boundary: Decouple nightly health from pull-request planning and merge-queue evidence reuse. Reuse only current-PR root evidence bound to the exact queue base and tested tree; route every rejected or failed evidence path to the full matrix; preserve scheduled nightly diagnostics.

Non-goals: No fail-fast changes, planner remapping, platform-matrix reduction, flaky-test fixes, Skill Hub changes, Code Quality changes, uv changes, Actions pinning, ruleset changes, or merge-queue policy changes.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: This is a maintainer-requested P0 correction to the CI control plane.

## Release Note

Release note: NONE

## Tests

Ruff: passed

Pytest: full CI controller suite 364 passed and 3 skipped; focused attestation, workflow, and CI-result contracts 191 passed.

Build: not applicable for this CI-only control-plane change.

Regression tests: added

Notes: actionlint and git diff check passed. GitNexus exact-base scan reported 4 changed files, LOW risk, and no runtime execution flow affected. GitNexus does not index the GitHub workflow control plane, so callers were also inventoried explicitly. An independent read-only review found no blocking issue or fail-open path.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: This PR changes the CI trust policy, so its own merge-queue entry is expected to use full fallback. Validate exact-tree reuse with the first ordinary non-CI-policy PR based on the new main.

## Safety

- Evidence remains schema v2 with the existing 72-hour TTL and 5-minute future-clock tolerance.
- Exact tree with a different base, composed evidence, derived evidence, non-root evidence, stale runs, and policy or execution-contract mismatches are rejected.
- Every attestation job failure, rejected candidate, missing artifact, or API error runs the full fail-closed matrix.
- The queue fast path requires a successful evidence job, reusable evidence, and a successful combined-tree installation and offline gateway canary before producing CI result on the merge-group SHA.
- Emergency rollback remains CI_OPTIMIZATION_MODE=shadow followed by revert.
- No public API, persisted data, runtime behavior, or client compatibility changes. The control-plane change is platform-neutral.
- No secrets, private data, runtime artifacts, or machine-specific paths are included.

## Third-Party Origin

Third-party origin: none

Details if non-none: No third-party code, rules, fixtures, or text were copied. The design was checked against official GitHub Actions behavior and read-only reference implementations.

## Documentation Changes

- [x] No documentation changes are required for this internal CI control-plane correction.
