### PR TITLE
Use merge-base for PR CI planning

### DIFF
--- a/.github/CI_OPTIMIZATION.md
+++ b/.github/CI_OPTIMIZATION.md
@@ -15,6 +15,13 @@ Times are operational targets, not timeouts. High-risk pull requests intentional
 slower. Provider-live, credential, and external-network tests remain excluded from required
 CI and retain their existing live markers.
 
+Pull-request path selection compares the PR head with its merge base, not directly with the
+current base tree. A branch that is behind `main` therefore does not inherit base-only changes
+as if the PR introduced them. This affects suite selection only: merge-queue reuse remains bound
+to the exact current base and tested tree, so a base advance still triggers the full fail-closed
+queue matrix. For an otherwise eligible non-policy PR, refreshing the branch and completing a
+new green PR CI run can make a later queue entry exact; reuse is decided again at queue time.
+
 ## Modes
 
 Set the Actions repository variable `CI_OPTIMIZATION_MODE` to one of:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,9 @@ jobs:
             echo "- Artifact: \`${ARTIFACT_NAME}\`"
             echo "- Queue base/head/tree: \`${QUEUE_BASE_SHA}\` / \`${QUEUE_HEAD_SHA}\` / \`${QUEUE_TREE_SHA}\`"
             echo "- Combined-tree domain smokes: \`${COMBINED_SMOKE_SUITES}\`"
+            if [[ "${REASON_CODE}" == "tree_mismatch" ]]; then
+              echo "- Fast-path note: the PR evidence does not match this queue tree, so this entry runs the full fail-closed matrix. If main advanced, refresh the PR against the latest main and wait for a new green PR CI run before requeueing. Reuse is always decided against the future entry's exact base and tree."
+            fi
             if [[ -n "${SOURCE_RUN_ID}" ]]; then
               echo "- Source run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}"
             fi
@@ -167,9 +170,15 @@ jobs:
               if [[ "${CI_OPTIMIZATION_MODE}" == "legacy" ]]; then
                 printf '.ci/run-all\n' > "${changed_files}"
               else
-                git diff --no-renames --name-only \
-                  "${{ github.event.pull_request.base.sha }}" \
-                  "${{ github.event.pull_request.head.sha }}" > "${changed_files}"
+                base_sha="${{ github.event.pull_request.base.sha }}"
+                head_sha="${{ github.event.pull_request.head.sha }}"
+                if git diff --merge-base --no-renames --name-only \
+                  "${base_sha}" "${head_sha}" -- > "${changed_files}"; then
+                  echo "Planning PR-owned changes from the merge base."
+                else
+                  echo "Unable to derive the PR-owned change set; running the full fail-closed matrix." >&2
+                  printf '.ci/run-all\n' > "${changed_files}"
+                fi
               fi
               ;;
             merge_group)

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -185,6 +185,148 @@ def test_default_ci_blocks_pull_requests_and_main_pushes() -> None:
     assert "nightly" not in pull_request_case.lower()
 
 
