### PR TITLE
Preserve terminal activity during stream pressure

### DIFF
--- a/opensquilla-webui/e2e/task-ownership-stop.spec.ts
+++ b/opensquilla-webui/e2e/task-ownership-stop.spec.ts
@@ -34,6 +34,16 @@ async function preparePage(page: Page) {
     contentType: 'application/json',
     body: JSON.stringify({ pending: [], mode: 'prompt', allowPatterns: [], denyPatterns: [] }),
   }))
+  await page.route('**/api/system/update', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ available: false }),
+  }))
+  await page.route('**/api/elevated-mode', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ enabled: false }),
+  }))
   await page.route('**/control/static/dist/opensquilla-mark.png', route => route.fulfill({
     status: 204,
     contentType: 'image/png',

--- a/opensquilla-webui/e2e/terminal-history-stale-live.spec.ts
+++ b/opensquilla-webui/e2e/terminal-history-stale-live.spec.ts
@@ -1,0 +1,163 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const CONTROL_URL = '/control/'
+const SESSION_KEY = 'agent:main:webchat:e2e-terminal-history-stale-live'
+const TASK_ID = 'task-e2e-terminal-history-stale-live'
+const BASE_TIME = 1_800_000_000_000
+
+function response(id: unknown, payload: unknown) {
+  return JSON.stringify({ type: 'res', id, ok: true, payload })
+}
+
+function terminalHistory() {
+  return {
+    messages: [{
+      role: 'user',
+      text: 'Stop after the provider retry.',
+      id: 'user-terminal-history',
+      message_id: 'user-terminal-history',
+      timestamp: BASE_TIME - 1_000,
+      turn_context: { turn_id: TASK_ID },
+    }],
+    turn_outcomes: [{
+      turn_id: TASK_ID,
+      task_id: TASK_ID,
+      status: 'cancelled',
+      started_at: BASE_TIME,
+      finished_at: BASE_TIME + 2_000,
+      outcome: { kind: 'cancelled', cancellation_source: 'webui_stop' },
+      activity_snapshot: {
+        version: 2,
+        task_id: TASK_ID,
+        turn_id: TASK_ID,
+        complete: true,
+        reasoning_utf16_length: 0,
+        entries: [
+          {
+            type: 'phase', id: 'provider:requesting:1', order: 1,
+            kind: 'provider', phase: 'requesting',
+            at: BASE_TIME, ended_at: BASE_TIME + 500,
+          },
+          {
+            type: 'phase', id: 'provider:retry_wait:2', order: 2,
+            kind: 'provider', phase: 'retry_wait', reason: 'rate_limited',
+            retry_after_ms: 1_000,
+            at: BASE_TIME + 500, ended_at: BASE_TIME + 2_000,
+          },
+        ],
+      },
+    }],
+    has_more: false,
+    canonical_complete: true,
+  }
+}
+
+async function installStaleLiveFixture(page: Page) {
+  await page.addInitScript(() => localStorage.setItem('opensquilla-locale', 'en'))
+  await page.route('**/api/approvals', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ pending: [], mode: 'prompt', allowPatterns: [], denyPatterns: [] }),
+  }))
+  await page.route('**/api/system/update', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ available: false }),
+  }))
+  await page.route('**/api/elevated-mode', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ enabled: false }),
+  }))
+  await page.routeWebSocket(/\/ws$/, ws => {
+    ws.send(JSON.stringify({ type: 'event', event: 'connect.challenge', payload: {} }))
+    ws.onMessage(message => {
+      const frame = JSON.parse(String(message)) as {
+        id?: string | number
+        method?: string
+        type?: string
+      }
+      if (frame.type === 'ping') {
+        ws.send(JSON.stringify({ type: 'pong' }))
+        return
+      }
+      if (frame.type !== 'req') return
+      if (frame.method === 'connect') {
+        ws.send(JSON.stringify({
+          protocol: 3,
+          policy: { tick_interval_ms: 30_000, concurrent_history_reads: true },
+        }))
+        return
+      }
+      const method = String(frame.method || '')
+      if (method === 'chat.history') {
+        ws.send(response(frame.id, terminalHistory()))
+        return
+      }
+      if (method === 'sessions.messages.snapshot') {
+        ws.send(response(frame.id, {
+          key: SESSION_KEY,
+          task_id: TASK_ID,
+          stream_generation: 'stale-terminal-generation',
+          current_stream_seq: 2,
+          events: [{
+            event: 'session.event.provider_activity',
+            payload: {
+              session_key: SESSION_KEY,
+              task_id: TASK_ID,
+              turn_id: TASK_ID,
+              stream_seq: 2,
+              emitted_at: BASE_TIME + 1_000,
+              phase: 'reasoning',
+            },
+          }],
+        }))
+        return
+      }
+      const staleLiveState = {
+        subscribed: true,
+        hydration_complete: true,
+        replay_complete: true,
+        stream_generation: 'stale-terminal-generation',
+        current_stream_seq: 2,
+        run_status: 'running',
+        active_task: { task_id: TASK_ID, status: 'running', started_at: BASE_TIME },
+        tasks: [{ task_id: TASK_ID, status: 'running' }],
+      }
+      const payloads: Record<string, unknown> = {
+        'agents.list': { agents: [] },
+        'commands.list_for_surface': { commands: [] },
+        'config.get': {
+          squilla_router: { enabled: false, rollout_phase: 'observe', tiers: {} },
+          permissions: {}, skills: {},
+        },
+        'models.routing.get': { mode: 'direct' },
+        'onboarding.status': { audioConfigured: false },
+        'sessions.list': { sessions: [], has_more: false },
+        'sessions.messages.subscribe': staleLiveState,
+        'sessions.messages.hydrate': staleLiveState,
+        'sessions.messages.unsubscribe': { subscribed: false },
+        'sessions.subscribe': { subscribed: true },
+        'usage.status': { sessions: [] },
+      }
+      ws.send(response(frame.id, payloads[method] ?? {}))
+    })
+  })
+}
+
+test('terminal history keeps activity-only output and rejects the same task stale live state', async ({
+  page,
+}) => {
+  await installStaleLiveFixture(page)
+
+  await page.goto(`${CONTROL_URL}chat?session=${encodeURIComponent(SESSION_KEY)}`)
+  await expect(page.locator('.conn-pill.connected')).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByText('Stop after the provider retry.', { exact: true })).toBeVisible()
+  await expect(page.getByRole('button', { name: /^Stopped/ })).toBeVisible()
+
+  const activity = page.locator('.msg-ai .assistant-activity')
+  await expect(activity).toBeVisible()
+  await expect(page.locator('.assistant-activity--live')).toHaveCount(0)
+  await expect(page.getByRole('button', { name: 'Stop current response' })).toHaveCount(0)
+  await expect(page.locator('.chat-send-btn[aria-label="Send"]')).toBeVisible()
+})

