### PR TITLE
Render global toasts above modal layers

### DIFF
--- a/opensquilla-webui/e2e/settings-modal.spec.ts
+++ b/opensquilla-webui/e2e/settings-modal.spec.ts
@@ -85,6 +85,53 @@ test.describe('Settings modal', () => {
     await expect(page.locator('.toast', { hasText: /Copied/ }).first()).toBeVisible()
   })
 
+  test('renders a failure toast above Settings from the body portal', async ({ page }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText: () => Promise.reject(new Error('Clipboard denied')) },
+      })
+      Object.defineProperty(document, 'execCommand', {
+        configurable: true,
+        value: () => false,
+      })
+    })
+    await openFromSidebar(page)
+
+    await dialog(page).getByRole('button', { name: 'Copy config path' }).click()
+    const toast = page.locator('.toast.toast--danger', { hasText: /Copy failed/ }).first()
+    await expect(toast).toBeVisible()
+
+    const placement = await toast.evaluate(element => {
+      const host = element.closest('[data-testid="toast-host"]')
+      const app = document.querySelector('#app')
+      const rect = element.getBoundingClientRect()
+      const topmost = document.elementFromPoint(
+        rect.left + rect.width / 2,
+        rect.top + rect.height / 2,
+      )
+      return {
+        bodyChild: host?.parentElement === document.body,
+        outsideApp: Boolean(host && app && !app.contains(host)),
+        fullyInViewport: rect.left >= 0
+          && rect.top >= 0
+          && rect.right <= window.innerWidth
+          && rect.bottom <= window.innerHeight,
+        aboveModal: topmost === element || element.contains(topmost),
+      }
+    })
+    expect(placement).toEqual({
+      bodyChild: true,
+      outsideApp: true,
+      fullyInViewport: true,
+      aboveModal: true,
+    })
+
+    await toast.getByRole('button', { name: 'Dismiss notification' }).click()
+    await expect(toast).toHaveCount(0)
+    await expect(dialog(page)).toBeVisible()
+  })
+
   test('rail switches sections, marks the active tab, and syncs the URL with replace', async ({ page }) => {
     await openFromSidebar(page)
     await expect(page).toHaveURL(/\/settings$/)

--- a/opensquilla-webui/src/App.toast-host.contract.test.ts
+++ b/opensquilla-webui/src/App.toast-host.contract.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+
+import appSource from './App.vue?raw'
+
+describe('App toast host layer contract', () => {
+  it('teleports the single global toast host directly to body', () => {
+    expect(appSource).toMatch(
+      /<Teleport to="body">\s*<ToastHost\s*\/>\s*<\/Teleport>/,
+    )
+    expect(appSource.match(/<ToastHost\s*\/>/g)).toHaveLength(1)
+  })
+})

--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -401,7 +401,9 @@
     </button>
   </nav>
 
-  <ToastHost />
+  <Teleport to="body">
+    <ToastHost />
+  </Teleport>
 
   <ConfirmModal />
 


### PR DESCRIPTION
## Scope

- Teleport the single global ToastHost to document.body.
- Preserve toast state, styling, positioning, actions, timers, and dismiss behavior.
- Add source-contract and browser coverage for a failure toast shown above Settings.

Branch target: main
Linked issue: None (tracked as Feishu P2-40)
Release note: Yes — notifications remain visible and interactive while Settings is open.

## Tests

- ToastHost and source-contract unit tests passed.
- WebUI typecheck and architecture, theme, security, and i18n guards passed.
- Managed Vite Playwright regression passed.
- Cross-review found no blocking issues.

## Safety and compatibility

- Client-only DOM placement change; no RPC, configuration, persistence, or data migration impact.
- The app is client-rendered and document.body exists before mount.
- The global host remains a singleton and is removed with the App lifecycle.

## Third-party origin

None. The implementation and tests are original to OpenSquilla.