+def test_pr_change_selection_uses_merge_base_and_ignores_base_only_changes(
+    tmp_path: Path,
+) -> None:
+    workflow = _workflow("ci.yml")
+    checkout = next(
+        step
+        for step in workflow["jobs"]["plan-ci"]["steps"]
+        if step.get("uses") == "actions/checkout@v4"
+    )
+    assert checkout["with"]["fetch-depth"] == 0
+
+    text = (WORKFLOW_DIR / "ci.yml").read_text(encoding="utf-8")
+    pull_request_case = text.split("            pull_request)", 1)[1].split(
+        "              ;;", 1
+    )[0]
+    assert "git diff --merge-base --no-renames --name-only" in pull_request_case
+    assert '"${base_sha}" "${head_sha}" -- > "${changed_files}"' in pull_request_case
+    assert "Unable to derive the PR-owned change set" in pull_request_case
+    assert 'printf \'.ci/run-all\\n\' > "${changed_files}"' in pull_request_case
+
+    executable_case = (
+        'changed_files="${CHANGED_FILES}"\n'
+        + pull_request_case.replace(
+            "${{ github.event.pull_request.base.sha }}", "${BASE_SHA}"
+        ).replace("${{ github.event.pull_request.head.sha }}", "${HEAD_SHA}")
+    )
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args: str) -> str:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    def select_changed_files(base_sha: str, head_sha: str) -> list[str]:
+        changed_files = tmp_path / "changed-files.txt"
+        changed_files.write_text("stale partial result\n", encoding="utf-8")
+        env = os.environ.copy()
+        env.update(
+            {
+                "BASE_SHA": base_sha,
+                "CHANGED_FILES": changed_files.as_posix(),
+                "CI_OPTIMIZATION_MODE": "enforce",
+                "HEAD_SHA": head_sha,
+            }
+        )
+        result = subprocess.run(
+            [_bash_executable(), "-euo", "pipefail", "-c", executable_case],
+            cwd=repo,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        return changed_files.read_text(encoding="utf-8").splitlines()
+
+    def plan_changed_files(paths: list[str]) -> dict:
+        planner_input = tmp_path / "planner-input.txt"
+        planner_input.write_text("\n".join(paths) + "\n", encoding="utf-8")
+        result = subprocess.run(
+            [
+                sys.executable,
+                ".github/scripts/plan_ci.py",
+                planner_input.as_posix(),
+                "--repo",
+                ".",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return json.loads(result.stdout)
+
+    git("init", "-b", "main")
+    git("config", "user.name", "CI Test")
+    git("config", "user.email", "ci@example.invalid")
+    (repo / "README.md").write_text("baseline\n", encoding="utf-8")
+    git("add", "README.md")
+    git("commit", "-m", "baseline")
+
+    git("switch", "-c", "feature")
+    feature_path = repo / "src/opensquilla/cli/config_cmd.py"
+    feature_path.parent.mkdir(parents=True)
+    feature_path.write_text("FEATURE = True\n", encoding="utf-8")
+    git("add", feature_path.relative_to(repo).as_posix())
+    git("commit", "-m", "feature change")
+    head_sha = git("rev-parse", "HEAD")
+
+    git("switch", "main")
+    base_only_path = repo / ".github/ci/trust-policy.v1.json"
+    base_only_path.parent.mkdir(parents=True)
+    base_only_path.write_text("{}\n", encoding="utf-8")
+    git("add", base_only_path.relative_to(repo).as_posix())
+    git("commit", "-m", "base-only CI policy change")
+    base_sha = git("rev-parse", "HEAD")
+
+    changed = select_changed_files(base_sha, head_sha)
+    assert changed == ["src/opensquilla/cli/config_cmd.py"]
+    plan = plan_changed_files(changed)
+    assert plan["full_fallback"] is False
+    assert plan["reason_codes"] == ["python_targeted"]
+
+    two_tree_changed = git(
+        "diff",
+        "--no-renames",
+        "--name-only",
+        base_sha,
+        head_sha,
+    ).splitlines()
+    assert ".github/ci/trust-policy.v1.json" in two_tree_changed
+    two_tree_plan = plan_changed_files(two_tree_changed)
+    assert two_tree_plan["full_fallback"] is True
+    assert "ci_policy_changed" in two_tree_plan["reason_codes"]
+
+    git("switch", "--orphan", "unrelated")
+    unrelated_path = repo / "unrelated.txt"
+    unrelated_path.write_text("unrelated history\n", encoding="utf-8")
+    git("add", "unrelated.txt")
+    git("commit", "-m", "unrelated root")
+    unrelated_sha = git("rev-parse", "HEAD")
+    git("switch", "main")
+
+    assert select_changed_files(base_sha, unrelated_sha) == [".ci/run-all"]
+
+
+def test_queue_summary_explains_tree_mismatch_fallback() -> None:
+    text = (WORKFLOW_DIR / "ci.yml").read_text(encoding="utf-8")
+
+    assert 'if [[ "${REASON_CODE}" == "tree_mismatch" ]]' in text
+    assert "this entry runs the full fail-closed matrix" in text
+    assert "If main advanced" in text
+    assert "wait for a new green PR CI run before requeueing" in text
+    assert "future entry's exact base and tree" in text
+
+
 def test_ci_fast_paths_keep_the_required_check_and_fail_closed() -> None:
     workflow = _workflow("ci.yml")
     jobs = workflow["jobs"]


### PR DESCRIPTION
## Scope

- Derive pull-request changed paths from the PR head and its merge base, so changes that landed only on `main` are not attributed to a behind branch.
- Fall back to `.ci/run-all` when Git cannot derive or diff the merge base.
- Explain `tree_mismatch` queue fallback without weakening exact-base or exact-tree reuse.
- Add an executable Git-DAG contract proving the corrected path list stays targeted while the former two-tree list would force a CI-policy full run.

Target branch: `main`

Linked issue: None

## Verification

- `uv run pytest tests/test_ci -q` — 388 passed, 3 skipped
- `uv run pytest tests/test_ci/test_workflows.py -q` — 68 passed after the final wording review
- `uv run ruff check .github/scripts tests/test_ci`
- `actionlint -color=false`
- `git diff --check`
- Independent review — no blockers
- GitNexus pre-edit impact could not resolve `.github` because the current index omits the CI control plane. Required `detect_changes(compare main)` reported unrelated historical drift from a stale local/indexed `main`; the same detection against current `origin/main` reports exactly three changed files, no affected product processes, and LOW risk.

## Rollout and safety

- Merge-queue evidence remains exact-base, exact-tree, PR-root-only, and fail-closed.
- Merge-group evidence misses still run the complete queue matrix; no targeted queue fallback is introduced.
- Push diff behavior, Nightly behavior, required check names, test matrices, and ruleset settings are unchanged.
- This PR changes `ci.yml`, so its own PR and merge-queue entry are expected to run full CI. Validate reuse later with an ordinary non-policy PR based on the resulting `main`.

## Compatibility and release notes

- No public API, persisted data, configuration, client, desktop, or upgrade compatibility change.
- Platform behavior is CI-control-plane-only; the contract executes the workflow shell through Git Bash on Windows.
- Release note: not required.

## Third-party origin

Implementation is original. Git merge-base behavior was checked against Git and GitHub documentation; no third-party code, comments, fixtures, identifiers, or wording were copied.
