### PR TITLE
Honor exact model repetition thresholds

### DIFF
--- a/src/opensquilla/engine/repetition_guard.py
+++ b/src/opensquilla/engine/repetition_guard.py
@@ -65,7 +65,13 @@ _CODE_CALL_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*\(")
 
 @dataclass(frozen=True, slots=True)
 class RepetitionGuardPolicy:
-    """Conservative fixed policy for one provider attempt."""
+    """Conservative fixed policy for one provider attempt.
+
+    Repetition counts include the first occurrence of the repeated unit.
+    ``required_consecutive_checks`` requires that many adjacent period pairs
+    inside the candidate suffix to meet the similarity threshold; it does not
+    add later stream checkpoints after ``min_repetitions`` has been reached.
+    """
 
     max_buffer_chars: int = 65_536
     check_stride_chars: int = 256
@@ -131,7 +137,6 @@ class StreamingRepetitionGuard:
         self._normalized_chars = 0
         self._next_check = self.policy.check_stride_chars
         self._last_whitespace: str | None = None
-        self._repeat_evidence_streak = 0
 
     @property
     def buffered_chars(self) -> int:
@@ -145,7 +150,6 @@ class StreamingRepetitionGuard:
         self._normalized_chars = 0
         self._next_check = self.policy.check_stride_chars
         self._last_whitespace = None
-        self._repeat_evidence_streak = 0
 
     def feed(self, text: str) -> tuple[str, RepetitionDetection | None]:
         if not text:
@@ -175,11 +179,7 @@ class StreamingRepetitionGuard:
             pending.clear()
             candidate = self._detect()
             self._next_check += self.policy.check_stride_chars
-            if candidate is None:
-                self._repeat_evidence_streak = 0
-                continue
-            self._repeat_evidence_streak += 1
-            if self._repeat_evidence_streak >= self.policy.required_consecutive_checks:
+            if candidate is not None:
                 return text[: raw_index + 1], candidate
 
         if pending:
@@ -215,7 +215,7 @@ class StreamingRepetitionGuard:
 
     def _detect(self) -> RepetitionDetection | None:
         policy = self.policy
-        if self._buffer_chars < policy.min_repeated_chars + policy.min_period_chars:
+        if self._buffer_chars < policy.min_repeated_chars:
             return None
 
         text = self._buffer_text()
@@ -238,15 +238,25 @@ class StreamingRepetitionGuard:
                     policy.large_period_min_repetitions,
                 )
             repeated_chars = max(min_repeated, period * min_repetitions)
-            if repeated_chars + period > len(text):
+            if repeated_chars > len(text):
                 continue
 
-            comparison = text[-(repeated_chars + period) :]
+            comparison = text[-repeated_chars:]
             previous = comparison[:-period]
             current = comparison[period:]
+            comparison_chars = len(previous)
+            if comparison_chars <= 0:
+                continue
             matches = sum(left == right for left, right in zip(previous, current, strict=True))
-            similarity = matches / repeated_chars
+            similarity = matches / comparison_chars
             if similarity < min_similarity:
