### PR TITLE
Cap RPC reconnect attempts

### DIFF
--- a/opensquilla-webui/src/lib/rpc.test.ts
+++ b/opensquilla-webui/src/lib/rpc.test.ts
@@ -648,11 +648,11 @@ describe('RpcClient', () => {
     client.disconnect()
   })
 
-  it('reconnects with the fixed 1/2/4/8/15 second backoff and resets after hello', async () => {
+  it('stops after the fixed 1/2/4/8/15 second reconnect budget', async () => {
     const client = new RpcClient()
     client.connect('ws://rpc.test')
 
-    const delays = [1_000, 2_000, 4_000, 8_000, 15_000, 15_000]
+    const delays = [1_000, 2_000, 4_000, 8_000, 15_000]
     for (const [index, delay] of delays.entries()) {
       MockWebSocket.instances[index].close()
       await vi.advanceTimersByTimeAsync(delay - 1)
@@ -661,17 +661,13 @@ describe('RpcClient', () => {
       expect(MockWebSocket.instances).toHaveLength(index + 2)
     }
 
-    const recovered = MockWebSocket.instances[MockWebSocket.instances.length - 1]!
-    establishConnection(recovered)
-    recovered.close()
-    await vi.advanceTimersByTimeAsync(999)
+    MockWebSocket.instances[delays.length].close()
+    await vi.advanceTimersByTimeAsync(60_000)
     expect(MockWebSocket.instances).toHaveLength(delays.length + 1)
-    await vi.advanceTimersByTimeAsync(1)
-    expect(MockWebSocket.instances).toHaveLength(delays.length + 2)
     client.disconnect()
   })
 
-  it('interrupts a saturated reconnect backoff when the browser comes online', async () => {
+  it('grants a fresh reconnect budget after an explicit connect', async () => {
     const client = new RpcClient()
     client.connect('ws://rpc.test')
 
@@ -680,16 +676,70 @@ describe('RpcClient', () => {
       MockWebSocket.instances[index].close()
       await vi.advanceTimersByTimeAsync(delay)
     }
-    const saturated = MockWebSocket.instances[delays.length]
-    saturated.close()
-
-    window.dispatchEvent(new Event('online'))
-    await vi.advanceTimersByTimeAsync(99)
+    MockWebSocket.instances[delays.length].close()
+    await vi.advanceTimersByTimeAsync(60_000)
     expect(MockWebSocket.instances).toHaveLength(delays.length + 1)
-    await vi.advanceTimersByTimeAsync(1)
+
+    client.connect('ws://rpc.test')
+    const reconnected = MockWebSocket.instances[delays.length + 1]
+    expect(reconnected).toBeDefined()
+    reconnected.close()
+    await vi.advanceTimersByTimeAsync(999)
     expect(MockWebSocket.instances).toHaveLength(delays.length + 2)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(MockWebSocket.instances).toHaveLength(delays.length + 3)
     client.disconnect()
   })
+
+  it('grants a fresh reconnect budget after a successful hello', async () => {
+    const client = new RpcClient()
+    client.connect('ws://rpc.test')
+
+    MockWebSocket.instances[0].close()
+    await vi.advanceTimersByTimeAsync(1_000)
+    MockWebSocket.instances[1].close()
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    const recovered = MockWebSocket.instances[2]
+    establishConnection(recovered)
+    recovered.close()
+    await vi.advanceTimersByTimeAsync(999)
+    expect(MockWebSocket.instances).toHaveLength(3)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(MockWebSocket.instances).toHaveLength(4)
+    client.disconnect()
+  })
+
+  it.each(['online', 'pageshow', 'visibilitychange'])(
+    'restarts an exhausted reconnect budget after a %s wake signal',
+    async (signal) => {
+      const client = new RpcClient()
+      client.connect('ws://rpc.test')
+
+      const delays = [1_000, 2_000, 4_000, 8_000, 15_000]
+      for (const [index, delay] of delays.entries()) {
+        MockWebSocket.instances[index].close()
+        await vi.advanceTimersByTimeAsync(delay)
+      }
+      const saturated = MockWebSocket.instances[delays.length]
+      saturated.close()
+
+      const target = signal === 'visibilitychange' ? document : window
+      target.dispatchEvent(new Event(signal))
+      await vi.advanceTimersByTimeAsync(99)
+      expect(MockWebSocket.instances).toHaveLength(delays.length + 1)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(MockWebSocket.instances).toHaveLength(delays.length + 2)
+
+      const awakened = MockWebSocket.instances[delays.length + 1]
+      awakened.close()
+      await vi.advanceTimersByTimeAsync(999)
+      expect(MockWebSocket.instances).toHaveLength(delays.length + 2)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(MockWebSocket.instances).toHaveLength(delays.length + 3)
+      client.disconnect()
+    },
+  )
 
   it('coalesces browser wake signals and keeps a healthy pong connection', async () => {
     const client = new RpcClient()

--- a/opensquilla-webui/src/lib/rpc.ts
+++ b/opensquilla-webui/src/lib/rpc.ts
@@ -192,6 +192,7 @@ export class RpcClient {
     this._token = token || null;
     this._guestSessionKey = this._guestSessionKey || loadGuestSessionKey();
     this._autoReconnect = true;
+    this._reconnectAttempt = 0;
     this._startLifecycleWatch();
     this._clearReconnectTimer();
     if (this._ws) {
@@ -826,11 +827,10 @@ export class RpcClient {
   private _scheduleReconnect(immediate: boolean = false): void {
     if (!this._autoReconnect) return;
     this._clearReconnectTimer();
+    if (!immediate && this._reconnectAttempt >= RECONNECT_BACKOFF_MS.length) return;
     const delay = immediate
       ? 0
-      : RECONNECT_BACKOFF_MS[
-          Math.min(this._reconnectAttempt, RECONNECT_BACKOFF_MS.length - 1)
-        ];
+      : RECONNECT_BACKOFF_MS[this._reconnectAttempt];
     this._reconnectTimer = setTimeout(() => {
       this._reconnectTimer = null;
       if (!this._autoReconnect || this._ws) return;


### PR DESCRIPTION
## Scope

- Stop automatic RPC reconnect scheduling after the 1/2/4/8/15 second retry budget is exhausted.
- Restore a fresh retry budget after explicit connect, successful hello, and browser wake signals.
- Add deterministic timer coverage for budget exhaustion and recovery paths.

## Target

main

## Linked issue

None

## Release note

Fix automatic reconnects continuing indefinitely after the retry budget is exhausted.

## Test results

- Related RPC/store/composable tests: 44 passed.
- Complete WebUI unit suite: 4664 passed.
- typecheck: passed.
- build: passed.
- git diff --check: passed.

## Safety / compatibility

No RPC protocol, persisted data, database, or configuration changes. The implementation uses existing WebSocket and lifecycle behavior and is platform-neutral across Web and Electron.

## Third-party origin

None.