### PR TITLE
refactor(application): add session history read seam

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -320,6 +320,7 @@
       "tests/integration/cli/tui_real_terminal/test_visual_layout_matrix.py",
       "tests/test_application/test_approval_patterns.py",
       "tests/test_application/test_session_directory.py",
+      "tests/test_application/test_session_history.py",
       "tests/test_application/test_session_transcript.py",
       "tests/test_attachment_workspace.py",
       "tests/test_bundled_voice_skills.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -649,6 +649,7 @@
     "tests/test_gateway/test_sandbox_v2_routes.py": 0.148,
     "tests/test_gateway/test_search_runtime_config_gateway.py": 0.01,
     "tests/test_gateway/test_security_headers.py": 0.037,
+    "tests/test_application/test_session_history.py": 0.01,
     "tests/test_gateway/test_session_model_routing.py": 0.01,
     "tests/test_gateway/test_session_model_routing_rpc.py": 0.01,
     "tests/test_gateway/test_chat_history_characterization.py": 0.01,

--- a/src/opensquilla/application/session_history.py
+++ b/src/opensquilla/application/session_history.py
@@ -1,0 +1,190 @@
+"""Application-owned session history page reads.
+
+The Gateway currently owns the v4 request parsing and the final chat-message
+projection.  This module owns the storage-independent part that is safe to
+extract first: choosing a canonical page when it is available and applying
+the same keyset pagination policy to an active transcript fallback.
+
+Adapters translate concrete storage failures into ``None`` for an unavailable
+canonical reader (while preserving retryable failures), and translate legacy
+wire cursors into :class:`HistoryCursor` values.  No RPC, WebSocket, Gateway,
+or persistence type is allowed to cross this boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol, cast
+
+type HistoryCursor = tuple[int, int]
+
+
+@dataclass(frozen=True, slots=True)
+class SessionHistoryQuery:
+    """Normalized input for one history page read.
+
+    ``before`` takes precedence over ``after`` when both are present.  The
+    Gateway adapter is responsible for preserving legacy malformed-value
+    behavior before constructing this value; the application receives a
+    positive limit and parsed cursors only.
+    """
+
+    session_key: str
+    limit: int
+    before: HistoryCursor | None = None
+    after: HistoryCursor | None = None
+    include_canonical: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class HistoryPage:
+    """Transport-neutral result of a bounded history read."""
+
+    entries: tuple[object, ...]
+    has_more: bool
+    canonical_available: bool
+    canonical_complete: bool
+
+
+class CanonicalHistoryReader(Protocol):
+    """Port for the preferred persisted/keyset history projection.
+
+    Returning ``None`` means that the canonical projection is unavailable and
+    the application should use the active transcript reader.  Implementations
+    must still raise retryable storage failures instead of converting them to
+    ``None`` so the Gateway can retain its existing error semantics.
+    """
+
+    async def read_canonical_page(
+        self,
+        session_key: str,
+        *,
+        limit: int,
+        before: HistoryCursor | None,
+        after: HistoryCursor | None,
+    ) -> HistoryPage | None: ...
+
+
+class ActiveHistoryReader(Protocol):
+    """Port for the legacy active transcript fallback."""
+
+    async def read_active_transcript(self, session_key: str) -> Sequence[object]: ...
+
+
+class SessionHistoryApplication:
+    """Read one history page through narrow, replaceable Ports."""
+
+    def __init__(
+        self,
+        *,
+        active: ActiveHistoryReader,
+        canonical: CanonicalHistoryReader | None = None,
+    ) -> None:
+        self._active = active
+        self._canonical = canonical
+
+    async def read_page(self, query: SessionHistoryQuery) -> HistoryPage:
+        """Prefer canonical storage, then apply the legacy fallback policy."""
+
+        if query.include_canonical and self._canonical is not None:
+            # The Port deliberately decides which implementation failures are
+            # recoverable.  Any exception that reaches here (for example a
+            # retryable storage-busy error) must remain visible to the adapter.
+            canonical_page = await self._canonical.read_canonical_page(
+                query.session_key,
+                limit=query.limit,
+                before=query.before,
+                after=query.after,
+            )
+            if canonical_page is not None:
+                return HistoryPage(
+                    entries=tuple(canonical_page.entries),
+                    has_more=bool(canonical_page.has_more),
+                    canonical_available=True,
+                    canonical_complete=bool(canonical_page.canonical_complete),
+                )
+
+        transcript = tuple(
+            await self._active.read_active_transcript(query.session_key)
+        )
+        entries, has_more = paginate_transcript(
+            transcript,
+            limit=query.limit,
+            before=query.before,
+            after=query.after,
+        )
+        return HistoryPage(
+            entries=entries,
+            has_more=has_more,
+            canonical_available=False,
+            canonical_complete=False,
+        )
+
+
+def cursor_for_entry(entry: object) -> HistoryCursor | None:
+    """Return the stable integer cursor used by the history Port."""
+
+    created_at = getattr(entry, "created_at", None)
+    stable_id = getattr(entry, "id", None) or getattr(entry, "message_id", None)
+    if created_at in {None, ""} or stable_id in {None, ""}:
+        return None
+    try:
+        return int(cast(Any, created_at)), int(cast(Any, stable_id))
+    except (TypeError, ValueError):
+        return None
+
+
+def paginate_transcript(
+    entries: Sequence[object],
+    *,
+    limit: int,
+    before: HistoryCursor | None = None,
+    after: HistoryCursor | None = None,
+) -> tuple[tuple[object, ...], bool]:
+    """Apply the current active-transcript keyset policy.
+
+    A missing cursor is treated as an unpositioned read, matching the legacy
+    handler.  When both cursors are supplied, ``before`` wins.  The caller
+    supplies a positive ``limit`` after v4 compatibility normalization.
+    """
+
+    rows = tuple(entries)
+    if not rows:
+        return (), False
+
+    before_index = _cursor_index(rows, before)
+    if before_index is not None:
+        start = max(0, before_index - limit)
+        return rows[start:before_index], start > 0
+
+    after_index = _cursor_index(rows, after)
+    if after_index is not None:
+        start = min(len(rows), after_index + 1)
+        end = min(len(rows), start + limit)
+        return rows[start:end], end < len(rows)
+
+    if len(rows) <= limit:
+        return rows, False
+    return rows[-limit:], True
+
+
+def _cursor_index(entries: Sequence[object], cursor: HistoryCursor | None) -> int | None:
+    if cursor is None:
+        return None
+    for index, entry in enumerate(entries):
+        if cursor_for_entry(entry) == cursor:
+            return index
+    return None
+
+
+__all__ = [
+    "ActiveHistoryReader",
+    "CanonicalHistoryReader",
+    "HistoryCursor",
+    "HistoryPage",
+    "SessionHistoryApplication",
+    "SessionHistoryQuery",
+    "cursor_for_entry",
+    "paginate_transcript",
+]

--- a/src/opensquilla/application/session_transcript.py
+++ b/src/opensquilla/application/session_transcript.py
@@ -5,10 +5,11 @@ transcript extraction slice.  It intentionally has no Gateway/RPC, transport,
 wire-alias, or concrete persistence imports.  The Gateway remains responsible
 for adapting v4 frames to these values until the later extraction slices.
 
-S4a exercises only the preview use case.  History cursors, reader ports, and
-page DTOs are deliberately deferred to S4c, after the real ``chat.history``
-call sites have been characterized; defining them here would create
-speculative surface area.
+S4a exercises only the preview use case.  The history cursor, reader ports,
+and page DTOs now live in the separate :mod:`session_history` module after
+the real ``chat.history`` call sites were characterized; keeping them in a
+separate module prevents preview and history concerns from growing one
+another's interface.
 """
 
 from __future__ import annotations

