### PR TITLE
refactor(webui): route session search through domain adapter

### DIFF
--- a/opensquilla-webui/scripts/lib/rpc-architecture-gate.mjs
+++ b/opensquilla-webui/scripts/lib/rpc-architecture-gate.mjs
@@ -176,6 +176,15 @@ export function evaluateRpcArchitectureGate({
       ) {
         failures.push(`${rel}: sessions.list wire literal is allowed only in its Contract Adapter.`)
       }
+      if (
+        ts.isStringLiteralLike(node)
+        && node.text === 'sessions.search'
+        && !isGatewayAdapter(rel)
+        && !isTestFile(rel)
+        && !isGeneratedContract(rel)
+      ) {
+        failures.push(`${rel}: sessions.search wire literal is allowed only in its Contract Adapter.`)
+      }
       ts.forEachChild(node, visit)
     }
     visit(source)

--- a/opensquilla-webui/scripts/rpc-debt/session-chat.mjs
+++ b/opensquilla-webui/scripts/rpc-debt/session-chat.mjs
@@ -1,7 +1,6 @@
 export const lane = 'session-chat'
 
 export const debt = {
-  'src/components/CommandPalette.vue': { call: 1 },
   'src/components/chat/PromptCacheKeepaliveDialog.vue': { call: 2 },
   'src/composables/chat/sessionBootstrapAdmission.ts': { waitForConnection: 2 },
   'src/composables/chat/useChatApprovals.ts': {

--- a/opensquilla-webui/src/adapters/gateway/sessionDirectoryV4.test.ts
+++ b/opensquilla-webui/src/adapters/gateway/sessionDirectoryV4.test.ts
@@ -8,6 +8,7 @@ import {
 } from './sessionDirectoryV4'
 import { SESSIONS_LIST_METHOD } from '@/contracts/generated/v4/sessionsList'
 import { SESSIONS_RESOLVE_METHOD } from '@/contracts/generated/v4/sessionsResolve'
+import { SESSIONS_SEARCH_METHOD } from '@/contracts/generated/v4/sessionsSearch'
 import type { SessionDirectory } from '@/modules/sessionDirectory'
 import { useSessions } from '@/composables/useSessions'
 
@@ -217,6 +218,134 @@ describe('v4 SessionDirectory Adapter', () => {
     })).rejects.toBe(abortError)
   })
 
