### PR TITLE
refactor(sessions): deepen session search application seam

### DIFF
--- a/src/opensquilla/application/session_directory.py
+++ b/src/opensquilla/application/session_directory.py
@@ -9,11 +9,15 @@ not know about RPC frames, scopes, or ``RpcContext``.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
+
+import structlog
 
 from opensquilla.session_key import canonicalize_session_key
+
+log = structlog.get_logger(__name__)
 
 
 class SessionDirectoryStorage(Protocol):
@@ -22,6 +26,63 @@ class SessionDirectoryStorage(Protocol):
     async def get_session(self, key: str) -> Any | None: ...
 
     async def list_sessions(self, *, limit: int = 100) -> Sequence[Any]: ...
+
+
+class SessionSearchStorage(SessionDirectoryStorage, Protocol):
+    """Optional search ports implemented by the persistence adapter.
+
+    Search is deliberately expressed as capability-shaped methods instead of
+    importing the concrete SQLite store.  Older test doubles and storage
+    implementations may omit the LIKE/title methods; ``SessionDirectory``
+    keeps the historical bounded fallbacks in that case.
+    """
+
+    async def search_sessions_by_title(
+        self, query: str, limit: int = 20
+    ) -> Sequence[Any]: ...
+
+    async def search_transcript(
+        self, query: str, session_id: str | None = None, limit: int = 20
+    ) -> Sequence[Mapping[str, Any]]: ...
+
+    async def search_transcript_like(
+        self, query: str, session_id: str | None = None, limit: int = 20
+    ) -> Sequence[Mapping[str, Any]]: ...
+
+    async def get_session(self, key: str) -> Any | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class SessionSearchProjection:
+    """Presentation-neutral projection supplied by a boundary adapter."""
+
+    title: str
+    effective_agent_id: str | None = None
+    surface: str | None = None
+    updated_at: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SessionSearchSessionHit:
+    key: str
+    projection: SessionSearchProjection
+
+
+@dataclass(frozen=True, slots=True)
+class SessionSearchMessageHit:
+    key: str
+    title: str
+    role: Any
+    snippet: str
+    created_at: Any
+
+
+@dataclass(frozen=True, slots=True)
+class SessionSearchResult:
+    query: str
+    sessions: tuple[SessionSearchSessionHit, ...]
+    messages: tuple[SessionSearchMessageHit, ...]
+    ts: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -48,6 +109,190 @@ class SessionDirectory:
 
     def __init__(self, storage: SessionDirectoryStorage) -> None:
         self._storage = storage
