### PR TITLE
Restart ready desktop gateways after unexpected exit

### DIFF
--- a/desktop/electron/scripts/test-desktop-gateway-orphan-recovery-flow.mjs
+++ b/desktop/electron/scripts/test-desktop-gateway-orphan-recovery-flow.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { execFile } from 'node:child_process'
-import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import net from 'node:net'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
@@ -33,6 +33,7 @@ const INITIAL_DESKTOP_STARTUP_BUDGET_MS = (
 const ORPHAN_RECOVERY_STARTUP_BUDGET_MS = (
   VERIFIED_ORPHAN_GATEWAY_RELEASE_TIMEOUT_MS + INITIAL_DESKTOP_STARTUP_BUDGET_MS
 )
+const GATEWAY_CHILD_CRASH_RECOVERY_BUDGET_MS = INITIAL_DESKTOP_STARTUP_BUDGET_MS + 10_000
 const CRASH_EXIT_BUDGET_MS = 15_000
 const WINDOWS_ELECTRON_CHILD_CLEANUP_COMMAND_TIMEOUT_MS = 20_000
 const WINDOWS_ELECTRON_CHILD_CLEANUP_BUDGET_MS = 30_000
@@ -404,7 +405,7 @@ try {
     ORPHAN_RECOVERY_STARTUP_BUDGET_MS,
   )
   secondApp = await launchDesktop(orphanRecoveryStartup, 'electron-relaunch')
-  await waitForDesktopRenderer(secondApp, userDataDir, orphanRecoveryStartup)
+  const secondPage = await waitForDesktopRenderer(secondApp, userDataDir, orphanRecoveryStartup)
   const secondOwnershipDir = await ownershipDirectory(
     userDataDir,
     secondApp,
@@ -439,18 +440,92 @@ try {
   }, 'orphan Gateway process exit', orphanRecoveryStartup.remainingMs(
     'orphan-process-exit',
   ), () => phaseDiagnostics(secondApp, userDataDir, orphanRecoveryStartup))
+  await withPhaseDeadline(
+    secondPage.locator('.conn-pill.connected').waitFor({ state: 'visible' }),
+    orphanRecoveryStartup,
+    'renderer-connected-before-child-crash',
+    secondApp,
+    userDataDir,
+  )
+  const rendererUrlBeforeCrash = secondPage.url()
+
+  // The same cross-platform hard-fault primitive now covers the inverse case:
+  // Electron remains healthy while its ready lifecycle-owned Gateway exits.
+  // The main-process lifecycle must replace it without a renderer action or a
+  // second Electron launch, and must leave the existing Control UI document up.
+  const childCrashRecovery = createPhaseBudget(
+    'ready-gateway-child-crash-recovery',
+    GATEWAY_CHILD_CRASH_RECOVERY_BUDGET_MS,
+  )
+  process.kill(secondRecord.pid, 'SIGKILL')
+  await withPhaseDeadline(
+    secondPage.locator('.conn-pill.connected').waitFor({ state: 'hidden' }),
+    childCrashRecovery,
+    'renderer-observed-child-crash',
+    secondApp,
+    userDataDir,
+  )
+  const thirdRecord = await waitFor(() => {
+    assertAppRunning(secondApp, childCrashRecovery, 'replacement-after-child-crash')
+    const loaded = loadDesktopGatewayOwnershipRecord(secondOwnershipDir)
+    if (loaded.status !== 'valid' || loaded.record.pid === secondRecord.pid) return null
+    return verifyDesktopGatewayOwnership(loaded.record).then(verified => (
+      verified ? loaded.record : null
+    ))
+  }, 'automatic Gateway replacement after child crash', childCrashRecovery.remainingMs(
+    'replacement-after-child-crash',
+  ), () => phaseDiagnostics(secondApp, userDataDir, childCrashRecovery))
+  ownedInstances.push({ ownershipDir: secondOwnershipDir, record: thirdRecord })
+  await waitFor(async () => {
+    assertAppRunning(secondApp, childCrashRecovery, 'replacement-ready')
+    const log = await readFile(join(userDataDir, 'logs', 'desktop.log'), 'utf8').catch(() => '')
+    return log.includes('"event":"gateway_unexpected_exit_restart_ready"')
+  }, 'automatic Gateway replacement readiness', childCrashRecovery.remainingMs(
+    'replacement-ready',
+  ), () => phaseDiagnostics(secondApp, userDataDir, childCrashRecovery))
+  await withPhaseDeadline(
+    secondPage.locator('.conn-pill.connected').waitFor({ state: 'visible' }),
+    childCrashRecovery,
+    'renderer-reconnected-after-child-restart',
+    secondApp,
+    userDataDir,
+  )
+  assert.notEqual(thirdRecord.pid, secondRecord.pid)
+  assert.equal(thirdRecord.port, secondRecord.port)
+  assert.equal(secondPage.url(), rendererUrlBeforeCrash)
+  assert.equal(
+    await withPhaseDeadline(
+      verifyDesktopGatewayOwnership(thirdRecord),
+      childCrashRecovery,
+      'verify-automatic-replacement-ownership',
+      secondApp,
+      userDataDir,
+    ),
+    true,
+  )
+  await waitFor(() => {
+    assertAppRunning(secondApp, childCrashRecovery, 'crashed-gateway-process-exit')
+    return !processAlive(secondRecord.pid)
+  }, 'crashed Gateway process exit', childCrashRecovery.remainingMs(
+    'crashed-gateway-process-exit',
+  ), () => phaseDiagnostics(secondApp, userDataDir, childCrashRecovery))
 
   await secondApp.close()
   secondApp = null
   assert.equal(
-    await waitForDesktopGatewayOwnershipRelease(secondOwnershipDir, secondRecord, {
+    await waitForDesktopGatewayOwnershipRelease(secondOwnershipDir, thirdRecord, {
       timeoutMs: 15_000,
       pollIntervalMs: 100,
     }),
     true,
   )
 
-  console.log(JSON.stringify({ ok: true, orphanPid: firstRecord.pid, replacementPid: secondRecord.pid }))
+  console.log(JSON.stringify({
+    ok: true,
+    orphanPid: firstRecord.pid,
+    replacementPid: secondRecord.pid,
+    childCrashReplacementPid: thirdRecord.pid,
+  }))
   flowSucceeded = true
 } finally {
   if (secondApp) await secondApp.close().catch(() => null)

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -550,6 +550,17 @@ function nativeWorkbenchFailureReason(event: NativeWorkbenchSurfaceEvent): strin
 }
 
 let gatewayStartPromise: Promise<GatewayState> | null = null
+const GATEWAY_UNEXPECTED_EXIT_RESTART_DELAYS_MS = [1_000, 2_000, 4_000] as const
+interface GatewayReadyAuthority {
+  profileKey: string
+  openFlowRevision: number
+}
+const gatewayReadyProcesses = new WeakMap<ChildProcessWithoutNullStreams, GatewayReadyAuthority>()
+let gatewayUnexpectedExitRestartGeneration = 0
+let gatewayUnexpectedExitRestartAttempt = 0
+let gatewayUnexpectedExitRestartTimer: NodeJS.Timeout | null = null
+let gatewayUnexpectedExitRestartProfileKey: string | null = null
+let gatewayUnexpectedExitRestartOpenFlowRevision = 0
 let onboardingSaveTelemetryAttempt = 0
 const onboardingFlows = new OnboardingFlowCoordinator<
   OnboardingPayload,
@@ -586,6 +597,7 @@ let gatewayConnectionRevision = 0
 let gatewayConnectionInstanceId: string | null = null
 
 function invalidateDesktopOpenFlow(): number {
+  cancelGatewayUnexpectedExitRestart('desktop open flow invalidated')
   desktopOpenFlowRevision += 1
   return desktopOpenFlowRevision
 }
@@ -3156,11 +3168,13 @@ async function loadDesktopSettings(): Promise<DesktopSettingsSnapshot> {
 }
 
 async function saveDesktopSettings(payload: DesktopSettingsPayload): Promise<DesktopSettingsSnapshot> {
+  cancelGatewayUnexpectedExitRestart('desktop settings save started')
   const connection = await saveDesktopCredential(payload)
   return settingsSnapshot(connection)
 }
 
 function clearReusableGatewayState(): void {
+  cancelGatewayUnexpectedExitRestart('Gateway state cleared')
   artifactPreviewLeaseBroker.clear()
   gatewayState.url = ''
   gatewayState.port = 0
@@ -8490,6 +8504,7 @@ async function resumeOwnedGatewayStartup(
 
   gatewayState.status = 'ready'
   gatewayState.error = undefined
+  markGatewayProcessReady(child)
   sendBootStatus('control')
   publishGatewayConnection()
   return gatewayState
@@ -8582,7 +8597,16 @@ async function recoverVerifiedOrphanGatewayBeforeSpawn(
 async function startGateway(): Promise<GatewayState> {
   const startupRevision = desktopOpenFlowRevision
   const startupProfileKey = desktopProfileKey()
-  const isCurrent = () => desktopOpenAuthorityIsCurrent(startupRevision, startupProfileKey)
+  const startupUnexpectedExitRestartGeneration = gatewayUnexpectedExitRestartProfileKey === null
+    ? null
+    : gatewayUnexpectedExitRestartGeneration
+  const isCurrent = () => (
+    desktopOpenAuthorityIsCurrent(startupRevision, startupProfileKey)
+    && (
+      startupUnexpectedExitRestartGeneration === null
+      || startupUnexpectedExitRestartGeneration === gatewayUnexpectedExitRestartGeneration
+    )
+  )
   const reusableGateway = forceOnboardingOnNextStartup
     ? null
     : await reuseHealthyGatewayState(isCurrent)
@@ -8773,6 +8797,10 @@ async function startGateway(): Promise<GatewayState> {
       windowsHide: true,
     }
   )
+  let childSpawnSucceeded = false
+  child.once('spawn', () => {
+    childSpawnSucceeded = true
+  })
   gatewayProcess = child
   gatewayProcessOwnershipContexts.set(child, {
     nonce: gatewayInstanceNonce,
@@ -8803,10 +8831,13 @@ async function startGateway(): Promise<GatewayState> {
   // stable OPENSQUILLA_PROFILE_IN_USE marker printed immediately before exit.
   child.once('close', (code, signal) => {
     const message = `gateway exited code=${code ?? 'null'} signal=${signal ?? 'null'}`
+    const abnormalExit = signal !== null || (code !== null && code !== 0)
     const portConflictExit = gatewayExitLooksLikePortInUse(gatewayOutputTail)
     const exitMessage = portConflictExit ? `${message}\nGateway port is already in use.` : message
     const classifiedMessage = classifyGatewayExitMessage(exitMessage, gatewayOutputTail)
     const isCurrentGateway = gatewayProcess === child
+    const childReadyAuthority = gatewayReadyProcesses.get(child) ?? null
+    const childWasReady = childReadyAuthority !== null
     if (isCurrentGateway) gatewayProcess = null
     writeLogLine(`\n[desktop] ${message}\n`)
     // Release the append fd; without this every (re)start leaks one open handle
@@ -8818,17 +8849,23 @@ async function startGateway(): Promise<GatewayState> {
       publishGatewayConnection()
       return
     }
-    gatewayState.status = 'error'
-    gatewayState.error = classifiedMessage
     childExitMessage = classifiedMessage
-    if (portConflictExit && !hasExplicitGatewayPort()) {
+    if (!childWasReady && portConflictExit && !hasExplicitGatewayPort()) {
       gatewayState.status = 'stopped'
       gatewayState.error = undefined
       publishGatewayConnection()
       return
     }
-    sendBootError(gatewayState.error)
-    publishGatewayConnection()
+    if (abnormalExit) {
+      if (scheduleGatewayUnexpectedExitRestart(
+        classifiedMessage,
+        childWasReady,
+        childReadyAuthority,
+      )) return
+    } else {
+      cancelGatewayUnexpectedExitRestart('Gateway exited normally')
+    }
+    publishTerminalGatewayExitError(classifiedMessage)
   })
 
   // A failed spawn (uv missing in dev, non-executable bundled binary) emits
@@ -8837,6 +8874,15 @@ async function startGateway(): Promise<GatewayState> {
   child.once('error', (err) => {
     const message = `gateway failed to start: ${err instanceof Error ? err.message : String(err)}`
     const isCurrentGateway = gatewayProcess === child
+    // ChildProcess also uses 'error' for failed kill/send operations after a
+    // successful spawn. Only a pre-spawn error proves there is no live child;
+    // an eventual close remains the sole exit authority for a started process.
+    if (childSpawnSucceeded) {
+      if (isCurrentGateway) {
+        desktopLog('gateway_child_process_error', { pid: child.pid, error: message })
+      }
+      return
+    }
     if (isCurrentGateway) gatewayProcess = null
     closeLogStream()
     if (!isCurrentGateway) return
@@ -8846,10 +8892,8 @@ async function startGateway(): Promise<GatewayState> {
       publishGatewayConnection()
       return
     }
-    gatewayState.status = 'error'
-    gatewayState.error = message
-    sendBootError(message)
-    publishGatewayConnection()
+    if (scheduleGatewayUnexpectedExitRestart(message, gatewayReadyProcesses.has(child))) return
+    publishTerminalGatewayExitError(message)
   })
 
   sendBootStatus('gateway-health')
@@ -8879,6 +8923,7 @@ async function startGateway(): Promise<GatewayState> {
   sendBootStatus('control')
   gatewayState.status = 'ready'
   gatewayState.error = undefined
+  markGatewayProcessReady(child)
   publishGatewayConnection()
   return gatewayState
 }
@@ -9113,6 +9158,135 @@ async function createMainWindow(): Promise<BrowserWindow> {
 
 function currentMainWindow(): BrowserWindow | null {
   return mainWindow && !mainWindow.isDestroyed() ? mainWindow : null
+}
+
+function invalidateGatewayUnexpectedExitRestart(): void {
+  gatewayUnexpectedExitRestartGeneration += 1
+  if (gatewayUnexpectedExitRestartTimer) clearTimeout(gatewayUnexpectedExitRestartTimer)
+  gatewayUnexpectedExitRestartTimer = null
+  gatewayUnexpectedExitRestartAttempt = 0
+  gatewayUnexpectedExitRestartProfileKey = null
+  gatewayUnexpectedExitRestartOpenFlowRevision = 0
+}
+
+function cancelGatewayUnexpectedExitRestart(reason: string): void {
+  const active = gatewayUnexpectedExitRestartProfileKey !== null
+    || gatewayUnexpectedExitRestartTimer !== null
+    || gatewayUnexpectedExitRestartAttempt > 0
+  if (active) {
+    desktopLog('gateway_unexpected_exit_restart_cancelled', {
+      attempt: gatewayUnexpectedExitRestartAttempt,
+      reason,
+    })
+  }
+  invalidateGatewayUnexpectedExitRestart()
+}
+
+function gatewayUnexpectedExitRestartAuthorityIsCurrent(generation: number): boolean {
+  return generation === gatewayUnexpectedExitRestartGeneration
+    && gatewayUnexpectedExitRestartProfileKey !== null
+    && !isQuitting
+    && !updateApplying
+    && appExitPhase === 'running'
+    && !desktopWriters.closed
+    && desktopOpenFlowRevision === gatewayUnexpectedExitRestartOpenFlowRevision
+    && desktopProfileKey() === gatewayUnexpectedExitRestartProfileKey
+}
+
+function publishTerminalGatewayExitError(message: string): void {
+  gatewayState.status = 'error'
+  gatewayState.error = message
+  sendBootError(message)
+  publishGatewayConnection()
+}
+
+function markGatewayProcessReady(child: ChildProcessWithoutNullStreams): void {
+  gatewayReadyProcesses.set(child, {
+    profileKey: desktopProfileKey(),
+    openFlowRevision: desktopOpenFlowRevision,
+  })
+  if (gatewayUnexpectedExitRestartProfileKey !== null) {
+    desktopLog('gateway_unexpected_exit_restart_ready', {
+      attempt: gatewayUnexpectedExitRestartAttempt,
+      pid: child.pid,
+      port: gatewayState.port,
+    })
+  }
+  invalidateGatewayUnexpectedExitRestart()
+}
+
+function scheduleGatewayUnexpectedExitRestart(
+  message: string,
+  startNewSeries: boolean,
+  readyAuthority: GatewayReadyAuthority | null = null,
+): boolean {
+  if (!startNewSeries && gatewayUnexpectedExitRestartProfileKey === null) return false
+  if (startNewSeries && gatewayUnexpectedExitRestartProfileKey === null) {
+    if (
+      !readyAuthority
+      || readyAuthority.profileKey !== desktopProfileKey()
+      || readyAuthority.openFlowRevision !== desktopOpenFlowRevision
+    ) return false
+    gatewayUnexpectedExitRestartGeneration += 1
+    gatewayUnexpectedExitRestartProfileKey = readyAuthority.profileKey
+    gatewayUnexpectedExitRestartOpenFlowRevision = readyAuthority.openFlowRevision
+  }
+
+  const generation = gatewayUnexpectedExitRestartGeneration
+  if (!gatewayUnexpectedExitRestartAuthorityIsCurrent(generation)) {
+    cancelGatewayUnexpectedExitRestart('lifecycle authority changed')
+    return false
+  }
+  if (gatewayUnexpectedExitRestartTimer) return true
+
+  if (gatewayUnexpectedExitRestartAttempt >= GATEWAY_UNEXPECTED_EXIT_RESTART_DELAYS_MS.length) {
+    desktopLog('gateway_unexpected_exit_restart_exhausted', {
+      attempts: gatewayUnexpectedExitRestartAttempt,
+      error: message,
+    })
+    invalidateGatewayUnexpectedExitRestart()
+    publishTerminalGatewayExitError(message)
+    return true
+  }
+
+  const attempt = gatewayUnexpectedExitRestartAttempt + 1
+  const delayMs = GATEWAY_UNEXPECTED_EXIT_RESTART_DELAYS_MS[attempt - 1]
+  gatewayUnexpectedExitRestartAttempt = attempt
+  gatewayState.status = 'starting'
+  gatewayState.error = undefined
+  sendBootStatus('gateway-start')
+  publishGatewayConnection()
+  desktopLog('gateway_unexpected_exit_restart_scheduled', {
+    attempt,
+    delayMs,
+    error: message,
+  })
+
+  gatewayUnexpectedExitRestartTimer = setTimeout(() => {
+    if (generation !== gatewayUnexpectedExitRestartGeneration) return
+    gatewayUnexpectedExitRestartTimer = null
+    if (!gatewayUnexpectedExitRestartAuthorityIsCurrent(generation)) {
+      cancelGatewayUnexpectedExitRestart('lifecycle authority changed before restart')
+      return
+    }
+    desktopLog('gateway_unexpected_exit_restart_attempt', { attempt })
+    void ensureGatewayStarted().then((gateway) => {
+      // Owned children reset the series at the exact ready publication point.
+      // Keep this fallback for a healthy reusable result without a child handle.
+      if (
+        gatewayUnexpectedExitRestartAuthorityIsCurrent(generation)
+        && gateway.status === 'ready'
+      ) {
+        invalidateGatewayUnexpectedExitRestart()
+      }
+    }).catch((error) => {
+      if (!gatewayUnexpectedExitRestartAuthorityIsCurrent(generation)) return
+      const retryMessage = error instanceof Error ? error.message : String(error)
+      scheduleGatewayUnexpectedExitRestart(retryMessage, false)
+    })
+  }, delayMs)
+  gatewayUnexpectedExitRestartTimer.unref()
+  return true
 }
 
 function ensureGatewayStarted(): Promise<GatewayState> {
@@ -9562,6 +9736,7 @@ function terminateGatewayProcess(
 }
 
 function stopGateway(): void {
+  cancelGatewayUnexpectedExitRestart('Gateway stop requested')
   artifactPreviewLeaseBroker.clear()
   if (!gatewayProcess || !gatewayState.owned) return
   const child = gatewayProcess
@@ -10998,6 +11173,7 @@ async function waitForGatewayProcessExit(
 async function stopAndJoinAllLifecycleOwnedGateways(
   stopCurrentProcess: (child: ChildProcessWithoutNullStreams) => void = () => stopGateway(),
 ): Promise<boolean> {
+  cancelGatewayUnexpectedExitRestart('Gateway stop/join requested')
   return await stopAndJoinLifecycleProcesses({
     currentProcess: () => (
       gatewayProcess && gatewayState.owned && !hasGatewayProcessExited(gatewayProcess)
@@ -12932,6 +13108,7 @@ ipcMain.handle('desktop:migration:run', async (
   }
 
   publishDesktopMigrationProgress('applying')
+  cancelGatewayUnexpectedExitRestart('profile migration started')
   isQuitting = true
   try {
     // Quiesce the owned gateway before the CLI writes (the uninstall-run

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -1350,8 +1350,8 @@ def test_desktop_gateway_port_selection_is_bind_aware_and_bounded() -> None:
     ) in recovery
     assert "gatewayExitLooksLikePortInUse(message)" in recovery
     assert "desktopLog('gateway_port_retry'" in recovery
-    assert "if (portConflictExit && !hasExplicitGatewayPort())" in start
-    assert "sendBootError(gatewayState.error)" in start
+    assert "if (!childWasReady && portConflictExit && !hasExplicitGatewayPort())" in start
+    assert "publishTerminalGatewayExitError(classifiedMessage)" in start
 
 
 def test_windows_gateway_hard_terminate_clears_pid_without_unlinking_lock() -> None:
@@ -1773,6 +1773,95 @@ def test_desktop_gateway_exit_classifies_newer_config_validation_errors() -> Non
     )
     assert "exitMessage: earlyExitMessage" in wait
     assert "if (result.status === 'exited') throw new Error(result.message)" in wait
+
+
+def test_ready_desktop_gateway_unexpected_exit_has_bounded_cross_platform_restart() -> None:
+    main_ts = _read("desktop/electron/src/main.ts")
+    start = _section(
+        main_ts,
+        "async function startGateway(): Promise<GatewayState>",
+        "async function startGatewayWithPortRecovery",
+    )
+    restart = _section(
+        main_ts,
+        "function invalidateGatewayUnexpectedExitRestart",
+        "function ensureGatewayStarted",
+    )
+    stop = _section(
+        main_ts,
+        "function stopGateway(): void",
+        "// ── Desktop updates",
+    )
+    join = _section(
+        main_ts,
+        "async function stopAndJoinAllLifecycleOwnedGateways",
+        "function restoreDownloadedUpdateRetryState",
+    )
+    migration = _section(
+        main_ts,
+        "ipcMain.handle('desktop:migration:run'",
+        "ipcMain.handle('desktop:migration:last-result'",
+    )
+
+    assert (
+        "const GATEWAY_UNEXPECTED_EXIT_RESTART_DELAYS_MS = [1_000, 2_000, 4_000] as const"
+        in main_ts
+    )
+    assert "const gatewayReadyProcesses = new WeakMap" in main_ts
+    assert "const startupUnexpectedExitRestartGeneration" in start
+    assert (
+        "startupUnexpectedExitRestartGeneration === gatewayUnexpectedExitRestartGeneration"
+        in start
+    )
+    assert "const childReadyAuthority = gatewayReadyProcesses.get(child)" in start
+    assert "const abnormalExit = signal !== null || (code !== null && code !== 0)" in start
+    assert "let childSpawnSucceeded = false" in start
+    assert "child.once('spawn', () =>" in start
+    post_spawn_error = _section(
+        start,
+        "if (childSpawnSucceeded)",
+        "if (isCurrentGateway) gatewayProcess = null",
+    )
+    assert "gateway_child_process_error" in post_spawn_error
+    assert "return" in post_spawn_error
+    abnormal_exit = _section(
+        start,
+        "if (abnormalExit)",
+        "publishTerminalGatewayExitError(classifiedMessage)",
+    )
+    assert "scheduleGatewayUnexpectedExitRestart" in abnormal_exit
+    assert "childWasReady" in abnormal_exit
+    assert "childReadyAuthority" in abnormal_exit
+    assert "cancelGatewayUnexpectedExitRestart('Gateway exited normally')" in abnormal_exit
+    assert (
+        "scheduleGatewayUnexpectedExitRestart(message, gatewayReadyProcesses.has(child))"
+        in start
+    )
+    assert "markGatewayProcessReady(child)" in start
+    assert "gatewayUnexpectedExitRestartAttempt + 1" in restart
+    assert "GATEWAY_UNEXPECTED_EXIT_RESTART_DELAYS_MS[attempt - 1]" in restart
+    assert (
+        "gatewayUnexpectedExitRestartAttempt >= GATEWAY_UNEXPECTED_EXIT_RESTART_DELAYS_MS.length"
+        in restart
+    )
+    assert "generation === gatewayUnexpectedExitRestartGeneration" in restart
+    assert "desktopOpenFlowRevision === gatewayUnexpectedExitRestartOpenFlowRevision" in restart
+    assert "desktopProfileKey() === gatewayUnexpectedExitRestartProfileKey" in restart
+    assert "readyAuthority.profileKey !== desktopProfileKey()" in restart
+    assert "readyAuthority.openFlowRevision !== desktopOpenFlowRevision" in restart
+    assert "!isQuitting" in restart
+    assert "!updateApplying" in restart
+    assert "appExitPhase === 'running'" in restart
+    assert "!desktopWriters.closed" in restart
+    assert "void ensureGatewayStarted()" in restart
+    assert "gatewayUnexpectedExitRestartTimer.unref()" in restart
+    assert "process.platform" not in restart
+    assert "cancelGatewayUnexpectedExitRestart('Gateway stop requested')" in stop
+    assert "cancelGatewayUnexpectedExitRestart('Gateway stop/join requested')" in join
+    assert "cancelGatewayUnexpectedExitRestart('Gateway state cleared')" in main_ts
+    assert "cancelGatewayUnexpectedExitRestart('desktop settings save started')" in main_ts
+    assert "cancelGatewayUnexpectedExitRestart('profile migration started')" in migration
+    assert "cancelGatewayUnexpectedExitRestart('desktop open flow invalidated')" in main_ts
 
 
 def test_start_gateway_preserves_host_path_without_static_runtime_injection() -> None:
@@ -3134,6 +3223,13 @@ def test_desktop_orphan_recovery_has_a_real_electron_process_flow() -> None:
     assert "verifyDesktopGatewayOwnership(firstRecord)" in script
     assert "await launchDesktop(" in script
     assert "loaded.record.pid !== firstRecord.pid" in script
+    assert "process.kill(secondRecord.pid, 'SIGKILL')" in script
+    assert "loaded.record.pid === secondRecord.pid" in script
+    assert "assert.equal(thirdRecord.port, secondRecord.port)" in script
+    assert "assert.equal(secondPage.url(), rendererUrlBeforeCrash)" in script
+    assert "'renderer-observed-child-crash'" in script
+    assert "'renderer-reconnected-after-child-restart'" in script
+    assert "verifyDesktopGatewayOwnership(thirdRecord)" in script
     assert "waitForDesktopGatewayOwnershipRelease" in script
     assert "export const DESKTOP_GATEWAY_STARTUP_TIMEOUT_MS = 120_000" in lifecycle
     assert "const VERIFIED_ORPHAN_GATEWAY_RELEASE_TIMEOUT_MS = 80_000" in main


### PR DESCRIPTION
## Scope

Scope boundary: Electron main-process lifecycle for an owned Gateway child that has reached ready and then exits abnormally with a signal or nonzero exit code. Retry after 1, 2, and 4 seconds, at most three times, and bind retry authority to that child ready profile and desktop open-flow revision. A clean code 0 exit remains a Desktop capability error and is not restarted.

Non-goals: No WebUI supervisor, IPC or public state-protocol changes, new lifecycle module, healthy Gateway restart, persisted-state migration, or changes to existing port recovery and startup semantics.

## Branch

Base branch: main

Target exception: maintainer-approved codex branch prefix for this task

## Issue

Linked issue: None

If None, reason: Internal tracker row 30 has no public GitHub issue.

## Release Note

Release note: NONE

## Tests

Ruff: ruff check tests/test_desktop/test_electron_startup_contract.py

Pytest: python -m pytest tests/test_desktop/test_electron_startup_contract.py -q; 128 passed

Build: npm run build

Regression tests: added

Notes: npm run test:gateway-lifecycle; npm run test:onboarding-flow; npm run test:gateway-orphan-recovery-flow; npm run test:mock-update-flow; npm run test:profile-import-flow; git diff --check. The unchanged onboarding E2E verified that POST /api/system/shutdown produces a Desktop capability error without restart. The real Electron SIGKILL flow verified that an abnormal ready-child exit is replaced on the same port while the existing renderer observes disconnect and reconnect.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: gateway

Maintainer-only note: No credentials or external service access are needed for this process-lifecycle change.

## Safety

Platform-neutral Node and Electron close code and signal classification; no shell-specific restart path. Existing platform-specific termination remains unchanged on Linux, macOS, and Windows. Expected stops and clean child shutdowns clear retry authority. Stale child close/error events, timer generations, and in-flight starts cannot revive a process. No IPC, public protocol, persisted state, configuration schema, or migration changes. No secrets, local-only artifacts, private prompts or transcripts, channel identifiers, AI session artifacts, non-public fixtures, or tests/_private/ contents are included.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

No documentation changes.