### PR TITLE
Retry interrupted history on replacement connections

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatSessionBootstrap.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionBootstrap.test.ts
@@ -476,12 +476,14 @@ describe('useChatSessionBootstrap', () => {
     expect(api.livePhase.value).toBe('ready')
   })
 
-  it('automatically subscribes on a late replacement socket after a recovery budget expires', async () => {
+  it('automatically retries interrupted history after the recovery budget expires', async () => {
+    vi.useFakeTimers()
     let resolveHistory!: (result: SessionPhaseResult) => void
     let resolveLive!: (result: SessionSubscriptionOutcome) => void
     let historyCalls = 0
     let liveCalls = 0
     const timeout = new RpcTimeoutError('session bootstrap', 7_000)
+    const connectionClosed = new Error('connection closed')
     const { api, loadHistory, subscribeSession } = createBootstrap({
       loadHistory: async () => {
         historyCalls += 1
@@ -513,16 +515,77 @@ describe('useChatSessionBootstrap', () => {
       expect(resolveLive).toBeTypeOf('function')
     })
     api.handleConnectionState('disconnected')
-    resolveHistory({ ok: false, error: timeout })
+    resolveHistory({ ok: false, error: connectionClosed })
     resolveLive({ ...UNAVAILABLE_FOR_TEST, error: timeout })
     await Promise.all([run.history, run.live])
 
+    await vi.advanceTimersByTimeAsync(15_001)
     api.handleConnectionState('disconnected')
     expect(api.livePhase.value).toBe('degraded')
     const lateRecovery = api.handleConnectionState('connected')
     await Promise.all([lateRecovery!.history, lateRecovery!.live])
 
-    expect(loadHistory).toHaveBeenCalledTimes(2)
+    expect(loadHistory).toHaveBeenCalledTimes(3)
+    expect(loadHistory.mock.calls[2]?.[0].attempt).toBe(0)
+    expect(loadHistory.mock.calls[2]?.[1]).toBe(true)
+    expect(subscribeSession).toHaveBeenCalledTimes(3)
+    expect(api.historyPhase.value).toBe('ready')
+    expect(api.livePhase.value).toBe('ready')
+  })
+
+  it.each([
+    {
+      label: 'deterministic INVALID_REQUEST',
+      error: Object.assign(new Error('invalid history request'), {
+        code: 'INVALID_REQUEST',
+        retryable: false,
+      }),
+      initialCalls: 1,
+    },
+    {
+      label: 'out-of-scope STORAGE_BUSY',
+      error: Object.assign(new Error('storage busy'), {
+        code: 'STORAGE_BUSY',
+        retryable: true,
+      }),
+      initialCalls: 2,
+    },
+  ])('does not retry $label history on a late replacement connection', async ({
+    error,
+    initialCalls,
+  }) => {
+    vi.useFakeTimers()
+    let resolveLive!: (result: SessionSubscriptionOutcome) => void
+    let liveCalls = 0
+    const timeout = new RpcTimeoutError('sessions.messages.subscribe', 7_000)
+    const { api, loadHistory, subscribeSession } = createBootstrap({
+      loadHistory: async () => ({ ok: false, error }),
+      subscribeSession: async () => {
+        liveCalls += 1
+        if (liveCalls === 1) {
+          return new Promise(resolve => {
+            resolveLive = resolve
+          })
+        }
+        return liveCalls === 2
+          ? { ...UNAVAILABLE_FOR_TEST, error: timeout }
+          : LIVE_READY
+      },
+    })
+
+    const run = api.startSessionBootstrap()
+    await vi.waitFor(() => expect(resolveLive).toBeTypeOf('function'))
+    api.handleConnectionState('disconnected')
+    resolveLive({ ...UNAVAILABLE_FOR_TEST, error: timeout })
+    await Promise.all([run.history, run.live])
+    expect(loadHistory).toHaveBeenCalledTimes(initialCalls)
+
+    await vi.advanceTimersByTimeAsync(15_001)
+    api.handleConnectionState('disconnected')
+    const lateRecovery = api.handleConnectionState('connected')
+    await Promise.all([lateRecovery!.history, lateRecovery!.live])
+
+    expect(loadHistory).toHaveBeenCalledTimes(initialCalls)
     expect(subscribeSession).toHaveBeenCalledTimes(3)
     expect(api.historyPhase.value).toBe('error')
     expect(api.livePhase.value).toBe('ready')
@@ -586,6 +649,109 @@ describe('useChatSessionBootstrap', () => {
     await run.live
 
     await vi.waitFor(() => expect(api.livePhase.value).toBe('ready'))
+    expect(subscribeSession).toHaveBeenCalledTimes(3)
+  })
+
+  it('recovers history when replacement connected before interrupted phases settled', async () => {
+    let resolveHistory!: (result: SessionPhaseResult) => void
+    let resolveLive!: (result: SessionSubscriptionOutcome) => void
+    let historyCalls = 0
+    let liveCalls = 0
+    const connectionClosed = new Error('connection closed')
+    const timeout = new RpcTimeoutError('chat.history', 7_000)
+    const { api, loadHistory, subscribeSession } = createBootstrap({
+      loadHistory: async () => {
+        historyCalls += 1
+        if (historyCalls === 1) {
+          return new Promise(resolve => {
+            resolveHistory = resolve
+          })
+        }
+        return historyCalls === 2
+          ? { ok: false, error: timeout }
+          : { ok: true }
+      },
+      subscribeSession: async () => {
+        liveCalls += 1
+        if (liveCalls === 1) {
+          return new Promise(resolve => {
+            resolveLive = resolve
+          })
+        }
+        return LIVE_READY
+      },
+    })
+
+    const run = api.startSessionBootstrap()
+    await vi.waitFor(() => {
+      expect(resolveHistory).toBeTypeOf('function')
+      expect(resolveLive).toBeTypeOf('function')
+    })
+    api.handleConnectionState('disconnected')
+    api.handleConnectionState('connected')
+    resolveHistory({ ok: false, error: connectionClosed })
+    resolveLive({ ...UNAVAILABLE_FOR_TEST, cancelled: true })
+    await run.live
+
+    await vi.waitFor(() => {
+      expect(api.historyPhase.value).toBe('ready')
+      expect(api.livePhase.value).toBe('ready')
+    })
+    expect(loadHistory).toHaveBeenCalledTimes(3)
+    expect(subscribeSession).toHaveBeenCalledTimes(2)
+  })
+
+  it('recovers history once when connected wins the disconnect-association race', async () => {
+    let resolveHistory!: (result: SessionPhaseResult) => void
+    let resolveLive!: (result: SessionSubscriptionOutcome) => void
+    let historyCalls = 0
+    let liveCalls = 0
+    const connectionClosed = new Error('connection closed')
+    const timeout = new RpcTimeoutError('chat.history', 7_000)
+    const { api, loadHistory, subscribeSession } = createBootstrap({
+      loadHistory: async () => {
+        historyCalls += 1
+        if (historyCalls === 1) {
+          return new Promise(resolve => {
+            resolveHistory = resolve
+          })
+        }
+        return historyCalls === 2
+          ? { ok: false, error: timeout }
+          : { ok: true }
+      },
+      subscribeSession: async () => {
+        liveCalls += 1
+        if (liveCalls === 1) {
+          return new Promise(resolve => {
+            resolveLive = resolve
+          })
+        }
+        return liveCalls === 2
+          ? { ...UNAVAILABLE_FOR_TEST, error: connectionClosed }
+          : LIVE_READY
+      },
+    })
+
+    const run = api.startSessionBootstrap()
+    await vi.waitFor(() => {
+      expect(resolveHistory).toBeTypeOf('function')
+      expect(resolveLive).toBeTypeOf('function')
+    })
+    api.handleConnectionState('connected')
+    resolveHistory({ ok: false, error: connectionClosed })
+    resolveLive({ ...UNAVAILABLE_FOR_TEST, error: connectionClosed })
+    await run.live
+
+    await vi.waitFor(() => {
+      expect(api.historyPhase.value).toBe('ready')
+      expect(api.livePhase.value).toBe('ready')
+    })
+    expect(loadHistory).toHaveBeenCalledTimes(3)
+    expect(subscribeSession).toHaveBeenCalledTimes(3)
+    api.handleConnectionState('connected')
+    await Promise.resolve()
+    expect(loadHistory).toHaveBeenCalledTimes(3)
     expect(subscribeSession).toHaveBeenCalledTimes(3)
   })
 

--- a/opensquilla-webui/src/composables/chat/useChatSessionBootstrap.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionBootstrap.ts
@@ -6,6 +6,7 @@ import {
   SESSION_BOOTSTRAP_BUDGET_MS,
   SESSION_PHASE_ATTEMPT_BUDGET_MS,
   isRpcAbort,
+  isRpcTimeout,
   retryAfterMs,
   shouldRetrySessionPhase,
   type SessionBootstrapPhaseContext,
@@ -48,6 +49,8 @@ interface ActiveBootstrap {
   freshLiveOutageForHistoryRetry: boolean
   awaitingReplacementConnection: boolean
   lateReplacementRecoveryUsed: boolean
+  lateReplacementHistoryRecoveryPhase: PhaseRuntime<SessionPhaseResult> | null
+  lateReplacementHistoryRecoveryUsed: boolean
   history: PhaseRuntime<SessionPhaseResult>
   live: PhaseRuntime<SessionSubscriptionOutcome>
 }
@@ -194,6 +197,7 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
       waiter.resolve(true)
     }
     releaseCriticalRequestsIfReady(run)
+    tryRecoverHistoryOnLateReplacement(run)
   }
 
   function markHistoryRequestSent(
@@ -279,6 +283,7 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
   function runHistoryPhase(
     run: ActiveBootstrap,
     retryFirst: boolean,
+    maxAttempts: 1 | 2 = 2,
   ): Promise<SessionPhaseResult> {
     const phase = run.history
     if (phase.running) return phase.promise
@@ -292,7 +297,7 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
         error: new RpcTimeoutError('chat.history', 0),
       }
       let requiredLiveQueueSequence = Math.max(1, run.liveQueueSequence)
-      while (phase.attempts < 2 && isCurrent(run)) {
+      while (phase.attempts < maxAttempts && isCurrent(run)) {
         if (Date.now() >= phase.deadlineAt) break
         if (!await waitForLiveSubscribeSent(
           run,
@@ -327,7 +332,7 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
           requiredLiveQueueSequence = liveQueueSequenceForAttempt + 1
         }
         if (
-          phase.attempts >= 2
+          phase.attempts >= maxAttempts
           || !shouldRetrySessionPhase(lastResult.error)
           || !await waitBeforeRetry(lastResult.error, run, phase.deadlineAt)
         ) {
@@ -336,13 +341,16 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
       }
       if (isCurrent(run)) historyPhase.value = 'error'
       return lastResult
-    })().finally(() => {
+    })().then(result => {
+      phase.result = result
+      return result
+    }).finally(() => {
       // A disconnected or exhausted phase may terminate before it can send.
       // Optional UI traffic must not remain globally blocked in that case.
       run.criticalQueue.historyTerminal = true
       releaseCriticalRequestsIfReady(run)
       phase.running = false
-      phase.result = null
+      tryRecoverHistoryOnLateReplacement(run)
     })
     return phase.promise
   }
@@ -456,6 +464,8 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
       freshLiveOutageForHistoryRetry: false,
       awaitingReplacementConnection: false,
       lateReplacementRecoveryUsed: false,
+      lateReplacementHistoryRecoveryPhase: null,
+      lateReplacementHistoryRecoveryUsed: false,
       history: historyRuntime(deadlineAt),
       live: liveRuntime(deadlineAt),
     }
@@ -520,7 +530,7 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
     return publicRun(run)
   }
 
-  function resetHistoryPhaseForManualRetry(run: ActiveBootstrap) {
+  function resetHistoryPhaseForRetry(run: ActiveBootstrap) {
     run.history = historyRuntime(Date.now() + SESSION_BOOTSTRAP_BUDGET_MS)
   }
 
@@ -535,7 +545,7 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
       return startSessionBootstrap({ includeHistory: true, force: true }).history
     }
     if (run.history.running) return run.history.promise
-    resetHistoryPhaseForManualRetry(run)
+    resetHistoryPhaseForRetry(run)
     // A user-initiated history retry is a new recovery operation. If its local
     // timeout recycles an otherwise-authoritative live socket, re-register live
     // with a fresh outage budget instead of inheriting exhausted attempts from
@@ -543,6 +553,51 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
     run.freshLiveOutageForHistoryRetry = true
     run.history.promise = runHistoryPhase(run, true)
     return run.history.promise
+  }
+
+  function armHistoryRecoveryForLateReplacement(run: ActiveBootstrap) {
+    if (
+      !isCurrent(run)
+      || !run.includeHistory
+      || run.lateReplacementHistoryRecoveryUsed
+    ) return
+    run.lateReplacementHistoryRecoveryPhase ??= run.history
+    tryRecoverHistoryOnLateReplacement(run)
+  }
+
+  function tryRecoverHistoryOnLateReplacement(run: ActiveBootstrap) {
+    const phase = run.lateReplacementHistoryRecoveryPhase
+    if (
+      !phase
+      || run.lateReplacementHistoryRecoveryUsed
+      || !isCurrent(run)
+    ) return
+    if (run.history !== phase) {
+      run.lateReplacementHistoryRecoveryPhase = null
+      return
+    }
+    if (phase.running || historyPhase.value !== 'error' || !phase.result) return
+    const terminal = phase.result
+    const recoverable = (
+      !terminal.ok
+      && !terminal.cancelled
+      && (
+        isRpcTimeout(terminal.error)
+        || requiresFreshLiveQueue(terminal.error)
+      )
+    )
+    if (!recoverable) {
+      run.lateReplacementHistoryRecoveryPhase = null
+      return
+    }
+    const liveSocketGeneration = run.criticalQueue.liveSocketGeneration
+    if (liveSocketGeneration === null) return
+
+    run.lateReplacementHistoryRecoveryUsed = true
+    run.lateReplacementHistoryRecoveryPhase = null
+    resetHistoryPhaseForRetry(run)
+    rearmCriticalQueue(run, true, liveSocketGeneration)
+    run.history.promise = runHistoryPhase(run, true, 1)
   }
 
   function retryLive(): Promise<SessionSubscriptionOutcome> {
@@ -648,6 +703,7 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
     }
     const replacementConnected = run.awaitingReplacementConnection
     run.awaitingReplacementConnection = false
+    if (replacementConnected) armHistoryRecoveryForLateReplacement(run)
     if (run.live.running) {
       const interruptedPhase = run.live
       const resumeOnReplacement = (outcome?: SessionSubscriptionOutcome) => {
@@ -681,6 +737,9 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
           skipSnapshot: interruptedPhase.skipSnapshot,
         }
         run.live.promise = runLivePhase(run)
+        if (transportFailedAfterConnected) {
+          armHistoryRecoveryForLateReplacement(run)
+        }
       }
       // The replacement handshake can finish before the interrupted subscribe
       // observes its cancellation. Resume exactly once after that old phase
@@ -704,6 +763,7 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
       rearmCriticalQueue(run, false)
       resetLivePhaseForManualRetry(run)
       run.live.promise = runLivePhase(run)
+      armHistoryRecoveryForLateReplacement(run)
       return publicRun(run)
     }
     return publicRun(run)


### PR DESCRIPTION
## Scope

- Retry terminal chat history hydration once when a newly authenticated replacement connection becomes available after a connection interruption or `RPC_TIMEOUT`.
- Keep the recovery bounded by the existing connection generation/run coordination and a history-specific one-shot gate.
- Add regression coverage for late replacement connections, both connected/disconnect race orderings, and excluded deterministic/non-scope errors.

## Target main

`main`

## Linked issue

None

## Release note

修复 Gateway 重启或替换连接晚到后，会话历史仍停留在不可恢复错误、需要手动重新加载的问题。

## Test results

- `useChatSessionBootstrap` coordinator tests: 27 passed
- Neighboring composable/store/RPC tests: 142 passed
- Full WebUI unit suite: 4664 passed
- WebUI typecheck: passed
- WebUI build: passed
- Playwright restart/history recovery tests: 2 passed
- `git diff --check`: passed

## Safety/compatibility

- Preserves the #1386 live connected/disconnect race recovery and its regression coverage.
- Grants exactly one supplemental history attempt only for connection interruption or `RPC_TIMEOUT`.
- Excludes `INVALID_REQUEST`, `STORAGE_BUSY`, and other errors from the supplemental attempt.
- No RPC/protocol, persistence, migration, or database changes.
- Platform-neutral across Web and Electron; no filesystem, process, signal, or operating-system-specific behavior changed.

## Third-party origin

None