### PR TITLE
docs: add ChinaXiv link for Chinese technical report

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -30,7 +30,7 @@
 
 ## Neuigkeiten
 
-- 📢 **2026-08-22** — Die englische Version unseres technischen Berichts ist jetzt auf aiXiv verfügbar: [aixiv.260822.000001](https://aixiv.science/abs/aixiv.260822.000001). Wie man OpenSquilla zitiert, steht unter [Zitieren](#zitieren).
+- 📢 **2026-08-22** — Die englische Version unseres technischen Berichts ist jetzt auf aiXiv verfügbar: [aixiv.260822.000001](https://aixiv.science/abs/aixiv.260822.000001), die chinesische Version auf ChinaXiv: [202608.00176](https://chinaxiv.org/abs/202608.00176). Wie man OpenSquilla zitiert, steht unter [Zitieren](#zitieren).
 
 - 📢 **2026-08-21** — PDF-Versionen unseres technischen Berichts sind jetzt in diesem Repository verfügbar: [English](docs/report/opensquilla-report-en.pdf) · [中文](docs/report/opensquilla-report-zh.pdf).
 

--- a/README.es.md
+++ b/README.es.md
@@ -30,7 +30,7 @@
 
 ## Novedades
 
-- 📢 **2026-08-22** — La versión en inglés de nuestro informe técnico ya está disponible en aiXiv: [aixiv.260822.000001](https://aixiv.science/abs/aixiv.260822.000001). Consulta [Cita](#cita) para saber cómo citar OpenSquilla.
+- 📢 **2026-08-22** — La versión en inglés de nuestro informe técnico ya está disponible en aiXiv: [aixiv.260822.000001](https://aixiv.science/abs/aixiv.260822.000001), y la versión en chino en ChinaXiv: [202608.00176](https://chinaxiv.org/abs/202608.00176). Consulta [Cita](#cita) para saber cómo citar OpenSquilla.
 
 - 📢 **2026-08-21** — Las versiones en PDF de nuestro informe técnico ya están disponibles en este repositorio: [English](docs/report/opensquilla-report-en.pdf) · [中文](docs/report/opensquilla-report-zh.pdf).
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -30,7 +30,7 @@
 
 ## Actualités
 
-- 📢 **2026-08-22** — La version anglaise de notre rapport technique est désormais disponible sur aiXiv : [aixiv.260822.000001](https://aixiv.science/abs/aixiv.260822.000001). Voir [Citation](#citation) pour savoir comment citer OpenSquilla.
+- 📢 **2026-08-22** — La version anglaise de notre rapport technique est désormais disponible sur aiXiv : [aixiv.260822.000001](https://aixiv.science/abs/aixiv.260822.000001), et la version chinoise sur ChinaXiv : [202608.00176](https://chinaxiv.org/abs/202608.00176). Voir [Citation](#citation) pour savoir comment citer OpenSquilla.
 
 - 📢 **2026-08-21** — Les versions PDF de notre rapport technique sont désormais disponibles dans ce dépôt : [English](docs/report/opensquilla-report-en.pdf) · [中文](docs/report/opensquilla-report-zh.pdf).
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -30,7 +30,7 @@
 
 ## お知らせ
 
-- 📢 **2026-08-22** — 技術レポートの英語版が aiXiv に公開されました: [aixiv.260822.000001](https://aixiv.science/abs/aixiv.260822.000001)。OpenSquilla の引用方法は[引用](#引用)をご覧ください。
+- 📢 **2026-08-22** — 技術レポートの英語版が aiXiv に公開されました: [aixiv.260822.000001](https://aixiv.science/abs/aixiv.260822.000001)。中国語版は ChinaXiv で公開されています: [202608.00176](https://chinaxiv.org/abs/202608.00176)。OpenSquilla の引用方法は[引用](#引用)をご覧ください。
 
 - 📢 **2026-08-21** — 技術レポートの PDF 版を本リポジトリに収録しました: [English](docs/report/opensquilla-report-en.pdf) · [中文](docs/report/opensquilla-report-zh.pdf)。
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## News
 
-- 📢 **2026-08-22** — The English version of our technical report is now on aiXiv: [aixiv.260822.000001](https://aixiv.science/abs/aixiv.260822.000001). See [Citation](#citation) for how to cite OpenSquilla.
+- 📢 **2026-08-22** — The English version of our technical report is now on aiXiv: [aixiv.260822.000001](https://aixiv.science/abs/aixiv.260822.000001), and the Chinese version is on ChinaXiv: [202608.00176](https://chinaxiv.org/abs/202608.00176). See [Citation](#citation) for how to cite OpenSquilla.
 
 - 📢 **2026-08-21** — PDF versions of our technical report are now available in this repo: [English](docs/report/opensquilla-report-en.pdf) · [中文](docs/report/opensquilla-report-zh.pdf).
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -30,7 +30,7 @@
 
 ## 最新动态
 
-- 📢 **2026-08-22** —— 技术报告英文版已登陆 aiXiv：[aixiv.260822.000001](https://aixiv.science/abs/aixiv.260822.000001)。如何引用 OpenSquilla 请见[引用](#引用)。
+- 📢 **2026-08-22** —— 技术报告英文版已登陆 aiXiv：[aixiv.260822.000001](https://aixiv.science/abs/aixiv.260822.000001)，中文版已登陆 ChinaXiv：[202608.00176](https://chinaxiv.org/abs/202608.00176)。如何引用 OpenSquilla 请见[引用](#引用)。
 
 - 📢 **2026-08-21** —— 技术报告的 PDF 版本现已收录在本仓库中：[English](docs/report/opensquilla-report-en.pdf) · [中文](docs/report/opensquilla-report-zh.pdf)。
 


### PR DESCRIPTION
## Summary
- The Chinese version of the technical report is now live on ChinaXiv: [202608.00176](https://chinaxiv.org/abs/202608.00176)
- Adds the ChinaXiv link alongside the existing aiXiv (English) link in the 2026-08-22 news entry across all six README translations (en, zh-Hans, ja, fr, es, de)

## Test plan
- [ ] Verify the ChinaXiv link resolves in a browser
- [ ] Confirm the news entry renders correctly in each README