### PR TITLE
refactor(gateway): connect chat history to application seam

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -584,6 +584,7 @@
       "tests/test_gateway/test_sandbox_v2_routes.py",
       "tests/test_gateway/test_search_runtime_config_gateway.py",
       "tests/test_gateway/test_security_headers.py",
+      "tests/test_gateway/test_session_history_adapter.py",
       "tests/test_gateway/test_session_model_routing.py",
       "tests/test_gateway/test_session_model_routing_rpc.py",
       "tests/test_gateway/test_session_preview_adapter.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -654,6 +654,7 @@
     "tests/test_gateway/test_session_model_routing_rpc.py": 0.01,
     "tests/test_gateway/test_chat_history_characterization.py": 0.01,
     "tests/test_gateway/test_session_preview_adapter.py": 0.01,
+    "tests/test_gateway/test_session_history_adapter.py": 0.01,
     "tests/test_gateway/test_session_streams.py": 0.038,
     "tests/test_gateway/test_sessions_bootstrap_history_characterization.py": 0.01,
     "tests/test_gateway/test_sessions_list_contract_adapter.py": 0.01,

--- a/src/opensquilla/gateway/adapters/session_history.py
+++ b/src/opensquilla/gateway/adapters/session_history.py
@@ -1,0 +1,286 @@
+"""Gateway adapter for the application-owned session history read seam.
+
+The v4 Gateway has historically combined three concerns in ``rpc_chat``:
+request cursor parsing, concrete session-manager/storage calls, and the
+transport-neutral choice between a canonical transcript and the active
+transcript.  This adapter owns the concrete side of that boundary.  The
+application module only receives normalized cursors and narrow reader Ports;
+the existing handler remains responsible for the final chat-message
+projection and response envelope.
+
+Keeping the adapter separate is intentional.  It lets the WebSocket handler
+and the bootstrap composition use exactly one history implementation while
+leaving the v4 wire shape and all legacy fallback/error semantics untouched.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import structlog
+
+from opensquilla.application.session_history import (
+    HistoryCursor,
+    HistoryPage,
+    SessionHistoryApplication,
+    paginate_transcript,
+)
+from opensquilla.chat.flattened_tool_markers import (
+    has_flattened_used_tool_line,
+    is_flattened_tool_result_dump,
+)
+from opensquilla.session.storage import StorageBusyError
+
+log = structlog.get_logger(__name__)
+
+
+def parse_history_cursor(value: object) -> HistoryCursor | None:
+    """Parse the legacy ``created_at|entry_id`` cursor without raising.
+
+    The v4 handler historically treated an absent, empty, or malformed
+    cursor as an unpositioned read.  Keeping that conversion in the adapter
+    means the application layer never needs to know the wire representation.
+    """
+
+    raw = str(value or "").strip()
+    if not raw or "|" not in raw:
+        return None
+    created_at, stable_id = raw.split("|", 1)
+    try:
+        return int(created_at), int(stable_id)
+    except ValueError:
+        return None
+
+
+def _cursor_text(entry: object | None) -> str | None:
+    """Render an entry cursor for compatibility reads inside this adapter."""
+
+    if entry is None:
+        return None
+    created_at = getattr(entry, "created_at", "")
+    stable_id = getattr(entry, "id", None) or getattr(entry, "message_id", "")
+    if created_at in {None, ""} or stable_id in {None, ""}:
+        return None
+    return f"{created_at}|{stable_id}"
+
+
+def canonical_page_parts(page: object) -> tuple[list[object], bool, bool]:
+    """Normalize the concrete manager's legacy page return shapes.
+
+    Older managers returned ``(entries, has_more)`` while newer ones return a
+    small object carrying ``canonical_complete``.  The shape belongs here at
+    the concrete boundary; neither the application service nor the handler
+    needs to branch on it.
+    """
+
+    if isinstance(page, dict):
+        entries = page.get("entries")
+        has_more = page.get("has_more", False)
+        canonical_complete = page.get("canonical_complete", True)
+    elif isinstance(page, tuple):
+        entries = page[0] if page else None
+        has_more = page[1] if len(page) > 1 else False
+        canonical_complete = page[2] if len(page) > 2 else True
+    else:
+        entries = getattr(page, "entries", None)
+        has_more = getattr(page, "has_more", False)
+        canonical_complete = getattr(page, "canonical_complete", True)
+    if entries is None:
+        raise TypeError("canonical transcript page is missing entries")
+    return list(entries), bool(has_more), bool(canonical_complete)
+
+
+class SessionHistoryStorageAdapter:
+    """Expose only the two history reader Ports required by the application.
+
+    ``manager`` is deliberately accepted as an opaque object.  The concrete
+    Gateway session manager has changed shape several times, and retaining
+    duck-typed capability checks here preserves compatibility with old test
+    doubles and packaged clients without leaking those checks into the
+    application module.
+    """
+
+    def __init__(self, manager: object) -> None:
+        self._manager = manager
+
+    async def read_canonical_page(
+        self,
+        session_key: str,
+        *,
+        limit: int,
+        before: HistoryCursor | None,
+        after: HistoryCursor | None,
+    ) -> HistoryPage | None:
+        """Read canonical history, returning ``None`` only when unavailable.
+
+        Non-retryable canonical failures historically fell back to the active
+        transcript.  ``StorageBusyError`` is intentionally preserved so the
+        dispatcher can return its existing retryable error envelope.
+        """
+
+        page_getter = getattr(self._manager, "get_canonical_transcript_page", None)
+        if callable(page_getter):
+            try:
+                page = await page_getter(
+                    session_key,
+                    limit=limit,
+                    before=before,
+                    after=after,
+                )
+                entries, has_more, canonical_complete = canonical_page_parts(page)
+                return HistoryPage(
+                    entries=tuple(entries),
+                    has_more=has_more,
+                    canonical_available=True,
+                    canonical_complete=canonical_complete,
+                )
+            except StorageBusyError:
+                raise
+            except Exception:  # noqa: BLE001 - preserve legacy active fallback
+                return None
+
+        getter = getattr(self._manager, "get_canonical_transcript", None)
+        if callable(getter):
+            try:
+                transcript = tuple(await getter(session_key))
+                page_entries, has_more = paginate_transcript(
+                    transcript,
+                    limit=limit,
+                    before=before,
+                    after=after,
+                )
+                return HistoryPage(
+                    entries=page_entries,
+                    has_more=has_more,
+                    canonical_available=True,
+                    canonical_complete=True,
+                )
+            except StorageBusyError:
+                raise
+            except Exception:  # noqa: BLE001 - preserve legacy active fallback
+                return None
+        return None
+
+    async def read_active_transcript(self, session_key: str) -> Sequence[object]:
+        """Read the legacy active transcript, preserving missing capability semantics."""
+
+        getter = getattr(self._manager, "get_transcript", None)
+        if not callable(getter):
+            return ()
+        transcript = await getter(session_key)
+        return tuple(transcript or ())
+
+    def application(self) -> SessionHistoryApplication:
+        """Compose the transport-neutral history application for this manager."""
+
+        return SessionHistoryApplication(active=self, canonical=self)
+
+    async def load_legacy_tool_projection_context(
+        self,
+        session_key: str,
+        entries: list[object],
+        *,
+        canonical_available: bool,
+    ) -> tuple[object | None, object | None]:
+        """Load one adjacent canonical row at either page edge when required.
+
+        This is a presentation compatibility read, not part of pagination.
+        It remains in the Gateway adapter because the marker format is a
+        legacy wire projection concern.  Errors have the same behavior as the
+        former handler helper: busy is retryable; other failures leave the
+        selected page intact and are logged.
+        """
+
+        if not entries or not canonical_available:
+            return None, None
+        page_getter = getattr(
+            self._manager,
+            "get_canonical_transcript_page",
+            None,
+        )
+        if not callable(page_getter):
+            return None, None
+
+        previous_entry = None
+        next_entry = None
+        oldest_cursor = parse_history_cursor(_cursor_text(entries[0]))
+        newest_cursor = parse_history_cursor(_cursor_text(entries[-1]))
+
+        if _needs_legacy_tool_lookbehind(entries[0]) and oldest_cursor is not None:
+            try:
+                page = await page_getter(
+                    session_key,
+                    limit=1,
+                    before=oldest_cursor,
+                    after=None,
+                )
+                candidates, _has_more, _complete = canonical_page_parts(page)
+            except StorageBusyError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - optional projection read
+                log.warning(
+                    "chat_history_legacy_projection_context_unavailable",
+                    edge="before",
+                    error_type=type(exc).__name__,
+                )
+                return None, None
+            if candidates:
+                candidate = candidates[-1]
+                candidate_cursor = parse_history_cursor(_cursor_text(candidate))
+                if candidate_cursor is not None and candidate_cursor < oldest_cursor:
+                    previous_entry = candidate
+
+        if _needs_legacy_tool_lookahead(entries[-1]) and newest_cursor is not None:
+            try:
+                page = await page_getter(
+                    session_key,
+                    limit=1,
+                    before=None,
+                    after=newest_cursor,
+                )
+                candidates, _has_more, _complete = canonical_page_parts(page)
+            except StorageBusyError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - optional projection read
+                log.warning(
+                    "chat_history_legacy_projection_context_unavailable",
+                    edge="after",
+                    error_type=type(exc).__name__,
+                )
+                return None, None
+            if candidates:
+                candidate = candidates[0]
+                candidate_cursor = parse_history_cursor(_cursor_text(candidate))
+                if candidate_cursor is not None and candidate_cursor > newest_cursor:
+                    next_entry = candidate
+        return previous_entry, next_entry
+
+
+def build_session_history_application(manager: object) -> SessionHistoryApplication:
+    """Build the history application and keep adapter ownership explicit."""
+
+    return SessionHistoryStorageAdapter(manager).application()
+
+
+def _needs_legacy_tool_lookbehind(entry: object | None) -> bool:
+    if entry is None or getattr(entry, "tool_call_id", None):
+        return False
+    role = str(getattr(entry, "role", "") or "").lower()
+    content = str(getattr(entry, "content", "") or "")
+    return role in {"tool", "user"} and is_flattened_tool_result_dump(content)
+
+
+def _needs_legacy_tool_lookahead(entry: object | None) -> bool:
+    if entry is None or getattr(entry, "tool_calls", None):
+        return False
+    role = str(getattr(entry, "role", "") or "").lower()
+    content = str(getattr(entry, "content", "") or "")
+    return role == "assistant" and has_flattened_used_tool_line(content)
+
+
+__all__ = [
+    "SessionHistoryStorageAdapter",
+    "build_session_history_application",
+    "canonical_page_parts",
+    "parse_history_cursor",
+]

--- a/src/opensquilla/gateway/rpc_chat.py
+++ b/src/opensquilla/gateway/rpc_chat.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 
 import structlog
 
+from opensquilla.application.session_history import SessionHistoryQuery
 from opensquilla.artifact_session import (
     ArtifactSessionService,
     MutationAttempt,
@@ -19,12 +20,12 @@ from opensquilla.artifact_session import (
     document_mutation_outcome_from_attempt,
 )
 from opensquilla.chat.conversation import ChatSendRequest, sessions_send_params
-from opensquilla.chat.flattened_tool_markers import (
-    has_flattened_used_tool_line,
-    is_flattened_tool_result_dump,
-)
 from opensquilla.chat.history import transcript_entries_to_chat_messages
 from opensquilla.chat.source import chat_source_metadata
+from opensquilla.gateway.adapters.session_history import (
+    SessionHistoryStorageAdapter,
+    parse_history_cursor,
+)
 from opensquilla.gateway.compaction_target import (
     effective_session_model,
     resolve_gateway_compaction_target,
@@ -553,53 +554,6 @@ def _chat_history_cursor(entry: object | None) -> str | None:
     return f"{created_at}|{stable_id}"
 
 
-def _chat_history_cursor_index(entries: list[object], cursor: object) -> int | None:
-    raw = str(cursor or "").strip()
-    if not raw:
-        return None
-    for idx, entry in enumerate(entries):
-        if _chat_history_cursor(entry) == raw:
-            return idx
-    return None
-
-
-def _chat_history_cursor_key(cursor: object) -> tuple[int, int] | None:
-    raw = str(cursor or "").strip()
-    if not raw or "|" not in raw:
-        return None
-    created_at, stable_id = raw.split("|", 1)
-    try:
-        return int(created_at), int(stable_id)
-    except ValueError:
-        return None
-
-
-def _chat_history_page(
-    entries: list[object],
-    *,
-    limit: int,
-    before: object = None,
-    after: object = None,
-) -> tuple[list[object], bool]:
-    if not entries:
-        return [], False
-    before_idx = _chat_history_cursor_index(entries, before)
-    if before_idx is not None:
-        end = before_idx
-        start = max(0, end - limit)
-        return entries[start:end], start > 0
-
-    after_idx = _chat_history_cursor_index(entries, after)
-    if after_idx is not None:
-        start = min(len(entries), after_idx + 1)
-        end = min(len(entries), start + limit)
-        return entries[start:end], end < len(entries)
-
-    if len(entries) <= limit:
-        return entries, False
-    return entries[-limit:], True
-
-
 def _session_summary_to_chat_payload(summary: object) -> dict[str, Any]:
     return {
         "id": getattr(summary, "id", None),
@@ -643,168 +597,6 @@ def _annotate_transcript_attachment_downloads(
     return messages
 
 
-def _canonical_page_parts(page: object) -> tuple[list[object], bool, bool]:
-    if isinstance(page, dict):
-        entries = page.get("entries")
-        has_more = page.get("has_more", False)
-        canonical_complete = page.get("canonical_complete", True)
-    elif isinstance(page, tuple):
-        entries = page[0] if page else None
-        has_more = page[1] if len(page) > 1 else False
-        canonical_complete = page[2] if len(page) > 2 else True
-    else:
-        entries = getattr(page, "entries", None)
-        has_more = getattr(page, "has_more", False)
-        canonical_complete = getattr(page, "canonical_complete", True)
-    if entries is None:
-        raise TypeError("canonical transcript page is missing entries")
-    return list(entries), bool(has_more), bool(canonical_complete)
-
-
-async def _load_chat_history_page(
-    mgr: object,
-    session_key: str,
-    *,
-    limit: int,
-    before: object = None,
-    after: object = None,
-    include_canonical: bool,
-) -> tuple[list[object], bool, bool, bool]:
-    if include_canonical:
-        page_getter = getattr(mgr, "get_canonical_transcript_page", None)
-        if callable(page_getter):
-            try:
-                page = await page_getter(
-                    session_key,
-                    limit=limit,
-                    before=_chat_history_cursor_key(before),
-                    after=_chat_history_cursor_key(after),
-                )
-                entries, has_more, canonical_complete = _canonical_page_parts(page)
-                return entries, has_more, True, canonical_complete
-            except StorageBusyError:
-                raise
-            except Exception:  # noqa: BLE001 - fall back to active transcript
-                pass
-        else:
-            getter = getattr(mgr, "get_canonical_transcript", None)
-            if callable(getter):
-                try:
-                    transcript = list(await getter(session_key))
-                    entries, has_more = _chat_history_page(
-                        transcript,
-                        limit=limit,
-                        before=before,
-                        after=after,
-                    )
-                    return entries, has_more, True, True
-                except StorageBusyError:
-                    raise
-                except Exception:  # noqa: BLE001 - fall back to active transcript
-                    pass
-    transcript_getter = getattr(mgr, "get_transcript", None)
-    if not callable(transcript_getter):
-        return [], False, False, False
-    transcript = await transcript_getter(session_key)
-    entries, has_more = _chat_history_page(
-        list(transcript or []),
-        limit=limit,
-        before=before,
-        after=after,
-    )
-    return entries, has_more, False, False
-
-
-def _needs_legacy_tool_lookbehind(entry: object | None) -> bool:
-    if entry is None or getattr(entry, "tool_call_id", None):
-        return False
-    role = str(getattr(entry, "role", "") or "").lower()
-    content = str(getattr(entry, "content", "") or "")
-    return role in {"tool", "user"} and is_flattened_tool_result_dump(content)
-
-
-def _needs_legacy_tool_lookahead(entry: object | None) -> bool:
-    if entry is None or getattr(entry, "tool_calls", None):
-        return False
-    role = str(getattr(entry, "role", "") or "").lower()
-    content = str(getattr(entry, "content", "") or "")
-    return role == "assistant" and has_flattened_used_tool_line(content)
-
-
-async def _load_legacy_tool_projection_context(
-    mgr: object,
-    session_key: str,
-    entries: list[object],
-    *,
-    canonical_available: bool,
-) -> tuple[object | None, object | None]:
-    """Load at most one adjacent row per page edge for legacy projection.
-
-    The selected page remains the pagination/accounting unit. These bounded
-    reads only provide enough context to recognize a marker/result pair split
-    by a page boundary; neither row is added to the response page.
-    """
-
-    if not entries or not canonical_available:
-        return None, None
-    page_getter = getattr(mgr, "get_canonical_transcript_page", None)
-    if not callable(page_getter):
-        return None, None
-
-    previous_entry = None
-    next_entry = None
-    oldest_cursor = _chat_history_cursor_key(_chat_history_cursor(entries[0]))
-    newest_cursor = _chat_history_cursor_key(_chat_history_cursor(entries[-1]))
-    if _needs_legacy_tool_lookbehind(entries[0]) and oldest_cursor is not None:
-        try:
-            page = await page_getter(
-                session_key,
-                limit=1,
-                before=oldest_cursor,
-                after=None,
-            )
-            candidates, _has_more, _complete = _canonical_page_parts(page)
-        except StorageBusyError:
-            raise
-        except Exception as exc:  # noqa: BLE001 - optional read-time projection
-            log.warning(
-                "chat_history_legacy_projection_context_unavailable",
-                edge="before",
-                error_type=type(exc).__name__,
-            )
-            return None, None
-        if candidates:
-            candidate = candidates[-1]
-            candidate_cursor = _chat_history_cursor_key(_chat_history_cursor(candidate))
-            if candidate_cursor is not None and candidate_cursor < oldest_cursor:
-                previous_entry = candidate
-
-    if _needs_legacy_tool_lookahead(entries[-1]) and newest_cursor is not None:
-        try:
-            page = await page_getter(
-                session_key,
-                limit=1,
-                before=None,
-                after=newest_cursor,
-            )
-            candidates, _has_more, _complete = _canonical_page_parts(page)
-        except StorageBusyError:
-            raise
-        except Exception as exc:  # noqa: BLE001 - optional read-time projection
-            log.warning(
-                "chat_history_legacy_projection_context_unavailable",
-                edge="after",
-                error_type=type(exc).__name__,
-            )
-            return None, None
-        if candidates:
-            candidate = candidates[0]
-            candidate_cursor = _chat_history_cursor_key(_chat_history_cursor(candidate))
-            if candidate_cursor is not None and candidate_cursor > newest_cursor:
-                next_entry = candidate
-    return previous_entry, next_entry
-
-
 async def _project_missing_history_usage(
     mgr: object,
     session_key: str,
@@ -838,7 +630,7 @@ async def _project_missing_history_usage(
     # A page is a contiguous keyset slice, so only rows after its last cursor
     # can hold a turn's terminal assistant row. Probing that suffix keeps the
     # newest page — the common read — from touching transcript rows at all.
-    page_cursor = _chat_history_cursor_key(_chat_history_cursor(entries[-1]))
+    page_cursor = parse_history_cursor(_chat_history_cursor(entries[-1]))
 
     continuing: set[str] = set()
     try:
@@ -1350,6 +1142,15 @@ async def _handle_chat_history(params: dict | None, ctx: RpcContext) -> dict:
     )
 
     mgr = _require_chat_session_manager(ctx)
+    history_adapter = SessionHistoryStorageAdapter(mgr)
+    history_application = history_adapter.application()
+    history_query = SessionHistoryQuery(
+        session_key=session_key,
+        limit=limit,
+        before=parse_history_cursor(before),
+        after=parse_history_cursor(after),
+        include_canonical=include_canonical,
+    )
 
     async def _load_page() -> tuple[
         list[object],
@@ -1359,28 +1160,19 @@ async def _handle_chat_history(params: dict | None, ctx: RpcContext) -> dict:
         object | None,
         object | None,
     ]:
-        entries, has_more, canonical_available, canonical_complete = (
-            await _load_chat_history_page(
-                mgr,
-                session_key,
-                limit=limit,
-                before=before,
-                after=after,
-                include_canonical=include_canonical,
-            )
-        )
+        page = await history_application.read_page(history_query)
+        entries = list(page.entries)
         entries = await _project_missing_history_usage(mgr, session_key, entries)
-        previous_entry, next_entry = await _load_legacy_tool_projection_context(
-            mgr,
+        previous_entry, next_entry = await history_adapter.load_legacy_tool_projection_context(
             session_key,
             entries,
-            canonical_available=canonical_available,
+            canonical_available=page.canonical_available,
         )
         return (
             entries,
-            has_more,
-            canonical_available,
-            canonical_complete,
+            page.has_more,
+            page.canonical_available,
+            page.canonical_complete,
             previous_entry,
             next_entry,
         )

--- a/tests/test_ci/test_windows_test_shards.py
+++ b/tests/test_ci/test_windows_test_shards.py
@@ -75,6 +75,7 @@ RECENTLY_ADDED_ACTIVE_TESTS = {
     "tests/contracts/test_sessions_resolve_contract.py",
     "tests/contracts/test_sessions_search_contract.py",
     "tests/test_gateway/test_session_preview_adapter.py",
+    "tests/test_gateway/test_session_history_adapter.py",
     "tests/test_gateway/test_sessions_bootstrap_history_characterization.py",
     "tests/test_application/test_session_history.py",
     "tests/test_application/test_session_transcript.py",

--- a/tests/test_gateway/test_session_history_adapter.py
+++ b/tests/test_gateway/test_session_history_adapter.py
@@ -1,0 +1,226 @@
+"""Tests for the concrete Gateway/session-history application seam."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from opensquilla.application.session_history import SessionHistoryQuery
+from opensquilla.gateway.adapters.session_history import (
+    SessionHistoryStorageAdapter,
+    canonical_page_parts,
+    parse_history_cursor,
+)
+from opensquilla.session.storage import StorageBusyError
+
+
+def row(index: int, *, role: str = "user", content: str | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=index,
+        message_id=f"m{index}",
+        created_at=index,
+        role=role,
+        content=content if content is not None else f"message {index}",
+    )
+
+
+def test_parse_history_cursor_keeps_legacy_unpositioned_cases() -> None:
+    assert parse_history_cursor(None) is None
+    assert parse_history_cursor("") is None
+    assert parse_history_cursor("not-a-cursor") is None
+    assert parse_history_cursor("1|not-an-int") is None
+    assert parse_history_cursor(" 2|7 ") == (2, 7)
+
+
+def test_canonical_page_parts_accepts_legacy_shapes() -> None:
+    first = row(1)
+    second = row(2)
+    assert canonical_page_parts({"entries": [first], "has_more": 1}) == (
+        [first],
+        True,
+        True,
+    )
+    assert canonical_page_parts(([first, second], False, False)) == (
+        [first, second],
+        False,
+        False,
+    )
+    assert canonical_page_parts(
+        SimpleNamespace(entries=(second,), has_more=True, canonical_complete=False)
+    ) == ([second], True, False)
+
+
+class CanonicalManager:
+    def __init__(self, page: object) -> None:
+        self.page = page
+        self.calls: list[dict[str, Any]] = []
+        self.active_calls: list[str] = []
+
+    async def get_canonical_transcript_page(
+        self,
+        session_key: str,
+        *,
+        limit: int,
+        before: tuple[int, int] | None = None,
+        after: tuple[int, int] | None = None,
+    ) -> object:
+        self.calls.append(
+            {
+                "session_key": session_key,
+                "limit": limit,
+                "before": before,
+                "after": after,
+            }
+        )
+        return self.page
+
+    async def get_transcript(self, session_key: str) -> list[SimpleNamespace]:
+        self.active_calls.append(session_key)
+        return [row(index) for index in range(1, 5)]
+
+
+@pytest.mark.asyncio
+async def test_adapter_composes_application_and_prefers_canonical_page() -> None:
+    manager = CanonicalManager(
+        SimpleNamespace(
+            entries=(row(3),),
+            has_more=True,
+            canonical_complete=True,
+        )
+    )
+    adapter = SessionHistoryStorageAdapter(manager)
+
+    result = await adapter.application().read_page(
+        SessionHistoryQuery(
+            session_key="agent:main:webchat:history",
+            limit=2,
+            before=(4, 4),
+        )
+    )
+
+    assert [getattr(item, "id") for item in result.entries] == [3]
+    assert result.has_more is True
+    assert result.canonical_available is True
+    assert result.canonical_complete is True
+    assert manager.active_calls == []
+    assert manager.calls == [
+        {
+            "session_key": "agent:main:webchat:history",
+            "limit": 2,
+            "before": (4, 4),
+            "after": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_adapter_falls_back_to_active_transcript_on_canonical_failure() -> None:
+    class BrokenManager(CanonicalManager):
+        async def get_canonical_transcript_page(self, *args: Any, **kwargs: Any) -> object:
+            raise RuntimeError("projection unavailable")
+
+    manager = BrokenManager(None)
+    adapter = SessionHistoryStorageAdapter(manager)
+    result = await adapter.application().read_page(
+        SessionHistoryQuery(
+            session_key="agent:main:webchat:history",
+            limit=2,
+            before=(4, 4),
+            after=(1, 1),
+        )
+    )
+
+    assert [getattr(item, "id") for item in result.entries] == [2, 3]
+    assert result.has_more is True
+    assert result.canonical_available is False
+    assert result.canonical_complete is False
+    assert manager.active_calls == ["agent:main:webchat:history"]
+
+
+@pytest.mark.asyncio
+async def test_adapter_preserves_storage_busy_error() -> None:
+    class BusyManager(CanonicalManager):
+        async def get_canonical_transcript_page(self, *args: Any, **kwargs: Any) -> object:
+            raise StorageBusyError(
+                "chat.history",
+                waited_ms=10,
+                retry_after_ms=100,
+                stage="read",
+                resource="transcript",
+            )
+
+    manager = BusyManager(None)
+    adapter = SessionHistoryStorageAdapter(manager)
+    with pytest.raises(StorageBusyError):
+        await adapter.application().read_page(
+            SessionHistoryQuery(
+                session_key="agent:main:webchat:history",
+                limit=1,
+            )
+        )
+    assert manager.active_calls == []
+
+
+@pytest.mark.asyncio
+async def test_adapter_uses_full_canonical_getter_when_page_capability_is_absent() -> None:
+    class FullCanonicalManager:
+        async def get_canonical_transcript(self, session_key: str) -> list[object]:
+            return [row(index) for index in range(1, 6)]
+
+        async def get_transcript(self, session_key: str) -> list[object]:
+            raise AssertionError("active fallback should not run")
+
+    adapter = SessionHistoryStorageAdapter(FullCanonicalManager())
+    result = await adapter.application().read_page(
+        SessionHistoryQuery(
+            session_key="agent:main:webchat:history",
+            limit=2,
+            after=(2, 2),
+        )
+    )
+    assert [getattr(item, "id") for item in result.entries] == [3, 4]
+    assert result.has_more is True
+    assert result.canonical_available is True
+    assert result.canonical_complete is True
+
+
+@pytest.mark.asyncio
+async def test_projection_context_uses_typed_cursors_and_preserves_edges() -> None:
+    class ProjectionManager(CanonicalManager):
+        async def get_canonical_transcript_page(
+            self,
+            session_key: str,
+            *,
+            limit: int,
+            before: tuple[int, int] | None = None,
+            after: tuple[int, int] | None = None,
+        ) -> object:
+            self.calls.append(
+                {
+                    "session_key": session_key,
+                    "limit": limit,
+                    "before": before,
+                    "after": after,
+                }
+            )
+            if before == (2, 2):
+                return ([row(1)], False)
+            if after == (2, 2):
+                return ([row(3)], False)
+            return ([row(2, role="tool", content="tool result")], False)
+
+    manager = ProjectionManager(None)
+    adapter = SessionHistoryStorageAdapter(manager)
+    entries = [
+        row(2, role="tool", content="[Tool result (x): tool result]"),
+        row(2, role="assistant", content="[Used tool: x]"),
+    ]
+    previous, following = await adapter.load_legacy_tool_projection_context(
+        "agent:main:webchat:history",
+        entries,
+        canonical_available=True,
+    )
+    assert previous is not None and getattr(previous, "id") == 1
+    assert following is not None and getattr(following, "id") == 3


### PR DESCRIPTION
## What

Implements the S4c2/S4c3 session-history vertical slice from the front/back separation plan.

- adds `SessionHistoryStorageAdapter` as the concrete Gateway-to-application boundary;
- moves canonical/active transcript selection, cursor parsing, pagination, page-shape normalization, and legacy edge projection out of `rpc_chat`;
- keeps `chat.history` response projection, lock/busy behavior, usage projection, and v4 JSON wire unchanged;
- adds adapter and compatibility tests and updates Windows shard governance metadata.

## Compatibility

No transport, protocol, database schema, TurnRunner, TaskRuntime, or client API changes. Existing canonical-page, full-canonical, active fallback, malformed cursor, StorageBusyError, and legacy tool-marker behavior are preserved.

## Validation

- 86 Gateway history/concurrency/bootstrap tests
- 15 application/adapter tests
- 16 architecture import/RPC contract tests
- 46 Windows shard governance tests (1 skipped by contract)
- ruff and mypy targeted checks

This PR intentionally does not migrate event subscriptions or commands; those remain later vertical slices.
