### PR TITLE
Explain retired pre-release Goal migrations

### DIFF
--- a/src/opensquilla/persistence/migrator.py
+++ b/src/opensquilla/persistence/migrator.py
@@ -75,15 +75,35 @@ _LEGACY_MIGRATION_ALIASES: dict[str, tuple[str, str]] = {
     ),
 }
 
+# Migration ids that only ever existed in a pre-release build and were RETIRED
+# rather than renumbered. These deliberately have no entry above: an alias marks
+# its replacement applied without replaying it, which is sound only when both
+# migrations produce the same schema. The pre-release Goal preview created a
+# `goal_runs` table, whereas V033/V034 create `session_goals` and
+# `goal_command_receipts` — disjoint schemas, so adopting the ids would record
+# the replacements as applied while their tables were never created.
+#
+# They are listed only so the downgrade guard can explain itself: such a database
+# is not ahead of this build, and no later release will ever read it.
+_RETIRED_PRERELEASE_MIGRATIONS: dict[str, str] = {
+    "V029__goal_runs": "a pre-release Goal preview build",
+    "V030__goal_run_retry": "a pre-release Goal preview build",
+}
+
 
 class SchemaAheadError(RuntimeError):
     """The database records migrations the running code does not know about.
 
-    Signals that the data was created or upgraded by a NEWER OpenSquilla build
-    than the one now running — e.g. a desktop auto-update that was later rolled
-    back to an older app. Booting would run old code against a newer schema (no
-    yoyo down-migration is invoked at boot), so we refuse loudly instead of
-    risking silent corruption.
+    Usually signals that the data was created or upgraded by a NEWER OpenSquilla
+    build than the one now running — e.g. a desktop auto-update that was later
+    rolled back to an older app. Booting would run old code against a newer
+    schema (no yoyo down-migration is invoked at boot), so we refuse loudly
+    instead of risking silent corruption.
+
+    It is also raised for a database carrying a retired pre-release lineage (see
+    :data:`_RETIRED_PRERELEASE_MIGRATIONS`), which is *not* ahead of this build.
+    The refusal is the same; only the guidance differs, because no later release
+    will ever be able to read it.
     """
 
 
@@ -566,6 +586,41 @@ def assert_schema_not_ahead(db_url: str, migrations_dir: Path) -> None:
     unknown = sorted(applied - known)
     if not unknown:
         return
