### PR TITLE
fix(gateway): make sandbox upgrade migration non-blocking

### DIFF
--- a/src/opensquilla/cli/recovery_cmd.py
+++ b/src/opensquilla/cli/recovery_cmd.py
@@ -61,7 +61,7 @@ def sandbox_upgrade_status(
     home: Path = typer.Option(..., "--home", exists=True, file_okay=False),
     json_output: bool = typer.Option(False, "--json"),
 ) -> None:
-    """Inspect the retained sandbox-upgrade journal without changing it."""
+    """Inspect optional sandbox normalization without changing the profile."""
     # Keep the ordinary recovery process below the runtime import boundary.
     # ``opensquilla.sandbox`` exposes a broad public surface at package import
     # time; only this diagnostic command needs the migration implementation.
@@ -71,9 +71,10 @@ def sandbox_upgrade_status(
     if json_output:
         typer.echo(json.dumps(report.to_dict(), ensure_ascii=False, sort_keys=True))
     else:
-        typer.echo(f"{report.status}: {'ready' if report.ok else 'recovery required'}")
-        typer.echo(f"journal: {report.journal_path}")
-        typer.echo(f"snapshot: {report.snapshot_path or '-'}")
+        typer.echo(f"{report.status}: {'ready' if report.ok else 'retry pending'}")
+        legacy_journal = report.journal_path if report.journal_path.exists() else "-"
+        typer.echo(f"legacy journal: {legacy_journal}")
+        typer.echo(f"legacy snapshot: {report.snapshot_path or '-'}")
         if report.error:
             typer.echo(report.error, err=True)
     if not report.ok:

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -3030,9 +3030,9 @@ async def build_services(
 
     configure_trusted_fake_ip_cidrs(config.tools.trusted_fake_ip_cidrs)
 
-    # Canonicalize released sandbox state before opening any persistent store.
-    # A failed prepared journal is intentionally left for explicit recovery;
-    # startup never guesses or rolls the profile back automatically.
+    # Best-effort normalization of released sandbox spellings. The config has
+    # already loaded through the legacy codec, so an optional on-disk cleanup
+    # must never make the gateway unavailable.
     config_path = Path(str(getattr(config, "config_path", "") or ""))
     if config_path.is_file():
         from opensquilla.sandbox.upgrade_migration import (
@@ -3044,22 +3044,20 @@ async def build_services(
         try:
             upgrade_report = ensure_sandbox_upgrade_migrated(config_path.parent)
         except Exception as exc:
-            log.exception(
+            log.warning(
                 "build_services.sandbox_upgrade_failed",
                 duration_ms=_elapsed_monotonic_ms(sandbox_upgrade_started_at),
                 error_type=type(exc).__name__,
+                error=str(exc),
             )
-            raise
-        log.info(
-            "build_services.sandbox_upgrade_finished",
-            ok=upgrade_report.ok,
-            status=upgrade_report.status,
-            duration_ms=_elapsed_monotonic_ms(sandbox_upgrade_started_at),
-        )
-        if not upgrade_report.ok:
-            raise RuntimeError(
-                "migration_failed_manual_recovery_required: "
-                f"{upgrade_report.error or upgrade_report.status}"
+        else:
+            logger = log.info if upgrade_report.ok and not upgrade_report.error else log.warning
+            logger(
+                "build_services.sandbox_upgrade_finished",
+                ok=upgrade_report.ok,
+                status=upgrade_report.status,
+                error=upgrade_report.error,
+                duration_ms=_elapsed_monotonic_ms(sandbox_upgrade_started_at),
             )
 
     # ── Sandbox runtime ─────────────────────────────────────────────

--- a/src/opensquilla/sandbox/upgrade_migration.py
+++ b/src/opensquilla/sandbox/upgrade_migration.py
@@ -1,27 +1,23 @@
-"""Idempotent direct-update migration for legacy sandbox state."""
+"""Lightweight, idempotent normalization for legacy sandbox run modes.
+
+The gateway already understands the released legacy spellings while loading a
+profile. This module only canonicalizes those spellings on disk when doing so
+is possible. It deliberately has no persistent backup or permission-hardening
+dependency: failure to normalize an optional compatibility field must never
+make the gateway unavailable.
+"""
 
 from __future__ import annotations
 
-import base64
-import binascii
-import hashlib
 import json
 import os
-import re
 import shutil
 import stat
-import subprocess
-import sys
 import tempfile
-import threading
-import time
 import tomllib
-import uuid
-from collections.abc import Iterator
-from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from opensquilla.lossless_toml import patch_import_config
 from opensquilla.sandbox.legacy_codec import (
@@ -33,660 +29,6 @@ from opensquilla.sandbox.legacy_codec import (
 MIGRATION_VERSION = 2
 JOURNAL_NAME = ".sandbox-upgrade-v2.json"
 SNAPSHOT_NAME = ".sandbox-upgrade-snapshot"
-WINDOWS_ACL_STAGE_TIMEOUT_SECONDS = 30.0
-_WINDOWS_IDENTITY_FALLBACK_TIMEOUT_SECONDS = 10.0
-_FILE_ATTRIBUTE_REPARSE_POINT = 0x400
-_ERROR_INSUFFICIENT_BUFFER = 122
-_TOKEN_QUERY = 0x0008
-_TOKEN_USER = 1
-
-
-_WINDOWS_PRIVATE_ACL_SCRIPT = r"""
-$ErrorActionPreference = "Stop"
-$utf8WithoutBom = [System.Text.UTF8Encoding]::new($false)
-[Console]::OutputEncoding = $utf8WithoutBom
-$OutputEncoding = $utf8WithoutBom
-$userSid = $env:OPENSQUILLA_UPGRADE_ACL_USER_SID
-$allowed = @($userSid)
-foreach ($trustedSid in @("S-1-5-18", "S-1-5-32-544")) {
-    if ($allowed -notcontains $trustedSid) {
-        $allowed += $trustedSid
-    }
-}
-$raw = [Console]::In.ReadToEnd()
-$parsed = $raw | ConvertFrom-Json
-if ($null -eq $parsed) { throw "ACL batch is empty" }
-$items = if ($parsed -is [System.Array]) { $parsed } else { @($parsed) }
-$itemCount = if ($items -is [System.Array]) { $items.Length } else { 1 }
-if ($itemCount -eq 0) { throw "ACL batch is empty" }
-$verifiedIds = New-Object 'System.Collections.Generic.List[string]'
-$verifiedPathUtf8Base64 = New-Object 'System.Collections.Generic.List[string]'
-$verifiedPathHashes = New-Object 'System.Collections.Generic.List[string]'
-$seenPaths = New-Object 'System.Collections.Generic.HashSet[string]'
-$fullControl = [System.Security.AccessControl.FileSystemRights]::FullControl
-foreach ($item in $items) {
-    $target = [string]$item.path
-    $itemId = [string]$item.id
-    if ($null -eq $item.directory -or $item.directory.GetType().Name -ne "Boolean") {
-        throw "ACL batch item directory flag is invalid"
-    }
-    $isDirectory = $item.directory
-    if ([string]::IsNullOrWhiteSpace($target) -or [string]::IsNullOrWhiteSpace($itemId)) {
-        throw "ACL batch item is invalid"
-    }
-    if (-not $seenPaths.Add($target)) { throw "ACL batch contains duplicate paths" }
-    $attributes = [System.IO.File]::GetAttributes($target)
-    if (($attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
-        throw "snapshot path is a reparse point: $target"
-    }
-    $actualDirectory = ($attributes -band [System.IO.FileAttributes]::Directory) -ne 0
-    if ($actualDirectory -ne $isDirectory) { throw "snapshot path type changed: $target" }
-    $acl = if ($isDirectory) {
-        [System.Security.AccessControl.DirectorySecurity]::new()
-    } else {
-        [System.Security.AccessControl.FileSecurity]::new()
-    }
-    $acl.SetAccessRuleProtection($true, $false)
-    $inheritance = [System.Security.AccessControl.InheritanceFlags]::None
-    if ($isDirectory) {
-        $inheritance = [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
-            [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
-    }
-    $propagation = [System.Security.AccessControl.PropagationFlags]::None
-    foreach ($sidText in $allowed) {
-        $sid = [System.Security.Principal.SecurityIdentifier]::new($sidText)
-        $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
-            $sid,
-            $fullControl,
-            $inheritance,
-            $propagation,
-            [System.Security.AccessControl.AccessControlType]::Allow
-        )
-        [void]$acl.AddAccessRule($rule)
-    }
-    if ($PSVersionTable.PSVersion.Major -ge 6) {
-        $verified = Get-Acl -LiteralPath $target
-        $needsSet = -not $verified.AreAccessRulesProtected
-        $initialRules = @($verified.Access)
-        if ($initialRules.Count -ne $allowed.Count) { $needsSet = $true }
-        foreach ($rule in $initialRules) {
-            $identity = $rule.IdentityReference.Translate(
-                [System.Security.Principal.SecurityIdentifier]
-            ).Value
-            if ($allowed -notcontains $identity -or
-                $rule.AccessControlType -ne
-                    [System.Security.AccessControl.AccessControlType]::Allow -or
-                $rule.IsInherited -or
-                $rule.FileSystemRights -ne $fullControl -or
-                $rule.InheritanceFlags -ne $inheritance -or
-                $rule.PropagationFlags -ne $propagation) {
-                $needsSet = $true
-                break
-            }
-        }
-        if ($needsSet) {
-            $inheritanceSddl = if ($isDirectory) { "OICI" } else { "" }
-            $sddl = "D:P" + (($allowed | ForEach-Object {
-                "(A;$inheritanceSddl;FA;;;$_)"
-            }) -join "")
-            $acl = $verified
-            $acl.SetSecurityDescriptorSddlForm($sddl)
-            Set-Acl -LiteralPath $target -AclObject $acl
-            $verified = Get-Acl -LiteralPath $target
-        }
-    } elseif ($isDirectory) {
-        [System.IO.Directory]::SetAccessControl($target, $acl)
-        $verified = [System.IO.Directory]::GetAccessControl($target)
-    } else {
-        [System.IO.File]::SetAccessControl($target, $acl)
-        $verified = [System.IO.File]::GetAccessControl($target)
-    }
-    $postAttributes = [System.IO.File]::GetAttributes($target)
-    if (($postAttributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
-        throw "snapshot path became a reparse point: $target"
-    }
-    if ((($postAttributes -band [System.IO.FileAttributes]::Directory) -ne 0) -ne $isDirectory) {
-        throw "snapshot path type changed after ACL update: $target"
-    }
-    if (-not $verified.AreAccessRulesProtected) { throw "DACL inheritance remains enabled" }
-    $rules = @($verified.Access)
-    if ($rules.Count -ne $allowed.Count) { throw "DACL contains an unexpected rule count" }
-    foreach ($rule in $rules) {
-        $identity = $rule.IdentityReference.Translate(
-            [System.Security.Principal.SecurityIdentifier]
-        ).Value
-        if ($allowed -notcontains $identity -or
-            $rule.AccessControlType -ne
-                [System.Security.AccessControl.AccessControlType]::Allow -or
-            $rule.IsInherited -or
-            $rule.FileSystemRights -ne $fullControl -or
-            $rule.InheritanceFlags -ne $inheritance -or
-            $rule.PropagationFlags -ne $propagation) {
-            throw "DACL verification failed"
-        }
-    }
-    foreach ($sidText in $allowed) {
-        $matchCount = 0
-        foreach ($rule in $rules) {
-            $identity = $rule.IdentityReference.Translate(
-                [System.Security.Principal.SecurityIdentifier]
-            ).Value
-            if ($identity -eq $sidText) { $matchCount += 1 }
-        }
-        if ($matchCount -ne 1) { throw "DACL principal verification failed" }
-    }
-    [void]$verifiedIds.Add($itemId)
-    $pathBytes = [System.Text.Encoding]::UTF8.GetBytes($target)
-    [void]$verifiedPathUtf8Base64.Add(
-        [System.Convert]::ToBase64String($pathBytes)
-    )
-    $hash = [System.Security.Cryptography.SHA256]::Create().ComputeHash(
-        $pathBytes
-    )
-    $pathHash = (
-        [System.BitConverter]::ToString($hash) -replace "-", ""
-    ).ToLowerInvariant()
-    [void]$verifiedPathHashes.Add($pathHash)
-}
-$resultJson = [ordered]@{
-    count = $verifiedIds.Count
-    ids = $verifiedIds.ToArray()
-    pathUtf8Base64 = $verifiedPathUtf8Base64.ToArray()
-    pathHashes = $verifiedPathHashes.ToArray()
-} | ConvertTo-Json -Compress
-[Console]::Out.WriteLine($resultJson)
-"""
-_WINDOWS_PRIVATE_ACL_ENCODED = base64.b64encode(
-    _WINDOWS_PRIVATE_ACL_SCRIPT.encode("utf-16-le")
-).decode("ascii")
-_WINDOWS_DLL_DIRECTORY_LOCK = threading.Lock()
-
-
-def _running_on_windows() -> bool:
-    return os.name == "nt"
-
-
-def _set_windows_dll_directory(path: str | None) -> None:
-    import ctypes
-
-    kernel32 = getattr(ctypes, "WinDLL")("kernel32", use_last_error=True)
-    setter = kernel32.SetDllDirectoryW
-    setter.argtypes = [ctypes.c_wchar_p]
-    setter.restype = ctypes.c_bool
-    if not setter(path):
-        error_code = int(getattr(ctypes, "get_last_error")())
-        raise OSError(error_code, "SetDllDirectoryW failed")
-
-
-@contextmanager
-def _system_windows_process_context() -> Iterator[None]:
-    bundle_root = getattr(sys, "_MEIPASS", None)
-    if not _running_on_windows() or not getattr(sys, "frozen", False) or not bundle_root:
-        yield
-        return
-
-    with _WINDOWS_DLL_DIRECTORY_LOCK:
-        _set_windows_dll_directory(None)
-        try:
-            yield
-        finally:
-            _set_windows_dll_directory(str(bundle_root))
-
-
-def _native_windows_user_sid() -> str:
-    import ctypes
-
-    class SidAndAttributes(ctypes.Structure):
-        _fields_ = [("sid", ctypes.c_void_p), ("attributes", ctypes.c_uint32)]
-
-    class TokenUser(ctypes.Structure):
-        _fields_ = [("user", SidAndAttributes)]
-
-    loader = getattr(ctypes, "WinDLL")
-    advapi32 = loader("advapi32", use_last_error=True)
-    kernel32 = loader("kernel32", use_last_error=True)
-    open_token = advapi32.OpenProcessToken
-    get_token = advapi32.GetTokenInformation
-    convert_sid = advapi32.ConvertSidToStringSidW
-    get_process = kernel32.GetCurrentProcess
-    close_handle = kernel32.CloseHandle
-    local_free = kernel32.LocalFree
-    open_token.argtypes = [
-        ctypes.c_void_p,
-        ctypes.c_uint32,
-        ctypes.POINTER(ctypes.c_void_p),
-    ]
-    open_token.restype = ctypes.c_int
-    get_token.argtypes = [
-        ctypes.c_void_p,
-        ctypes.c_uint32,
-        ctypes.c_void_p,
-        ctypes.c_uint32,
-        ctypes.POINTER(ctypes.c_uint32),
-    ]
-    get_token.restype = ctypes.c_int
-    convert_sid.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
-    convert_sid.restype = ctypes.c_int
-    get_process.argtypes = []
-    get_process.restype = ctypes.c_void_p
-    close_handle.argtypes = [ctypes.c_void_p]
-    close_handle.restype = ctypes.c_int
-    local_free.argtypes = [ctypes.c_void_p]
-    local_free.restype = ctypes.c_void_p
-
-    token = ctypes.c_void_p()
-    if not open_token(get_process(), _TOKEN_QUERY, ctypes.byref(token)):
-        error_number = int(getattr(ctypes, "get_last_error")())
-        raise OSError(error_number, "cannot open the current Windows process token")
-    try:
-        required = ctypes.c_uint32()
-        get_token(token, _TOKEN_USER, None, 0, ctypes.byref(required))
-        error_number = int(getattr(ctypes, "get_last_error")())
-        if required.value == 0 or error_number != _ERROR_INSUFFICIENT_BUFFER:
-            raise OSError(error_number, "cannot size the current Windows token user")
-        buffer = ctypes.create_string_buffer(required.value)
-        if not get_token(
-            token,
-            _TOKEN_USER,
-            buffer,
-            required.value,
-            ctypes.byref(required),
-        ):
-            error_number = int(getattr(ctypes, "get_last_error")())
-            raise OSError(error_number, "cannot read the current Windows token user")
-        token_user = ctypes.cast(buffer, ctypes.POINTER(TokenUser)).contents
-        string_sid = ctypes.c_void_p()
-        if not convert_sid(token_user.user.sid, ctypes.byref(string_sid)):
-            error_number = int(getattr(ctypes, "get_last_error")())
-            raise OSError(error_number, "cannot format the current Windows user SID")
-        try:
-            sid = ctypes.wstring_at(string_sid)
-        finally:
-            local_free(string_sid)
-    finally:
-        close_handle(token)
-    if not sid.startswith("S-"):
-        raise OSError("cannot resolve the current Windows user SID")
-    return sid
-
-
-def _current_windows_user_sid(*, deadline: float | None = None) -> str:
-    try:
-        with _system_windows_process_context():
-            return _native_windows_user_sid()
-    except (AttributeError, ImportError, OSError):
-        remaining = (
-            WINDOWS_ACL_STAGE_TIMEOUT_SECONDS
-            if deadline is None
-            else deadline - time.monotonic()
-        )
-        if remaining <= 0:
-            raise TimeoutError("Windows ACL migration timed out resolving the current user SID")
-        try:
-            with _system_windows_process_context():
-                completed = subprocess.run(
-                    ["whoami", "/user", "/fo", "csv", "/nh"],
-                    capture_output=True,
-                    check=False,
-                    timeout=min(_WINDOWS_IDENTITY_FALLBACK_TIMEOUT_SECONDS, remaining),
-                    stdin=subprocess.DEVNULL,
-                    creationflags=int(getattr(subprocess, "CREATE_NO_WINDOW", 0)),
-                )
-        except subprocess.TimeoutExpired as exc:
-            raise TimeoutError(
-                "Windows ACL migration timed out resolving the current user SID"
-            ) from exc
-        if completed.returncode != 0:
-            raise OSError("cannot resolve the current Windows user SID")
-        stdout = completed.stdout
-        if not isinstance(stdout, bytes):
-            raise OSError("cannot resolve the current Windows user SID")
-        sid_matches: list[bytes] = re.findall(
-            rb"(?<![A-Za-z0-9-])S-\d+(?:-\d+){2,}(?![A-Za-z0-9-])",
-            stdout,
-        )
-        if len(sid_matches) != 1:
-            raise OSError("cannot resolve the current Windows user SID")
-        return sid_matches[0].decode("ascii")
-
-
-def _remaining_windows_acl_time(deadline: float | None) -> float:
-    if deadline is None:
-        return WINDOWS_ACL_STAGE_TIMEOUT_SECONDS
-    remaining = deadline - time.monotonic()
-    if remaining <= 0:
-        raise TimeoutError("Windows ACL migration stage timed out")
-    return remaining
-
-
-def _path_is_directory(path: Path) -> bool:
-    value = path.lstat()
-    attributes = int(getattr(value, "st_file_attributes", 0))
-    if stat.S_ISLNK(value.st_mode) or attributes & _FILE_ATTRIBUTE_REPARSE_POINT:
-        raise OSError(f"snapshot path has an unsafe type: {path}")
-    if stat.S_ISDIR(value.st_mode):
-        return True
-    if stat.S_ISREG(value.st_mode):
-        return False
-    raise OSError(f"snapshot path has an unsafe type: {path}")
-
-def _path_exists_no_follow(path: Path) -> bool:
-    try:
-        path.lstat()
-    except FileNotFoundError:
-        return False
-    return True
-
-
-def _private_tree_entries(
-    root: Path,
-    *,
-    deadline: float | None = None,
-) -> tuple[tuple[Path, bool], ...]:
-    entries: list[tuple[Path, bool]] = []
-
-    def visit(path: Path, *, expected_directory: bool | None = None) -> None:
-        if deadline is not None and time.monotonic() >= deadline:
-            raise TimeoutError("Windows ACL migration stage timed out")
-        is_directory = _path_is_directory(path)
-        if expected_directory is not None and is_directory != expected_directory:
-            raise OSError(f"snapshot path type changed: {path}")
-        entries.append((path, is_directory))
-        if not is_directory:
-            return
-        with os.scandir(path) as iterator:
-            children = sorted(iterator, key=lambda item: item.name.casefold())
-        for child in children:
-            if deadline is not None and time.monotonic() >= deadline:
-                raise TimeoutError("Windows ACL migration stage timed out")
-            child_path = Path(child.path)
-            child_attributes = int(
-                getattr(child.stat(follow_symlinks=False), "st_file_attributes", 0)
-            )
-            if child_attributes & _FILE_ATTRIBUTE_REPARSE_POINT:
-                raise OSError(f"snapshot path has an unsafe type: {child_path}")
-            visit(child_path)
-
-    if not _path_is_directory(root):
-        raise OSError(f"snapshot root is not a directory: {root}")
-    visit(root)
-    return tuple(sorted(entries, key=lambda item: item[0].as_posix().casefold()))
-
-
-def _acl_batch_payload(entries: tuple[tuple[Path, bool], ...]) -> str:
-    return json.dumps(
-        [
-            {"id": str(index), "path": str(path), "directory": directory}
-            for index, (path, directory) in enumerate(entries)
-        ],
-        ensure_ascii=True,
-        separators=(",", ":"),
-    )
-
-
-def _acl_path_hash(path: Path) -> str:
-    return hashlib.sha256(str(path).encode("utf-8")).hexdigest()
-
-
-def _windows_acl_shells() -> tuple[str, ...]:
-    preferred = shutil.which("pwsh")
-    fallback = shutil.which("powershell")
-    shells = tuple(item for item in (preferred, fallback) if item is not None)
-    return shells or ("powershell",)
-
-
-def _protect_windows_acl_batch(
-    entries: tuple[tuple[Path, bool], ...],
-    *,
-    windows_user_sid: str,
-    deadline: float | None = None,
-) -> None:
-    if not entries:
-        raise OSError("ACL batch is empty")
-    normalized_paths = [os.path.normcase(os.path.abspath(str(path))) for path, _ in entries]
-    if len(set(normalized_paths)) != len(normalized_paths):
-        raise OSError("ACL batch contains duplicate paths")
-    for path, directory in entries:
-        _remaining_windows_acl_time(deadline)
-        if _path_is_directory(path) != directory:
-            raise OSError(f"snapshot path type changed: {path}")
-    environment = {
-        **os.environ,
-        "OPENSQUILLA_UPGRADE_ACL_USER_SID": windows_user_sid,
-    }
-    completed: subprocess.CompletedProcess[bytes] | None = None
-    shells = _windows_acl_shells()
-    for shell_index, shell in enumerate(shells):
-        try:
-            with _system_windows_process_context():
-                completed = subprocess.run(
-                    [
-                        shell,
-                        "-NoProfile",
-                        "-NonInteractive",
-                        "-NoLogo",
-                        "-EncodedCommand",
-                        _WINDOWS_PRIVATE_ACL_ENCODED,
-                    ],
-                    env=environment,
-                    input=_acl_batch_payload(entries).encode("ascii"),
-                    capture_output=True,
-                    check=False,
-                    timeout=_remaining_windows_acl_time(deadline),
-                    creationflags=int(getattr(subprocess, "CREATE_NO_WINDOW", 0)),
-                )
-        except subprocess.TimeoutExpired as exc:
-            raise TimeoutError("Windows ACL migration stage timed out") from exc
-        if completed is None:
-            raise OSError("cannot start Windows ACL helper")
-        if completed.returncode == 0:
-            break
-        detail = " ".join(
-            (completed.stderr or completed.stdout or b"")
-            .decode("utf-8", errors="replace")
-            .strip()
-            .split()
-        )
-        if (
-            shell_index + 1 >= len(shells)
-            or "securityprivilege" not in detail.casefold()
-        ):
-            break
-    if completed is None:
-        raise OSError("cannot start Windows ACL helper")
-    if completed.returncode != 0:
-        detail = " ".join(
-            (completed.stderr or completed.stdout or b"")
-            .decode("utf-8", errors="replace")
-            .strip()
-            .split()
-        )
-        suffix = f" ({detail[-500:]})" if detail else ""
-        raise OSError(f"cannot protect upgrade snapshot path ACL batch{suffix}")
-    try:
-        result = json.loads(completed.stdout.decode("ascii"))
-        if not isinstance(result, dict):
-            raise TypeError("ACL helper result is not an object")
-        ids = result["ids"]
-        encoded_paths = result["pathUtf8Base64"]
-        path_hashes = result["pathHashes"]
-        count = result["count"]
-        if (
-            isinstance(count, bool)
-            or not isinstance(count, int)
-            or not isinstance(ids, list)
-            or not all(isinstance(item, str) for item in ids)
-            or not isinstance(encoded_paths, list)
-            or not all(isinstance(item, str) for item in encoded_paths)
-            or not isinstance(path_hashes, list)
-            or not all(isinstance(item, str) for item in path_hashes)
-        ):
-            raise TypeError("ACL helper result has invalid field types")
-        paths = [
-            base64.b64decode(item, validate=True).decode("utf-8")
-            for item in encoded_paths
-        ]
-    except (
-        AttributeError,
-        binascii.Error,
-        KeyError,
-        TypeError,
-        UnicodeDecodeError,
-        ValueError,
-    ) as exc:
-        raise OSError("Windows ACL helper returned an invalid verification result") from exc
-    expected_ids = [str(index) for index in range(len(entries))]
-    expected_paths = [str(path) for path, _ in entries]
-    expected_hashes = [_acl_path_hash(path) for path, _ in entries]
-    if (
-        count != len(expected_ids)
-        or ids != expected_ids
-        or paths != expected_paths
-        or path_hashes != expected_hashes
-    ):
-        raise OSError("Windows ACL helper did not verify the requested paths exactly")
-    for path, directory in entries:
-        _remaining_windows_acl_time(deadline)
-        if _path_is_directory(path) != directory:
-            raise OSError(f"snapshot path changed after ACL verification: {path}")
-
-
-def _protect_private_path(
-    path: Path,
-    *,
-    directory: bool,
-    windows_user_sid: str | None,
-    deadline: float | None = None,
-) -> None:
-    if _path_is_directory(path) != directory:
-        raise OSError(f"snapshot path has an unsafe type: {path}")
-
-    if _running_on_windows():
-        if windows_user_sid is None:
-            raise OSError("current Windows user SID is unavailable")
-        try:
-            _protect_windows_acl_batch(
-                ((path, directory),),
-                windows_user_sid=windows_user_sid,
-                deadline=deadline,
-            )
-        except TimeoutError as exc:
-            raise OSError(f"Windows ACL hardening timed out: {path}") from exc
-        return
-
-    mode = 0o700 if directory else 0o600
-    path.chmod(mode)
-    if stat.S_IMODE(path.stat().st_mode) != mode:
-        raise OSError(f"cannot protect upgrade snapshot path: {path}")
-
-
-def _create_private_directory(
-    path: Path,
-    *,
-    windows_user_sid: str | None,
-    protect: bool = True,
-    deadline: float | None = None,
-) -> None:
-    path.mkdir(mode=0o777 if _running_on_windows() else 0o700)
-    if protect:
-        _protect_private_path(
-            path,
-            directory=True,
-            windows_user_sid=windows_user_sid,
-            deadline=deadline,
-        )
-
-
-def _copy_private_file(
-    source: Path,
-    destination: Path,
-    *,
-    windows_user_sid: str | None,
-    protect: bool = True,
-    deadline: float | None = None,
-) -> None:
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0)
-    descriptor = os.open(destination, flags, 0o600)
-    try:
-        with source.open("rb") as source_handle, os.fdopen(descriptor, "wb") as target_handle:
-            descriptor = -1
-            shutil.copyfileobj(source_handle, target_handle)
-            target_handle.flush()
-            os.fsync(target_handle.fileno())
-            if not _running_on_windows():
-                os.fchmod(target_handle.fileno(), 0o600)
-    finally:
-        if descriptor >= 0:
-            os.close(descriptor)
-    if protect:
-        _protect_private_path(
-            destination,
-            directory=False,
-            windows_user_sid=windows_user_sid,
-            deadline=deadline,
-        )
-
-
-def _protect_private_tree(
-    root: Path,
-    *,
-    windows_user_sid: str | None,
-    deadline: float | None = None,
-) -> None:
-    entries = _private_tree_entries(root, deadline=deadline)
-    if _running_on_windows():
-        if windows_user_sid is None:
-            raise OSError("current Windows user SID is unavailable")
-        _protect_windows_acl_batch(
-            entries,
-            windows_user_sid=windows_user_sid,
-            deadline=deadline,
-        )
-    else:
-        for path, directory in entries:
-            _protect_private_path(
-                path,
-                directory=directory,
-                windows_user_sid=windows_user_sid,
-                deadline=deadline,
-            )
-    after = _private_tree_entries(root, deadline=deadline)
-    before_keys = tuple((str(path), directory) for path, directory in entries)
-    after_keys = tuple((str(path), directory) for path, directory in after)
-    if before_keys != after_keys:
-        raise OSError("snapshot tree changed during ACL migration")
-
-
-def _remove_failed_snapshot(path: Path, *, original_error: Exception) -> None:
-    try:
-        if path.exists():
-            shutil.rmtree(path)
-        if path.exists():
-            raise OSError("path still exists after cleanup")
-    except Exception:
-        raise OSError(f"upgrade snapshot failed and cleanup failed: {path}") from original_error
-
-
-def _make_snapshot_staging_directory(home: Path) -> Path:
-    if not _running_on_windows():
-        return Path(
-            tempfile.mkdtemp(
-                prefix=f".{SNAPSHOT_NAME}.",
-                suffix=".tmp",
-                dir=home,
-            )
-        )
-    for _ in range(100):
-        candidate = home / f".{SNAPSHOT_NAME}.{uuid.uuid4().hex}.tmp"
-        try:
-            # Let the profile parent provide the initial Windows DACL.  The
-            # helper hardens this empty directory before any snapshot bytes
-            # are written and rejects any injected entry after hardening.
-            candidate.mkdir(mode=0o777)
-        except FileExistsError:
-            continue
-        return candidate
-    raise FileExistsError("cannot create a unique upgrade snapshot staging directory")
 
 
 @dataclass(frozen=True)
@@ -711,12 +53,33 @@ class UpgradeMigrationReport:
         }
 
 
+@dataclass(frozen=True)
+class _PlannedWrite:
+    path: Path
+    payload: bytes
+    format: Literal["toml", "json"]
+
+
+def _path_exists_no_follow(path: Path) -> bool:
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError:
+        # An inaccessible legacy artifact still exists for cleanup purposes,
+        # but must not make report construction raise during gateway startup.
+        return True
+    return True
+
+
 def _atomic_write(path: Path, payload: bytes) -> None:
+    """Durably write *payload* beside *path*, then atomically replace it."""
+
     path.parent.mkdir(parents=True, exist_ok=True)
-    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
     temporary_path = Path(temporary)
     try:
-        with os.fdopen(fd, "wb") as handle:
+        with os.fdopen(descriptor, "wb") as handle:
             handle.write(payload)
             handle.flush()
             os.fsync(handle.fileno())
@@ -725,45 +88,15 @@ def _atomic_write(path: Path, payload: bytes) -> None:
         temporary_path.unlink(missing_ok=True)
 
 
-def _write_json(path: Path, payload: dict[str, Any]) -> None:
-    _atomic_write(
-        path,
-        json.dumps(
-            payload,
-            ensure_ascii=False,
-            indent=2,
-            sort_keys=True,
-        ).encode("utf-8")
-        + b"\n",
-    )
+def _validate_payload(planned: _PlannedWrite) -> None:
+    text = planned.payload.decode("utf-8")
+    if planned.format == "toml":
+        tomllib.loads(text)
+    else:
+        json.loads(text)
 
 
-def _store_candidates(home: Path) -> tuple[Path, ...]:
-    candidates = [
-        home / "config.toml",
-        home / "desktop-preferences.json",
-        home / "preferences.json",
-        home / "sessions.db",
-        home / "state" / "sessions.db",
-        home / "data" / "sessions.db",
-    ]
-    return tuple(path for path in candidates if path.is_file())
-
-
-def inventory_sandbox_stores(home: str | Path) -> tuple[Path, ...]:
-    root = Path(home).expanduser().absolute()
-    return _store_candidates(root)
-
-
-def _digest(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        while chunk := handle.read(1024 * 1024):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def _config_mode(payload: dict[str, Any]):
+def _config_mode_arguments(payload: dict[str, Any]) -> dict[str, object]:
     sandbox = payload.get("sandbox")
     sandbox_table = sandbox if isinstance(sandbox, dict) else {}
     permissions = payload.get("permissions")
@@ -779,18 +112,30 @@ def _config_mode(payload: dict[str, Any]):
         arguments["sandbox_enabled"] = sandbox_table["enabled"]
     if "security_grading" in sandbox_table:
         arguments["grading_enabled"] = sandbox_table["security_grading"]
-    return decode_legacy_config_mode(**arguments)
+    return arguments
 
 
-def lossless_patch_sandbox_fields(raw: bytes) -> tuple[bytes, str]:
+def lossless_patch_sandbox_fields(raw: bytes) -> tuple[bytes, str | None]:
+    """Canonicalize a released legacy run mode without touching other TOML."""
+
     original = tomllib.loads(raw.decode("utf-8"))
+    arguments = _config_mode_arguments(original)
+    if not arguments:
+        return raw, None
+
+    mode = decode_legacy_config_mode(**arguments)
+    sandbox = original.get("sandbox")
+    current = sandbox.get("run_mode") if isinstance(sandbox, dict) else None
+    if current == mode.value:
+        return raw, mode.value
+
     transformed = json.loads(json.dumps(original))
-    mode = _config_mode(original)
-    sandbox = transformed.setdefault("sandbox", {})
-    if not isinstance(sandbox, dict):
+    transformed_sandbox = transformed.setdefault("sandbox", {})
+    if not isinstance(transformed_sandbox, dict):
         raise ValueError("sandbox config must be a table")
-    sandbox["run_mode"] = mode.value
+    transformed_sandbox["run_mode"] = mode.value
     patched = patch_import_config(raw, original, transformed)
+    tomllib.loads(patched.decode("utf-8"))
     return patched, mode.value
 
 
@@ -813,204 +158,162 @@ def _canonicalize_preferences(value: Any) -> Any:
     return result
 
 
+def _preference_payload(value: Any) -> bytes:
+    payload = (
+        json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True).encode("utf-8")
+        + b"\n"
+    )
+    json.loads(payload.decode("utf-8"))
+    return payload
+
+
+def _plan_writes(home: Path) -> tuple[tuple[_PlannedWrite, ...], str | None]:
+    planned: list[_PlannedWrite] = []
+    canonical_mode: str | None = None
+
+    config_path = home / "config.toml"
+    if config_path.is_file():
+        original = config_path.read_bytes()
+        patched, canonical_mode = lossless_patch_sandbox_fields(original)
+        if patched != original:
+            planned.append(_PlannedWrite(config_path, patched, "toml"))
+
+    for name in ("desktop-preferences.json", "preferences.json"):
+        path = home / name
+        if not path.is_file():
+            continue
+        original_bytes = path.read_bytes()
+        original = json.loads(original_bytes.decode("utf-8"))
+        transformed = _canonicalize_preferences(original)
+        if transformed != original:
+            planned.append(_PlannedWrite(path, _preference_payload(transformed), "json"))
+
+    return tuple(planned), canonical_mode
+
+
+def _legacy_artifacts_present(home: Path) -> bool:
+    return any(_path_exists_no_follow(home / name) for name in (SNAPSHOT_NAME, JOURNAL_NAME))
+
+
+def _remove_legacy_path(path: Path) -> None:
+    metadata = path.lstat()
+    attributes = int(getattr(metadata, "st_file_attributes", 0))
+    is_reparse = bool(attributes & 0x400)
+    if stat.S_ISDIR(metadata.st_mode) and not stat.S_ISLNK(metadata.st_mode) and not is_reparse:
+        shutil.rmtree(path)
+    else:
+        path.unlink()
+
+
+def _cleanup_legacy_artifacts(home: Path) -> tuple[str, ...]:
+    errors: list[str] = []
+    for name in (SNAPSHOT_NAME, JOURNAL_NAME):
+        path = home / name
+        try:
+            if _path_exists_no_follow(path):
+                _remove_legacy_path(path)
+        except Exception as exc:  # best-effort compatibility artifact cleanup
+            errors.append(f"{name}: {type(exc).__name__}: {exc}")
+    return tuple(errors)
+
+
+def inventory_sandbox_stores(home: str | Path) -> tuple[Path, ...]:
+    """Return only configuration files that this migrator may rewrite."""
+
+    root = Path(home).expanduser().absolute()
+    return tuple(
+        path
+        for path in (
+            root / "config.toml",
+            root / "desktop-preferences.json",
+            root / "preferences.json",
+        )
+        if path.is_file()
+    )
+
+
 class SandboxUpgradeCoordinator:
     def __init__(self, home: str | Path) -> None:
         self.home = Path(home).expanduser().absolute()
         self.journal_path = self.home / JOURNAL_NAME
         self.snapshot_path = self.home / SNAPSHOT_NAME
 
-    def _load_journal(self) -> dict[str, Any] | None:
-        if not self.journal_path.exists():
-            return None
-        payload = json.loads(self.journal_path.read_text(encoding="utf-8"))
-        if not isinstance(payload, dict) or payload.get("migrationVersion") != MIGRATION_VERSION:
-            raise ValueError("unsupported sandbox upgrade journal")
-        return payload
-
-    def _manual_recovery_report(
+    def _report(
         self,
         *,
-        store_names: tuple[str, ...],
-        error: Exception,
+        ok: bool,
+        status: str,
+        canonical_mode: str | None = None,
+        stores: tuple[str, ...] = (),
+        error: str | None = None,
     ) -> UpgradeMigrationReport:
-        failed = {
-            "migrationVersion": MIGRATION_VERSION,
-            "status": "prepared",
-            "stores": store_names,
-            "snapshot": str(self.snapshot_path),
-            "error": f"{type(error).__name__}: {error}",
-        }
-        _write_json(self.journal_path, failed)
         return UpgradeMigrationReport(
-            ok=False,
-            status="manual_recovery_required",
-            canonical_mode=None,
+            ok=ok,
+            status=status,
+            canonical_mode=canonical_mode,
             journal_path=self.journal_path,
             snapshot_path=(
                 self.snapshot_path if _path_exists_no_follow(self.snapshot_path) else None
             ),
-            stores=store_names,
-            error=str(failed["error"]),
+            stores=stores,
+            error=error,
         )
-
-    def _snapshot(self, stores: tuple[Path, ...]) -> None:
-        deadline = (
-            time.monotonic() + WINDOWS_ACL_STAGE_TIMEOUT_SECONDS
-            if _running_on_windows()
-            else None
-        )
-        windows_user_sid = (
-            _current_windows_user_sid(deadline=deadline) if _running_on_windows() else None
-        )
-        if _path_exists_no_follow(self.snapshot_path):
-            _protect_private_tree(
-                self.snapshot_path,
-                windows_user_sid=windows_user_sid,
-                deadline=deadline,
-            )
-            return
-        staging = _make_snapshot_staging_directory(self.home)
-        promoted = False
-        try:
-            _protect_private_path(
-                staging,
-                directory=True,
-                windows_user_sid=windows_user_sid,
-                deadline=deadline,
-            )
-            if next(staging.iterdir(), None) is not None:
-                raise OSError("upgrade snapshot staging is not empty after hardening")
-            materialization_started: float | None = None
-            if deadline is not None:
-                _remaining_windows_acl_time(deadline)
-                materialization_started = time.monotonic()
-            try:
-                manifest: list[dict[str, object]] = []
-                for source in stores:
-                    relative = source.relative_to(self.home)
-                    destination = staging / relative
-                    current = staging
-                    for part in relative.parts[:-1]:
-                        current = current / part
-                        if not current.exists():
-                            _create_private_directory(
-                                current,
-                                windows_user_sid=windows_user_sid,
-                                protect=False,
-                                deadline=deadline,
-                            )
-                    _copy_private_file(
-                        source,
-                        destination,
-                        windows_user_sid=windows_user_sid,
-                        protect=False,
-                        deadline=deadline,
-                    )
-                    manifest.append(
-                        {
-                            "path": relative.as_posix(),
-                            "sha256": _digest(destination),
-                            "size": destination.stat().st_size,
-                        }
-                    )
-                manifest_path = staging / "manifest.json"
-                _write_json(manifest_path, {"stores": manifest})
-            finally:
-                if deadline is not None and materialization_started is not None:
-                    deadline += time.monotonic() - materialization_started
-            _protect_private_tree(
-                staging,
-                windows_user_sid=windows_user_sid,
-                deadline=deadline,
-            )
-            os.replace(staging, self.snapshot_path)
-            promoted = True
-            _protect_private_tree(
-                self.snapshot_path,
-                windows_user_sid=windows_user_sid,
-                deadline=deadline,
-            )
-        except Exception as exc:
-            cleanup = self.snapshot_path if promoted else staging
-            _remove_failed_snapshot(cleanup, original_error=exc)
-            raise
 
     def run(self) -> UpgradeMigrationReport:
-        from opensquilla.recovery.locking import acquire_profile_locks
-
-        self.home.mkdir(parents=True, exist_ok=True)
-        with acquire_profile_locks(self.home, timeout=30.0):
-            return self._run_locked()
-
-    def _run_locked(self) -> UpgradeMigrationReport:
-        self.home.mkdir(parents=True, exist_ok=True)
-        stores = inventory_sandbox_stores(self.home)
-        store_names = tuple(path.relative_to(self.home).as_posix() for path in stores)
-        journal = self._load_journal()
-        if journal is not None and journal.get("status") == "committed":
-            try:
-                if not _path_exists_no_follow(self.snapshot_path):
-                    raise OSError("committed sandbox upgrade snapshot is missing")
-                self._snapshot(())
-            except Exception as exc:
-                return self._manual_recovery_report(
-                    store_names=store_names,
-                    error=exc,
-                )
-            return UpgradeMigrationReport(
-                ok=True,
-                status="committed",
-                canonical_mode=journal.get("canonicalMode"),
-                journal_path=self.journal_path,
-                snapshot_path=self.snapshot_path,
-                stores=store_names,
-            )
         try:
-            self._snapshot(stores)
-            prepared = {
-                "migrationVersion": MIGRATION_VERSION,
-                "status": "prepared",
-                "preparedAt": int(time.time()),
-                "stores": store_names,
-                "snapshot": str(self.snapshot_path),
-            }
-            _write_json(self.journal_path, prepared)
-            canonical_mode: str | None = None
-            config_path = self.home / "config.toml"
-            if config_path.is_file():
-                patched, canonical_mode = lossless_patch_sandbox_fields(
-                    config_path.read_bytes()
-                )
-                if patched != config_path.read_bytes():
-                    _atomic_write(config_path, patched)
-            for name in ("desktop-preferences.json", "preferences.json"):
-                preference_path = self.home / name
-                if not preference_path.is_file():
-                    continue
-                original = json.loads(preference_path.read_text(encoding="utf-8"))
-                transformed = _canonicalize_preferences(original)
-                if transformed != original:
-                    _write_json(preference_path, transformed)
-            committed = {
-                **prepared,
-                "status": "committed",
-                "committedAt": int(time.time()),
-                "canonicalMode": canonical_mode,
-            }
-            _write_json(self.journal_path, committed)
-            return UpgradeMigrationReport(
-                ok=True,
-                status="committed",
-                canonical_mode=canonical_mode,
-                journal_path=self.journal_path,
-                snapshot_path=self.snapshot_path,
-                stores=store_names,
-            )
+            initial_writes, canonical_mode = _plan_writes(self.home)
         except Exception as exc:
-            return self._manual_recovery_report(
-                store_names=store_names,
-                error=exc,
+            return self._report(
+                ok=False,
+                status="retry_required",
+                error=f"{type(exc).__name__}: {exc}",
             )
+
+        # The common, already-canonical path is read-only: do not even create
+        # profile lock files when there is no migration or legacy cleanup.
+        if not initial_writes and not _legacy_artifacts_present(self.home):
+            return self._report(
+                ok=True,
+                status="not_required",
+                canonical_mode=canonical_mode,
+            )
+
+        try:
+            from opensquilla.recovery.locking import acquire_profile_locks
+
+            with acquire_profile_locks(self.home, timeout=0.0):
+                # Re-plan under the lock so a concurrent successful migration
+                # turns this invocation into a no-op instead of a stale write.
+                planned_writes, canonical_mode = _plan_writes(self.home)
+                store_names = tuple(item.path.name for item in planned_writes)
+                for planned in planned_writes:
+                    _validate_payload(planned)
+                for planned in planned_writes:
+                    _atomic_write(planned.path, planned.payload)
+                cleanup_errors = _cleanup_legacy_artifacts(self.home)
+        except Exception as exc:
+            return self._report(
+                ok=False,
+                status="retry_required",
+                canonical_mode=canonical_mode,
+                stores=tuple(item.path.name for item in initial_writes),
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+        if cleanup_errors:
+            return self._report(
+                ok=True,
+                status="cleanup_pending",
+                canonical_mode=canonical_mode,
+                stores=store_names,
+                error="; ".join(cleanup_errors),
+            )
+        return self._report(
+            ok=True,
+            status="committed" if planned_writes else "not_required",
+            canonical_mode=canonical_mode,
+            stores=store_names,
+        )
 
 
 def ensure_sandbox_upgrade_migrated(home: str | Path) -> UpgradeMigrationReport:
@@ -1020,42 +323,31 @@ def ensure_sandbox_upgrade_migrated(home: str | Path) -> UpgradeMigrationReport:
 def inspect_sandbox_upgrade(home: str | Path) -> UpgradeMigrationReport:
     coordinator = SandboxUpgradeCoordinator(home)
     try:
-        journal = coordinator._load_journal()
+        planned, canonical_mode = _plan_writes(coordinator.home)
     except Exception as exc:
-        return UpgradeMigrationReport(
+        return coordinator._report(
             ok=False,
-            status="manual_recovery_required",
-            canonical_mode=None,
-            journal_path=coordinator.journal_path,
-            snapshot_path=(
-                coordinator.snapshot_path
-                if _path_exists_no_follow(coordinator.snapshot_path)
-                else None
-            ),
-            stores=(),
+            status="retry_required",
             error=f"{type(exc).__name__}: {exc}",
         )
-    if journal is None:
-        return UpgradeMigrationReport(
+    stores = tuple(item.path.name for item in planned)
+    if planned:
+        return coordinator._report(
             ok=True,
-            status="not_started",
-            canonical_mode=None,
-            journal_path=coordinator.journal_path,
-            snapshot_path=None,
-            stores=(),
+            status="pending",
+            canonical_mode=canonical_mode,
+            stores=stores,
         )
-    return UpgradeMigrationReport(
-        ok=journal.get("status") == "committed",
-        status=str(journal.get("status") or "manual_recovery_required"),
-        canonical_mode=journal.get("canonicalMode"),
-        journal_path=coordinator.journal_path,
-        snapshot_path=(
-            coordinator.snapshot_path
-            if _path_exists_no_follow(coordinator.snapshot_path)
-            else None
-        ),
-        stores=tuple(str(item) for item in journal.get("stores", ())),
-        error=journal.get("error"),
+    if _legacy_artifacts_present(coordinator.home):
+        return coordinator._report(
+            ok=True,
+            status="legacy_artifacts_present",
+            canonical_mode=canonical_mode,
+        )
+    return coordinator._report(
+        ok=True,
+        status="not_required",
+        canonical_mode=canonical_mode,
     )
 
 

--- a/tests/test_gateway/test_boot_media_root.py
+++ b/tests/test_gateway/test_boot_media_root.py
@@ -9,6 +9,7 @@ other test failure. This pins the production wiring.
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -63,6 +64,57 @@ async def test_build_services_wires_media_root_into_session_manager(
         media_root = services.session_manager._media_root
         assert media_root is not None
         assert media_root == media_root_from_config(config)
+    finally:
+        await services.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_kind", ["exception", "report"])
+async def test_build_services_continues_when_optional_sandbox_migration_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_kind: str,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path / "state"))
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('[sandbox]\nrun_mode = "trusted"\n', encoding="utf-8")
+
+    def reject_background_task(coro):
+        close = getattr(coro, "close", None)
+        if callable(close):
+            close()
+        raise AssertionError("unit tests must not schedule real sandbox setup")
+
+    def fail_optional_migration(_home: Path):
+        if failure_kind == "exception":
+            raise PermissionError("residual process holds the config")
+        return SimpleNamespace(
+            ok=False,
+            status="retry_required",
+            error="residual process holds the config",
+        )
+
+    monkeypatch.setattr(
+        "opensquilla.gateway.boot.create_background_task",
+        reject_background_task,
+    )
+    monkeypatch.setattr(
+        "opensquilla.sandbox.upgrade_migration.ensure_sandbox_upgrade_migrated",
+        fail_optional_migration,
+    )
+
+    services = await build_services(
+        config=GatewayConfig(
+            config_path=str(config_path),
+            memory={"flush_enabled": False},
+            sandbox={"auto_setup": False},
+        ),
+        session_db_path=":memory:",
+        seed_agent_workspaces=False,
+    )
+    try:
+        assert services.session_manager is not None
+        assert 'run_mode = "trusted"' in config_path.read_text(encoding="utf-8")
     finally:
         await services.close()
 

--- a/tests/test_live_artifact_prompt_annotations_e2e.py
+++ b/tests/test_live_artifact_prompt_annotations_e2e.py
@@ -440,30 +440,31 @@ def test_isolated_home_environment_supports_path_home_in_child(tmp_path: Path) -
     assert env["USERPROFILE"] == str(isolated_home.resolve())
 
 
-@pytest.mark.skipif(os.name != "nt", reason="Windows isolated-profile ACL smoke")
-def test_isolated_home_environment_supports_windows_acl_hardening(tmp_path: Path) -> None:
+@pytest.mark.skipif(os.name != "nt", reason="Windows isolated-profile migration smoke")
+def test_isolated_home_environment_supports_lightweight_sandbox_migration(
+    tmp_path: Path,
+) -> None:
     isolated_home = tmp_path / "user-state"
     isolated_home.mkdir()
-    protected = tmp_path / "protected"
-    protected.mkdir()
+    config = isolated_home / "config.toml"
+    config.write_text('[sandbox]\nrun_mode = "trusted"\n', encoding="utf-8")
     env = e2e._worker_environment("synthetic-rotated-key")
     e2e._apply_isolated_home_environment(env, isolated_home)
     env["PYTHONPATH"] = str(e2e.SRC_DIR)
     code = (
         "from pathlib import Path; import sys; "
-        "from opensquilla.sandbox.upgrade_migration import "
-        "_current_windows_user_sid, _protect_private_path; "
-        "print('acl-child-imported', flush=True); "
-        "sid = _current_windows_user_sid(); "
-        "print(f'acl-child-sid={sid}', flush=True); "
-        "_protect_private_path(Path(sys.argv[1]), directory=True, "
-        "windows_user_sid=sid); "
-        "print('acl-child-protected', flush=True)"
+        "from opensquilla.sandbox.upgrade_migration import SandboxUpgradeCoordinator; "
+        "report = SandboxUpgradeCoordinator(Path(sys.argv[1])).run(); "
+        "assert report.ok, report; "
+        "assert report.status == 'committed', report; "
+        "assert 'run_mode = \"safe\"' in "
+        "(Path(sys.argv[1]) / 'config.toml').read_text(encoding='utf-8'); "
+        "print('sandbox-migration-complete', flush=True)"
     )
 
     try:
         subprocess.run(
-            [sys.executable, "-c", code, str(protected)],
+            [sys.executable, "-c", code, str(isolated_home)],
             check=True,
             capture_output=True,
             env=env,
@@ -472,12 +473,12 @@ def test_isolated_home_environment_supports_windows_acl_hardening(tmp_path: Path
         )
     except subprocess.TimeoutExpired as exc:
         raise AssertionError(
-            f"isolated Windows ACL hardening timed out: stdout={exc.stdout!r} "
+            f"isolated Windows sandbox migration timed out: stdout={exc.stdout!r} "
             f"stderr={exc.stderr!r}"
         ) from exc
     except subprocess.CalledProcessError as exc:
         raise AssertionError(
-            f"isolated Windows ACL hardening failed: stdout={exc.stdout!r} "
+            f"isolated Windows sandbox migration failed: stdout={exc.stdout!r} "
             f"stderr={exc.stderr!r}"
         ) from exc
 

--- a/tests/test_live_artifact_prompt_annotations_e2e.py
+++ b/tests/test_live_artifact_prompt_annotations_e2e.py
@@ -44,6 +44,52 @@ def _load_module():
 e2e = _load_module()
 
 
+def _router_bundle_is_hydrated(bundle: Path | None = None) -> bool:
+    """Return whether the checked-out Router bundle contains real LFS assets."""
+
+    if bundle is None:
+        bundle = (
+            e2e.SRC_DIR
+            / "opensquilla"
+            / "squilla_router"
+            / "models"
+            / "v4.2_phase3_inference"
+        )
+    manifest_path = bundle / "artifact_manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+
+    pointer_prefix = b"version https://git-lfs.github.com/spec/v1"
+    for entry in manifest.get("files", []):
+        raw_path = entry.get("path")
+        if not isinstance(raw_path, str) or not raw_path:
+            continue
+        path = bundle / raw_path
+        try:
+            with path.open("rb") as handle:
+                if handle.read(len(pointer_prefix)) == pointer_prefix:
+                    return False
+        except OSError:
+            return False
+    return True
+
+
+def test_router_bundle_hydration_guard_detects_lfs_pointer(tmp_path: Path) -> None:
+    manifest = {"files": [{"path": "model.onnx"}]}
+    (tmp_path / "artifact_manifest.json").write_text(
+        json.dumps(manifest),
+        encoding="utf-8",
+    )
+    model = tmp_path / "model.onnx"
+    model.write_bytes(b"version https://git-lfs.github.com/spec/v1\n")
+    assert _router_bundle_is_hydrated(tmp_path) is False
+
+    model.write_bytes(b"hydrated-router-model")
+    assert _router_bundle_is_hydrated(tmp_path) is True
+
+
 class _DeterministicArtifactProvider:
     """Local OpenAI-compatible fixture for one real Direct mutation turn."""
 
@@ -1148,6 +1194,9 @@ async def test_owned_gateway_html_workbench_lifecycle_is_offline_and_immutable(
 async def test_owned_gateway_mutations_use_real_rpc_and_local_provider(
     tmp_path: Path,
 ) -> None:
+    if not _router_bundle_is_hydrated():
+        pytest.skip("Squilla Router Git LFS assets are not hydrated in this checkout")
+
     provider = _DeterministicArtifactProvider()
     provider.start()
     driver = e2e.GatewayCertificationDriver(

--- a/tests/test_lossless_toml.py
+++ b/tests/test_lossless_toml.py
@@ -1,10 +1,9 @@
 """Contract tests for the comment-preserving TOML patcher.
 
-``patch_import_config`` runs on every Gateway boot (``lossless_patch_sandbox_fields``
-stamps ``sandbox.run_mode``), so a config it refuses to scan is a config the
-Gateway refuses to start on. The scanner is line-oriented, which makes values
-that span several physical lines — arrays of inline tables, nested arrays,
-triple-quoted strings — the interesting cases.
+The optional sandbox compatibility cleanup uses ``patch_import_config`` only
+when a released legacy RunMode field is present. The scanner is line-oriented,
+which makes values that span several physical lines — arrays of inline tables,
+nested arrays, triple-quoted strings — the interesting cases.
 """
 
 from __future__ import annotations
@@ -90,22 +89,20 @@ host = "127.0.0.1"
 def test_untouched_array_of_inline_tables_does_not_block_the_patch() -> None:
     """Regression for #1106.
 
-    The Control UI writes ``agents`` as a multi-line array of inline tables. The
-    boot migration only stamps ``sandbox.run_mode``, but the scan aborted on the
-    array's rows before reaching that edit, so the Gateway never started again.
+    The Control UI writes ``agents`` as a multi-line array of inline tables. An
+    older boot migration stamped ``sandbox.run_mode``, but the scan aborted on
+    the array's rows before reaching that edit.
     """
     patched = _patched(AGENTS_CONFIG, lambda payload: payload.update(port=18793))
     assert patched == AGENTS_CONFIG.decode("utf-8").replace("18792", "18793")
 
 
-def test_boot_migration_stamps_run_mode_next_to_an_agents_array() -> None:
+def test_boot_migration_leaves_agents_only_config_unchanged() -> None:
     from opensquilla.sandbox.upgrade_migration import lossless_patch_sandbox_fields
 
     patched, mode = lossless_patch_sandbox_fields(AGENTS_CONFIG)
-    payload = tomllib.loads(patched.decode("utf-8"))
-    assert payload["sandbox"]["run_mode"] == mode
-    assert payload["agents"] == [{"id": "qa-agent", "name": "QA Agent", "enabled": True}]
-    assert b'{ id = "qa-agent", name = "QA Agent", enabled = true },' in patched
+    assert patched == AGENTS_CONFIG
+    assert mode is None
 
 
 def test_nested_multi_line_array_rows_are_not_read_as_table_headers() -> None:

--- a/tests/test_migration/test_sandbox_direct_update.py
+++ b/tests/test_migration/test_sandbox_direct_update.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-import base64
+import inspect
 import json
-import os
-import stat
-import subprocess
 import tomllib
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from pathlib import Path
-from types import SimpleNamespace
-from typing import Any
 
 import pytest
 
@@ -17,29 +15,29 @@ from opensquilla.sandbox.upgrade_migration import SandboxUpgradeCoordinator
 
 
 @pytest.mark.parametrize(
-    ("legacy_mode", "canonical"),
+    ("legacy_mode", "canonical", "expected_status"),
     [
-        ("standard", "safe"),
-        ("trusted", "safe"),
-        ("managed", "safe"),
-        ("full", "full"),
+        ("standard", "safe", "committed"),
+        ("trusted", "safe", "committed"),
+        ("managed", "safe", "committed"),
+        ("full", "full", "not_required"),
     ],
 )
-def test_direct_update_preserves_mode_comments_and_unknown_fields(
+def test_direct_update_preserves_comments_and_unknown_fields(
     tmp_path: Path,
     legacy_mode: str,
     canonical: str,
+    expected_status: str,
 ) -> None:
     config = tmp_path / "config.toml"
     config.write_text(
-        f"""
-# retained comment
-unknown_top = "keep"
-
-[sandbox]
-run_mode = "{legacy_mode}" # retained inline
-mystery = 42
-""".lstrip(),
+        (
+            "# retained comment\n"
+            'unknown_top = "keep"\n\n'
+            "[sandbox]\n"
+            f'run_mode = "{legacy_mode}" # retained inline\n'
+            "mystery = 42\n"
+        ),
         encoding="utf-8",
     )
     preferences = tmp_path / "desktop-preferences.json"
@@ -51,6 +49,7 @@ mystery = 42
     report = SandboxUpgradeCoordinator(tmp_path).run()
 
     assert report.ok is True
+    assert report.status == expected_status
     assert report.canonical_mode == canonical
     text = config.read_text(encoding="utf-8")
     assert "# retained comment" in text
@@ -59,1044 +58,294 @@ mystery = 42
     assert parsed["sandbox"]["run_mode"] == canonical
     assert parsed["sandbox"]["mystery"] == 42
     assert parsed["unknown_top"] == "keep"
-    assert json.loads(preferences.read_text()) == {
+    assert json.loads(preferences.read_text(encoding="utf-8")) == {
         "runMode": canonical,
         "unknown": {"keep": True},
     }
 
 
-def test_direct_update_is_idempotent_and_keeps_one_snapshot(tmp_path: Path) -> None:
-    (tmp_path / "config.toml").write_text(
-        '[sandbox]\nrun_mode = "trusted"\n',
-        encoding="utf-8",
+def test_already_canonical_profile_performs_no_disk_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text('[sandbox]\nrun_mode = "safe"\n', encoding="utf-8")
+    preferences = tmp_path / "preferences.json"
+    preferences.write_text('{"runMode":"full"}', encoding="utf-8")
+    before = {path: path.read_bytes() for path in (config, preferences)}
+
+    def unexpected_write(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("canonical migration must not write")
+
+    monkeypatch.setattr(upgrade_migration, "_atomic_write", unexpected_write)
+    report = SandboxUpgradeCoordinator(tmp_path).run()
+
+    assert report.ok is True
+    assert report.status == "not_required"
+    assert {path: path.read_bytes() for path in before} == before
+    assert not (tmp_path / upgrade_migration.SNAPSHOT_NAME).exists()
+    assert not (tmp_path / upgrade_migration.JOURNAL_NAME).exists()
+
+
+def test_missing_profile_is_not_created_by_optional_migration(tmp_path: Path) -> None:
+    missing_home = tmp_path / "not-installed"
+
+    report = SandboxUpgradeCoordinator(missing_home).run()
+
+    assert report.ok is True
+    assert report.status == "not_required"
+    assert not missing_home.exists()
+
+
+def test_unrelated_config_is_not_given_a_sandbox_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = tmp_path / "config.toml"
+    original = b'agents = [{ id = "qa", name = "QA" }]\n'
+    config.write_bytes(original)
+    monkeypatch.setattr(
+        upgrade_migration,
+        "_atomic_write",
+        lambda *_args, **_kwargs: pytest.fail("unrelated config was rewritten"),
     )
+
+    report = SandboxUpgradeCoordinator(tmp_path).run()
+
+    assert report.status == "not_required"
+    assert config.read_bytes() == original
+
+
+def test_only_changed_config_files_are_replaced_and_sessions_db_is_ignored(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text('[sandbox]\nrun_mode = "trusted"\n', encoding="utf-8")
+    preferences = tmp_path / "preferences.json"
+    preferences.write_text('{"runMode":"safe"}', encoding="utf-8")
     database = tmp_path / "state" / "sessions.db"
     database.parent.mkdir()
-    database.write_bytes(b"legacy-database")
+    database.write_bytes(b"in-use-session-data")
+    writes: list[str] = []
+    real_atomic_write = upgrade_migration._atomic_write
+
+    def record_write(path: Path, payload: bytes) -> None:
+        writes.append(path.name)
+        real_atomic_write(path, payload)
+
+    monkeypatch.setattr(upgrade_migration, "_atomic_write", record_write)
+
+    report = SandboxUpgradeCoordinator(tmp_path).run()
+
+    assert report.ok is True
+    assert writes == ["config.toml"]
+    assert database.read_bytes() == b"in-use-session-data"
+    assert database not in upgrade_migration.inventory_sandbox_stores(tmp_path)
+    assert not (tmp_path / upgrade_migration.SNAPSHOT_NAME).exists()
+
+
+def test_atomic_replace_failure_leaves_target_unchanged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "config.toml"
+    original = b'[sandbox]\nrun_mode = "trusted"\n'
+    target.write_bytes(original)
+
+    def fail_replace(_source: object, _destination: object) -> None:
+        raise PermissionError("file is held by a residual process")
+
+    monkeypatch.setattr(upgrade_migration.os, "replace", fail_replace)
+
+    with pytest.raises(PermissionError, match="residual process"):
+        upgrade_migration._atomic_write(target, b'[sandbox]\nrun_mode = "safe"\n')
+
+    assert target.read_bytes() == original
+    assert not list(tmp_path.glob(".config.toml.*"))
+
+
+def test_coordinator_reports_retry_without_corrupting_locked_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = tmp_path / "config.toml"
+    original = b'[sandbox]\nrun_mode = "standard"\n'
+    config.write_bytes(original)
+    monkeypatch.setattr(
+        upgrade_migration,
+        "_atomic_write",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(PermissionError("sharing violation")),
+    )
+
+    report = SandboxUpgradeCoordinator(tmp_path).run()
+
+    assert report.ok is False
+    assert report.status == "retry_required"
+    assert "sharing violation" in str(report.error)
+    assert config.read_bytes() == original
+
+
+def test_busy_profile_lock_returns_immediately_for_a_later_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = tmp_path / "config.toml"
+    original = b'[sandbox]\nrun_mode = "trusted"\n'
+    config.write_bytes(original)
+    observed_timeouts: list[float] = []
+
+    @contextmanager
+    def busy_lock(_home: Path, *, timeout: float) -> Iterator[None]:
+        observed_timeouts.append(timeout)
+        raise TimeoutError("old gateway still owns the profile lock")
+        yield
+
+    monkeypatch.setattr("opensquilla.recovery.locking.acquire_profile_locks", busy_lock)
+
+    report = SandboxUpgradeCoordinator(tmp_path).run()
+
+    assert observed_timeouts == [0.0]
+    assert report.ok is False
+    assert report.status == "retry_required"
+    assert config.read_bytes() == original
+
+
+def test_prepared_legacy_artifacts_resume_idempotently_then_cleanup(tmp_path: Path) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text('[sandbox]\nrun_mode = "standard"\n', encoding="utf-8")
+    snapshot = tmp_path / upgrade_migration.SNAPSHOT_NAME
+    snapshot.mkdir()
+    (snapshot / "config.toml").write_bytes(config.read_bytes())
+    journal = tmp_path / upgrade_migration.JOURNAL_NAME
+    journal.write_text(
+        json.dumps({"migrationVersion": 2, "status": "prepared"}),
+        encoding="utf-8",
+    )
+
+    report = SandboxUpgradeCoordinator(tmp_path).run()
+
+    assert report.ok is True
+    assert report.status == "committed"
+    assert 'run_mode = "safe"' in config.read_text(encoding="utf-8")
+    assert not snapshot.exists()
+    assert not journal.exists()
+
+
+def test_committed_journal_does_not_require_snapshot_or_acl(tmp_path: Path) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text('[sandbox]\nrun_mode = "safe"\n', encoding="utf-8")
+    journal = tmp_path / upgrade_migration.JOURNAL_NAME
+    journal.write_text(
+        json.dumps({"migrationVersion": 2, "status": "committed"}),
+        encoding="utf-8",
+    )
+
+    report = SandboxUpgradeCoordinator(tmp_path).run()
+
+    assert report.ok is True
+    assert report.status == "not_required"
+    assert not journal.exists()
+    assert report.snapshot_path is None
+
+
+def test_cleanup_failure_is_non_blocking_and_retried_later(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "config.toml").write_text(
+        '[sandbox]\nrun_mode = "safe"\n',
+        encoding="utf-8",
+    )
+    snapshot = tmp_path / upgrade_migration.SNAPSHOT_NAME
+    snapshot.mkdir()
+
+    def fail_cleanup(path: Path) -> None:
+        raise PermissionError(f"busy: {path.name}")
+
+    monkeypatch.setattr(upgrade_migration, "_remove_legacy_path", fail_cleanup)
+
+    report = SandboxUpgradeCoordinator(tmp_path).run()
+
+    assert report.ok is True
+    assert report.status == "cleanup_pending"
+    assert "PermissionError" in str(report.error)
+    assert snapshot.exists()
+
+
+def test_invalid_legacy_journal_is_not_manual_recovery(tmp_path: Path) -> None:
+    journal = tmp_path / upgrade_migration.JOURNAL_NAME
+    journal.write_text('{"migrationVersion":999}', encoding="utf-8")
+
+    report = upgrade_migration.inspect_sandbox_upgrade(tmp_path)
+
+    assert report.ok is True
+    assert report.status == "legacy_artifacts_present"
+    assert journal.exists()
+
+
+def test_repeated_run_is_idempotent(tmp_path: Path) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text('[sandbox]\nrun_mode = "managed"\n', encoding="utf-8")
 
     first = SandboxUpgradeCoordinator(tmp_path).run()
+    after_first = config.read_bytes()
     second = SandboxUpgradeCoordinator(tmp_path).run()
 
-    assert first.ok and second.ok
-    assert second.status == "committed"
-    assert (tmp_path / ".sandbox-upgrade-snapshot" / "state" / "sessions.db").read_bytes() == (
-        b"legacy-database"
-    )
-    assert len(list(tmp_path.glob(".sandbox-upgrade-snapshot*"))) == 1
+    assert first.status == "committed"
+    assert second.status == "not_required"
+    assert config.read_bytes() == after_first
 
 
-def test_prepared_agent_config_retries_to_committed_without_losing_the_agent(
-    tmp_path: Path,
-) -> None:
-    raw = b'''agents = [
-    { id = "qa-agent", name = "QA Agent", enabled = true },
-]
-'''
-    config = tmp_path / "config.toml"
-    config.write_bytes(raw)
-    snapshot = tmp_path / upgrade_migration.SNAPSHOT_NAME
-    snapshot.mkdir()
-    (snapshot / "config.toml").write_bytes(raw)
-    (snapshot / "manifest.json").write_text(
-        json.dumps({"stores": [{"path": "config.toml"}]}) + "\n",
-        encoding="utf-8",
-    )
-    (tmp_path / upgrade_migration.JOURNAL_NAME).write_text(
-        json.dumps(
-            {
-                "migrationVersion": upgrade_migration.MIGRATION_VERSION,
-                "status": "prepared",
-                "stores": ["config.toml"],
-                "snapshot": str(snapshot),
-                "error": (
-                    "LosslessTomlPatchError: unsupported TOML key expression: { id"
-                ),
-            }
-        )
-        + "\n",
+def test_concurrent_migrations_serialize_and_converge(tmp_path: Path) -> None:
+    (tmp_path / "config.toml").write_text(
+        '[sandbox]\nrun_mode = "trusted"\n',
         encoding="utf-8",
     )
 
-    report = SandboxUpgradeCoordinator(tmp_path).run()
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        reports = list(pool.map(lambda _: SandboxUpgradeCoordinator(tmp_path).run(), range(2)))
 
-    assert report.ok is True
-    assert report.status == "committed"
-    assert (snapshot / "config.toml").read_bytes() == raw
-    patched = config.read_bytes()
-    assert b'{ id = "qa-agent", name = "QA Agent", enabled = true },' in patched
-    assert tomllib.loads(patched.decode("utf-8"))["sandbox"]["run_mode"] == "full"
-    journal = json.loads((tmp_path / upgrade_migration.JOURNAL_NAME).read_text())
-    assert journal["status"] == "committed"
-
-
-@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
-def test_direct_update_snapshot_is_owner_only_on_posix(tmp_path: Path) -> None:
-    config = tmp_path / "config.toml"
-    config.write_text('[sandbox]\nrun_mode = "trusted"\n', encoding="utf-8")
-    database = tmp_path / "state" / "sessions.db"
-    database.parent.mkdir()
-    database.write_bytes(b"legacy-database")
-    config.chmod(0o644)
-    database.chmod(0o644)
-
-    report = SandboxUpgradeCoordinator(tmp_path).run()
-
-    assert report.ok is True
-    snapshot = tmp_path / ".sandbox-upgrade-snapshot"
-    directories = [snapshot, snapshot / "state"]
-    files = [
-        snapshot / "config.toml",
-        snapshot / "state" / "sessions.db",
-        snapshot / "manifest.json",
-    ]
-    assert all(stat.S_IMODE(path.stat().st_mode) == 0o700 for path in directories)
-    assert all(stat.S_IMODE(path.stat().st_mode) == 0o600 for path in files)
-
-
-def _mock_windows_acl(
-    monkeypatch: pytest.MonkeyPatch,
-    events: list[tuple[str, Path, tuple[str, ...]]],
-    *,
-    fail_when: Any | None = None,
-) -> None:
-    monkeypatch.setattr(upgrade_migration, "_running_on_windows", lambda: True)
-    monkeypatch.setattr(
-        upgrade_migration,
-        "_current_windows_user_sid",
-        lambda **_kwargs: "S-1-5-21-1234",
-    )
-
-    def run(command: list[str], **kwargs: object) -> SimpleNamespace:
-        if command[0] == "whoami":
-            return SimpleNamespace(
-                returncode=0,
-                stdout=b'"DESKTOP\\owner","S-1-5-21-1234"\n',
-                stderr=b"",
-            )
-        environment = kwargs["env"]
-        assert isinstance(environment, dict)
-        assert environment["OPENSQUILLA_UPGRADE_ACL_USER_SID"] == "S-1-5-21-1234"
-        payload = kwargs["input"]
-        assert isinstance(payload, bytes)
-        items = json.loads(payload.decode("ascii"))
-        assert isinstance(items, list) and items
-        paths = [Path(item["path"]) for item in items]
-        for path in paths:
-            events.append(("acl", path, tuple(command)))
-        failed = any(
-            fail_when is not None and fail_when(path, events)
-            for path in paths
-        )
-        result = {
-            "count": len(items),
-            "ids": [str(index) for index in range(len(items))],
-            "pathUtf8Base64": [
-                base64.b64encode(item["path"].encode("utf-8")).decode("ascii")
-                for item in items
-            ],
-            "pathHashes": [
-                upgrade_migration._acl_path_hash(Path(item["path"]))
-                for item in items
-            ],
-        }
-        assert kwargs["timeout"] > 0
-        assert kwargs["creationflags"] == int(
-            getattr(subprocess, "CREATE_NO_WINDOW", 0)
-        )
-        assert "text" not in kwargs
-        assert Path(command[0]).stem.casefold() in {"powershell", "pwsh"}
-        assert tuple(command[1:5]) == (
-            "-NoProfile",
-            "-NonInteractive",
-            "-NoLogo",
-            "-EncodedCommand",
-        )
-        return SimpleNamespace(
-            returncode=5 if failed else 0,
-            stdout=json.dumps(result).encode("ascii"),
-            stderr=b"access denied" if failed else b"",
-        )
-
-    monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
-
-
-def test_windows_acl_script_keeps_host_specific_acl_apis_bounded() -> None:
-    script = upgrade_migration._WINDOWS_PRIVATE_ACL_SCRIPT
-
-    assert "Get-Acl -LiteralPath $target" in script
-    assert "Set-Acl -LiteralPath $target -AclObject $acl" in script
-    assert "Select-Object" not in script
-    assert "Where-Object" not in script
-    assert "[System.IO.Directory]::GetAccessControl($target)" in script
-    assert "[System.IO.File]::GetAccessControl($target)" in script
-    assert "pathHashes" in script
-    assert "pathUtf8Base64 = $verifiedPathUtf8Base64.ToArray()" in script
-    assert "[Console]::OutputEncoding = $utf8WithoutBom" in script
-    assert "paths = $verifiedPaths.ToArray()" not in script
-    assert "-ne $fullControl" in script
-
-
-def test_windows_acl_batch_round_trips_non_ascii_path_over_ascii_protocol(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    target = tmp_path / "中文快照"
-    target.mkdir()
-
-    def run(_command: list[str], **kwargs: object) -> SimpleNamespace:
-        payload = kwargs["input"]
-        assert isinstance(payload, bytes)
-        assert payload.isascii()
-        items = json.loads(payload.decode("ascii"))
-        result = {
-            "count": 1,
-            "ids": ["0"],
-            "pathUtf8Base64": [
-                base64.b64encode(items[0]["path"].encode("utf-8")).decode("ascii")
-            ],
-            "pathHashes": [upgrade_migration._acl_path_hash(target)],
-        }
-        stdout = json.dumps(result, separators=(",", ":")).encode("ascii")
-        assert stdout.isascii()
-        return SimpleNamespace(returncode=0, stdout=stdout, stderr=b"")
-
-    monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
-
-    upgrade_migration._protect_windows_acl_batch(
-        ((target, True),),
-        windows_user_sid="S-1-5-21-1234",
-    )
-
-
-def test_windows_acl_batch_falls_back_to_windows_powershell_on_privilege_error(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    target = tmp_path / "snapshot"
-    target.mkdir()
-    calls: list[str] = []
-    timeouts: list[float] = []
-
-    monkeypatch.setattr(
-        upgrade_migration,
-        "_windows_acl_shells",
-        lambda: ("pwsh", "powershell"),
-    )
-
-    def run(command: list[str], **kwargs: object) -> SimpleNamespace:
-        calls.append(command[0])
-        timeout = kwargs["timeout"]
-        assert isinstance(timeout, (int, float))
-        timeouts.append(timeout)
-        if command[0] == "pwsh":
-            return SimpleNamespace(
-                returncode=1,
-                stdout=b"",
-                stderr=b"SeSecurityPrivilege",
-            )
-        result = {
-            "count": 1,
-            "ids": ["0"],
-            "pathUtf8Base64": [base64.b64encode(str(target).encode()).decode("ascii")],
-            "pathHashes": [upgrade_migration._acl_path_hash(target)],
-        }
-        return SimpleNamespace(
-            returncode=0,
-            stdout=json.dumps(result).encode("ascii"),
-            stderr=b"",
-        )
-
-    monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
-
-    upgrade_migration._protect_windows_acl_batch(
-        ((target, True),),
-        windows_user_sid="S-1-5-21-1234",
-        deadline=upgrade_migration.time.monotonic() + 30,
-    )
-
-    assert calls == ["pwsh", "powershell"]
-    assert 0 < timeouts[1] <= timeouts[0]
-
-
-@pytest.mark.parametrize(
-    "case",
-    ["malformed_base64", "invalid_utf8", "count", "path", "hash"],
-)
-def test_windows_acl_batch_rejects_malformed_or_mismatched_verification(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-    case: str,
-) -> None:
-    target = tmp_path / "中文快照"
-    target.mkdir()
-    encoded_path = base64.b64encode(str(target).encode("utf-8")).decode("ascii")
-    result: dict[str, object] = {
-        "count": 1,
-        "ids": ["0"],
-        "pathUtf8Base64": [encoded_path],
-        "pathHashes": [upgrade_migration._acl_path_hash(target)],
+    assert {report.status for report in reports} <= {
+        "committed",
+        "not_required",
+        "retry_required",
     }
-    if case == "malformed_base64":
-        result["pathUtf8Base64"] = ["not base64!"]
-    elif case == "invalid_utf8":
-        result["pathUtf8Base64"] = [
-            base64.b64encode(b"\xff").decode("ascii")
-        ]
-    elif case == "count":
-        result["count"] = 2
-    elif case == "path":
-        result["pathUtf8Base64"] = [
-            base64.b64encode(b"C:\\wrong").decode("ascii")
-        ]
-    else:
-        result["pathHashes"] = ["0" * 64]
-
-    def run(_command: list[str], **_kwargs: object) -> SimpleNamespace:
-        return SimpleNamespace(
-            returncode=0,
-            stdout=json.dumps(result).encode("ascii"),
-            stderr=b"",
-        )
-
-    monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
-
-    with pytest.raises(OSError, match="Windows ACL helper"):
-        upgrade_migration._protect_windows_acl_batch(
-            ((target, True),),
-            windows_user_sid="S-1-5-21-1234",
-        )
+    assert any(report.ok for report in reports)
+    assert 'run_mode = "safe"' in (tmp_path / "config.toml").read_text(encoding="utf-8")
 
 
-def test_whoami_fallback_parses_sid_from_non_utf8_bytes_and_caps_timeout(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    def fail_native_sid() -> str:
-        raise OSError("synthetic native SID failure")
+def test_migrator_has_no_platform_acl_or_powershell_dependency() -> None:
+    source = inspect.getsource(upgrade_migration)
 
-    observed: dict[str, object] = {}
+    assert "setsecurityinfo" not in source.casefold()
+    assert "dacl" not in source.casefold()
+    assert "subprocess" not in source
+    assert "sessions.db" not in source
+    assert "os.name" not in source
+    assert ".chmod" not in source
+    assert "fchmod" not in source
 
-    def run(command: list[str], **kwargs: object) -> SimpleNamespace:
-        observed.update(kwargs)
-        assert command == ["whoami", "/user", "/fo", "csv", "/nh"]
-        return SimpleNamespace(
-            returncode=0,
-            stdout=(
-                b'"'
-                + "中文用户".encode("cp936")
-                + b'","S-1-5-21-1234-5678-9012-1001"\r\n'
-            ),
-            stderr=b"",
-        )
 
-    monkeypatch.setattr(upgrade_migration, "_native_windows_user_sid", fail_native_sid)
-    monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
-
-    sid = upgrade_migration._current_windows_user_sid(
-        deadline=upgrade_migration.time.monotonic() + 30
+def test_gateway_boot_does_not_raise_for_sandbox_normalization_failure() -> None:
+    root = Path(__file__).parents[2]
+    source = (root / "src" / "opensquilla" / "gateway" / "boot.py").read_text(
+        encoding="utf-8"
     )
-
-    assert sid == "S-1-5-21-1234-5678-9012-1001"
-    timeout = observed["timeout"]
-    assert isinstance(timeout, (int, float))
-    assert 0 < timeout <= upgrade_migration._WINDOWS_IDENTITY_FALLBACK_TIMEOUT_SECONDS
-    assert observed["stdin"] == subprocess.DEVNULL
-    assert "text" not in observed
-
-
-@pytest.mark.parametrize(
-    "stdout",
-    [
-        b'"DESKTOP\\owner","missing"\r\n',
-        (
-            b'"DESKTOP\\owner","S-1-5-21-1234-5678-9012-1001" '
-            b'"S-1-5-21-1234-5678-9012-1002"\r\n'
-        ),
-    ],
-)
-def test_whoami_fallback_rejects_missing_or_multiple_sids(
-    monkeypatch: pytest.MonkeyPatch,
-    stdout: bytes,
-) -> None:
-    def fail_native_sid() -> str:
-        raise OSError("synthetic native SID failure")
-
-    def run(_command: list[str], **_kwargs: object) -> SimpleNamespace:
-        return SimpleNamespace(returncode=0, stdout=stdout, stderr=b"")
-
-    monkeypatch.setattr(upgrade_migration, "_native_windows_user_sid", fail_native_sid)
-    monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
-
-    with pytest.raises(OSError, match="cannot resolve"):
-        upgrade_migration._current_windows_user_sid()
-
-
-def test_windows_acl_batch_rejects_incomplete_helper_verification(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    monkeypatch.setattr(upgrade_migration, "_running_on_windows", lambda: True)
-    monkeypatch.setattr(
-        upgrade_migration,
-        "_current_windows_user_sid",
-        lambda **_kwargs: "S-1-5-21-1234",
-    )
-    target = tmp_path / "snapshot"
-    target.mkdir()
-
-    def run(_command: list[str], **_kwargs: object) -> SimpleNamespace:
-        return SimpleNamespace(
-            returncode=0,
-            stdout=json.dumps(
-                {
-                    "count": 1,
-                    "ids": ["0"],
-                    "pathUtf8Base64": [],
-                    "pathHashes": [],
-                }
-            ).encode("ascii"),
-            stderr=b"",
-        )
-
-    monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
-
-    with pytest.raises(OSError, match="requested paths exactly"):
-        upgrade_migration._protect_windows_acl_batch(
-            ((target, True),),
-            windows_user_sid="S-1-5-21-1234",
-        )
-
-
-def test_windows_acl_batch_timeout_fails_closed(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    monkeypatch.setattr(upgrade_migration, "_running_on_windows", lambda: True)
-    target = tmp_path / "snapshot"
-    target.mkdir()
-
-    def run(_command: list[str], **_kwargs: object) -> SimpleNamespace:
-        raise subprocess.TimeoutExpired("powershell", 0.01)
-
-    monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
-
-    with pytest.raises(TimeoutError, match="ACL migration stage timed out"):
-        upgrade_migration._protect_windows_acl_batch(
-            ((target, True),),
-            windows_user_sid="S-1-5-21-1234",
-            deadline=upgrade_migration.time.monotonic() + 1,
-        )
-
-
-def test_private_tree_rejects_reparse_points_without_following_them(
-    tmp_path: Path,
-) -> None:
-    root = tmp_path / "snapshot"
-    root.mkdir()
-    outside = tmp_path / "outside"
-    outside.mkdir()
-    (outside / "secret.txt").write_text("secret", encoding="utf-8")
-    link = root / "redirect"
-    try:
-        link.symlink_to(outside, target_is_directory=True)
-    except (OSError, NotImplementedError) as exc:
-        pytest.skip(f"symlink unavailable: {exc}")
-
-    with pytest.raises(OSError, match="unsafe type"):
-        upgrade_migration._private_tree_entries(root)
-
-
-def test_private_tree_rejects_file_root(tmp_path: Path) -> None:
-    root = tmp_path / "snapshot"
-    root.write_text("not a directory", encoding="utf-8")
-
-    with pytest.raises(OSError, match="snapshot root is not a directory"):
-        upgrade_migration._private_tree_entries(root)
-
-
-def test_windows_acl_process_timeout_is_actionable(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    snapshot = tmp_path / "snapshot"
-    snapshot.mkdir()
-    monkeypatch.setattr(upgrade_migration, "_running_on_windows", lambda: True)
-
-    def run(command: list[str], **_kwargs: object) -> SimpleNamespace:
-        raise subprocess.TimeoutExpired(
-            command,
-            upgrade_migration.WINDOWS_ACL_STAGE_TIMEOUT_SECONDS,
-        )
-
-    monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
-
-    with pytest.raises(OSError, match="Windows ACL hardening timed out"):
-        upgrade_migration._protect_private_path(
-            snapshot,
-            directory=True,
-            windows_user_sid="S-1-5-21-1234",
-        )
-
-
-def test_frozen_windows_acl_process_restores_packaged_dll_directory(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    snapshot = tmp_path / "snapshot"
-    snapshot.mkdir()
-    events: list[tuple[str, str | None]] = []
-    monkeypatch.setattr(upgrade_migration, "_running_on_windows", lambda: True)
-    monkeypatch.setattr(upgrade_migration.sys, "frozen", True, raising=False)
-    monkeypatch.setattr(
-        upgrade_migration.sys,
-        "_MEIPASS",
-        "C:/synthetic/bundle/_internal",
-        raising=False,
-    )
-    monkeypatch.setattr(
-        upgrade_migration,
-        "_set_windows_dll_directory",
-        lambda path: events.append(("dll", path)),
-    )
-
-    def run(_command: list[str], **kwargs: object) -> SimpleNamespace:
-        events.append(("run", None))
-        payload = kwargs.get("input")
-        if isinstance(payload, bytes):
-            items = json.loads(payload.decode("ascii"))
-            stdout = json.dumps(
-                {
-                    "count": len(items),
-                    "ids": [str(index) for index in range(len(items))],
-                    "pathUtf8Base64": [
-                        base64.b64encode(item["path"].encode("utf-8")).decode("ascii")
-                        for item in items
-                    ],
-                    "pathHashes": [
-                        upgrade_migration._acl_path_hash(Path(item["path"]))
-                        for item in items
-                    ],
-                }
-            ).encode("ascii")
-        else:
-            stdout = b'"DESKTOP\\owner","S-1-5-21-1234"\n'
-        return SimpleNamespace(returncode=0, stdout=stdout, stderr=b"")
-
-    monkeypatch.setattr(upgrade_migration.subprocess, "run", run)
-
-    upgrade_migration._protect_private_path(
-        snapshot,
-        directory=True,
-        windows_user_sid="S-1-5-21-1234",
-    )
-
-    assert events == [
-        ("dll", None),
-        ("run", None),
-        ("dll", "C:/synthetic/bundle/_internal"),
-    ]
-
-
-def test_frozen_windows_acl_process_restores_dll_directory_after_launch_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    events: list[tuple[str, str | None]] = []
-    monkeypatch.setattr(upgrade_migration, "_running_on_windows", lambda: True)
-    monkeypatch.setattr(upgrade_migration.sys, "frozen", True, raising=False)
-    monkeypatch.setattr(
-        upgrade_migration.sys,
-        "_MEIPASS",
-        "C:/synthetic/bundle/_internal",
-        raising=False,
-    )
-    monkeypatch.setattr(
-        upgrade_migration,
-        "_set_windows_dll_directory",
-        lambda path: events.append(("dll", path)),
-    )
-
-    with pytest.raises(OSError, match="synthetic launch failure"):
-        with upgrade_migration._system_windows_process_context():
-            events.append(("run", None))
-            raise OSError("synthetic launch failure")
-
-    assert events == [
-        ("dll", None),
-        ("run", None),
-        ("dll", "C:/synthetic/bundle/_internal"),
-    ]
-
-
-def test_windows_snapshot_acl_is_applied_in_copy_and_promotion_order(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    config = tmp_path / "config.toml"
-    config.write_text('[sandbox]\nrun_mode = "trusted"\n', encoding="utf-8")
-    database = tmp_path / "state" / "sessions.db"
-    database.parent.mkdir()
-    database.write_bytes(b"legacy-database")
-    events: list[tuple[str, Path, tuple[str, ...]]] = []
-    _mock_windows_acl(monkeypatch, events)
-
-    real_copyfileobj = upgrade_migration.shutil.copyfileobj
-
-    def copyfileobj(source: Any, destination: Any, length: int = 0) -> None:
-        events.append(("copy", config, ()))
-        real_copyfileobj(source, destination, length)
-
-    monkeypatch.setattr(upgrade_migration.shutil, "copyfileobj", copyfileobj)
-    real_replace = upgrade_migration.os.replace
-
-    def replace(source: str | Path, destination: str | Path) -> None:
-        target = Path(destination)
-        if target.name == upgrade_migration.SNAPSHOT_NAME:
-            events.append(("promote", target, ()))
-        real_replace(source, destination)
-
-    monkeypatch.setattr(upgrade_migration.os, "replace", replace)
-
-    report = SandboxUpgradeCoordinator(tmp_path).run()
-
-    assert report.ok is True
-    staging_acl = next(
-        index
-        for index, event in enumerate(events)
-        if event[0] == "acl" and event[1].name.endswith(".tmp")
-    )
-    copy = next(index for index, event in enumerate(events) if event[0] == "copy")
-    copied_file_acl = next(
-        index
-        for index, event in enumerate(events)
-        if event[0] == "acl"
-        and event[1].name == "config.toml"
-        and upgrade_migration.SNAPSHOT_NAME not in event[1].parts
-    )
-    promote = next(index for index, event in enumerate(events) if event[0] == "promote")
-    final_revalidation = next(
-        index
-        for index, event in enumerate(events)
-        if index > promote
-        and event[0] == "acl"
-        and event[1] == tmp_path / upgrade_migration.SNAPSHOT_NAME
-    )
-    assert staging_acl < copy < copied_file_acl < promote < final_revalidation
-
-    protected_paths = {event[1] for event in events if event[0] == "acl"}
-    assert tmp_path / upgrade_migration.SNAPSHOT_NAME / "config.toml" in protected_paths
-    assert (
-        tmp_path / upgrade_migration.SNAPSHOT_NAME / "state" / "sessions.db"
-        in protected_paths
-    )
-    assert tmp_path / upgrade_migration.SNAPSHOT_NAME / "manifest.json" in protected_paths
-    for _kind, _path, command in (event for event in events if event[0] == "acl"):
-        assert Path(command[0]).stem.casefold() in {"powershell", "pwsh"}
-        assert tuple(command[1:5]) == (
-            "-NoProfile",
-            "-NonInteractive",
-            "-NoLogo",
-            "-EncodedCommand",
-        )
-
-
-@pytest.mark.parametrize("slow_phase", ["copy", "digest"])
-def test_windows_snapshot_materialization_does_not_consume_acl_deadline(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-    slow_phase: str,
-) -> None:
-    config = tmp_path / "config.toml"
-    config.write_text('[sandbox]\nrun_mode = "trusted"\n', encoding="utf-8")
-    monkeypatch.setattr(upgrade_migration, "_running_on_windows", lambda: True)
-    monkeypatch.setattr(
-        upgrade_migration,
-        "_current_windows_user_sid",
-        lambda **_kwargs: "S-1-5-21-1234",
-    )
-    clock = [100.0]
-    monkeypatch.setattr(upgrade_migration.time, "monotonic", lambda: clock[0])
-    remaining_before_acl: list[float] = []
-
-    def protect_acl(
-        _entries: tuple[tuple[Path, bool], ...],
-        *,
-        windows_user_sid: str,
-        deadline: float | None = None,
-    ) -> None:
-        assert windows_user_sid == "S-1-5-21-1234"
-        remaining_before_acl.append(
-            upgrade_migration._remaining_windows_acl_time(deadline)
-        )
-        if len(remaining_before_acl) == 1:
-            clock[0] += 5.0
-
-    monkeypatch.setattr(
-        upgrade_migration,
-        "_protect_windows_acl_batch",
-        protect_acl,
-    )
-
-    real_copyfileobj = upgrade_migration.shutil.copyfileobj
-    real_digest = upgrade_migration._digest
-
-    def slow_copyfileobj(source: Any, destination: Any, length: int = 0) -> None:
-        clock[0] += upgrade_migration.WINDOWS_ACL_STAGE_TIMEOUT_SECONDS + 1
-        real_copyfileobj(source, destination, length)
-
-    def slow_digest(path: Path) -> str:
-        clock[0] += upgrade_migration.WINDOWS_ACL_STAGE_TIMEOUT_SECONDS + 1
-        return real_digest(path)
-
-    if slow_phase == "copy":
-        monkeypatch.setattr(
-            upgrade_migration.shutil,
-            "copyfileobj",
-            slow_copyfileobj,
-        )
-    else:
-        monkeypatch.setattr(upgrade_migration, "_digest", slow_digest)
-
-    report = SandboxUpgradeCoordinator(tmp_path).run()
-
-    assert report.ok is True
-    assert report.status == "committed"
-    assert clock[0] == 136.0
-    assert remaining_before_acl == pytest.approx([30.0, 25.0, 25.0])
-
-
-def test_windows_acl_budget_exhaustion_requires_manual_recovery(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    (tmp_path / "config.toml").write_text(
-        '[sandbox]\nrun_mode = "trusted"\n',
-        encoding="utf-8",
-    )
-    monkeypatch.setattr(upgrade_migration, "_running_on_windows", lambda: True)
-    monkeypatch.setattr(
-        upgrade_migration,
-        "_current_windows_user_sid",
-        lambda **_kwargs: "S-1-5-21-1234",
-    )
-    clock = [100.0]
-    monkeypatch.setattr(upgrade_migration.time, "monotonic", lambda: clock[0])
-    copied = False
-
-    def exhaust_acl_budget(
-        _entries: tuple[tuple[Path, bool], ...],
-        *,
-        windows_user_sid: str,
-        deadline: float | None = None,
-    ) -> None:
-        assert windows_user_sid == "S-1-5-21-1234"
-        clock[0] += upgrade_migration.WINDOWS_ACL_STAGE_TIMEOUT_SECONDS + 1
-        upgrade_migration._remaining_windows_acl_time(deadline)
-
-    def copyfileobj(_source: Any, _destination: Any, _length: int = 0) -> None:
-        nonlocal copied
-        copied = True
-
-    monkeypatch.setattr(
-        upgrade_migration,
-        "_protect_windows_acl_batch",
-        exhaust_acl_budget,
-    )
-    monkeypatch.setattr(upgrade_migration.shutil, "copyfileobj", copyfileobj)
-
-    report = SandboxUpgradeCoordinator(tmp_path).run()
-
-    assert report.ok is False
-    assert report.status == "manual_recovery_required"
-    assert report.snapshot_path is None
-    assert copied is False
-    assert "Windows ACL hardening timed out" in str(report.error)
-    journal = json.loads(
-        (tmp_path / upgrade_migration.JOURNAL_NAME).read_text(encoding="utf-8")
-    )
-    assert journal["status"] == "prepared"
-
-
-def test_committed_legacy_snapshot_is_hardened_before_success(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    snapshot = tmp_path / upgrade_migration.SNAPSHOT_NAME
-    snapshot.mkdir()
-    copied_config = snapshot / "config.toml"
-    copied_config.write_text("legacy snapshot", encoding="utf-8")
-    (tmp_path / upgrade_migration.JOURNAL_NAME).write_text(
-        json.dumps(
-            {
-                "migrationVersion": upgrade_migration.MIGRATION_VERSION,
-                "status": "committed",
-                "stores": ["config.toml"],
-            }
-        ),
-        encoding="utf-8",
-    )
-    events: list[tuple[str, Path, tuple[str, ...]]] = []
-    _mock_windows_acl(monkeypatch, events)
-
-    report = SandboxUpgradeCoordinator(tmp_path).run()
-
-    assert report.ok is True
-    protected_paths = {event[1] for event in events if event[0] == "acl"}
-    assert snapshot in protected_paths
-    assert copied_config in protected_paths
-
-
-def test_committed_legacy_snapshot_acl_failure_requires_manual_recovery(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    snapshot = tmp_path / upgrade_migration.SNAPSHOT_NAME
-    snapshot.mkdir()
-    (snapshot / "config.toml").write_text("legacy snapshot", encoding="utf-8")
-    (tmp_path / upgrade_migration.JOURNAL_NAME).write_text(
-        json.dumps(
-            {
-                "migrationVersion": upgrade_migration.MIGRATION_VERSION,
-                "status": "committed",
-                "stores": ["config.toml"],
-            }
-        ),
-        encoding="utf-8",
-    )
-    events: list[tuple[str, Path, tuple[str, ...]]] = []
-    _mock_windows_acl(
-        monkeypatch,
-        events,
-        fail_when=lambda path, _events: path == snapshot,
-    )
-
-    report = SandboxUpgradeCoordinator(tmp_path).run()
-
-    assert report.ok is False
-    assert report.status == "manual_recovery_required"
-    assert report.snapshot_path == snapshot
-    journal = json.loads((tmp_path / upgrade_migration.JOURNAL_NAME).read_text(encoding="utf-8"))
-    assert journal["status"] == "prepared"
-    assert "cannot protect upgrade snapshot path" in journal["error"]
-
-
-def test_committed_journal_without_snapshot_fails_closed(tmp_path: Path) -> None:
-    (tmp_path / upgrade_migration.JOURNAL_NAME).write_text(
-        json.dumps(
-            {
-                "migrationVersion": upgrade_migration.MIGRATION_VERSION,
-                "status": "committed",
-                "stores": ["config.toml"],
-                "snapshot": str(tmp_path / upgrade_migration.SNAPSHOT_NAME),
-            }
-        ),
-        encoding="utf-8",
-    )
-
-    report = SandboxUpgradeCoordinator(tmp_path).run()
-
-    assert report.ok is False
-    assert report.status == "manual_recovery_required"
-    assert "committed sandbox upgrade snapshot is missing" in str(report.error)
-    journal = json.loads(
-        (tmp_path / upgrade_migration.JOURNAL_NAME).read_text(encoding="utf-8")
-    )
-    assert journal["status"] == "prepared"
-
-
-@pytest.mark.skipif(os.name != "nt", reason="Windows DACL smoke")
-def test_windows_private_acl_replaces_explicit_everyone_grants(tmp_path: Path) -> None:
-    directory = tmp_path / "\u4e2d\u6587\u5feb\u7167"
-    directory.mkdir()
-    file_path = directory / "config.toml"
-    file_path.write_text("sensitive", encoding="utf-8")
-    subprocess.run(
-        ["icacls", str(directory), "/grant:r", "*S-1-1-0:(OI)(CI)F", "/L"],
-        check=True,
-        capture_output=True,
-    )
-    subprocess.run(
-        ["icacls", str(file_path), "/grant:r", "*S-1-1-0:F", "/L"],
-        check=True,
-        capture_output=True,
-    )
-    user_sid = upgrade_migration._current_windows_user_sid()
-
-    upgrade_migration._protect_private_path(
-        directory,
-        directory=True,
-        windows_user_sid=user_sid,
-    )
-    upgrade_migration._protect_private_path(
-        file_path,
-        directory=False,
-        windows_user_sid=user_sid,
-    )
-
-    verifier = r"""
-$ErrorActionPreference = "Stop"
-$target = $env:OPENSQUILLA_TEST_ACL_TARGET
-$attributes = [System.IO.File]::GetAttributes($target)
-$isDirectory = ($attributes -band [System.IO.FileAttributes]::Directory) -ne 0
-$acl = if ($isDirectory) {
-    [System.IO.Directory]::GetAccessControl($target)
-} else {
-    [System.IO.File]::GetAccessControl($target)
-}
-$sids = @($acl.Access | ForEach-Object {
-    $_.IdentityReference.Translate(
-        [System.Security.Principal.SecurityIdentifier]
-    ).Value
-} | Sort-Object -Unique)
-[ordered]@{
-    protected = $acl.AreAccessRulesProtected
-    count = @($acl.Access).Count
-    inherited = @($acl.Access | Where-Object { $_.IsInherited }).Count
-    sids = $sids
-} | ConvertTo-Json -Compress
-"""
-    encoded = base64.b64encode(verifier.encode("utf-16-le")).decode("ascii")
-    expected_sids = sorted({user_sid, "S-1-5-18", "S-1-5-32-544"})
-    for path in (directory, file_path):
-        completed = subprocess.run(
-            [
-                "powershell",
-                "-NoProfile",
-                "-NonInteractive",
-                "-EncodedCommand",
-                encoded,
-            ],
-            env={**os.environ, "OPENSQUILLA_TEST_ACL_TARGET": str(path)},
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        verified = json.loads(completed.stdout)
-        assert verified == {
-            "protected": True,
-            "count": len(expected_sids),
-            "inherited": 0,
-            "sids": expected_sids,
-        }
-
-
-@pytest.mark.parametrize("failure_phase", ["staging", "copied_file", "final"])
-def test_windows_snapshot_acl_failure_is_fail_closed(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-    failure_phase: str,
-) -> None:
-    (tmp_path / "config.toml").write_text(
-        '[sandbox]\nrun_mode = "trusted"\n',
-        encoding="utf-8",
-    )
-    events: list[tuple[str, Path, tuple[str, ...]]] = []
-
-    def fail_when(path: Path, current: list[tuple[str, Path, tuple[str, ...]]]) -> bool:
-        promoted = any(event[0] == "promote" for event in current)
-        if failure_phase == "staging":
-            return path.name.endswith(".tmp") and len(current) == 1
-        if failure_phase == "copied_file":
-            return path.name == "config.toml" and not promoted
-        return failure_phase == "final" and path == tmp_path / upgrade_migration.SNAPSHOT_NAME
-
-    _mock_windows_acl(monkeypatch, events, fail_when=fail_when)
-    real_replace = upgrade_migration.os.replace
-
-    def replace(source: str | Path, destination: str | Path) -> None:
-        target = Path(destination)
-        if target.name == upgrade_migration.SNAPSHOT_NAME:
-            events.append(("promote", target, ()))
-        real_replace(source, destination)
-
-    monkeypatch.setattr(upgrade_migration.os, "replace", replace)
-
-    report = SandboxUpgradeCoordinator(tmp_path).run()
-
-    assert report.ok is False
-    assert report.status == "manual_recovery_required"
-    assert report.snapshot_path is None
-    assert not (tmp_path / upgrade_migration.SNAPSHOT_NAME).exists()
-    assert not list(tmp_path.glob(f".{upgrade_migration.SNAPSHOT_NAME}.*.tmp"))
-    journal = json.loads((tmp_path / upgrade_migration.JOURNAL_NAME).read_text(encoding="utf-8"))
-    assert journal["status"] == "prepared"
-    assert "cannot protect upgrade snapshot path" in journal["error"]
-
-
-def test_windows_staging_is_rechecked_empty_before_copy(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    (tmp_path / "config.toml").write_text("sensitive", encoding="utf-8")
-    events: list[tuple[str, Path, tuple[str, ...]]] = []
-    _mock_windows_acl(monkeypatch, events)
-    real_protect = upgrade_migration._protect_private_path
-    injected = False
-
-    def protect(
-        path: Path,
-        *,
-        directory: bool,
-        windows_user_sid: str | None,
-        deadline: float | None = None,
-    ) -> None:
-        nonlocal injected
-        real_protect(
-            path,
-            directory=directory,
-            windows_user_sid=windows_user_sid,
-            deadline=deadline,
-        )
-        if directory and path.name.endswith(".tmp") and not injected:
-            (path / "unexpected").write_text("injected", encoding="utf-8")
-            injected = True
-
-    monkeypatch.setattr(upgrade_migration, "_protect_private_path", protect)
-    copied = False
-
-    def copyfileobj(_source: Any, _destination: Any, _length: int = 0) -> None:
-        nonlocal copied
-        copied = True
-
-    monkeypatch.setattr(upgrade_migration.shutil, "copyfileobj", copyfileobj)
-
-    report = SandboxUpgradeCoordinator(tmp_path).run()
-
-    assert report.ok is False
-    assert copied is False
-    assert "staging is not empty after hardening" in str(report.error)
-    assert not list(tmp_path.glob(f".{upgrade_migration.SNAPSHOT_NAME}.*.tmp"))
-
-
-def test_windows_snapshot_cleanup_failure_is_reported(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    (tmp_path / "config.toml").write_text("sensitive", encoding="utf-8")
-    events: list[tuple[str, Path, tuple[str, ...]]] = []
-
-    def fail_final(path: Path, current: list[tuple[str, Path, tuple[str, ...]]]) -> bool:
-        return (
-            any(event[0] == "promote" for event in current)
-            and path == tmp_path / upgrade_migration.SNAPSHOT_NAME
-        )
-
-    _mock_windows_acl(monkeypatch, events, fail_when=fail_final)
-    real_replace = upgrade_migration.os.replace
-
-    def replace(source: str | Path, destination: str | Path) -> None:
-        target = Path(destination)
-        if target.name == upgrade_migration.SNAPSHOT_NAME:
-            events.append(("promote", target, ()))
-        real_replace(source, destination)
-
-    monkeypatch.setattr(upgrade_migration.os, "replace", replace)
-
-    def refuse_cleanup(_path: Path) -> None:
-        raise OSError("cleanup denied")
-
-    monkeypatch.setattr(upgrade_migration.shutil, "rmtree", refuse_cleanup)
-
-    report = SandboxUpgradeCoordinator(tmp_path).run()
-
-    assert report.ok is False
-    assert report.status == "manual_recovery_required"
-    assert "upgrade snapshot failed and cleanup failed" in str(report.error)
+    block_start = source.index("# Best-effort normalization of released sandbox spellings")
+    block_end = source.index("# ── Sandbox runtime", block_start)
+    migration_block = source[block_start:block_end]
+
+    assert "migration_failed_manual_recovery_required" not in migration_block
+    assert "raise RuntimeError" not in migration_block
+    assert "log.warning" in migration_block
+    assert "upgrade_report.ok and not upgrade_report.error" in migration_block
+
+
+def test_atomic_writer_is_platform_neutral() -> None:
+    source = inspect.getsource(upgrade_migration._atomic_write)
+
+    assert "tempfile.mkstemp" in source
+    assert "os.fsync" in source
+    assert "os.replace" in source
+    assert "os.name" not in source

--- a/tests/test_recovery/test_recovery_cmd.py
+++ b/tests/test_recovery/test_recovery_cmd.py
@@ -205,6 +205,33 @@ def test_inspect_command_emits_fixed_json_protocol(tmp_path: Path) -> None:
     assert payload["effective_workspace"] == str(workspace)
 
 
+def test_sandbox_upgrade_status_treats_missing_snapshot_as_non_blocking(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "opensquilla"
+    home.mkdir()
+    (home / "config.toml").write_text(
+        '[sandbox]\nrun_mode = "safe"\n',
+        encoding="utf-8",
+    )
+    (home / ".sandbox-upgrade-v2.json").write_text(
+        json.dumps({"migrationVersion": 2, "status": "committed"}),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        recovery_app,
+        ["sandbox-upgrade-status", "--home", str(home), "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["status"] == "legacy_artifacts_present"
+    assert payload["snapshotPath"] is None
+    assert payload["error"] is None
+
+
 def test_recover_config_command_repairs_corrupt_config_over_json_protocol(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_recovery/test_sandbox_upgrade_journal.py
+++ b/tests/test_recovery/test_sandbox_upgrade_journal.py
@@ -38,9 +38,11 @@ def test_interrupted_prepared_journal_retries_to_commit(tmp_path: Path) -> None:
     assert report.ok is True
     assert report.status == "committed"
     assert inspect_sandbox_upgrade(tmp_path).ok is True
+    assert not coordinator.snapshot_path.exists()
+    assert not coordinator.journal_path.exists()
 
 
-def test_invalid_journal_requires_manual_recovery_without_rollback(
+def test_invalid_legacy_journal_is_reported_as_non_blocking_artifact(
     tmp_path: Path,
 ) -> None:
     journal = tmp_path / ".sandbox-upgrade-v2.json"
@@ -48,8 +50,8 @@ def test_invalid_journal_requires_manual_recovery_without_rollback(
 
     report = inspect_sandbox_upgrade(tmp_path)
 
-    assert report.ok is False
-    assert report.status == "manual_recovery_required"
+    assert report.ok is True
+    assert report.status == "legacy_artifacts_present"
     assert journal.exists()
 
 
@@ -69,7 +71,12 @@ def test_concurrent_direct_update_migrations_serialize_on_profile_lock(
             )
         )
 
-    assert all(report.ok and report.status == "committed" for report in reports)
+    assert {report.status for report in reports} <= {
+        "committed",
+        "not_required",
+        "retry_required",
+    }
+    assert any(report.ok for report in reports)
     assert 'run_mode = "safe"' in (tmp_path / "config.toml").read_text(
         encoding="utf-8"
     )


### PR DESCRIPTION
## Scope

Scope boundary: Simplify the released Sandbox upgrade migration so it only normalizes legacy RunMode configuration and never blocks Gateway startup.

Non-goals: This PR does not redesign global versus session RunMode semantics and does not change sandbox runtime selection.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Refs #1439, #1440

If None, reason: N/A

## Release Note

Release note: Sandbox upgrade normalization no longer requires PowerShell or ACL rewriting, no longer creates snapshots or backs up sessions.db, and no longer blocks Gateway startup when files are locked.

## Tests

Ruff: passed locally and in CI

Pytest: focused local suite: 284 passed, 2 skipped; CI targeted suite: 10949 passed, 149 skipped, 35 deselected

Build: CI frontend artifact and cross-platform recovery jobs passed

Regression tests: added

Notes: Added coverage for missing PowerShell assumptions, residual process locks, atomic replacement failure, idempotent reruns, old prepared/committed artifacts, and non-blocking Gateway startup. Router E2E now explicitly skips in targeted checkouts where Git LFS model assets are not hydrated; full CI with hydrated assets continues to run it. The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: gateway

Maintainer-only note: No credentialed live check is required.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents must not be committed.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.