### PR TITLE
fix(cli): exit non-zero on failed or unavailable session export (#1448)

### DIFF
--- a/src/opensquilla/cli/sessions_cmd.py
+++ b/src/opensquilla/cli/sessions_cmd.py
@@ -305,12 +305,12 @@ def sessions_export(
     result: dict[str, Any] | None = asyncio.run(_with_client(_run))
     if result is _CLIENT_UNAVAILABLE:
         console.print("[dim]Session export requires a running gateway.[/dim]")
-        return
+        raise typer.Exit(1)
     if result is _ACTION_FAILED:
-        return
+        raise typer.Exit(1)
     if result is None:
         console.print("[red]Session export returned no data.[/red]")
-        return
+        raise typer.Exit(1)
     target = output or Path(f"{session_id.replace(':', '-')}.{format}")
     if format == "json":
         target.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")


### PR DESCRIPTION
### Summary

Fixes #1448.

When `opensquilla sessions export` encountered an RPC failure (e.g. `NOT_FOUND` on missing session key) or when the gateway client was unavailable / returned no data, it caught the failure sentinel but returned normally with exit code 0.

### Changes
- Raise `typer.Exit(1)` when `_with_client` returns `_CLIENT_UNAVAILABLE`, `_ACTION_FAILED`, or `None` during session export, ensuring scripts and CI pipelines reliably detect export failures.