--- a/opensquilla-webui/src/composables/chat/useChatHistory.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatHistory.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { nextTick, ref, type Ref } from 'vue'
 
 import { useChatHistory } from './useChatHistory'
-import type { ChatMessage } from '@/types/chat'
+import type { ChatMessage, ChatTurnOutcome } from '@/types/chat'
 import type { ChatHistoryResponse } from '@/types/rpc'
 import { RpcTimeoutError } from '@/lib/rpc'
 
@@ -15,6 +15,7 @@ function makeHistory(autoScroll = true, overrides: {
   scrollEpoch?: Ref<number>
   threadRef?: Ref<HTMLElement | null>
   concurrentHistoryReads?: boolean
+  onTerminalTask?: (outcome: ChatTurnOutcome) => void
 } = {}) {
   const response: ChatHistoryResponse = overrides.response || {
     messages: [
@@ -52,6 +53,7 @@ function makeHistory(autoScroll = true, overrides: {
     scrollEpoch: overrides.scrollEpoch,
     stripTimePrefix: text => text,
     scrollToBottom,
+    onTerminalTask: overrides.onTerminalTask,
   })
   return { api, rpc, scrollToBottom, messages }
 }
@@ -2176,6 +2178,69 @@ describe('useChatHistory optimistic local rows', () => {
       cancellationSource: 'webui_stop',
       acceptedRoutingMode: 'ensemble',
     })
+  })
+
+  it('restores terminal activity without an assistant transcript row', async () => {
+    const onTerminalTask = vi.fn()
+    const { api, messages } = makeHistory(true, {
+      onTerminalTask,
+      response: {
+        messages: [{
+          id: 'user-cancelled',
+          message_id: 'user-cancelled',
+          role: 'user',
+          text: 'stop after the retry',
+          timestamp: '2026-07-07T10:00:00Z',
+          turn_context: { turn_id: 'turn-cancelled' },
+        }],
+        turn_outcomes: [{
+          turn_id: 'turn-cancelled',
+          task_id: 'task-cancelled',
+          status: 'cancelled',
+          finished_at: 2_000,
+          activity_snapshot: {
+            version: 2,
+            task_id: 'task-cancelled',
+            turn_id: 'turn-cancelled',
+            complete: true,
+            reasoning_utf16_length: 0,
+            entries: [
+              {
+                type: 'phase', id: 'provider:requesting:1', order: 1,
+                kind: 'provider', phase: 'requesting', at: 1_000, ended_at: 1_200,
+              },
+              {
+                type: 'phase', id: 'provider:retry_wait:2', order: 2,
+                kind: 'provider', phase: 'retry_wait', reason: 'rate_limited',
+                retry_after_ms: 500, at: 1_200, ended_at: 2_000,
+              },
+            ],
+          },
+          outcome: { kind: 'cancelled', cancellation_source: 'webui_stop' },
+        }],
+        has_more: false,
+        canonical_complete: true,
+      },
+    })
+
+    await api.loadHistory()
+
+    expect(messages.value.map(message => message.role)).toEqual(['user', 'assistant'])
+    expect(messages.value[1]).toMatchObject({
+      text: '',
+      turnId: 'turn-cancelled',
+      messageId: 'terminal-activity:task-cancelled',
+      activitySnapshot: { version: 2, complete: true },
+      activitySnapshotIncomplete: false,
+      statusHistory: [
+        expect.objectContaining({ action: 'provider:requesting', activityOrder: 1 }),
+        expect.objectContaining({ action: 'provider:rate_limited:1', activityOrder: 2 }),
+      ],
+    })
+    expect(onTerminalTask).toHaveBeenCalledWith(expect.objectContaining({
+      taskId: 'task-cancelled',
+      status: 'cancelled',
+    }))
   })
 
   it('restores usage barrier activity and its retryable error from terminal history', async () => {

--- a/opensquilla-webui/src/composables/chat/useChatHistory.ts
+++ b/opensquilla-webui/src/composables/chat/useChatHistory.ts
@@ -2,6 +2,7 @@ import { nextTick, ref, type Ref } from 'vue'
 import type {
   ChatMessage,
   ChatTimelineSegment,
+  ChatTurnOutcome,
   ChatUsagePayload,
   RawToolCallPayload,
 } from '@/types/chat'
@@ -445,11 +446,13 @@ function attachHistoryTurnOutcomes(
     }
   })
 
