### PR TITLE
fix(cli): give sessions export/delete/resume and bundle the selected profile

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -895,6 +895,7 @@
       "tests/test_cli/test_init_cmd.py",
       "tests/test_cli/test_migrate_cmd.py",
       "tests/test_cli/test_onboard_status_json.py",
+      "tests/test_cli/test_profile_target_resolution.py",
       "tests/test_cli/test_sandbox_cmd.py",
       "tests/test_cli/test_search_cmd.py",
       "tests/test_cli/test_url_utils.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -210,6 +210,7 @@
     "tests/test_cli/test_onboard_status_json.py": 0.566,
     "tests/test_cli/test_output_helpers.py": 0.01,
     "tests/test_cli/test_profile_env_loading.py": 5.578,
+    "tests/test_cli/test_profile_target_resolution.py": 5.4,
     "tests/test_cli/test_providers_cmd.py": 0.793,
     "tests/test_cli/test_router_cmd.py": 2.78,
     "tests/test_cli/test_sandbox_cmd.py": 1.827,

--- a/src/opensquilla/cli/bundle_cmd.py
+++ b/src/opensquilla/cli/bundle_cmd.py
@@ -23,11 +23,17 @@ def _live_enrichment() -> dict[str, Any]:
 
     async def _fetch() -> dict[str, Any]:
         from opensquilla.cli import gateway_client as gateway_client_module
+        from opensquilla.cli.gateway_rpc import default_gateway_url
 
         client = gateway_client_module.GatewayClient()
         extra: dict[str, Any] = {}
         try:
-            await client.connect("ws://localhost:18791/ws")
+            # The rest of the bundle is read from the selected profile's home.
+            # Enriching it from a hardcoded 127.0.0.1:18791 meant a bundle
+            # collected under `--profile x` could carry `doctor`/`channels`
+            # sections describing a different gateway, and nothing in the file
+            # said so — worse than having no live section at all (#1374).
+            await client.connect(default_gateway_url())
             for key, method in (("doctor", "doctor.status"), ("channels", "channels.status")):
                 try:
                     extra[key] = dict(await client.call(method, {}))

--- a/src/opensquilla/cli/sessions_cmd.py
+++ b/src/opensquilla/cli/sessions_cmd.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -14,10 +13,9 @@ from rich.table import Table
 
 from opensquilla.cli.chat.session_state import messages_to_markdown
 from opensquilla.cli.gateway_client import session_history_all
-from opensquilla.cli.gateway_rpc import run_gateway_sync
+from opensquilla.cli.gateway_rpc import default_gateway_url, run_gateway_sync
 from opensquilla.cli.output import print_json
 from opensquilla.cli.ui import ACCENT, ACCENT_HEADER, console, error_panel
-from opensquilla.cli.url_utils import normalize_gateway_url
 
 app = typer.Typer(help="Manage chat sessions.")
 
@@ -109,9 +107,13 @@ async def _with_client(action):
 
     client = GatewayClient()
     try:
-        await client.connect(
-            normalize_gateway_url(os.environ.get("OPENSQUILLA_GATEWAY_URL", "ws://localhost:18791/ws"))
-        )
+        # `default_gateway_url()` is what `sessions list`/`show`/`abort` reach
+        # through `run_gateway_sync`. The literal this replaced skipped the
+        # config entirely, so `resume`, `delete` and `export` went to
+        # 127.0.0.1:18791 no matter which profile was selected — a named
+        # profile's gateway on another port was invisible to them (#1379).
+        # `OPENSQUILLA_GATEWAY_URL` still wins; the resolver checks it first.
+        await client.connect(default_gateway_url())
         return await action(client)
     except SystemExit as exc:
         console.print(f"[dim]{exc}[/dim]")

