### PR TITLE
Keep unknown chat sends out of composer

### DIFF
--- a/desktop/electron/scripts/test-v1-html-agent-edit-e2e.mjs
+++ b/desktop/electron/scripts/test-v1-html-agent-edit-e2e.mjs
@@ -1391,13 +1391,26 @@ async function typeAndSubmitAnnotation(electronApp, body) {
 async function dropNextChatSend(page) {
   await page.evaluate(() => {
     window.__opensquillaV1DroppedChatSend = false
+    window.__opensquillaV1DroppedChatSendRequest = null
+    window.__opensquillaV1ReplayedChatSendRequest = null
     const originalSend = WebSocket.prototype.send
-    WebSocket.prototype.send = function dropSyntheticSessionsSend(data) {
+    const captureReplay = function captureSyntheticSessionsReplay(data) {
       if (
         typeof data === 'string'
         && data.includes('"method":"chat.send"')
       ) {
         WebSocket.prototype.send = originalSend
+        window.__opensquillaV1ReplayedChatSendRequest = JSON.parse(data)
+      }
+      return originalSend.call(this, data)
+    }
+    WebSocket.prototype.send = function dropSyntheticSessionsSend(data) {
+      if (
+        typeof data === 'string'
+        && data.includes('"method":"chat.send"')
+      ) {
+        window.__opensquillaV1DroppedChatSendRequest = JSON.parse(data)
+        WebSocket.prototype.send = captureReplay
         window.__opensquillaV1DroppedChatSend = true
         this.close(4000, 'synthetic sessions.send disconnect')
         return
@@ -1432,7 +1445,8 @@ const evidence = {
   changesAfterAgentPatch: '',
   previewHeading: '',
   annotationModeExitedAfterAcceptance: false,
-  annotationSendFailureRetained: false,
+  annotationUnknownSendPreserved: false,
+  annotationReplayIdentityMatched: false,
   annotationAcceptanceEvents: [],
   annotationModeAfterAcceptance: null,
   annotationRequests: 0,
@@ -1736,6 +1750,8 @@ try {
     })
   })
   const annotationRequestStart = provider.requests.length
+  const annotationUserMessageStart = await page.locator('.msg-user').count()
+  const sentAnnotationStart = await page.getByTestId('sent-prompt-annotation').count()
   await page.locator('.chat-textarea').fill(ANNOTATION_MESSAGE)
   await dropNextChatSend(page)
   await submitChatComposer(page)
@@ -1751,8 +1767,23 @@ try {
   await waitForSettledTurn(page)
   assert.equal(
     await page.locator('.chat-textarea').inputValue(),
+    '',
+    'an unknown send must not duplicate the optimistic user message in the composer',
+  )
+  assert.equal(
+    await page.locator('.msg-user').count(),
+    annotationUserMessageStart + 1,
+    'an unknown send must retain exactly one optimistic user message',
+  )
+  assert.equal(
+    await page.locator('.msg-user').last().locator('.msg-user-bubble').innerText(),
     ANNOTATION_MESSAGE,
-    'a disconnected send must retain the user message for retry',
+    'the optimistic user message must retain the submitted text',
+  )
+  assert.equal(
+    await page.getByTestId('sent-prompt-annotation').count(),
+    sentAnnotationStart,
+    'unaccepted annotations must remain drafts instead of duplicating into history',
   )
   assert.equal(
     await page.locator('.chat-prompt-annotation-chip').count(),
@@ -1771,9 +1802,31 @@ try {
     0,
     'a disconnected send must not publish an acceptance event',
   )
-  evidence.annotationSendFailureRetained = true
+  evidence.annotationUnknownSendPreserved = true
 
   await submitChatComposer(page)
+  await page.waitForFunction(
+    () => window.__opensquillaV1ReplayedChatSendRequest !== null,
+    undefined,
+    { timeout: TIMEOUT_MS },
+  )
+  const replayedAnnotationRequests = await page.evaluate(() => ({
+    dropped: window.__opensquillaV1DroppedChatSendRequest,
+    replayed: window.__opensquillaV1ReplayedChatSendRequest,
+  }))
+  assert.ok(replayedAnnotationRequests.dropped, 'the dropped chat.send request must be captured')
+  assert.ok(replayedAnnotationRequests.replayed, 'the replayed chat.send request must be captured')
+  assert.deepEqual(
+    replayedAnnotationRequests.replayed.params,
+    replayedAnnotationRequests.dropped.params,
+    'the retry must replay the exact immutable chat.send params and request identity',
+  )
+  assert.equal(
+    replayedAnnotationRequests.replayed.params.clientRequestId,
+    replayedAnnotationRequests.dropped.params.clientRequestId,
+    'the retry must reuse the original clientRequestId',
+  )
+  evidence.annotationReplayIdentityMatched = true
   await waitFor(
     () => provider.requests.slice(annotationRequestStart)
       .some(payload => annotationToolNames(payload).length > 0),
@@ -1807,6 +1860,11 @@ try {
     timeout: TIMEOUT_MS,
   })
   assert.equal(
+    evidence.annotationAcceptanceEvents.length,
+    1,
+    'the exact replay must publish one annotation acceptance event',
+  )
+  assert.equal(
     await page.locator('.chat-prompt-annotation-chip').filter({ hasText: ANNOTATION_BODY }).count(),
     0,
     'accepted annotation must leave the composer',
@@ -1815,6 +1873,16 @@ try {
     await page.locator('.chat-prompt-annotation-chip').count(),
     0,
     'all accepted annotations must leave the composer together',
+  )
+  assert.equal(
+    await page.locator('.msg-user').count(),
+    annotationUserMessageStart + 1,
+    'the exact replay must not append a second optimistic user message',
+  )
+  assert.equal(
+    await page.getByTestId('sent-prompt-annotation').count(),
+    sentAnnotationStart + 2,
+    'the exact replay must materialize each accepted annotation exactly once',
   )
   evidence.annotationModeExitedAfterAcceptance = true
   assert.match(await versionsTab.innerText(), /3/)

--- a/desktop/electron/scripts/test-v1-html-agent-edit-e2e.mjs
+++ b/desktop/electron/scripts/test-v1-html-agent-edit-e2e.mjs
@@ -1445,7 +1445,7 @@ const evidence = {
   changesAfterAgentPatch: '',
   previewHeading: '',
   annotationModeExitedAfterAcceptance: false,
-  annotationUnknownSendPreserved: false,
+  annotationUnknownSendSettledWithoutDuplicates: false,
   annotationReplayIdentityMatched: false,
   annotationAcceptanceEvents: [],
   annotationModeAfterAcceptance: null,
@@ -1772,13 +1772,8 @@ try {
   )
   assert.equal(
     await page.locator('.msg-user').count(),
-    annotationUserMessageStart + 1,
-    'an unknown send must retain exactly one optimistic user message',
-  )
-  assert.equal(
-    await page.locator('.msg-user').last().locator('.msg-user-bubble').innerText(),
-    ANNOTATION_MESSAGE,
-    'the optimistic user message must retain the submitted text',
+    annotationUserMessageStart,
+    'an unaccepted synthetic send must not leave a duplicate user message in history',
   )
   assert.equal(
     await page.getByTestId('sent-prompt-annotation').count(),
@@ -1802,7 +1797,7 @@ try {
     0,
     'a disconnected send must not publish an acceptance event',
   )
-  evidence.annotationUnknownSendPreserved = true
+  evidence.annotationUnknownSendSettledWithoutDuplicates = true
 
   await submitChatComposer(page)
   await page.waitForFunction(
@@ -1874,15 +1869,13 @@ try {
     0,
     'all accepted annotations must leave the composer together',
   )
-  assert.equal(
-    await page.locator('.msg-user').count(),
-    annotationUserMessageStart + 1,
-    'the exact replay must not append a second optimistic user message',
-  )
-  assert.equal(
-    await page.getByTestId('sent-prompt-annotation').count(),
-    sentAnnotationStart + 2,
-    'the exact replay must materialize each accepted annotation exactly once',
+  await waitFor(
+    async () => (
+      await page.locator('.msg-user').count() === annotationUserMessageStart + 1
+      && await page.getByTestId('sent-prompt-annotation').count() === sentAnnotationStart + 2
+    ),
+    'one accepted annotation user message with two unique annotations',
+    TIMEOUT_MS,
   )
   evidence.annotationModeExitedAfterAcceptance = true
   assert.match(await versionsTab.innerText(), /3/)

--- a/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
@@ -34,6 +34,7 @@ import {
   listPendingMetaDiscards,
   persistPendingMetaDiscard,
 } from '@/utils/chat/metaDiscardOutbox'
+import { RpcTransportError } from '@/lib/rpc'
 import type {
   PendingInputWal,
   ResponseHandoffWalRecord,
@@ -3041,7 +3042,7 @@ describe('useChatSend attachment payloads', () => {
     expect(pendingAttachments.value).toEqual([failed])
   })
 
-  it('restores an unknown-acceptance send for idempotent retry', async () => {
+  it('keeps an accepted=null send out of the composer and replays its exact identity', async () => {
     const ready: Attachment = {
       kind: 'staged',
       local_id: 1,
@@ -3051,27 +3052,38 @@ describe('useChatSend attachment payloads', () => {
     }
     const pendingAttachments = ref<Attachment[]>([ready])
     const pendingSessionIntent = ref<string | null>('NEW')
-    const pendingForkBeforeMessageId = ref<string | null>('msg-B')
     const rpc = {
-      call: vi.fn().mockRejectedValue(new Error('network down')),
+      call: vi.fn()
+        .mockRejectedValueOnce(new RpcTransportError('Connection closed', null))
+        .mockResolvedValueOnce({
+          sessionKey: 'agent:main:webchat:test',
+          task_id: 'task-replayed',
+        }),
     }
     const { api, options } = makeOptions({
       rpc,
       pendingAttachments,
       pendingSessionIntent,
-      pendingForkBeforeMessageId,
     })
 
     await api.onSend()
 
-    expect(pendingAttachments.value).toEqual([ready])
-    expect(options.inputText.value).toBe('hello')
+    const firstParams = rpc.call.mock.calls[0]?.[1]
+    expect(pendingAttachments.value).toEqual([])
+    expect(options.inputText.value).toBe('')
     expect(pendingSessionIntent.value).toBe('NEW')
-    expect(pendingForkBeforeMessageId.value).toBe('msg-B')
+    expect(options.messages.value.filter(message => message.role === 'user')).toHaveLength(1)
     expect(options.messages.value[options.messages.value.length - 1]).toMatchObject({
       role: 'error',
-      text: 'Send failed: network down',
+      text: 'Send failed: Connection closed',
     })
+
+    await api.onSend()
+
+    expect(rpc.call.mock.calls[1]?.[1]).toEqual(firstParams)
+    expect(options.messages.value.filter(message => message.role === 'user')).toHaveLength(1)
+    expect(options.inputText.value).toBe('')
+    expect(pendingSessionIntent.value).toBeNull()
   })
 
   it('sends pending fork target and clears it after chat.send is accepted', async () => {
@@ -4078,13 +4090,13 @@ describe('useChatSend attachment payloads', () => {
     expect(secondParams).not.toHaveProperty('collaborationMode')
   })
 
-  it('replays an unknown-acceptance draft with its original mode and request id', async () => {
+  it('replays an unknown-acceptance attempt with its original mode and request id', async () => {
     const inputText = ref('inspect and plan')
     const pendingSessionIntent = ref<string | null>('new_chat')
     const initialCollaborationMode = ref<CollaborationMode>('plan')
     const rpc = {
       call: vi.fn()
-        .mockRejectedValueOnce(new Error('response lost'))
+        .mockRejectedValueOnce(new RpcTransportError('Connection closed', null))
         .mockResolvedValueOnce({
           sessionKey: 'agent:main:webchat:test',
           task_id: 'task-plan',
@@ -4118,7 +4130,7 @@ describe('useChatSend attachment payloads', () => {
     const initialCollaborationMode = ref<CollaborationMode>('plan')
     const rpc = {
       call: vi.fn()
-        .mockRejectedValueOnce(new Error('response lost'))
+        .mockRejectedValueOnce(new RpcTransportError('Connection closed', null))
         .mockResolvedValueOnce({
           sessionKey: 'agent:main:webchat:test',
           task_id: 'task-plan',
@@ -6810,7 +6822,7 @@ describe('useChatSend Ensemble image guard', () => {
     expect(pendingAttachments.value).toEqual([image])
   })
 
-  it('blocks a recovered image retry after the user switches to Ensemble', async () => {
+  it('blocks a recovered image retry without restoring it after switching to Ensemble', async () => {
     const image = readyAttachment('image/jpg', { name: 'photo.jpg' })
     const pendingAttachments = ref<Attachment[]>([image])
     const modelRoutingMode = ref<'off' | 'llm_ensemble'>('off')
@@ -6826,8 +6838,8 @@ describe('useChatSend Ensemble image guard', () => {
     await api.onSend()
 
     expect(rpc.call).toHaveBeenCalledOnce()
-    expect(options.inputText.value).toBe('hello')
-    expect(pendingAttachments.value).toEqual([image])
+    expect(options.inputText.value).toBe('')
+    expect(pendingAttachments.value).toEqual([])
   })
 
   it('preserves an auto-drained queued image after routing switches to Ensemble', async () => {

--- a/opensquilla-webui/src/composables/chat/useChatSend.promptAnnotations.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.promptAnnotations.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import i18n from '@/i18n'
 import { useToasts } from '@/composables/useToasts'
+import { RpcTransportError } from '@/lib/rpc'
 import type { ChatMessage, ChatPendingItem } from '@/types/chat'
 import type { PromptAnnotationSnapshot } from '@/types/promptAnnotations'
 import type {
@@ -396,6 +397,47 @@ describe('useChatSend prompt annotations', () => {
     expect(userMessages).toHaveLength(1)
     expect(userMessages[0]?.promptAnnotations?.map(item => item.annotationId))
       .toEqual(['annotation-2', 'annotation-1'])
+  })
+
+  it('keeps accepted=null annotation text out of the composer and replays its exact identity', async () => {
+    const inputText = ref('Answer the selected annotations without changing the document.')
+    const promptAnnotationIds = ref<readonly string[]>(['annotation-2', 'annotation-1'])
+    const harness = createHarness({ inputText, promptAnnotationIds })
+    harness.rpc.call
+      .mockRejectedValueOnce(new RpcTransportError('Connection closed', null))
+      .mockResolvedValueOnce({
+        sessionKey: 'agent:main:webchat:test',
+        task_id: 'task-replayed-annotation-send',
+        acceptedPromptAnnotationIds: ['annotation-2', 'annotation-1'],
+      })
+
+    await harness.api.onSend()
+
+    const firstParams = harness.rpc.call.mock.calls[0]?.[1]
+    expect(firstParams).toBeDefined()
+    expect(inputText.value).toBe('')
+    expect(promptAnnotationIds.value).toEqual(['annotation-2', 'annotation-1'])
+    const userMessagesAfterUnknown = harness.options.messages.value
+      .filter(message => message.role === 'user')
+    expect(userMessagesAfterUnknown).toHaveLength(1)
+    expect(userMessagesAfterUnknown[0]?.text)
+      .toBe('Answer the selected annotations without changing the document.')
+    expect(harness.options.acknowledgePromptAnnotations).not.toHaveBeenCalled()
+
+    await harness.api.onSend()
+
+    const secondParams = harness.rpc.call.mock.calls[1]?.[1]
+    expect(secondParams).toEqual(firstParams)
+    expect(secondParams?.clientRequestId).toBe(firstParams?.clientRequestId)
+    expect(harness.options.messages.value.filter(message => message.role === 'user'))
+      .toHaveLength(1)
+    expect(inputText.value).toBe('')
+    expect(harness.options.acknowledgePromptAnnotations).toHaveBeenCalledOnce()
+    expect(harness.options.acknowledgePromptAnnotations).toHaveBeenCalledWith(
+      ['annotation-2', 'annotation-1'],
+      ['annotation-2', 'annotation-1'],
+      'agent:main:webchat:test',
+    )
   })
 
   it('acknowledges accepted annotations exactly once after receipt recovery', async () => {

--- a/opensquilla-webui/src/composables/chat/useChatSend.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.ts
@@ -3224,16 +3224,22 @@ export function useChatSend(options: UseChatSendOptions) {
       const acceptedSessionKey = acceptedError?.sessionKey || requestSessionKey
       const rememberRetryableAttempt = (restoreComposer: boolean) => {
         if (!shouldRestoreSendAttempt(err)) return
-        attempt.requiresIdempotentReplay = hasUnknownAcceptance(err)
+        const acceptanceUnknown = hasUnknownAcceptance(err)
+        attempt.requiresIdempotentReplay = acceptanceUnknown
         if (preserveComposer) {
           if (sendOpts.rememberRetryableAttempt) {
             sendOpts.rememberRetryableAttempt(attempt)
           } else {
             recoveredAttempt = attempt
           }
+        } else if (acceptanceUnknown) {
+          // The optimistic user bubble already owns this payload. Keep its
+          // immutable request identity for exact replay without presenting the
+          // same text as a new editable draft.
+          recoveredAttempt = attempt
         } else if (restoreComposer) {
           restoreSendAttempt(attempt, {
-            requiresIdempotentReplay: hasUnknownAcceptance(err),
+            requiresIdempotentReplay: false,
           })
         }
       }


### PR DESCRIPTION
## Scope

Scope boundary: Keep an ordinary chat send with unknown RPC acceptance attached to its existing optimistic bubble and immutable SendAttempt instead of restoring it into the composer. Exact retry reuses the original request parameters and clientRequestId.

Non-goals: No changes to accepted=false restoration, durable outbox storage, IndexedDB, RPC protocol, Gateway behavior, or backend persistence.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Tracked in the project’s internal bug backlog rather than a public GitHub Issue.

## Release Note

Release note: Prevent chat sends with an unknown acceptance state from reappearing in the composer.

## Tests

Ruff: N/A (frontend-only change)

Pytest: N/A (frontend-only change)

Build: `cd opensquilla-webui && npm run typecheck`

Regression tests: added

Notes:
- Targeted accepted=null and accepted=false regression selection: 3 passed.
- Full `useChatSend.attachments.test.ts`: 233 passed.
- Architecture, chat security, theme, i18n, and Vue TypeScript checks passed.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents have not been committed.

The change is platform-neutral browser state handling and does not alter persisted or public contracts.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No documentation files changed.
- [x] No links or examples were added.
- [x] No user or environment-specific data was added.
