### PR TITLE
Fix deleted subagent session cards

### DIFF
--- a/opensquilla-webui/e2e/session-created-card.spec.ts
+++ b/opensquilla-webui/e2e/session-created-card.spec.ts
@@ -9,9 +9,18 @@ function response(id: string | number | undefined, payload: unknown) {
   return JSON.stringify({ type: 'res', id, ok: true, payload })
 }
 
+function errorResponse(id: string | number | undefined, code: string, message: string) {
+  return JSON.stringify({
+    type: 'res',
+    id,
+    ok: false,
+    error: { code, message, retryable: false },
+  })
+}
+
 async function mockSessionCreatedHistory(
   page: Page,
-  options: { liveHandoff?: boolean } = {},
+  options: { liveHandoff?: boolean, deletedFirstChild?: boolean } = {},
 ) {
   await page.addInitScript(() => {
     window.localStorage.setItem('opensquilla-locale', 'en')
@@ -42,6 +51,14 @@ async function mockSessionCreatedHistory(
       }
       if (method === 'chat.history') {
         const sessionKey = String(params.sessionKey || '')
+        if (options.deletedFirstChild && sessionKey === FIRST_CHILD_KEY) {
+          ws.send(errorResponse(
+            frame.id as string | number | undefined,
+            'NOT_FOUND',
+            'Session not found',
+          ))
+          return
+        }
         if (sessionKey === PARENT_KEY) {
           if (options.liveHandoff) {
             ws.send(response(frame.id as string | number | undefined, {
@@ -72,7 +89,11 @@ async function mockSessionCreatedHistory(
                 tool_calls: [{
                   tool_use_id: 'spawn-first',
                   name: 'sessions_spawn',
-                  result: JSON.stringify({ session_key: FIRST_CHILD_KEY, status: 'queued' }),
+                  result: JSON.stringify({
+                    session_key: FIRST_CHILD_KEY,
+                    status: 'queued',
+                    title: 'Inspect first child',
+                  }),
                   execution_status: { status: 'success' },
                 }],
               }],
@@ -104,12 +125,20 @@ async function mockSessionCreatedHistory(
               tool_calls: [{
                 tool_use_id: 'spawn-first',
                 name: 'sessions_spawn',
-                result: JSON.stringify({ session_key: FIRST_CHILD_KEY, status: 'queued' }),
+                result: JSON.stringify({
+                  session_key: FIRST_CHILD_KEY,
+                  status: 'queued',
+                  title: 'Inspect first child',
+                }),
                 execution_status: { status: 'success' },
               }, {
                 tool_use_id: 'spawn-second',
                 name: 'sessions_spawn',
-                result: JSON.stringify({ session_key: SECOND_CHILD_KEY, status: 'queued' }),
+                result: JSON.stringify({
+                  session_key: SECOND_CHILD_KEY,
+                  status: 'queued',
+                  title: 'Verify second child',
+                }),
                 execution_status: { status: 'success' },
               }],
             }, {
@@ -196,6 +225,31 @@ async function mockSessionCreatedHistory(
         }))
         return
       }
+      if (method === 'sessions.resolve') {
+        const key = String(params.key || '')
+        if (options.deletedFirstChild && key === FIRST_CHILD_KEY) {
+          ws.send(errorResponse(
+            frame.id as string | number | undefined,
+            'NOT_FOUND',
+            'Session not found',
+          ))
+        } else {
+          ws.send(response(frame.id as string | number | undefined, { session_key: key }))
+        }
+        return
+      }
+      if (
+        method === 'sessions.messages.subscribe'
+        && options.deletedFirstChild
+        && String(params.key || '') === FIRST_CHILD_KEY
+      ) {
+        ws.send(errorResponse(
+          frame.id as string | number | undefined,
+          'SESSION_NOT_FOUND',
+          'Session was deleted or does not exist.',
+        ))
+        return
+      }
       const payloads: Record<string, unknown> = {
         'agents.list': { agents: [] },
         'commands.list_for_surface': { commands: [] },
@@ -247,7 +301,8 @@ test('restores ordered created-chat cards and opens the selected child session',
   await expect(cards).toHaveCount(2)
   await expect(cards.nth(0)).toHaveAttribute('data-session-key', FIRST_CHILD_KEY)
   await expect(cards.nth(1)).toHaveAttribute('data-session-key', SECOND_CHILD_KEY)
-  await expect(cards.nth(0)).toContainText('Chat created')
+  await expect(cards.nth(0)).toContainText('Inspect first child')
+  await expect(cards.nth(1)).toContainText('Verify second child')
   await expect(page.getByText('session_key')).toHaveCount(0)
   await expect(page.getByText('Sub-agent', { exact: true })).toHaveCount(0)
   await expect(page.getByText('subagent_completion')).toHaveCount(0)
@@ -257,7 +312,7 @@ test('restores ordered created-chat cards and opens the selected child session',
   await expect(finalReply.getByTestId('session-created-card')).toHaveCount(2)
   await expect.poll(async () => {
     const text = await finalReply.innerText()
-    return text.indexOf('Parent final reply') < text.indexOf('Chat created')
+    return text.indexOf('Parent final reply') < text.indexOf('Inspect first child')
   }).toBe(true)
 
   await page.reload()
@@ -270,6 +325,35 @@ test('restores ordered created-chat cards and opens the selected child session',
   await expect.poll(() => new URL(page.url()).searchParams.get('session')).toBe(SECOND_CHILD_KEY)
   await expect(page.getByText(`Opened child session ${SECOND_CHILD_KEY}`)).toBeVisible()
   await expect(page.getByRole('group', { name: 'Router selected deepseek-v4-pro' })).toBeVisible()
+})
+
+test('disables a deleted child card and keeps the sibling openable', async ({ page }) => {
+  await mockSessionCreatedHistory(page, { deletedFirstChild: true })
+  await page.goto(CONTROL_URL + 'chat?session=' + encodeURIComponent(PARENT_KEY))
+
+  const cards = page.getByTestId('session-created-card')
+  await expect(cards).toHaveCount(2)
+  await expect(cards.nth(0)).toHaveAttribute('data-session-state', 'available')
+  await expect(cards.nth(0).getByRole('button', { name: 'Open chat' })).toBeEnabled()
+  await cards.nth(0).getByRole('button', { name: 'Open chat' }).click()
+  await expect(cards.nth(0)).toHaveAttribute('data-session-state', 'missing')
+  await expect(cards.nth(0)).toContainText('Inspect first child')
+  await expect(cards.nth(0)).toContainText('Deleted')
+  await expect(cards.nth(0).getByRole('button', { name: 'Deleted' })).toBeDisabled()
+  await expect.poll(() => new URL(page.url()).searchParams.get('session')).toBe(PARENT_KEY)
+  await expect(cards.nth(1)).toHaveAttribute('data-session-state', 'available')
+
+  await cards.nth(1).getByRole('button', { name: 'Open chat' }).click()
+  await expect.poll(() => new URL(page.url()).searchParams.get('session')).toBe(SECOND_CHILD_KEY)
+})
+
+test('shows one terminal state for a missing child deep link', async ({ page }) => {
+  await mockSessionCreatedHistory(page, { deletedFirstChild: true })
+  await page.goto(CONTROL_URL + 'chat?session=' + encodeURIComponent(FIRST_CHILD_KEY))
+
+  await expect(page.getByText('Session was deleted or does not exist')).toBeVisible()
+  await expect(page.getByText('Conversation history temporarily unavailable')).toHaveCount(0)
+  await expect(page.getByText('Turn failed')).toHaveCount(0)
 })
 
 test('keeps only the router above a created-chat card during the parent handoff', async ({ page }) => {

--- a/opensquilla-webui/src/components/chat/AssistantMessage.session-created.test.ts
+++ b/opensquilla-webui/src/components/chat/AssistantMessage.session-created.test.ts
@@ -46,7 +46,11 @@ function timeline(call: ChatToolCall): ChatStreamTimelineItem[] {
   }]
 }
 
-async function mount(message: ChatRenderedMessage, onOpenSession = vi.fn()) {
+async function mount(
+  message: ChatRenderedMessage,
+  onOpenSession = vi.fn(),
+  resolveSessionAvailability?: (sessionKey: string) => Promise<boolean>,
+) {
   const el = document.createElement('div')
   document.body.appendChild(el)
   const app = createApp(AssistantMessage, {
@@ -67,6 +71,7 @@ async function mount(message: ChatRenderedMessage, onOpenSession = vi.fn()) {
     toolSecondaryText: () => '',
     copyMessage: async () => true,
     onOpenSession,
+    resolveSessionAvailability,
   })
   apps.push(app)
   app.use(i18n)
@@ -105,7 +110,7 @@ describe('AssistantMessage created session cards', () => {
     }))
 
     expect(el.querySelectorAll('[data-testid="session-created-card"]')).toHaveLength(1)
-    expect(el.textContent).toContain('Chat created')
+    expect(el.textContent).toContain('Chat abc12345')
     expect(el.textContent).not.toContain('session_key')
     expect(el.querySelector('.tool-row')).toBeNull()
 
@@ -128,6 +133,38 @@ describe('AssistantMessage created session cards', () => {
       'agent:main:subagent:abc12345',
       'agent:main:subagent:def67890',
     ])
+    expect(el.textContent).toContain('Chat abc12345')
+    expect(el.textContent).toContain('Chat def67890')
+  })
+
+  it('shows the spawn title and disables a card when the session was deleted', async () => {
+    const call = spawnCall({
+      result: JSON.stringify({
+        session_key: 'agent:main:subagent:abc12345',
+        title: 'Inspect session cleanup',
+      }),
+    })
+    const onOpenSession = vi.fn()
+    const resolveSessionAvailability = vi.fn().mockResolvedValue(false)
+    const { el } = await mount(
+      message({ toolCalls: [call], timelineItems: timeline(call) }),
+      onOpenSession,
+      resolveSessionAvailability,
+    )
+
+    expect(resolveSessionAvailability).not.toHaveBeenCalled()
+    el.querySelector<HTMLButtonElement>('.session-created-card__open')?.click()
+    await vi.waitFor(() => {
+      expect(el.querySelector('[data-testid="session-created-card"]')
+        ?.getAttribute('data-session-state')).toBe('missing')
+    })
+    expect(el.textContent).toContain('Inspect session cleanup')
+    expect(el.textContent).toContain('Deleted')
+    const button = el.querySelector<HTMLButtonElement>('.session-created-card__open')
+    expect(button?.disabled).toBe(true)
+    button?.click()
+    expect(onOpenSession).not.toHaveBeenCalled()
+    expect(resolveSessionAvailability).toHaveBeenCalledTimes(1)
   })
 
   it('keeps malformed and failed results out of the semantic card surface', async () => {
@@ -158,6 +195,6 @@ describe('AssistantMessage created session cards', () => {
       }],
     }))
     const replyText = target.el.textContent || ''
-    expect(replyText.indexOf('Parent final reply')).toBeLessThan(replyText.indexOf('Chat created'))
+    expect(replyText.indexOf('Parent final reply')).toBeLessThan(replyText.indexOf('Chat abc12345'))
   })
 })

--- a/opensquilla-webui/src/components/chat/AssistantMessage.vue
+++ b/opensquilla-webui/src/components/chat/AssistantMessage.vue
@@ -230,6 +230,8 @@
         v-for="createdSession in createdSessions"
         :key="createdSession.callId"
         :session-key="createdSession.sessionKey"
+        :title="createdSession.title"
+        :resolve-session-availability="resolveSessionAvailability"
         @open="$emit('openSession', $event)"
       />
 
@@ -526,6 +528,7 @@ const props = defineProps<{
   showTurnOutcome?: boolean
   goalOutcome?: GoalSnapshot | null
   goalElapsed?: string
+  resolveSessionAvailability?: (sessionKey: string) => Promise<boolean>
 }>()
 
 const emit = defineEmits<{

--- a/opensquilla-webui/src/components/chat/ChatMessageList.vue
+++ b/opensquilla-webui/src/components/chat/ChatMessageList.vue
@@ -92,6 +92,7 @@
           :show-turn-outcome="isTurnTip(entry.index)"
           :goal-outcome="goalOutcomeFor(messages[entry.index], entry.index)"
           :goal-elapsed="goalElapsed"
+          :resolve-session-availability="resolveSessionAvailability"
           @fork="$emit('forkConversation', forkThroughTurnId(entry.index))"
           @regenerate="$emit('regenerateMessage', $event)"
           @toggle-share="$emit('toggleShareMessage', $event)"
@@ -203,6 +204,7 @@ const props = defineProps<{
   isStreaming?: boolean
   goal?: GoalSnapshot | null
   goalElapsed?: string
+  resolveSessionAvailability?: (sessionKey: string) => Promise<boolean>
   /** Required for long-history virtualization; omitted by legacy embedders. */
   scrollContainer?: HTMLElement | null
   /** Session/render epoch used to invalidate deferred scroll corrections. */

--- a/opensquilla-webui/src/components/chat/ChatSessionRecoveryStatus.vue
+++ b/opensquilla-webui/src/components/chat/ChatSessionRecoveryStatus.vue
@@ -26,7 +26,7 @@
       <span v-if="description">{{ description }}</span>
     </span>
     <button
-      v-if="isFailure"
+      v-if="isRetryableFailure"
       type="button"
       class="chat-session-recovery-status__retry btn btn--ghost"
       data-testid="chat-session-recovery-retry"
@@ -55,6 +55,11 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const statusRef = ref<HTMLElement | null>(null)
 const isFailure = computed(() => (
+  props.state === 'history-error'
+  || props.state === 'live-degraded'
+  || props.state === 'session-missing'
+))
+const isRetryableFailure = computed(() => (
   props.state === 'history-error' || props.state === 'live-degraded'
 ))
 const isBusy = computed(() => !isFailure.value)
@@ -70,6 +75,8 @@ const title = computed(() => {
       return t('chat.liveConnecting')
     case 'live-degraded':
       return t('chat.liveUnavailable')
+    case 'session-missing':
+      return t('chat.sessionCreated.missing')
   }
 })
 const description = computed(() => {
@@ -84,6 +91,8 @@ const description = computed(() => {
       return ''
     case 'live-degraded':
       return t('chat.liveUnavailableDescription')
+    case 'session-missing':
+      return ''
   }
 })
 const action = computed(() => (
@@ -122,7 +131,8 @@ function requestRetry() {
 }
 
 .chat-session-recovery-status--history-error,
-.chat-session-recovery-status--live-degraded {
+.chat-session-recovery-status--live-degraded,
+.chat-session-recovery-status--session-missing {
   background: color-mix(in srgb, var(--warn) 8%, var(--bg-surface));
   border-color: color-mix(in srgb, var(--warn) 35%, var(--border));
 }

--- a/opensquilla-webui/src/components/chat/ClarifyCard.source.test.ts
+++ b/opensquilla-webui/src/components/chat/ClarifyCard.source.test.ts
@@ -57,7 +57,9 @@ describe('ClarifyCard submit feedback', () => {
     expect(chatViewSource).toContain(':submitted="clarifySubmitted"')
     expect(chatViewSource).not.toContain("&& !clarifySubmitted.value")
     expect(chatViewSource).toContain(
-      ':input-disabled="Boolean(dockedPlanQuestionnaire) || Boolean(forkTransition)"',
+      `:input-disabled="Boolean(dockedPlanQuestionnaire)
+        || Boolean(forkTransition)
+        || historyState.sessionMissing"`,
     )
     expect(composerSource).toContain(':disabled="inputDisabled"')
   })

--- a/opensquilla-webui/src/components/chat/SessionCreatedCard.vue
+++ b/opensquilla-webui/src/components/chat/SessionCreatedCard.vue
@@ -3,36 +3,77 @@
     class="session-created-card"
     data-testid="session-created-card"
     :data-session-key="sessionKey"
+    :data-session-state="availability"
   >
     <span class="session-created-card__identity">
       <Icon name="chat" :size="17" />
-      <span>{{ t('chat.sessionCreated.title') }}</span>
+      <span>{{ displayTitle }}</span>
     </span>
     <button
       type="button"
       class="session-created-card__open"
-      :aria-label="t('chat.sessionCreated.open')"
-      @click="$emit('open', sessionKey)"
+      :aria-label="availability === 'missing'
+        ? t('chat.sessionCreated.deleted')
+        : t('chat.sessionCreated.open')"
+      :disabled="availability !== 'available'"
+      @click="openSession"
     >
-      {{ t('chat.sessionCreated.open') }}
-      <Icon name="chevronRight" :size="15" />
+      {{ availability === 'missing'
+        ? t('chat.sessionCreated.deleted')
+        : t('chat.sessionCreated.open') }}
+      <Icon v-if="availability !== 'missing'" name="chevronRight" :size="15" />
     </button>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/Icon.vue'
 
-defineProps<{
+const props = defineProps<{
   sessionKey: string
+  title?: string
+  resolveSessionAvailability?: (sessionKey: string) => Promise<boolean>
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   open: [sessionKey: string]
 }>()
 
 const { t } = useI18n()
+const availability = ref<'checking' | 'available' | 'missing'>('available')
+
+const displayTitle = computed(() => {
+  const title = props.title?.trim()
+  if (title) return title
+  const segments = props.sessionKey.split(':')
+  const suffix = segments[segments.length - 1]?.slice(-8) || props.sessionKey.slice(-8)
+  return t('chat.sessionCreated.fallbackTitle', { suffix })
+})
+
+async function openSession() {
+  if (availability.value !== 'available') return
+  const sessionKey = props.sessionKey
+  const resolveAvailability = props.resolveSessionAvailability
+  if (!resolveAvailability) {
+    emit('open', sessionKey)
+    return
+  }
+  availability.value = 'checking'
+  try {
+    const available = await resolveAvailability(sessionKey)
+    if (props.sessionKey !== sessionKey) return
+    availability.value = available ? 'available' : 'missing'
+    if (available) emit('open', sessionKey)
+  } catch {
+    // Preserve legacy navigation on transient failures. Only an authoritative
+    // not-found result disables the historical card.
+    if (props.sessionKey !== sessionKey) return
+    availability.value = 'available'
+    emit('open', sessionKey)
+  }
+}
 </script>
 
 <style scoped>
@@ -69,6 +110,12 @@ const { t } = useI18n()
   color: var(--text-muted);
 }
 
+.session-created-card__identity > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .session-created-card__open {
   flex: 0 0 auto;
   gap: var(--sp-1);
@@ -85,6 +132,16 @@ const { t } = useI18n()
 .session-created-card__open:hover {
   background: var(--bg-hover);
   color: var(--text);
+}
+
+.session-created-card__open:disabled {
+  cursor: default;
+  opacity: var(--state-disabled-opacity);
+}
+
+.session-created-card__open:disabled:hover {
+  background: transparent;
+  color: var(--text-muted);
 }
 
 .session-created-card__open:focus-visible {

--- a/opensquilla-webui/src/composables/chat/useChatHistory.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatHistory.test.ts
@@ -830,6 +830,21 @@ describe('useChatHistory canonical pagination', () => {
     })
   })
 
+  it('classifies a missing session separately from a retryable history failure', async () => {
+    const { api, rpc } = makeHistory()
+    rpc.call.mockRejectedValueOnce(Object.assign(new Error('missing'), {
+      code: 'NOT_FOUND',
+    }))
+
+    await api.loadHistory()
+
+    expect(api.historyState.value).toMatchObject({
+      initialLoadStatus: 'error',
+      recoveryError: true,
+      sessionMissing: true,
+    })
+  })
+
   it('keeps loaded messages visible and exposes an inline recovery error after refresh fails', async () => {
     const { api, rpc, messages } = makeHistory()
     await api.loadHistory()

--- a/opensquilla-webui/src/composables/chat/useChatHistory.ts
+++ b/opensquilla-webui/src/composables/chat/useChatHistory.ts
@@ -33,6 +33,7 @@ import {
   isRpcAbort,
   phaseCallOptions,
   phaseTimeoutMs,
+  rpcErrorCode,
   type SessionBootstrapPhaseContext,
   type SessionPhaseResult,
 } from '@/composables/chat/sessionBootstrapContract'
@@ -668,6 +669,7 @@ export interface ChatHistoryState {
   initialLoadStatus: InitialHistoryLoadStatus
   loadEarlierError: boolean
   recoveryError: boolean
+  sessionMissing: boolean
 }
 
 interface HistoryLoadParams {
@@ -727,6 +729,7 @@ export function useChatHistory(options: UseChatHistoryOptions) {
     initialLoadStatus: 'pending',
     loadEarlierError: false,
     recoveryError: false,
+    sessionMissing: false,
   })
 
   function cancelAnchorStabilization() {
@@ -882,6 +885,7 @@ export function useChatHistory(options: UseChatHistoryOptions) {
         : initialLoadError ? 'error' : 'ready',
       loadEarlierError: false,
       recoveryError: prepend ? historyState.value.recoveryError : initialLoadError,
+      sessionMissing: false,
     }
   }
 
@@ -910,6 +914,7 @@ export function useChatHistory(options: UseChatHistoryOptions) {
       initialLoadStatus: 'pending',
       loadEarlierError: false,
       recoveryError: false,
+      sessionMissing: false,
     }
     return crossedSession
   }
@@ -1346,6 +1351,8 @@ export function useChatHistory(options: UseChatHistoryOptions) {
             : historyState.value.initialLoadStatus,
           loadEarlierError: Boolean(params.prepend),
           recoveryError: !params.prepend,
+          sessionMissing: !params.prepend
+            && ['NOT_FOUND', 'SESSION_NOT_FOUND'].includes(rpcErrorCode(error)),
         }
         flushPendingHistorySync()
       }

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -3313,7 +3313,10 @@
   "chat": {
     "sessionCreated": {
       "title": "Chat erstellt",
-      "open": "Chat öffnen"
+      "open": "Chat öffnen",
+      "fallbackTitle": "Chat {suffix}",
+      "deleted": "Gelöscht",
+      "missing": "Die Sitzung wurde gelöscht oder ist nicht vorhanden"
     },
     "promptCacheKeepalive": {
       "action": "Prompt-Cache aktiv halten",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -3401,7 +3401,10 @@
   "chat": {
     "sessionCreated": {
       "title": "Chat created",
-      "open": "Open chat"
+      "open": "Open chat",
+      "fallbackTitle": "Chat {suffix}",
+      "deleted": "Deleted",
+      "missing": "Session was deleted or does not exist"
     },
     "promptCacheKeepalive": {
       "action": "Prompt cache keepalive",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -3313,7 +3313,10 @@
   "chat": {
     "sessionCreated": {
       "title": "Chat creado",
-      "open": "Abrir chat"
+      "open": "Abrir chat",
+      "fallbackTitle": "Chat {suffix}",
+      "deleted": "Eliminado",
+      "missing": "La sesión se eliminó o no existe"
     },
     "promptCacheKeepalive": {
       "action": "Mantener caché del prompt",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -3313,7 +3313,10 @@
   "chat": {
     "sessionCreated": {
       "title": "Discussion créée",
-      "open": "Ouvrir la discussion"
+      "open": "Ouvrir la discussion",
+      "fallbackTitle": "Discussion {suffix}",
+      "deleted": "Supprimée",
+      "missing": "La session a été supprimée ou n’existe pas"
     },
     "promptCacheKeepalive": {
       "action": "Maintien du cache de prompt",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -3313,7 +3313,10 @@
   "chat": {
     "sessionCreated": {
       "title": "チャットを作成しました",
-      "open": "チャットを開く"
+      "open": "チャットを開く",
+      "fallbackTitle": "チャット {suffix}",
+      "deleted": "削除済み",
+      "missing": "セッションは削除されたか存在しません"
     },
     "promptCacheKeepalive": {
       "action": "プロンプトキャッシュの維持",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -3401,7 +3401,10 @@
   "chat": {
     "sessionCreated": {
       "title": "聊天已创建",
-      "open": "打开聊天"
+      "open": "打开聊天",
+      "fallbackTitle": "聊天 {suffix}",
+      "deleted": "已删除",
+      "missing": "会话已删除或不存在"
     },
     "promptCacheKeepalive": {
       "action": "提示词缓存保活",

--- a/opensquilla-webui/src/types/chat.ts
+++ b/opensquilla-webui/src/types/chat.ts
@@ -672,6 +672,7 @@ export interface ChatMessageMeta {
 export interface ChatCreatedSessionLink {
   callId: string
   sessionKey: string
+  title?: string
 }
 
 export interface ChatRenderedMessage {

--- a/opensquilla-webui/src/utils/chat/createdSessions.test.ts
+++ b/opensquilla-webui/src/utils/chat/createdSessions.test.ts
@@ -93,6 +93,20 @@ describe('created session tool results', () => {
     ])
   })
 
+  it('keeps an optional normalized title without changing legacy results', () => {
+    expect(createdSessionFromToolCall(call({
+      result: JSON.stringify({
+        session_key: 'agent:main:subagent:abc12345',
+        title: '  Inspect session cleanup  ',
+      }),
+    }))).toEqual({
+      callId: 'spawn-1',
+      sessionKey: 'agent:main:subagent:abc12345',
+      title: 'Inspect session cleanup',
+    })
+    expect(createdSessionFromToolCall(call())).not.toHaveProperty('title')
+  })
+
   it('restores links from legacy messages that only carry toolCalls', () => {
     expect(createdSessionsFromMessage(message({ toolCalls: [call()] }))).toEqual([
       { callId: 'spawn-1', sessionKey: 'agent:main:subagent:abc12345' },

--- a/opensquilla-webui/src/utils/chat/createdSessions.ts
+++ b/opensquilla-webui/src/utils/chat/createdSessions.ts
@@ -25,8 +25,7 @@ function resultRecord(value: unknown): Record<string, unknown> | null {
     : null
 }
 
-function spawnedSessionKey(value: unknown): string | null {
-  const record = resultRecord(value)
+function spawnedSessionKey(record: Record<string, unknown> | null): string | null {
   const key = typeof record?.session_key === 'string'
     ? record.session_key.trim()
     : ''
@@ -43,11 +42,14 @@ export function createdSessionFromToolCall(
     || call.isError
     || call.status !== 'success'
   ) return null
-  const sessionKey = spawnedSessionKey(call.result)
+  const record = resultRecord(call.result)
+  const sessionKey = spawnedSessionKey(record)
   if (!sessionKey) return null
+  const title = typeof record?.title === 'string' ? record.title.trim() : ''
   return {
     callId: call.toolId,
     sessionKey,
+    ...(title ? { title } : {}),
   }
 }
 

--- a/opensquilla-webui/src/utils/chat/sessionLoadState.ts
+++ b/opensquilla-webui/src/utils/chat/sessionLoadState.ts
@@ -8,6 +8,7 @@ export type ChatSessionRecoveryState =
   | Exclude<ChatHistoryRecoveryState, null>
   | 'live-connecting'
   | 'live-degraded'
+  | 'session-missing'
 
 export interface ResolveChatHistoryRecoveryStateOptions {
   isDraftLanding: boolean

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -139,7 +139,12 @@
           </div>
         </template>
         <ChatSessionRecoveryStatus
-          v-if="!forkTransition && visibleHistoryRecoveryState"
+          v-if="!forkTransition && historyState.sessionMissing"
+          :key="`${sessionKey}:missing`"
+          state="session-missing"
+        />
+        <ChatSessionRecoveryStatus
+          v-else-if="!forkTransition && visibleHistoryRecoveryState"
           :key="`${sessionKey}:history`"
           :state="visibleHistoryRecoveryState"
           @retry="retryHistory"
@@ -157,7 +162,7 @@
           {{ t('chat.noMessagesYet') }}
         </div>
         <HistoryLoadSentinel
-          v-if="!isNewChatLanding && !forkTransition"
+          v-if="!isNewChatLanding && !forkTransition && !historyState.sessionMissing"
           :scroll-container="threadRef"
           :has-more="historyState.hasMore"
           :loading="historyState.loadingEarlier"
@@ -172,6 +177,7 @@
         />
 
         <div
+          v-if="!historyState.sessionMissing"
           class="chat-message-surface"
           :class="{ 'chat-message-surface--preview': forkTransition }"
           :inert="forkTransition ? true : undefined"
@@ -214,6 +220,7 @@
           :scroll-epoch="scrollEpoch"
           :goal="currentGoalRun"
           :goal-elapsed="goalLastElapsed"
+          :resolve-session-availability="resolveCreatedSessionAvailability"
           @fork-conversation="forkConversation"
           @edit-message="editMessage"
           @edit-attachment="editAttachmentResource"
@@ -653,7 +660,9 @@
       :placeholder="composerPlaceholder"
       :send-button-title="sendButtonTitle"
       :send-blocked-message="composerSendBlockedMessage"
-      :input-disabled="Boolean(dockedPlanQuestionnaire) || Boolean(forkTransition)"
+      :input-disabled="Boolean(dockedPlanQuestionnaire)
+        || Boolean(forkTransition)
+        || historyState.sessionMissing"
       :run-mode="runMode"
       :allowed-run-modes="composerAllowedRunModes"
       :safe-setup-available="composerSafeSetupAvailable"
@@ -904,7 +913,10 @@ import {
   type RunModePolicy,
 } from '@/composables/chat/useChatRunModePreference'
 import { useChatSessionBootstrap } from '@/composables/chat/useChatSessionBootstrap'
-import { autoSendDraftIsUnchanged } from '@/composables/chat/sessionBootstrapContract'
+import {
+  autoSendDraftIsUnchanged,
+  rpcErrorCode,
+} from '@/composables/chat/sessionBootstrapContract'
 import {
   acquireSessionBootstrapAdmission,
   claimSessionBootstrapAdmission,
@@ -1142,6 +1154,17 @@ const toolResultModal = ref<{
 /* ── Stores / Router ───────────────────────────────────────────────── */
 
 const rpc = useRpcStore()
+
+async function resolveCreatedSessionAvailability(sessionKey: string): Promise<boolean> {
+  try {
+    await rpc.call('sessions.resolve', { key: sessionKey })
+    return true
+  } catch (error: unknown) {
+    const code = rpcErrorCode(error)
+    if (code === 'NOT_FOUND' || code === 'SESSION_NOT_FOUND') return false
+    throw error
+  }
+}
 const sandboxSetupStore = useSandboxSetupStore()
 const {
   ensuring: sandboxSetupPending,
@@ -4201,6 +4224,7 @@ watch(isNewChatLanding, landing => {
 }, { flush: 'post' })
 
 const historyRecoveryState = computed(() => {
+  if (historyState.value.sessionMissing) return null
   return resolveChatHistoryRecoveryState({
     isDraftLanding: isNewChatLanding.value,
     initialHistoryStatus: historyState.value.initialLoadStatus,
@@ -4214,6 +4238,7 @@ const visibleHistoryRecoveryState = computed(() => (
 ))
 
 const liveRecoveryState = computed(() => {
+  if (historyState.value.sessionMissing) return null
   if (livePhase.value === 'degraded') return 'live-degraded' as const
   if (
     livePhase.value === 'connecting'

--- a/src/opensquilla/gateway/rpc_sessions.py
+++ b/src/opensquilla/gateway/rpc_sessions.py
@@ -10029,6 +10029,7 @@ async def _delete_session_with_lifecycle(
 
         get_approval_queue().expire_pending_for_session(canonical_key)
         await storage.delete_session(canonical_key)
+        get_session_streams().evict(canonical_key)
         for pending_input_id, session_ids in pending_material_owners.items():
             _cleanup_pending_input_scopes(
                 ctx=ctx,
@@ -11364,6 +11365,16 @@ async def _hydrate_sessions_messages_metadata(
 @_d.method("sessions.messages.subscribe", scope="operator.read")
 async def _handle_sessions_messages_subscribe(params: dict | None, ctx: RpcContext) -> dict:
     key = _require_key(params)
+    if ":subagent:" in key:
+        storage = get_session_storage(getattr(ctx, "session_manager", None))
+        session = await storage.get_session(key) if storage is not None else None
+        if session is None:
+            raise RpcHandlerError(
+                "SESSION_NOT_FOUND",
+                "Session was deleted or does not exist.",
+                retryable=False,
+                accepted=False,
+            )
     fast_ack = (params or {}).get("fast_ack") is True
     subscription_mgr = getattr(ctx, "subscription_manager", None)
     registered_new = False

--- a/src/opensquilla/gateway/session_streams.py
+++ b/src/opensquilla/gateway/session_streams.py
@@ -85,6 +85,7 @@ class SessionStreamRegistry:
         # persists its terminal row. Build the allowlisted v2 immediately and
         # retain only that sanitized, identity-bound value across the handoff.
         self._terminal_activity_snapshots_by_task: dict[str, dict[str, Any]] = {}
+        self._terminal_session_by_task: dict[str, str] = {}
         self._terminal_task_order: deque[str] = deque()
         self._completed_events_by_session: dict[str, deque[BufferedSessionEvent]] = {}
         self._reset_stream_seqs_by_session: dict[str, list[int]] = {}
@@ -229,12 +230,14 @@ class SessionStreamRegistry:
         if task_id not in self._terminal_activity_snapshots_by_task:
             self._terminal_task_order.append(task_id)
         self._terminal_activity_snapshots_by_task[task_id] = snapshot
+        self._terminal_session_by_task[task_id] = session_key
         # Terminal persistence normally consumes immediately. This defensive
         # bound covers crashes in the finalizer without retaining raw events
         # or whole runs for the process lifetime.
         while len(self._terminal_task_order) > 64:
             stale_task_id = self._terminal_task_order.popleft()
             self._terminal_activity_snapshots_by_task.pop(stale_task_id, None)
+            self._terminal_session_by_task.pop(stale_task_id, None)
 
     def take_terminal_activity_snapshot(
         self,
@@ -248,6 +251,7 @@ class SessionStreamRegistry:
 
         frozen = self._terminal_activity_snapshots_by_task.pop(task_id, None)
         if frozen is not None:
+            self._terminal_session_by_task.pop(task_id, None)
             try:
                 self._terminal_task_order.remove(task_id)
             except ValueError:
@@ -274,6 +278,31 @@ class SessionStreamRegistry:
             task_id=task_id,
             turn_id=turn_id,
         )
+
+    def evict(self, session_key: str) -> None:
+        """Discard every process-local stream artifact owned by one session."""
+
+        self._seq_by_session.pop(session_key, None)
+        self._events_by_session.pop(session_key, None)
+        self._clear_live_state(session_key)
+        self._completed_events_by_session.pop(session_key, None)
+        self._reset_stream_seqs_by_session.pop(session_key, None)
+        self._reset_events_by_session.pop(session_key, None)
+
+        terminal_task_ids = {
+            task_id
+            for task_id, owner_session_key in self._terminal_session_by_task.items()
+            if owner_session_key == session_key
+        }
+        if terminal_task_ids:
+            for task_id in terminal_task_ids:
+                self._terminal_activity_snapshots_by_task.pop(task_id, None)
+                self._terminal_session_by_task.pop(task_id, None)
+            self._terminal_task_order = deque(
+                task_id
+                for task_id in self._terminal_task_order
+                if task_id not in terminal_task_ids
+            )
 
     def _trim_session_events(self, events: deque[BufferedSessionEvent]) -> None:
         while len(events) > self._max_events_per_session:

--- a/src/opensquilla/tools/builtin/sessions.py
+++ b/src/opensquilla/tools/builtin/sessions.py
@@ -640,6 +640,7 @@ async def sessions_spawn(
                 "agent_id": resolved_agent_id,
                 "task_id": handle.task_id,
                 "status": "queued",
+                **({"title": session_title} if session_title else {}),
                 "spawn_depth": spawn_depth,
                 "completion_delivery": "pushed_to_parent_session",
                 "yield_instruction": (

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -7067,6 +7067,40 @@ class TestSessionsDelete:
         } == set(matching_ids)
 
     @pytest.mark.asyncio
+    async def test_delete_evicts_only_the_deleted_session_stream(
+        self,
+        dispatcher,
+        session,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        sibling_key = "agent:main:subagent:delete-stream-sibling"
+        streams = SessionStreamRegistry()
+        streams.record(
+            session.session_key,
+            "task.failed",
+            {"task_id": "task-deleted", "status": "failed"},
+        )
+        streams.record(
+            sibling_key,
+            "task.failed",
+            {"task_id": "task-sibling", "status": "failed"},
+        )
+        monkeypatch.setattr(rpc_sessions, "get_session_streams", lambda: streams)
+
+        res = await dispatcher.dispatch(
+            "delete-stream-eviction",
+            "sessions.delete",
+            {"key": session.session_key},
+            make_ctx(session_manager=FakeSessionManager([session])),
+        )
+
+        assert res.ok is True
+        assert streams.replay(session.session_key, 0).events == []
+        assert [
+            event.event_name for event in streams.replay(sibling_key, 0).events
+        ] == ["task.failed"]
+
+    @pytest.mark.asyncio
     async def test_delete_holds_lifecycle_fences_through_cleanup(
         self,
         dispatcher,
@@ -8764,6 +8798,36 @@ class TestSessionsSubscribe:
 
 
 class TestSessionsMessagesSubscribe:
+    @pytest.mark.asyncio
+    async def test_missing_subagent_is_rejected_before_replaying_failed_task(
+        self,
+        dispatcher,
+    ):
+        key = "agent:main:subagent:missing-replay"
+        streams = get_session_streams()
+        streams.record(
+            key,
+            "task.failed",
+            {"task_id": "task-missing", "status": "failed"},
+        )
+        subscriptions = SubscriptionManager()
+        try:
+            response = await dispatcher.dispatch(
+                "missing-subagent-subscribe",
+                "sessions.messages.subscribe",
+                {"key": key, "since_stream_seq": 0},
+                make_ctx(
+                    session_manager=FakeSessionManager([]),
+                    subscription_manager=subscriptions,
+                ),
+            )
+
+            assert response.ok is False
+            assert response.error.code == "SESSION_NOT_FOUND"
+            assert subscriptions.get_message_subscribers(key) == set()
+        finally:
+            streams.evict(key)
+
     @pytest.mark.asyncio
     async def test_messages_hydrate_uses_bounded_interactive_storage_scope(
         self,

--- a/tests/test_session_streams_meta_events.py
+++ b/tests/test_session_streams_meta_events.py
@@ -51,3 +51,76 @@ def test_meta_events_survive_buffer_trim_pressure():
     kept = [e.event_name for e in result.events]
     assert "session.event.meta_run_announced" in kept
     assert "session.event.meta_step_state" in kept
+
+
+def test_evict_clears_only_the_target_session_stream_state():
+    reg = SessionStreamRegistry(max_events_per_session=500)
+    target = "agent:main:subagent:target-stream"
+    sibling = "agent:main:subagent:sibling-stream"
+
+    for session_key, task_id in ((target, "task-target"), (sibling, "task-sibling")):
+        reg.record(
+            session_key,
+            "session.event.provider_activity",
+            {"task_id": task_id, "turn_id": task_id, "phase": "requesting"},
+        )
+        reg.record(
+            session_key,
+            "session.event.tool_use_start",
+            {
+                "task_id": task_id,
+                "turn_id": task_id,
+                "tool_use_id": f"{task_id}-tool",
+                "tool_name": "synthetic_tool",
+                "arguments": {},
+            },
+        )
+        reg.record(
+            session_key,
+            "session.event.tool_result",
+            {
+                "task_id": task_id,
+                "turn_id": task_id,
+                "tool_use_id": f"{task_id}-tool",
+                "tool_name": "synthetic_tool",
+                "result": "ok",
+            },
+        )
+        reg.record(
+            session_key,
+            "session.event.done",
+            {"task_id": task_id, "turn_id": task_id},
+        )
+        reg.record(
+            session_key,
+            "session.event.state_change",
+            {"task_id": f"{task_id}-live", "to_state": "running"},
+        )
+
+    reg.evict(target)
+
+    target_replay = reg.replay(target, 0)
+    assert target_replay.current_stream_seq == 0
+    assert target_replay.events == []
+    assert reg.live_snapshot(target).events == []
+    assert reg.take_terminal_activity_snapshot(
+        target,
+        "task-target",
+        turn_id="task-target",
+    ) is None
+
+    sibling_replay = reg.replay(sibling, 0)
+    assert sibling_replay.current_stream_seq == 5
+    assert [event.event_name for event in sibling_replay.events] == [
+        "session.event.provider_activity",
+        "session.event.tool_use_start",
+        "session.event.tool_result",
+        "session.event.done",
+        "session.event.state_change",
+    ]
+    assert reg.live_snapshot(sibling).task_id == "task-sibling-live"
+    assert reg.take_terminal_activity_snapshot(
+        sibling,
+        "task-sibling",
+        turn_id="task-sibling",
+    ) is not None

--- a/tests/test_tools/test_sessions_spawn_regressions.py
+++ b/tests/test_tools/test_sessions_spawn_regressions.py
@@ -309,11 +309,12 @@ async def test_sessions_spawn_persists_explicit_or_task_derived_title(
 
     token = current_tool_context.set(_ctx())
     try:
-        await sessions_tool.sessions_spawn(task=task, title=title)
+        result = json.loads(await sessions_tool.sessions_spawn(task=task, title=title))
     finally:
         current_tool_context.reset(token)
 
     assert mgr.created[0]["derived_title"] == expected
+    assert result["title"] == expected
     assert mgr.created[0]["origin"]["task"] == task
     assert mgr.created[0]["origin"]["execution_task"].endswith(task)
 


### PR DESCRIPTION
## Scope

- Add an optional title to successful sessions_spawn results and keep legacy results distinguishable with a session-key suffix fallback.
- Evict replay, live, reset, completed, and terminal stream state only after the matching session is durably deleted.
- Validate created-session cards only when clicked, mark missing children as deleted, and prevent navigation to them without eager per-card RPC traffic.
- Collapse missing child deep links to one non-retryable deleted-session state and suppress stale task failure replay.

This intentionally does not add batch resolve RPCs, generation identifiers, tombstones, or parent transcript rewriting.

## Target

main

## Linked issue

None

## Release note

Not added; this is a targeted session-card lifecycle bug fix.

## Compatibility

- The title field is additive and optional; older clients ignore it and older transcripts use the key-suffix fallback.
- No database or persisted transcript migration is required.
- Non-NOT_FOUND resolve failures retain legacy navigation behavior.
- The change is platform-neutral and does not use filesystem, process, signal, or OS-specific APIs.

## Tests

- uv run pytest -q tests/test_tools/test_sessions_spawn_regressions.py — 18 passed
- uv run pytest -q tests/test_gateway/test_session_streams.py tests/test_session_streams_meta_events.py — 31 passed
- uv run pytest -q tests/test_gateway/test_rpc_sessions.py::TestSessionsDelete tests/test_gateway/test_rpc_sessions.py::TestSessionsMessagesSubscribe — 44 passed
- uv run ruff check on changed Python and test files — passed
- npm run test:unit for created-session parsing, cards, and history — 78 passed
- npm run typecheck — passed, including architecture, security, theme, and i18n guards
- Chromium session-created-card E2E — 4 passed

The E2E coverage verifies distinct titles, deletion isolation from a sibling card, click-time validation without eager resolves, and a missing deep link with no duplicate history/turn failure state.

## Safety

Tests use synthetic session identifiers and offline mocks. No credentials, real transcripts, or user data are included.

## Third-party origin

None.