### PR TITLE
fix(ci): validate release contracts for README changes

### DIFF
--- a/.github/ci/suites.v1.json
+++ b/.github/ci/suites.v1.json
@@ -250,6 +250,7 @@
     },
     "release-packaging": {
       "execution_inputs": [
+        "README*.md",
         "README.release.md",
         "RELEASES.md",
         ".github/scripts/prestage-release-to-oss.sh",

--- a/.github/scripts/plan_ci.py
+++ b/.github/scripts/plan_ci.py
@@ -1478,6 +1478,13 @@ def plan_changes(
         # Dependency metadata must fail closed even when it is added beneath a
         # documentation directory; docs-only routing is not a trust boundary.
         if _is_docs(path) and not _is_dependency(path):
+            if path == "README.md" or (
+                "/" not in path
+                and path.startswith("README.")
+                and path.endswith(".md")
+            ):
+                suites.add("release-packaging")
+                reasons.add("packaging_changed")
             continue
         all_docs = False
 

--- a/tests/test_ci/test_plan_ci.py
+++ b/tests/test_ci/test_plan_ci.py
@@ -66,7 +66,7 @@ def _platform_cells(plan: dict[str, Any], suite: str) -> set[tuple[str, str]]:
 def test_docs_only_plan_is_small_and_canonical(
     tmp_path: Path, suite_config: dict[str, Any]
 ) -> None:
-    plan = _plan(tmp_path, suite_config, "README.zh-Hans.md", "docs/ci.md")
+    plan = _plan(tmp_path, suite_config, "docs/architecture.md", "docs/ci.md")
 
     assert plan["required_suites"] == ["readme-locale", "workflow-lint"]
     assert plan["desktop_matrix"] == []
@@ -80,6 +80,33 @@ def test_docs_only_plan_is_small_and_canonical(
     assert set(plan["suite_execution_digests"]) == set(plan["required_suites"])
     assert json.loads(canonical_json(plan)) == plan
     assert " " not in canonical_json(plan)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "README.md",
+        "README.zh-Hans.md",
+        "README.product.md",
+    ],
+)
+def test_root_readmes_select_release_packaging_contract(
+    tmp_path: Path,
+    suite_config: dict[str, Any],
+    path: str,
+) -> None:
+    plan = _plan(tmp_path, suite_config, path)
+
+    assert plan["required_suites"] == [
+        "readme-locale",
+        "release-packaging",
+        "workflow-lint",
+    ]
+    assert plan["desktop_matrix"] == []
+    assert plan["python_matrix"] == {"ubuntu": [], "windows": []}
+    assert plan["python_targets"] == []
+    assert plan["full_fallback"] is False
+    assert plan["reason_codes"] == ["docs_only", "packaging_changed"]
 
 
 def test_plan_and_digest_are_order_independent(
@@ -1145,6 +1172,24 @@ def test_noncritical_workflow_content_changes_workflow_lint_execution_digest(
     )
 
 
+def test_root_readme_content_changes_release_packaging_execution_digest(
+    tmp_path: Path, suite_config: dict[str, Any]
+) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text("first\n", encoding="utf-8")
+    first = plan_changes(["README.md"], repo=tmp_path, config=suite_config)
+
+    readme.write_text("second\n", encoding="utf-8")
+    second = plan_changes(["README.md"], repo=tmp_path, config=suite_config)
+
+    assert first["full_fallback"] is False
+    assert second["full_fallback"] is False
+    assert (
+        first["suite_execution_digests"]["release-packaging"]
+        != second["suite_execution_digests"]["release-packaging"]
+    )
+
+
 def test_removed_windows_compat_suite_has_no_contract_or_matrix_entry(
     tmp_path: Path, suite_config: dict[str, Any]
 ) -> None:
@@ -1233,6 +1278,14 @@ def test_readme_locale_inputs_cover_the_executed_node_contract(
         "opensquilla-webui/src/i18n/index.ts",
     } <= inputs
     assert "scripts/check_readme_locale_parity.py" not in inputs
+
+
+def test_release_packaging_inputs_cover_root_readmes(
+    suite_config: dict[str, Any],
+) -> None:
+    inputs = set(suite_config["suites"]["release-packaging"]["execution_inputs"])
+
+    assert "README*.md" in inputs
 
 
 def test_managed_toolchain_inputs_cover_bundled_consumers_and_tests(

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -1072,14 +1072,17 @@ def test_changelog_has_current_release_section_and_unreleased() -> None:
     assert "[Unreleased]" in text, "CHANGELOG.md must retain an [Unreleased] section"
 
 
-def test_readme_release_install_uses_latest_assets_and_pinned_alternative() -> None:
+def test_readme_release_install_uses_versioned_assets_and_pinned_wheel() -> None:
     readme = Path("README.md").read_text(encoding="utf-8")
 
-    assert f"OpenSquilla-{CURRENT_DESKTOP_VERSION}-mac-arm64.dmg" in readme
-    assert f"OpenSquilla-{CURRENT_DESKTOP_VERSION}-win-x64.exe" in readme
-    assert "versioned GitHub assets" in readme
-    assert "Alibaba Cloud OSS mirror" in readme
-    assert "Portable archives remain retired" in readme
+    assert (
+        f"releases/download/{CURRENT_TAG}/"
+        f"OpenSquilla-{CURRENT_DESKTOP_VERSION}-mac-arm64.dmg" in readme
+    )
+    assert (
+        f"releases/download/{CURRENT_TAG}/"
+        f"OpenSquilla-{CURRENT_DESKTOP_VERSION}-win-x64.exe" in readme
+    )
     assert "releases/latest/download/OpenSquilla-windows-x64-portable.zip" not in readme
     assert (
         f"releases/download/{CURRENT_TAG}/opensquilla-{CURRENT_VERSION}-py3-none-any.whl" in readme
@@ -1087,6 +1090,24 @@ def test_readme_release_install_uses_latest_assets_and_pinned_alternative() -> N
     assert "opensquilla-latest-py3-none-any.whl" not in readme
     assert "Python wheel installs use versioned wheel filenames" in readme
     assert "Release install commands use published GitHub release assets" in readme
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        Path("README.md"),
+        Path("README.zh-Hans.md"),
+        Path("README.ja.md"),
+        Path("README.fr.md"),
+        Path("README.de.md"),
+        Path("README.es.md"),
+    ],
+)
+def test_readmes_point_to_canonical_release_notes(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+
+    assert "[`CHANGELOG.md`](CHANGELOG.md)" in text, path
+    assert "[`docs/releases/`](docs/releases/)" in text, path
 
 
 def test_all_readmes_default_install_paths_to_the_current_preview() -> None:


### PR DESCRIPTION
## Scope

Scope boundary: Align the release consistency contract with the README structure introduced by #1459, and route root `README*.md` changes through the Ubuntu `release-packaging` suite.

Non-goals: No README content changes, product/runtime changes, release artifact changes, Windows/full-matrix expansion for future README-only pull requests, or changes from #1460.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: This repairs a main-branch test and CI-routing inconsistency exposed after docs-only PR #1459 removed stale What's New prose.

## Release Note

Release note: NONE | Test and CI routing correction only; no user-visible runtime behavior changes.

## Tests

Ruff: `uv run ruff check .github/scripts/plan_ci.py tests/test_ci/test_plan_ci.py tests/test_release_consistency.py`

Pytest: 359 passed, 2 skipped across the release-packaging job tests plus CI planner, attestation, and workflow contracts. Focused post-review rerun: 168 passed.

Build: N/A; no production or package source changed.

Regression tests: added

Notes: The stale prose assertions are replaced with exact current-tag desktop and wheel URL contracts. Six localized READMEs must point to `CHANGELOG.md` and `docs/releases/`. Root README changes select `readme-locale`, `release-packaging`, and `workflow-lint` only; Python, Windows, and Desktop matrices remain empty. The release suite digest now includes root `README*.md` content.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: release

Maintainer-only note: No credentialed check is needed because the change only validates repository text and deterministic CI planning.

## Safety

No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, or `tests/_private/` contents are included.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] No documentation content changed.
- [x] Added assertions reference existing `CHANGELOG.md` and `docs/releases/` repository paths.
- [x] No examples, secrets, local paths, or private transcripts were added.
