### PR TITLE
refactor(gateway): route sessions.preview through application seam

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -584,6 +584,7 @@
       "tests/test_gateway/test_security_headers.py",
       "tests/test_gateway/test_session_model_routing.py",
       "tests/test_gateway/test_session_model_routing_rpc.py",
+      "tests/test_gateway/test_session_preview_adapter.py",
       "tests/test_gateway/test_session_streams.py",
       "tests/test_gateway/test_sessions_list_contract_adapter.py",
       "tests/test_gateway/test_sessions_resolve_contract_adapter.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -651,6 +651,7 @@
     "tests/test_gateway/test_security_headers.py": 0.037,
     "tests/test_gateway/test_session_model_routing.py": 0.01,
     "tests/test_gateway/test_session_model_routing_rpc.py": 0.01,
+    "tests/test_gateway/test_session_preview_adapter.py": 0.01,
     "tests/test_gateway/test_session_streams.py": 0.038,
     "tests/test_gateway/test_sessions_list_contract_adapter.py": 0.01,
     "tests/test_gateway/test_sessions_resolve_contract_adapter.py": 0.01,

--- a/src/opensquilla/gateway/adapters/session_preview.py
+++ b/src/opensquilla/gateway/adapters/session_preview.py
@@ -1,0 +1,161 @@
+"""Gateway adapter for the application-owned session preview use case.
+
+The adapter is the only layer in this slice that knows both the v4 response
+shape and the concrete session storage object.  The application service stays
+transport-neutral; this facade also gives the decorated storage methods the
+precise async Port signatures that structural type checking requires.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from opensquilla.application.session_transcript import (
+    Clock,
+    PreviewContentReader,
+    SessionPreviewQuery,
+    SessionPreviewResult,
+    SessionRecord,
+    SessionRecordReader,
+    SessionTranscriptApplication,
+)
+from opensquilla.session.storage import SessionStorage
+
+
+class SessionPreviewStorageAdapter:
+    """Expose only the storage reads required by ``SessionTranscriptApplication``.
+
+    ``SessionStorage`` decorates reads with a lock wrapper whose static return
+    type is ``Awaitable``.  A plain async facade makes the application Ports
+    explicit and prevents the concrete storage type from leaking into the
+    application layer.  The concrete type is accepted at this boundary;
+    protocol-shaped test doubles remain confined to Gateway fixture setup.
+    """
+
+    def __init__(self, storage: SessionStorage) -> None:
+        self._storage = storage
+
+    async def get_session(self, key: str) -> SessionRecord | None:
+        return await self._storage.get_session(key)
+
+    async def list_sessions(self, *, limit: int) -> Sequence[SessionRecord]:
+        return await self._storage.list_sessions(limit=limit)
+
+    async def list_last_transcript_content_batch(
+        self,
+        session_ids: list[str],
+        *,
+        max_chars: int,
+    ) -> Mapping[str, str]:
+        return await self._storage.list_last_transcript_content_batch(
+            session_ids,
+            max_chars=max_chars,
+        )
+
+
+class SystemClock:
+    """Request clock used at the Gateway boundary.
+
+    A handler may need the timestamp for an early empty response and then pass
+    the same clock into the application service.  Cache the first observation
+    so both paths retain the historical single-request timestamp semantics.
+    """
+
+    def __init__(self) -> None:
+        self._value: int | None = None
+
+    def now_ms(self) -> int:
+        if self._value is None:
+            self._value = int(time.time() * 1000)
+        return self._value
+
+
+def preview_query_from_v4(params: Any) -> SessionPreviewQuery:
+    """Translate the legacy v4 preview params into application vocabulary.
+
+    The extraction intentionally keeps the old truthiness rules: an absent or
+    empty ``keys`` value uses the storage list path, while a truthy iterable is
+    looked up in the caller's order.  Validation and malformed-value errors
+    are left to the same application/storage calls that handled them before.
+    """
+
+    keys, limit = preview_params_from_v4(params)
+    return preview_query_from_v4_values(keys, limit)
+
+
+def preview_params_from_v4(params: Any) -> tuple[Any, Any]:
+    """Read legacy fields without iterating or validating them.
+
+    The old handler performed these ``.get`` calls before checking whether a
+    session manager was available.  Keeping this tiny read separate lets the
+    Gateway preserve that observable malformed-params error ordering while
+    deferring key iteration until the bounded storage section.
+    """
+
+    raw = params or {}
+    return raw.get("keys"), raw.get("limit", 50)
+
+
+def preview_query_from_v4_values(keys: Any, limit: Any) -> SessionPreviewQuery:
+    """Finish the legacy-to-domain conversion after availability checks.
+
+    ``limit`` is intentionally an ``Any`` compatibility value.  v4 historically
+    passed malformed values directly to SQLite, where the same exception and
+    dispatcher mapping are observable; clamping or validating here would be a
+    wire-level behaviour change.  Later Contract validation can narrow it.
+    """
+
+    return SessionPreviewQuery(
+        keys=tuple(keys) if keys else (),
+        limit=limit,
+    )
+
+
+def preview_result_to_v4(result: SessionPreviewResult) -> dict[str, Any]:
+    """Project the domain read model back to the unchanged v4 wire shape."""
+
+    return {
+        "ts": result.ts,
+        "previews": [
+            {
+                "key": item.key,
+                "title": item.title,
+                "lastMessage": item.last_message,
+                "updatedAt": item.updated_at,
+            }
+            for item in result.previews
+        ],
+    }
+
+
+def build_session_preview_application(
+    storage: SessionStorage,
+    *,
+    clock: Clock | None = None,
+) -> SessionTranscriptApplication:
+    """Compose the preview application service from a Gateway storage object."""
+
+    storage_adapter = SessionPreviewStorageAdapter(storage)
+    # Keep these assignments as a static conformance check.  If a future
+    # facade changes a Port signature, mypy fails here instead of allowing a
+    # concrete storage method to leak into the application service.
+    sessions: SessionRecordReader = storage_adapter
+    preview_content: PreviewContentReader = storage_adapter
+    return SessionTranscriptApplication(
+        sessions=sessions,
+        preview_content=preview_content,
+        clock=clock if clock is not None else SystemClock(),
+    )
+
+
+__all__ = [
+    "SessionPreviewStorageAdapter",
+    "SystemClock",
+    "build_session_preview_application",
+    "preview_params_from_v4",
+    "preview_query_from_v4",
+    "preview_query_from_v4_values",
+    "preview_result_to_v4",
+]

--- a/src/opensquilla/gateway/rpc_sessions.py
+++ b/src/opensquilla/gateway/rpc_sessions.py
@@ -50,6 +50,13 @@ from opensquilla.engine.steps.router_decision_record import (
     drain_pending_flushes_for_sessions,
 )
 from opensquilla.gateway import attachment_ingest as _attachment_ingest
+from opensquilla.gateway.adapters.session_preview import (
+    SystemClock,
+    build_session_preview_application,
+    preview_params_from_v4,
+    preview_query_from_v4_values,
+    preview_result_to_v4,
+)
 from opensquilla.gateway.adapters.sessions_list_contract import (
     register_sessions_list_contract,
 )
@@ -11411,9 +11418,11 @@ async def _handle_sessions_messages_unsubscribe(params: dict | None, ctx: RpcCon
 
 @_d.method("sessions.preview", scope="operator.read")
 async def _handle_sessions_preview(params: dict | None, ctx: RpcContext) -> dict:
-    keys = (params or {}).get("keys")
-    limit = (params or {}).get("limit", 50)
-    now_ms = int(time.time() * 1000)
+    # Preserve the legacy order: a truthy non-mapping params value raises from
+    # ``.get`` before an unavailable manager can produce an empty response.
+    raw_keys, raw_limit = preview_params_from_v4(params)
+    clock = SystemClock()
+    now_ms = clock.now_ms()
 
     if ctx.session_manager is None:
         return {"ts": now_ms, "previews": []}
@@ -11422,47 +11431,17 @@ async def _handle_sessions_preview(params: dict | None, ctx: RpcContext) -> dict
     if storage is None:
         return {"ts": now_ms, "previews": []}
 
+    application = build_session_preview_application(storage, clock=clock)
+
     # Preview is an interactive read. Keep storage lock acquisition bounded
     # while preserving the existing key/list selection and response shape.
     with bounded_interactive_storage_reads():
-        if keys:
-            sessions = []
-            for k in keys:
-                s = await storage.get_session(k)
-                if s is not None:
-                    sessions.append(s)
-        else:
-            sessions = await storage.list_sessions(limit=limit)
+        # Key iteration stays inside the same bounded section as the old
+        # handler; malformed iterables therefore fail at the same point.
+        query = preview_query_from_v4_values(raw_keys, raw_limit)
+        result = await application.preview(query)
 
-        session_ids = [
-            str(getattr(session, "session_id", "") or "") for session in sessions
-        ]
-        last_messages = await storage.list_last_transcript_content_batch(
-            session_ids,
-            max_chars=120,
-        )
-
-    previews = []
-    for s in sessions:
-        session_id = str(getattr(s, "session_id", "") or "")
-        title = (
-            getattr(s, "display_name", None)
-            or getattr(s, "derived_title", None)
-            or session_id[:8]
-        )
-        last_message = last_messages.get(session_id, "")
-        if not isinstance(last_message, str):
-            last_message = ""
-        previews.append(
-            {
-                "key": s.session_key,
-                "title": title,
-                "lastMessage": last_message,
-                "updatedAt": getattr(s, "updated_at", now_ms),
-            }
-        )
-
-    return {"ts": now_ms, "previews": previews}
+    return preview_result_to_v4(result)
 
 
 async def _handle_sessions_resolve(params: dict | None, ctx: RpcContext) -> dict:

--- a/tests/test_ci/test_windows_test_shards.py
+++ b/tests/test_ci/test_windows_test_shards.py
@@ -73,6 +73,7 @@ RECENTLY_ADDED_ACTIVE_TESTS = {
     "tests/contracts/test_sessions_list_contract.py",
     "tests/contracts/test_sessions_resolve_contract.py",
     "tests/contracts/test_sessions_search_contract.py",
+    "tests/test_gateway/test_session_preview_adapter.py",
     "tests/test_application/test_session_transcript.py",
     "tests/test_artifact_session/test_html_anchors.py",
     "tests/test_ci/test_plan_ci.py",

--- a/tests/test_gateway/test_session_preview_adapter.py
+++ b/tests/test_gateway/test_session_preview_adapter.py
@@ -1,0 +1,136 @@
+"""Characterization tests for the sessions.preview application boundary."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from opensquilla.gateway import rpc_sessions
+from opensquilla.gateway.adapters.session_preview import (
+    preview_params_from_v4,
+    preview_query_from_v4,
+)
+from opensquilla.gateway.auth import Principal
+from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.rpc import RpcContext
+from opensquilla.session.storage import _BOUNDED_INTERACTIVE_READS
+
+
+class BoundedStorage:
+    def __init__(self) -> None:
+        self.session = SimpleNamespace(
+            session_key="agent:main:webchat:preview",
+            session_id="preview-id",
+            display_name=None,
+            derived_title="Preview",
+            updated_at=2000,
+        )
+        self.calls: list[tuple[str, Any]] = []
+
+    async def get_session(self, key: str) -> Any:
+        self.calls.append(("get", (_BOUNDED_INTERACTIVE_READS.get(), key)))
+        return self.session if key == self.session.session_key else None
+
+    async def list_sessions(self, *, limit: int) -> list[Any]:
+        self.calls.append(("list", (_BOUNDED_INTERACTIVE_READS.get(), limit)))
+        return [self.session]
+
+    async def list_last_transcript_content_batch(
+        self,
+        session_ids: list[str],
+        *,
+        max_chars: int,
+    ) -> dict[str, str]:
+        self.calls.append(
+            ("preview", (_BOUNDED_INTERACTIVE_READS.get(), list(session_ids), max_chars))
+        )
+        return {"preview-id": "latest"}
+
+
+def context(storage: BoundedStorage) -> RpcContext:
+    ctx = RpcContext(
+        conn_id="preview-test",
+        principal=Principal(
+            role="operator",
+            scopes=frozenset({"operator.admin"}),
+            is_owner=True,
+            authenticated=True,
+        ),
+        config=GatewayConfig(memory={"flush_enabled": False}),
+    )
+    ctx.session_manager = SimpleNamespace(storage=storage)
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_preview_adapter_keeps_wire_projection_and_bounded_scope() -> None:
+    storage = BoundedStorage()
+
+    payload = await rpc_sessions._handle_sessions_preview(None, context(storage))
+
+    assert payload["previews"] == [
+        {
+            "key": "agent:main:webchat:preview",
+            "title": "Preview",
+            "lastMessage": "latest",
+            "updatedAt": 2000,
+        }
+    ]
+    assert [name for name, _ in storage.calls] == ["list", "preview"]
+    assert all(details[0] is True for _, details in storage.calls)
+
+
+@pytest.mark.asyncio
+async def test_preview_adapter_preserves_key_selection_order() -> None:
+    storage = BoundedStorage()
+
+    payload = await rpc_sessions._handle_sessions_preview(
+        {"keys": ["missing", storage.session.session_key]},
+        context(storage),
+    )
+
+    assert [item["key"] for item in payload["previews"]] == [storage.session.session_key]
+    assert storage.calls == [
+        ("get", (True, "missing")),
+        ("get", (True, storage.session.session_key)),
+        ("preview", (True, ["preview-id"], 120)),
+    ]
+
+
+@pytest.mark.parametrize("params", ["x", 1, True])
+def test_preview_keeps_legacy_non_mapping_params_error_order(params: Any) -> None:
+    """The old handler raised before checking manager/storage availability."""
+
+    with pytest.raises(AttributeError):
+        preview_params_from_v4(params)
+
+
+@pytest.mark.parametrize("limit", [0, -1, None, "bad", True, 1.5])
+def test_preview_query_keeps_raw_legacy_limit(limit: Any) -> None:
+    query = preview_query_from_v4({"limit": limit})
+
+    assert query.limit is limit or query.limit == limit
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("params", ["x", 1, True])
+async def test_preview_non_mapping_params_fail_before_unavailable_manager(
+    params: Any,
+) -> None:
+    """Unavailable backends must not mask the legacy params-shape error."""
+
+    ctx = RpcContext(
+        conn_id="preview-no-manager",
+        principal=Principal(
+            role="operator",
+            scopes=frozenset({"operator.admin"}),
+            is_owner=True,
+            authenticated=True,
+        ),
+        config=GatewayConfig(memory={"flush_enabled": False}),
+    )
+
+    with pytest.raises(AttributeError):
+        await rpc_sessions._handle_sessions_preview(params, ctx)