+
+    @staticmethod
+    def normalize_search_input(query: object = "", limit: object = 20) -> tuple[str, int]:
+        """Normalize the legacy ``sessions.search`` inputs in one place."""
+
+        normalized_query = str(query or "").strip()
+        try:
+            normalized_limit = int(cast(Any, limit))
+        except (TypeError, ValueError):
+            normalized_limit = 20
+        return normalized_query, max(1, min(normalized_limit, 50))
+
+    async def search(
+        self,
+        query: object = "",
+        limit: object = 20,
+        *,
+        now_ms: int,
+        project: Callable[[Any, str], SessionSearchProjection],
+        derive_transcript_title: Callable[[str], str] | None = None,
+    ) -> SessionSearchResult:
+        """Run the session directory query behind storage-independent ports.
+
+        ``project`` is the only presentation hook.  It is supplied by the
+        Gateway adapter and returns a small domain projection; the application
+        module never imports Gateway view or RPC code.  Search failures are
+        isolated per source: a title failure or transcript index failure
+        degrades to an empty result, matching the v4 behaviour.
+        """
+
+        normalized_query, normalized_limit = self.normalize_search_input(query, limit)
+        if not normalized_query:
+            return SessionSearchResult(normalized_query, (), (), now_ms)
+
+        title_sessions: Sequence[Any] = ()
+        title_search = getattr(self._storage, "search_sessions_by_title", None)
+        if callable(title_search):
+            # The historical handler lets title-index failures propagate.  The
+            # application seam must preserve that contract; only transcript
+            # enrichment/search failures are best-effort.
+            title_sessions = await title_search(normalized_query, normalized_limit)
+        else:
+            recent = await self._storage.list_sessions(limit=200)
+            needle = normalized_query.lower()
+            title_sessions = [
+                session
+                for session in recent
+                if needle
+                in " ".join(
+                    text
+                    for text in (
+                        str(getattr(session, "display_name", "") or ""),
+                        str(getattr(session, "derived_title", "") or ""),
+                        str(getattr(session, "subject", "") or ""),
+                    )
+                    if text
+                ).lower()
+            ][:normalized_limit]
+
+        title_inputs = await self._transcript_titles(title_sessions, derive_transcript_title)
+        title_hits: list[SessionSearchSessionHit] = []
+        title_keys: set[str] = set()
+        for session in title_sessions:
+            key = str(getattr(session, "session_key", "") or "")
+            if not key:
+                continue
+            projection = project(
+                session,
+                title_inputs.get(str(getattr(session, "session_id", "") or ""), ""),
+            )
+            title_keys.add(canonicalize_session_key(key))
+            title_hits.append(SessionSearchSessionHit(key=key, projection=projection))
+
+        rows: Sequence[Mapping[str, Any]] = ()
+        try:
+            non_ascii = any(ord(ch) > 127 for ch in normalized_query)
+            if non_ascii:
+                search_like = getattr(self._storage, "search_transcript_like", None)
+                if callable(search_like):
+                    rows = await search_like(normalized_query, limit=normalized_limit)
+            else:
+                search_fts = getattr(self._storage, "search_transcript", None)
+                if callable(search_fts):
+                    rows = await search_fts(normalized_query, limit=normalized_limit)
+        except Exception:
+            log.warning("sessions.search.transcript_failed", exc_info=True)
+            rows = ()
+
+        pending: list[tuple[str, str, Mapping[str, Any]]] = []
+        content_keys: set[str] = set()
+        for row in rows:
+            raw_key = str(row.get("session_key") or "")
+            canonical_key = canonicalize_session_key(raw_key)
+            if not canonical_key or canonical_key in title_keys or canonical_key in content_keys:
+                continue
+            content_keys.add(canonical_key)
+            pending.append((raw_key, canonical_key, row))
+
+        enriched_sessions: list[Any] = []
+        get_session = getattr(self._storage, "get_session", None)
+        if callable(get_session):
+            for _, canonical_key, _ in pending:
+                try:
+                    session = await get_session(canonical_key)
+                except Exception:
+                    session = None
+                if session is not None:
+                    enriched_sessions.append(session)
+        enriched_titles = await self._transcript_titles(enriched_sessions, derive_transcript_title)
+        title_by_key: dict[str, str] = {}
+        for session in enriched_sessions:
+            key = str(getattr(session, "session_key", "") or "")
+            title_by_key[canonicalize_session_key(key)] = project(
+                session,
+                enriched_titles.get(str(getattr(session, "session_id", "") or ""), ""),
+            ).title
+
+        message_hits = tuple(
+            SessionSearchMessageHit(
+                key=raw_key,
+                title=title_by_key.get(canonical_key, ""),
+                role=row.get("role"),
+                snippet=row.get("snippet") or "",
+                created_at=row.get("created_at"),
+            )
+            for raw_key, canonical_key, row in pending
+        )
+        return SessionSearchResult(
+            normalized_query,
+            tuple(title_hits),
+            message_hits,
+            now_ms,
+        )
+
+    async def _transcript_titles(
+        self,
+        sessions: Sequence[Any],
+        derive_title: Callable[[str], str] | None,
+    ) -> dict[str, str]:
+        """Read a bounded amount of user transcript content for enrichment."""
+
+        if derive_title is None:
+            return {}
+        session_ids = [
+            str(getattr(session, "session_id", "") or "")
+            for session in sessions
+            if str(getattr(session, "session_id", "") or "")
+        ]
+        if not session_ids:
+            return {}
+        title_inputs: dict[str, list[str]] = {session_id: [] for session_id in session_ids}
+        batch = getattr(self._storage, "list_user_transcript_content_batch", None)
+        if callable(batch):
+            try:
+                grouped = await batch(session_ids, limit_per_session=3)
+                title_inputs.update(
+                    {
+                        str(session_id): [str(value) for value in values if value]
+                        for session_id, values in grouped.items()
+                    }
+                )
+            except Exception:
+                pass
+        if not any(title_inputs.values()):
+            get_transcript = getattr(self._storage, "get_transcript", None)
+            if callable(get_transcript):
+                for session_id in session_ids:
+                    try:
+                        entries = await get_transcript(session_id, limit=8)
+                    except Exception:
+                        continue
+                    title_inputs[session_id] = [
+                        str(getattr(entry, "content", "") or "")
+                        for entry in entries
+                        if str(getattr(entry, "role", "") or "").lower() == "user"
+                    ][:3]
+        titles: dict[str, str] = {}
+        for session_id, values in title_inputs.items():
+            for value in values:
+                title = derive_title(value)
+                if title:
+                    titles[session_id] = title
+                    break
+        return titles
 
     async def resolve(self, reference: str) -> SessionResolution:
         session = await _resolve_session_record(self._storage, reference)
