### PR TITLE
fix(sandbox): stop injecting the PowerShell proxy prelude when no proxy is set

### DIFF
--- a/src/opensquilla/sandbox/operation_profile.py
+++ b/src/opensquilla/sandbox/operation_profile.py
@@ -1048,8 +1048,18 @@ def _looks_like_installer_artifact(value: str) -> bool:
 
 
 def _shell_script(parts: tuple[str, ...]) -> str:
+    shell_name = _command_name(parts[0]).lower() if parts else ""
+    is_powershell = shell_name in {"powershell", "pwsh"}
     for index, part in enumerate(parts[1:], start=1):
-        if _is_shell_command_option(part.lower()):
+        option = part.lower()
+        if is_powershell:
+            # PowerShell's command payload follows -c / -Command.  Other
+            # single-dash flags (e.g. -NonInteractive, -ExecutionPolicy) also
+            # contain a "c" but are options, not the command token, so they must
+            # not be mistaken for it.
+            if option in {"-c", "-command"}:
+                return " ".join(parts[index + 1 :])
+        elif _is_shell_command_option(option):
             return " ".join(parts[index + 1 :])
     return " ".join(parts[1:])
 

--- a/src/opensquilla/tools/builtin/shell.py
+++ b/src/opensquilla/tools/builtin/shell.py
@@ -2312,9 +2312,29 @@ if (-not [string]::IsNullOrWhiteSpace($__opensquillaProxy)) {
 """.strip()
 
 
+def _host_shell_proxy_set() -> bool:
+    """True when a downstream proxy is set for the host shell.
+
+    Mirrors the env-variable probe inside ``_WINDOWS_POWERSHELL_PROXY_PRELUDE``
+    (HTTPS_PROXY then HTTP_PROXY, case-insensitive) so the wrapper only injects
+    the proxy preamble when it actually has an effect.  Skipping the preamble
+    when no proxy is configured is what keeps the emitted command line clean for
+    AV heuristics that flag ``powershell.exe -Command ... Invoke-WebRequest /
+    WebProxy`` even when the payload is a benign no-op.
+    """
+    return bool(
+        os.environ.get("HTTPS_PROXY")
+        or os.environ.get("https_proxy")
+        or os.environ.get("HTTP_PROXY")
+        or os.environ.get("http_proxy")
+    )
+
+
 def _windows_with_powershell_proxy_defaults(command: str) -> str:
-    prelude = _WINDOWS_POWERSHELL_PROXY_PRELUDE
     command = command.strip()
+    if not _host_shell_proxy_set():
+        return command
+    prelude = _WINDOWS_POWERSHELL_PROXY_PRELUDE
     if not command:
         return prelude
     return f"{prelude.rstrip(';')}; {command}"

--- a/tests/test_sandbox/test_shell_code_network_hints.py
+++ b/tests/test_sandbox/test_shell_code_network_hints.py
@@ -987,9 +987,12 @@ def test_trusted_windows_tools_collapse_host_network_to_managed_proxy(
     assert code_policy.network is NetworkMode.PROXY_ALLOWLIST
 
 
-def test_windows_direct_powershell_argv_injects_proxy_defaults() -> None:
+def test_windows_direct_powershell_argv_injects_proxy_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from opensquilla.tools.builtin import shell
 
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:8080")
     argv = shell._windows_direct_powershell_argv(
         "Invoke-WebRequest -UseBasicParsing https://example.com"
     )
@@ -1002,6 +1005,25 @@ def test_windows_direct_powershell_argv_injects_proxy_defaults() -> None:
     assert "System.Net.Sockets.TcpClient" not in command
     assert "Invoke-OpenSquillaProxyNetworkFallback" not in command
     assert ";;" not in command
+
+
+def test_windows_direct_powershell_argv_omits_proxy_prelude_without_proxy() -> None:
+    from opensquilla.tools.builtin import shell
+
+    # No HTTP(S)_PROXY in the environment: the wrapper must not emit the proxy
+    # preamble. Always emitting Invoke-WebRequest / WebProxy text — even as an
+    # inert no-op — trips AV heuristics such as 360 风险进程防护's
+    # "PowerShell 下载攻击" signature on every command, breaking unattended use.
+    argv = shell._windows_direct_powershell_argv(
+        "Invoke-WebRequest -UseBasicParsing https://example.com"
+    )
+    command = argv[-1]
+
+    assert "$PSDefaultParameterValues['Invoke-WebRequest:Proxy']" not in command
+    assert "$PSDefaultParameterValues['Invoke-RestMethod:Proxy']" not in command
+    assert "[System.Net.WebRequest]::DefaultWebProxy" not in command
+    assert "[System.Net.WebProxy]" not in command
+    assert "Invoke-WebRequest -UseBasicParsing https://example.com" in command
 
 
 def test_windows_shell_host_handles_invoke_webrequest_status_via_managed_proxy(


### PR DESCRIPTION
## Problem

On Windows the host shell tool runs every command through:

```
powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "<proxy prelude>; <cmd>"
```

The proxy prelude (`_WINDOWS_POWERSHELL_PROXY_PRELUDE`) is injected **unconditionally** and always carries `Invoke-WebRequest` / `Invoke-RestMethod` / `System.Net.WebRequest` / `WebProxy` / `CredentialCache` — even when `HTTP(S)_PROXY` is unset and the in-script `if` can never fire.

That combination (network-download APIs plus `-ExecutionPolicy Bypass`) is an exact match for AV heuristics such as **360 风险进程防护's "PowerShell 下载攻击" signature**, which fires on *every* command and cannot be permanently dismissed (behavioral interception re-evaluates each unique command line). This breaks unattended use on machines with 360, common in Chinese enterprises.

## Fix

Gate the prelude in Python: emit it only when a downstream proxy is actually configured. With no proxy, the wrapper produces a clean `-Command "<cmd>"` with no `WebProxy` / `Invoke-WebRequest` text. Functionally a no-op (the prelude's `if` guarded the proxy application anyway — it just should not have been *emitted* when there was nothing to apply).

## Latent classifier bug this exposed (fixed here)

Removing the prelude revealed a bug the prelude had been masking: the operation-profile command classifier located the PowerShell payload by treating **any** single-dash flag containing a `c` as the command token. So `-NonInteractive` and `-ExecutionPolicy` (which precede `-Command` in the real argv) made `_shell_script` return `-ExecutionPolicy Bypass -Command composer install`, and `composer install` / `poetry install` were misclassified as `unknown_shell` instead of `package_install` — which would break sandbox package-install approval.

`_shell_script` is now shell-aware: for `powershell`/`pwsh` only `-c` / `-Command` select the payload; POSIX shells keep existing `-c` / short-cluster matching.

## Verification

- New test: `_windows_direct_powershell_argv` omits the proxy prelude when no proxy is set; existing inject test now sets `HTTPS_PROXY` to keep asserting the proxy path.
- `test_operation_profile.py` + `test_shell_code_network_hints.py` + related sandbox suite: all pass (sandbox dir: 1786 passed, 347 skipped).
- Confirmed `composer install` / `poetry install` classify as `package_install` both with and without a proxy env var.