### PR TITLE
Validate provider credentials before onboarding save

### DIFF
--- a/desktop/electron/scripts/test-onboarding-flow.mjs
+++ b/desktop/electron/scripts/test-onboarding-flow.mjs
@@ -1,5 +1,6 @@
 import { strict as assert } from 'node:assert'
 import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { createServer } from 'node:http'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
@@ -38,6 +39,81 @@ async function waitFor(check, label, timeoutMs = 60_000) {
   }
   const suffix = lastError ? ` Last error: ${lastError.message || lastError}` : ''
   throw new Error(`Timed out waiting for ${label}.${suffix}`)
+}
+
+async function fileExists(path) {
+  try {
+    await readFile(path)
+    return true
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false
+    throw error
+  }
+}
+
+async function startOnboardingProbeServer(initialMode = 'success') {
+  let mode = initialMode
+  const requests = []
+  const server = createServer((request, response) => {
+    const body = []
+    request.on('data', (chunk) => body.push(chunk))
+    request.on('end', () => {
+      requests.push({
+        method: request.method,
+        url: request.url,
+        authorization: request.headers.authorization || '',
+        body: Buffer.concat(body).toString('utf8'),
+      })
+      if (mode === 'reject') {
+        response.writeHead(401, { 'content-type': 'application/json' })
+        response.end(JSON.stringify({
+          error: {
+            message: 'Synthetic credential rejected.',
+            type: 'authentication_error',
+            code: 'invalid_api_key',
+          },
+        }))
+        return
+      }
+      response.writeHead(200, { 'content-type': 'text/event-stream' })
+      response.end([
+        'data: {"id":"chatcmpl-onboarding-test","object":"chat.completion.chunk","created":0,"model":"synthetic-model","choices":[{"index":0,"delta":{"role":"assistant","content":"ok"},"finish_reason":null}]}',
+        '',
+        'data: {"id":"chatcmpl-onboarding-test","object":"chat.completion.chunk","created":0,"model":"synthetic-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}',
+        '',
+        'data: [DONE]',
+        '',
+      ].join('\n'))
+    })
+  })
+  await new Promise((resolveListen, rejectListen) => {
+    const onError = (error) => rejectListen(error)
+    server.once('error', onError)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', onError)
+      resolveListen()
+    })
+  })
+  const address = server.address()
+  assert.ok(address && typeof address !== 'string')
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    requests,
+    setMode(nextMode) {
+      mode = nextMode
+    },
+    async close() {
+      await new Promise((resolveClose, rejectClose) => {
+        server.close((error) => (error ? rejectClose(error) : resolveClose()))
+      })
+    },
+  }
+}
+
+async function setOnboardingBaseUrl(page, baseUrl) {
+  await page.locator('#baseUrl').evaluate((input, value) => {
+    input.value = value
+  }, baseUrl)
 }
 
 async function readOnboardingTelemetry(userDataDir) {
@@ -635,6 +711,74 @@ async function verifySubmitFeedbackAndSingleFlight() {
 
 await verifySubmitFeedbackAndSingleFlight()
 
+async function verifyProbeBeforePersistenceAndRetry() {
+  const probeServer = await startOnboardingProbeServer('reject')
+  const { app, userDataDir, userDataRoot } = await launchIsolatedOnboarding(
+    'opensquilla-electron-onboarding-probe-test-',
+  )
+  const credentialPath = join(userDataDir, 'desktop-credential.json')
+  const configPath = join(userDataDir, 'opensquilla', 'config.toml')
+  const syntheticKey = 'synthetic-probe-retry-key'
+  try {
+    const page = await setupWindow(app)
+    await page.locator('#providerSelectToggle').click()
+    await page.locator('[data-provider-option="openai"]').click()
+    await page.locator('#apiKey').fill(syntheticKey)
+    await setOnboardingBaseUrl(page, probeServer.baseUrl)
+    const submittedModel = await page.locator('#model').inputValue()
+
+    await page.locator('#finish').click()
+    const errorText = await waitFor(async () => {
+      const text = (await page.locator('#error').innerText()).trim()
+      const formReady = await page.locator('#setup-form').getAttribute('aria-busy') === 'false'
+      return text && formReady && !await page.locator('#finish').isDisabled() ? text : null
+    }, 'rejected provider probe to restore onboarding editing')
+    assert.match(errorText, /401|authentication|credential|API key/i)
+    assert.equal(errorText.includes(syntheticKey), false, 'probe errors must redact the submitted key')
+    assert.equal(await page.locator('#apiKey').inputValue(), syntheticKey)
+    assert.equal(await fileExists(credentialPath), false, 'a rejected probe must not persist credentials')
+    assert.equal(await fileExists(configPath), false, 'a rejected probe must not persist config')
+    const failedTrace = await waitFor(async () => {
+      const records = await readOnboardingTelemetry(userDataDir)
+      return records.find((record) => (
+        record.event === 'onboarding_save_finished' && record.outcome === 'threw'
+      )) || null
+    }, 'rejected provider probe timing trace')
+    assert.equal(failedTrace.writerAdmitted, false)
+    assert.equal(failedTrace.settingsPersistedConfirmed, false)
+    assert.equal(probeServer.requests.length, 1)
+    assert.equal(probeServer.requests[0].method, 'POST')
+    assert.equal(probeServer.requests[0].url, '/v1/chat/completions')
+    assert.equal(probeServer.requests[0].authorization, `Bearer ${syntheticKey}`)
+    assert.equal(JSON.parse(probeServer.requests[0].body).model, submittedModel)
+
+    probeServer.setMode('success')
+    await page.locator('#finish').click()
+    const saved = await waitFor(async () => {
+      if (!await fileExists(credentialPath) || !await fileExists(configPath)) return null
+      return JSON.parse(await readFile(credentialPath, 'utf8'))
+    }, 'successful retry to persist onboarding settings')
+    assert.equal(saved.provider, 'openai')
+    assert.equal(saved.model, submittedModel)
+    assert.equal(saved.baseUrl, probeServer.baseUrl)
+    assert.equal(probeServer.requests.length, 2, 'retry must perform a fresh provider probe')
+    assert.equal(probeServer.requests[1].authorization, `Bearer ${syntheticKey}`)
+    assert.equal(JSON.parse(probeServer.requests[1].body).model, submittedModel)
+  } catch (error) {
+    const desktopLog = await readFile(join(userDataDir, 'logs', 'desktop.log'), 'utf8')
+      .catch(() => '<desktop log unavailable>')
+    throw new Error(`${error?.message || error}\nDesktop log:\n${desktopLog}`, { cause: error })
+  } finally {
+    await app.close().catch(() => {})
+    await probeServer.close().catch(() => {})
+    await rm(userDataRoot, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+await verifyProbeBeforePersistenceAndRetry()
+
+const successfulProbeServer = await startOnboardingProbeServer()
+
 const { app, userDataDir, userDataRoot } = await launchIsolatedOnboarding(
   'opensquilla-electron-onboarding-test-',
 )
@@ -965,6 +1109,7 @@ try {
   assert.equal(await page.locator('#searchKeyLabel').isVisible(), false)
   assert.equal(await page.locator('#searchApiKeyError').innerText(), '')
   assert.equal(await page.locator('#apiKey').inputValue(), 'synthetic-tokenrhythm-key')
+  await setOnboardingBaseUrl(page, successfulProbeServer.baseUrl)
   await page.locator('#finish').click()
 
   const saved = await waitFor(async () => {
@@ -1005,6 +1150,13 @@ try {
   assert.match(config, /\[squilla_router\.tiers\.c3\][\s\S]*?model = "glm-5.2"[\s\S]*?ensemble_enabled = true/)
   assert.doesNotMatch(config, /thinking_level\s*=/)
   assert.match(config, /\[llm_ensemble\]\nenabled = false/)
+  assert.equal(successfulProbeServer.requests.length, 1)
+  assert.equal(successfulProbeServer.requests[0].url, '/v1/chat/completions')
+  assert.equal(
+    successfulProbeServer.requests[0].authorization,
+    'Bearer synthetic-tokenrhythm-key',
+  )
+  assert.equal(JSON.parse(successfulProbeServer.requests[0].body).model, credential.model)
 
   const readyConnection = await waitFor(async () => {
     const connection = await desktopPage.evaluate(
@@ -1124,5 +1276,6 @@ try {
   }, null, 2))
 } finally {
   await app.close().catch(() => {})
+  await successfulProbeServer.close().catch(() => {})
   await rm(userDataRoot, { recursive: true, force: true }).catch(() => {})
 }

--- a/desktop/electron/scripts/test-profile-import-flow.mjs
+++ b/desktop/electron/scripts/test-profile-import-flow.mjs
@@ -1,6 +1,7 @@
 import { strict as assert } from 'node:assert'
 import { spawnSync } from 'node:child_process'
 import { lstat, mkdir, mkdtemp, readFile, readdir, realpath, rm, writeFile } from 'node:fs/promises'
+import { createServer } from 'node:http'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
@@ -31,6 +32,65 @@ async function waitFor(check, label, timeoutMs = 90_000) {
     await delay(250)
   }
   throw new Error(`Timed out waiting for ${label}: ${lastError?.message || lastError || ''}`)
+}
+
+async function startFakeProvider() {
+  let mode = 'reject'
+  const requests = []
+  const server = createServer((request, response) => {
+    const body = []
+    request.on('data', (chunk) => body.push(chunk))
+    request.on('end', () => {
+      requests.push({
+        method: request.method,
+        url: request.url,
+        authorization: request.headers.authorization || '',
+        body: Buffer.concat(body).toString('utf8'),
+      })
+      if (mode === 'reject') {
+        response.writeHead(401, { 'content-type': 'application/json' })
+        response.end(JSON.stringify({
+          error: {
+            message: 'Synthetic imported credential rejected.',
+            type: 'authentication_error',
+            code: 'invalid_api_key',
+          },
+        }))
+        return
+      }
+      response.writeHead(200, { 'content-type': 'text/event-stream' })
+      response.end([
+        'data: {"id":"chatcmpl-import-test","object":"chat.completion.chunk","created":0,"model":"synthetic-model","choices":[{"index":0,"delta":{"role":"assistant","content":"ok"},"finish_reason":null}]}',
+        '',
+        'data: {"id":"chatcmpl-import-test","object":"chat.completion.chunk","created":0,"model":"synthetic-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}',
+        '',
+        'data: [DONE]',
+        '',
+      ].join('\n'))
+    })
+  })
+  await new Promise((resolveListen, rejectListen) => {
+    const onError = (error) => rejectListen(error)
+    server.once('error', onError)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', onError)
+      resolveListen()
+    })
+  })
+  const address = server.address()
+  assert.ok(address && typeof address !== 'string')
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    requests,
+    setMode(nextMode) {
+      mode = nextMode
+    },
+    async close() {
+      await new Promise((resolveClose, rejectClose) => {
+        server.close((error) => (error ? rejectClose(error) : resolveClose()))
+      })
+    },
+  }
 }
 
 function runPython(source, args) {
@@ -298,6 +358,7 @@ with sqlite3.connect(Path(sys.argv[1]) / "state" / "sessions.db") as connection:
 
 const root = await realpath(await mkdtemp(join(tmpdir(), 'opensquilla-profile-import-e2e-')))
 let app = null
+let fakeProvider = null
 try {
   if (importScreenshotDir) await mkdir(importScreenshotDir, { recursive: true })
 
@@ -405,6 +466,7 @@ try {
 
   // Settings import with a required key must release exclusive admission before
   // onboarding, preserve source config bytes, and retain the previous credential.
+  fakeProvider = await startFakeProvider()
   const settingsHome = join(root, 'settings-home')
   const settingsSource = join(settingsHome, '.opensquilla')
   const settingsUserData = join(root, 'settings-user-data')
@@ -414,7 +476,7 @@ try {
   await writeProviderProfileConfig(settingsSource, {
     provider: 'openai',
     model: 'gpt-5.4-mini',
-    baseUrl: 'https://api.openai.com/v1',
+    baseUrl: fakeProvider.baseUrl,
     apiKeyEnv: 'OPENAI_API_KEY',
     searchProvider: 'brave',
     searchApiKeyEnv: 'BRAVE_API_KEY',
@@ -429,7 +491,7 @@ try {
   await writeProviderProfileConfig(settingsTarget, {
     provider: 'openai',
     model: 'synthetic-old-target-model',
-    baseUrl: 'https://api.openai.com/v1',
+    baseUrl: fakeProvider.baseUrl,
     apiKeyEnv: 'OPENAI_API_KEY',
     routerEnabled: true,
     disableNetworkObservability: false,
@@ -437,7 +499,7 @@ try {
   const oldCredential = await seedDesktopCredential(settingsUserData, {
     provider: 'openai',
     model: 'synthetic-old-target-model',
-    baseUrl: 'https://api.openai.com/v1',
+    baseUrl: fakeProvider.baseUrl,
     apiKeyEnv: 'OPENAI_API_KEY',
     apiKey: 'synthetic-old-target-key',
   })
@@ -467,6 +529,7 @@ try {
   })
   assert.equal(await requiredKeyOnboarding.locator('#provider').inputValue(), 'openai')
   assert.equal(await requiredKeyOnboarding.locator('#model').inputValue(), 'gpt-5.4-mini')
+  assert.equal(await requiredKeyOnboarding.locator('#baseUrl').inputValue(), fakeProvider.baseUrl)
   const importedConfigBeforeCredential = await readFile(join(settingsTarget, 'config.toml'))
   assert.match(importedConfigBeforeCredential.toString('utf8'), /search_provider = "brave"/)
   assert.match(importedConfigBeforeCredential.toString('utf8'), /confidence_threshold = 0\.77/)
@@ -474,7 +537,39 @@ try {
     importedConfigBeforeCredential.toString('utf8'),
     /disable_network_observability = true/,
   )
+  const credentialBeforeRejectedProbe = await readFile(
+    join(settingsUserData, 'desktop-credential.json'),
+  ).catch(() => null)
+  const pendingBeforeRejectedProbe = await readFile(
+    join(settingsUserData, 'migration-provider-setup.json'),
+  )
   await requiredKeyOnboarding.locator('#apiKey').fill('synthetic-new-imported-key')
+  await requiredKeyOnboarding.locator('#finish').click()
+
+  const rejectedProbeError = await waitFor(async () => {
+    const error = (await requiredKeyOnboarding.locator('#error').innerText()).trim()
+    const ready = await requiredKeyOnboarding.locator('#setup-form').getAttribute('aria-busy')
+      === 'false'
+    return error && ready && !await requiredKeyOnboarding.locator('#finish').isDisabled()
+      ? error
+      : null
+  }, 'rejected imported credential probe')
+  assert.match(rejectedProbeError, /401|authentication|credential|API key/i)
+  assert.equal(rejectedProbeError.includes('synthetic-new-imported-key'), false)
+  assert.deepEqual(
+    await readFile(join(settingsUserData, 'desktop-credential.json')).catch(() => null),
+    credentialBeforeRejectedProbe,
+    'rejected provider probe wrote imported credential',
+  )
+  assert.deepEqual(
+    await readFile(join(settingsUserData, 'migration-provider-setup.json')),
+    pendingBeforeRejectedProbe,
+    'rejected provider probe cleared the pending adoption marker',
+  )
+  assert.deepEqual(await readFile(join(settingsTarget, 'config.toml')), importedConfigBeforeCredential)
+  assert.deepEqual(await readFile(join(settingsTarget, '.env')), importedEnvBytes)
+
+  fakeProvider.setMode('success')
   await requiredKeyOnboarding.locator('#finish').click()
 
   const adopted = await waitFor(async () => {
@@ -493,6 +588,21 @@ try {
     Buffer.from(adopted.encryptedApiKey, 'base64').toString('utf8'),
     'synthetic-new-imported-key',
   )
+  assert.equal(fakeProvider.requests.length, 2)
+  assert.equal(fakeProvider.requests[0].method, 'POST')
+  assert.equal(fakeProvider.requests[0].url, '/v1/chat/completions')
+  assert.equal(
+    fakeProvider.requests[0].authorization,
+    'Bearer synthetic-new-imported-key',
+  )
+  assert.equal(JSON.parse(fakeProvider.requests[0].body).model, 'gpt-5.4-mini')
+  assert.equal(fakeProvider.requests[1].method, 'POST')
+  assert.equal(fakeProvider.requests[1].url, '/v1/chat/completions')
+  assert.equal(
+    fakeProvider.requests[1].authorization,
+    'Bearer synthetic-new-imported-key',
+  )
+  assert.equal(JSON.parse(fakeProvider.requests[1].body).model, 'gpt-5.4-mini')
   assert.deepEqual(
     await readFile(join(settingsTarget, 'config.toml')),
     importedConfigBeforeCredential,
@@ -525,6 +635,8 @@ try {
   }
   await app.close()
   app = null
+  await fakeProvider.close()
+  fakeProvider = null
 
   console.log(JSON.stringify({
     cliDoesNotTriggerOnboardingTransfer: true,
@@ -539,5 +651,6 @@ try {
   }, null, 2))
 } finally {
   if (app) await app.close().catch(() => {})
+  if (fakeProvider) await fakeProvider.close().catch(() => {})
   await rm(root, { recursive: true, force: true })
 }

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -13239,6 +13239,22 @@ async function performOnboardingSave(
       ))
     }
 
+    // Validate credential-backed providers before entering writer admission:
+    // a rejected draft must never reach credential/config persistence. Keep
+    // keyless providers such as Ollama on their existing local-first path.
+    const provider = PROVIDER_BY_ID.get(normalizeProvider(payload.provider))
+    if (provider?.requiresApiKey) {
+      try {
+        const probe = await probeOnboardingProvider(payload)
+        if (!probe.ok) {
+          throw new Error(probe.message || 'Configuration verification failed.')
+        }
+      } catch (error) {
+        if (flow.state === 'saving') flow.state = 'editing'
+        throw error
+      }
+    }
+
     let finishWriter: (() => void) | null = null
     try {
       finishWriter = beginDesktopWriterOperation('complete desktop onboarding')

--- a/tests/test_desktop/test_onboarding_main_process_flow_contract.py
+++ b/tests/test_desktop/test_onboarding_main_process_flow_contract.py
@@ -96,6 +96,14 @@ def test_onboarding_save_preserves_recovery_and_writer_ordering() -> None:
     telemetry_start = save.index("const telemetry = new OnboardingSaveTelemetry(")
     recovery_stage = save.index("'primary_recovery_inspect'")
     recovery = save.index("() => refreshPrimaryRecoveryAfterImportAttempt()")
+    provider_lookup = save.index(
+        "PROVIDER_BY_ID.get(normalizeProvider(payload.provider))"
+    )
+    provider_probe = save.index("await probeOnboardingProvider(payload)")
+    probe_failure = save.index("throw new Error(probe.message")
+    restore_after_probe = save.index(
+        "if (flow.state === 'saving') flow.state = 'editing'", probe_failure
+    )
     admission = save.index("beginDesktopWriterOperation('complete desktop onboarding')")
     writer_admitted = save.index("telemetry.markWriterAdmitted()")
     marker_stage = save.index("'pending_setup_read'")
@@ -116,7 +124,8 @@ def test_onboarding_save_preserves_recovery_and_writer_ordering() -> None:
     complete = save.index("if (!completeOnboardingFlow(flow, credential))")
     telemetry_finish = save.index("telemetry.finish()")
 
-    assert telemetry_start < recovery_stage < recovery < admission < writer_admitted
+    assert telemetry_start < recovery_stage < recovery < provider_lookup < provider_probe
+    assert provider_probe < probe_failure < restore_after_probe < admission < writer_admitted
     assert writer_admitted < marker_stage < marker < settings_stage
     assert settings_stage < refresh_keychain < imported < settings_persisted
     assert refresh_keychain < ordinary < settings_persisted
@@ -125,6 +134,7 @@ def test_onboarding_save_preserves_recovery_and_writer_ordering() -> None:
     assert "app.isPackaged" in save
     assert "(event, detail) => desktopLog(event, detail)" in save
     assert "return telemetry.recordReturned(" in save
+    assert "if (provider?.requiresApiKey)" in save
     assert "if (flow.state === 'saving') flow.state = 'editing'" in save
     assert "throw error" in save
 


### PR DESCRIPTION
## Scope

Scope boundary: Validate the final Desktop onboarding provider payload before writer admission whenever the selected catalog provider requires an API key. This includes ordinary onboarding and the same Finish flow used for imported credential adoption. A failed probe restores editing and cannot persist credentials or generated config; a successful retry follows the existing save/adoption path.

Non-goals: New validation protocols, database migrations, error-code families, verification pages, search-provider validation, or unrelated onboarding and migration changes.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: The defect is tracked in the internal Feishu requirements and bug table as P2 row 29; there is no public GitHub issue.

## Reproduction

Before this change, a non-empty invalid provider key passed Desktop onboarding and wrote provider settings. The provider returned HTTP 401 only when the first model request was attempted.

The ordinary onboarding regression reproduces the credential failure with an isolated Electron user directory and a loopback OpenAI-compatible server. The imported-adoption regression uses a second stateful loopback provider: the first probe returns HTTP 401 and the retry returns a valid SSE completion.

## Minimal Fix

- Reuse the existing `probeOnboardingProvider` and `models probe-draft` path with the exact save payload: provider, model, base URL, and API key.
- Run the probe after recovery inspection but before writer admission for every `requiresApiKey` onboarding save, including imported credential adoption.
- On probe failure, restore the onboarding flow to `editing` and reuse the existing error display.
- Continue into the existing writer and ordinary/imported persistence path only after probe success.
- Skip the probe only for providers whose catalog entry does not require an API key, preserving Ollama and existing out-of-catalog compatibility behavior.

No flow-source bypass, public protocol, persistence schema, database, or error-code contract was added.

## Release Note

Release note: Desktop onboarding now verifies credential-backed model providers before saving their settings.

## Tests

Ruff: `uv run ruff check tests/test_desktop/test_onboarding_main_process_flow_contract.py` — passed

Pytest:

- `uv run pytest tests/test_desktop/test_onboarding_main_process_flow_contract.py tests/test_desktop/test_electron_startup_contract.py -q` — 131 passed
- `uv run pytest tests/test_cli/test_models_probe.py tests/test_provider/test_failure_injection.py tests/test_desktop/test_onboarding_main_process_flow_contract.py -q` — 38 passed

Build: `cd desktop/electron && npm run build` — passed through the Electron regressions below

Regression tests: added

Notes:

- `cd desktop/electron && npm run test:onboarding-flow` — passed. The isolated ordinary flow proves HTTP 401 leaves credential/config files absent, records `writerAdmitted=false` and `settingsPersistedConfirmed=false`, restores editing, and persists only after a fresh successful probe.
- `cd desktop/electron && npm run test:profile-import-flow` — passed. The required-key imported flow points source config, target config, and onboarding payload at a local fake provider. Its first 401 leaves credential, durable marker, imported config, and imported `.env` unchanged; the same page then retries against a successful response and completes adoption.
- The profile-import fake asserts both requests use `/v1/chat/completions`, model `gpt-5.4-mini`, and the newly entered synthetic key. The server is closed in success and failure cleanup paths.
- `cd desktop/electron && npm run test:onboarding-coordinator` — passed on the same production orchestration.
- `cd desktop/electron && npm run test:onboarding-telemetry` — passed on the same production orchestration.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: provider

Maintainer-only note: Deterministic loopback regressions cover ordinary and imported onboarding without real credentials. A live provider check is not required for correctness.

## Safety

Only synthetic credentials and isolated temporary profiles are used. Failed validation occurs before writer admission and does not write provider configuration or credentials. Imported config and `.env` byte preservation are asserted across both rejection and successful adoption. The implementation is platform-neutral and reuses the existing Linux, macOS, and Windows probe launcher. Keyless providers, persisted schemas, public IPC shapes, and existing client contracts are unchanged.

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents are not committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A; no third-party code, fixtures, or text were copied or adapted.

## Documentation Changes

- [x] No documentation files changed.
- [x] Test fixtures use only synthetic credentials and loopback endpoints.
