### PR TITLE
Correct gateway port configuration examples

### DIFF
--- a/README.product.md
+++ b/README.product.md
@@ -136,7 +136,7 @@ opensquilla configure search --search-provider duckduckgo
 opensquilla configure search --search-provider tavily --api-key-env TAVILY_API_KEY
 opensquilla configure channels
 opensquilla config get llm.provider
-opensquilla config set gateway.port 18791
+opensquilla config set port 18791
 ```
 
 See [`docs/configuration.md`](docs/configuration.md) for details.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -245,7 +245,7 @@ Raw config:
 
 ```sh
 opensquilla config get llm.provider
-opensquilla config set gateway.port 18791
+opensquilla config set port 18791
 ```
 
 More detail:

--- a/tests/test_cli/test_cli_product_completeness.py
+++ b/tests/test_cli/test_cli_product_completeness.py
@@ -197,6 +197,17 @@ def test_models_list_table_warns_about_provider_listing_errors(monkeypatch):
     assert "auth_invalid" in result.stderr
 
 
+def test_config_port_docs_use_public_top_level_key() -> None:
+    root = Path(__file__).resolve().parents[2]
+    expected = "opensquilla config set port 18791"
+    invalid = "opensquilla config set gateway.port"
+
+    for relative_path in ("docs/cli.md", "README.product.md"):
+        text = (root / relative_path).read_text(encoding="utf-8")
+        assert expected in text, relative_path
+        assert invalid not in text, relative_path
+
+
 def test_config_get_honors_env_path_and_redacts(tmp_path: Path, monkeypatch):
     target = tmp_path / "opensquilla.toml"
     target.write_text(


### PR DESCRIPTION
## Scope

- Correct the gateway port examples in `docs/cli.md` and `README.product.md` to use the public top-level `port` key.
- Add a focused documentation contract test in the existing CLI completeness test file.

Base branch: `main`.
Linked issue: Fixes #1408.
Release note: documentation correction; no runtime behavior change.

## Root cause

The two public examples used `gateway.port`, but `GatewayConfig` exposes `port` at the top level and maps it to `OPENSQUILLA_GATEWAY_PORT`.

## Tests

- `pytest tests/test_cli/test_cli_product_completeness.py::test_config_port_docs_use_public_top_level_key -q` — 1 passed.
- `pytest tests/test_cli/test_config_set_key_validation.py -q` — 27 passed.
- `ruff check tests/test_cli/test_cli_product_completeness.py` — passed.
- `git diff --check` — passed.
- Isolated temporary config: `config set port 19876` and `config get port` both exited 0; TOML persisted `port = 19876`.

## Compatibility, safety, and platforms

No CLI, schema, environment mapping, persisted-state, protocol, permission, or trust-boundary behavior changes. No alias or migration is added. The documentation and static test change are platform-neutral; the isolated round-trip was run on macOS arm64 with Python 3.12.13. Windows and Linux were not manually rerun for this documentation-only change.

## Non-goals

- Add a `gateway.port` compatibility alias.
- Change runtime configuration loading or persistence.
- Change environment-variable behavior.

Third-party origin: none.