### PR TITLE
Attribute listed models to the configured provider id

### DIFF
--- a/src/opensquilla/provider/ollama.py
+++ b/src/opensquilla/provider/ollama.py
@@ -795,7 +795,7 @@ class OllamaProvider:
                 data = resp.json()
                 return [
                     ModelInfo(
-                        provider=self.provider_name,
+                        provider=self.provider_id,
                         model_id=m["name"],
                         display_name=m.get("name", ""),
                         context_window=m.get("details", {}).get("context_length", 0),

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -3051,8 +3051,13 @@ class OpenAIProvider:
         # Keep configured deployment identity separate from the adapter family
         # (``provider_name``) and wire dialect (``_provider_kind``).  A
         # DashScope or DeepSeek instance still needs OpenAI-family behavior,
-        # but must never be attributed to OpenAI in telemetry.
-        self.provider_id = (provider_id or self.provider_name).strip()
+        # but must never be attributed to OpenAI in telemetry.  Direct
+        # construction (tests, ad-hoc embedding) falls back to the dialect
+        # rather than to ``provider_name``: this adapter serves every
+        # OpenAI-compatible dialect, so ``provider_name`` would attribute a
+        # DashScope or OpenRouter instance to OpenAI, which is exactly what
+        # this field exists to prevent.
+        self.provider_id = (provider_id or self._provider_kind).strip()
         self._compat = compat or compat_policy_for_kind(self._provider_kind)
         self._replay_provider_state = replay_provider_state
         self._provider_routing: Mapping[str, str] = provider_routing or {}
@@ -6190,7 +6195,7 @@ class OpenAIProvider:
                             reasoning = published_capabilities.reasoning
                         result.append(
                             ModelInfo(
-                                provider=self._provider_kind,
+                                provider=self.provider_id,
                                 model_id=model.model_id,
                                 display_name=model.display_name,
                                 context_window=(
@@ -6250,7 +6255,7 @@ class OpenAIProvider:
                 else:
                     models = [
                         ModelInfo(
-                            provider=self._provider_kind,
+                            provider=self.provider_id,
                             model_id=m["id"],
                             display_name=m.get("name", m.get("id", "")),
                             context_window=m.get("context_length", 0),

--- a/src/opensquilla/provider/openai_codex.py
+++ b/src/opensquilla/provider/openai_codex.py
@@ -923,7 +923,7 @@ class OpenAICodexProvider:
     async def list_models(self) -> list[ModelInfo]:
         return [
             ModelInfo(
-                provider=self.provider_name,
+                provider=self.provider_id,
                 model_id=model_id,
                 display_name=display_name,
                 context_window=272_000,

--- a/src/opensquilla/provider/openai_responses.py
+++ b/src/opensquilla/provider/openai_responses.py
@@ -968,7 +968,7 @@ class OpenAIResponsesProvider:
             if isinstance(model_id, str):
                 models.append(
                     ModelInfo(
-                        provider=self.provider_name,
+                        provider=self.provider_id,
                         model_id=model_id,
                         display_name=raw.get("name") or model_id,
                     )

--- a/tests/test_contracts/test_models_list_wire.py
+++ b/tests/test_contracts/test_models_list_wire.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import httpx
 import pytest
 
 from opensquilla.gateway.rpc import RpcContext
@@ -289,6 +290,48 @@ async def test_models_list_envelope_keys_are_frozen() -> None:
     assert envelope["errors"] == [
         {"provider": "test-provider", "kind": "auth_invalid", "detail": "invalid api key"}
     ]
+
+
+async def test_models_list_provider_filter_matches_the_configured_provider_id(
+    monkeypatch,
+) -> None:
+    # End-to-end shape of the ``models.list`` provider filter: rows carry the
+    # configured provider id, so ``--provider <configured id>`` matches and the
+    # underlying wire dialect does not. Real adapter, mock transport, no
+    # credentials.
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(
+            200,
+            json={"object": "list", "data": [{"id": "listed-model", "object": "model"}]},
+        )
+    )
+    real_async_client = httpx.AsyncClient
+
+    def patched(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr("opensquilla.provider.openai.httpx.AsyncClient", patched)
+    selector = ModelSelector(
+        SelectorConfig(
+            primary=ProviderConfig(
+                provider="vllm",
+                model="listed-model",
+                base_url="http://127.0.0.1:8000/v1",
+            )
+        )
+    )
+    ctx = RpcContext(conn_id="test", provider_selector=selector)
+
+    unfiltered = await _handle_models_list({}, ctx)
+    assert [row["provider"] for row in unfiltered["models"]] == ["vllm"]
+
+    matched = await _handle_models_list({"provider": "vllm"}, ctx)
+    assert [row["id"] for row in matched["models"]] == ["listed-model"]
+
+    # "openai" is vllm's wire dialect, never its configured identity.
+    mismatched = await _handle_models_list({"provider": "openai"}, ctx)
+    assert mismatched["models"] == []
 
 
 async def test_tokenrhythm_models_list_is_snapshot_only(monkeypatch) -> None:

--- a/tests/test_provider/golden/streams/openai_compat/minimax_text_tool_synthesis.events.json
+++ b/tests/test_provider/golden/streams/openai_compat/minimax_text_tool_synthesis.events.json
@@ -27,7 +27,7 @@
     "model": "minimax-test-1",
     "model_usage_breakdown": [],
     "output_tokens": 22,
-    "provider": "openai",
+    "provider": "minimax",
     "reasoning_content": null,
     "reasoning_tokens": 0,
     "stop_reason": "stop",

--- a/tests/test_provider/golden/streams/openai_compat/tokenrhythm_duplicate_finish_usage.events.json
+++ b/tests/test_provider/golden/streams/openai_compat/tokenrhythm_duplicate_finish_usage.events.json
@@ -33,7 +33,7 @@
     "model": "deepseek-v4-flash",
     "model_usage_breakdown": [],
     "output_tokens": 9,
-    "provider": "openai",
+    "provider": "tokenrhythm",
     "reasoning_content": "Reasoning about the reply.",
     "reasoning_tokens": 6,
     "stop_reason": "stop",

--- a/tests/test_provider/golden/streams/openai_compat/tokenrhythm_single_finish_usage.events.json
+++ b/tests/test_provider/golden/streams/openai_compat/tokenrhythm_single_finish_usage.events.json
@@ -28,7 +28,7 @@
     "model": "deepseek-v4-flash",
     "model_usage_breakdown": [],
     "output_tokens": 17,
-    "provider": "openai",
+    "provider": "tokenrhythm",
     "reasoning_content": "Synthetic reasoning.",
     "reasoning_tokens": 8,
     "stop_reason": "stop",

--- a/tests/test_provider/test_list_models_provider_identity.py
+++ b/tests/test_provider/test_list_models_provider_identity.py
@@ -1,0 +1,170 @@
+"""``list_models`` must attribute rows to the configured deployment identity.
+
+A provider row's ``provider`` field is the configured ``provider_id`` (the
+registry spec id an operator selected), not the wire dialect
+(``_provider_kind``) and not the adapter family (``provider_name``). Those
+three axes diverge for 11 runtime-supported specs, so attributing a listing
+to either of the latter two mislabels the row — and ``models.list``'s
+``provider`` filter compares that field verbatim, so a mislabeled row is
+unreachable by its own configured id.
+
+Every case here drives the real adapter through a mock transport: offline,
+deterministic, credential-free.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from opensquilla.provider.openai import OpenAIProvider
+from opensquilla.provider.registry import get_provider_spec
+from opensquilla.provider.selector import ProviderConfig, build_provider_from_config
+
+
+def _patch_models_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+    module: str,
+    payload: dict[str, Any],
+) -> None:
+    """Serve ``payload`` for any GET issued by ``module``'s httpx client."""
+
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, json=payload))
+    real_async_client = httpx.AsyncClient
+
+    def patched(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(f"{module}.httpx.AsyncClient", patched)
+
+
+# (provider_id, base_url) for openai_compat specs whose provider_id differs
+# from their wire dialect. Keys are synthetic; base urls are never dialed.
+_OPENAI_COMPAT_MISLABEL_CASES = [
+    ("vllm", "http://127.0.0.1:8000/v1"),
+    ("custom", "http://127.0.0.1:8000/v1"),
+    ("kimi_coding_openai", "https://api.moonshot.cn/v1"),
+    ("mimo_openai", "https://api.example.invalid/v1"),
+    ("minimax_openai", "https://api.example.invalid/v1"),
+    ("minimax_coding_openai", "https://api.example.invalid/v1"),
+    ("bailian_coding_cn", "https://api.example.invalid/v1"),
+    ("tencent_token_plan", "https://api.example.invalid/v1"),
+    ("tencent_tokenhub_intl", "https://api.example.invalid/v1"),
+]
+
+
+@pytest.mark.parametrize(("provider_id", "base_url"), _OPENAI_COMPAT_MISLABEL_CASES)
+async def test_openai_compat_listing_reports_configured_provider_id(
+    monkeypatch: pytest.MonkeyPatch,
+    provider_id: str,
+    base_url: str,
+) -> None:
+    # Guard the premise: these specs only exercise the defect because their
+    # provider_id and wire dialect genuinely diverge.
+    spec = get_provider_spec(provider_id)
+    assert spec.provider_id != spec.provider_kind
+
+    _patch_models_endpoint(
+        monkeypatch,
+        "opensquilla.provider.openai",
+        {"object": "list", "data": [{"id": "listed-model", "object": "model"}]},
+    )
+    provider = build_provider_from_config(
+        ProviderConfig(
+            provider=provider_id,
+            model="listed-model",
+            api_key="synthetic-list-models-key",
+            base_url=base_url,
+        )
+    )
+
+    rows = await provider.list_models()
+
+    assert [row.provider for row in rows] == [provider_id]
+    # The dialect must not leak into attribution even though it drives the wire.
+    assert rows[0].provider != spec.provider_kind
+
+
+@pytest.mark.parametrize(
+    "provider_id",
+    ["byteplus_coding_plan", "volcengine_coding_plan"],
+)
+async def test_openai_responses_listing_reports_configured_provider_id(
+    monkeypatch: pytest.MonkeyPatch,
+    provider_id: str,
+) -> None:
+    # The responses adapter's provider_name is the canonical
+    # "openai_responses" spec id, so plan surfaces sharing the backend used
+    # to report that id instead of their own.
+    _patch_models_endpoint(
+        monkeypatch,
+        "opensquilla.provider.openai_responses",
+        {"object": "list", "data": [{"id": "listed-model"}]},
+    )
+    provider = build_provider_from_config(
+        ProviderConfig(
+            provider=provider_id,
+            model="listed-model",
+            api_key="synthetic-list-models-key",
+            base_url="https://api.example.invalid/v1",
+        )
+    )
+
+    rows = await provider.list_models()
+
+    assert [row.provider for row in rows] == [provider_id]
+
+
+async def test_ollama_listing_reports_configured_provider_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_models_endpoint(
+        monkeypatch,
+        "opensquilla.provider.ollama",
+        {"models": [{"name": "llama3.2", "details": {"context_length": 8192}}]},
+    )
+    provider = build_provider_from_config(
+        ProviderConfig(
+            provider="ollama",
+            model="llama3.2",
+            base_url="http://127.0.0.1:11434",
+        )
+    )
+
+    rows = await provider.list_models()
+
+    assert [row.provider for row in rows] == ["ollama"]
+
+
+def test_direct_construction_falls_back_to_the_dialect_not_openai() -> None:
+    # OpenAIProvider serves every OpenAI-compatible dialect, so falling back
+    # to provider_name ("openai") would attribute a foreign deployment to
+    # OpenAI. Direct construction is a test/ad-hoc path; production always
+    # passes provider_id through the selector.
+    sniffed = OpenAIProvider(
+        api_key="synthetic-list-models-key",
+        model="deepseek/deepseek-v4-flash",
+        base_url="https://openrouter.ai/api/v1",
+    )
+    assert sniffed.provider_id == "openrouter"
+
+    explicit_kind = OpenAIProvider(
+        api_key="synthetic-list-models-key",
+        model="minimax-test-1",
+        base_url="https://api.example.invalid/v1",
+        provider_kind="minimax",
+    )
+    assert explicit_kind.provider_id == "minimax"
+
+    # An explicit provider_id still wins over the dialect.
+    configured = OpenAIProvider(
+        api_key="synthetic-list-models-key",
+        model="listed-model",
+        base_url="https://api.example.invalid/v1",
+        provider_kind="minimax",
+        provider_id="minimax_coding_openai",
+    )
+    assert configured.provider_id == "minimax_coding_openai"


### PR DESCRIPTION
Fixes #1346

## Problem

`list_models` labelled every row with the wire dialect (`_provider_kind`) or the adapter family (`provider_name`) instead of the configured deployment identity (`provider_id`). Those three axes diverge for 11 runtime-supported specs, so a `vllm` endpoint listed its models as `openai`, `kimi_coding_openai` as `moonshot`, and `byteplus_coding_plan` as `openai_responses`.

`models.list` compares its `provider` filter against that field verbatim, so a mislabeled row was unreachable by its own configured id:

```
$ opensquilla models list --provider vllm     # configured id -> no rows
$ opensquilla models list --provider openai   # matches a provider never configured
```

Every other catalog consumer already resolves against the configured `provider_id` (`engine/pricing.py`, `engine/subagent.py`, `engine/steps/squilla_router.py`, `onboarding/probe.py`), and the openai adapter's own usage/billing sites already used `self.provider_id` — the listing paths were the outlier, not the rule.

## Change

`list_models` now attributes rows to `self.provider_id` in the four affected adapters (`openai`, `openai_responses`, `ollama`, `openai_codex`). The anthropic adapter was already correct.

`OpenAIProvider`'s direct-construction fallback also moves from `provider_name` to the resolved dialect: that adapter serves every OpenAI-compatible dialect, so falling back to `provider_name` (always `"openai"`) attributed a DashScope or OpenRouter instance to OpenAI — exactly what the field exists to prevent. Three stream goldens are regenerated for the resulting `DoneEvent.provider` attribution; the diff is that one field and nothing else.

`_provider_kind` remains the wire dialect everywhere it belongs (payload shaping, trace recording, install-id headers).

## Scope boundary

- **Backend only.** The Web UI and desktop model pickers are unaffected: they call `onboarding.models.discover`, whose `probe.py` rows carry the caller's `provider_id` and never the mislabeled field. The defect is reachable through `models.list` — CLI/TUI and external control clients.
- **Wire shape unchanged.** No key added, renamed, or removed; only the `provider` value is corrected.
- Nine rows change their catalog `source` (provenance) as a side effect of resolving under the correct id. That surfaces a pre-existing gap in `catalog_overrides.toml` (e.g. `tencent_tokenhub_intl` has no corrections table while its dialect does) rather than introducing one — the layers those rows now resolve through are the same ones budgeting and pricing have always used for these providers. Left out of this PR deliberately to keep the identity fix reviewable.

## Tests

New `tests/test_provider/test_list_models_provider_identity.py` drives the real adapters through a mock transport — offline, deterministic, credential-free, fork-safe:

- all 9 `openai_compat` specs whose `provider_id != provider_kind`, asserting the row carries the configured id and not the dialect
- both `openai_responses` plan surfaces
- `ollama`
- the direct-construction fallback, including that an explicit `provider_id` still wins

`tests/test_contracts/test_models_list_wire.py` gains an end-to-end guard on the reported symptom: a `vllm`-configured selector yields `provider == "vllm"`, `--provider vllm` matches, `--provider openai` returns nothing.

All 13 new assertions fail on the unpatched tree and pass after.

## Verification

- `ruff check src tests` — clean
- `pytest tests/test_provider tests/test_provider_*.py` — 2691 passed, 2 skipped
- `pytest tests/test_contracts tests/test_gateway tests/test_cross_provider_tiers.py tests/test_model_router_*.py` — 3872 passed
- `pytest tests/test_onboarding tests/test_cli tests/test_engine` — 5049 passed
- `npm --prefix opensquilla-webui run build` — clean
- `uv build --wheel` — clean

Remaining local failures (33 in the onboarding/cli/engine set, 3 in `test_turn_ingress_rpc.py`) are byte-identical before and after this change — Windows symlink-permission and temp-path environment failures, not regressions. Verified by diffing the failure lists against a stashed-source baseline.

Third-party origin: none
