### PR TITLE
Route image capability by session mode

### DIFF
--- a/opensquilla-webui/e2e/session-routing-image-capability.spec.ts
+++ b/opensquilla-webui/e2e/session-routing-image-capability.spec.ts
@@ -1,0 +1,225 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const CONTROL_URL = '/control/chat?session='
+const SESSION_KEY = 'agent:main:webchat:e2e-session-routing-image'
+const PNG_DATA = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+  'base64',
+)
+
+const CAPABILITIES_BY_MODE = {
+  direct: {
+    image_input: { admission: 'allowed', reason: 'model_vision_supported' },
+  },
+  router: {
+    image_input: { admission: 'allowed', reason: 'router_image_route_available' },
+  },
+  ensemble: {
+    image_input: { admission: 'blocked', reason: 'ensemble_mode_unsupported' },
+  },
+}
+
+function response(id: string, payload: unknown) {
+  return JSON.stringify({ type: 'res', id, ok: true, payload })
+}
+
+async function installGateway(page: Page) {
+  const methods: string[] = []
+  const routingSets: Array<Record<string, unknown>> = []
+  const chatSends: Array<Record<string, unknown>> = []
+
+  await page.addInitScript(() => {
+    window.localStorage.setItem('opensquilla-locale', 'en')
+  })
+  await page.route('**/api/approvals', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ pending: [] }),
+  }))
+  await page.route('**/api/elevated-mode', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ enabled: false }),
+  }))
+  await page.route('**/api/system/update', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      current: '0.0.0-e2e',
+      latest: null,
+      available: false,
+      url: null,
+      checkedAt: null,
+    }),
+  }))
+  await page.routeWebSocket(/\/ws$/, ws => {
+    ws.send(JSON.stringify({ type: 'event', event: 'connect.challenge', payload: {} }))
+    ws.onMessage(message => {
+      const frame = JSON.parse(String(message)) as {
+        id?: string
+        method?: string
+        params?: Record<string, unknown>
+        type?: string
+      }
+      if (frame.type !== 'req') return
+      const method = String(frame.method || '')
+      methods.push(method)
+      if (method === 'connect') {
+        ws.send(JSON.stringify({
+          type: 'hello-ok',
+          protocol: 3,
+          server: { version: 'e2e', conn_id: 'session-routing-image-gateway' },
+          features: {
+            methods: [
+              'chat.send',
+              'models.routing.get',
+              'models.routing.set',
+              'sessions.routing.get',
+              'sessions.routing.set',
+            ],
+            events: ['models.routing.changed', 'sessions.routing.changed'],
+          },
+          snapshot: {},
+          policy: { tick_interval_ms: 30_000 },
+          auth: {
+            principal: {
+              isOwner: true,
+              authState: 'authenticated',
+            },
+          },
+        }))
+        return
+      }
+      if (method === 'sessions.routing.set') {
+        routingSets.push(frame.params || {})
+        ws.send(response(String(frame.id), {
+          sessionKey: SESSION_KEY,
+          mode: 'router',
+          revision: 3,
+          source: 'session',
+          initialized: true,
+        }))
+        return
+      }
+      if (method === 'models.routing.set') {
+        ws.send(response(String(frame.id), {}))
+        return
+      }
+      if (method === 'chat.send') {
+        chatSends.push(frame.params || {})
+        ws.send(response(String(frame.id), {
+          accepted: true,
+          session: SESSION_KEY,
+          task_id: 'session-routing-image-task',
+          stream_seq: 1,
+        }))
+        return
+      }
+
+      const history = [
+        { role: 'user', text: 'First question', message_id: 'history-user-1' },
+        { role: 'assistant', text: 'First answer', message_id: 'history-assistant-1' },
+        { role: 'user', text: 'Second question', message_id: 'history-user-2' },
+        { role: 'assistant', text: 'Second answer', message_id: 'history-assistant-2' },
+      ]
+      const payloads: Record<string, unknown> = {
+        'agents.list': { agents: [] },
+        'chat.history': { messages: history, has_more: false, canonical_complete: true },
+        'commands.list_for_surface': { commands: [] },
+        'config.get': {
+          squilla_router: { enabled: false, rollout_phase: 'observe', tiers: {} },
+          llm_ensemble: { enabled: true, selection_mode: 'static_openrouter_b5' },
+          permissions: {},
+          skills: {},
+        },
+        'models.routing.get': {
+          mode: 'ensemble',
+          selection_mode: 'static_openrouter_b5',
+          image_input: CAPABILITIES_BY_MODE.ensemble.image_input,
+          capabilities_by_mode: CAPABILITIES_BY_MODE,
+        },
+        'onboarding.status': { audioConfigured: false },
+        'sessions.list': { sessions: [], has_more: false },
+        'sessions.messages.snapshot': {
+          key: SESSION_KEY,
+          events: [],
+          current_stream_seq: 0,
+        },
+        'sessions.messages.subscribe': {
+          key: SESSION_KEY,
+          sessionId: 'session-routing-image',
+          subscribed: true,
+          hydration_complete: true,
+          replay_complete: true,
+          current_stream_seq: 0,
+          run_status: 'idle',
+        },
+        'sessions.messages.hydrate': {
+          key: SESSION_KEY,
+          sessionId: 'session-routing-image',
+          hydration_complete: true,
+          run_status: 'idle',
+        },
+        'sessions.routing.get': {
+          sessionKey: SESSION_KEY,
+          mode: 'ensemble',
+          revision: 2,
+          source: 'session',
+          initialized: true,
+        },
+        'usage.status': { sessions: [] },
+      }
+      ws.send(response(String(frame.id), payloads[method] ?? {}))
+    })
+  })
+
+  return { chatSends, methods, routingSets }
+}
+
+test('session Router capability overrides the blocked global Ensemble scalar for images', async ({
+  page,
+}) => {
+  const gateway = await installGateway(page)
+  await page.goto(CONTROL_URL + encodeURIComponent(SESSION_KEY))
+  await expect(page.locator('.conn-pill.connected')).toBeVisible({ timeout: 10_000 })
+  await expect(page.locator('.chat-textarea')).toBeEditable({ timeout: 10_000 })
+  await expect(page.locator('.msg-user')).toHaveCount(2)
+  await expect.poll(() => gateway.methods.filter(method => method === 'sessions.routing.get').length)
+    .toBeGreaterThan(0)
+
+  const routingButton = page.getByRole('button', {
+    name: "This chat's model routing",
+    exact: true,
+  })
+  await expect(routingButton).toHaveClass(/chat-model-routing-btn--llm_ensemble/)
+  await routingButton.click()
+  await page.getByRole('radio', { name: /AI-powered single-model router/ }).click()
+
+  await expect.poll(() => gateway.routingSets).toEqual([{
+    sessionKey: SESSION_KEY,
+    mode: 'router',
+    expectedRevision: 2,
+  }])
+  await expect(routingButton).toHaveClass(/chat-model-routing-btn--squilla_router/)
+
+  await page.locator('input[type="file"]').setInputFiles({
+    name: 'router-capable.png',
+    mimeType: 'image/png',
+    buffer: PNG_DATA,
+  })
+  await page.locator('.chat-textarea').fill('Describe this image once.')
+  await expect(page.locator('.attachment-chip')).toContainText('router-capable.png')
+  await expect(page.locator('.chat-composer-send-status')).toHaveCount(0)
+
+  const sendButton = page.locator('.chat-send-btn[aria-label="Send"]')
+  await expect(sendButton).toBeEnabled()
+  await sendButton.click()
+
+  await expect.poll(() => gateway.chatSends.length).toBe(1)
+  expect(gateway.chatSends[0]?.message).toBe('Describe this image once.')
+  expect(gateway.chatSends[0]?.attachments).toEqual([
+    expect.objectContaining({ name: 'router-capable.png', mime: 'image/png' }),
+  ])
+  expect(gateway.methods).not.toContain('models.routing.set')
+  expect(gateway.routingSets).toHaveLength(1)
+})

--- a/opensquilla-webui/src/composables/chat/useChatFeatureToggles.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatFeatureToggles.test.ts
@@ -1,10 +1,26 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useChatFeatureToggles } from './useChatFeatureToggles'
 import source from './useChatFeatureToggles.ts?raw'
+import chatViewSource from '@/views/ChatView.vue?raw'
 import type { RpcCallOptions } from '@/lib/rpc'
-import type { ModelRoutingMode } from '@/types/modelRouting'
+import type {
+  ModelRoutingCapabilitiesByMode,
+  ModelRoutingMode,
+} from '@/types/modelRouting'
 
 type RpcResult = Record<string, unknown> | Error | Promise<unknown>
