### PR TITLE
Preserve versioned session naming API roots

### DIFF
--- a/src/opensquilla/provider/_openai_compat_url.py
+++ b/src/opensquilla/provider/_openai_compat_url.py
@@ -1,0 +1,23 @@
+"""Internal URL helpers for OpenAI-compatible providers."""
+
+from __future__ import annotations
+
+import re
+
+# Some OpenAI-compatible API roots carry a non-integer version segment before
+# an adapter namespace.  Gemini's documented compatibility root is
+# ``/v1beta/openai``: appending our canonical ``/v1`` again produces the
+# nonexistent ``/v1beta/openai/v1/chat/completions`` endpoint.  Treat these
+# roots exactly like the existing ``/v1`` ... ``/vN`` forms.
+_VERSIONED_BASE_URL_RE = re.compile(
+    r"/v\d+(?:(?:alpha|beta)\d*)?(?:/openai)?$",
+)
+
+
+def _versioned_api_url(base_url: str, path: str) -> str:
+    """Join a canonical ``/v1/...`` path to an API root without duplication."""
+
+    base = base_url.rstrip("/")
+    if path.startswith("/v1/") and _VERSIONED_BASE_URL_RE.search(base):
+        return f"{base}{path[3:]}"
+    return f"{base}{path}"

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -25,6 +25,7 @@ from opensquilla.execution_status import compact_provider_status, derive_is_erro
 from opensquilla.safety.secret_redaction import redact_secret_text
 from opensquilla.secrets import clean_header_secret
 
+from ._openai_compat_url import _versioned_api_url
 from .app_attribution import is_provider_app_host, provider_app_headers
 from .candidate_artifact import (
     CandidateArtifactBuilder,
@@ -200,25 +201,6 @@ _OPENAI_STREAM_NOOP_CHOICE_KEYS = frozenset(
     {"index", "delta", "finish_reason", "native_finish_reason"}
 )
 _OPENAI_STREAM_NOOP_DELTA_KEYS = frozenset({"content", "role"})
-# Some OpenAI-compatible API roots carry a non-integer version segment before
-# an adapter namespace.  Gemini's documented compatibility root is
-# ``/v1beta/openai``: appending our canonical ``/v1`` again produces the
-# nonexistent ``/v1beta/openai/v1/chat/completions`` endpoint.  Treat these
-# roots exactly like the existing ``/v1`` ... ``/vN`` forms.
-_VERSIONED_BASE_URL_RE = re.compile(
-    r"/v\d+(?:(?:alpha|beta)\d*)?(?:/openai)?$",
-)
-
-
-def _versioned_api_url(base_url: str, path: str) -> str:
-    """Join a canonical ``/v1/...`` path to an API root without duplication."""
-
-    base = base_url.rstrip("/")
-    if path.startswith("/v1/") and _VERSIONED_BASE_URL_RE.search(base):
-        return f"{base}{path[3:]}"
-    return f"{base}{path}"
-
-
 _EPHEMERAL_CACHE_CONTROL: dict[str, str] = {"type": "ephemeral"}
 _DASHSCOPE_MAX_CACHE_MARKERS = 4
 _DASHSCOPE_CACHE_MARKER_ROLES = {"system", "user", "assistant", "tool"}

--- a/src/opensquilla/session/naming.py
+++ b/src/opensquilla/session/naming.py
@@ -327,10 +327,9 @@ async def call_naming_llm(
     if not api_key or not (first_message or "").strip():
         return None
 
-    url = base_url.rstrip("/")
-    if not url.endswith("/v1"):
-        url += "/v1"
-    url += "/chat/completions"
+    from opensquilla.provider._openai_compat_url import _versioned_api_url
+
+    url = _versioned_api_url(base_url, "/v1/chat/completions")
 
     system_prompt = _build_system_prompt(language)
     budget_provider = provider or (

--- a/tests/test_session/test_naming.py
+++ b/tests/test_session/test_naming.py
@@ -412,6 +412,50 @@ async def test_call_naming_llm_payload_and_sanitization(monkeypatch):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    ("base_url", "expected_url"),
+    [
+        (
+            "https://open.bigmodel.cn/api/paas/v4/",
+            "https://open.bigmodel.cn/api/paas/v4/chat/completions",
+        ),
+        (
+            "https://openrouter.ai/api/v1",
+            "https://openrouter.ai/api/v1/chat/completions",
+        ),
+        (
+            "https://compatible.example/api",
+            "https://compatible.example/api/v1/chat/completions",
+        ),
+        (
+            "https://compatible.example/api/",
+            "https://compatible.example/api/v1/chat/completions",
+        ),
+    ],
+)
+async def test_call_naming_llm_builds_versioned_api_url(
+    monkeypatch,
+    base_url,
+    expected_url,
+):
+    captured: dict = {}
+    monkeypatch.setattr(
+        "opensquilla.session.naming.httpx.AsyncClient",
+        lambda **kwargs: _fake_client(captured),
+    )
+
+    title = await call_naming_llm(
+        "Help me reset my password please",
+        model="naming-model",
+        api_key="test-key",
+        base_url=base_url,
+    )
+
+    assert title == "Reset my password"
+    assert captured["url"] == expected_url
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     ("provider", "base_url", "expected_max_tokens"),
     [
         ("tokenrhythm", "https://custom-tokenrhythm.example/v1", 1024),


### PR DESCRIPTION
## Scope

- Reuse one lightweight OpenAI-compatible versioned URL helper for session naming.
- Preserve existing vN, alpha/beta, and openai adapter roots without appending a duplicate v1 segment.
- Keep the helper out of the heavyweight provider module load path to avoid token-budget side effects.

Branch target: main
Linked issue: None (tracked as Feishu P2-41)
Release note: Yes — session naming now works with versioned compatible API roots such as Zhipu v4.

## Tests

- 113 related session naming, OpenAI-compatible, OpenAI Responses, and import architecture tests passed.
- Ruff and diff checks passed.
- Cross-review found no blocking issues.

## Safety and compatibility

- Platform-neutral URL construction change.
- OpenAI-compatible and Responses provider URL behavior remains covered and unchanged.
- No public API, wire schema, persisted state, or configuration migration change.
- The helper depends only on the Python standard library.

## Third-party origin

None. The implementation and tests are original to OpenSquilla.