+    retired = sorted(set(unknown) & _RETIRED_PRERELEASE_MIGRATIONS.keys())
+    if retired:
+        origins = sorted({_RETIRED_PRERELEASE_MIGRATIONS[migration_id] for migration_id in retired})
+        log.error(
+            "migrator.schema_retired_prerelease",
+            extra={
+                "db_path": str(db_path),
+                "retired_migrations": retired,
+                "unknown_migrations": unknown,
+            },
+        )
+        also_unknown = [
+            migration_id
+            for migration_id in unknown
+            if migration_id not in _RETIRED_PRERELEASE_MIGRATIONS
+        ]
+        # A retired lineage does not rule out the database ALSO being genuinely
+        # ahead, so never let the friendlier explanation swallow the rest.
+        trailer = (
+            f" It also records {', '.join(also_unknown)}, which this build does "
+            "not know about either."
+            if also_unknown
+            else ""
+        )
+        raise SchemaAheadError(
+            f"The OpenSquilla database at {db_path} was written by "
+            f"{' and '.join(origins)}, which recorded {', '.join(retired)}. Those "
+            "migrations were retired rather than renumbered: the goal_runs table "
+            "they created was replaced by session_goals and goal_command_receipts, "
+            "so there is no in-place upgrade path and no later release that can "
+            "read this lineage. Move this file aside to keep it — it stays "
+            "readable with any SQLite client — and OpenSquilla will create a fresh "
+            "database on the next start, or restore a backup taken with a released "
+            f"version.{trailer}"
+        )
     log.error(
         "migrator.schema_ahead",
         extra={"db_path": str(db_path), "unknown_migrations": unknown},

--- a/tests/test_persistence/test_migrator.py
+++ b/tests/test_persistence/test_migrator.py
@@ -660,6 +660,64 @@ def test_apply_pending_raises_when_database_is_ahead_of_code(tmp_path: Path) -> 
         apply_pending(str(db_path), migrations_dir)
 
 
+def test_apply_pending_explains_retired_prerelease_goal_lineage(tmp_path: Path) -> None:
+    migrations_dir = tmp_path / "migrations"
+    _write_demo_migration(migrations_dir)
+    db_path = tmp_path / "sessions.db"
+
+    apply_pending(str(db_path), migrations_dir)
+    # A pre-release Goal build recorded these ids. They were retired rather than
+    # renumbered: V033/V034 replaced the goal_runs table with session_goals and
+    # goal_command_receipts, so there is no replacement to adopt and no newer
+    # release to update to.
+    for migration_id in ("V029__goal_runs", "V030__goal_run_retry"):
+        _record_applied_migration(db_path, migration_id)
+
+    with pytest.raises(migrator.SchemaAheadError) as excinfo:
+        apply_pending(str(db_path), migrations_dir)
+
+    message = str(excinfo.value)
+    assert "V029__goal_runs" in message
+    assert "V030__goal_run_retry" in message
+    # The generic "you are running old code" advice is wrong here and must not
+    # be what the user is told: no newer version exists to update to.
+    assert "was created by a newer version" not in message
+    assert "Update OpenSquilla to a matching or newer version" not in message
+    # Name the incompatibility and a recovery that keeps the existing file.
+    assert "session_goals" in message
+
+
+def test_apply_pending_still_reports_genuinely_ahead_ids_alongside_retired(
+    tmp_path: Path,
+) -> None:
+    migrations_dir = tmp_path / "migrations"
+    _write_demo_migration(migrations_dir)
+    db_path = tmp_path / "sessions.db"
+
+    apply_pending(str(db_path), migrations_dir)
+    _record_applied_migration(db_path, "V029__goal_runs")
+    _record_applied_migration(db_path, "V999__from_the_future")
+
+    with pytest.raises(migrator.SchemaAheadError) as excinfo:
+        apply_pending(str(db_path), migrations_dir)
+
+    message = str(excinfo.value)
+    # The retired lineage must not hide a database that is also genuinely ahead.
+    assert "V029__goal_runs" in message
+    assert "V999__from_the_future" in message
+
+
+def test_retired_prerelease_ids_are_not_also_aliases() -> None:
+    # An alias marks its replacement applied WITHOUT replaying it, which is only
+    # sound when both migrations produce the same schema. The retired ids exist
+    # precisely because they do not, so the two tables must stay disjoint.
+    overlap = (
+        migrator._RETIRED_PRERELEASE_MIGRATIONS.keys()
+        & migrator._LEGACY_MIGRATION_ALIASES.keys()
+    )
+    assert not overlap, f"retired ids must never be adopted as aliases: {sorted(overlap)}"
+
+
 def test_read_applied_migration_ids_handles_missing_ledger(tmp_path: Path) -> None:
     db_path = tmp_path / "empty.db"
     with sqlite3.connect(db_path) as connection:


### PR DESCRIPTION
## Scope

Scope boundary: `assert_schema_not_ahead` in `src/opensquilla/persistence/migrator.py`, plus tests. No migration files are added or changed, no schema changes, and no behaviour change for any database that does not record the retired pre-release Goal ids.

Non-goals: carrying pre-release Goal data forward. As below, the schemas are incompatible, so no in-place upgrade is attempted here.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Refs #1186

Deliberately `Refs`, not `Fixes`. This corrects what the user is told; it does not give #1186 the compatibility path or data-preserving recovery workflow the issue also asks about. Left open for you to decide — I asked in a comment on the issue.

## Release Note

Release note: A session database written by a pre-release Goal preview build now explains what happened and how to recover with the file intact, instead of reporting that it came from a newer version of OpenSquilla.

## Tests

Ruff: `ruff check src tests` — passes.

Pytest: `pytest tests/test_persistence tests/test_migrations` — 235 passed, 4 skipped.

Build: not run; no build-affecting change.

Regression tests: added — three, in `tests/test_persistence/test_migrator.py`:
- the retired lineage produces an accurate message and drops the false "newer version" advice
- a retired id never suppresses a genuinely unknown id recorded alongside it
- the retired ids and `_LEGACY_MIGRATION_ALIASES` stay disjoint, so a future edit cannot quietly make them adoptable

Notes: also ran `mypy src/opensquilla --show-error-codes`. The 12 reported errors are pre-existing and in unrelated files (`squilla_router/self_learning`, `search/providers`, `ui.py`); `migrator.py` is clean. `ruff format --check` reports both touched files as unformatted, but that is also true on an unmodified `main`, so I left formatting alone rather than mixing it in.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Third-Party Origin

Third-party origin: none

---

### What's wrong

A database written by a pre-release Goal preview records `V029__goal_runs` and `V030__goal_run_retry`. Neither id exists on `main`, so `assert_schema_not_ahead` classifies the database as coming from a newer build:

```text
The OpenSquilla database at ...\sessions.db was created by a newer version and
records 2 migration(s) this build does not know about (V029__goal_runs,
V030__goal_run_retry). Update OpenSquilla to a matching or newer version, or
restore a backup taken with this version.
```

Both instructions are dead ends. There is no newer release to update to, and the lineage is retired rather than ahead.

### Reproduced

Windows 11 (build 26200), Python 3.12.2, against current `main`. Applied the real migration chain to a fresh `sessions.db`, then rewrote the yoyo ledger to record `V029__goal_runs` / `V030__goal_run_retry` in place of `V033__goal_runs` / `V034__goal_message_anchor`, and re-ran `apply_pending` — producing the message above, matching the report in #1186.

### Why these ids are not added to `_LEGACY_MIGRATION_ALIASES`

That was my first instinct and it is unsafe. The adoption path marks a replacement applied *without replaying it*, which is sound only when both migrations produce the same schema. Comparing the pre-release migrations at wade19990814-hue/opensquilla-wade@5187bb7 against `main`:

| | tables created |
|---|---|
| `V029__goal_runs` + `V030__goal_run_retry` | `goal_runs` |
| `V033__goal_runs` + `V034__goal_message_anchor` | `session_goals`, `goal_command_receipts` |

Disjoint — a redesign, not a renumbering. An alias would record `V033`/`V034` as applied while `session_goals` and `goal_command_receipts` were never created, leaving the app querying tables that do not exist. That is worse than the current hard failure and precisely the silent corruption the guard exists to prevent.

### The change

Recognise the lineage without adopting it. `_RETIRED_PRERELEASE_MIGRATIONS` lists the two ids with a note on where they came from, and the guard raises the same `SchemaAheadError` with guidance that is actually true: what wrote the database, why there is no upgrade path, and that moving the file aside preserves it. Any genuinely unknown ids recorded alongside are still named, so the friendlier explanation cannot mask a database that really is ahead.

The refusal itself is unchanged — that part was right.

---

*Written with AI assistance (Claude). I reproduced the failure on my own Windows machine, verified the migration comparison against the linked pre-release commit, and ran the checks above locally before opening this. Errors are mine.*