--- a/tests/test_application/test_session_history.py
+++ b/tests/test_application/test_session_history.py
@@ -1,0 +1,179 @@
+"""Tests for the storage- and transport-independent history seam."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from opensquilla.application.session_history import (
+    HistoryPage,
+    SessionHistoryApplication,
+    SessionHistoryQuery,
+    paginate_transcript,
+)
+
+
+def entry(index: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=index,
+        message_id=f"m{index}",
+        created_at=index,
+        role="user",
+        content=f"message {index}",
+    )
+
+
+class ActivePort:
+    def __init__(self, rows: list[Any]) -> None:
+        self.rows = rows
+        self.calls: list[str] = []
+
+    async def read_active_transcript(self, session_key: str) -> list[Any]:
+        self.calls.append(session_key)
+        return self.rows
+
+
+class CanonicalPort:
+    def __init__(self, page: HistoryPage | None = None) -> None:
+        self.page = page
+        self.calls: list[dict[str, Any]] = []
+
+    async def read_canonical_page(
+        self,
+        session_key: str,
+        *,
+        limit: int,
+        before: tuple[int, int] | None,
+        after: tuple[int, int] | None,
+    ) -> HistoryPage | None:
+        self.calls.append(
+            {
+                "session_key": session_key,
+                "limit": limit,
+                "before": before,
+                "after": after,
+            }
+        )
+        return self.page
+
+
+@pytest.mark.asyncio
+async def test_canonical_page_is_preferred_and_metadata_is_normalized() -> None:
+    active = ActivePort([entry(1)])
+    canonical = CanonicalPort(
+        HistoryPage(
+            entries=(entry(2),),
+            has_more=True,
+            canonical_available=False,
+            canonical_complete=True,
+        )
+    )
+    app = SessionHistoryApplication(active=active, canonical=canonical)
+
+    result = await app.read_page(
+        SessionHistoryQuery(
+            session_key="agent:main:webchat:history",
+            limit=2,
+            before=(3, 3),
+            after=(1, 1),
+        )
+    )
+
+    assert canonical.page is not None
+    assert result.entries[0] is canonical.page.entries[0]
+    assert result.has_more is True
+    assert result.canonical_available is True
+    assert result.canonical_complete is True
+    assert active.calls == []
+    assert canonical.calls == [
+        {
+            "session_key": "agent:main:webchat:history",
+            "limit": 2,
+            "before": (3, 3),
+            "after": (1, 1),
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unavailable_canonical_reader_falls_back_with_before_precedence() -> None:
+    active = ActivePort([entry(index) for index in range(1, 6)])
+    canonical = CanonicalPort(None)
+    app = SessionHistoryApplication(active=active, canonical=canonical)
+
+    result = await app.read_page(
+        SessionHistoryQuery(
+            session_key="agent:main:webchat:history",
+            limit=2,
+            before=(4, 4),
+            after=(1, 1),
+        )
+    )
+
+    assert [getattr(row, "id") for row in result.entries] == [2, 3]
+    assert result.has_more is True
+    assert result.canonical_available is False
+    assert result.canonical_complete is False
+    assert active.calls == ["agent:main:webchat:history"]
+
+
+@pytest.mark.asyncio
+async def test_include_canonical_false_does_not_call_canonical_port() -> None:
+    active = ActivePort([entry(index) for index in range(1, 4)])
+    canonical = CanonicalPort(
+        HistoryPage(
+            entries=(entry(9),),
+            has_more=False,
+            canonical_available=True,
+            canonical_complete=True,
+        )
+    )
+    app = SessionHistoryApplication(active=active, canonical=canonical)
+
+    result = await app.read_page(
+        SessionHistoryQuery(
+            session_key="agent:main:webchat:history",
+            limit=2,
+            include_canonical=False,
+        )
+    )
+
+    assert [getattr(row, "id") for row in result.entries] == [2, 3]
+    assert canonical.calls == []
+    assert active.calls == ["agent:main:webchat:history"]
+
+
+@pytest.mark.asyncio
+async def test_reader_failures_are_not_silently_swallowed() -> None:
+    active = ActivePort([entry(1)])
+
+    class BrokenCanonical(CanonicalPort):
+        async def read_canonical_page(self, *args: Any, **kwargs: Any) -> HistoryPage | None:
+            raise RuntimeError("retryable storage failure")
+
+    app = SessionHistoryApplication(active=active, canonical=BrokenCanonical())
+    with pytest.raises(RuntimeError, match="retryable storage failure"):
+        await app.read_page(
+            SessionHistoryQuery(
+                session_key="agent:main:webchat:history",
+                limit=1,
+            )
+        )
+    assert active.calls == []
+
+
+def test_paginate_transcript_preserves_latest_window_and_after_cursor() -> None:
+    rows = [entry(index) for index in range(1, 6)]
+
+    latest, latest_more = paginate_transcript(rows, limit=2)
+    forward, forward_more = paginate_transcript(rows, limit=2, after=(2, 2))
+    missing, missing_more = paginate_transcript(rows, limit=2, after=(99, 99))
+
+    assert [getattr(row, "id") for row in latest] == [4, 5]
+    assert latest_more is True
+    assert [getattr(row, "id") for row in forward] == [3, 4]
+    assert forward_more is True
+    assert [getattr(row, "id") for row in missing] == [4, 5]
+    assert missing_more is True

--- a/tests/test_ci/test_windows_test_shards.py
+++ b/tests/test_ci/test_windows_test_shards.py
@@ -76,6 +76,7 @@ RECENTLY_ADDED_ACTIVE_TESTS = {
     "tests/contracts/test_sessions_search_contract.py",
     "tests/test_gateway/test_session_preview_adapter.py",
     "tests/test_gateway/test_sessions_bootstrap_history_characterization.py",
+    "tests/test_application/test_session_history.py",
     "tests/test_application/test_session_transcript.py",
     "tests/test_artifact_session/test_html_anchors.py",
     "tests/test_ci/test_plan_ci.py",


### PR DESCRIPTION
## Summary
- add transport-neutral `SessionHistoryApplication` for canonical/active transcript page reads
- define narrow canonical and active history Ports plus typed cursor/page/query values
- preserve canonical preference, active fallback pagination, before-over-after precedence, and fatal reader errors
- add focused application tests and register the new test in Windows shard governance

## Scope
This is S4c1. It introduces the application seam only; the existing `chat.history` Gateway handler, v4 WebSocket wire, bootstrap private call, storage implementation, and WebUI are unchanged. S4c2 will add the Gateway adapter after this seam is reviewed.

## Validation
- application and transcript tests passed
- chat/session history regression tests passed (63)
- architecture gates passed (16)
- Windows shard governance passed
- ruff and mypy passed
- `git diff --check` passed

## Design boundary
No RPC/Gateway/WebSocket/persistence imports are allowed in the application module. Legacy aliases, error mapping, and concrete storage failures remain adapter responsibilities.