+
+const CAPABILITIES_BY_MODE: ModelRoutingCapabilitiesByMode = {
+  direct: {
+    image_input: { admission: 'allowed', reason: 'model_vision_supported' },
+  },
+  router: {
+    image_input: { admission: 'allowed', reason: 'router_image_route_available' },
+  },
+  ensemble: {
+    image_input: { admission: 'blocked', reason: 'ensemble_mode_unsupported' },
+  },
+}
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void
@@ -19,6 +35,7 @@ function createHarness(options: {
   routingGetResults?: RpcResult[]
   patchResults?: RpcResult[]
   readCallOptions?: RpcCallOptions
+  supportsMethod?: (method: string) => boolean
 } = {}) {
   const configGetResults = [...(options.configGetResults ?? [{}])]
   const routingGetResults = [...(options.routingGetResults ?? [])]
@@ -54,6 +71,7 @@ function createHarness(options: {
       eventHandlers.set(event, handler)
       return () => eventHandlers.delete(event)
     }),
+    supportsMethod: options.supportsMethod,
   }
   const api = useChatFeatureToggles({
     rpc,
@@ -307,23 +325,23 @@ describe('useChatFeatureToggles model routing mode', () => {
       }],
     })
     await blocked.api.loadFeatureToggles()
-    expect(blocked.api.imageInputAdmission.value).toBe('blocked')
-    expect(blocked.api.imageInputAdmissionReason.value).toBe('model_vision_unsupported')
+    expect(blocked.api.globalImageInputAdmission.value).toBe('blocked')
+    expect(blocked.api.globalImageInputAdmissionReason.value).toBe('model_vision_unsupported')
 
     const legacyDirect = createHarness({
       configGetResults: [{ llm_ensemble: { enabled: false } }],
       routingGetResults: [{ mode: 'direct' }],
     })
     await legacyDirect.api.loadFeatureToggles()
-    expect(legacyDirect.api.imageInputAdmission.value).toBe('unknown')
+    expect(legacyDirect.api.globalImageInputAdmission.value).toBe('unknown')
 
     const legacyEnsemble = createHarness({
       configGetResults: [{ llm_ensemble: { enabled: true } }],
       routingGetResults: [{ mode: 'ensemble' }],
     })
     await legacyEnsemble.api.loadFeatureToggles()
-    expect(legacyEnsemble.api.imageInputAdmission.value).toBe('blocked')
-    expect(legacyEnsemble.api.imageInputAdmissionReason.value).toBe(
+    expect(legacyEnsemble.api.globalImageInputAdmission.value).toBe('blocked')
+    expect(legacyEnsemble.api.globalImageInputAdmissionReason.value).toBe(
       'ensemble_mode_unsupported',
     )
   })
@@ -352,12 +370,229 @@ describe('useChatFeatureToggles model routing mode', () => {
         reason: 'router_image_route_available',
       },
     })
-    expect(api.imageInputAdmission.value).toBe('allowed')
+    expect(api.globalImageInputAdmission.value).toBe('allowed')
 
     cleanup()
     expect(rpc.on).toHaveBeenCalledWith('models.routing.changed', expect.any(Function))
     emit('models.routing.changed', { mode: 'direct' })
     expect(api.modelRoutingMode.value).toBe('squilla_router')