-  // A pre-provider barrier may fail before an assistant transcript row exists.
-  // Materialize one status-only assistant row from the terminal task snapshot
-  // so refresh and reconnect show the completed route/activity trace.
+  // A terminal task may finish before an assistant transcript row exists.
+  // Materialize one activity-only assistant row so refresh and reconnect keep
+  // the durable route/activity trace inspectable.
   for (const outcome of outcomes) {
-    if (!isUsageAccountingBarrier(outcome.errorClass) || !outcome.statusHistory?.length) continue
+    const legacyUsageActivity = isUsageAccountingBarrier(outcome.errorClass)
+      && Boolean(outcome.statusHistory?.length)
+    if (!outcome.activitySnapshot && !legacyUsageActivity) continue
     if (enriched.some(message => message.turnId === outcome.turnId && message.role === 'assistant')) continue
     const turnIndexes = enriched.flatMap((message, index) =>
       message.turnId === outcome.turnId ? [index] : [],
@@ -457,16 +460,34 @@ function attachHistoryTurnOutcomes(
     if (!turnIndexes.length) continue
     const firstTerminalIndex = turnIndexes.find(index => enriched[index]?.role === 'error')
     const insertionIndex = firstTerminalIndex ?? Math.max(...turnIndexes) + 1
-    enriched.splice(insertionIndex, 0, {
+    const activityOnlyMessage: ChatMessage = {
       role: 'assistant',
       text: '',
       ts: outcome.finishedAt ?? null,
       turnId: outcome.turnId,
       turnOutcome: outcome,
-      statusHistory: outcome.statusHistory.map(entry => ({ ...entry })),
+      statusHistory: (outcome.statusHistory || []).map(entry => ({ ...entry })),
       messageId: `terminal-activity:${outcome.taskId || outcome.turnId}`,
       restoredFromHistory: true,
-    })
+    }
+    if (outcome.activitySnapshot) {
+      const snapshotReasoningBlocks = outcome.activitySnapshot.complete
+        ? activityReasoningBlocks(outcome.activitySnapshot, '')
+        : undefined
+      const snapshotComplete = Boolean(
+        outcome.activitySnapshot.complete
+        && snapshotReasoningBlocks !== undefined
+        && activitySnapshotMatchesMessage(outcome.activitySnapshot, activityOnlyMessage),
+      )
+      activityOnlyMessage.activitySnapshot = snapshotComplete
+        ? outcome.activitySnapshot
+        : { ...outcome.activitySnapshot, complete: false }
+      activityOnlyMessage.activitySnapshotIncomplete = !snapshotComplete
+      if (snapshotComplete) {
+        activityOnlyMessage.reasoningBlocks = snapshotReasoningBlocks?.map(block => ({ ...block }))
+      }
+    }
+    enriched.splice(insertionIndex, 0, activityOnlyMessage)
   }
 
   // The task outcome is the durable authority for a pre-provider usage
@@ -653,6 +674,7 @@ export interface UseChatHistoryOptions {
   scrollEpoch?: Ref<number>
   stripTimePrefix: (text: string) => string
   scrollToBottom: () => void
+  onTerminalTask?: (outcome: ChatTurnOutcome) => void
 }
 
 export interface ChatHistoryState {
@@ -728,6 +750,20 @@ export function useChatHistory(options: UseChatHistoryOptions) {
     loadEarlierError: false,
     recoveryError: false,
   })
+
+  function notifyTerminalTasks(data: ChatHistoryResponse) {
+    if (!options.onTerminalTask) return
+    for (const raw of data.turn_outcomes || []) {
+      const outcome = normalizeTurnOutcome(raw)
+      if (
+        outcome?.taskId
+        && ['succeeded', 'failed', 'cancelled', 'timeout', 'abandoned', 'interrupted']
+          .includes(outcome.status.toLowerCase())
+      ) {
+        options.onTerminalTask(outcome)
+      }
+    }
+  }
 
   function cancelAnchorStabilization() {
     const stop = stopAnchorStabilization
@@ -1044,6 +1080,8 @@ export function useChatHistory(options: UseChatHistoryOptions) {
         }
       }
 
+      if (canonicalAvailable !== false) notifyTerminalTasks(data)
+
       const summaryIds = summaryCompactionIds(data)
       let mapped = attachHistoryTurnOutcomes(
         msgs.map(message => mapHistoryMessage(message, summaryIds)),
@@ -1123,6 +1161,8 @@ export function useChatHistory(options: UseChatHistoryOptions) {
             flushPendingHistorySync()
             return { ok: false }
           }
+
+          notifyTerminalTasks(bridgeData)
 
           const page = attachHistoryTurnOutcomes(
             (bridgeData.messages || []).map(message =>

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
@@ -214,6 +214,38 @@ describe('useChatRpcEventHandlers route-card ownership', () => {
 })
 
 describe('useChatRpcEventHandlers live snapshot restoration', () => {
+  it('starts restored activity at the earliest server event timestamp', () => {
+    const harness = createHarness()
+    harness.stream.isStreaming.value = false
+    try {
+      harness.api.restoreLiveTurnSnapshot({
+        key: 'agent:main:test',
+        task_id: 'task-clock',
+        current_stream_seq: 2,
+        events: [
+          {
+            event: 'session.event.provider_activity',
+            payload: {
+              session_key: 'agent:main:test', task_id: 'task-clock',
+              stream_seq: 1, emitted_at: 2_000, phase: 'requesting',
+            },
+          },
+          {
+            event: 'session.event.thinking',
+            payload: {
+              session_key: 'agent:main:test', task_id: 'task-clock',
+              stream_seq: 2, emitted_at: 3_000, text: 'reasoning',
+            },
+          },
+        ],
+      })
+
+      expect(harness.stream.startStreaming).toHaveBeenCalledWith(2_000, false)
+    } finally {
+      harness.stop()
+    }
+  })
+
   it('replays a committed tool timeline including its authoritative end', () => {
     const { api, stream, stop } = createHarness()
     try {

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
@@ -79,7 +79,10 @@ export interface ChatRpcStreamApi {
   isStreaming: Ref<boolean>
   streamBubble: Ref<boolean>
   streamHasVisibleOutput: Ref<boolean>
-  startStreaming: () => void
+  startStreaming: (
+    activityStartedAt?: number | string | null,
+    recordInitialActivity?: boolean,
+  ) => void
   endStreaming: (opts?: { reason?: string, suppressed?: boolean }) => void
   checkpointForUserMessage?: (turnId: string, boundaryKey?: string) => void
   acknowledgeSteerBoundary?: (
@@ -942,13 +945,19 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
         }]
       })
       .sort(comparePendingReplayEntries)
+    const restoredStartedAt = replayEntries.reduce<number | undefined>((earliest, entry) => {
+      if (entry.kind !== 'stream') return earliest
+      const startedAt = explicitActivityStartedAt(entry.payload)
+      if (startedAt === undefined) return earliest
+      return earliest === undefined ? startedAt : Math.min(earliest, startedAt)
+    }, undefined)
     // Open/reset the live reducer before accepting the first authoritative
     // snapshot frame. startStreaming() clears the prior turn log, including
     // its accepted activity-order context; doing that from the first event
     // handler would therefore erase that frame's stream_seq and force the
     // entire restored turn onto the legacy reordered renderer.
     if (replayEntries.length > 0 && !stream.isStreaming.value) {
-      stream.startStreaming()
+      stream.startStreaming(restoredStartedAt, false)
     }
     for (const entry of replayEntries) {
       if (entry.kind !== 'stream') continue
@@ -1395,13 +1404,17 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
   }
 
   function activityStartedAt(payload: StreamEventEnvelope): number {
+    return explicitActivityStartedAt(payload) ?? Date.now()
+  }
+
+  function explicitActivityStartedAt(payload: StreamEventEnvelope): number | undefined {
     const value = Number(
       payload.started_at
       ?? payload.startedAt
       ?? payload.emitted_at
       ?? payload.emittedAt,
     )
-    return Number.isFinite(value) && value > 0 ? value : Date.now()
+    return Number.isFinite(value) && value > 0 ? value : undefined
   }
 
   function recordActivityPhase(label: string, key = label) {

--- a/opensquilla-webui/src/composables/chat/useChatSessionSubscription.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionSubscription.test.ts
@@ -8,6 +8,7 @@ import {
 import { SESSION_PHASE_ATTEMPT_BUDGET_MS } from './sessionBootstrapContract'
 import { RpcTimeoutError, type RpcCallOptions } from '@/lib/rpc'
 import type { ChatRunStatus, ChatRunStatusState } from '@/types/chat'
+import { useChatTaskOwnership } from './useChatTaskOwnership'
 
 function createSubscription(hasActiveInterrupt = false) {
   const resetStreamLiveTurnState = vi.fn()
@@ -392,6 +393,71 @@ describe('useChatSessionSubscription', () => {
       ],
     })
     expect(lastStreamSeq.value).toBe(2402)
+  })
+
+  it('rejects a live snapshot for a task already settled by history', async () => {
+    const taskOwnership = useChatTaskOwnership()
+    taskOwnership.noteTerminal('task-settled')
+    const onLiveSnapshot = vi.fn()
+    const startStreaming = vi.fn()
+    const resetStreamLiveTurnState = vi.fn()
+    const runStatus = ref<ChatRunStatus>({ status: 'idle', label: 'Idle', task: null })
+    const rpc: UseChatSessionSubscriptionOptions['rpc'] = {
+      waitForConnection: vi.fn(async () => {}),
+      call: vi.fn(async (method: string) => {
+        if (method === 'sessions.messages.snapshot') {
+          return {
+            key: 'agent:main:webchat:settled-history',
+            task_id: 'task-settled',
+            current_stream_seq: 40,
+            events: [{
+              event: 'session.event.thinking',
+              payload: { task_id: 'task-settled', text: 'stale', stream_seq: 40 },
+            }],
+          }
+        }
+        return {
+          subscribed: true,
+          hydration_complete: true,
+          run_status: 'running',
+          active_task: { task_id: 'task-settled', status: 'running', started_at: 1_000 },
+          active_task_group_ids: ['stale-task-group'],
+          current_stream_seq: 40,
+          replay_complete: true,
+        }
+      }) as UseChatSessionSubscriptionOptions['rpc']['call'],
+    }
+    const activeTaskGroups = ref(new Set<string>())
+    const subscription = useChatSessionSubscription({
+      rpc,
+      sessionKey: ref('agent:main:webchat:settled-history'),
+      lastStreamSeq: ref(0),
+      runStatus,
+      isStreaming: ref(false),
+      hasActiveInterrupt: ref(false),
+      activeStreamTaskId: ref(''),
+      activeTaskGroups,
+      taskOwnership,
+      sessionRunStatus: source => ({
+        status: String(source?.run_status || 'idle') as ChatRunStatusState,
+        label: '',
+        task: source?.active_task || null,
+      }),
+      startStreaming,
+      loadHistory: vi.fn(),
+      resetStreamIdleTimer: vi.fn(),
+      resetStreamLiveTurnState,
+      onLiveSnapshot,
+    })
+
+    const outcome = await subscription.subscribeSession()
+
+    expect(onLiveSnapshot).not.toHaveBeenCalled()
+    expect(startStreaming).not.toHaveBeenCalled()
+    expect(resetStreamLiveTurnState).not.toHaveBeenCalled()
+    expect(runStatus.value.status).toBe('idle')
+    expect([...activeTaskGroups.value]).toEqual([])
+    expect(outcome).toEqual({ authoritative: true, live: false, backgroundOnly: false })
   })
 
   it('hydrates the authoritative run-mode lock from the subscription snapshot', async () => {

--- a/opensquilla-webui/src/composables/chat/useChatSessionSubscription.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionSubscription.ts
@@ -51,7 +51,10 @@ export interface UseChatSessionSubscriptionOptions {
   ownershipHydrationRequired?: () => boolean
   acceptanceStopPending?: Ref<boolean>
   sessionRunStatus: (source: ChatRunStatusSource | null | undefined) => ChatRunStatus
-  startStreaming: () => void
+  startStreaming: (
+    activityStartedAt?: number | string | null,
+    recordInitialActivity?: boolean,
+  ) => void
   /** Adopt durable task timing even when snapshot replay already opened the bubble. */
   reconcileStreamTaskClock?: (snapshot: {
     sessionKey: string
@@ -281,14 +284,29 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
     if (runModeLock && typeof runModeLock === 'object') {
       options.onRunModeLock?.(runModeLock)
     }
-    options.onSnapshot?.(res)
-    options.taskOwnership?.applySnapshot(res, true)
+    const rawActiveTask = res.active_task || res.activeTask || null
+    const rawActiveTaskId = chatTaskId(rawActiveTask)
+    const rawRunStatus = String(res.run_status || res.runStatus || '').toLowerCase()
+    const settledLiveTask = LIVE_RUN_STATES.includes(rawRunStatus)
+      && Boolean(rawActiveTaskId)
+      && options.taskOwnership?.isSettled(rawActiveTaskId) === true
+    const effectiveSnapshot = settledLiveTask
+      ? {
+          ...res,
+          run_status: 'idle' as const,
+          runStatus: 'idle' as const,
+          active_task: null,
+          activeTask: null,
+        }
+      : res
+    options.onSnapshot?.(effectiveSnapshot)
+    options.taskOwnership?.applySnapshot(effectiveSnapshot, true)
     // Do not clear an acceptance-result-unknown Stop from an idle snapshot.
     // The subscription can race ahead of the original ingress commit, so only
     // the matching send transaction (receipt/rejection) or an explicit session
     // reset may release that latch.  Its idempotent replay must still inherit
     // the Stop intent and abort the exact accepted task once the receipt exists.
-    applySessionRunState(res)
+    applySessionRunState(effectiveSnapshot)
     // A pending inline interrupt is newer, stronger evidence than an idle
     // subscription snapshot that raced with the approval request.
     if (
@@ -301,17 +319,21 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
       })
     }
     const liveTaskSnapshot = LIVE_RUN_STATES.includes(options.runStatus.value.status)
-    reconcileActiveTaskGroups(res)
+    if (!settledLiveTask) reconcileActiveTaskGroups(res)
     if (liveTaskSnapshot && !options.isStreaming.value) {
-      options.startStreaming()
+      const activeTask = (effectiveSnapshot.active_task || effectiveSnapshot.activeTask) as {
+        started_at?: number | string | null
+        startedAt?: number | string | null
+      } | null | undefined
+      options.startStreaming(activeTask?.started_at ?? activeTask?.startedAt)
       // startStreaming establishes the live bubble with a generic running
       // placeholder. Restore the authoritative active-task payload (including
       // steer_capability) that came from hydration instead of waiting for a
       // later task.running event to repair it.
-      applySessionRunState(res)
+      applySessionRunState(effectiveSnapshot)
     }
     if (liveTaskSnapshot) {
-      const activeTask = (res.active_task || res.activeTask) as {
+      const activeTask = (effectiveSnapshot.active_task || effectiveSnapshot.activeTask) as {
         task_id?: string
         taskId?: string
         started_at?: number | string | null
@@ -568,9 +590,15 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
             // snapshot response. Never reset the live surface behind them.
             && snapshot.current_stream_seq >= options.lastStreamSeq.value
           ) {
-            onLiveSnapshot?.(snapshot)
+            const snapshotTaskId = typeof snapshot.task_id === 'string'
+              ? snapshot.task_id
+              : ''
+            const settledSnapshot = Boolean(
+              snapshotTaskId && options.taskOwnership?.isSettled(snapshotTaskId),
+            )
+            if (!settledSnapshot) onLiveSnapshot?.(snapshot)
             options.lastStreamSeq.value = Math.max(0, snapshot.current_stream_seq)
-            snapshotTaskLive = Boolean(snapshot.task_id)
+            snapshotTaskLive = Boolean(snapshot.task_id) && !settledSnapshot
           }
         }
       }

--- a/opensquilla-webui/src/composables/chat/useChatStream.render.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatStream.render.test.ts
@@ -183,6 +183,19 @@ describe('useChatStream render coalescing', () => {
     api.cleanup()
   })
 
+  it('seeds a restored timeline before recording the initial activity phase', () => {
+    vi.setSystemTime(10_000)
+    const { api } = makeStream()
+
+    api.startStreaming(1_000, false)
+    api.setAcceptedActivityStartedAt(2_000)
+    api.setStreamActivity('Waiting for model', 'provider:requesting')
+
+    expect(api.foldedTurn.value.statusHistory.map(entry => entry.at)).toEqual([2_000])
+    expect(api.streamTurnElapsed.value).toBe('9s')
+    api.cleanup()
+  })
+
   it('restores the turn elapsed clock from a replayed reasoning boundary', () => {
     vi.setSystemTime(20_000)
     const { api } = makeStream()

--- a/opensquilla-webui/src/composables/chat/useChatStream.ts
+++ b/opensquilla-webui/src/composables/chat/useChatStream.ts
@@ -487,7 +487,10 @@ export function useChatStream(options: UseChatStreamOptions) {
     streamActivityTick.value++
   }
 
-  function startStreaming() {
+  function startStreaming(
+    activityStartedAt?: number | string | null,
+    recordInitialActivity = true,
+  ) {
     checkpointedRaw = ''
     checkpointedAcrossToolBoundary = false
     activeStreamTurnId = ''
@@ -504,16 +507,18 @@ export function useChatStream(options: UseChatStreamOptions) {
         : { status: 'running' },
     })
     resetStreamState()
+    const restoredStartedAt = normalizedTaskStartedAt(activityStartedAt) ?? 0
+    setAcceptedActivityStartedAt(restoredStartedAt || undefined)
     openToolGroups.value = new Set()
     openToolItems.value = new Set()
     streamToolGroupSeq = 0
     streamRound.value = 1
     streamTaskClockIdentity = ''
-    streamTurnStartedAt.value = Date.now()
+    streamTurnStartedAt.value = restoredStartedAt || Date.now()
     noteStreamSignal()
     streamBubble.value = true
     streamShowHeader.value = options.lastHeaderRole.value !== 'assistant'
-    setStreamActivity('Sending')
+    setStreamActivity('Sending', 'Sending', recordInitialActivity)
     options.autoScroll.value = true
     resetStreamIdleTimer()
   }

--- a/opensquilla-webui/src/composables/chat/useChatTaskOwnership.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatTaskOwnership.test.ts
@@ -132,4 +132,19 @@ describe('useChatTaskOwnership', () => {
     expect(ownership.runningTaskId.value).toBe('task-A')
     expect([...ownership.queuedTaskIds.value]).toEqual(['task-B'])
   })
+
+  it('does not restore a task that terminal history already settled', () => {
+    const ownership = useChatTaskOwnership()
+    ownership.noteTerminal('task-settled')
+
+    ownership.applySnapshot({
+      run_status: 'running',
+      active_task: { task_id: 'task-settled', status: 'running' },
+      tasks: [{ task_id: 'task-settled', status: 'running' }],
+    } as never, true)
+
+    expect(ownership.isSettled('task-settled')).toBe(true)
+    expect(ownership.runningTaskId.value).toBe('')
+    expect(ownership.hasAuthoritativeWork.value).toBe(false)
+  })
 })

--- a/opensquilla-webui/src/composables/chat/useChatTaskOwnership.ts
+++ b/opensquilla-webui/src/composables/chat/useChatTaskOwnership.ts
@@ -94,6 +94,7 @@ export interface ChatTaskOwnershipApi {
     wasQueued: boolean
     wasStopTarget: boolean
   }
+  isSettled: (taskId: string) => boolean
   isQueued: (taskId: string) => boolean
   isBackgroundQueued: (taskId: string) => boolean
   beginStop: () => string
@@ -234,11 +235,17 @@ export function useChatTaskOwnership(initiallyResolved = true): ChatTaskOwnershi
       rememberSettled(snapshotLastTaskId)
     }
     const activeStatus = taskStatus(activeTask)
-    const runningTask = (
+    const runningCandidates = (
       activeStatus === 'running' || activeStatus === 'approval_pending'
-        ? activeTask
-        : tasks.find(task => ['running', 'approval_pending'].includes(taskStatus(task))) || null
+        ? [activeTask, ...tasks]
+        : tasks
     )
+    const runningTask = runningCandidates.find(task => {
+      const taskId = chatTaskId(task)
+      return ['running', 'approval_pending'].includes(taskStatus(task))
+        && Boolean(taskId)
+        && !settledTaskIds.has(taskId)
+    }) || null
     const nextRunningTaskId = chatTaskId(runningTask)
     const nextQueuedTaskIds = queuedIdsFromSnapshot(source, activeTask)
       .filter(taskId => taskId !== nextRunningTaskId && !settledTaskIds.has(taskId))
@@ -271,6 +278,10 @@ export function useChatTaskOwnership(initiallyResolved = true): ChatTaskOwnershi
 
   function isQueued(taskId: string): boolean {
     return Boolean(taskId && queuedTaskIds.value.has(taskId))
+  }
+
+  function isSettled(taskId: string): boolean {
+    return Boolean(taskId && settledTaskIds.has(taskId))
   }
 
   function isBackgroundQueued(taskId: string): boolean {
@@ -308,6 +319,7 @@ export function useChatTaskOwnership(initiallyResolved = true): ChatTaskOwnershi
     noteQueued,
     noteRunning,
     noteTerminal,
+    isSettled,
     isQueued,
     isBackgroundQueued,
     beginStop,

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -883,7 +883,7 @@ import { useChatRpcEventHandlers } from '@/composables/chat/useChatRpcEventHandl
 import { useChatRpcSubscriptions } from '@/composables/chat/useChatRpcSubscriptions'
 import { useChatSend, type ChatSendOutcome } from '@/composables/chat/useChatSend'
 import { useChatSteerDelivery } from '@/composables/chat/useChatSteerDelivery'
-import { useChatTaskOwnership } from '@/composables/chat/useChatTaskOwnership'
+import { chatTaskId, useChatTaskOwnership } from '@/composables/chat/useChatTaskOwnership'
 import {
   composerRunModeSelectionAction,
   effectiveComposerRunMode,
@@ -2240,6 +2240,28 @@ const chatHistory = useChatHistory({
   scrollEpoch,
   stripTimePrefix,
   scrollToBottom,
+  onTerminalTask: outcome => {
+    const taskId = outcome.taskId || ''
+    if (!taskId) return
+    taskOwnership.noteTerminal(taskId)
+    const ownsLiveStream = activeStreamTaskId.value === taskId
+    const ownsRunStatus = chatTaskId(runStatus.value.task) === taskId
+    if (ownsLiveStream) {
+      resetStreamLiveTurnState()
+      activeStreamTaskId.value = outcome.status === 'cancelled'
+        ? STOPPED_STREAM_TASK_ID
+        : FINISHED_STREAM_TASK_ID
+    }
+    if (ownsLiveStream || ownsRunStatus) {
+      applySessionRunState({
+        run_status: outcome.status === 'cancelled'
+          ? 'cancelled'
+          : outcome.status === 'failed' ? 'failed' : 'idle',
+        active_task: null,
+        last_task: { task_id: taskId, status: outcome.status },
+      })
+    }
+  },
 })
 const {
   historySessionKey,

--- a/src/opensquilla/gateway/session_streams.py
+++ b/src/opensquilla/gateway/session_streams.py
@@ -182,6 +182,12 @@ class SessionStreamRegistry:
         self._live_task_by_session.pop(session_key, None)
         self._live_generation_epoch_by_session.pop(session_key, None)
 
+    def _clear_live_state_for_task(self, session_key: str, task_id: str) -> bool:
+        if self._live_task_by_session.get(session_key) != task_id:
+            return False
+        self._clear_live_state(session_key)
+        return True
+
     def _store_terminal_activity_snapshot(
         self,
         session_key: str,
@@ -269,11 +275,15 @@ class SessionStreamRegistry:
             turn_id=turn_id,
             terminal_at=terminal_at,
         )
-        return terminal_activity_snapshot(
+        durable_snapshot = terminal_activity_snapshot(
             snapshot,
             task_id=task_id,
             turn_id=turn_id,
         )
+        if durable_snapshot is None:
+            return None
+        self._clear_live_state_for_task(session_key, task_id)
+        return durable_snapshot
 
     def _trim_session_events(self, events: deque[BufferedSessionEvent]) -> None:
         while len(events) > self._max_events_per_session:

--- a/src/opensquilla/gateway/websocket.py
+++ b/src/opensquilla/gateway/websocket.py
@@ -361,6 +361,16 @@ class WsConnection:
                 meta=meta,
             )
             self._enqueue_frame(frame)
+            # A producer can emit hundreds of tool/text deltas through an
+            # await chain whose queue fast path never actually suspends. Give
+            # the healthy writer a chance to drain at half capacity before a
+            # cooperative burst mistakes event-loop starvation for a slow
+            # consumer and force-closes the connection at the hard limit.
+            if (
+                not self._closing
+                and self._outbox.qsize() >= max(1, self._writer_queue_maxsize // 2)
+            ):
+                await asyncio.sleep(0)
             return
         # Legacy direct-send path (pre-auth, kill-switch off, or post-stop).
         async with self._send_lock:

--- a/tests/test_gateway/test_session_streams.py
+++ b/tests/test_gateway/test_session_streams.py
@@ -959,6 +959,63 @@ def test_terminal_handoff_retains_only_sanitized_v2_and_is_single_use() -> None:
     ) is None
 
 
+def test_terminal_handoff_clears_matching_live_task_without_done_event() -> None:
+    registry = SessionStreamRegistry()
+    session_key = "agent:main:cancelled-terminal-snapshot"
+    common = {"task_id": "task-cancelled", "turn_id": "task-cancelled"}
+    registry.record(
+        session_key,
+        "session.event.provider_activity",
+        {**common, "phase": "requesting"},
+    )
+    registry.record(
+        session_key,
+        "session.event.thinking",
+        {**common, "block_id": "reasoning-1", "text": "synthetic reasoning"},
+    )
+
+    snapshot = registry.take_terminal_activity_snapshot(
+        session_key,
+        "task-cancelled",
+        turn_id="task-cancelled",
+        terminal_at=10_000,
+    )
+
+    assert snapshot is not None
+    assert snapshot["complete"] is True
+    assert registry.live_snapshot(session_key).task_id is None
+    assert registry.live_snapshot(session_key).events == []
+
+
+def test_terminal_handoff_does_not_clear_successor_live_task() -> None:
+    registry = SessionStreamRegistry()
+    session_key = "agent:main:terminal-successor"
+    first = {"task_id": "task-first", "turn_id": "task-first"}
+    successor = {"task_id": "task-successor", "turn_id": "task-successor"}
+    registry.record(
+        session_key,
+        "session.event.provider_activity",
+        {**first, "phase": "requesting"},
+    )
+    registry.record(session_key, "session.event.done", first)
+    registry.record(
+        session_key,
+        "session.event.provider_activity",
+        {**successor, "phase": "requesting"},
+    )
+
+    snapshot = registry.take_terminal_activity_snapshot(
+        session_key,
+        "task-first",
+        turn_id="task-first",
+    )
+
+    assert snapshot is not None
+    live = registry.live_snapshot(session_key)
+    assert live.task_id == "task-successor"
+    assert [event.payload["task_id"] for event in live.events] == ["task-successor"]
+
+
 def test_live_snapshot_keeps_text_presentation_boundaries(monkeypatch) -> None:
     registry = SessionStreamRegistry()
     session_key = "agent:main:text-presentation"

--- a/tests/test_gateway/test_ws_writer_queue.py
+++ b/tests/test_gateway/test_ws_writer_queue.py
@@ -85,6 +85,15 @@ async def _flush_writer(conn: WsConnection, *, deadline: float = 1.0) -> None:
         await asyncio.sleep(0.01)
 
 
+async def _block_writer(conn: WsConnection, fake: _FakeWebSocket) -> None:
+    """Park the writer in send_text so overflow tests model a genuinely slow socket."""
+
+    fake._send_event = asyncio.Event()
+    fake._send_unblock = asyncio.Event()
+    await conn.send_raw_text('{"type":"writer-test-probe"}')
+    await asyncio.wait_for(fake._send_event.wait(), timeout=1.0)
+
+
 def _turn_committed_payload(**overrides: object) -> dict[str, object]:
     payload: dict[str, object] = {
         "schema_version": 1,
@@ -280,16 +289,13 @@ async def test_lossy_drop_log_has_full_field_set_for_tick() -> None:
     conn = WsConnection(conn_id="cx-tick", ws=fake)  # type: ignore[arg-type]
     conn._start_writer(maxsize=4, enabled=True)
 
-    # Block the writer's first send so it never drains the queue.
-    fake._send_event = asyncio.Event()
-    fake._send_unblock = asyncio.Event()
     try:
+        await _block_writer(conn, fake)
         with structlog.testing.capture_logs() as logs:
-            # Push 4 ticks synchronously (queue path has no inner await,
-            # so no yield → writer doesn't run yet).
+            # Push 4 ticks while the writer is blocked on the probe.
             for i in range(4):
                 await conn.send_event("tick", {"time_ms": i})
-            # Push 5th — queue is full (writer hasn't started). Triggers
+            # Push 5th — queue is full (writer cannot drain). Triggers
             # same-kind eviction.
             await conn.send_event("tick", {"time_ms": 999})
 
@@ -325,9 +331,8 @@ async def test_control_overflow_triggers_force_close_with_overflow_log() -> None
     conn = WsConnection(conn_id="cx-overflow", ws=fake)  # type: ignore[arg-type]
     conn._start_writer(maxsize=4, enabled=True)
 
-    fake._send_event = asyncio.Event()
-    fake._send_unblock = asyncio.Event()
     try:
+        await _block_writer(conn, fake)
         with structlog.testing.capture_logs() as logs:
             # Fill the queue with 4 CONTROL frames (text_delta).
             for i in range(4):
@@ -365,6 +370,74 @@ async def test_control_overflow_triggers_force_close_with_overflow_log() -> None
     # Force-close should have invoked ws.close with code 1011.
     assert fake.close_code == 1011
     assert fake.close_reason == "writer_backpressure"
+
+
+@pytest.mark.asyncio
+async def test_healthy_writer_drains_512_tool_delta_burst_before_terminal_frames() -> None:
+    """A healthy writer must not look slow just because the producer never yielded."""
+
+    fake = _FakeWebSocket()
+    conn = WsConnection(conn_id="cx-tool-pressure", ws=fake)  # type: ignore[arg-type]
+    conn._start_writer(maxsize=512, enabled=True)
+    session_key = "agent:main:webchat:synthetic-pressure"
+    task_id = "task-synthetic-pressure"
+    tool_use_id = "tool-synthetic-pressure"
+    try:
+        for index in range(512):
+            await conn.send_event(
+                "session.event.tool_use_delta",
+                {
+                    "session_key": session_key,
+                    "task_id": task_id,
+                    "tool_use_id": tool_use_id,
+                    "json_fragment": "x",
+                    "stream_seq": index + 1,
+                },
+            )
+        await conn.send_event(
+            "session.event.tool_result",
+            {
+                "session_key": session_key,
+                "task_id": task_id,
+                "tool_use_id": tool_use_id,
+                "result": "synthetic-ok",
+                "stream_seq": 513,
+            },
+        )
+        await conn.send_event(
+            "session.event.provider_activity",
+            {
+                "session_key": session_key,
+                "task_id": task_id,
+                "phase": "fallback",
+                "reason": "primary_failed",
+                "stream_seq": 514,
+            },
+        )
+        await conn.send_event(
+            "session.event.done",
+            {
+                "session_key": session_key,
+                "task_id": task_id,
+                "status": "succeeded",
+                "stream_seq": 515,
+            },
+        )
+        await _flush_writer(conn)
+
+        frames = [json.loads(line) for line in fake.sent]
+        assert conn._closing is False
+        assert fake.close_code is None
+        assert len(frames) == 515
+        assert [frame["seq"] for frame in frames] == list(range(1, 516))
+        assert [frame["payload"]["stream_seq"] for frame in frames] == list(range(1, 516))
+        assert frames[-3]["event"] == "session.event.tool_result"
+        assert frames[-3]["payload"]["result"] == "synthetic-ok"
+        assert frames[-2]["event"] == "session.event.provider_activity"
+        assert frames[-2]["payload"]["phase"] == "fallback"
+        assert frames[-1]["event"] == "session.event.done"
+    finally:
+        await conn._stop_writer()
 
 
 # ---------------------------------------------------------------------------
@@ -584,11 +657,9 @@ async def test_same_kind_eviction_only_drops_same_kind() -> None:
     conn = WsConnection(conn_id="cx-evict", ws=fake)  # type: ignore[arg-type]
     conn._start_writer(maxsize=4, enabled=True)
 
-    fake._send_event = asyncio.Event()
-    fake._send_unblock = asyncio.Event()
     try:
-        # Synchronous fill: 3 text_delta + 1 tick = 4 items (queue full).
-        # No yield happens during these pushes (queue path is sync).
+        await _block_writer(conn, fake)
+        # Fill with 3 text_delta + 1 tick while the writer is blocked.
         await conn.send_event(
             "session.event.text_delta",
             {"chunk": "b", "session_key": "s", "stream_seq": 2},
@@ -641,9 +712,8 @@ async def test_drop_log_null_safe_for_tick_payload() -> None:
     conn = WsConnection(conn_id="cx-null", ws=fake)  # type: ignore[arg-type]
     conn._start_writer(maxsize=2, enabled=True)
 
-    fake._send_event = asyncio.Event()
-    fake._send_unblock = asyncio.Event()
     try:
+        await _block_writer(conn, fake)
         # Synchronous fill to maxsize=2, then 1 more triggers eviction.
         await conn.send_event("tick", {"time_ms": 1})
         await conn.send_event("tick", {"time_ms": 2})
@@ -748,9 +818,8 @@ async def test_principle2_text_delta_overflow_closes_not_drops() -> None:
     conn = WsConnection(conn_id="cx-p2", ws=fake)  # type: ignore[arg-type]
     conn._start_writer(maxsize=2, enabled=True)
 
-    fake._send_event = asyncio.Event()
-    fake._send_unblock = asyncio.Event()
     try:
+        await _block_writer(conn, fake)
         with structlog.testing.capture_logs() as logs:
             # Synchronous: fill queue (2) + 1 overflow.
             for i in range(3):


### PR DESCRIPTION
## Scope

- Clear terminal live activity only when the terminal snapshot still owns the same task identity, preserving same-session successor work.
- Let durable terminal history override stale live snapshots, render activity-only terminal rows, and restore server timestamps without inserting synthetic current-time activity ahead of replay.
- Prevent healthy high-frequency tool bursts from starving the per-connection WebSocket writer until its 512-frame hard limit. The queue size and loss policy are unchanged; tool results, fallback activity, terminal events, WS sequence, and stream sequence remain lossless and ordered.

## Target

- Base branch: `main`
- Head branch: `codex/fix-terminal-activity-backpressure`

## Linked issue

- None (tracked outside GitHub).

## Verification

- `uv run pytest -q tests/test_gateway/test_ws_writer_queue.py tests/test_gateway/test_websocket_frame_validation.py tests/test_gateway/test_websocket_request_concurrency.py tests/test_gateway/test_event_bridge_meta_events.py tests/test_gateway/test_session_streams.py` — 99 passed
- `uv run ruff check src/opensquilla/gateway/websocket.py src/opensquilla/gateway/session_streams.py tests/test_gateway/test_ws_writer_queue.py tests/test_gateway/test_session_streams.py` — passed
- `npm run test:unit -- useChatTaskOwnership.test.ts useChatHistory.test.ts useChatSessionSubscription.test.ts useChatStream.render.test.ts useChatRpcEventHandlers.test.ts` — 239 passed
- Chromium: `task-ownership-stop.spec.ts` and `terminal-history-stale-live.spec.ts` — 2 passed
- `npm run build` — architecture, security, theme, i18n, TypeScript, Vite, and artifact verification passed

## Compatibility and safety

- No database migration, protocol field, persisted-state schema, or queue-size change.
- The existing slow-consumer hard close remains in place for genuinely blocked sockets; this only adds cooperative scheduling for a healthy writer under a burst.
- Platform-neutral asyncio and browser state changes; no filesystem, process, signal, or OS-specific behavior.
- Tests use synthetic session/task identifiers and no credentials or user data.

## Release note status

- Not added; suitable for inclusion in the next generated bug-fix release notes.

## Third-party origin

- None. No third-party code, fixtures, identifiers, or wording were copied.