--- a/tests/test_cli/test_profile_target_resolution.py
+++ b/tests/test_cli/test_profile_target_resolution.py
@@ -1,0 +1,191 @@
+"""`sessions export`/`delete`/`resume` and `bundle` aim at the selected profile.
+
+Those four, and no others. `--profile qa` puts the profile's home on
+`OPENSQUILLA_PROFILE`, which moves the resolved config, which carries the port
+that profile's gateway binds. Commands routed through `run_gateway_sync` follow
+that chain. These four did not: they connected to a literal
+`ws://localhost:18791/ws`, so a profile gateway on another port was invisible
+to them — issues #1379 and #1374.
+
+`sessions export` was the reported symptom, and `delete` is the one that
+matters most among the four: sent to the wrong gateway it does not merely fail
+to find the session, it operates on whatever gateway is listening on 18791.
+
+Two commands are still profile-blind and are not covered here, because in both
+the literal is the default of a documented `--gateway` option rather than an
+internal fallback: `reset`, which mutates session state and so carries the same
+risk as `delete`, and `mcp-server run`. Changing an option default changes
+`--help` and the flag's advertised contract, so those move in their own
+reviewed change rather than riding along with this one.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from opensquilla.cli.main import app
+
+runner = CliRunner()
+
+PROFILE_PORT = 18823
+DEFAULT_URL = "ws://localhost:18791/ws"
+
+
+@pytest.fixture
+def profile_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A home whose gateway config binds a non-default port.
+
+    `--profile qa-export` reaches the port through
+    `OPENSQUILLA_PROFILE` -> `profile_home()` -> `default_opensquilla_home()` ->
+    the resolved `config.toml` -> its `port`. This fixture enters that chain one
+    link later, at the home, because the suite sets `OPENSQUILLA_STATE_DIR` for
+    isolation and that override outranks `OPENSQUILLA_HOME` inside
+    `default_opensquilla_home()`. The first link is pinned on its own in
+    `test_the_profile_env_moves_the_resolved_url`; everything below it is where
+    the defect was.
+    """
+
+    home = tmp_path / "qa-export"
+    home.mkdir(parents=True)
+    (home / "config.toml").write_text(
+        f'host = "127.0.0.1"\nport = {PROFILE_PORT}\n', encoding="utf-8"
+    )
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_URL", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(home))
+    return home
+
+
+def test_the_profile_env_moves_the_resolved_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The first link: a selected profile really does change the target."""
+
+    from opensquilla.cli.gateway_rpc import default_gateway_url
+
+    homes = tmp_path / "homes"
+    (homes / "qa-export").mkdir(parents=True)
+    (homes / "qa-export" / "config.toml").write_text(
+        f'host = "127.0.0.1"\nport = {PROFILE_PORT}\n', encoding="utf-8"
+    )
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_URL", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_STATE_DIR", raising=False)
+    monkeypatch.setenv("OPENSQUILLA_HOME", str(homes))
+
+    monkeypatch.setenv("OPENSQUILLA_PROFILE", "qa-export")
+    assert f":{PROFILE_PORT}/" in default_gateway_url()
+
+    monkeypatch.delenv("OPENSQUILLA_PROFILE")
+    assert default_gateway_url() == DEFAULT_URL
+
+
+@pytest.fixture
+def connected_urls(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record every URL a CLI command asks the gateway client to connect to."""
+
+    urls: list[str] = []
+
+    class RecordingClient:
+        async def connect(self, url: str, *, token: str | None = None) -> None:
+            urls.append(url)
+
+        async def call(self, method: str, params: dict | None = None) -> Any:
+            return {}
+
+        async def list_sessions(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {"sessions": [], "count": 0}
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("opensquilla.cli.gateway_client.GatewayClient", RecordingClient)
+    return urls
+
+
+# The three that used the literal, and one that already resolved correctly and
+# has to keep doing so.
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["sessions", "export", "some-session-key"],
+        ["sessions", "delete", "some-session-key", "--yes"],
+        ["sessions", "resume", "some-session-key"],
+        ["sessions", "show", "some-session-key"],
+    ],
+    ids=["export", "delete", "resume", "show"],
+)
+def test_a_sessions_command_aims_at_the_selected_profile(
+    argv: list[str], profile_home: Path, connected_urls: list[str]
+) -> None:
+    runner.invoke(app, argv)
+
+    assert connected_urls, f"{argv[1]} never opened a gateway connection"
+    for url in connected_urls:
+        assert f":{PROFILE_PORT}/" in url, url
+        assert url != DEFAULT_URL
+
+
+def test_the_bundle_enriches_from_the_profile_it_is_collecting(
+    profile_home: Path, connected_urls: list[str], tmp_path: Path
+) -> None:
+    """The rest of the bundle is read from the profile's home.
+
+    Live `doctor`/`channels` sections taken from a different gateway would be
+    wrong in a way the file does not disclose.
+    """
+
+    runner.invoke(app, ["bundle", "--output", str(tmp_path / "b.zip"), "--json"])
+
+    assert connected_urls, "bundle never attempted live enrichment"
+    for url in connected_urls:
+        assert f":{PROFILE_PORT}/" in url, url
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["sessions", "export", "some-session-key"],
+        ["sessions", "delete", "some-session-key", "--yes"],
+        ["sessions", "show", "some-session-key"],
+    ],
+    ids=["export", "delete", "show"],
+)
+def test_an_explicit_gateway_url_still_wins(
+    argv: list[str],
+    profile_home: Path,
+    connected_urls: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The env override outranks the profile, as it did before."""
+
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_URL", "ws://127.0.0.1:19999/ws")
+
+    runner.invoke(app, argv)
+
+    assert connected_urls
+    for url in connected_urls:
+        assert ":19999/" in url, url
+
+
+def test_no_profile_still_means_the_release_default(
+    tmp_path: Path, connected_urls: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Nothing configured must land exactly where it always did."""
+
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_URL", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("OPENSQUILLA_PROFILE", raising=False)
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(empty))
+
+    runner.invoke(app, ["sessions", "export", "some-session-key"])
+
+    assert connected_urls
+    for url in connected_urls:
+        assert url == DEFAULT_URL, url


