### PR TITLE
Stop retrying rate limits on the same deployment

### DIFF
--- a/scripts/live_long_task_case_driver.py
+++ b/scripts/live_long_task_case_driver.py
@@ -1696,19 +1696,6 @@ def _run_rpc_case(
     counts["compactions"] = observation.compactions
     if case.scenario == "router":
         counts["router_decisions"] = asyncio.run(_router_decision_count(gateway, session_key))
-    if case.scenario == "fault_429_retry_after" and proxy is not None:
-        records_snapshot = proxy.records
-        if len(records_snapshot) >= 2:
-            retry_wait_ms = max(
-                0.0,
-                (
-                    records_snapshot[1].received_monotonic_ns
-                    - records_snapshot[0].received_monotonic_ns
-                )
-                / 1_000_000,
-            )
-            metrics["retry_wait_ms"] = retry_wait_ms
-            counts["retry_after_honored"] = int(retry_wait_ms >= 8_000)
     if case.scenario == "fallback":
         assert case.fallback_provider is not None
         counts["fallback_before_request"] = int(
@@ -1738,12 +1725,22 @@ def _run_rpc_case(
     )
 
     partial_terminal_is_expected = case.scenario == "fault_partial_then_reset"
+    rate_limit_terminal_is_expected = (
+        case.scenario == "fault_429_retry_after"
+        and observation.terminal_event == "session.event.error"
+        and physical_requests == 1
+        and _failure_class_from_records(records) == "rate-limit"
+    )
     passed = observation.completed or (
         partial_terminal_is_expected
         and bool(observation.terminal_event)
         and observation.text_chunks > 0
-    )
-    if not partial_terminal_is_expected and assistant_markers < 1:
+    ) or rate_limit_terminal_is_expected
+    if (
+        not partial_terminal_is_expected
+        and not rate_limit_terminal_is_expected
+        and assistant_markers < 1
+    ):
         passed = False
     if case.scenario == "tool_compaction" and observation.compactions < 1:
         passed = False

--- a/scripts/live_long_task_release_gate.py
+++ b/scripts/live_long_task_release_gate.py
@@ -268,7 +268,7 @@ _MINIMUM_PHYSICAL_REQUESTS: Final[dict[str, int]] = {
     # manual compaction performs one additional summarization request.
     "tool_compaction": 3,
     "long_answer": 1,
-    "fault_429_retry_after": 2,
+    "fault_429_retry_after": 1,
     "fault_503": 2,
     "fault_reset_before_first_token": 2,
     "fault_partial_then_reset": 2,
@@ -664,9 +664,10 @@ def validate_scenario_evidence(case: CaseSpec, result: DriverResult) -> None:
         if dom_nodes is None or int(dom_nodes) > 15_000:
             raise ValueError("scenario evidence requires counts.dom_nodes <= 15000")
     elif scenario == "fault_429_retry_after":
-        _require_count(result, "retry_legs")
-        _require_count(result, "retry_after_honored")
-        _require_metric_at_least(result, "retry_wait_ms", 8_000)
+        if result.physical_requests != 1:
+            raise ValueError("rate-limit scenario must not retry the same deployment")
+        if int(result.counts.get("retry_legs", 0)) != 0:
+            raise ValueError("rate-limit scenario must report zero retry legs")
     elif scenario in {"fault_503", "fault_reset_before_first_token"}:
         _require_count(result, "retry_legs")
     elif scenario == "fault_partial_then_reset":

--- a/src/opensquilla/engine/fallback.py
+++ b/src/opensquilla/engine/fallback.py
@@ -15,7 +15,6 @@ from opensquilla.provider.failures import ProviderFailureKind, classify_provider
 
 _RETRYABLE_FAILURE_KINDS = frozenset(
     {
-        ProviderFailureKind.RATE_LIMITED,
         ProviderFailureKind.PROVIDER_OVERLOADED,
         ProviderFailureKind.TRANSPORT_TRANSIENT,
         ProviderFailureKind.CONTEXT_OVERFLOW,

--- a/tests/test_engine/test_provider_activity.py
+++ b/tests/test_engine/test_provider_activity.py
@@ -173,12 +173,49 @@ def test_selector_buffer_coalesces_tool_deltas_and_rejects_oversized_content() -
 
 
 @pytest.mark.asyncio
-async def test_agent_emits_structured_activity_and_honors_retry_after(
+async def test_agent_surfaces_rate_limit_without_same_deployment_retry_or_sleep(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     provider = _SequenceProvider(
         [
             [ErrorEvent(message="synthetic rate limit", code="429", retry_after_s=8.0)],
+            [TextDeltaEvent(text="ok"), DoneEvent(stop_reason="stop")],
+        ]
+    )
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr("opensquilla.engine.agent.asyncio.sleep", fake_sleep)
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            max_provider_retries=1,
+            retry_base_backoff_ms=1_000,
+            retry_max_backoff_ms=1_000,
+        ),
+    )
+
+    events = [event async for event in agent.run_turn("hello")]
+    activity = [event for event in events if isinstance(event, ProviderActivityEvent)]
+
+    terminal = next(event for event in events if isinstance(event, EngineErrorEvent))
+    assert provider.calls == 1
+    assert sleeps == []
+    assert not any(event.phase in {"retry_wait", "retrying"} for event in activity)
+    assert terminal.code == "429"
+    assert terminal.failure_kind == ProviderFailureKind.RATE_LIMITED.value
+    assert not any("synthetic rate limit" in repr(event) for event in activity)
+
+
+@pytest.mark.asyncio
+async def test_agent_retries_same_deployment_provider_overload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _SequenceProvider(
+        [
+            [ErrorEvent(message="synthetic overload", code="503", retry_after_s=8.0)],
             [TextDeltaEvent(text="ok"), DoneEvent(stop_reason="stop")],
         ]
     )
@@ -208,9 +245,9 @@ async def test_agent_emits_structured_activity_and_honors_retry_after(
         "retrying",
         "requesting",
     ]
-    assert activity[1].reason == "rate_limited"
+    assert activity[1].reason == ProviderFailureKind.PROVIDER_OVERLOADED.value
     assert activity[1].retry_after_ms == 8_000
-    assert not any("synthetic rate limit" in repr(event) for event in activity)
+    assert not any("synthetic overload" in repr(event) for event in activity)
 
 
 @pytest.mark.asyncio
@@ -262,7 +299,7 @@ async def test_retry_after_that_exceeds_turn_deadline_does_not_retry_early(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     provider = _SequenceProvider(
-        [[ErrorEvent(message="synthetic rate limit", code="429", retry_after_s=8.0)]]
+        [[ErrorEvent(message="synthetic overload", code="503", retry_after_s=8.0)]]
     )
     sleeps: list[float] = []
 
@@ -289,7 +326,7 @@ async def test_retry_after_that_exceeds_turn_deadline_does_not_retry_early(
         and event.phase in {"retry_wait", "retrying"}
         for event in events
     )
-    assert any(isinstance(event, EngineErrorEvent) and event.code == "429" for event in events)
+    assert any(isinstance(event, EngineErrorEvent) and event.code == "503" for event in events)
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_long_task_case_driver.py
+++ b/tests/test_live_long_task_case_driver.py
@@ -987,9 +987,10 @@ def test_fault_429_case_proves_retry_after_was_not_violated(
     result, exit_code = driver.execute_case(case)
 
     assert exit_code == driver.EXIT_PASSED
-    assert result["metrics"]["retry_wait_ms"] >= 8_000
-    assert result["counts"]["retry_after_honored"] == 1
-    assert result["counts"]["accounted_provider_legs"] == 2
+    assert result["status"] == "passed"
+    assert result["physical_requests"] == 1
+    assert result["counts"]["retry_legs"] == 0
+    assert result["counts"]["accounted_provider_legs"] == 1
 
 
 @pytest.mark.ci_serial

--- a/tests/test_live_long_task_release_gate.py
+++ b/tests/test_live_long_task_release_gate.py
@@ -111,8 +111,8 @@ def test_mandatory_matrix_has_fixed_provider_model_and_repeat_coverage() -> None
             if case.scenario not in {"fault_429_retry_after", "fault_reset_before_first_token"}
         )
 
-    assert gate.minimum_physical_requests(cases) == 117
-    assert gate.BudgetLimits().physical_requests - gate.minimum_physical_requests(cases) == 3
+    assert gate.minimum_physical_requests(cases) == 111
+    assert gate.BudgetLimits().physical_requests - gate.minimum_physical_requests(cases) == 9
 
 
 def test_repeat_override_applies_to_each_selected_matrix_row() -> None:

--- a/tests/test_provider/test_failure_injection.py
+++ b/tests/test_provider/test_failure_injection.py
@@ -80,7 +80,7 @@ async def test_retryable_failures_then_success_drives_each_retry_hop() -> None:
     provider = _FakeProvider()
     injector = FailureInjector(
         script=[
-            ProviderFailureKind.RATE_LIMITED,
+            ProviderFailureKind.TRANSPORT_TRANSIENT,
             ProviderFailureKind.PROVIDER_OVERLOADED,
             "succeed",
         ]
@@ -96,13 +96,13 @@ async def test_retryable_failures_then_success_drives_each_retry_hop() -> None:
     assert done.text == "ok"
     assert len(provider.calls) == 1  # only the "succeed" outcome reached it
     assert injector.consumed == [
-        ProviderFailureKind.RATE_LIMITED,
+        ProviderFailureKind.TRANSPORT_TRANSIENT,
         ProviderFailureKind.PROVIDER_OVERLOADED,
         "succeed",
     ]
     retry_logs = [entry for entry in captured if entry.get("event") == "provider.retry"]
     assert [entry["kind"] for entry in retry_logs] == [
-        ProviderFailureKind.RATE_LIMITED.value,
+        ProviderFailureKind.TRANSPORT_TRANSIENT.value,
         ProviderFailureKind.PROVIDER_OVERLOADED.value,
     ]
 
@@ -113,7 +113,7 @@ async def test_exhausted_script_delegates_every_further_call() -> None:
     assert injector.consumed == []
 
     provider = _FakeProvider()
-    agent = _agent(provider, FailureInjector(script=[ProviderFailureKind.RATE_LIMITED]))
+    agent = _agent(provider, FailureInjector(script=[ProviderFailureKind.TRANSPORT_TRANSIENT]))
 
     events = [event async for event in agent.run_turn("hello")]
 
@@ -144,19 +144,19 @@ async def test_auth_invalid_surfaces_without_retry() -> None:
     assert not any(entry.get("event") == "provider.retry" for entry in captured)
 
 
-async def test_retry_exhaustion_surfaces_terminal_error() -> None:
+async def test_rate_limit_surfaces_without_same_deployment_retry() -> None:
     provider = _FakeProvider()
-    injector = FailureInjector(
-        script=[ProviderFailureKind.RATE_LIMITED, ProviderFailureKind.RATE_LIMITED]
-    )
-    agent = _agent(provider, injector, max_provider_retries=1)
+    injector = FailureInjector(script=[ProviderFailureKind.RATE_LIMITED, "succeed"])
+    agent = _agent(provider, injector, max_provider_retries=3)
 
-    events = [event async for event in agent.run_turn("hello")]
+    with structlog.testing.capture_logs() as captured:
+        events = [event async for event in agent.run_turn("hello")]
 
     error = next(event for event in events if event.kind == "error")
     assert error.code == "429"
     assert provider.calls == []
-    assert len(injector.consumed) == 2
+    assert injector.consumed == [ProviderFailureKind.RATE_LIMITED]
+    assert not any(entry.get("event") == "provider.retry" for entry in captured)
 
 
 # ---------------------------------------------------------------------------
@@ -181,16 +181,17 @@ def test_injected_kinds_map_to_rotation_decisions() -> None:
     )
 
 
-def test_fallback_model_rotation_order_after_exhaustion() -> None:
+def test_retry_classification_and_fallback_model_rotation_order() -> None:
     from opensquilla.engine.fallback import FallbackPolicy
 
     policy = FallbackPolicy(
         max_retries=1,
         fallback_models=["model-primary", "model-fb-1", "model-fb-2"],
     )
-    # Retry budget exhausts...
-    assert policy.should_retry(ProviderFailureKind.RATE_LIMITED, 0) is True
-    assert policy.should_retry(ProviderFailureKind.RATE_LIMITED, 1) is False
+    # Rate limits bypass same-deployment retries; transient overloads retain them.
+    assert policy.should_retry(ProviderFailureKind.RATE_LIMITED, 0) is False
+    assert policy.should_retry(ProviderFailureKind.PROVIDER_OVERLOADED, 0) is True
+    assert policy.should_retry(ProviderFailureKind.PROVIDER_OVERLOADED, 1) is False
     # ...then the fallback chain rotates in declared order and terminates.
     assert policy.get_fallback_model("model-primary") == "model-fb-1"
     assert policy.get_fallback_model("model-fb-1") == "model-fb-2"


### PR DESCRIPTION
## Scope

- Remove rate-limited failures from same-deployment Agent retries.
- Keep selector fallback, Retry-After handling between fallback authorities, and transient 503 retries unchanged.
- Preserve the original 429 terminal failure when no fallback exists.

Branch target: main
Linked issue: None (tracked as Feishu P1-26)
Release note: Yes — direct requests now surface an exhausted rate limit without replaying the same deployment.

## Tests

- 235 related provider, fallback, Retry-After, and Agent tests passed.
- Ruff passed.
- Cross-review found no blocking issues.

## Safety and compatibility

- Platform-neutral behavior change.
- No persisted state, configuration, wire schema, or client compatibility changes.
- Existing provider fallback behavior remains available.

## Third-party origin

None. The implementation and tests are original to OpenSquilla.
