### PR TITLE
fix(webui): turn the Router off instead of surfacing router_provider_conflict on active-provider removal

### DIFF
--- a/opensquilla-webui/src/composables/setup/useSetupCatalog.privacy.test.ts
+++ b/opensquilla-webui/src/composables/setup/useSetupCatalog.privacy.test.ts
@@ -4851,6 +4851,56 @@ describe('useSetupCatalog configured provider management', () => {
     app.unmount()
   })
 
+  it('turns the Router off instead of surfacing router_provider_conflict when active removal would leave a foreign tier', async () => {
+    const status = {
+      ...statusWithDeepSeek(),
+      llmProfileStatus: statusWithDeepSeek().llmProfileStatus.map(profile => (
+        profile.provider === 'deepseek'
+          ? { ...profile, primaryEligible: true, primaryBlockReason: '' }
+          : profile
+      )),
+    }
+    rpcCall.mockImplementation(async (method: string) => {
+      if (method === 'onboarding.catalog') return { providers }
+      if (method === 'onboarding.status') return status
+      if (method === 'channels.status') return { channels: [] }
+      // A custom Router whose tiers still name the *current* primary (openai).
+      // Removing openai promotes deepseek, which the backend would reject with
+      // router_provider_conflict while cross-provider routing is off. The client
+      // must mirror activateProvider and send routerAction: 'disable' instead.
+      if (method === 'config.get') {
+        return {
+          ...configWithProfiles('deepseek'),
+          squilla_router: {
+            enabled: true,
+            cross_provider_tiers: false,
+            preset_binding: 'custom',
+            tiers: { c0: { provider: 'openai', model: 'gpt-4.1-mini' } },
+          },
+          llm_ensemble: { enabled: false },
+        }
+      }
+      if (method === 'onboarding.models.discover') {
+        return { ok: true, source: 'none', models: [] }
+      }
+      if (method === 'onboarding.llmProfile.active.remove') return { changed: true }
+      throw new Error(`Unexpected RPC method: ${method}`)
+    })
+    const { api, app } = await mountCatalog()
+
+    await api.removeProviderProfile('openai')
+
+    expect(rpcCall).toHaveBeenCalledWith('onboarding.llmProfile.active.remove', {
+      providerId: 'openai',
+      replacementProviderId: 'deepseek',
+      routerAction: 'disable',
+    })
+    expect(pushToast).toHaveBeenCalledWith(
+      'OpenAI was removed. Model Routing was turned off because its saved tiers use another provider.',
+    )
+    app.unmount()
+  })
+
   it('requests the OpenRouter image default when active removal promotes that profile', async () => {
     const openrouter = {
       providerId: 'openrouter',

--- a/opensquilla-webui/src/composables/setup/useSetupCatalog.ts
+++ b/opensquilla-webui/src/composables/setup/useSetupCatalog.ts
@@ -2900,11 +2900,21 @@ async function removeProviderProfile(providerId: string) {
     primaryLabel: t('setup.provider.removeConfirmPrimary'),
   })
   if (!ok) return
+  let routerAction: 'disable' | undefined
   try {
     if (row.active && replacement) {
+      // Removing the active provider promotes the replacement through the same
+      // primary-swap path as activateProvider. A custom/legacy Router whose
+      // tiers still name another provider cannot be executed safely after that
+      // swap while cross-provider routing is off, so the backend would reject
+      // the removal with an untranslated router_provider_conflict. Detect the
+      // conflict up front and mirror activateProvider: keep the saved tiers,
+      // turn the Router off, and let the operator re-enable it deliberately.
+      routerAction = routerConflictsWithTarget(replacement.providerId) ? 'disable' : undefined
       await rpc.call('onboarding.llmProfile.active.remove', {
         providerId: provider,
         replacementProviderId: replacement.providerId,
+        ...(routerAction ? { routerAction } : {}),
         ...imageGenerationIntentPayload(replacement.providerId, {
           respectProviderEditorChoice: false,
         }),
@@ -2935,7 +2945,12 @@ async function removeProviderProfile(providerId: string) {
         provider: providerLabel,
       }), { tone: 'warn' })
     } else {
-      pushToast(t('setup.toast.providerProfileRemoved', { provider: providerLabel }))
+      pushToast(t(
+        routerAction === 'disable'
+          ? 'setup.toast.providerRemovedRouterDisabled'
+          : 'setup.toast.providerProfileRemoved',
+        { provider: providerLabel },
+      ))
     }
   } catch (err) {
     pushToast(saveFailedMessage(err), { tone: 'danger' })

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -1679,6 +1679,7 @@
       "providerProfileRemoved": "{provider} wurde entfernt.",
       "providerProfileRemovedImageEnv": "{provider} wurde aus dem Modelldienst entfernt. Die Bilderzeugung bleibt über {envKey} verfügbar.",
       "providerProfileRemovedImageNeedsCredential": "{provider} wurde entfernt. Anbieter und Modell der Bilderzeugung bleiben erhalten, benötigen jetzt aber Zugangsdaten.",
+      "providerRemovedRouterDisabled": "{provider} wurde entfernt. Das Modell-Routing wurde deaktiviert, weil gespeicherte Stufen einen anderen Anbieter verwenden.",
       "providerCredentialRemoved": "Die Zugangsdaten für {provider} wurden entfernt.",
       "providerCredentialExternalStillActive": "Der in OpenSquilla gespeicherte Zugangsdatenverweis für {provider} wurde entfernt, aber die Systemumgebungsvariable {envKey} stellt weiterhin Zugangsdaten bereit.",
       "providerActivated": "{provider} ist jetzt aktiv.",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -1767,6 +1767,7 @@
       "providerProfileRemoved": "{provider} was removed.",
       "providerProfileRemovedImageEnv": "{provider} was removed from Model Service. Image generation remains available through {envKey}.",
       "providerProfileRemovedImageNeedsCredential": "{provider} was removed. Image generation kept its provider and model, but now needs a credential.",
+      "providerRemovedRouterDisabled": "{provider} was removed. Model Routing was turned off because its saved tiers use another provider.",
       "providerCredentialRemoved": "{provider} credential was removed.",
       "providerCredentialExternalStillActive": "Cleared {provider}'s saved credential reference, but system environment variable {envKey} is still providing a credential.",
       "providerActivated": "{provider} is now active.",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -1679,6 +1679,7 @@
       "providerProfileRemoved": "Se eliminó {provider}.",
       "providerProfileRemovedImageEnv": "Se eliminó {provider} del servicio de modelos. La generación de imágenes sigue disponible mediante {envKey}.",
       "providerProfileRemovedImageNeedsCredential": "Se eliminó {provider}. La generación de imágenes conservó el proveedor y el modelo, pero ahora necesita una credencial.",
+      "providerRemovedRouterDisabled": "Se eliminó {provider}. El enrutamiento de modelos se desactivó porque sus niveles guardados usan otro proveedor.",
       "providerCredentialRemoved": "Se eliminaron las credenciales de {provider}.",
       "providerCredentialExternalStillActive": "Se eliminó la referencia a las credenciales de {provider} guardada en OpenSquilla, pero la variable de entorno del sistema {envKey} sigue proporcionando credenciales.",
       "providerActivated": "{provider} está activo.",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -1679,6 +1679,7 @@
       "providerProfileRemoved": "{provider} a été supprimé.",
       "providerProfileRemovedImageEnv": "{provider} a été supprimé du service de modèles. La génération d’images reste disponible via {envKey}.",
       "providerProfileRemovedImageNeedsCredential": "{provider} a été supprimé. La génération d’images a conservé son fournisseur et son modèle, mais nécessite désormais un identifiant.",
+      "providerRemovedRouterDisabled": "{provider} a été supprimé. Le routage des modèles a été désactivé car ses niveaux enregistrés utilisent un autre fournisseur.",
       "providerCredentialRemoved": "Les identifiants de {provider} ont été supprimés.",
       "providerCredentialExternalStillActive": "La référence aux identifiants de {provider} enregistrée dans OpenSquilla a été supprimée, mais la variable d’environnement système {envKey} fournit toujours des identifiants.",
       "providerActivated": "{provider} est maintenant actif.",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -1679,6 +1679,7 @@
       "providerProfileRemoved": "{provider} を削除しました。",
       "providerProfileRemovedImageEnv": "モデルサービスから {provider} を削除しました。画像生成は {envKey} により引き続き利用できます。",
       "providerProfileRemovedImageNeedsCredential": "{provider} を削除しました。画像生成のプロバイダーとモデルは保持されていますが、認証情報の設定が必要です。",
+      "providerRemovedRouterDisabled": "{provider} を削除しました。保存済みの階層が別のプロバイダーを使用しているため、モデルルーティングをオフにしました。",
       "providerCredentialRemoved": "{provider} の認証情報を削除しました。",
       "providerCredentialExternalStillActive": "OpenSquilla に保存された {provider} の認証情報参照を削除しましたが、システム環境変数 {envKey} から引き続き認証情報が提供されています。",
       "providerActivated": "{provider} をアクティブにしました。",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -1767,6 +1767,7 @@
       "providerProfileRemoved": "已删除 {provider}。",
       "providerProfileRemovedImageEnv": "已从模型服务删除 {provider}；图像生成继续通过 {envKey} 使用。",
       "providerProfileRemovedImageNeedsCredential": "已删除 {provider}；图像生成保留了服务商和模型，但现在需要配置凭据。",
+      "providerRemovedRouterDisabled": "已删除 {provider}；由于已保存的路由层级使用其他服务商，模型路由已关闭。",
       "providerCredentialRemoved": "已删除 {provider} 的凭据。",
       "providerCredentialExternalStillActive": "已清除 OpenSquilla 中保存的 {provider} 凭据引用，但系统环境变量 {envKey} 仍在提供凭据。",
       "providerActivated": "已将 {provider} 设为当前使用。",


### PR DESCRIPTION
## Problem

Removing the active provider promotes the replacement through the same primary-swap path as `activateProvider`. When the Router is a custom/legacy binding with cross-provider routing off and a tier still names the previous provider, the backend rejects the removal with `router_provider_conflict`.

That code is not in `RPC_ERROR_KEYS`, so the WebUI falls back to the raw backend English string — the user sees `保存失败: custom Router tiers reference provider(s) that differ from the new primary: deepseek` instead of a guided action, and the remove fails with no way forward.

## Fix

Mirror `activateProvider`: detect the conflict up front **against the replacement** (which is the primary after the swap) and send `routerAction: "disable"` when it exists. This keeps the saved tiers intact and turns the Router off so the removal succeeds; the operator can review and re-enable it deliberately from Model Routing. Also report the same through a new `providerRemovedRouterDisabled` toast in all six locales.

## Verification

- New test: active removal with a custom Router tier naming the previous provider now sends `routerAction: "disable"` and shows the router-disabled toast.
- Full WebUI unit suite passes (375 files / 4644 tests).