### PR TITLE
Keep tool progress out of final answers

### DIFF
--- a/opensquilla-webui/src/components/chat/AssistantMessage.activity-fold.test.ts
+++ b/opensquilla-webui/src/components/chat/AssistantMessage.activity-fold.test.ts
@@ -897,6 +897,35 @@ describe('AssistantMessage activity disclosure', () => {
       .toBe('Checked constraints and compatibility.')
   })
 
+  it('keeps explicit tool progress inside activity instead of the Plan intro', async () => {
+    const marker = 'E2E_TOOL_PROGRESS_MARKER'
+    const el = mountMessage(baseMessage({
+      text: marker,
+      timelineItems: [
+        {
+          type: 'text',
+          key: 'progress-marker',
+          html: `<p>${marker}</p>`,
+          rawText: marker,
+          presentation: 'intermediate',
+        },
+        timelineGroup(successfulCall('submit-plan', 'submit_plan')),
+      ],
+      parts: [planPart()],
+      statusHistory: [],
+    }))
+    await nextTick()
+
+    const activity = el.querySelector<HTMLElement>('.assistant-activity')
+    const outsideText = [...el.querySelectorAll<HTMLElement>('.msg-ai-text')]
+      .filter(node => !activity?.contains(node))
+
+    expect(el.querySelector('.plan-card')).not.toBeNull()
+    expect(activity?.textContent).toContain(marker)
+    expect(el.querySelector('.plan-message-intro')).toBeNull()
+    expect(outsideText.every(node => !node.textContent?.includes(marker))).toBe(true)
+  })
+
   it('does not add a generic completed receipt below a Plan card', async () => {
     const el = mountMessage(baseMessage({
       text: '',

--- a/opensquilla-webui/src/composables/chat/useChatMessageActions.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatMessageActions.test.ts
@@ -918,6 +918,56 @@ describe('useChatMessageActions protocol-shaped copy text', () => {
     expect(copyTextWithFallback).toHaveBeenCalledWith('Final answer.\n\nAI generated')
   })
 
+  it('does not copy explicit intermediate-only activity as an answer', async () => {
+    const { api } = makeOptions([], text => text, () => 'AI generated')
+
+    const copied = await api.copyMessage(renderedMessage({
+      role: 'assistant',
+      displayRole: 'assistant',
+      text: 'Work narration.',
+      timelineItems: [
+        {
+          type: 'text',
+          key: 'work',
+          html: 'Work narration.',
+          rawText: 'Work narration.',
+          presentation: 'intermediate',
+        },
+        {
+          type: 'tool-group',
+          key: 'finish',
+          group: {
+            groupId: 'finish',
+            operationKey: 'file.read',
+            label: 'Read',
+            iconName: 'edit',
+            calls: [{
+              toolId: 'finish',
+              renderKey: 'finish',
+              name: 'read_file',
+              displayName: 'Read',
+              inputRaw: '{"path":"README.md"}',
+              inputPreview: 'README.md',
+              isRunning: false,
+              status: 'success',
+              isError: false,
+              result: 'ok',
+              resultPreview: 'ok',
+              isOpen: false,
+            }],
+            secondary: '',
+            isRunning: false,
+            isError: false,
+            status: 'success',
+          },
+        },
+      ],
+    }))
+
+    expect(copied).toBe(false)
+    expect(copyTextWithFallback).not.toHaveBeenCalled()
+  })
+
   it('copies the complete terminal Markdown answer from an ordinary tool transcript', async () => {
     const { api } = makeOptions([], text => text, () => 'AI generated')
 

--- a/opensquilla-webui/src/composables/chat/useChatMessageActions.ts
+++ b/opensquilla-webui/src/composables/chat/useChatMessageActions.ts
@@ -88,6 +88,7 @@ export function useChatMessageActions(options: UseChatMessageActionsOptions) {
     if (answer.source === 'canonical') {
       return options.sanitizeCopyText(answer.text, { provenance })
     }
+    if (answer.source === 'explicit-no-answer') return ''
     // The raw message text can be absent in older history, so rebuild only
     // that source-less compatibility case from the available segments while
     // applying the same provenance-aware silent-reply projection as the body.
@@ -106,6 +107,7 @@ export function useChatMessageActions(options: UseChatMessageActionsOptions) {
   async function copyMessage(msg: ChatRenderedMessage): Promise<boolean> {
     try {
       const text = copyableMessageText(msg)
+      if (!text) return false
       const isAssistant = (msg.displayRole || msg.role) === 'assistant'
       const label = isAssistant ? options.aiGeneratedLabel?.().trim() : ''
       await copyTextWithFallback(label && text ? `${text}\n\n${label}` : text)

--- a/opensquilla-webui/src/utils/chat/assistantActivity.test.ts
+++ b/opensquilla-webui/src/utils/chat/assistantActivity.test.ts
@@ -629,6 +629,61 @@ describe('projectAssistantActivity', () => {
     expect(projection.answerPart?.rawText).toBe(canonical)
   })
 
+  it('uses explicit intermediate presentation across a preceding transparent control', () => {
+    const canonical = 'Narration.\n\nFinal answer.'
+    const projection = projectAssistantActivity(
+      message({
+        text: canonical,
+        timelineItems: [
+          {
+            type: 'text',
+            key: 'narration',
+            html: 'Narration.',
+            rawText: 'Narration.',
+            presentation: 'intermediate',
+          },
+          toolGroup([call('checkpoint', { name: 'plan_run_checkpoint' })], 'checkpoint'),
+          {
+            type: 'text',
+            key: 'answer',
+            html: 'Final answer.',
+            rawText: 'Final answer.',
+            presentation: 'answer',
+          },
+        ],
+      }),
+      text => text,
+    )
+
+    expect(projection.answerSource).toBe('terminal-control-boundary')
+    expect(projection.answerPart?.rawText).toBe('Final answer.')
+    expect(projection.activityItems.map(item => item.key)).toEqual(['narration'])
+  })
+
+  it('keeps a terminal-tool turn with only explicit intermediate text out of the answer', () => {
+    const canonical = 'Work narration.'
+    const projection = projectAssistantActivity(
+      message({
+        text: canonical,
+        timelineItems: [
+          {
+            type: 'text',
+            key: 'narration',
+            html: 'Work narration.',
+            rawText: 'Work narration.',
+            presentation: 'intermediate',
+          },
+          toolGroup([call('finish', { name: 'read_file' })], 'finish'),
+        ],
+      }),
+      text => text,
+    )
+
+    expect(projection.answerSource).toBe('explicit-no-answer')
+    expect(projection.answerPart).toBeNull()
+    expect(projection.activityItems.map(item => item.key)).toEqual(['narration', 'finish'])
+  })
+
   it.each([
     ['streaming', { isStreaming: true }, 'working' as const],
     ['terminal failure', { terminalFailure: true }, 'failed' as const],

--- a/opensquilla-webui/src/utils/chat/assistantActivity.ts
+++ b/opensquilla-webui/src/utils/chat/assistantActivity.ts
@@ -196,6 +196,7 @@ export type AssistantAnswerSource =
   | 'canonical'
   | 'terminal-timeline-boundary'
   | 'terminal-control-boundary'
+  | 'explicit-no-answer'
   | 'none'
 
 export interface AssistantAnswerResolution {
@@ -552,7 +553,22 @@ function terminalTimelineAnswerCandidate(
   // preceding work narration inside Activity even when no tool separates it
   // from the final answer span.
   const boundaryItem = timeline[index]
-  const crossedPresentationBoundary = index >= 0
+  let semanticBoundaryIndex = index
+  let crossedPrecedingControl = false
+  while (
+    semanticBoundaryIndex >= 0
+    && isSuccessfulAnswerTransparentControlGroup(timeline[semanticBoundaryIndex]!)
+  ) {
+    crossedPrecedingControl = true
+    semanticBoundaryIndex -= 1
+  }
+  const semanticBoundaryItem = timeline[semanticBoundaryIndex]
+  const crossedPresentationBoundary = semanticBoundaryIndex >= 0
+    && semanticBoundaryItem?.type === 'text'
+    && semanticBoundaryItem.presentation === 'intermediate'
+  const crossedConfirmedControlBoundary = crossedPrecedingControl
+    && crossedPresentationBoundary
+  const crossedImmediatePresentationBoundary = index >= 0
     && boundaryItem?.type === 'text'
     && boundaryItem.presentation === 'intermediate'
   const crossedOrdinaryToolBoundary = index >= 0
@@ -561,7 +577,8 @@ function terminalTimelineAnswerCandidate(
   if (
     !crossedControlBoundary
     && !crossedOrdinaryToolBoundary
-    && !crossedPresentationBoundary
+    && !crossedImmediatePresentationBoundary
+    && !crossedConfirmedControlBoundary
   ) return null
 
   const compact = chunks.join('')
@@ -570,7 +587,7 @@ function terminalTimelineAnswerCandidate(
     compact,
     readable: readableTextAggregate(chunks),
     indexes,
-    source: crossedControlBoundary
+    source: crossedControlBoundary || crossedConfirmedControlBoundary
       ? 'terminal-control-boundary'
       : 'terminal-timeline-boundary',
   }
@@ -616,6 +633,30 @@ export function resolveAssistantAnswer(
         ? 'readable'
         : null
     : null
+  const textItems = timeline.filter(
+    (item): item is Extract<ChatStreamTimelineItem, { type: 'text' }> =>
+      item.type === 'text',
+  )
+  const hasExplicitIntermediateOnly = textItems.length > 0
+    && textItems.every(item => item.presentation === 'intermediate')
+  const hasSemanticActivityBoundary = timeline.some(item => item.type === 'tool-group')
+    || Boolean(message.planRevisions?.length)
+  const allToolsSettledSuccessfully = timeline.every(item =>
+    item.type !== 'tool-group' || isSettledSuccessfulToolGroup(item),
+  )
+  const canUseExplicitNoAnswer = completedAnswerLifecycle(message, lifecycle)
+    && hasSemanticActivityBoundary
+    && hasExplicitIntermediateOnly
+    && allToolsSettledSuccessfully
+    && (matchedAggregate !== null || !canonical.trim())
+
+  if (canUseExplicitNoAnswer) {
+    return {
+      text: '',
+      source: 'explicit-no-answer',
+      activityItems: visibleTimeline,
+    }
+  }
   const canUseTerminalBoundary = completedAnswerLifecycle(message, lifecycle)
     && matchedAggregate !== null
     && candidate !== null
@@ -1182,7 +1223,9 @@ export function projectAssistantActivity(
   const answerResolution = resolveAssistantAnswer(presentationMessage, timeline, lifecycle)
   const hasTimelineText = timeline.some(item => item.type === 'text')
   const hasCanonicalAnswer = Boolean(answerResolution.text.trim())
-  const canSeparateActivity = hasCanonicalAnswer || !hasTimelineText
+  const canSeparateActivity = hasCanonicalAnswer
+    || answerResolution.source === 'explicit-no-answer'
+    || !hasTimelineText
   const hasStructuralAnswerBoundary =
     answerResolution.source === 'terminal-control-boundary'
     || answerResolution.source === 'terminal-timeline-boundary'

--- a/src/opensquilla/engine/turn_runner/stream_consumer_stage.py
+++ b/src/opensquilla/engine/turn_runner/stream_consumer_stage.py
@@ -549,6 +549,13 @@ class _ToolUseStartHandler:
         event: ToolUseStartEvent,
         state: _StreamState,
     ) -> ToolUseStartEvent:
+        # Agent text is streamed optimistically as ``answer`` until the provider
+        # reveals a tool call.  Once that boundary is known, the preceding run is
+        # work narration, not the terminal answer.  The live surface has already
+        # received the deltas, but correcting the durable segment here keeps the
+        # settled UI, history reloads, copy, and export on the semantic contract.
+        if state.current_text_parts and state.current_text_presentation == "answer":
+            state.current_text_presentation = "intermediate"
         _flush_current_text_segment(state)
         state.turn_segments.append(
             {

--- a/tests/test_engine/turn_runner/test_canonical_text_contract.py
+++ b/tests/test_engine/turn_runner/test_canonical_text_contract.py
@@ -197,7 +197,7 @@ async def test_literal_protocol_like_text_is_canonical_across_stream_done_and_pe
     assert state.turn_segments[0] == {
         "type": "text",
         "text": literal_text,
-        "presentation": "answer",
+        "presentation": "intermediate",
     }
 
     final_text, transcript = await _finalize(state, done_event)
@@ -207,7 +207,7 @@ async def test_literal_protocol_like_text_is_canonical_across_stream_done_and_pe
     assert transcript.calls[0]["tool_calls"][0] == {
         "type": "text",
         "text": literal_text,
-        "presentation": "answer",
+        "presentation": "intermediate",
     }
 
 
@@ -403,7 +403,7 @@ def test_conflicting_done_aggregate_cannot_resurrect_discarded_retry_text() -> N
     assert "".join(state.final_text_parts) == "kept answer"
 
 
-def test_conflicting_done_snapshot_preserves_tool_events_and_replaces_only_text() -> None:
+def test_conflicting_done_snapshot_preserves_tool_events_and_intermediate_activity() -> None:
     state = _make_state()
     text_handler = _TextDeltaHandler()
     text_handler.handle(TextDeltaEvent(text="stale pre-tool narration"), state)
@@ -430,7 +430,13 @@ def test_conflicting_done_snapshot_preserves_tool_events_and_replaces_only_text(
     assert extra == []
     assert done_event.text == "canonical successful answer"
     assert "".join(state.final_text_parts) == "canonical successful answer"
+    assert state.turn_segments[0] == {
+        "type": "text",
+        "text": "stale pre-tool narration",
+        "presentation": "intermediate",
+    }
     assert [segment["type"] for segment in state.turn_segments] == [
+        "text",
         "tool_use",
         "tool_result",
     ]

--- a/tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py
@@ -755,7 +755,7 @@ def test_tool_use_start_handler_preserves_canonical_details_text_segment() -> No
     assert state.turn_segments[0] == {
         "type": "text",
         "text": expected,
-        "presentation": "answer",
+        "presentation": "intermediate",
     }
     assert "".join(state.final_text_parts) == expected
 
@@ -774,7 +774,7 @@ def test_tool_use_start_handler_flushes_text_and_appends_segment() -> None:
         state,
     )
     assert state.turn_segments == [
-        {"type": "text", "text": "pre", "presentation": "answer"},
+        {"type": "text", "text": "pre", "presentation": "intermediate"},
         {"type": "tool_use", "tool_use_id": "t1", "name": "echo", "input": ""},
     ]
     assert state.current_text_parts == []
@@ -2113,7 +2113,7 @@ async def test_system_event_normalization_preserves_text_around_tool_boundary(
     assert inp.state.turn_segments[0] == {
         "type": "text",
         "text": "Preparing.",
-        "presentation": "answer",
+        "presentation": "intermediate",
     }
     assert inp.state.current_text_parts == ["Finished."]
     assert "NO_REPLY" not in str(inp.state.turn_segments)
@@ -2192,7 +2192,7 @@ async def test_system_event_removes_bare_marker_after_tool_without_newline() -> 
     assert inp.state.turn_segments[0] == {
         "type": "text",
         "text": "Visible body.",
-        "presentation": "answer",
+        "presentation": "intermediate",
     }
     assert inp.state.current_text_parts == []
     assert inp.state.final_text_parts == ["Visible body."]
@@ -2932,7 +2932,7 @@ async def test_outer_stage_persists_literal_text_before_native_tool_segment() ->
     await _drain(stage, _make_input(state=state))
 
     assert state.turn_segments[:2] == [
-        {"type": "text", "text": literal, "presentation": "answer"},
+        {"type": "text", "text": literal, "presentation": "intermediate"},
         {
             "type": "tool_use",
             "tool_use_id": "native-1",


### PR DESCRIPTION
## Scope

- Reclassify text emitted before a subsequently revealed tool call as durable `intermediate` activity.
- Make the Web UI respect explicit intermediate/no-answer boundaries for settled tool and Plan turns.
- Keep intermediate-only activity out of answer copy behavior.
- Add backend persistence, frontend projection, Plan rendering, and copy regressions.

## Target and issue

- Target branch: `main`
- Linked issue: None

## Release note

User-visible bug fix: progress text emitted between tool calls no longer appears in the final answer body after completion or history reload. The progress remains available in the Activity disclosure.

## Verification

- `uv run ruff check src/opensquilla/engine/turn_runner/stream_consumer_stage.py tests/test_engine/turn_runner/test_stream_consumer_stage_unit.py tests/test_engine/turn_runner/test_canonical_text_contract.py`
- `.venv/bin/pytest -q tests/test_engine/turn_runner tests/test_gateway/test_rpc_chat_history.py tests/test_engine/test_agent_reasoning_reemit.py` — 574 passed
- `npm run test:unit` — 4,659 passed
- `npm run typecheck`
- `npm run build`
- Real OpenRouter E2E in Plan mode: progress marker appeared once in Activity, zero times in the answer body, and the Plan card remained intact.
- Real OpenRouter E2E in default mode: intermediate marker appeared only in Activity and the terminal answer appeared only in the answer body.

## Safety and compatibility

- Platform-neutral presentation and transcript behavior; no OS-specific code paths changed.
- No database schema, configuration, or public RPC field changes.
- Existing history rows without explicit presentation metadata retain the current fail-open compatibility behavior.
- `incomplete_tool_call` provider recovery is a separate reliability issue and is intentionally out of scope.

## Third-party origin

None. No third-party code or generated external assets were copied into this change.