+  it('searches through the typed Adapter and preserves the v4 call policy', async () => {
+    const ready = vi.fn().mockResolvedValue(undefined)
+    const requestTransport = vi.fn().mockResolvedValue({
+      sessions: [{
+        key: 'agent:main:s1',
+        title: 'Deploy planning',
+        effectiveAgentId: 'main',
+        surface: 'webchat',
+        updatedAt: 1700000000000,
+        extension: { retained: true },
+      }],
+      messages: [{
+        key: 'agent:main:s2',
+        title: 'Grocery list',
+        role: 'user',
+        snippet: 'buy >>>milk<<< today',
+        createdAt: 1700000000001,
+        future_field: 'ignored by the domain projection',
+      }],
+      query: 'milk',
+      ts: 1700000000002,
+      delivery_context: { source: 'search-index' },
+    })
+    const directory = createV4SessionDirectory({
+      ready,
+      request: requestTransport as SessionDirectoryTransport['request'],
+    })
+    const controller = new AbortController()
+
+    await expect(directory.search({
+      query: 'milk',
+      limit: 12,
+      signal: controller.signal,
+    })).resolves.toEqual({
+      sessions: [{
+        key: 'agent:main:s1',
+        title: 'Deploy planning',
+        surface: 'webchat',
+      }],
+      messages: [{
+        key: 'agent:main:s2',
+        title: 'Grocery list',
+        snippet: 'buy >>>milk<<< today',
+        createdAt: 1700000000001,
+      }],
+    })
+    expect(ready).toHaveBeenCalledWith({
+      timeoutMs: 10_000,
+      signal: controller.signal,
+      timeoutAction: 'reject',
+      abortAction: 'reject',
+    })
+    expect(requestTransport).toHaveBeenCalledWith(
+      SESSIONS_SEARCH_METHOD,
+      { query: 'milk', limit: 12 },
+      { ...callPolicy, signal: controller.signal },
+    )
+  })
+
+  it('accepts the legacy string timestamp while keeping search domain fields narrow', async () => {
+    const directory = createV4SessionDirectory({
+      request: vi.fn().mockResolvedValue({
+        sessions: [{
+          key: 'agent:main:legacy', title: 'Legacy', effectiveAgentId: null,
+          surface: null, updatedAt: null, future: true,
+        }],
+        messages: [{
+          key: 'agent:main:legacy', title: 'Legacy', role: null,
+          snippet: 'legacy result', createdAt: '1700000000000',
+        }],
+        query: 'legacy', ts: 1700000000002,
+      }) as SessionDirectoryTransport['request'],
+    })
+
+    await expect(directory.search({ query: 'legacy' })).resolves.toEqual({
+      sessions: [{ key: 'agent:main:legacy', title: 'Legacy', surface: null }],
+      messages: [{
+        key: 'agent:main:legacy', title: 'Legacy',
+        snippet: 'legacy result', createdAt: 1700000000000,
+      }],
+    })
+  })
+
+  it('maps search Gateway errors and rejects malformed results at the seam', async () => {
+    const failure = Object.assign(new Error('not allowed'), { code: 'UNAUTHORIZED' })
+    const denied = createV4SessionDirectory({
+      request: vi.fn().mockRejectedValue(failure) as SessionDirectoryTransport['request'],
+    })
+    await expect(denied.search({ query: 'secret' })).rejects.toMatchObject({
+      name: 'SessionDirectoryError',
+      code: 'forbidden',
+    })
+
+    const malformed = createV4SessionDirectory({
+      request: vi.fn().mockResolvedValue({ sessions: [], messages: [] }) as
+        SessionDirectoryTransport['request'],
+    })
+    await expect(malformed.search({ query: 'milk' })).rejects.toMatchObject({
+      name: 'SessionDirectoryError',
+      code: 'unavailable',
+    })
+  })
+
+  it('maps an unavailable legacy search method to the domain error', async () => {
+    const failure = Object.assign(new Error('method missing'), { code: 'METHOD_NOT_FOUND' })
+    const directory = createV4SessionDirectory({
+      request: vi.fn().mockRejectedValue(failure) as SessionDirectoryTransport['request'],
+    })
+
+    await expect(directory.search({ query: 'milk' })).rejects.toMatchObject({
+      name: 'SessionDirectoryError',
+      code: 'unsupported',
+    })
+  })
+
+  it('preserves caller cancellation for search requests', async () => {
+    const controller = new AbortController()
+    const abortError = Object.assign(new Error('cancelled'), { name: 'AbortError' })
+    const directory = createV4SessionDirectory({
+      request: vi.fn().mockRejectedValue(abortError) as SessionDirectoryTransport['request'],
+    })
+
+    await expect(directory.search({
+      query: 'milk',
+      signal: controller.signal,
+    })).rejects.toBe(abortError)
+  })
+
   it('owns its v4 readiness, timeout, and abort policy', async () => {
     const controller = new AbortController()
     const ready = vi.fn().mockResolvedValue(undefined)
@@ -292,6 +421,7 @@ describe('v4 SessionDirectory Adapter', () => {
         key: first.key,
         id: 'session-one',
       }),
+      search: vi.fn().mockResolvedValue({ sessions: [], messages: [] }),
     }
     setActivePinia(createPinia())
     const sessions = useSessions(directory)

--- a/opensquilla-webui/src/adapters/gateway/sessionDirectoryV4.ts
+++ b/opensquilla-webui/src/adapters/gateway/sessionDirectoryV4.ts
@@ -12,12 +12,20 @@ import {
   type SessionsResolveResult,
 } from '@/contracts/generated/v4/sessionsResolve'
 import { validateSessionsResolveResult } from '@/contracts/generated/v4/sessionsResolveValidators.mjs'
+import {
+  SESSIONS_SEARCH_METHOD,
+  type SessionsSearchParams,
+  type SessionsSearchResult as SessionsSearchWireResult,
+} from '@/contracts/generated/v4/sessionsSearch'
+import { validateSessionsSearchResult } from '@/contracts/generated/v4/sessionsSearchValidators.mjs'
 import type {
   ResolvedSession,
   SessionCount,
   SessionDirectory,
   SessionItem,
   SessionPage,
+  SessionSearchRequest,
+  SessionSearchResult,
 } from '@/modules/sessionDirectory'
 import { SessionDirectoryError } from '@/modules/sessionDirectory'
 import {
@@ -259,19 +267,25 @@ export function normalizeV4SessionItem(item: unknown): SessionItem | null {
 export function createV4SessionDirectory(
   transport: SessionDirectoryTransport,
 ): SessionDirectory {
+  async function requestWithPolicy<T>(
+    method: string,
+    params: Record<string, unknown>,
+    signal: AbortSignal | undefined,
+    abortMessage: string,
+  ): Promise<T> {
+    const options = signal ? { ...SESSION_DIRECTORY_CALL_OPTIONS, signal } : SESSION_DIRECTORY_CALL_OPTIONS
+    await transport.ready?.({ ...options, timeoutAction: 'reject', abortAction: 'reject' })
+    if (signal?.aborted) throw signal.reason || new Error(abortMessage)
+    return transport.request<T>(method, params, options)
+  }
+
   async function call(params: SessionsListParams, signal?: AbortSignal) {
-    const options = signal
-      ? { ...SESSION_DIRECTORY_CALL_OPTIONS, signal }
-      : SESSION_DIRECTORY_CALL_OPTIONS
-    await transport.ready?.(
-      {
-        timeoutMs: options.timeoutMs,
-        signal: options.signal,
-        timeoutAction: 'reject', abortAction: 'reject',
-      },
+    const result = await requestWithPolicy<Partial<SessionsListResult>>(
+      SESSIONS_LIST_METHOD,
+      params,
+      signal,
+      'Session directory request aborted',
     )
-    if (signal?.aborted) throw signal.reason || new Error('Session directory request aborted')
-    const result = await transport.request(SESSIONS_LIST_METHOD, params, options)
     return objectValue(result) as Partial<SessionsListResult> || {}
   }
 
@@ -317,31 +331,17 @@ export function createV4SessionDirectory(
 
     async resolve(request): Promise<ResolvedSession> {
       const params: SessionsResolveParams = { key: request.key }
-      const options = request.signal
-        ? { ...SESSION_DIRECTORY_CALL_OPTIONS, signal: request.signal }
-        : SESSION_DIRECTORY_CALL_OPTIONS
       try {
-        await transport.ready?.({
-          timeoutMs: options.timeoutMs,
-          signal: options.signal,
-          timeoutAction: 'reject',
-          abortAction: 'reject',
-        })
-        if (request.signal?.aborted) {
-          throw request.signal.reason || new Error('Session resolution request aborted')
-        }
-        const raw = await transport.request(
+        const raw = await requestWithPolicy<SessionsResolveResult>(
           SESSIONS_RESOLVE_METHOD,
           params,
-          options,
+          request.signal,
+          'Session resolution request aborted',
         )
-        if (!validateSessionsResolveResult(raw)) {
-          throw new SessionDirectoryError(
-            'unavailable',
-            'sessions.resolve returned an invalid response',
-          )
-        }
-        const result = raw as SessionsResolveResult
+        if (!validateSessionsResolveResult(raw)) throw new SessionDirectoryError(
+          'unavailable', 'sessions.resolve returned an invalid response',
+        )
+        const result = raw
         if (
           typeof result.session_key !== 'string'
           || typeof result.session_id !== 'string'
@@ -354,6 +354,32 @@ export function createV4SessionDirectory(
         return {
           key: result.session_key,
           id: result.session_id,
+        }
+      } catch (error) {
+        if (isAbort(error, request.signal)) throw error
+        throw sessionDirectoryError(error)
+      }
+    },
+
+    async search(request: SessionSearchRequest): Promise<SessionSearchResult> {
+      try {
+        const params: SessionsSearchParams = { query: request.query }
+        if (request.limit !== undefined) params.limit = request.limit
+        const raw = await requestWithPolicy<SessionsSearchWireResult>(
+          SESSIONS_SEARCH_METHOD,
+          params,
+          request.signal,
+          'Session search request aborted',
+        )
+        if (!validateSessionsSearchResult(raw)) throw new SessionDirectoryError(
+          'unavailable', 'sessions.search returned an invalid response',
+        )
+        const wire = raw
+        return {
+          sessions: wire.sessions.map(({ key, title, surface }) => ({ key, title, surface })),
+          messages: wire.messages.map(({ key, title, snippet, createdAt }) => ({
+            key, title, snippet, createdAt: numberValue(createdAt),
+          })),
         }
       } catch (error) {
         if (isAbort(error, request.signal)) throw error

--- a/opensquilla-webui/src/architecture/rpcArchitectureGate.integration.test.ts
+++ b/opensquilla-webui/src/architecture/rpcArchitectureGate.integration.test.ts
@@ -97,6 +97,16 @@ describe('transport architecture gate ledger integration', () => {
     )
   })
 
+  it('keeps sessions.search wire literals inside the Contract Adapter', () => {
+    const root = seededFixture(`
+      import { useRpcStore } from './stores/rpc'
+      useRpcStore().call('sessions.search')
+    `)
+    expect(evaluateRpcArchitectureGate({ root, debtLanes: oneCallLane }).failures).toContain(
+      'src/feature.ts: sessions.search wire literal is allowed only in its Contract Adapter.',
+    )
+  })
+
   it('fails when a paid-down entry remains in the ledger', () => {
     const root = seededFixture('export const value = 1')
     expect(evaluateRpcArchitectureGate({ root, debtLanes: oneCallLane }).failures).toContain(

--- a/opensquilla-webui/src/components/CommandPalette.test.ts
+++ b/opensquilla-webui/src/components/CommandPalette.test.ts
@@ -1,19 +1,19 @@
 // @vitest-environment happy-dom
 import { createApp, nextTick, type App } from 'vue'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import i18n from '@/i18n'
+import {
+  SESSION_DIRECTORY_KEY,
+  type SessionDirectory,
+  type SessionSearchResult,
+} from '@/modules/sessionDirectory'
 import CommandPalette from './CommandPalette.vue'
 
 const routerPush = vi.fn()
-const rpcCall = vi.fn(async () => ({ sessions: [], messages: [] }))
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: routerPush }),
-}))
-
-vi.mock('@/stores/rpc', () => ({
-  useRpcStore: () => ({ call: rpcCall }),
 }))
 
 vi.mock('@/composables/useBgm', () => ({
@@ -23,25 +23,50 @@ vi.mock('@/composables/useBgm', () => ({
   }),
 }))
 
-describe('CommandPalette navigation commands', () => {
+function emptySearch(): SessionSearchResult {
+  return { sessions: [], messages: [] }
+}
+
+function fakeDirectory(
+  search: SessionDirectory['search'] = vi.fn().mockResolvedValue(emptySearch()),
+): SessionDirectory {
+  return {
+    listPage: vi.fn().mockResolvedValue({ items: [], hasMore: false, nextCursor: null }),
+    count: vi.fn().mockResolvedValue({ value: 0, exact: true }),
+    resolve: vi.fn().mockResolvedValue({
+      key: 'agent:main:webchat:default',
+      id: 'default',
+    }),
+    search,
+  }
+}
+
+describe('CommandPalette navigation and conversation search', () => {
   let app: App<Element> | null = null
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    i18n.global.locale.value = 'en'
+  })
 
   afterEach(() => {
     app?.unmount()
     app = null
     document.body.innerHTML = ''
     routerPush.mockReset()
-    rpcCall.mockReset()
+    vi.clearAllTimers()
+    vi.useRealTimers()
   })
 
-  async function mountPalette() {
+  async function mountPalette(directory = fakeDirectory()) {
     const el = document.createElement('div')
     document.body.appendChild(el)
     app = createApp(CommandPalette, { open: true, recents: [] })
     app.use(i18n)
+    app.provide(SESSION_DIRECTORY_KEY, directory)
     app.mount(el)
     await nextTick()
-    return el
+    return { directory, el }
   }
 
   async function search(el: Element, value: string) {
@@ -51,9 +76,16 @@ describe('CommandPalette navigation commands', () => {
     await nextTick()
   }
 
+  async function settleSearch() {
+    await vi.advanceTimersByTimeAsync(180)
+    await nextTick()
+    // The Adapter promise and the component's continuation each get a turn.
+    await Promise.resolve()
+    await nextTick()
+  }
+
   it('shows one primary usage destination for English and Chinese queries', async () => {
-    i18n.global.locale.value = 'en'
-    const el = await mountPalette()
+    const { el } = await mountPalette()
 
     await search(el, 'usage')
     expect(Array.from(el.querySelectorAll('.cmdp-option__label')).map(node => node.textContent))
@@ -63,5 +95,109 @@ describe('CommandPalette navigation commands', () => {
     expect(Array.from(el.querySelectorAll('.cmdp-option__label')).map(node => node.textContent))
       .toEqual(['View usage'])
     expect(el.querySelector('.cmdp-group-label')?.textContent).toBe('Work')
+  })
+
+  it('debounces search by 180ms and sends the domain request', async () => {
+    const searchCall = vi.fn().mockResolvedValue(emptySearch())
+    const { directory, el } = await mountPalette(fakeDirectory(searchCall))
+
+    await search(el, 'milk')
+    await vi.advanceTimersByTimeAsync(179)
+    expect(directory.search).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(directory.search).toHaveBeenCalledTimes(1)
+    expect(directory.search).toHaveBeenCalledWith({ query: 'milk', limit: 12 })
+  })
+
+  it('renders session and message hits with transcript highlighting', async () => {
+    const searchCall = vi.fn().mockResolvedValue({
+      sessions: [{
+        key: 'agent:main:s1',
+        title: 'Deploy planning',
+        surface: 'webchat',
+      }],
+      messages: [{
+        key: 'agent:main:s2',
+        title: 'Grocery list',
+        snippet: 'buy >>>milk<<< today',
+        createdAt: 1700000000000,
+      }],
+    } satisfies SessionSearchResult)
+    const { el } = await mountPalette(fakeDirectory(searchCall))
+
+    await search(el, 'milk')
+    await settleSearch()
+
+    expect(Array.from(el.querySelectorAll('.cmdp-option__label')).map(node => node.textContent))
+      .toEqual(['Deploy planning', 'Grocery list'])
+    expect(el.querySelector('.cmdp-option__snippet')?.textContent).toBe('buy milk today')
+    expect(el.querySelector('.cmdp-option__snippet mark.cmdp-mark')?.textContent).toBe('milk')
+  })
+
+  it('does not let a stale search response replace the latest query', async () => {
+    let resolveFirst!: (value: SessionSearchResult) => void
+    let resolveSecond!: (value: SessionSearchResult) => void
+    const first = new Promise<SessionSearchResult>(resolve => { resolveFirst = resolve })
+    const second = new Promise<SessionSearchResult>(resolve => { resolveSecond = resolve })
+    const searchCall = vi.fn()
+      .mockReturnValueOnce(first)
+      .mockReturnValueOnce(second)
+    const { el } = await mountPalette(fakeDirectory(searchCall))
+
+    await search(el, 'first')
+    await vi.advanceTimersByTimeAsync(180)
+    await search(el, 'second')
+    await vi.advanceTimersByTimeAsync(180)
+    expect(searchCall).toHaveBeenCalledTimes(2)
+
+    resolveSecond({
+      sessions: [{ key: 'agent:main:new', title: 'Second result', surface: null }],
+      messages: [],
+    })
+    await nextTick()
+    await Promise.resolve()
+    await nextTick()
+    expect(el.textContent).toContain('Second result')
+
+    resolveFirst({
+      sessions: [{ key: 'agent:main:old', title: 'First result', surface: null }],
+      messages: [],
+    })
+    await nextTick()
+    await Promise.resolve()
+    await nextTick()
+    expect(el.textContent).toContain('Second result')
+    expect(el.textContent).not.toContain('First result')
+  })
+
+  it('clears results after a search error and stops the searching indicator', async () => {
+    const searchCall = vi.fn().mockRejectedValue(new Error('search unavailable'))
+    const { el } = await mountPalette(fakeDirectory(searchCall))
+
+    await search(el, 'milk')
+    await settleSearch()
+
+    expect(el.querySelector('.cmdp-searching')).toBeNull()
+    expect(el.querySelector('.cmdp-option__snippet')).toBeNull()
+    expect(el.querySelector('.cmdp-empty')?.textContent).toContain('No matches')
+  })
+
+  it('does not search short ASCII queries and clears prior hits', async () => {
+    const searchCall = vi.fn().mockResolvedValue({
+      sessions: [{ key: 'agent:main:s1', title: 'Milk planning', surface: null }],
+      messages: [],
+    } satisfies SessionSearchResult)
+    const { el } = await mountPalette(fakeDirectory(searchCall))
+
+    await search(el, 'milk')
+    await settleSearch()
+    expect(el.textContent).toContain('Milk planning')
+
+    await search(el, 'm')
+    expect(searchCall).toHaveBeenCalledTimes(1)
+    expect(el.textContent).not.toContain('Milk planning')
+    expect(el.querySelector('.cmdp-option__snippet')).toBeNull()
+    expect(el.querySelector('.cmdp-searching')).toBeNull()
   })
 })

--- a/opensquilla-webui/src/components/CommandPalette.vue
+++ b/opensquilla-webui/src/components/CommandPalette.vue
@@ -87,18 +87,22 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import { computed, inject, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import Icon from './Icon.vue'
 import { useDialogA11y } from '@/composables/useDialogA11y'
 import { useBgm } from '@/composables/useBgm'
 import { getWorkNavigationSection } from '@/router/nav'
-import { useRpcStore } from '@/stores/rpc'
+import {
+  SESSION_DIRECTORY_KEY,
+  type SessionDirectory,
+  type SessionSearchMessageHit,
+  type SessionSearchSessionHit,
+} from '@/modules/sessionDirectory'
 import { highlightFtsSnippet } from '@/utils/searchSnippet'
 import type { SidebarSection } from '@/composables/useSessions'
 import type { IconName } from '@/utils/icons'
-import type { MessageSearchHit, SessionSearchHit, SessionsSearchResponse } from '@/types/rpc'
 
 const props = defineProps<{
   open: boolean
@@ -121,7 +125,9 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const router = useRouter()
-const rpcStore = useRpcStore()
+const injectedSessionDirectory = inject(SESSION_DIRECTORY_KEY)
+if (!injectedSessionDirectory) throw new Error('SessionDirectory was not provided')
+const sessionDirectory: SessionDirectory = injectedSessionDirectory
 const { enabled: bgmEnabled, setEnabled: setBgmEnabled } = useBgm()
 
 const dialogRef = ref<HTMLElement | null>(null)
@@ -297,10 +303,10 @@ const filtered = computed<Command[]>(() => {
 
 // ---------------------------------------------------------------------------
 // Conversation search — async, debounced, server-side over titles + transcript
-// content (sessions.search). Results append below the static nav/action groups.
+// content. Results append below the static nav/action groups.
 // ---------------------------------------------------------------------------
-const sessionHits = ref<SessionSearchHit[]>([])
-const messageHits = ref<MessageSearchHit[]>([])
+const sessionHits = ref<SessionSearchSessionHit[]>([])
+const messageHits = ref<SessionSearchMessageHit[]>([])
 const searching = ref(false)
 let debounceTimer: ReturnType<typeof setTimeout> | null = null
 // Monotonic token so a slow response from an earlier keystroke can't overwrite
@@ -317,7 +323,7 @@ async function runSearch(q: string) {
   const token = ++searchToken
   searching.value = true
   try {
-    const res = await rpcStore.call<SessionsSearchResponse>('sessions.search', { query: q, limit: 12 })
+    const res = await sessionDirectory.search({ query: q, limit: 12 })
     if (token !== searchToken) return
     sessionHits.value = res?.sessions ?? []
     messageHits.value = res?.messages ?? []

--- a/opensquilla-webui/src/composables/usage/useUsageData.setRange.test.ts
+++ b/opensquilla-webui/src/composables/usage/useUsageData.setRange.test.ts
@@ -93,6 +93,7 @@ function mountUsageData() {
     listPage: vi.fn().mockResolvedValue({ items: [], hasMore: false, nextCursor: null }),
     count: vi.fn().mockResolvedValue({ value: 0, exact: true }),
     resolve: vi.fn().mockResolvedValue({ key: 'agent:main:webchat:default', id: 'default' }),
+    search: vi.fn().mockResolvedValue({ sessions: [], messages: [] }),
   }
   const api = scope.run(() => useUsageData(directory))!
   return { api, directory, scope }

--- a/opensquilla-webui/src/modules/sessionDirectory.ts
+++ b/opensquilla-webui/src/modules/sessionDirectory.ts
@@ -45,6 +45,14 @@ export interface ResolvedSession {
   id: string
 }
 
+export type SessionSearchSessionHit = { key: string; title: string; surface: string | null }
+export type SessionSearchMessageHit = { key: string; title: string; snippet: string; createdAt: number | null }
+export type SessionSearchResult = {
+  sessions: SessionSearchSessionHit[]
+  messages: SessionSearchMessageHit[]
+}
+export type SessionSearchRequest = RequestOptions & { query: string; limit?: number }
+
 export type SessionDirectoryErrorCode =
   | 'not-found'
   | 'unsupported'
@@ -75,6 +83,7 @@ export interface SessionDirectory {
   ): Promise<SessionPage>
   count(options?: SessionDirectoryQueryOptions): Promise<SessionCount | null>
   resolve(request: { key: string } & RequestOptions): Promise<ResolvedSession>
+  search(request: SessionSearchRequest): Promise<SessionSearchResult>
 }
 
 export const SESSION_DIRECTORY_KEY: InjectionKey<SessionDirectory> = Symbol('SessionDirectory')

--- a/opensquilla-webui/src/types/rpc.ts
+++ b/opensquilla-webui/src/types/rpc.ts
@@ -67,33 +67,6 @@ export interface ProjectWorkspaceHistoryDeleteResponse {
   deletedSessionKeys?: string[]
 }
 
-/** One title/subject match from `sessions.search`. */
-export interface SessionSearchHit {
-  key: string
-  title: string
-  effectiveAgentId?: string | null
-  surface?: string | null
-  updatedAt?: number | null
-}
-
-/** One transcript (full-text) match from `sessions.search`. The snippet wraps
- *  matched terms in `>>>`/`<<<` delimiters (highlighted by the renderer). */
-export interface MessageSearchHit {
-  key: string
-  title: string
-  role?: string | null
-  snippet: string
-  createdAt?: number | null
-  effectiveAgentId?: string | null
-}
-
-export interface SessionsSearchResponse {
-  sessions?: SessionSearchHit[]
-  messages?: MessageSearchHit[]
-  query?: string
-  ts?: number
-}
-
 export interface ArtifactPayload {
   id?: string
   key?: string


### PR DESCRIPTION
## Scope

Scope boundary: migrate the WebUI `sessions.search` caller to the existing `SessionDirectory` domain seam and v4 Contract Adapter.

Non-goals: no Gateway business-implementation change, WebSocket/transport change, event migration, Python client migration, or full front/back separation in this PR. The FTS `>>>…<<<` snippet presentation contract remains unchanged for a later Session Query/Inspector slice.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: This is the next planned vertical refactoring slice after the merged sessions.search Contract/Gateway Adapter; it does not fix a user-reported issue.

## Release Note

Release note: NONE |

## What changed

- Added authored `SessionDirectory.search()` request/result types and migrated `CommandPalette.vue` away from `useRpcStore().call()` and the legacy search DTOs.
- Added v4 Adapter projection and generated-result validation. Generated wire types are imported only by the Gateway Adapter; the domain result keeps only UI-facing fields and normalizes legacy numeric timestamps to `number | null`.
- Reused one readiness/timeout/abort policy for list, resolve, and search without changing the transport or Gateway implementation.
- Deleted the three obsolete search DTOs from `types/rpc.ts` and removed the paid-down raw-call ledger entry.
- Added an exact `sessions.search` literal architecture guard and integration coverage, plus Adapter, component, debounce/race/error, and compatibility tests.

## Compatibility

The v4 JSON envelope, method name, params (`query`/`limit`), scope, permission behavior, error mapping, legacy aliases, and backend implementation are unchanged. Existing `main` Gateway responses (including additive fields and string timestamps) are accepted. This PR does not claim the complete compatibility matrix or real-WebSocket E2E migration; those belong to the later Python/client and end-to-end slices.

## Tests

Ruff: not run (no Python production changes)

Pytest: `PYTHONPATH=src .venv/bin/pytest -q tests/test_ci/test_rpc_architecture_contracts.py` (13 passed)

Build: `npm run build` (passed; Vite artifact verification, 397 files)

Regression tests: added

Additional checks:

- `npm run test:unit` (386 files, 4,972 tests passed)
- targeted Vitest (55 passed after final change)
- `npm run typecheck`, `npm run check:rpc-architecture` (passed)
- GitNexus detect-changes: 10 files / 18 symbols, low risk; base and current indexes both report 13 existing import cycles.

Notes: full unit tests may print a caught local probe connection AggregateError; the test run still completed successfully. The generated Contract files are unchanged in this PR and generator determinism remains covered by the existing Contract CI.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks.

## Safety

No secrets, private transcripts, or local build artifacts are committed.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
