### PR TITLE
Restore the latest unsent chat draft after restart

### DIFF
--- a/opensquilla-webui/e2e/new-chat.spec.ts
+++ b/opensquilla-webui/e2e/new-chat.spec.ts
@@ -2,8 +2,139 @@ import { test, expect } from '@playwright/test'
 
 const CONTROL_URL = '/control/'
 const LIVE = process.env.OPENSQUILLA_E2E_LIVE === '1'
+const RECENT_DRAFT_SESSION_KEY = 'opensquilla.chat.recent-draft-session'
+
+async function seedRecoverableDraft(
+  page: import('@playwright/test').Page,
+  key: string,
+  text: string,
+  active = false,
+) {
+  await page.goto(CONTROL_URL)
+  await page.evaluate(({ key, text, active, pointerKey }) => {
+    localStorage.setItem(`opensquilla.chat.draft:${key}`, text)
+    localStorage.setItem(pointerKey, key)
+    if (active) localStorage.setItem('opensquilla_active_session', key)
+  }, { key, text, active, pointerKey: RECENT_DRAFT_SESSION_KEY })
+}
 
 test.describe('New chat draft state', () => {
+  test('cold /chat/new restores the most recent provisional draft', async ({ page }) => {
+    const key = 'agent:main:webchat:e2e-cold-draft'
+    await seedRecoverableDraft(page, key, 'unfinished cold-start task')
+
+    await page.goto(CONTROL_URL + 'chat/new')
+
+    await expect(page).toHaveURL(/\/chat\/new$/)
+    await expect(page.locator('.chat-textarea')).toHaveValue('unfinished cold-start task')
+  })
+
+  test('cold /chat/new restores an existing session draft and its route', async ({ page }) => {
+    const key = 'agent:main:webchat:e2e-existing-draft'
+    await seedRecoverableDraft(page, key, 'unfinished existing reply', true)
+
+    await page.goto(CONTROL_URL + 'chat/new')
+
+    await expect(page).toHaveURL(/\/chat\?session=agent(?::|%3A)main/)
+    await expect(page.locator('.chat-textarea')).toHaveValue('unfinished existing reply')
+  })
+
+  test('explicit New task discards a recovered draft instead of reviving it', async ({ page }) => {
+    const key = 'agent:main:webchat:e2e-discarded-draft'
+    await seedRecoverableDraft(page, key, 'discard this task')
+    await page.goto(CONTROL_URL + 'chat/new')
+    await expect(page.locator('.chat-textarea')).toHaveValue('discard this task')
+
+    await page.locator('.sidebar-new-session').click()
+
+    await expect(page).toHaveURL(/\/chat\/new\?agent=main$/)
+    await expect(page.locator('.chat-textarea')).toHaveValue('')
+    await expect.poll(() => page.evaluate(({ key, pointerKey }) => ({
+      draft: localStorage.getItem(`opensquilla.chat.draft:${key}`),
+      pointer: localStorage.getItem(pointerKey),
+    }), { key, pointerKey: RECENT_DRAFT_SESSION_KEY })).toEqual({
+      draft: null,
+      pointer: null,
+    })
+  })
+
+  test('explicit New task preserves another session draft', async ({ page }) => {
+    const otherKey = 'agent:main:webchat:e2e-other-draft'
+    await seedRecoverableDraft(page, otherKey, 'keep the other draft')
+    await page.goto(CONTROL_URL + 'chat?session=agent:main:webchat:e2e-current-session')
+    await expect(page.locator('.chat-textarea')).toHaveValue('')
+
+    await page.locator('.sidebar-new-session').click()
+
+    await expect(page).toHaveURL(/\/chat\/new\?agent=main$/)
+    expect(await page.evaluate(({ key, pointerKey }) => ({
+      draft: localStorage.getItem(`opensquilla.chat.draft:${key}`),
+      pointer: localStorage.getItem(pointerKey),
+    }), { key: otherKey, pointerKey: RECENT_DRAFT_SESSION_KEY })).toEqual({
+      draft: 'keep the other draft',
+      pointer: otherKey,
+    })
+  })
+
+  test('clearing a recovered composer prevents it from returning after reload', async ({ page }) => {
+    const key = 'agent:main:webchat:e2e-cleared-draft'
+    await seedRecoverableDraft(page, key, 'clear before reload')
+    await page.goto(CONTROL_URL + 'chat/new')
+    const textarea = page.locator('.chat-textarea')
+    await expect(textarea).toHaveValue('clear before reload')
+
+    await textarea.fill('')
+    await expect.poll(() => page.evaluate(pointerKey => (
+      localStorage.getItem(pointerKey)
+    ), RECENT_DRAFT_SESSION_KEY)).toBeNull()
+    await page.reload()
+
+    await expect(textarea).toHaveValue('')
+  })
+
+  test('a corrupt recovery pointer is retired without blocking a clean draft', async ({ page }) => {
+    await page.goto(CONTROL_URL)
+    await page.evaluate(pointerKey => {
+      localStorage.setItem(pointerKey, 'not-a-session')
+    }, RECENT_DRAFT_SESSION_KEY)
+
+    await page.goto(CONTROL_URL + 'chat/new')
+
+    await expect(page.locator('.chat-textarea')).toHaveValue('')
+    expect(await page.evaluate(pointerKey => (
+      localStorage.getItem(pointerKey)
+    ), RECENT_DRAFT_SESSION_KEY)).toBeNull()
+  })
+
+  test('an explicit prefill wins over a recoverable draft', async ({ page }) => {
+    const key = 'agent:main:webchat:e2e-prefill-draft'
+    await seedRecoverableDraft(page, key, 'stale draft text')
+    await page.evaluate(() => {
+      window.history.replaceState(
+        { ...window.history.state, prefill: 'explicit prefill text' },
+        '',
+        '/control/chat/new?agent=main',
+      )
+    })
+
+    await page.reload()
+
+    await expect(page.locator('.chat-textarea')).toHaveValue('explicit prefill text')
+    const storage = await page.evaluate(({ key, pointerKey }) => {
+      const pointer = localStorage.getItem(pointerKey)
+      return {
+        oldDraft: localStorage.getItem(`opensquilla.chat.draft:${key}`),
+        pointer,
+        explicitDraft: pointer
+          ? localStorage.getItem(`opensquilla.chat.draft:${pointer}`)
+          : null,
+      }
+    }, { key, pointerKey: RECENT_DRAFT_SESSION_KEY })
+    expect(storage.oldDraft).toBeNull()
+    expect(storage.pointer).not.toBe(key)
+    expect(storage.explicitDraft).toBe('explicit prefill text')
+  })
+
   test('New chat lands on a clean draft with no session key', async ({ page }) => {
     await page.goto(CONTROL_URL)
     await page.waitForSelector('.conn-pill', { timeout: 10000 })

--- a/opensquilla-webui/src/composables/chat/useChatDraftPersistence.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatDraftPersistence.test.ts
@@ -3,7 +3,11 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { effectScope, nextTick, ref } from 'vue'
 
-import { useChatDraftPersistence } from './useChatDraftPersistence'
+import {
+  RECENT_DRAFT_SESSION_KEY,
+  recentDraftSessionKey,
+  useChatDraftPersistence,
+} from './useChatDraftPersistence'
 
 function mount(sessionKey: ReturnType<typeof ref<string>>, inputText: ReturnType<typeof ref<string>>) {
   const scope = effectScope()
@@ -37,6 +41,7 @@ describe('useChatDraftPersistence', () => {
     await nextTick()
 
     expect(inputText2.value).toBe('half-written instruction')
+    expect(localStorage.getItem(RECENT_DRAFT_SESSION_KEY)).toBe('agent:main:webchat:a')
   })
 
   it('keeps drafts isolated per session and does not clobber typed text', async () => {
@@ -77,6 +82,85 @@ describe('useChatDraftPersistence', () => {
     inputText.value = '' // send path empties the composer
     await nextTick()
     expect(localStorage.getItem('opensquilla.chat.draft:agent:main:webchat:a')).toBeNull()
+    expect(localStorage.getItem(RECENT_DRAFT_SESSION_KEY)).toBeNull()
+  })
+
+  it('points to only the most recently edited non-empty draft', async () => {
+    const sessionKey = ref('agent:main:webchat:a')
+    const inputText = ref('')
+    mount(sessionKey, inputText)
+
+    inputText.value = 'draft A'
+    await nextTick()
+    sessionKey.value = 'agent:main:webchat:b'
+    await nextTick()
+    inputText.value = 'draft B'
+    await nextTick()
+
+    expect(recentDraftSessionKey()).toBe('agent:main:webchat:b')
+    expect(localStorage.getItem('opensquilla.chat.draft:agent:main:webchat:a')).toBe('draft A')
+  })
+
+  it('explicitly discards the recoverable draft without scanning other drafts', async () => {
+    localStorage.setItem('opensquilla.chat.draft:agent:main:webchat:older', 'older draft')
+    const sessionKey = ref('agent:main:webchat:recent')
+    const inputText = ref('')
+    const { api } = mount(sessionKey, inputText)
+    inputText.value = 'discard me'
+    await nextTick()
+
+    api.discardRecentDraft()
+
+    expect(localStorage.getItem(RECENT_DRAFT_SESSION_KEY)).toBeNull()
+    expect(localStorage.getItem('opensquilla.chat.draft:agent:main:webchat:recent')).toBeNull()
+    expect(localStorage.getItem('opensquilla.chat.draft:agent:main:webchat:older')).toBe('older draft')
+  })
+
+  it('does not recreate a discarded pointer while an explicit new task changes session', async () => {
+    const sessionKey = ref('agent:main:webchat:discarded')
+    const inputText = ref('')
+    const { api } = mount(sessionKey, inputText)
+    inputText.value = 'discard before switching'
+    await nextTick()
+
+    // Match ChatView's explicit-new ordering: empty and discard before the
+    // provisional session key changes.
+    inputText.value = ''
+    api.clearDraft(sessionKey.value)
+    api.discardRecentDraft()
+    sessionKey.value = 'agent:main:webchat:fresh'
+    await nextTick()
+
+    expect(localStorage.getItem(RECENT_DRAFT_SESSION_KEY)).toBeNull()
+    expect(localStorage.getItem('opensquilla.chat.draft:agent:main:webchat:discarded')).toBeNull()
+  })
+
+  it('does not delete another session draft when the current session starts a new task', () => {
+    const otherKey = 'agent:main:webchat:other'
+    localStorage.setItem(`opensquilla.chat.draft:${otherKey}`, 'keep this draft')
+    localStorage.setItem(RECENT_DRAFT_SESSION_KEY, otherKey)
+    const sessionKey = ref('agent:main:webchat:current')
+    const inputText = ref('')
+    const { api } = mount(sessionKey, inputText)
+
+    api.clearDraft(sessionKey.value)
+
+    expect(localStorage.getItem(RECENT_DRAFT_SESSION_KEY)).toBe(otherKey)
+    expect(localStorage.getItem(`opensquilla.chat.draft:${otherKey}`)).toBe('keep this draft')
+  })
+
+  it('retires a corrupt or stale recovery pointer', () => {
+    localStorage.setItem(RECENT_DRAFT_SESSION_KEY, '')
+    expect(recentDraftSessionKey()).toBe('')
+    expect(localStorage.getItem(RECENT_DRAFT_SESSION_KEY)).toBeNull()
+
+    localStorage.setItem(RECENT_DRAFT_SESSION_KEY, 'not-a-session')
+    expect(recentDraftSessionKey()).toBe('')
+    expect(localStorage.getItem(RECENT_DRAFT_SESSION_KEY)).toBeNull()
+
+    localStorage.setItem(RECENT_DRAFT_SESSION_KEY, 'agent:main:webchat:missing')
+    expect(recentDraftSessionKey()).toBe('')
+    expect(localStorage.getItem(RECENT_DRAFT_SESSION_KEY)).toBeNull()
   })
 
   it('does not overwrite text already typed in the newly-active session', async () => {

--- a/opensquilla-webui/src/composables/chat/useChatDraftPersistence.ts
+++ b/opensquilla-webui/src/composables/chat/useChatDraftPersistence.ts
@@ -1,9 +1,48 @@
 import { watch, type Ref } from 'vue'
 
 const DRAFT_KEY_PREFIX = 'opensquilla.chat.draft:'
+export const RECENT_DRAFT_SESSION_KEY = 'opensquilla.chat.recent-draft-session'
 // Cap what we persist so a giant paste cannot bloat localStorage; the composer
 // itself is unbounded, only the saved copy is capped.
 const MAX_DRAFT_CHARS = 100_000
+
+function draftKey(key: string): string {
+  return DRAFT_KEY_PREFIX + key
+}
+
+function validDraftSessionKey(key: string): boolean {
+  if (!key || key.length > 512 || key !== key.trim()) return false
+  if (/[/\u0000-\u001f\u007f\s]/.test(key)) return false
+  const marker = ':webchat:'
+  const markerIndex = key.indexOf(marker)
+  return key.startsWith('agent:')
+    && markerIndex > 'agent:'.length
+    && markerIndex + marker.length < key.length
+}
+
+function clearRecentDraftPointer(key?: string): void {
+  try {
+    const current = localStorage.getItem(RECENT_DRAFT_SESSION_KEY)
+    if (!key || current === key) localStorage.removeItem(RECENT_DRAFT_SESSION_KEY)
+  } catch {
+    // Storage can be unavailable in private or restricted contexts.
+  }
+}
+
+/** Return the single recoverable draft session, retiring stale/corrupt pointers. */
+export function recentDraftSessionKey(): string {
+  try {
+    const key = localStorage.getItem(RECENT_DRAFT_SESSION_KEY)
+    if (key === null) return ''
+    if (!validDraftSessionKey(key) || !localStorage.getItem(draftKey(key))) {
+      localStorage.removeItem(RECENT_DRAFT_SESSION_KEY)
+      return ''
+    }
+    return key
+  } catch {
+    return ''
+  }
+}
 
 export interface UseChatDraftPersistenceOptions {
   sessionKey: Ref<string>
@@ -22,17 +61,15 @@ export interface UseChatDraftPersistenceOptions {
  * complaint. Storage failures (private mode, quota) are swallowed.
  */
 export function useChatDraftPersistence(options: UseChatDraftPersistenceOptions) {
-  function draftKey(key: string): string {
-    return DRAFT_KEY_PREFIX + key
-  }
-
   function saveDraft(key: string, text: string): void {
     if (!key) return
     try {
       if (text) {
         localStorage.setItem(draftKey(key), text.slice(0, MAX_DRAFT_CHARS))
+        localStorage.setItem(RECENT_DRAFT_SESSION_KEY, key)
       } else {
         localStorage.removeItem(draftKey(key))
+        clearRecentDraftPointer(key)
       }
     } catch {
       // Ignore storage failures in private or restricted contexts.
@@ -52,8 +89,19 @@ export function useChatDraftPersistence(options: UseChatDraftPersistenceOptions)
     if (!key) return
     try {
       localStorage.removeItem(draftKey(key))
+      clearRecentDraftPointer(key)
     } catch {
       // Ignore.
+    }
+  }
+
+  function discardRecentDraft(): void {
+    try {
+      const key = localStorage.getItem(RECENT_DRAFT_SESSION_KEY) || ''
+      if (validDraftSessionKey(key)) localStorage.removeItem(draftKey(key))
+      localStorage.removeItem(RECENT_DRAFT_SESSION_KEY)
+    } catch {
+      // Ignore storage failures in private or restricted contexts.
     }
   }
 
@@ -84,5 +132,5 @@ export function useChatDraftPersistence(options: UseChatDraftPersistenceOptions)
     saveDraft(options.sessionKey.value, text)
   })
 
-  return { saveDraft, loadDraft, clearDraft }
+  return { saveDraft, loadDraft, clearDraft, discardRecentDraft }
 }

--- a/opensquilla-webui/src/composables/chat/useChatSessionRoute.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionRoute.test.ts
@@ -5,6 +5,7 @@ import {
   shouldCanonicalizeInitialDraftRoute,
   useChatSessionRoute,
 } from './useChatSessionRoute'
+import { RECENT_DRAFT_SESSION_KEY } from './useChatDraftPersistence'
 
 const { routeMock, routerMock } = vi.hoisted(() => ({
   routeMock: {
@@ -48,6 +49,78 @@ describe('useChatSessionRoute', () => {
 
     expect(route.draftAgentId()).toBe('main')
     expect(route.resolveInitialSession().sessionKey).toMatch(/^agent:main:webchat:[a-z0-9]+$/)
+  })
+
+  it('recovers a provisional new-task draft on a cold /chat/new entry', () => {
+    const key = 'agent:main:webchat:cold-draft'
+    localStorage.setItem(`opensquilla.chat.draft:${key}`, 'unfinished task')
+    localStorage.setItem(RECENT_DRAFT_SESSION_KEY, key)
+    const route = useChatSessionRoute(ref(''))
+
+    expect(route.resolveInitialSession()).toEqual({
+      sessionKey: key,
+      hasUrlSession: false,
+      draft: true,
+      recoveredDraft: true,
+    })
+  })
+
+  it('recovers an existing active session draft as a routable session', () => {
+    const key = 'agent:main:webchat:existing'
+    localStorage.setItem('opensquilla_active_session', key)
+    localStorage.setItem(`opensquilla.chat.draft:${key}`, 'unfinished reply')
+    localStorage.setItem(RECENT_DRAFT_SESSION_KEY, key)
+    const route = useChatSessionRoute(ref(''))
+
+    expect(route.resolveInitialSession()).toEqual({
+      sessionKey: key,
+      hasUrlSession: false,
+      draft: false,
+      recoveredDraft: true,
+    })
+  })
+
+  it('does not recover a previous draft for an explicit new task', () => {
+    const key = 'agent:main:webchat:previous'
+    localStorage.setItem(`opensquilla.chat.draft:${key}`, 'do not restore')
+    localStorage.setItem(RECENT_DRAFT_SESSION_KEY, key)
+    const route = useChatSessionRoute(ref(''))
+
+    const initial = route.resolveInitialSession({ recoverDraft: false })
+
+    expect(initial.sessionKey).not.toBe(key)
+    expect(initial).toMatchObject({ draft: true, recoveredDraft: false })
+  })
+
+  it('does not recover a draft after it was sent or cleared', () => {
+    const key = 'agent:main:webchat:sent'
+    localStorage.setItem(RECENT_DRAFT_SESSION_KEY, key)
+    const route = useChatSessionRoute(ref(''))
+
+    const initial = route.resolveInitialSession()
+
+    expect(initial.sessionKey).not.toBe(key)
+    expect(initial.recoveredDraft).toBe(false)
+    expect(localStorage.getItem(RECENT_DRAFT_SESSION_KEY)).toBeNull()
+  })
+
+  it('does not let Agent or project draft entries recover an unrelated recent draft', () => {
+    const key = 'agent:main:webchat:previous'
+    localStorage.setItem(`opensquilla.chat.draft:${key}`, 'do not restore')
+    localStorage.setItem(RECENT_DRAFT_SESSION_KEY, key)
+    routeMock.query = { agent: 'research' }
+    const route = useChatSessionRoute(ref(''))
+
+    expect(route.resolveInitialSession()).toMatchObject({
+      sessionKey: expect.stringMatching(/^agent:research:webchat:/),
+      recoveredDraft: false,
+    })
+
+    routeMock.query = { agent: 'main', project: 'project-a' }
+    expect(route.resolveInitialSession()).toMatchObject({
+      sessionKey: expect.stringMatching(/^agent:main:webchat:/),
+      recoveredDraft: false,
+    })
   })
 
   it('keeps only the project id in a project draft route and can return to a default draft', () => {

--- a/opensquilla-webui/src/composables/chat/useChatSessionRoute.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionRoute.ts
@@ -1,5 +1,6 @@
 import type { Ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { recentDraftSessionKey } from '@/composables/chat/useChatDraftPersistence'
 import {
   agentIdFromSessionKey,
   canonicalSessionKey,
@@ -13,6 +14,17 @@ const DRAFT_CHAT_PATH = '/chat/new'
 export interface PersistSessionOptions {
   updateRoute?: boolean
   source?: string
+}
+
+export interface ResolveInitialSessionOptions {
+  recoverDraft?: boolean
+}
+
+export interface InitialSessionResolution {
+  sessionKey: string
+  hasUrlSession: boolean
+  draft: boolean
+  recoveredDraft: boolean
 }
 
 export interface InitialDraftCanonicalizationState {
@@ -42,6 +54,15 @@ function writeStoredSession(key: string) {
     localStorage.setItem(ACTIVE_SESSION_STORAGE_KEY, key)
   } catch {
     // Storage can be unavailable in restricted browser contexts.
+  }
+}
+
+function readStoredSession(): string {
+  try {
+    const key = localStorage.getItem(ACTIVE_SESSION_STORAGE_KEY) || ''
+    return key ? canonicalSessionKey(key) : ''
+  } catch {
+    return ''
   }
 }
 
@@ -116,14 +137,42 @@ export function useChatSessionRoute(sessionKey: Ref<string>) {
     return webchatSessionKey(agent, Math.random().toString(36).slice(2, 10))
   }
 
-  function resolveInitialSession(): { sessionKey: string; hasUrlSession: boolean; draft: boolean } {
+  function resolveInitialSession(
+    options: ResolveInitialSessionOptions = {},
+  ): InitialSessionResolution {
     const urlSession = readSessionFromUrl()
     if (urlSession) {
-      return { sessionKey: canonicalSessionKey(urlSession), hasUrlSession: true, draft: false }
+      return {
+        sessionKey: canonicalSessionKey(urlSession),
+        hasUrlSession: true,
+        draft: false,
+        recoveredDraft: false,
+      }
+    }
+    const mayRecoverDraft = options.recoverDraft !== false
+      && isDraftRoute()
+      && !readAgentFromUrl()
+      && !readProjectFromUrl()
+      && !hasLegacyNewChatQuery()
+    if (mayRecoverDraft) {
+      const recoveredSessionKey = recentDraftSessionKey()
+      if (recoveredSessionKey) {
+        return {
+          sessionKey: recoveredSessionKey,
+          hasUrlSession: false,
+          draft: readStoredSession() !== recoveredSessionKey,
+          recoveredDraft: true,
+        }
+      }
     }
     // No explicit session in the URL: open a clean draft instead of silently
     // restoring a previous session.
-    return { sessionKey: createSessionKey(draftAgentId()), hasUrlSession: false, draft: true }
+    return {
+      sessionKey: createSessionKey(draftAgentId()),
+      hasUrlSession: false,
+      draft: true,
+      recoveredDraft: false,
+    }
   }
 
   return {

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -1497,7 +1497,7 @@ const chatElevatedMode = useChatElevatedMode({
 })
 // Persist the composer draft per session so a refresh / session switch / crash
 // before the backend accepts a send cannot silently lose typed text (issue 248).
-useChatDraftPersistence({ sessionKey, inputText })
+const draftPersistence = useChatDraftPersistence({ sessionKey, inputText })
 const {
   elevatedMode,
   loadElevatedMode,
@@ -2011,6 +2011,7 @@ const {
   hasLegacyNewChatQuery,
   isDraftRoute,
   persistSession,
+  readAgentFromUrl,
   readProjectFromUrl,
   readSessionFromUrl,
   resolveInitialSession,
@@ -6410,9 +6411,20 @@ onMounted(async () => {
   window.addEventListener('pointercancel', onThreadPointerEnd)
   bindBottomIntersectionObserver()
   const initialRouteFullPath = route.fullPath
+  const initialHistoryState = window.history.state as Record<string, unknown> | null
+  const hasExplicitDraftPrefill = typeof initialHistoryState?.prefill === 'string'
+    && initialHistoryState.prefill.length > 0
+  const explicitFreshTask = isDraftRoute() && Boolean(
+    readAgentFromUrl()
+    || readProjectFromUrl()
+    || hasLegacyNewChatQuery()
+    || hasExplicitDraftPrefill,
+  )
+  if (explicitFreshTask) draftPersistence.discardRecentDraft()
   // Initialize session key. Without an explicit ?session= the view opens as a
-  // draft instead of restoring a previous session.
-  const initialSession = resolveInitialSession()
+  // draft, except for the one most-recent non-empty draft recovered on a cold
+  // /chat/new entry. Explicit new-task handoffs always remain clean.
+  const initialSession = resolveInitialSession({ recoverDraft: !explicitFreshTask })
   sessionKey.value = initialSession.sessionKey
   bindTailLayoutObservers()
   let initialDraftProjectGeneration: number | null = null
@@ -6436,7 +6448,10 @@ onMounted(async () => {
     }
   } else {
     activeProjectWorkspace.beginSessionResolution(initialSession.sessionKey)
-    persistSession(sessionKey.value, { updateRoute: false, source: 'chatView.initialSession' })
+    persistSession(sessionKey.value, {
+      updateRoute: initialSession.recoveredDraft,
+      source: 'chatView.initialSession',
+    })
   }
 
   // Load elevated mode
@@ -6762,6 +6777,10 @@ watch(freshTaskDraft.request, request => {
   if (!request) return
   draftProjectHydration.invalidate()
   landingPrefilled.value = false
+  // Clear before changing sessionKey. The draft watcher then observes an empty
+  // outgoing composer and cannot recreate the discarded recovery pointer.
+  inputText.value = ''
+  draftPersistence.clearDraft(sessionKey.value)
   if (request.workspaceId && rpc.canChooseProject) {
     const workspace = projectWorkspaces.byId.value.get(request.workspaceId)
     if (workspace) {


### PR DESCRIPTION
## Scope

- Restore the single most recent non-empty unsent draft when a cold start enters bare /chat/new.
- Preserve the existing per-session draft format and add only one localStorage recovery pointer.
- Restore an active durable session as an existing session, while a provisional draft remains provisional.
- Keep explicit New task, prefill, agent, and project entries clean and authoritative.
- Clear only the draft being abandoned; do not scan or delete unrelated session drafts.
- No draftId model, SQLite or IPC storage, database migration, or historical draft scan.

## Branch target

main

## Linked issue

None. Tracks Feishu demand and bug management row 31.

## Release notes

Fixes loss of the most recent unsent chat draft across a complete app restart.

## Tests

- npm run test:unit -- src/composables/chat/useChatDraftPersistence.test.ts src/composables/chat/useChatSessionRoute.test.ts src/composables/chat/useChatSessionRuntime.draft.test.ts
  - 3 files, 20 tests passed.
- OPENSQUILLA_PLAYWRIGHT_MANAGE_WEBUI=1 OPENSQUILLA_WEBUI_BASE_URL=http://127.0.0.1:41743 npm run test:e2e -- e2e/new-chat.spec.ts --project=chromium --workers=1 --grep cold|explicit New task|clearing a recovered|corrupt recovery|explicit prefill
  - 7 tests passed.
- npm run build
  - Architecture, security, design-system, i18n, typecheck, Vite build, and bundle guards passed.
- git diff --check
  - Passed.

Regression coverage includes provisional drafts, active existing-session drafts, explicit New task cleanup, preservation of unrelated session drafts, composer clearing, explicit prefill precedence, and corrupt or stale pointers.

## Safety and compatibility

- Existing draft keys and values are unchanged; the only new state is one validated recovery pointer.
- Empty, corrupt, or stale pointers fail closed and are retired.
- No backend, RPC, protocol, or database changes.
- Browser localStorage behavior is platform-neutral across Linux, macOS, and Windows desktop builds.
- The focused browser tests are deterministic and do not require a live Gateway.

## Third-party origin

None.