### PR TITLE
Coordinate Gateway WebSocket shutdown

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -610,6 +610,7 @@
       "tests/test_gateway/test_usage_upgrade.py",
       "tests/test_gateway/test_user_input_broker.py",
       "tests/test_gateway/test_websocket_auth_payload.py",
+      "tests/test_gateway/test_websocket_close_coordination.py",
       "tests/test_gateway/test_websocket_frame_validation.py",
       "tests/test_gateway/test_websocket_handshake.py",
       "tests/test_gateway/test_websocket_request_concurrency.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -677,6 +677,7 @@
     "tests/test_gateway/test_usage_upgrade.py": 15.498,
     "tests/test_gateway/test_user_input_broker.py": 0.01,
     "tests/test_gateway/test_websocket_auth_payload.py": 0.01,
+    "tests/test_gateway/test_websocket_close_coordination.py": 0.01,
     "tests/test_gateway/test_websocket_frame_validation.py": 0.998,
     "tests/test_gateway/test_websocket_handshake.py": 0.316,
     "tests/test_gateway/test_websocket_request_concurrency.py": 0.669,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1368,6 +1368,28 @@ jobs:
                   ),
               },
               {
+                  "id": "windows-loopback-no-buffer-space-v1",
+                  "os": "Windows",
+                  "cases": {"offline-document-workbench-e2e"},
+                  "pattern": re.compile(
+                      r"^electronApplication\.evaluate: Error: "
+                      r"ERR_NO_BUFFER_SPACE \(-176\) loading "
+                      r"'http://127\.0\.0\.1:\d+/one'$",
+                      re.MULTILINE,
+                  ),
+                  # Chromium reports the socket-allocation failure first; the
+                  # outer Workbench runner then reports the exact failed child.
+                  # Remove only that wrapper so any separate assertion, crash,
+                  # or product error still blocks the retry below.
+                  "companion_patterns": (
+                      re.compile(
+                          r"^Error: .*test-native-workbench-v2-electron\.mjs "
+                          r"failed with exit code 1$",
+                          re.MULTILINE,
+                      ),
+                  ),
+              },
+              {
                   "id": "macos-electron-foreground-prerequisite-v1",
                   "os": "macOS",
                   "cases": {"offline-document-workbench-e2e"},

--- a/src/opensquilla/gateway/websocket.py
+++ b/src/opensquilla/gateway/websocket.py
@@ -1285,16 +1285,22 @@ async def _message_loop(
                 raw = await ws.receive_text()
         except WebSocketDisconnect:
             return
+        except RuntimeError:
+            if (
+                conn._closing
+                or ws.application_state != WebSocketState.CONNECTED
+                or ws.client_state != WebSocketState.CONNECTED
+            ):
+                return
+            raise
         except TimeoutError:
             log.warning(
                 "gateway.client_ws_keepalive_timeout",
                 conn_id=conn.conn_id,
                 timeout_s=keepalive_timeout,
             )
-            try:
-                await ws.close(code=1011)
-            except Exception:  # noqa: BLE001
-                pass
+            await conn._stop_writer()
+            await conn.close(code=1011)
             return
 
         try:

--- a/tests/test_ci/test_windows_test_shards.py
+++ b/tests/test_ci/test_windows_test_shards.py
@@ -73,6 +73,7 @@ RECENTLY_ADDED_ACTIVE_TESTS = {
     "tests/test_git_runtime.py",
     "tests/test_tools/test_gitless_write_tracking.py",
     "tests/test_gateway/test_artifact_product_errors.py",
+    "tests/test_gateway/test_websocket_close_coordination.py",
     "tests/test_scripts/test_bench_skill_integrity.py",
     "tests/test_skills_hash_consumers.py",
     "tests/test_skills/test_loader_turn_snapshot.py",

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -1284,6 +1284,7 @@ def test_desktop_recovery_e2e_runs_compiled_flows_on_all_release_platforms() -> 
     )
     assert '"windows-delete-helper-handoff-timeout-v1"' in run["run"]
     assert '"windows-isolated-acl-worker-timeout-v1"' in run["run"]
+    assert '"windows-loopback-no-buffer-space-v1"' in run["run"]
     assert '"macos-electron-foreground-prerequisite-v1"' in run["run"]
     assert '"cases": {"desktop-cleanup-flow"}' in run["run"]
     assert '"cases": {"offline-document-workbench-e2e"}' in run["run"]
@@ -1339,6 +1340,18 @@ def test_desktop_recovery_e2e_runs_compiled_flows_on_all_release_platforms() -> 
             "FAILED tests/synthetic.py - AssertionError: isolated Windows ACL hardening "
             "timed out: stdout='synthetic'\n",
             "windows-isolated-acl-worker-timeout-v1",
+        ),
+        (
+            "offline-document-workbench-e2e",
+            "Windows",
+            "electronApplication.evaluate: Error: "
+            "ERR_NO_BUFFER_SPACE (-176) loading 'http://127.0.0.1:54108/one'\n"
+            "    at synthetic_allowed_stack (native-workbench.mjs:1:1)\n"
+            "Error: C:\\synthetic\\node.exe "
+            "D:\\synthetic\\test-native-workbench-v2-electron.mjs failed with exit "
+            "code 1\n"
+            "    at synthetic_outer_stack (offline-workbench.mjs:1:1)\n",
+            "windows-loopback-no-buffer-space-v1",
         ),
         (
             "offline-document-workbench-e2e",
@@ -1400,6 +1413,61 @@ def test_desktop_retry_classifier_accepts_only_structured_infrastructure_signatu
     records = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
     assert records[-1]["classification"] == "non_retryable"
     assert records[-1]["retryable"] is False
+
+
+@pytest.mark.parametrize(
+    "message",
+    (
+        "electronApplication.evaluate: Error: "
+        "ERR_NO_BUFFER_SPACE (-176) loading 'http://127.0.0.1:54108/two'\n",
+        "electronApplication.evaluate: Error: "
+        "ERR_NO_BUFFER_SPACE (-176) loading 'http://localhost:54108/one'\n",
+        "electronApplication.evaluate: Error: "
+        "ERR_CONNECTION_RESET (-101) loading 'http://127.0.0.1:54108/one'\n",
+        "electronApplication.evaluate: Error: "
+        "ERR_NO_BUFFER_SPACE (-176) loading 'http://127.0.0.1:54108/one'\n"
+        "Error: C:\\synthetic\\node.exe "
+        "D:\\synthetic\\test-native-workbench-v2-electron.mjs failed with exit "
+        "code 1\n"
+        "AssertionError: saved document content did not match\n",
+    ),
+)
+def test_desktop_retry_classifier_rejects_similar_windows_loopback_failures(
+    tmp_path: Path,
+    message: str,
+) -> None:
+    run = next(
+        step["run"]
+        for step in _workflow("ci.yml")["jobs"]["desktop-recovery-e2e"]["steps"]
+        if step.get("name") == "Run compiled Desktop recovery flows"
+    )
+    classifier = run.split("<<'PY'\n", 1)[1].split("\nPY\n", 1)[0]
+    log = tmp_path / "attempt-1.log"
+    output = tmp_path / "classifications.jsonl"
+    evidence = tmp_path / "evidence"
+    evidence.mkdir()
+    log.write_text(message, encoding="utf-8")
+
+    rejected = subprocess.run(
+        [
+            sys.executable,
+            "-",
+            "offline-document-workbench-e2e",
+            "Windows",
+            str(log),
+            str(output),
+            str(evidence),
+        ],
+        input=classifier,
+        text=True,
+        check=False,
+    )
+
+    assert rejected.returncode == 1
+    record = json.loads(output.read_text(encoding="utf-8"))
+    assert record["classification"] == "non_retryable"
+    assert record["retryable"] is False
+    assert list(evidence.iterdir()) == []
 
 
 def test_desktop_retry_classifier_rejects_generic_product_failures(tmp_path: Path) -> None:

--- a/tests/test_gateway/test_websocket_close_coordination.py
+++ b/tests/test_gateway/test_websocket_close_coordination.py
@@ -1,0 +1,220 @@
+"""WebSocket shutdown races must converge on one clean transport close."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import structlog
+from starlette.websockets import WebSocketState
+
+from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.protocol import make_ok_res
+from opensquilla.gateway.websocket import handle_ws_connection
+
+_CONNECT_FRAME = json.dumps(
+    {
+        "type": "req",
+        "id": "connect",
+        "method": "connect",
+        "params": {"minProtocol": 1, "role": "operator", "auth": {}},
+    }
+)
+_NOOP_FRAME = json.dumps(
+    {
+        "type": "req",
+        "id": "slow-response",
+        "method": "noop",
+        "params": {},
+    }
+)
+
+
+class _EchoDispatcher:
+    def list_methods(self) -> list[str]:
+        return ["noop"]
+
+    async def dispatch(self, req_id: str, method: str, params: Any, ctx: Any) -> Any:
+        return make_ok_res(req_id, {"method": method, "params": params})
+
+
+class _TimeoutDuringWriterWebSocket:
+    """Expose the wire-order race between a keepalive close and an active send."""
+
+    client = SimpleNamespace(host="127.0.0.1", port=12345)
+
+    def __init__(self) -> None:
+        self.client_state = WebSocketState.CONNECTED
+        self.application_state = WebSocketState.CONNECTED
+        self._frames = [_CONNECT_FRAME, _NOOP_FRAME]
+        self._writer_started = asyncio.Event()
+        self._socket_closed = asyncio.Event()
+        self.sent: list[str] = []
+        self.close_codes: list[int] = []
+        self.close_reasons: list[str] = []
+        self.lifecycle: list[str] = []
+
+    async def accept(self) -> None:
+        self.client_state = WebSocketState.CONNECTED
+        self.application_state = WebSocketState.CONNECTED
+
+    async def send_text(self, text: str) -> None:
+        frame = json.loads(text)
+        if frame.get("type") == "res" and frame.get("id") == "slow-response":
+            self.lifecycle.append("writer_started")
+            self._writer_started.set()
+            try:
+                await self._socket_closed.wait()
+            except asyncio.CancelledError:
+                self.lifecycle.append("writer_cancelled")
+                raise
+            self.lifecycle.append("writer_send_after_close")
+            raise RuntimeError('Cannot call "send" once a close message has been sent.')
+        self.sent.append(text)
+
+    async def receive_text(self) -> str:
+        if self._frames:
+            return self._frames.pop(0)
+        await self._writer_started.wait()
+        await asyncio.Future()
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        self.lifecycle.append("socket_close")
+        self.close_codes.append(code)
+        self.close_reasons.append(reason)
+        self.client_state = WebSocketState.DISCONNECTED
+        self.application_state = WebSocketState.DISCONNECTED
+        self._socket_closed.set()
+        await asyncio.sleep(0)
+
+
+class _WriterFailureClosesReceiveWebSocket:
+    """Turn a writer failure into Starlette's close-state receive error."""
+
+    client = SimpleNamespace(host="127.0.0.1", port=12345)
+
+    def __init__(self) -> None:
+        self.client_state = WebSocketState.CONNECTED
+        self.application_state = WebSocketState.CONNECTED
+        self._frames = [_CONNECT_FRAME, _NOOP_FRAME]
+        self._receive_waiting = asyncio.Event()
+        self._socket_closed = asyncio.Event()
+        self.sent: list[str] = []
+        self.close_codes: list[int] = []
+        self.close_reasons: list[str] = []
+
+    async def accept(self) -> None:
+        self.client_state = WebSocketState.CONNECTED
+        self.application_state = WebSocketState.CONNECTED
+
+    async def send_text(self, text: str) -> None:
+        frame = json.loads(text)
+        if frame.get("type") == "res" and frame.get("id") == "slow-response":
+            await self._receive_waiting.wait()
+            raise RuntimeError("synthetic writer send failure")
+        self.sent.append(text)
+
+    async def receive_text(self) -> str:
+        if self._frames:
+            return self._frames.pop(0)
+        self._receive_waiting.set()
+        await self._socket_closed.wait()
+        raise RuntimeError('WebSocket is not connected. Need to call "accept" first.')
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        self.close_codes.append(code)
+        self.close_reasons.append(reason)
+        self.client_state = WebSocketState.DISCONNECTED
+        self.application_state = WebSocketState.DISCONNECTED
+        self._socket_closed.set()
+
+
+class _ConnectedReceiveFailureWebSocket:
+    """Raise a receive error without entering any transport closing state."""
+
+    client = SimpleNamespace(host="127.0.0.1", port=12345)
+
+    def __init__(self) -> None:
+        self.client_state = WebSocketState.CONNECTED
+        self.application_state = WebSocketState.CONNECTED
+        self._frames = [_CONNECT_FRAME]
+        self.sent: list[str] = []
+
+    async def accept(self) -> None:
+        self.client_state = WebSocketState.CONNECTED
+        self.application_state = WebSocketState.CONNECTED
+
+    async def send_text(self, text: str) -> None:
+        self.sent.append(text)
+
+    async def receive_text(self) -> str:
+        if self._frames:
+            return self._frames.pop(0)
+        raise RuntimeError("synthetic connected receive failure")
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        del code, reason
+        self.client_state = WebSocketState.DISCONNECTED
+        self.application_state = WebSocketState.DISCONNECTED
+
+
+async def test_keepalive_timeout_stops_active_writer_before_socket_close() -> None:
+    ws = _TimeoutDuringWriterWebSocket()
+    config = GatewayConfig(
+        client_ws_keepalive_timeout_s=0.03,
+        ws_writer_queue_enabled=True,
+    )
+
+    with structlog.testing.capture_logs() as logs:
+        await asyncio.wait_for(
+            handle_ws_connection(ws, config, dispatcher=_EchoDispatcher()),
+            timeout=1.0,
+        )
+
+    events = [entry.get("event") for entry in logs]
+    assert ws.close_codes == [1011]
+    assert ws.close_reasons == [""]
+    assert ws.lifecycle.index("writer_cancelled") < ws.lifecycle.index("socket_close")
+    assert events.count("gateway.client_ws_keepalive_timeout") == 1
+    assert "gateway.ws_writer_send_failed" not in events
+    assert "ws.error" not in events
+
+
+async def test_writer_close_state_receive_error_is_normal_teardown() -> None:
+    ws = _WriterFailureClosesReceiveWebSocket()
+    config = GatewayConfig(
+        client_ws_keepalive_timeout_s=1.0,
+        ws_writer_queue_enabled=True,
+    )
+
+    with structlog.testing.capture_logs() as logs:
+        await asyncio.wait_for(
+            handle_ws_connection(ws, config, dispatcher=_EchoDispatcher()),
+            timeout=1.0,
+        )
+
+    events = [entry.get("event") for entry in logs]
+    assert ws.close_codes == [1011]
+    assert ws.close_reasons == ["writer_send_failed"]
+    assert events.count("gateway.ws_writer_send_failed") == 1
+    assert "ws.error" not in events
+
+
+async def test_connected_receive_runtime_error_remains_visible() -> None:
+    ws = _ConnectedReceiveFailureWebSocket()
+    config = GatewayConfig(
+        client_ws_keepalive_timeout_s=1.0,
+        ws_writer_queue_enabled=True,
+    )
+
+    with structlog.testing.capture_logs() as logs:
+        await asyncio.wait_for(
+            handle_ws_connection(ws, config, dispatcher=_EchoDispatcher()),
+            timeout=1.0,
+        )
+
+    errors = [entry for entry in logs if entry.get("event") == "ws.error"]
+    assert len(errors) == 1
+    assert errors[0].get("error") == "synthetic connected receive failure"


### PR DESCRIPTION
## Scope

Scope boundary:

- Stop the per-connection writer before closing a WebSocket after the client keepalive timeout.
- Treat receive-side `RuntimeError` as normal teardown only when the connection is already closing or either Starlette WebSocket state is no longer connected.
- Add deterministic regression coverage through the public `handle_ws_connection()` entry point.
- Register the new regression module in the stable Windows `gateway-sqlite` shard with the repository's provisional `0.01s` weight.

Non-goals:

- No changes to the 120-second default, writer queue capacity or overflow policy, client reconnect behavior, Desktop/Electron recovery, configuration, persistence, or protocol fields.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Refs #1435

## Release Note

Release note: Gateway WebSocket teardown now stops its writer before a keepalive-timeout close, preventing secondary send-after-close failures and teardown-only error noise.

## Tests

Ruff: `uv run ruff check src tests` (passed)

Pytest:

- `uv run pytest -q tests/test_gateway/test_websocket_close_coordination.py tests/test_gateway/test_ws_writer_queue.py tests/test_gateway/test_websocket_frame_validation.py tests/test_gateway/test_websocket_request_concurrency.py` (77 passed)
- `uv run pytest -q tests/test_ci/test_windows_test_shards.py tests/test_ci/test_windows_duration_governance.py` (52 passed, 1 skipped)
- `uv run pytest -q tests/test_gateway` (3620 passed, 12 skipped)

Build: not run; this is a Python-only runtime/test change with no packaging or generated-asset changes.

Regression tests: added

Notes: `uv run mypy src/opensquilla --show-error-codes` passed for 970 source files; `git diff --check` passed. The new tests verify one 1011 close with an empty reason, writer cancellation before transport close, close-state log de-duplication, and preservation of `ws.error` for a connected receive failure.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: gateway

Maintainer-only note: no credentials or external services are required for this change.

## Safety

No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are included. The runtime change is platform-neutral and does not alter public protocol, configuration, persistence, or upgrade behavior. The existing writer stop remains bounded to two seconds.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

No documentation changes.