@@ -117,5 +362,10 @@ async def _resolve_session_record_for_bootstrap(
 __all__ = [
     "SessionDirectory",
     "SessionDirectoryStorage",
+    "SessionSearchMessageHit",
+    "SessionSearchProjection",
+    "SessionSearchResult",
+    "SessionSearchSessionHit",
+    "SessionSearchStorage",
     "SessionResolution",
 ]

--- a/src/opensquilla/application/session_directory.py
+++ b/src/opensquilla/application/session_directory.py
@@ -134,9 +134,9 @@ class SessionDirectory:
 
         ``project`` is the only presentation hook.  It is supplied by the
         Gateway adapter and returns a small domain projection; the application
-        module never imports Gateway view or RPC code.  Search failures are
-        isolated per source: a title failure or transcript index failure
-        degrades to an empty result, matching the v4 behaviour.
+        module never imports Gateway view or RPC code.  Transcript index and
+        enrichment failures remain best-effort, while title-index failures
+        retain the historical propagation semantics of the v4 handler.
         """
 
         normalized_query, normalized_limit = self.normalize_search_input(query, limit)

--- a/src/opensquilla/gateway/rpc_sessions.py
+++ b/src/opensquilla/gateway/rpc_sessions.py
@@ -24,6 +24,7 @@ import structlog
 from opensquilla.agents.scope import default_workspace_dir, resolve_agent_workspace_dir
 from opensquilla.application.session_directory import (
     SessionDirectory,
+    SessionSearchProjection,
     _resolve_session_record_for_bootstrap,
 )
 from opensquilla.artifacts import enrich_artifact_event_dict
@@ -2936,16 +2937,12 @@ async def _handle_sessions_search(params: dict | None, ctx: RpcContext) -> dict:
     way ``sessions.list`` derives them so results read like the sidebar.
     """
     now_ms = int(time.time() * 1000)
-    query = ""
-    limit = 20
+    raw_query: object = ""
+    raw_limit: object = 20
     if isinstance(params, dict):
-        query = str(params.get("query") or "").strip()
-        try:
-            limit = int(params.get("limit", 20))
-        except (TypeError, ValueError):
-            limit = 20
-    limit = max(1, min(limit, 50))
-
+        raw_query = params.get("query")
+        raw_limit = params.get("limit", 20)
+    query, _ = SessionDirectory.normalize_search_input(raw_query, raw_limit)
     empty = {"sessions": [], "messages": [], "query": query, "ts": now_ms}
     if not query or ctx.session_manager is None:
         return empty
@@ -2953,104 +2950,55 @@ async def _handle_sessions_search(params: dict | None, ctx: RpcContext) -> dict:
     if storage is None:
         return empty
 
-    # Title hits.
-    # Prefer the dedicated global query (matches every session, builds view rows
-    # only for the matches). Fall back to a bounded recent scan for storage
-    # doubles that don't implement it.
-    title_search = getattr(storage, "search_sessions_by_title", None)
-    if callable(title_search):
-        title_sessions = await title_search(query, limit)
-    else:
-        needle = query.lower()
-        recent = await storage.list_sessions(limit=200)
-        title_sessions = [
-            s
-            for s in recent
-            if needle
-            in " ".join(
-                p
-                for p in (
-                    str(getattr(s, "display_name", "") or ""),
-                    str(getattr(s, "derived_title", "") or ""),
-                    str(getattr(s, "subject", "") or ""),
-                )
-                if p
-            ).lower()
-        ][:limit]
-
-    transcript_titles = await _list_transcript_titles(storage, title_sessions)
-    session_hits: list[dict[str, Any]] = []
-    title_keys: set[str] = set()
     channel_types = _channel_types_from_config(getattr(ctx, "config", None))
-    for s in title_sessions:
+
+    def project(session: Any, transcript_title: str) -> SessionSearchProjection:
         view = build_session_view_item(
-            s,
+            session,
             entry_count=0,
             task_rows=[],
             now_ms=now_ms,
-            transcript_title=transcript_titles.get(getattr(s, "session_id", ""), ""),
+            transcript_title=transcript_title,
             channel_types=channel_types,
         )
-        title_keys.add(canonicalize_session_key(s.session_key))
-        session_hits.append(
-            {
-                "key": s.session_key,
-                "title": str(view.get("title") or ""),
-                "effectiveAgentId": view.get("effectiveAgentId"),
-                "surface": view.get("surface"),
-                "updatedAt": view.get("updatedAt"),
-            }
+        return SessionSearchProjection(
+            title=str(view.get("title") or ""),
+            effective_agent_id=view.get("effectiveAgentId"),
+            surface=view.get("surface"),
+            updated_at=view.get("updatedAt"),
         )
 
-    # Content hits.
-    # ASCII queries use the ranked, indexed FTS path. Non-ASCII queries (CJK and
-    # other scripts the FTS tokenizer can't segment) use a substring LIKE scan,
-    # the only option for them. ASCII deliberately has NO LIKE fallback so a
-    # common keystroke can never trigger an unbounded full-table content scan.
-    has_like = hasattr(storage, "search_transcript_like")
-    non_ascii = any(ord(ch) > 127 for ch in query)
-    rows: list[dict[str, Any]] = []
-    try:
-        if non_ascii:
-            if has_like:
-                rows = await storage.search_transcript_like(query, limit=limit)
-        else:
-            rows = await storage.search_transcript(query, limit=limit)
-    except Exception:
-        log.warning("sessions.search.transcript_failed", exc_info=True)
-        rows = []
-
-    # One row per session, never repeating a session already shown as a title
-    # hit, enriched with the session title via a small bounded lookup.
-    pending: list[tuple[str, str, dict[str, Any]]] = []
-    content_keys: set[str] = set()
-    for row in rows:
-        raw_key = str(row.get("session_key") or "")
-        canon = canonicalize_session_key(raw_key)
-        if not canon or canon in title_keys or canon in content_keys:
-            continue
-        content_keys.add(canon)
-        pending.append((raw_key, canon, row))
-
-    title_map = await _titles_for_keys(
-        storage,
-        [canon for _, canon, _ in pending],
-        now_ms,
-        channel_types=channel_types,
+    result = await SessionDirectory(storage).search(
+        raw_query,
+        raw_limit,
+        now_ms=now_ms,
+        project=project,
+        derive_transcript_title=derive_transcript_title,
     )
-    message_hits: list[dict[str, Any]] = []
-    for raw_key, canon, row in pending:
-        message_hits.append(
+    return {
+        "sessions": [
             {
-                "key": raw_key,
-                "title": title_map.get(canon, ""),
-                "role": row.get("role"),
-                "snippet": row.get("snippet") or "",
-                "createdAt": row.get("created_at"),
+                "key": hit.key,
+                "title": hit.projection.title,
+                "effectiveAgentId": hit.projection.effective_agent_id,
+                "surface": hit.projection.surface,
+                "updatedAt": hit.projection.updated_at,
             }
-        )
-
-    return {"sessions": session_hits, "messages": message_hits, "query": query, "ts": now_ms}
+            for hit in result.sessions
+        ],
+        "messages": [
+            {
+                "key": hit.key,
+                "title": hit.title,
+                "role": hit.role,
+                "snippet": hit.snippet,
+                "createdAt": hit.created_at,
+            }
+            for hit in result.messages
+        ],
+        "query": result.query,
+        "ts": result.ts,
+    }
 
 
 @_d.method("sessions.create", scope="operator.write")

--- a/tests/test_application/test_session_directory.py
+++ b/tests/test_application/test_session_directory.py
@@ -7,7 +7,10 @@ from typing import Any
 
 import pytest
 
-from opensquilla.application.session_directory import SessionDirectory
+from opensquilla.application.session_directory import (
+    SessionDirectory,
+    SessionSearchProjection,
+)
 
 
 class Storage:
@@ -133,3 +136,167 @@ async def test_ambiguous_prefix_and_missing_reference_keep_legacy_errors() -> No
 
     with pytest.raises(KeyError, match="Session not found: missing"):
         await SessionDirectory(storage).resolve("missing")
+
+
+class SearchStorage(Storage):
+    def __init__(self, *, titles=None, rows=None, like_rows=None):
+        super().__init__(rows=titles or [])
+        self.rows = titles or []
+        self.rows_result = rows or []
+        self.like_rows = like_rows or []
+        self.search_calls: list[tuple[str, int]] = []
+        self.like_calls: list[tuple[str, int]] = []
+
+    async def get_session(self, key: str):
+        for row in self.rows:
+            if row.session_key == key:
+                return row
+        return None
+
+    async def search_sessions_by_title(self, query: str, limit: int = 20):
+        return [row for row in self.rows if query.lower() in row.display_name.lower()][:limit]
+
+    async def search_transcript(self, query: str, session_id=None, limit: int = 20):
+        self.search_calls.append((query, limit))
+        return self.rows_result[:limit]
+
+    async def search_transcript_like(self, query: str, session_id=None, limit: int = 20):
+        self.like_calls.append((query, limit))
+        return self.like_rows[:limit]
+
+
+def _search_projection(row: Any, transcript_title: str) -> SessionSearchProjection:
+    return SessionSearchProjection(
+        title=row.display_name or transcript_title,
+        effective_agent_id="main",
+        surface="webchat",
+        updated_at=row.updated_at,
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_normalizes_limit_and_keeps_wire_independent_result() -> None:
+    row = session(display_name="Deploy planning")
+    storage = SearchStorage(titles=[row])
+
+    result = await SessionDirectory(storage).search(
+        "  deploy  ",
+        "999",
+        now_ms=123,
+        project=_search_projection,
+    )
+
+    assert result.query == "deploy"
+    assert result.ts == 123
+    assert result.sessions[0].projection.title == "Deploy planning"
+    assert storage.search_calls == [("deploy", 50)]
+
+
+@pytest.mark.asyncio
+async def test_search_routes_non_ascii_to_like_and_deduplicates_title_hits() -> None:
+    row = session(display_name="部署讨论")
+    storage = SearchStorage(
+        titles=[row],
+        like_rows=[
+            {"session_key": row.session_key, "role": "user", "snippet": "部署", "created_at": 1},
+            {
+                "session_key": row.session_key,
+                "role": "assistant",
+                "snippet": "部署",
+                "created_at": 2,
+            },
+        ],
+    )
+
+    result = await SessionDirectory(storage).search(
+        "部署",
+        20,
+        now_ms=123,
+        project=_search_projection,
+    )
+
+    assert storage.like_calls == [("部署", 20)]
+    assert storage.search_calls == []
+    assert len(result.sessions) == 1
+    assert result.messages == ()
+
+
+@pytest.mark.asyncio
+async def test_search_transcript_failure_degrades_to_title_results() -> None:
+    row = session(display_name="Deploy planning")
+
+    class BrokenStorage(SearchStorage):
+        async def search_transcript(self, query, session_id=None, limit=20):
+            raise RuntimeError("index unavailable")
+
+    result = await SessionDirectory(BrokenStorage(titles=[row])).search(
+        "deploy",
+        20,
+        now_ms=123,
+        project=_search_projection,
+    )
+
+    assert [hit.key for hit in result.sessions] == [row.session_key]
+    assert result.messages == ()
+
+
+@pytest.mark.asyncio
+async def test_search_title_failure_keeps_legacy_propagation() -> None:
+    class BrokenTitleStorage(SearchStorage):
+        async def search_sessions_by_title(self, query, limit=20):
+            raise RuntimeError("title index unavailable")
+
+    with pytest.raises(RuntimeError, match="title index unavailable"):
+        await SessionDirectory(BrokenTitleStorage()).search(
+            "deploy",
+            20,
+            now_ms=123,
+            project=_search_projection,
+        )
+
+
+@pytest.mark.asyncio
+async def test_search_uses_bounded_title_fallback_for_legacy_storage() -> None:
+    row = session(display_name="Deploy planning")
+
+    class LegacyStorage(Storage):
+        async def search_transcript(self, query, session_id=None, limit=20):
+            return []
+
+    storage = LegacyStorage(rows=[row])
+    result = await SessionDirectory(storage).search(
+        "deploy",
+        20,
+        now_ms=123,
+        project=_search_projection,
+    )
+
+    assert [hit.key for hit in result.sessions] == [row.session_key]
+    assert storage.list_limits == [200]
+
+
+@pytest.mark.asyncio
+async def test_search_enriches_content_hit_without_repeating_title_hit() -> None:
+    row = session(display_name="Grocery list")
+    storage = SearchStorage(
+        titles=[row],
+        rows=[
+            {
+                "session_key": row.session_key,
+                "role": "user",
+                "snippet": ">>>milk<<<",
+                "created_at": 10,
+            }
+        ],
+    )
+
+    result = await SessionDirectory(storage).search(
+        "milk",
+        20,
+        now_ms=123,
+        project=_search_projection,
+    )
+
+    assert result.sessions == ()
+    assert len(result.messages) == 1
+    assert result.messages[0].title == "Grocery list"

--- a/tests/test_ci/test_rpc_architecture_contracts.py
+++ b/tests/test_ci/test_rpc_architecture_contracts.py
@@ -51,16 +51,15 @@ SESSIONS_LIST_GATEWAY_ADAPTER = (
 RUNTIME_RPC_METHOD_BASELINE = 306
 STATIC_RPC_DECORATOR_BASELINE = 297
 
-# Physical lines in the sessions/runtime slice at the merged F2 baseline.
+# Physical lines in the sessions/runtime slice at the merged S1 baseline.
 # Contract sources, generators, fixtures, tests and generated artifacts are
-# reported separately.  F2 established the first private transport seam; the
-# S1 seam is allowed a bounded amount of authored code while it moves resolve
-# out of the legacy handler.  The budget includes every new authored runtime
-# file (application Port, two adapters and the neutral key helper); generated
-# code, fixtures and tests remain separate.  The final Z1 closure gate remains
-# responsible for making the complete migration smaller than the #1460 baseline.
-AUTHORED_RUNTIME_LOC_BASELINE = 25_590
-S1_AUTHORED_RUNTIME_GROWTH_BUDGET = 450
+# reported separately.  S1 established the first application seam; S2a moves
+# the search orchestration behind it and is allowed only a small, explicit
+# amount of authored code while the later cleanup PR removes the old DTOs and
+# adapter glue.  The final Z1 closure gate remains responsible for making the
+# complete migration smaller than the #1460 baseline.
+AUTHORED_RUNTIME_LOC_BASELINE = 26_018
+S2A_AUTHORED_RUNTIME_GROWTH_BUDGET = 220
 AUTHORED_RUNTIME_FILES = (
     "opensquilla-webui/src/App.vue",
     "opensquilla-webui/src/components/sessions/SessionInspectDrawer.vue",
@@ -440,13 +439,13 @@ def _physical_lines(relative_paths: tuple[str, ...]) -> int:
     )
 
 
-def test_s1_authored_runtime_stays_within_bounded_seam_budget() -> None:
+def test_s2a_authored_runtime_stays_within_bounded_seam_budget() -> None:
     current = _physical_lines(AUTHORED_RUNTIME_FILES)
     growth = current - AUTHORED_RUNTIME_LOC_BASELINE
-    assert growth <= S1_AUTHORED_RUNTIME_GROWTH_BUDGET, (
-        f"sessions.resolve authored runtime grew by {growth} lines "
-        f"from merged F2 baseline {AUTHORED_RUNTIME_LOC_BASELINE}; "
-        f"S1 budget is {S1_AUTHORED_RUNTIME_GROWTH_BUDGET}"
+    assert growth <= S2A_AUTHORED_RUNTIME_GROWTH_BUDGET, (
+        f"sessions.search authored runtime grew by {growth} lines "
+        f"from merged S1 baseline {AUTHORED_RUNTIME_LOC_BASELINE}; "
+        f"S2a budget is {S2A_AUTHORED_RUNTIME_GROWTH_BUDGET}"
     )
 
 


### PR DESCRIPTION
## Summary

This is the first `sessions.search` vertical slice after #1469. It deepens the `SessionDirectory` application module without changing the v4 wire contract or any client surface.

### Changes

- Move search input normalization, title lookup (including the bounded legacy fallback), ASCII/Unicode routing, deduplication, transcript-title enrichment, and best-effort transcript failure handling into `SessionDirectory.search()`.
- Keep the Gateway handler limited to session-storage lookup, a presentation projector, and mapping the domain result back to the existing v4 payload.
- Keep `RpcContext`, WebSocket transport, storage schema/SQL, WebUI, CLI, MCP, and all other session methods unchanged.
- Add application-level tests for normalization, FTS/LIKE routing, deduplication, legacy fallback, enrichment, and failure semantics.
- Rebaseline the authored-runtime gate at the merged S1 baseline with a bounded S2a budget; the final closure gate still owns the cumulative deletion check.

### Compatibility

The following semantics are intentionally unchanged: `operator.read`/guest policy, empty-query response, limit coercion and clamp, title-index failure propagation, transcript failure degradation, CJK LIKE search, title/content deduplication, response field names, and timestamps.

### Evidence

- GitNexus was indexed against this branch (`115,495` nodes, `223,816` edges). `SessionDirectory` has one incoming Gateway edge and no application-to-Gateway dependency; the previous handler's dynamic RPC incoming edge remains a known graph blind spot.
- Targeted application, Gateway search, architecture-import, and RPC architecture tests: `86 passed`.
- Mypy, Ruff, compileall, and `git diff --check` pass.

### Non-goals

No Contract schema or generated code, WebUI migration, Python-client migration, `sessions.preview`, chat history, subscriptions, runtime, transport, or database changes are included. Those remain separate S2b–S2d slices.