+                continue
+            if not _has_consecutive_period_evidence(
+                comparison,
+                period=period,
+                checks=max(1, policy.required_consecutive_checks),
+                min_similarity=min_similarity,
+            ):
                 continue
             return RepetitionDetection(
                 period_chars=period,
@@ -293,6 +303,29 @@ class StreamingRepetitionGuard:
                     occurrences += 1
         ranked = sorted(votes, key=lambda period: (-votes[period], period))
         return sorted(ranked[: policy.max_candidate_periods])
+
+
+def _has_consecutive_period_evidence(
+    text: str,
+    *,
+    period: int,
+    checks: int,
+    min_similarity: float,
+) -> bool:
+    """Require recent adjacent periods to independently meet the threshold."""
+
+    evidence_chars = period * (checks + 1)
+    if evidence_chars > len(text):
+        return False
+    evidence = text[-evidence_chars:]
+    for index in range(checks):
+        start = index * period
+        previous = evidence[start : start + period]
+        current = evidence[start + period : start + period * 2]
+        matches = sum(left == right for left, right in zip(previous, current, strict=True))
+        if matches / period < min_similarity:
+            return False
+    return True
 
 
 def _looks_structured(text: str, period: int) -> bool:

--- a/tests/test_engine/test_stream_repetition_guard.py
+++ b/tests/test_engine/test_stream_repetition_guard.py
@@ -82,6 +82,55 @@ def test_repetition_detection_is_chunk_invariant() -> None:
     assert detection.structured is False
 
 
+@pytest.mark.parametrize(
+    ("repetitions", "expected_detection"),
+    [
+        pytest.param(7, False, id="below-threshold"),
+        pytest.param(8, True, id="at-threshold"),
+    ],
+)
+def test_min_repetitions_is_an_exact_boundary(
+    repetitions: int,
+    expected_detection: bool,
+) -> None:
+    unit = _aperiodic_unit(512)
+    payload = unit * repetitions
+
+    results = [_feed_in_chunks(payload, chunk_size)[:2] for chunk_size in (1, 137, len(payload))]
+
+    assert {len(emitted) for emitted, _ in results} == {len(payload)}
+    assert {(detection is not None) for _, detection in results} == {expected_detection}
+    if expected_detection:
+        detections = {detection for _, detection in results}
+        assert len(detections) == 1
+        detection = detections.pop()
+        assert detection is not None
+        assert detection.period_chars == len(unit)
+        assert detection.repetitions == repetitions
+
+
+def test_new_content_breaks_repetition_before_the_threshold() -> None:
+    unit = _aperiodic_unit(512)
+    payload = unit * 7 + unit[::-1] + unit
+
+    emitted, detection, _ = _feed_in_chunks(payload, 137)
+
+    assert detection is None
+    assert emitted == payload
+
+
+def test_recent_divergence_blocks_aggregate_near_repetition() -> None:
+    unit = _aperiodic_unit(512)
+    divergent = "_" * 16 + unit[16:]
+    payload = unit * 7 + divergent
+
+    emitted, detection, guard = _feed_in_chunks(payload, 137)
+
+    assert 512 in guard._candidate_periods(guard._buffer_text())
+    assert detection is None
+    assert emitted == payload
+
+
 def test_highly_similar_repetition_with_small_changing_field_is_detected() -> None:
     rows = [
         (
@@ -567,6 +616,20 @@ async def test_tool_boundary_resets_repetition_budget() -> None:
     ]
 
 
+@pytest.mark.asyncio
+async def test_guard_preserves_prefix_shaped_provider_deltas() -> None:
+    async def stream() -> AsyncIterator[Any]:
+        for delta in ("A", "AB", "ABC"):
+            yield ProviderText(text=delta)
+        yield ProviderDone()
+
+    events = [event async for event in guard_provider_text_stream(stream())]
+    text_events = [event.text for event in events if isinstance(event, ProviderText)]
+
+    assert text_events == ["A", "AB", "ABC"]
+    assert "".join(text_events) == "AABABC"
+
+
 class _RecordingSink:
     def __init__(self) -> None:
         self.started: list[UsageCallStart] = []
@@ -604,6 +667,73 @@ class _RepeatingProvider:
 
     async def list_models(self) -> list[Any]:
         return []
+
+
+class _LengthCappedRepeatingProvider:
+    provider_name = "synthetic"
+
+    def __init__(self, payload: str) -> None:
+        self.payload = payload
+        self.calls = 0
+        self.close_calls = 0
+
+    def chat(
+        self,
+        messages: list[Message],
+        tools: list[Any] | None = None,
+        config: ChatConfig | None = None,
+    ) -> AsyncIterator[Any]:
+        del messages, tools, config
+        self.calls += 1
+
+        async def stream() -> AsyncIterator[Any]:
+            try:
+                yield ProviderText(text=self.payload)
+                yield ProviderDone(stop_reason="length")
+            finally:
+                self.close_calls += 1
+
+        return stream()
+
+    async def list_models(self) -> list[Any]:
+        return []
+
+
+@pytest.mark.asyncio
+async def test_repetition_precedes_same_attempt_length_terminal_once() -> None:
+    sink = _RecordingSink()
+    unit = _aperiodic_unit(512)
+    provider = _LengthCappedRepeatingProvider(unit * 8)
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            max_iterations=1,
+            length_capped_continuations=1,
+            provider_id="synthetic",
+            model_id="looping-model",
+        ),
+        usage_event_sink=sink,
+        usage_execution_context=UsageExecutionContext(
+            execution_id="execution-length-loop",
+            agent_run_id="run-length-loop",
+            turn_id="turn-length-loop",
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("continue")]
+
+    assert [event.code for event in events if event.kind == "error"] == [
+        MODEL_REPETITION_LOOP_CODE
+    ]
+    assert not any(event.kind == "warning" for event in events)
+    assert not any(event.kind == "done" for event in events)
+    assert provider.calls == 1
+    assert provider.close_calls == 1
+    assert len(sink.started) == 1
+    assert sink.finalized == []
+    assert [(call.event_id, reason) for call, reason in sink.unknown] == [
+        (sink.started[0].event_id, MODEL_REPETITION_LOOP_CODE)
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope

- Make the configured repetition count an exact boundary: N-1 occurrences continue and the Nth complete occurrence stops.
- Preserve the existing false-positive protection by requiring adjacent period pairs inside the candidate suffix, without adding hidden later stream checkpoints.
- Verify that repetition termination wins over a same-attempt length terminal exactly once, including stream close and usage accounting.
- Preserve ordinary TextDeltaEvent payloads verbatim, including prefix-shaped deltas such as A, AB, and ABC.

## Protocol boundary

TextDeltaEvent remains a delta contract. This change does not guess cumulative snapshots from string prefixes and does not add an unused snapshot event. No built-in provider has been confirmed to emit cumulative snapshots into this guard. Existing post-tool presentation compatibility remains outside the guard.

## Target

main

## Linked issue

None

## Release note

Fix model repetition detection occurring later than its configured complete-occurrence threshold.

## Test results

- uv run pytest tests/test_engine/test_stream_repetition_guard.py tests/test_gateway/test_task_runtime_terminal_message.py tests/test_gateway/test_terminal_reply.py -q: 107 passed.
- uv run ruff check src/opensquilla/engine/repetition_guard.py tests/test_engine/test_stream_repetition_guard.py: passed.
- uv run mypy src/opensquilla/engine/repetition_guard.py --show-error-codes: passed.
- git diff --check: passed.

## Safety / compatibility

No provider protocol, public error code, configuration, persisted state, database, or client contract changes. The algorithm is platform-neutral. Existing structured-output and near-repetition safeguards remain covered by the full guard regression file.

## Third-party origin

None.