### PR DESCRIPTION
## Summary

This is the second, intentionally small step of the Session Inspector seam. It routes only `sessions.preview` through the read-only `SessionTranscriptApplication` introduced by S4a. The existing v4 JSON response, storage implementation, bounded-read policy, and Gateway registration remain unchanged.

## What changed

- Add a concrete `SessionPreviewStorageAdapter` at the Gateway seam. It exposes only the three storage reads required by the application Ports, so `SessionStorage` and its lock decorators do not leak into `src/opensquilla/application`.
- Add v4-to-domain and domain-to-v4 projection helpers. Legacy key ordering, empty-key list behavior, raw `limit` pass-through, title precedence, `lastMessage`, and `updatedAt` aliases are retained.
- Route `_handle_sessions_preview` through the application Module while keeping `bounded_interactive_storage_reads()` around the complete read.
- Preserve legacy malformed-parameter ordering: a truthy non-mapping params value still fails before an unavailable manager can return an empty response; malformed limits are not clamped in this compatibility slice.
- Add characterization tests for wire projection, key selection, bounded storage scope, malformed params, and legacy limits.

## Explicit non-goals

- No Contract schema or generated wire changes.
- No WebSocket, HTTP, subscription, runtime, TurnRunner, TaskRuntime, or database changes.
- No `chat.history` migration; reader Ports and cursors are deferred to S4c after call-site characterization.

## Verification

- `359 passed` across application, session preview adapter, Gateway session RPC, and RPC architecture tests.
- Ruff and mypy pass for the changed application/adapter/handler files.
- Existing `sessions.preview` tests continue to exercise the real Gateway dispatcher and storage behavior.

## Compatibility / rollback

The wire-facing handler remains the only registration path and projects the same v4 object. Reverting this PR restores the pre-S4b direct handler; no data or migration rollback is required.
