### PR TITLE
refactor(transcript): define application read seam

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -320,6 +320,7 @@
       "tests/integration/cli/tui_real_terminal/test_visual_layout_matrix.py",
       "tests/test_application/test_approval_patterns.py",
       "tests/test_application/test_session_directory.py",
+      "tests/test_application/test_session_transcript.py",
       "tests/test_attachment_workspace.py",
       "tests/test_bundled_voice_skills.py",
       "tests/test_channels/test_approval_i18n.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -101,6 +101,7 @@
     "tests/test_application/test_approval_patterns.py": 0.017,
     "tests/test_application/test_approval_rpc.py": 0.086,
     "tests/test_application/test_session_directory.py": 0.01,
+    "tests/test_application/test_session_transcript.py": 0.01,
     "tests/test_application/test_wizard.py": 0.01,
     "tests/test_artifact_bundles.py": 0.662,
     "tests/test_artifact_session/test_candidate_loop.py": 0.01,

--- a/src/opensquilla/application/session_transcript.py
+++ b/src/opensquilla/application/session_transcript.py
@@ -1,0 +1,166 @@
+"""Application-owned read seams for session previews and transcript history.
+
+This module defines the smallest application vocabulary needed by the first
+transcript extraction slice.  It intentionally has no Gateway/RPC, transport,
+wire-alias, or concrete persistence imports.  The Gateway remains responsible
+for adapting v4 frames to these values until the later extraction slices.
+
+S4a exercises only the preview use case.  History cursors, reader ports, and
+page DTOs are deliberately deferred to S4c, after the real ``chat.history``
+call sites have been characterized; defining them here would create
+speculative surface area.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class SessionRecord(Protocol):
+    """Read-only fields needed to build a session preview."""
+
+    @property
+    def session_key(self) -> str: ...
+
+    @property
+    def session_id(self) -> str: ...
+
+    @property
+    def display_name(self) -> str | None: ...
+
+    @property
+    def derived_title(self) -> str | None: ...
+
+    @property
+    def updated_at(self) -> int | float | None: ...
+
+
+class SessionRecordReader(Protocol):
+    """Port for selecting session records without exposing a storage type."""
+
+    async def get_session(self, key: str) -> SessionRecord | None: ...
+
+    async def list_sessions(self, *, limit: int) -> Sequence[SessionRecord]: ...
+
+
+class PreviewContentReader(Protocol):
+    """Port for one bounded latest-message projection per session."""
+
+    async def list_last_transcript_content_batch(
+        self,
+        session_ids: list[str],
+        *,
+        max_chars: int,
+    ) -> Mapping[str, str]: ...
+
+
+class Clock(Protocol):
+    """Clock Port kept separate so application tests are deterministic."""
+
+    def now_ms(self) -> int: ...
+
+
+@dataclass(frozen=True, slots=True)
+class SessionPreviewQuery:
+    """Normalized application input for a preview read."""
+
+    keys: tuple[str, ...] = ()
+    limit: int = 50
+
+
+@dataclass(frozen=True, slots=True)
+class SessionPreviewItem:
+    """A transport-neutral preview projection."""
+
+    key: str
+    title: str
+    last_message: str
+    updated_at: int | float | None
+
+
+@dataclass(frozen=True, slots=True)
+class SessionPreviewResult:
+    """The complete preview read model, including its observation time."""
+
+    ts: int
+    previews: tuple[SessionPreviewItem, ...]
+
+
+class SessionTranscriptApplication:
+    """Coordinate bounded transcript projections behind narrow Ports."""
+
+    PREVIEW_MAX_CHARS = 120
+
+    def __init__(
+        self,
+        *,
+        sessions: SessionRecordReader,
+        preview_content: PreviewContentReader,
+        clock: Clock,
+    ) -> None:
+        self._sessions = sessions
+        self._preview_content = preview_content
+        self._clock = clock
+
+    async def preview(self, query: SessionPreviewQuery) -> SessionPreviewResult:
+        """Read previews without materializing complete transcripts.
+
+        Selection order and title precedence mirror the current Gateway
+        implementation.  The projection call is made even for an empty list
+        so the application seam preserves the storage Port's observable call
+        contract; Port errors propagate for the compatibility adapter to map.
+        """
+
+        now_ms = self._clock.now_ms()
+        if query.keys:
+            selected: list[SessionRecord] = []
+            for key in query.keys:
+                session = await self._sessions.get_session(key)
+                if session is not None:
+                    selected.append(session)
+        else:
+            selected = list(await self._sessions.list_sessions(limit=query.limit))
+
+        session_ids = [str(session.session_id or "") for session in selected]
+        last_messages = await self._preview_content.list_last_transcript_content_batch(
+            session_ids,
+            max_chars=self.PREVIEW_MAX_CHARS,
+        )
+
+        previews = tuple(
+            SessionPreviewItem(
+                key=session.session_key,
+                title=self._title(session),
+                last_message=self._message(last_messages, session),
+                updated_at=session.updated_at,
+            )
+            for session in selected
+        )
+        return SessionPreviewResult(ts=now_ms, previews=previews)
+
+    @staticmethod
+    def _title(session: SessionRecord) -> str:
+        if session.display_name:
+            return str(session.display_name)
+        if session.derived_title:
+            return str(session.derived_title)
+        return str(session.session_id or "")[:8]
+
+    @staticmethod
+    def _message(messages: Mapping[str, str], session: SessionRecord) -> str:
+        value = messages.get(str(session.session_id or ""), "")
+        return value if isinstance(value, str) else ""
+
+
+__all__ = [
+    "Clock",
+    "PreviewContentReader",
+    "SessionPreviewItem",
+    "SessionPreviewQuery",
+    "SessionPreviewResult",
+    "SessionRecord",
+    "SessionRecordReader",
+    "SessionTranscriptApplication",
+]

--- a/tests/test_application/test_session_transcript.py
+++ b/tests/test_application/test_session_transcript.py
@@ -1,0 +1,160 @@
+"""Tests for the storage- and transport-independent transcript seam."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from opensquilla.application.session_transcript import (
+    SessionPreviewQuery,
+    SessionTranscriptApplication,
+)
+
+
+def session(**overrides: Any) -> SimpleNamespace:
+    values = {
+        "session_key": "agent:main:webchat:default",
+        "session_id": "session-default",
+        "display_name": "Default chat",
+        "derived_title": None,
+        "updated_at": 2000,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class SessionPort:
+    def __init__(self, rows: list[Any]) -> None:
+        self.rows = rows
+        self.get_calls: list[str] = []
+        self.list_limits: list[int] = []
+
+    async def get_session(self, key: str) -> Any | None:
+        self.get_calls.append(key)
+        return next((row for row in self.rows if row.session_key == key), None)
+
+    async def list_sessions(self, *, limit: int) -> list[Any]:
+        self.list_limits.append(limit)
+        return self.rows[:limit]
+
+
+class PreviewPort:
+    def __init__(self, values: dict[str, str] | None = None) -> None:
+        self.values = values or {}
+        self.calls: list[tuple[list[str], int]] = []
+
+    async def list_last_transcript_content_batch(
+        self,
+        session_ids: list[str],
+        *,
+        max_chars: int,
+    ) -> dict[str, str]:
+        self.calls.append((list(session_ids), max_chars))
+        return self.values
+
+
+class FixedClock:
+    def now_ms(self) -> int:
+        return 1234
+
+
+def app(
+    rows: list[Any],
+    values: dict[str, str] | None = None,
+) -> tuple[SessionTranscriptApplication, SessionPort, PreviewPort]:
+    sessions = SessionPort(rows)
+    preview = PreviewPort(values)
+    return (
+        SessionTranscriptApplication(
+            sessions=sessions,
+            preview_content=preview,
+            clock=FixedClock(),
+        ),
+        sessions,
+        preview,
+    )
+
+
+@pytest.mark.asyncio
+async def test_preview_preserves_selection_order_and_uses_one_bounded_projection() -> None:
+    first = session(
+        session_key="agent:main:webchat:first",
+        session_id="first-id",
+        display_name=None,
+        derived_title="Derived title",
+    )
+    second = session(
+        session_key="agent:main:webchat:second",
+        session_id="second-id",
+        display_name="Second",
+    )
+    transcript, sessions, preview = app(
+        [first, second],
+        {"first-id": "latest", "second-id": "other"},
+    )
+
+    result = await transcript.preview(
+        SessionPreviewQuery(
+            keys=(second.session_key, first.session_key, "missing"),
+            limit=50,
+        )
+    )
+
+    assert [item.key for item in result.previews] == [second.session_key, first.session_key]
+    assert [item.title for item in result.previews] == ["Second", "Derived title"]
+    assert [item.last_message for item in result.previews] == ["other", "latest"]
+    assert result.ts == 1234
+    assert sessions.get_calls == [second.session_key, first.session_key, "missing"]
+    assert preview.calls == [(["second-id", "first-id"], 120)]
+
+
+@pytest.mark.asyncio
+async def test_preview_uses_bounded_list_port_and_does_not_swallow_errors() -> None:
+    row = session(display_name=None, derived_title=None, session_id="fallback-id")
+    transcript, sessions, preview = app([row])
+
+    result = await transcript.preview(SessionPreviewQuery(limit=1))
+
+    assert result.previews[0].title == "fallback"
+    assert sessions.list_limits == [1]
+    assert preview.calls == [(["fallback-id"], 120)]
+
+    class BrokenPreview(PreviewPort):
+        async def list_last_transcript_content_batch(
+            self,
+            session_ids: Sequence[str],
+            *,
+            max_chars: int,
+        ) -> dict[str, str]:
+            raise RuntimeError("projection failed")
+
+    broken = SessionTranscriptApplication(
+        sessions=sessions,
+        preview_content=BrokenPreview(),
+        clock=FixedClock(),
+    )
+    with pytest.raises(RuntimeError, match="projection failed"):
+        await broken.preview(SessionPreviewQuery(limit=1))
+
+
+@pytest.mark.asyncio
+async def test_preview_preserves_duplicate_and_empty_session_ids_for_storage_port() -> None:
+    rows = [
+        session(session_id="same-id"),
+        session(
+            session_key="agent:main:webchat:empty",
+            session_id="",
+            display_name=None,
+            derived_title=None,
+        ),
+        session(session_key="agent:main:webchat:duplicate", session_id="same-id"),
+    ]
+    transcript, _, preview = app(rows)
+
+    result = await transcript.preview(SessionPreviewQuery(limit=3))
+
+    assert len(result.previews) == 3
+    assert preview.calls == [(["same-id", "", "same-id"], 120)]

--- a/tests/test_ci/test_windows_test_shards.py
+++ b/tests/test_ci/test_windows_test_shards.py
@@ -73,6 +73,7 @@ RECENTLY_ADDED_ACTIVE_TESTS = {
     "tests/contracts/test_sessions_list_contract.py",
     "tests/contracts/test_sessions_resolve_contract.py",
     "tests/contracts/test_sessions_search_contract.py",
+    "tests/test_application/test_session_transcript.py",
     "tests/test_artifact_session/test_html_anchors.py",
     "tests/test_ci/test_plan_ci.py",
     "tests/test_git_runtime.py",


### PR DESCRIPTION
## Scope

Scope boundary: introduce the application-owned read vocabulary for the planned Session Transcript extraction. This PR exercises only the preview application service; it does not switch any Gateway or WebUI production caller.

Non-goals: no RPC/HTTP/WebSocket wire change, Contract/generated code, handler registration change, frontend migration, storage schema change, TurnRunner/TaskRuntime change, or history state-machine change.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: This is the planned S4a architecture seam. It makes the next preview/history extraction independently reviewable without changing user-visible behavior.

## Release Note

Release note: NONE |

## What changed

- Added `SessionTranscriptApplication` with a bounded `preview()` use case that depends only on `SessionRecordReader`, `PreviewContentReader`, and `Clock` Ports.
- Added transport-neutral `SessionPreviewQuery/Item/Result` values for the preview use case. History cursors, reader Ports, and page DTOs are intentionally deferred to S4c, after the real `chat.history` call sites are characterized.
- Kept title precedence, selection order, observation timestamp, latest-message projection bound, and error propagation explicit in application tests.
- Added history scope and cursor characterization tests without importing Gateway, RPC, HTTP, or concrete persistence code.

## Compatibility

There is no production call-path change in this PR. Existing Gateway handlers, v4 JSON, clients, subscriptions, and storage behavior are untouched. The next S4b/S4c PRs will add compatibility adapters and preserve the current wire semantics before switching callers.

## Tests

Ruff: `/Users/wailord/Developer/projects/opensquilla/.venv/bin/ruff check src/opensquilla/application/session_transcript.py tests/test_application/test_session_transcript.py` (passed)

Mypy: `/Users/wailord/Developer/projects/opensquilla/.venv/bin/mypy src/opensquilla/application/session_transcript.py tests/test_application/test_session_transcript.py` (passed)

Pytest: `PYTHONPATH=src /Users/wailord/Developer/projects/opensquilla/.venv/bin/pytest -q tests/test_application tests/test_ci/test_rpc_architecture_contracts.py` (45 passed)

Additional checks:

- `git diff --cached --check` (passed)
- GitNexus baseline `f4defb9e` vs working tree: 0 affected processes; import cycle count remains 13 in both indexes.
- The application module has no Gateway/RPC/HTTP or concrete storage imports; generated wire types are not introduced.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: no credentials or live environment are required.

## Safety

No secrets, private transcripts, or local build artifacts are committed.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
