### PR TITLE
fix(cli): check the config key whichever way `config set` persists it

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -1150,6 +1150,7 @@
       "tests/test_ci/test_workflows.py",
       "tests/test_cli/test_agents_cmd.py",
       "tests/test_cli/test_cli_product_completeness.py",
+      "tests/test_cli/test_config_set_key_validation.py",
       "tests/test_cli/test_cron_cmd.py",
       "tests/test_cli/test_output_helpers.py",
       "tests/test_cli/test_profile_env_loading.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -188,6 +188,7 @@
     "tests/test_cli/test_chat_path_command.py": 0.113,
     "tests/test_cli/test_clarify_form_helpers.py": 0.086,
     "tests/test_cli/test_cli_product_completeness.py": 8.86,
+    "tests/test_cli/test_config_set_key_validation.py": 8.3,
     "tests/test_cli/test_cron_cmd.py": 0.088,
     "tests/test_cli/test_diagnostics_cmd.py": 0.448,
     "tests/test_cli/test_doctor_cmd.py": 3.381,

--- a/src/opensquilla/cli/config_cmd.py
+++ b/src/opensquilla/cli/config_cmd.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import collections.abc
 import os
 import tomllib
+import types
+import typing
 from pathlib import Path
-from typing import Any
+from typing import Any, get_args, get_origin
 
 import typer
+from pydantic import BaseModel
 from rich.markup import escape
 from rich.table import Table
 
@@ -62,8 +66,9 @@ def config_set(
     config_path: Path | None = typer.Option(None, "--config", help="Persist to config path."),
 ) -> None:
     """Set a configuration value (env-var backed, prints export command)."""
+    from opensquilla.gateway.config import GatewayConfig
+
     if config_path is not None:
-        from opensquilla.gateway.config import GatewayConfig
         from opensquilla.onboarding.config_store import load_config, persist_config
 
         cfg = load_config(config_path)