+  })
+
+  it('atomically applies a complete capability matrix', async () => {
+    const { api } = createHarness({
+      configGetResults: [{}],
+      routingGetResults: [{
+        mode: 'ensemble',
+        image_input: CAPABILITIES_BY_MODE.ensemble.image_input,
+        capabilities_by_mode: CAPABILITIES_BY_MODE,
+      }],
+    })
+
+    await api.loadFeatureToggles()
+
+    expect(api.modelRoutingCapabilitiesByMode.value).toEqual(CAPABILITIES_BY_MODE)
+    expect(api.globalImageInputAdmission.value).toBe('blocked')
+  })
+
+  it('clears the whole matrix when a later snapshot is missing or partial', async () => {
+    const { api } = createHarness({
+      configGetResults: [{}, {}, {}],
+      routingGetResults: [
+        {
+          mode: 'ensemble',
+          image_input: CAPABILITIES_BY_MODE.ensemble.image_input,
+          capabilities_by_mode: CAPABILITIES_BY_MODE,
+        },
+        {
+          mode: 'ensemble',
+          image_input: CAPABILITIES_BY_MODE.ensemble.image_input,
+          capabilities_by_mode: {
+            direct: CAPABILITIES_BY_MODE.direct,
+            ensemble: CAPABILITIES_BY_MODE.ensemble,
+          },
+        },
+        {
+          mode: 'ensemble',
+          image_input: CAPABILITIES_BY_MODE.ensemble.image_input,
+        },
+      ],
+    })
+
+    await api.loadFeatureToggles()
+    expect(api.modelRoutingCapabilitiesByMode.value).toEqual(CAPABILITIES_BY_MODE)
+
+    await api.loadFeatureToggles()
+    expect(api.modelRoutingCapabilitiesByMode.value).toBeNull()
+
+    await api.loadFeatureToggles()
+    expect(api.modelRoutingCapabilitiesByMode.value).toBeNull()
+  })
+
+  it('does not let a late routing GET overwrite a newer changed event', async () => {
+    vi.stubGlobal('document', {
+      visibilityState: 'visible',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })
+    vi.stubGlobal('window', {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })
+    const pending = deferred<Record<string, unknown>>()
+    const { api, emit, rpc } = createHarness({
+      configGetResults: [{}],
+      routingGetResults: [pending.promise],
+    })
+    const cleanup = api.bindFeatureRefresh()
+    const load = api.loadFeatureToggles()
+    await vi.waitFor(() => {
+      expect(rpc.call.mock.calls.filter(([method]) => method === 'models.routing.get')).toHaveLength(1)
+    })
+
+    emit('models.routing.changed', {
+      mode: 'router',
+      image_input: CAPABILITIES_BY_MODE.router.image_input,
+      capabilities_by_mode: CAPABILITIES_BY_MODE,
+    })
+    pending.resolve({
+      mode: 'ensemble',
+      image_input: CAPABILITIES_BY_MODE.ensemble.image_input,
+      capabilities_by_mode: CAPABILITIES_BY_MODE,
+    })
+    await load
+
+    expect(api.modelRoutingMode.value).toBe('squilla_router')
+    expect(api.globalImageInputAdmission.value).toBe('allowed')
+    cleanup()
+  })
+
+  it('only applies the latest overlapping routing GET', async () => {
+    const first = deferred<Record<string, unknown>>()
+    const second = deferred<Record<string, unknown>>()
+    const { api, rpc } = createHarness({
+      configGetResults: [{}, {}],
+      routingGetResults: [first.promise, second.promise],
+    })
+    const firstLoad = api.loadFeatureToggles()
+    await vi.waitFor(() => {
+      expect(rpc.call.mock.calls.filter(([method]) => method === 'models.routing.get')).toHaveLength(1)
+    })
+    const secondLoad = api.loadFeatureToggles()
+    await vi.waitFor(() => {
+      expect(rpc.call.mock.calls.filter(([method]) => method === 'models.routing.get')).toHaveLength(2)
+    })
+
+    second.resolve({
+      mode: 'router',
+      image_input: CAPABILITIES_BY_MODE.router.image_input,
+      capabilities_by_mode: CAPABILITIES_BY_MODE,
+    })
+    await secondLoad
+    first.resolve({
+      mode: 'ensemble',
+      image_input: CAPABILITIES_BY_MODE.ensemble.image_input,
+      capabilities_by_mode: CAPABILITIES_BY_MODE,
+    })
+    await firstLoad
+
+    expect(api.modelRoutingMode.value).toBe('squilla_router')
+    expect(api.globalImageInputAdmission.value).toBe('allowed')
+  })
+
+  it('does not let an older overlapping config response overwrite the latest refresh', async () => {
+    const firstConfig = deferred<Record<string, unknown>>()
+    const { api, rpc } = createHarness({
+      configGetResults: [
+        firstConfig.promise,
+        {
+          skills: { coding_mode: false },
+          squilla_router: { enabled: true, rollout_phase: 'full' },
+        },
+      ],
+      routingGetResults: [{
+        mode: 'router',
+        image_input: CAPABILITIES_BY_MODE.router.image_input,
+        capabilities_by_mode: CAPABILITIES_BY_MODE,
+      }],
+    })
+    const firstLoad = api.loadFeatureToggles()
+    await vi.waitFor(() => {
+      expect(rpc.call.mock.calls.filter(([method]) => method === 'config.get')).toHaveLength(1)
+    })
+
+    await api.loadFeatureToggles()
+    firstConfig.resolve({
+      skills: { coding_mode: true },
+      llm_ensemble: { enabled: true },
+    })
+    await firstLoad
+
+    expect(api.codingModeEnabled.value).toBe(false)
+    expect(api.modelRoutingMode.value).toBe('squilla_router')
+    expect(api.modelRoutingCapabilitiesByMode.value).toEqual(CAPABILITIES_BY_MODE)
+  })
+
+  it('clears a prior canonical matrix when the connected Gateway lacks routing RPC', async () => {
+    let supportsRouting = true
+    const { api } = createHarness({
+      configGetResults: [
+        {},
+        { llm_ensemble: { enabled: true } },
+      ],
+      routingGetResults: [
+        {
+          mode: 'router',
+          image_input: CAPABILITIES_BY_MODE.router.image_input,
+          capabilities_by_mode: CAPABILITIES_BY_MODE,
+        },
+      ],
+      supportsMethod: method => method !== 'models.routing.get' || supportsRouting,
+    })
+
+    await api.loadFeatureToggles()
+    expect(api.modelRoutingCapabilitiesByMode.value).toEqual(CAPABILITIES_BY_MODE)
+
+    supportsRouting = false
+    await api.loadFeatureToggles()
+
+    expect(api.modelRoutingCapabilitiesByMode.value).toBeNull()
+    expect(api.modelRoutingMode.value).toBe('llm_ensemble')
+    expect(api.globalImageInputAdmission.value).toBe('blocked')
+    expect(api.globalImageInputAdmissionReason.value).toBe('ensemble_mode_unsupported')
+  })
+
+  it('preserves the last canonical matrix on a transient routing RPC failure', async () => {
+    const { api } = createHarness({
+      configGetResults: [
+        {},
+        { llm_ensemble: { enabled: true } },
+      ],
+      routingGetResults: [
+        {
+          mode: 'router',
+          image_input: CAPABILITIES_BY_MODE.router.image_input,
+          capabilities_by_mode: CAPABILITIES_BY_MODE,
+        },
+        Object.assign(new Error('routing request timed out'), { code: 'RPC_TIMEOUT' }),
+      ],
+    })
+
+    await api.loadFeatureToggles()
+    await api.loadFeatureToggles()
+
+    expect(api.modelRoutingCapabilitiesByMode.value).toEqual(CAPABILITIES_BY_MODE)
+    expect(api.modelRoutingMode.value).toBe('squilla_router')
+    expect(api.globalImageInputAdmission.value).toBe('allowed')
+  })
+
+  it('refreshes the capability matrix when the chat reconnects', () => {
+    const watcherStart = chatViewSource.indexOf('// Hello refreshes method capabilities on reconnect')
+    const watcherEnd = chatViewSource.indexOf('watch(shareableMessageCount', watcherStart)
+    const reconnectWatcher = chatViewSource.slice(watcherStart, watcherEnd)
+
+    expect(watcherStart).toBeGreaterThanOrEqual(0)
+    expect(watcherEnd).toBeGreaterThan(watcherStart)
+    expect(reconnectWatcher).toContain('void loadFeatureToggles()')
   })
 
   it.each([

--- a/opensquilla-webui/src/composables/chat/useChatFeatureToggles.ts
+++ b/opensquilla-webui/src/composables/chat/useChatFeatureToggles.ts
@@ -2,7 +2,12 @@ import { computed, ref } from 'vue'
 import i18n from '@/i18n'
 import { useToasts } from '@/composables/useToasts'
 import type { ChatRouterTierConfig } from '@/types/chat'
-import type { ImageInputAdmission, ModelRoutingMode } from '@/types/modelRouting'
+import type {
+  ImageInputAdmission,
+  ModelRoutingCapabilitiesByMode,
+  ModelRoutingMode,
+  ModelRoutingSnapshot,
+} from '@/types/modelRouting'
 import { normalizeModelRoutingMode } from '@/types/modelRouting'
 import { normalizeRouterTier, sortRouterTiers } from '@/utils/chat/routerTiers'
 import { encodeRouterShape, decodeRouterShape } from '@/utils/chat/routerShapeCache'
@@ -28,6 +33,7 @@ type RpcClient = {
     callOptions?: RpcCallOptions,
   ) => Promise<T>
   on?: (event: string, handler: (payload: unknown) => void) => () => void
+  supportsMethod?: (method: string) => boolean
 }
 
 export interface UseChatFeatureTogglesOptions {
@@ -66,16 +72,47 @@ interface ChatFeatureConfig {
   }
 }
 
-interface ModelRoutingSnapshot {
-  mode?: 'direct' | 'router' | 'ensemble'
-  selection_mode?: string
-  image_input?: {
-    admission?: 'allowed' | 'blocked' | 'unknown'
-    reason?: string
-  }
+const ROUTER_SHAPE_KEY = 'opensquilla.router.shape'
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
 }
 
-const ROUTER_SHAPE_KEY = 'opensquilla.router.shape'
+function parseCapabilitiesByMode(value: unknown): ModelRoutingCapabilitiesByMode | null {
+  const source = record(value)
+  if (!source) return null
+
+  const parsed = {} as ModelRoutingCapabilitiesByMode
+  for (const mode of ['direct', 'router', 'ensemble'] as const) {
+    const modeCapabilities = record(source[mode])
+    const imageInput = record(modeCapabilities?.image_input)
+    const admission = imageInput?.admission
+    const reason = imageInput?.reason
+    if (
+      (admission !== 'allowed' && admission !== 'blocked' && admission !== 'unknown')
+      || typeof reason !== 'string'
+      || !reason
+    ) return null
+    parsed[mode] = {
+      image_input: {
+        admission,
+        reason,
+      },
+    }
+  }
+  return parsed
+}
+
+function isMethodNotFound(error: unknown): boolean {
+  const candidate = record(error)
+  const message = error instanceof Error
+    ? error.message
+    : String(candidate?.message || error || '')
+  return candidate?.code === 'METHOD_NOT_FOUND' || /method not found/i.test(message)
+}
+
 export function useChatFeatureToggles(options: UseChatFeatureTogglesOptions) {
   const { pushToast } = useToasts()
   const routerEnabled = ref(false)
@@ -91,9 +128,13 @@ export function useChatFeatureToggles(options: UseChatFeatureTogglesOptions) {
   const llmEnsembleSelectionMode = ref('')
   const llmEnsembleSettingsBusy = ref(false)
   const modelRoutingSettingsBusy = ref(false)
-  const imageInputAdmission = ref<ImageInputAdmission>('unknown')
-  const imageInputAdmissionReason = ref('capability_unknown')
+  const globalImageInputAdmission = ref<ImageInputAdmission>('unknown')
+  const globalImageInputAdmissionReason = ref('capability_unknown')
+  const modelRoutingCapabilitiesByMode = ref<ModelRoutingCapabilitiesByMode | null>(null)
   let hasCanonicalImageAdmission = false
+  let modelRoutingRequestGeneration = 0
+  let modelRoutingEventGeneration = 0
+  let latestModelRoutingSnapshot: ModelRoutingSnapshot | undefined
   const routerSlots = ref<string[]>([])
   const routerModels = ref<Record<string, string>>({})
   const routerTierConfigs = ref<Record<string, ChatRouterTierConfig>>({})
@@ -106,30 +147,34 @@ export function useChatFeatureToggles(options: UseChatFeatureTogglesOptions) {
   function applyModelRoutingSnapshot(snapshot: ModelRoutingSnapshot | undefined) {
     const mode = snapshot?.mode
     if (!mode) return false
+    latestModelRoutingSnapshot = snapshot
     llmEnsembleEnabled.value = mode === 'ensemble'
     // The product control remains one three-state selector. The existing
     // routerEnabled ref means "routing feature active" to ChatView, so Ensemble
     // remains active here even when its static selection mode bypasses the
     // SquillaRouter implementation internally.
     routerEnabled.value = mode !== 'direct'
+    modelRoutingCapabilitiesByMode.value = parseCapabilitiesByMode(
+      snapshot.capabilities_by_mode,
+    )
     if (typeof snapshot.selection_mode === 'string') {
       llmEnsembleSelectionMode.value = snapshot.selection_mode
     }
     const admission = snapshot.image_input?.admission
     if (admission === 'allowed' || admission === 'blocked' || admission === 'unknown') {
       hasCanonicalImageAdmission = true
-      imageInputAdmission.value = admission
-      imageInputAdmissionReason.value = String(
+      globalImageInputAdmission.value = admission
+      globalImageInputAdmissionReason.value = String(
         snapshot.image_input?.reason || 'capability_unknown',
       )
     } else if (mode === 'ensemble') {
       hasCanonicalImageAdmission = false
-      imageInputAdmission.value = 'blocked'
-      imageInputAdmissionReason.value = 'ensemble_mode_unsupported'
+      globalImageInputAdmission.value = 'blocked'
+      globalImageInputAdmissionReason.value = 'ensemble_mode_unsupported'
     } else {
       hasCanonicalImageAdmission = false
-      imageInputAdmission.value = 'unknown'
-      imageInputAdmissionReason.value = 'capability_unknown'
+      globalImageInputAdmission.value = 'unknown'
+      globalImageInputAdmissionReason.value = 'capability_unknown'
     }
     return true
   }
@@ -147,8 +192,8 @@ export function useChatFeatureToggles(options: UseChatFeatureTogglesOptions) {
     llmEnsembleEnabled.value = ensembleEnabled
     llmEnsembleSelectionMode.value = String(cfg?.llm_ensemble?.selection_mode || '')
     if (!hasCanonicalImageAdmission) {
-      imageInputAdmission.value = ensembleEnabled ? 'blocked' : 'unknown'
-      imageInputAdmissionReason.value = ensembleEnabled
+      globalImageInputAdmission.value = ensembleEnabled ? 'blocked' : 'unknown'
+      globalImageInputAdmissionReason.value = ensembleEnabled
         ? 'ensemble_mode_unsupported'
         : 'capability_unknown'
     }
@@ -201,17 +246,42 @@ export function useChatFeatureToggles(options: UseChatFeatureTogglesOptions) {
     }
   }
 
+  async function applyLegacyModelRoutingFallback(cfg: ChatFeatureConfig | undefined) {
+    latestModelRoutingSnapshot = undefined
+    modelRoutingCapabilitiesByMode.value = null
+    hasCanonicalImageAdmission = false
+    await applyFeatureConfig(cfg)
+  }
+
   async function loadFeatureToggles() {
+    const requestGeneration = ++modelRoutingRequestGeneration
+    const eventGeneration = modelRoutingEventGeneration
+    let cfg: ChatFeatureConfig | undefined
     try {
       await waitForSessionRpcConnection(options.rpc, options.readCallOptions)
-      const cfg = options.readCallOptions
+      cfg = options.readCallOptions
         ? await options.rpc.call<ChatFeatureConfig>(
             'config.get',
             undefined,
             options.readCallOptions,
           )
         : await options.rpc.call<ChatFeatureConfig>('config.get')
+      if (requestGeneration !== modelRoutingRequestGeneration) return
       await applyFeatureConfig(cfg, { refreshUsage: true })
+      if (requestGeneration !== modelRoutingRequestGeneration) return
+      // Config remains the compatibility source for older Gateways. A routing
+      // event observed while it loaded is newer, so restore that atomic public
+      // snapshot and retire this read before it can start a stale canonical GET.
+      if (eventGeneration !== modelRoutingEventGeneration) {
+        if (latestModelRoutingSnapshot) {
+          applyModelRoutingSnapshot(latestModelRoutingSnapshot)
+        }
+        return
+      }
+      if (options.rpc.supportsMethod?.('models.routing.get') === false) {
+        await applyLegacyModelRoutingFallback(cfg)
+        return
+      }
       try {
         const routing = options.readCallOptions
           ? await options.rpc.call<ModelRoutingSnapshot>(
@@ -220,10 +290,30 @@ export function useChatFeatureToggles(options: UseChatFeatureTogglesOptions) {
               options.readCallOptions,
             )
           : await options.rpc.call<ModelRoutingSnapshot>('models.routing.get')
-        applyModelRoutingSnapshot(routing)
-      } catch {
-        // Older Gateways have no canonical routing RPC; the config projection
-        // applied above remains the read-only compatibility snapshot.
+        if (
+          requestGeneration === modelRoutingRequestGeneration
+          && eventGeneration === modelRoutingEventGeneration
+        ) {
+          applyModelRoutingSnapshot(routing)
+        }
+      } catch (error) {
+        if (
+          requestGeneration !== modelRoutingRequestGeneration
+          || eventGeneration !== modelRoutingEventGeneration
+        ) return
+        if (!isMethodNotFound(error)) {
+          // A timeout or transient server/transport error is not evidence that
+          // the Gateway contract disappeared. Preserve the last authoritative
+          // matrix so a known block cannot accidentally degrade to unknown.
+          if (latestModelRoutingSnapshot) {
+            applyModelRoutingSnapshot(latestModelRoutingSnapshot)
+          }
+          return
+        }
+        // A successful connection to an older Gateway must not retain a
+        // matrix learned from the previous connection. Clear the canonical
+        // cache as one unit, then re-apply this Gateway's config projection.
+        await applyLegacyModelRoutingFallback(cfg)
       }
     } catch {
       // Feature toggles are optional for older gateways.
@@ -339,6 +429,7 @@ export function useChatFeatureToggles(options: UseChatFeatureTogglesOptions) {
     }
     const onFocus = () => schedule()
     const unbindRouting = options.rpc.on?.('models.routing.changed', (payload) => {
+      modelRoutingEventGeneration += 1
       if (payload && typeof payload === 'object') {
         applyModelRoutingSnapshot(payload as ModelRoutingSnapshot)
         scheduleHistorySync?.()
@@ -361,8 +452,9 @@ export function useChatFeatureToggles(options: UseChatFeatureTogglesOptions) {
     routerSettingsBusy,
     modelRoutingMode,
     modelRoutingSettingsBusy,
-    imageInputAdmission,
-    imageInputAdmissionReason,
+    globalImageInputAdmission,
+    globalImageInputAdmissionReason,
+    modelRoutingCapabilitiesByMode,
     codingModeEnabled,
     codingModeSettingsBusy,
     llmEnsembleEnabled,

--- a/opensquilla-webui/src/composables/chat/useChatPendingQueue.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatPendingQueue.test.ts
@@ -1817,6 +1817,55 @@ describe('useChatPendingQueue delivery state', () => {
     }
   })
 
+  it('drains an image queue item exactly once after the live capability unblocks', async () => {
+    vi.useFakeTimers()
+    let blocked = true
+    const dispatchPendingItem = vi.fn(async () => 'accepted' as const)
+    const { inputText, pendingAttachments, queue } = makeQueue(
+      dispatchPendingItem,
+      () => blocked,
+    )
+    try {
+      inputText.value = 'describe the queued image'
+      pendingAttachments.value = [{
+        kind: 'staged',
+        local_id: 41,
+        name: 'queued-image.png',
+        mime: 'image/png',
+        size: 64,
+        file_uuid: 'synthetic-image-token',
+      }]
+      await queue.enqueuePendingInput(inputText.value)
+
+      queue.schedulePendingDrainAfterTerminal()
+      await vi.advanceTimersByTimeAsync(50)
+      expect(dispatchPendingItem).not.toHaveBeenCalled()
+      expect(queue.pendingQueue.value).toHaveLength(1)
+
+      blocked = false
+      // ChatView deliberately issues both signals when routing changes. The
+      // queue must re-read current capability without scheduling two sends.
+      queue.schedulePendingDrainAfterTerminal()
+      queue.flushDeferredPendingDrain()
+      queue.flushDeferredPendingDrain()
+      await vi.advanceTimersByTimeAsync(50)
+      await nextTick()
+
+      expect(dispatchPendingItem).toHaveBeenCalledOnce()
+      expect(dispatchPendingItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: 'describe the queued image',
+          attachments: [expect.objectContaining({ name: 'queued-image.png' })],
+        }),
+        'agent:main:webchat:test',
+      )
+      expect(queue.pendingQueue.value).toEqual([])
+    } finally {
+      queue.cleanup()
+      vi.useRealTimers()
+    }
+  })
+
   it.each(['visible', 'hidden'] as const)(
     'never dispatches an A-session %s lease after switching to B before nextTick',
     async kind => {

--- a/opensquilla-webui/src/composables/chat/useChatSessionRouting.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionRouting.test.ts
@@ -2,16 +2,35 @@ import { ref } from 'vue'
 import { describe, expect, it, vi } from 'vitest'
 
 import { useChatSessionRouting } from './useChatSessionRouting'
-import type { ModelRoutingMode } from '@/types/modelRouting'
+import type {
+  ImageInputAdmission,
+  ModelRoutingCapabilitiesByMode,
+  ModelRoutingMode,
+} from '@/types/modelRouting'
 
 const SESSION_ONE = 'agent:main:webchat:one'
 const SESSION_TWO = 'agent:main:webchat:two'
+
+const CAPABILITIES_BY_MODE: ModelRoutingCapabilitiesByMode = {
+  direct: {
+    image_input: { admission: 'allowed', reason: 'model_vision_supported' },
+  },
+  router: {
+    image_input: { admission: 'allowed', reason: 'router_image_route_available' },
+  },
+  ensemble: {
+    image_input: { admission: 'blocked', reason: 'ensemble_mode_unsupported' },
+  },
+}
 
 function harness(options: {
   globalMode?: ModelRoutingMode
   draft?: boolean
   getResponse?: unknown
   available?: boolean
+  globalImageInputAdmission?: ImageInputAdmission
+  globalImageInputAdmissionReason?: string
+  capabilitiesByMode?: ModelRoutingCapabilitiesByMode | null
 } = {}) {
   const handlers = new Map<string, (payload: unknown) => void>()
   const rpc = {
@@ -23,6 +42,15 @@ function harness(options: {
   }
   const sessionKey = ref(SESSION_ONE)
   const globalMode = ref<ModelRoutingMode>(options.globalMode ?? 'off')
+  const globalImageInputAdmission = ref<ImageInputAdmission>(
+    options.globalImageInputAdmission ?? 'unknown',
+  )
+  const globalImageInputAdmissionReason = ref(
+    options.globalImageInputAdmissionReason ?? 'capability_unknown',
+  )
+  const capabilitiesByMode = ref<ModelRoutingCapabilitiesByMode | null>(
+    options.capabilitiesByMode ?? null,
+  )
   const isStreaming = ref(false)
   const isDraft = ref(options.draft === true)
   const available = ref(options.available !== false)
@@ -31,12 +59,28 @@ function harness(options: {
     rpc,
     sessionKey,
     globalMode,
+    globalImageInputAdmission,
+    globalImageInputAdmissionReason,
+    capabilitiesByMode,
     available,
     isStreaming,
     isDraft: () => isDraft.value,
     notifyError,
   })
-  return { api, available, globalMode, handlers, isDraft, isStreaming, notifyError, rpc, sessionKey }
+  return {
+    api,
+    available,
+    capabilitiesByMode,
+    globalImageInputAdmission,
+    globalImageInputAdmissionReason,
+    globalMode,
+    handlers,
+    isDraft,
+    isStreaming,
+    notifyError,
+    rpc,
+    sessionKey,
+  }
 }
 
 describe('useChatSessionRouting', () => {
@@ -211,6 +255,9 @@ describe('useChatSessionRouting', () => {
       rpc,
       sessionKey: ref(SESSION_ONE),
       globalMode: ref<ModelRoutingMode>('off'),
+      globalImageInputAdmission: ref<ImageInputAdmission>('unknown'),
+      globalImageInputAdmissionReason: ref('capability_unknown'),
+      capabilitiesByMode: ref(null),
       isStreaming: ref(false),
       isDraft: () => false,
       notifyError: vi.fn(),
@@ -250,5 +297,82 @@ describe('useChatSessionRouting', () => {
 
     expect(api.mode.value).toBe('squilla_router')
     expect(api.revision.value).toBe(0)
+  })
+
+  it('selects image admission from the current session mode matrix', () => {
+    const { api } = harness({
+      globalMode: 'llm_ensemble',
+      globalImageInputAdmission: 'blocked',
+      globalImageInputAdmissionReason: 'ensemble_mode_unsupported',
+      capabilitiesByMode: CAPABILITIES_BY_MODE,
+    })
+
+    api.applyBootstrap({ key: SESSION_ONE, mode: 'router', revision: 2 })
+
+    expect(api.imageInputAdmission.value).toBe('allowed')
+    expect(api.imageInputAdmissionReason.value).toBe('router_image_route_available')
+  })
+
+  it('blocks when the session switches from a globally allowed mode to ensemble', () => {
+    const { api } = harness({
+      globalMode: 'off',
+      globalImageInputAdmission: 'allowed',
+      globalImageInputAdmissionReason: 'model_vision_supported',
+      capabilitiesByMode: CAPABILITIES_BY_MODE,
+    })
+
+    api.applyBootstrap({ key: SESSION_ONE, mode: 'ensemble', revision: 1 })
+
+    expect(api.imageInputAdmission.value).toBe('blocked')
+    expect(api.imageInputAdmissionReason.value).toBe('ensemble_mode_unsupported')
+  })
+
+  it('uses the matrix for an explicit non-global draft mode', async () => {
+    const { api } = harness({
+      draft: true,
+      globalMode: 'llm_ensemble',
+      capabilitiesByMode: CAPABILITIES_BY_MODE,
+    })
+
+    await api.setMode('squilla_router')
+
+    expect(api.initialRoutingMode.value).toBe('router')
+    expect(api.imageInputAdmission.value).toBe('allowed')
+  })
+
+  it('uses a legacy scalar only when session and global modes match', () => {
+    const matching = harness({
+      globalMode: 'llm_ensemble',
+      globalImageInputAdmission: 'blocked',
+      globalImageInputAdmissionReason: 'ensemble_mode_unsupported',
+    })
+    expect(matching.api.imageInputAdmission.value).toBe('blocked')
+
+    matching.api.applyBootstrap({ key: SESSION_ONE, mode: 'router', revision: 1 })
+
+    expect(matching.api.imageInputAdmission.value).toBe('unknown')
+    expect(matching.api.imageInputAdmissionReason.value).toBe('capability_unknown')
+  })
+
+  it('recomputes capability updates without changing the session revision', () => {
+    const { api, capabilitiesByMode } = harness({
+      capabilitiesByMode: CAPABILITIES_BY_MODE,
+    })
+    api.applyBootstrap({ key: SESSION_ONE, mode: 'router', revision: 4 })
+    expect(api.imageInputAdmission.value).toBe('allowed')
+
+    capabilitiesByMode.value = {
+      ...CAPABILITIES_BY_MODE,
+      router: {
+        image_input: {
+          admission: 'blocked',
+          reason: 'router_image_route_unavailable',
+        },
+      },
+    }
+
+    expect(api.revision.value).toBe(4)
+    expect(api.imageInputAdmission.value).toBe('blocked')
+    expect(api.imageInputAdmissionReason.value).toBe('router_image_route_unavailable')
   })
 })

--- a/opensquilla-webui/src/composables/chat/useChatSessionRouting.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionRouting.ts
@@ -1,6 +1,9 @@
 import { computed, ref, watch, type Ref } from 'vue'
 import type {
   GatewayModelRoutingMode,
+  ImageInputCapability,
+  ImageInputAdmission,
+  ModelRoutingCapabilitiesByMode,
   ModelRoutingMode,
 } from '@/types/modelRouting'
 import {
@@ -24,6 +27,9 @@ export interface UseChatSessionRoutingOptions {
   rpc: RpcClient
   sessionKey: Ref<string>
   globalMode: Readonly<Ref<ModelRoutingMode>>
+  globalImageInputAdmission: Readonly<Ref<ImageInputAdmission>>
+  globalImageInputAdmissionReason: Readonly<Ref<string>>
+  capabilitiesByMode: Readonly<Ref<ModelRoutingCapabilitiesByMode | null>>
   available?: Readonly<Ref<boolean>>
   isStreaming: Readonly<Ref<boolean>>
   isDraft: () => boolean
@@ -108,6 +114,23 @@ export function useChatSessionRouting(options: UseChatSessionRoutingOptions) {
       ? modelRoutingModeToGateway(mode.value)
       : null
   ))
+  const effectiveImageInputCapability = computed<ImageInputCapability>(() => {
+    const sessionMode = modelRoutingModeToGateway(mode.value)
+    const capabilitiesByMode = options.capabilitiesByMode.value
+    if (capabilitiesByMode) return capabilitiesByMode[sessionMode].image_input
+    if (sessionMode === modelRoutingModeToGateway(options.globalMode.value)) {
+      return {
+        admission: options.globalImageInputAdmission.value,
+        reason: options.globalImageInputAdmissionReason.value,
+      }
+    }
+    return {
+      admission: 'unknown',
+      reason: 'capability_unknown',
+    }
+  })
+  const imageInputAdmission = computed(() => effectiveImageInputCapability.value.admission)
+  const imageInputAdmissionReason = computed(() => effectiveImageInputCapability.value.reason)
 
   function reset() {
     generation += 1
@@ -285,6 +308,9 @@ export function useChatSessionRouting(options: UseChatSessionRoutingOptions) {
     modeAppliesNextTurn,
     hasAuthoritativeSnapshot,
     initialRoutingMode,
+    effectiveImageInputCapability,
+    imageInputAdmission,
+    imageInputAdmissionReason,
     applyBootstrap,
     load,
     reset,

--- a/opensquilla-webui/src/types/modelRouting.ts
+++ b/opensquilla-webui/src/types/modelRouting.ts
@@ -8,6 +8,28 @@ export const GATEWAY_MODEL_ROUTING_MODES = ['direct', 'router', 'ensemble'] as c
 
 export type GatewayModelRoutingMode = (typeof GATEWAY_MODEL_ROUTING_MODES)[number]
 
+export interface ImageInputCapability {
+  admission: ImageInputAdmission
+  reason: string
+}
+
+export interface ModelRoutingModeCapabilities {
+  image_input: ImageInputCapability
+}
+
+export type ModelRoutingCapabilitiesByMode = Record<
+  GatewayModelRoutingMode,
+  ModelRoutingModeCapabilities
+>
+
+/** Additive public snapshot returned by models.routing.get/set/changed. */
+export interface ModelRoutingSnapshot {
+  mode?: GatewayModelRoutingMode
+  selection_mode?: string
+  image_input?: Partial<ImageInputCapability>
+  capabilities_by_mode?: unknown
+}
+
 export function isModelRoutingMode(value: unknown): value is ModelRoutingMode {
   return typeof value === 'string' && MODEL_ROUTING_MODES.includes(value as ModelRoutingMode)
 }

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -2050,8 +2050,9 @@ const {
   routerSlots,
   routerModels,
   modelRoutingMode: globalModelRoutingMode,
-  imageInputAdmission,
-  imageInputAdmissionReason,
+  globalImageInputAdmission,
+  globalImageInputAdmissionReason,
+  modelRoutingCapabilitiesByMode,
   routerVisualEffectsEnabled,
   routerVisualMode,
   codingModeEnabled,
@@ -2073,6 +2074,9 @@ const chatSessionRouting = useChatSessionRouting({
   rpc,
   sessionKey,
   globalMode: globalModelRoutingMode,
+  globalImageInputAdmission,
+  globalImageInputAdmissionReason,
+  capabilitiesByMode: modelRoutingCapabilitiesByMode,
   available: sessionRoutingAvailable,
   isStreaming,
   isDraft: isDraftSurface,
@@ -2085,6 +2089,8 @@ const {
   mode: modelRoutingMode,
   busy: modelRoutingSettingsBusy,
   initialRoutingMode,
+  imageInputAdmission,
+  imageInputAdmissionReason,
 } = chatSessionRouting
 const sessionRoutingSendBlockedReason = computed(() => (
   modelRoutingSettingsBusy.value ? t('chat.composer.routingUpdateBlocked') : ''
@@ -6889,10 +6895,10 @@ watch(sessionKey, () => {
 // Hello refreshes method capabilities on reconnect. Retry the durable index
 // for the current Session then; older gateways simply remain on history/live.
 watch(() => rpc.state, (state, previous) => {
+  if (state !== 'connected' || previous === 'connected') return
+  void loadFeatureToggles()
   if (
-    state === 'connected'
-    && previous !== 'connected'
-    && sessionKey.value
+    sessionKey.value
     && pendingSessionIntent.value !== 'new_chat'
   ) {
     void loadSessionArtifactsAfterReconnect()

--- a/src/opensquilla/gateway/model_routing.py
+++ b/src/opensquilla/gateway/model_routing.py
@@ -448,6 +448,76 @@ def model_routing_snapshot(config: Any) -> dict[str, Any]:
     }
 
 
+def model_routing_snapshot_for_mode(
+    config: Any,
+    mode: ModelRoutingMode | str,
+) -> dict[str, Any]:
+    """Project the public routing snapshot for one mode without mutating config.
+
+    Acceptance snapshots intentionally freeze only the routing-owned subtrees.
+    Overlay them onto the live config before deriving public capabilities so
+    Direct and Router still see the active deployment's non-public ``llm``
+    authority while the returned snapshot remains secret-free.
+    """
+
+    captured = capture_model_routing_config(config, session_mode=mode)
+    overlay_live_config = getattr(captured, "overlay_live_config", None)
+    effective_config = (
+        overlay_live_config(config) if callable(overlay_live_config) else captured
+    )
+    return model_routing_snapshot(effective_config)
+
+
+def model_routing_capabilities_by_mode(config: Any) -> dict[str, dict[str, Any]]:
+    """Return a complete, independently fault-tolerant capability matrix."""
+
+    capabilities: dict[str, dict[str, Any]] = {}
+    for mode in ("direct", "router", "ensemble"):
+        try:
+            snapshot = model_routing_snapshot_for_mode(config, mode)
+            image_input = snapshot.get("image_input")
+            if not isinstance(image_input, dict):
+                raise ValueError("image_input capability is unavailable")
+            admission = image_input.get("admission")
+            reason = image_input.get("reason")
+            if admission not in {"allowed", "blocked", "unknown"}:
+                raise ValueError("image_input admission is invalid")
+            if not isinstance(reason, str) or not reason:
+                raise ValueError("image_input reason is invalid")
+            capabilities[mode] = {
+                "image_input": {
+                    "admission": admission,
+                    "reason": reason,
+                }
+            }
+        except Exception:  # noqa: BLE001 - isolate one failed mode projection
+            capabilities[mode] = {
+                "image_input": {
+                    "admission": "unknown",
+                    "reason": "capability_unknown",
+                }
+            }
+    return capabilities
+
+
+def model_routing_public_snapshot(config: Any) -> dict[str, Any]:
+    """Return the additive operator-facing snapshot including all mode capabilities."""
+
+    snapshot = model_routing_snapshot(config)
+    capabilities_by_mode = model_routing_capabilities_by_mode(config)
+    current_capabilities = capabilities_by_mode.get(str(snapshot.get("mode")), {})
+    current_image_input = current_capabilities.get("image_input")
+    return {
+        **snapshot,
+        # Preserve the legacy scalar while making it a projection of the
+        # canonical current mode.  This matters for Router observe configs,
+        # whose internal snapshot deliberately retains router diagnostics even
+        # though their public/effective mode is Direct.
+        "image_input": current_image_input or snapshot["image_input"],
+        "capabilities_by_mode": capabilities_by_mode,
+    }
+
+
 def model_routing_patches(
     config: Any,
     mode: str,
@@ -830,12 +900,13 @@ async def broadcast_model_routing_changed(
     *,
     source: str,
     config: Any | None = None,
+    snapshot: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Broadcast the canonical snapshot to every readable operator surface."""
 
     active_config = config if config is not None else getattr(ctx, "config", None)
-    snapshot = model_routing_snapshot(active_config)
-    payload = {**snapshot, "source": source}
+    public_snapshot = snapshot or model_routing_public_snapshot(active_config)
+    payload = {**public_snapshot, "source": source}
     subscription_manager = getattr(ctx, "subscription_manager", None)
     if subscription_manager is None:
         return payload
@@ -870,13 +941,14 @@ async def broadcast_model_routing_changed_if_needed(
     """
 
     active_config = config if config is not None else getattr(ctx, "config", None)
-    current = model_routing_snapshot(active_config)
+    current = model_routing_public_snapshot(active_config)
     if current == previous:
         return None
     return await broadcast_model_routing_changed(
         ctx,
         source=source,
         config=active_config,
+        snapshot=current,
     )
 
 
@@ -887,9 +959,12 @@ __all__ = [
     "broadcast_model_routing_changed_if_needed",
     "capture_model_routing_config",
     "durable_model_routing_config_snapshot",
+    "model_routing_capabilities_by_mode",
     "model_routing_mode_for_write",
     "model_routing_patches",
+    "model_routing_public_snapshot",
     "model_routing_snapshot",
+    "model_routing_snapshot_for_mode",
     "reconcile_model_routing_write",
     "restore_durable_model_routing_config_snapshot",
 ]

--- a/src/opensquilla/gateway/rpc_config.py
+++ b/src/opensquilla/gateway/rpc_config.py
@@ -27,7 +27,7 @@ from opensquilla.gateway.config_secrets import (
 )
 from opensquilla.gateway.model_routing import (
     broadcast_model_routing_changed_if_needed,
-    model_routing_snapshot,
+    model_routing_public_snapshot,
     reconcile_model_routing_write,
 )
 from opensquilla.gateway.rpc import RpcContext, get_dispatcher
@@ -776,7 +776,7 @@ async def _handle_config_set(params: dict | None, ctx: RpcContext) -> dict[str, 
         raise ValueError("No config available")
 
     previous_config = ctx.config.model_copy(deep=True)
-    old_model_routing = model_routing_snapshot(ctx.config)
+    old_model_routing = model_routing_public_snapshot(ctx.config)
     old_live_catalog_fingerprint = _live_catalog_fingerprint(ctx.config)
     old_memory_fingerprint = _memory_restart_fingerprint(ctx.config)
     old_channels_fingerprint = _channels_restart_fingerprint(ctx.config)
@@ -901,7 +901,7 @@ async def _handle_config_patch(
         raise ValueError("No config available")
 
     previous_config = ctx.config.model_copy(deep=True)
-    old_model_routing = model_routing_snapshot(ctx.config)
+    old_model_routing = model_routing_public_snapshot(ctx.config)
     old_live_catalog_fingerprint = _live_catalog_fingerprint(ctx.config)
     old_memory_fingerprint = _memory_restart_fingerprint(ctx.config)
     old_channels_fingerprint = _channels_restart_fingerprint(ctx.config)
@@ -1095,7 +1095,7 @@ async def _handle_config_apply(params: dict | None, ctx: RpcContext) -> dict[str
         if ctx.config is not None and hasattr(ctx.config, "model_dump")
         else {}
     )
-    old_model_routing = model_routing_snapshot(ctx.config)
+    old_model_routing = model_routing_public_snapshot(ctx.config)
     config_payload, redacted_paths = _restore_redacted_values(config_payload, old_payload)
     config_payload = _strip_public_derived_config_fields(config_payload)
 
@@ -1221,7 +1221,7 @@ async def _handle_config_reload(params: dict | None, ctx: RpcContext) -> dict[st
         raise ValueError("No config available")
 
     previous_config = ctx.config.model_copy(deep=True)
-    old_model_routing = model_routing_snapshot(ctx.config)
+    old_model_routing = model_routing_public_snapshot(ctx.config)
     from opensquilla.onboarding.config_store import load_config, resolve_config_path
 
     target, _source = resolve_config_path(getattr(ctx.config, "config_path", None) or None)

--- a/src/opensquilla/gateway/rpc_models.py
+++ b/src/opensquilla/gateway/rpc_models.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from opensquilla.gateway.model_routing import (
     model_routing_patches,
-    model_routing_snapshot,
+    model_routing_public_snapshot,
 )
 from opensquilla.gateway.rpc import RpcContext, get_dispatcher
 from opensquilla.provider.model_catalog import ModelCatalog
@@ -262,7 +262,7 @@ async def _handle_models_routing_get(
 ) -> dict[str, Any]:
     if ctx.config is None:
         raise ValueError("No config available")
-    return model_routing_snapshot(ctx.config)
+    return model_routing_public_snapshot(ctx.config)
 
 
 @_d.method("models.routing.set", scope="operator.write")
@@ -284,7 +284,7 @@ async def _handle_models_routing_set(
         ctx,
     )
     return {
-        **model_routing_snapshot(ctx.config),
+        **model_routing_public_snapshot(ctx.config),
         "patched": list(patch_result.get("patched") or []),
         "restart_required": bool(
             patch_result.get("restartRequired", patch_result.get("restart_required", False))

--- a/src/opensquilla/gateway/rpc_sessions.py
+++ b/src/opensquilla/gateway/rpc_sessions.py
@@ -12505,6 +12505,12 @@ async def _handle_sessions_bootstrap(params: dict | None, ctx: RpcContext) -> di
         session_routing_revision=routing["revision"],
         session_routing_source=routing["source"],
     )
+    overlay_live_config = getattr(effective_routing_config, "overlay_live_config", None)
+    effective_runtime_config = (
+        overlay_live_config(ctx.config)
+        if callable(overlay_live_config)
+        else effective_routing_config
+    )
 
     metadata: dict[str, Any] = {
         "session_key": session_key,
@@ -12549,7 +12555,7 @@ async def _handle_sessions_bootstrap(params: dict | None, ctx: RpcContext) -> di
             "running_count": running_count,
         },
         "runtime": {
-            "model_routing": model_routing_snapshot(effective_routing_config),
+            "model_routing": model_routing_snapshot(effective_runtime_config),
         },
         "routing": routing,
         "collaboration": _plan_collaboration_snapshot(session),

--- a/tests/test_gateway/test_rpc_model_routing.py
+++ b/tests/test_gateway/test_rpc_model_routing.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from opensquilla.gateway import model_routing as model_routing_module
 from opensquilla.gateway import websocket as gateway_websocket
 from opensquilla.gateway.auth import Principal
 from opensquilla.gateway.config import GatewayConfig
@@ -15,8 +16,10 @@ from opensquilla.gateway.model_routing import (
     apply_model_routing_mode,
     capture_model_routing_config,
     ensemble_activation_preview,
+    model_routing_capabilities_by_mode,
     model_routing_mode_for_write,
     model_routing_patches,
+    model_routing_public_snapshot,
     model_routing_snapshot,
 )
 from opensquilla.gateway.routing import RouteEnvelope, SourceKind
@@ -381,6 +384,150 @@ def test_model_routing_snapshot_exposes_direct_image_admission(
     assert "proxy" not in str(snapshot)
 
 
+def test_model_routing_public_snapshot_exposes_complete_capability_matrix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Catalog:
+        def set_user_overrides(self, _overrides: Any) -> None:
+            return None
+
+        def resolve_deployment_vision_support(
+            self,
+            model: str,
+            **_kwargs: Any,
+        ) -> str:
+            return "supported" if model in {"direct-vision", "router-vision"} else "unsupported"
+
+    monkeypatch.setattr(
+        "opensquilla.provider.model_catalog.shared_catalog",
+        lambda: _Catalog(),
+    )
+    config = GatewayConfig(
+        llm={
+            "provider": "openrouter",
+            "model": "direct-vision",
+            "api_key": "synthetic-secret-key",
+            "proxy": "https://synthetic-proxy.invalid",
+        },
+        squilla_router={
+            "enabled": False,
+            "rollout_phase": "observe",
+            "tiers": {
+                "c1": {
+                    "model": "router-vision",
+                    "supports_image": True,
+                }
+            },
+        },
+        llm_ensemble={
+            "enabled": True,
+            "selection_mode": "static_openrouter_b5",
+        },
+    )
+    before = config.model_dump(mode="python")
+
+    snapshot = model_routing_public_snapshot(config)
+
+    assert set(snapshot["capabilities_by_mode"]) == {
+        "direct",
+        "router",
+        "ensemble",
+    }
+    assert snapshot["capabilities_by_mode"] == {
+        "direct": {
+            "image_input": {
+                "admission": "allowed",
+                "reason": "model_vision_supported",
+            }
+        },
+        "router": {
+            "image_input": {
+                "admission": "allowed",
+                "reason": "router_image_route_available",
+            }
+        },
+        "ensemble": {
+            "image_input": {
+                "admission": "blocked",
+                "reason": "ensemble_mode_unsupported",
+            }
+        },
+    }
+    assert snapshot["mode"] == "ensemble"
+    assert snapshot["image_input"] == snapshot["capabilities_by_mode"]["ensemble"][
+        "image_input"
+    ]
+    assert config.model_dump(mode="python") == before
+    assert "synthetic-secret-key" not in str(snapshot)
+    assert "synthetic-proxy.invalid" not in str(snapshot)
+    assert "capabilities_by_mode" not in model_routing_snapshot(config)
+
+
+def test_model_routing_public_snapshot_projects_router_as_current_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Catalog:
+        def resolve_deployment_vision_support(self, *_args: Any, **_kwargs: Any) -> str:
+            return "supported"
+
+    monkeypatch.setattr(
+        "opensquilla.provider.model_catalog.shared_catalog",
+        lambda: _Catalog(),
+    )
+    config = GatewayConfig(
+        squilla_router={
+            "enabled": True,
+            "rollout_phase": "full",
+            "tiers": {
+                "c1": {"model": "router-vision", "supports_image": True},
+            },
+        },
+        llm_ensemble={"enabled": False},
+    )
+
+    snapshot = model_routing_public_snapshot(config)
+
+    assert snapshot["mode"] == "router"
+    assert snapshot["image_input"] == {
+        "admission": "allowed",
+        "reason": "router_image_route_available",
+    }
+    assert snapshot["image_input"] == snapshot["capabilities_by_mode"]["router"][
+        "image_input"
+    ]
+
+
+def test_model_routing_capability_projection_isolates_one_mode_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original = model_routing_module.model_routing_snapshot_for_mode
+
+    def project(config: Any, mode: str) -> dict[str, Any]:
+        if mode == "router":
+            raise RuntimeError("synthetic router projection failure")
+        return original(config, mode)
+
+    monkeypatch.setattr(model_routing_module, "model_routing_snapshot_for_mode", project)
+
+    capabilities = model_routing_capabilities_by_mode(GatewayConfig())
+
+    assert capabilities["router"] == {
+        "image_input": {
+            "admission": "unknown",
+            "reason": "capability_unknown",
+        }
+    }
+    assert capabilities["direct"]["image_input"]["admission"] in {
+        "allowed",
+        "blocked",
+        "unknown",
+    }
+    assert capabilities["ensemble"]["image_input"] == {
+        "admission": "blocked",
+        "reason": "ensemble_mode_unsupported",
+    }
+
+
 @pytest.mark.parametrize(
     ("tiers", "vision_support", "expected"),
     [
@@ -527,6 +674,10 @@ async def test_models_routing_get_is_read_only() -> None:
     result = await _handle_models_routing_get(None, _ctx(config))
 
     assert result["mode"] == "ensemble"
+    assert set(result["capabilities_by_mode"]) == {"direct", "router", "ensemble"}
+    assert result["image_input"] == result["capabilities_by_mode"]["ensemble"][
+        "image_input"
+    ]
     assert config.model_dump() == before
 
 
@@ -563,7 +714,7 @@ async def test_onboarding_router_configure_broadcasts_one_canonical_change(
         (
             "models.routing.changed",
             {
-                **model_routing_snapshot(config),
+                **model_routing_public_snapshot(config),
                 "source": "onboarding.router.configure",
             },
         )
@@ -666,7 +817,7 @@ async def test_onboarding_ensemble_configure_broadcasts_one_canonical_change(
         (
             "models.routing.changed",
             {
-                **model_routing_snapshot(config),
+                **model_routing_public_snapshot(config),
                 "source": "onboarding.ensemble.configure",
             },
         )
@@ -680,17 +831,19 @@ async def test_models_routing_set_reuses_safe_patch_broadcast_exactly_once(
     config = GatewayConfig(config_path=str(tmp_path / "routing-set.toml"))
     ctx, events = _routing_event_ctx(config, monkeypatch)
 
-    await _handle_models_routing_set({"mode": "direct"}, ctx)
+    result = await _handle_models_routing_set({"mode": "direct"}, ctx)
 
+    expected = model_routing_public_snapshot(config)
     assert events == [
         (
             "models.routing.changed",
             {
-                **model_routing_snapshot(config),
+                **expected,
                 "source": "config.patch.safe",
             },
         )
     ]
+    assert result["capabilities_by_mode"] == expected["capabilities_by_mode"]
 
 
 @pytest.mark.parametrize(
@@ -717,7 +870,7 @@ async def test_admin_config_hot_apply_broadcasts_one_canonical_routing_change(
     )
 
     expected = {
-        **model_routing_snapshot(config),
+        **model_routing_public_snapshot(config),
         "source": case,
     }
     assert events == [("models.routing.changed", expected)]
@@ -749,6 +902,68 @@ async def test_admin_config_hot_apply_does_not_broadcast_unchanged_routing(
 
     assert events == []
     assert "model_routing" not in response
+
+
+async def test_inactive_router_capability_change_broadcasts_public_snapshot(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Catalog:
+        def set_user_overrides(self, _overrides: Any) -> None:
+            return None
+
+        def resolve_deployment_vision_support(
+            self,
+            model: str,
+            **_kwargs: Any,
+        ) -> str:
+            return "supported" if model == "router-vision" else "unsupported"
+
+    monkeypatch.setattr(
+        "opensquilla.provider.model_catalog.shared_catalog",
+        lambda: _Catalog(),
+    )
+    config = GatewayConfig(
+        config_path=str(tmp_path / "inactive-router-capability.toml"),
+        llm={"provider": "openrouter", "model": "direct-text"},
+        llm_ensemble={
+            "enabled": True,
+            "selection_mode": "static_openrouter_b5",
+        },
+        squilla_router={
+            "enabled": False,
+            "rollout_phase": "observe",
+            "tiers": {
+                "c1": {"model": "router-text", "supports_image": True},
+            },
+        },
+    )
+    ctx, events = _routing_event_ctx(config, monkeypatch)
+    before = model_routing_public_snapshot(config)
+    assert before["mode"] == "ensemble"
+    assert before["capabilities_by_mode"]["router"]["image_input"][
+        "admission"
+    ] == "blocked"
+
+    response = await _handle_config_patch(
+        {"patches": {"squilla_router.tiers.c1.model": "router-vision"}},
+        ctx,
+    )
+
+    after = model_routing_public_snapshot(config)
+    assert after["mode"] == "ensemble"
+    assert after["image_input"] == before["image_input"]
+    assert after["capabilities_by_mode"]["router"]["image_input"] == {
+        "admission": "allowed",
+        "reason": "router_image_route_available",
+    }
+    assert events == [
+        (
+            "models.routing.changed",
+            {**after, "source": "config.patch"},
+        )
+    ]
+    assert response["model_routing"] == events[0][1]
 
 
 async def test_safe_patch_noop_does_not_broadcast_model_routing_change(
@@ -813,7 +1028,7 @@ async def test_legacy_safe_patch_ensemble_enable_repairs_router_dependency_once(
     assert config.squilla_router.enabled is True
     assert config.squilla_router.rollout_phase == "full"
     expected = {
-        **model_routing_snapshot(config),
+        **model_routing_public_snapshot(config),
         "source": "config.patch.safe",
     }
     assert events == [("models.routing.changed", expected)]

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -10960,6 +10960,69 @@ class TestSessionsBootstrap:
         assert res.payload["stream_cursor"] == stream["stream_seq"]
 
     @pytest.mark.asyncio
+    async def test_bootstrap_overlays_live_llm_for_session_direct_image_capability(
+        self,
+        dispatcher,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        class _Catalog:
+            def resolve_deployment_vision_support(self, *_args, **_kwargs) -> str:
+                return "supported"
+
+        monkeypatch.setattr(
+            "opensquilla.provider.model_catalog.shared_catalog",
+            lambda: _Catalog(),
+        )
+        key = "agent:main:webchat:bootstrap-direct-vision"
+        session = FakeSession(session_key=key, session_id="bootstrap-direct-vision")
+        manager = FakeSessionManager([session])
+
+        async def get_session_routing(
+            candidate: str,
+            *,
+            fallback_mode: str,
+        ) -> dict[str, Any]:
+            assert candidate == key
+            assert fallback_mode == "ensemble"
+            return {
+                "mode": "direct",
+                "revision": 3,
+                "source": "session",
+                "initialized": True,
+            }
+
+        manager.get_session_routing = get_session_routing  # type: ignore[attr-defined]
+        ctx = make_ctx(
+            session_manager=manager,
+            config=GatewayConfig(
+                workspace_dir=str(tmp_path / "workspace"),
+                llm={"provider": "openrouter", "model": "direct-vision"},
+                llm_ensemble={
+                    "enabled": True,
+                    "selection_mode": "static_openrouter_b5",
+                },
+                squilla_router={"enabled": False, "rollout_phase": "observe"},
+            ),
+        )
+
+        res = await dispatcher.dispatch(
+            "bootstrap-direct-vision",
+            "sessions.bootstrap",
+            {"key": key},
+            ctx,
+        )
+
+        assert res.ok is True
+        assert res.payload["routing"]["mode"] == "direct"
+        assert res.payload["routing"]["revision"] == 3
+        assert res.payload["runtime"]["model_routing"]["mode"] == "direct"
+        assert res.payload["runtime"]["model_routing"]["image_input"] == {
+            "admission": "allowed",
+            "reason": "model_vision_supported",
+        }
+
+    @pytest.mark.asyncio
     async def test_legacy_bootstrap_preserves_transcript_larger_than_one_mib(
         self, dispatcher
     ):


### PR DESCRIPTION
## Scope

- Add an additive `capabilities_by_mode` matrix to public model-routing snapshots while preserving the legacy top-level `image_input` field.
- Derive the effective image capability from the current session route, including old-Gateway fallback and request/event race protection.
- Make the composer, send path, and pending queue consume the same effective capability.
- Add backend, frontend, WebSocket, and Playwright regressions for session-local image routing.

## Branch target

- Base: `main`
- Head: `fix/session-routing-capability-matrix`

## Linked issue

- None

## Release note

- Fixed image attachments remaining blocked after an existing conversation switches from Ensemble to a vision-capable Router route.

## Verification

- `104 passed` — routing RPC, session routing, bootstrap, and WebSocket request concurrency.
- `342 passed` — routing matrix, session switching, pending queue, attachment send guards, and composer image guards.
- `1 passed` — production-preview Chromium scenario covering an existing two-turn conversation, Ensemble → Router, PNG attachment, and exactly one send.
- Scoped Ruff and mypy passed.
- WebUI typecheck, architecture/security/i18n guards, production build, runtime bundle guard, and 404-file artifact verification passed.
- Manual in-app browser verification covered both button and Enter submission; each produced exactly one `chat.send`, with no global `models.routing.set` call.

## Safety and compatibility

- RPC change is additive; existing clients continue to use the legacy scalar.
- No database, persisted session, or configuration migration.
- Capability projections expose only admission/reason values and do not return provider keys, proxy settings, or live configuration.
- Gateway startup and internal mode-provider paths retain the lightweight legacy snapshot.
- `unknown` remains non-blocking in the client, with the Gateway as final authority.
- Platform-neutral change; no filesystem, subprocess, signal, or OS-specific behavior changed.

## Third-party origin

- None.