### PR DESCRIPTION
--profile qa sets OPENSQUILLA_PROFILE, which moves default_opensquilla_home(), which moves the resolved config.toml, which carries the port that profile's gateway binds. default_gateway_url() follows that chain, and sessions list, show and abort reach it through run_gateway_sync.
Four call sites did not. sessions_cmd._with_client connected to a literal ws://localhost:18791/ws, so export, delete and resume addressed the default gateway whatever profile was selected. The reported export failure with NOT_FOUND (#1379) is the visible half; delete is the half that is not merely inconvenient, because aimed at the wrong gateway it does not fail safe — it operates on whatever is listening on 18791.
bundle._live_enrichment carried the same literal (#1374). Everything else in a bundle is read from the selected profile's home, so the doctor and channels sections could describe a different gateway entirely and nothing in the file says so. A wrong live section is worse than no live section, because the bundle still looks complete.
Both now call default_gateway_url(). It checks OPENSQUILLA_GATEWAY_URL first, so the env override keeps outranking the profile exactly as before, and with nothing configured it resolves to the same release default. The bundle's stated contract — "the bundle must work identically with a dead gateway" — is untouched: the call sits inside the block whose failure path already returns {}.
Scope boundary: two call sites, sessions_cmd._with_client and bundle_cmd._live_enrichment, plus the two now-unused imports that leaves behind. No change to default_gateway_url(), to the profile/home/config resolution it walks, or to any command that already used it. doctor keeps its own literal, which is only the pre-initialisation overwritten by _target_url_for_doctor on the line below; and mcp-server run keeps its literal deliberately — there it is the default of a documented --gateway option, so changing it changes --help output and the flag's advertised contract, which reads like a separate decision rather than part of this fix.
Both manifest edits register the new test file for the Windows shards.
Base branch: main.

Target exception: none — an ordinary bug fix against main.

Linked issue: closes #1379, closes #1374.

Release note: sessions export, sessions delete, sessions resume and the live sections of bundle now address the gateway of the selected --profile instead of always 127.0.0.1:18791.
Tests
tests/test_cli/test_profile_target_resolution.py, 10 cases. Four fail on current main — exactly the four defective commands — and sessions show, which was already correct, passes on both sides as the control:

a home whose config.toml binds 18823, then sessions export / delete / resume / show and bundle, asserting on the URL each one actually hands the gateway client;
test_the_profile_env_moves_the_resolved_url pins the first link on its own — OPENSQUILLA_PROFILE set resolves to the profile's port, unset resolves to the release default — because the rest of the file enters the chain at the home. The suite sets OPENSQUILLA_STATE_DIR for isolation and that override outranks OPENSQUILLA_HOME inside default_opensquilla_home(), so the two halves are pinned separately rather than one test pretending to cover both;
OPENSQUILLA_GATEWAY_URL still wins over the profile, for all three sessions commands;
nothing configured still lands on exactly ws://localhost:18791/ws.

tests/test_cli and tests/test_observability/test_bundle.py pass in full (888 passed); tests/test_health, test_rpc_sessions and test_api_sessions pass (392 passed); tests/test_ci/test_windows_test_shards.py passes with the new file registered.
Maintainer live check: start a profile gateway on another port — opensquilla --profile qa-export gateway start --bind 127.0.0.1 --port 18823 — create a session on it, then run opensquilla --profile qa-export sessions export <key> with no OPENSQUILLA_GATEWAY_URL set. It reaches 18823 instead of failing NOT_FOUND against 18791. opensquilla --profile qa-export bundle now takes its doctor/channels sections from that same gateway. With no profile selected both behave as before.
Third-party origin: none. No new dependency; the fix calls a resolver that already exists in opensquilla/cli/gateway_rpc.py.