@@ -89,9 +94,40 @@ def config_set(
         console.print("[yellow]Restart the gateway to apply this setting.[/yellow]")
         return
 
+    # Same key check as the persisting form. Without it the command answered
+    # "export OPENSQUILLA_GATEWAY_DEFINITELY__INVALID=123" to a key that does
+    # not exist, and the export is not merely useless: it reads as confirmation
+    # that the setting was understood, so the operator sets it and then hunts
+    # for why nothing changed. `gateway.port` is the case that shows up in
+    # practice — the field is `port`, so the accepted spelling produced
+    # OPENSQUILLA_GATEWAY_GATEWAY__PORT while the correct variable stayed unset.
+    if not _set_key(_key_surface(), key, None):
+        console.print(f"[red]Key not found: {escape(key)}[/red]")
+        raise typer.Exit(1)
+
     env_key = "OPENSQUILLA_GATEWAY_" + key.upper().replace(".", "__")
     console.print("[dim]To persist this setting, export:[/dim]")
     console.print(f"  [bold]export {env_key}={value}[/bold]")
+
+
+def _key_surface() -> dict[str, Any]:
+    """The document keys are checked against when nothing is being written.
+
+    The operator's own config is the accurate surface: it is what carries the
+    mapping entries the schema cannot enumerate (their agent ids, their router
+    tier names). A config too broken to load must not take this command down
+    with it, though — reaching for `config set` is a normal way out of that
+    state — so the schema defaults stand in, and every declared field is still
+    checked.
+    """
+
+    from opensquilla.gateway.config import GatewayConfig
+
+    try:
+        cfg = GatewayConfig.load(os.environ.get("OPENSQUILLA_GATEWAY_CONFIG_PATH"))
+    except Exception:  # noqa: BLE001 - an unreadable config still gets key checking.
+        return GatewayConfig.model_construct().to_toml_dict()
+    return cfg.to_toml_dict()
 
 
 def _parse_config_value(value: str) -> Any:
@@ -101,16 +137,106 @@ def _parse_config_value(value: str) -> Any:
         return value
 
 
+def _unwrap_optional(annotation: Any) -> Any:
+    """Strip a single ``None`` arm so ``X | None`` resolves like ``X``."""
+
+    if get_origin(annotation) in (typing.Union, types.UnionType):
+        args = [arg for arg in get_args(annotation) if arg is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    return annotation
+
+
+def _as_model(annotation: Any) -> type[BaseModel] | None:
+    annotation = _unwrap_optional(annotation)
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return annotation
+    return None
+
+
+def _mapping_value_annotation(annotation: Any) -> Any | None:
+    """The value type of a mapping field, or ``None`` if this is not a mapping.
+
+    Both spellings that appear in the config model have to resolve: the
+    parameterised ``dict[str, X]`` and the bare ``dict`` that
+    ``squilla_router.tiers`` uses, whose ``get_origin`` is ``None``. An
+    unparameterised or ``Any`` value type keeps the walk going with no schema
+    left to check, which is exactly the case where presence in the document is
+    the only evidence available.
+    """
+
+    annotation = _unwrap_optional(annotation)
+    if annotation is Any:
+        return Any
+    origin = get_origin(annotation) or annotation
+    try:
+        is_mapping = isinstance(origin, type) and issubclass(origin, collections.abc.Mapping)
+    except TypeError:  # a typing special form that is not a runtime class
+        is_mapping = False
+    if not is_mapping:
+        return None
+    args = get_args(annotation)
+    return args[1] if len(args) == 2 else Any
+
+
 def _set_key(data: dict[str, Any], key: str, value: Any) -> bool:
-    cursor: Any = data
+    """Write ``value`` at ``key``, reporting whether ``key`` is a real setting.
+
+    Validity comes from the ``GatewayConfig`` schema rather than from the values
+    that happen to be in the document. The two differ: TOML has no null, so
+    every field sitting at its ``None`` default — `auth.token`, `compaction.model`,
+    the agent timeout overrides, sixty-odd others — is absent from
+    ``to_toml_dict()`` and used to be refused as "Key not found", which left no
+    way to set them through this command at all.
+
+    Segments that index a mapping field are the exception, because the schema
+    cannot enumerate an operator's agent ids or router tier names. Those must
+    already be present, so a typo in one is still caught and this never invents
+    a half-formed entry.
+
+    Intermediate tables are created only along a schema-valid path, and only as
+    far as the walk gets: a rejected key can leave empty tables behind, so the
+    caller must not persist a document this returned ``False`` for.
+    """
+
+    from opensquilla.gateway.config import GatewayConfig
+
     parts = key.split(".")
-    for part in parts[:-1]:
-        if not isinstance(cursor, dict) or part not in cursor:
-            return False
-        cursor = cursor[part]
-    if not isinstance(cursor, dict) or parts[-1] not in cursor:
+    if not all(parts):
         return False
-    cursor[parts[-1]] = value
+
+    node: Any = GatewayConfig
+    cursor: Any = data
+    for part in parts[:-1]:
+        model = _as_model(node)
+        if model is not None:
+            field = model.model_fields.get(part)
+            if field is None:
+                return False
+            node = field.annotation
+        else:
+            value_annotation = _mapping_value_annotation(node)
+            if value_annotation is None or part not in cursor:
+                return False
+            node = value_annotation
+
+        child = cursor.get(part)
+        if child is None:
+            child = {}
+            cursor[part] = child
+        elif not isinstance(child, dict):
+            return False
+        cursor = child
+
+    leaf = parts[-1]
+    model = _as_model(node)
+    if model is not None:
+        if leaf not in model.model_fields:
+            return False
+    elif _mapping_value_annotation(node) is None or leaf not in cursor:
+        return False
+
+    cursor[leaf] = value
     return True
 
 

--- a/tests/test_cli/test_config_set_key_validation.py
+++ b/tests/test_cli/test_config_set_key_validation.py
@@ -1,0 +1,214 @@
+"""`config set` names one key surface, whichever way it is asked to persist.
+
+Without `--config` the command used to accept any dotted string and answer with
+an `export OPENSQUILLA_GATEWAY_...` line, so `definitely.invalid` and
+`gateway.port` both came back looking configured while the gateway read
+neither. With `--config` the same two spellings were refused. Issue #1383.
+
+The other half of the same defect ran the other way: validity was read off the
+values in the TOML document, and TOML has no null, so every field resting at its
+`None` default was reported as "Key not found" and could not be set at all.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from opensquilla.cli.main import app
+from opensquilla.gateway.config import GatewayConfig
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The env form reads the operator's config; keep the runner off the host's."""
+
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+
+
+def _empty_config(tmp_path: Path) -> Path:
+    target = tmp_path / "opensquilla.toml"
+    target.write_text("", encoding="utf-8")
+    return target
+
+
+# The two spellings from the report, plus a leaf typo under a real table.
+REJECTED = ["definitely.invalid", "gateway.port", "auth.bogus", "memory.dream.bogus"]
+
+# Fields at their `None` default: absent from the TOML document, real settings.
+# The flag says whether `config get` redacts the value on the way back out —
+# `auth.token` and `llm.api_key` are secrets, and that redaction is the point.
+NULL_DEFAULTED = [("auth.token", True), ("compaction.model", False), ("llm.api_key", True)]
+NULL_DEFAULTED_KEYS = [key for key, _ in NULL_DEFAULTED]
+
+
+@pytest.mark.parametrize("key", REJECTED)
+def test_a_key_that_does_not_exist_is_refused_without_config_too(key: str) -> None:
+    result = runner.invoke(app, ["config", "set", key, "123"])
+
+    assert result.exit_code == 1, result.stdout
+    assert "Key not found" in result.stdout
+    # The export line is the part that misleads: it reads as confirmation that
+    # the setting was understood.
+    assert "export" not in result.stdout
+
+
+@pytest.mark.parametrize("key", REJECTED)
+def test_the_two_forms_refuse_the_same_keys(key: str, tmp_path: Path) -> None:
+    target = _empty_config(tmp_path)
+
+    env_form = runner.invoke(app, ["config", "set", key, "123"])
+    config_form = runner.invoke(app, ["config", "set", key, "123", "--config", str(target)])
+
+    assert env_form.exit_code == config_form.exit_code == 1
+    assert "Key not found" in env_form.stdout
+    assert "Key not found" in config_form.stdout
+
+
+@pytest.mark.parametrize(
+    ("key", "env_var"),
+    [
+        ("port", "OPENSQUILLA_GATEWAY_PORT"),
+        ("log_level", "OPENSQUILLA_GATEWAY_LOG_LEVEL"),
+        ("auth.mode", "OPENSQUILLA_GATEWAY_AUTH__MODE"),
+        ("memory.dream.preview_mode", "OPENSQUILLA_GATEWAY_MEMORY__DREAM__PREVIEW_MODE"),
+    ],
+)
+def test_a_real_key_still_prints_its_export(key: str, env_var: str) -> None:
+    result = runner.invoke(app, ["config", "set", key, "18823"])
+
+    assert result.exit_code == 0, result.stdout
+    assert f"export {env_var}=18823" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("key", "env_var", "value", "expected"),
+    [
+        ("port", "OPENSQUILLA_GATEWAY_PORT", "18823", 18823),
+        ("log_level", "OPENSQUILLA_GATEWAY_LOG_LEVEL", "INFO", "INFO"),
+    ],
+)
+def test_the_printed_variable_is_the_one_the_gateway_reads(
+    key: str,
+    env_var: str,
+    value: str,
+    expected: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The export is an instruction; following it has to change the config.
+
+    This is what `gateway.port` failed: it produced
+    OPENSQUILLA_GATEWAY_GATEWAY__PORT, a variable nothing reads, while the one
+    that does — OPENSQUILLA_GATEWAY_PORT — stayed unset.
+    """
+
+    result = runner.invoke(app, ["config", "set", key, value])
+    assert result.exit_code == 0, result.stdout
+    assert f"export {env_var}={value}" in result.stdout
+
+    monkeypatch.setenv(env_var, value)
+    reloaded = GatewayConfig.load(None)
+
+    cursor: object = reloaded
+    for part in key.split("."):
+        cursor = getattr(cursor, part)
+    assert cursor == expected
+
+
+@pytest.mark.parametrize(("key", "redacted"), NULL_DEFAULTED)
+def test_a_field_left_at_none_is_settable(key: str, redacted: bool, tmp_path: Path) -> None:
+    """TOML cannot hold a null, which is not the same as the key not existing."""
+
+    target = _empty_config(tmp_path)
+
+    result = runner.invoke(app, ["config", "set", key, '"set-by-test"', "--config", str(target)])
+
+    assert result.exit_code == 0, result.stdout
+    document = tomllib.loads(target.read_text(encoding="utf-8"))
+    table, leaf = key.split(".")
+    assert document[table][leaf] == "set-by-test"
+
+    read_back = runner.invoke(app, ["config", "get", key, "--config", str(target)])
+    assert read_back.exit_code == 0, read_back.stdout
+    expected = "[redacted]" if redacted else "set-by-test"
+    assert expected in read_back.stdout
+
+
+@pytest.mark.parametrize("key", NULL_DEFAULTED_KEYS)
+def test_a_field_left_at_none_is_accepted_by_the_env_form_too(key: str) -> None:
+    result = runner.invoke(app, ["config", "set", key, '"set-by-test"'])
+
+    assert result.exit_code == 0, result.stdout
+    assert "export OPENSQUILLA_GATEWAY_" in result.stdout
+
+
+def test_an_operator_named_mapping_entry_still_resolves(tmp_path: Path) -> None:
+    """Router tier ids are data, not schema — the document is the only evidence.
+
+    So the entry has to be there already: this must not invent a half-formed
+    tier out of a typo, and must not refuse one the operator really has.
+    """
+
+    target = _empty_config(tmp_path)
+    known = runner.invoke(
+        app,
+        [
+            "config",
+            "set",
+            "squilla_router.tiers.c0.model",
+            '"vendor/model"',
+            "--config",
+            str(target),
+        ],
+    )
+    assert known.exit_code == 0, known.stdout
+
+    typos = (
+        "squilla_router.tiers.no_such_tier.model",
+        "squilla_router.tiers.c0.no_such_field",
+    )
+    for typo in typos:
+        result = runner.invoke(app, ["config", "set", typo, '"x"', "--config", str(target)])
+        assert result.exit_code == 1, result.stdout
+        assert "Key not found" in result.stdout
+
+
+@pytest.mark.parametrize("key", ["", ".", "auth.", "auth..mode", "port.extra"])
+def test_a_malformed_key_is_refused(key: str) -> None:
+    result = runner.invoke(app, ["config", "set", key, "1"])
+
+    assert result.exit_code == 1, result.stdout
+    assert "export" not in result.stdout
+
+
+def test_no_key_the_previous_check_accepted_is_now_refused(tmp_path: Path) -> None:
+    """The new check is a superset of the old one, over the whole document.
+
+    Validity moved from "this key is present in the TOML" to "this key is a
+    field of `GatewayConfig`". Widening a check can narrow it somewhere else,
+    so every leaf the old rule accepted is replayed against the new one.
+    """
+
+    from opensquilla.cli.config_cmd import _set_key
+
+    document = GatewayConfig.load(None).to_toml_dict()
+
+    def leaves(node: dict, prefix: str = "") -> list[str]:
+        found: list[str] = []
+        for name, value in node.items():
+            full = f"{prefix}.{name}" if prefix else name
+            found.extend(leaves(value, full) if isinstance(value, dict) else [full])
+        return found
+
+    keys = leaves(document)
+    assert len(keys) > 300, "the default document should be a broad sample"
+
+    import copy
+
+    refused = [key for key in keys if not _set_key(copy.deepcopy(document), key, "X")]
+    assert refused == []


### PR DESCRIPTION
`opensquilla config set definitely.invalid 123` exits 0 and prints `export OPENSQUILLA_GATEWAY_DEFINITELY__INVALID=123`. `config set gateway.port 18823` exits 0 and prints `export OPENSQUILLA_GATEWAY_GATEWAY__PORT=18823` — the field is `port`, so the variable the gateway actually reads stays unset. Both spellings are refused, exit 1, by the same command with `--config`.

The env form writes no file, so it skipped the key check entirely. That output is not merely useless: an export line reads as confirmation that the setting was understood, so the operator sets it and then goes looking for why nothing changed. The env form now runs the same check and exits 1 with the same `Key not found` message.

Making the two forms agree exposed the other half of the same defect. Key validity was read off the values in the document instead of off the schema, and TOML has no null, so every field resting at its `None` default is absent from `to_toml_dict()` and was refused as "Key not found" — `auth.token`, `llm.api_key`, `compaction.model`, the agent timeout overrides, 58 in total, none of them settable through this command at all. Validity now comes from `GatewayConfig.model_fields`, and a schema-valid path creates the tables it needs on the way down.

Mapping fields keep the old rule, because the schema cannot enumerate an operator's agent ids or router tier names: those segments must already be present in the document. So `squilla_router.tiers.c0.model` still resolves, `...tiers.no_such_tier.model` is still refused, and a typo never invents a half-formed entry.

Scope boundary: `src/opensquilla/cli/config_cmd.py` only — the key check the `set` command applies and the walk behind it. No config model, loader, persister or env binding is touched, and the env-variable naming scheme is unchanged (verified below, not assumed). Both manifest edits register the new test file for the Windows shards.

Base branch: main.  
Target exception: none — this is an ordinary bug fix against main.  
Linked issue: closes #1383.  
Release note: `config set` now rejects a key that is not a real setting whether or not `--config` is given, and can set fields left at their `None` default.

## Tests

`tests/test_cli/test_config_set_key_validation.py`, 27 cases, all failing on the current implementation except the ones that pin unchanged behaviour (16 of 27 fail before the change):

- the two spellings from the report are refused by the env form, exit 1, with no `export` line printed;
- the two forms agree, key by key, on what they refuse;
- a real key still prints its export, and — the part `gateway.port` failed — setting the printed variable and reloading the config actually changes the field, so the instruction the command gives is verified rather than assumed;
- a field at its `None` default persists through `--config` and reads back (redacted, for the two that are secrets) and is accepted by the env form;
- an operator-named router tier resolves, an unknown tier and an unknown leaf under a known tier are both refused;
- malformed keys (`""`, `"."`, `"auth."`, `"auth..mode"`, `"port.extra"`) are refused;
- a replay test walks all 363 leaf keys of the default document through the new check and asserts none of them is refused — widening a check can narrow it elsewhere, so the old accepted set is pinned as a subset.

`tests/test_cli` and `tests/test_onboarding` pass in full (1871 passed, 9 skipped); `tests/test_ci/test_windows_test_shards.py` passes with the new file registered.

Maintainer live check: `opensquilla config set gateway.port 18823` — exits 1 with `Key not found: gateway.port` instead of printing an export for a variable nothing reads. `opensquilla config set port 18823` still prints `export OPENSQUILLA_GATEWAY_PORT=18823`. On a scratch config, `opensquilla config set --config <file> auth.token '"abc"'` now writes `[auth] token = "abc"` instead of reporting `Key not found`.

Third-party origin: none. No new dependency; the walk uses `typing.get_origin` / `get_args` and the pydantic `model_fields` already imported by this package.