### PR TITLE
refactor: extract conversation runtime seams

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
@@ -44,11 +44,9 @@ import {
   FINISHED_STREAM_TASK_ID,
   PENDING_STREAM_TASK_ID,
   STOPPED_STREAM_TASK_ID,
-  acceptStreamSeq as decideStreamSeq,
   activeTaskGroupRunState as buildActiveTaskGroupRunState,
   isCurrentSessionPayload as payloadIsCurrentSession,
   isCurrentTaskPayload as payloadIsCurrentTask,
-  isStaleEpoch as payloadIsStaleEpoch,
   payloadTaskId,
   sessionChangeIsTerminal as payloadSessionChangeIsTerminal,
   sessionErrorMessage as eventSessionErrorMessage,
@@ -64,6 +62,11 @@ import {
   type ChatSteerDeliveryApi,
 } from './useChatSteerDelivery'
 import type { ChatStreamModelCallIdentity } from './useChatStream'
+import {
+  createConversationRuntime,
+  type ConversationRuntime,
+} from '@/modules/conversationRuntime'
+import { conversationCursorSignal } from '@/utils/chat/streamEvents'
 
 export interface ChatUsageAccumulator {
   input: number
@@ -133,9 +136,12 @@ type ChatCompactionPlacement = 'activity' | 'standalone'
 type ChatCompactionPresentationResult = boolean | ChatCompactionPlacement | void
 
 export interface UseChatRpcEventHandlersOptions {
+  /** Shared transport-independent conversation cursor policy. */
+  conversationRuntime?: ConversationRuntime
   sessionKey: Ref<string>
   currentEpoch: Ref<number>
   lastStreamSeq: Ref<number>
+  streamGeneration?: Ref<string | null>
   observeStreamGeneration?: (payload: unknown) => boolean
   activeTaskGroups: Ref<Set<string>>
   taskOwnership?: ChatTaskOwnershipApi
@@ -416,6 +422,22 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
     usageModel,
     stream,
   } = options
+  const conversationRuntime = options.conversationRuntime ?? createConversationRuntime()
+  const streamGeneration = options.streamGeneration ?? ref<string | null>(null)
+
+  function cursor() {
+    return conversationRuntime.createCursor(sessionKey.value, {
+      sessionEpoch: currentEpoch.value,
+      streamGeneration: streamGeneration.value,
+      streamSeq: lastStreamSeq.value,
+    })
+  }
+
+  function syncCursor(next: ReturnType<ConversationRuntime['createCursor']>) {
+    currentEpoch.value = next.sessionEpoch
+    lastStreamSeq.value = next.streamSeq
+    streamGeneration.value = next.streamGeneration
+  }
   const steerDelivery = options.steerDelivery || useChatSteerDelivery({
     sessionKey,
     activeTurnId: activeStreamTaskId,
@@ -976,7 +998,10 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
       typeof snapshot.current_stream_seq === 'number'
       && Number.isFinite(snapshot.current_stream_seq)
     ) {
-      lastStreamSeq.value = Math.max(0, snapshot.current_stream_seq)
+      syncCursor(conversationRuntime.restoreSnapshot(
+        cursor(),
+        conversationCursorSignal(snapshot),
+      ))
     }
   }
 
@@ -1373,7 +1398,10 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
   onScopeDispose(clearTurnCommitTracking)
 
   function isStaleEpoch(payload: StreamEventEnvelope): boolean {
-    return payloadIsStaleEpoch(payload, currentEpoch.value)
+    return conversationRuntime.isStaleEpoch(
+      cursor(),
+      conversationCursorSignal(payload).sessionEpoch,
+    )
   }
 
   function isCurrentSessionPayload(payload: StreamEventEnvelope): boolean {
@@ -1388,10 +1416,21 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
   }
 
   function acceptStreamSeq(payload: StreamEventEnvelope): boolean {
+    const signal = conversationCursorSignal(payload)
     options.observeStreamGeneration?.(payload)
-    const decision = decideStreamSeq(payload, sessionKey.value, lastStreamSeq.value)
+    let current = cursor()
+    if (!options.observeStreamGeneration) {
+      const generation = conversationRuntime.observeGeneration(current, signal)
+      current = generation.cursor
+      if (generation.reset) stream.resetLiveTurnState?.()
+    }
+    const decision = conversationRuntime.acceptEvent(current, signal, {
+      observeGeneration: false,
+    })
+    // The subscription adapter may already have reset the live reducer. Keep
+    // the cursor mirror in sync without triggering a second reset.
+    syncCursor(decision.cursor)
     if (decision.accepted) {
-      lastStreamSeq.value = decision.nextStreamSeq
       const rawOrder = payload.stream_seq ?? payload.streamSeq
       stream.setAcceptedActivityOrder?.(
         typeof rawOrder === 'number' && Number.isSafeInteger(rawOrder) && rawOrder > 0
@@ -1992,10 +2031,13 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
   }
 
   function handleRpcEpochChanged(payload: SessionEventPayload) {
-    const ep = payload?.epoch
-    if (typeof ep === 'number' && Number.isFinite(ep) && ep > currentEpoch.value) {
+    const transition = conversationRuntime.advanceEpoch(
+      cursor(),
+      conversationCursorSignal(payload).sessionEpoch,
+    )
+    if (transition.changed) {
       activeTaskGroups.value.clear()
-      currentEpoch.value = ep
+      syncCursor(transition.cursor)
     }
   }
 

--- a/opensquilla-webui/src/composables/chat/useChatSessionSubscription.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionSubscription.ts
@@ -9,6 +9,11 @@ import type {
   SessionMessagesSubscribeParams,
   SessionMessagesSubscribeResponse,
 } from '@/types/rpc'
+import {
+  createConversationRuntime,
+  type ConversationRuntime,
+} from '@/modules/conversationRuntime'
+import { conversationCursorSignal } from '@/utils/chat/streamEvents'
 import type { RpcCallOptions, RpcConnectionWaitOptions } from '@/lib/rpc'
 import type { ChatTaskOwnershipApi } from '@/composables/chat/useChatTaskOwnership'
 import { chatTaskId } from '@/composables/chat/useChatTaskOwnership'
@@ -60,6 +65,8 @@ interface SessionSubscriptionLease {
 
 export interface UseChatSessionSubscriptionOptions {
   rpc: RpcClient
+  /** Shared domain policy; omitted callers receive an equivalent local seam. */
+  conversationRuntime?: ConversationRuntime
   sessionKey: Ref<string>
   lastStreamSeq: Ref<number>
   runStatus: Ref<ChatRunStatus>
@@ -132,6 +139,7 @@ const UNAVAILABLE_SUBSCRIPTION: SessionSubscriptionOutcome = {
 export function useChatSessionSubscription(options: UseChatSessionSubscriptionOptions) {
   const isHydrating = ref(false)
   const streamGeneration = ref<string | null>(null)
+  const conversationRuntime = options.conversationRuntime ?? createConversationRuntime()
   let subscriptionAttempt = 0
   let activeSubscription: {
     key: string
@@ -148,6 +156,18 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
   let activeController: AbortController | null = null
   let activeMetadataController: AbortController | null = null
   let metadataHydrationSequence = 0
+
+  function cursor() {
+    return conversationRuntime.createCursor(options.sessionKey.value, {
+      streamGeneration: streamGeneration.value,
+      streamSeq: options.lastStreamSeq.value,
+    })
+  }
+
+  function syncCursor(next: ReturnType<ConversationRuntime['createCursor']>) {
+    streamGeneration.value = next.streamGeneration
+    options.lastStreamSeq.value = next.streamSeq
+  }
 
   function detachedHydrationAdvertised(): boolean {
     const methods = options.rpc.policy?.concurrent_optional_read_methods
@@ -274,13 +294,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
 
   function generationFrom(source: unknown): string | null {
     if (typeof source === 'string') return source || null
-    if (!source || typeof source !== 'object') return null
-    const envelope = source as {
-      stream_generation?: unknown
-      streamGeneration?: unknown
-    }
-    const value = envelope.stream_generation ?? envelope.streamGeneration
-    return typeof value === 'string' && value ? value : null
+    return conversationCursorSignal(source).streamGeneration ?? null
   }
 
   /**
@@ -289,32 +303,13 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
    * sequence numbers are accepted instead of compared with the retired stream.
    */
   function observeStreamGeneration(source: unknown): boolean {
-    const generation = generationFrom(source)
-    if (!generation || generation === streamGeneration.value) return false
-    const previous = streamGeneration.value
-    streamGeneration.value = generation
-    if (previous === null) {
-      // A page can survive an in-place upgrade from a legacy Gateway which did
-      // not expose generations.  In that case the client owns a numeric cursor
-      // but cannot prove it belongs to the newly observed stream.  Reset when
-      // the new stream is visibly behind, or explicitly reports a generation
-      // gap; otherwise merely adopt the generation (the ordinary first
-      // subscribe response has an equal/current cursor).
-      const envelope = source && typeof source === 'object'
-        ? source as {
-            current_stream_seq?: unknown
-            replay_gap_reason?: unknown
-            stream_seq?: unknown
-          }
-        : null
-      const sequence = envelope?.stream_seq ?? envelope?.current_stream_seq
-      const newStreamIsBehind = typeof sequence === 'number'
-        && Number.isFinite(sequence)
-        && sequence < options.lastStreamSeq.value
-      const generationGap = envelope?.replay_gap_reason === 'stream_generation_changed'
-      if (!newStreamIsBehind && !generationGap) return false
-    }
-    options.lastStreamSeq.value = 0
+    const transition = conversationRuntime.observeGeneration(
+      cursor(),
+      conversationCursorSignal(source),
+    )
+    if (!transition.changed) return false
+    syncCursor(transition.cursor)
+    if (!transition.reset) return false
     options.resetStreamLiveTurnState()
     return true
   }
@@ -335,8 +330,8 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
     // A mixed-version reconnect can land on an older Gateway which ignores
     // generation fields. Treat that capability downgrade as a new stream so
     // its lower sequence numbers are not hidden behind the modern cursor.
-    streamGeneration.value = null
-    options.lastStreamSeq.value = 0
+    const reset = conversationRuntime.reset(cursor())
+    syncCursor(reset)
     options.resetStreamLiveTurnState()
     return true
   }
@@ -345,21 +340,13 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
     res: SessionMessagesSubscribeResponse,
     generationReset: boolean,
   ) {
-    const current = typeof res.current_stream_seq === 'number'
-      && Number.isFinite(res.current_stream_seq)
-      ? Math.max(0, res.current_stream_seq)
-      : null
-    if (res.replay_complete === false || generationReset) {
-      if (current !== null) {
-        options.lastStreamSeq.value = generationReset
-          && options.lastStreamSeq.value === 0
-          ? current
-          : Math.max(options.lastStreamSeq.value, current)
-      }
-      options.loadHistory()
-    } else if (current !== null) {
-      options.lastStreamSeq.value = Math.max(options.lastStreamSeq.value, current)
-    }
+    const transition = conversationRuntime.applyReplayCursor(
+      cursor(),
+      conversationCursorSignal(res),
+      generationReset,
+    )
+    syncCursor(transition.cursor)
+    if (transition.requiresHistory) options.loadHistory()
   }
 
   function applyHydratedSubscriptionState(
@@ -688,19 +675,17 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
           // bounded replay protocol so mixed-version client updates still work.
         } else {
           const snapshot = snapshotResult.value
-          const snapshotGeneration = generationFrom(snapshot)
+          const snapshotDecision = conversationRuntime.acceptSnapshot(
+            cursor(),
+            conversationCursorSignal(snapshot),
+          )
           if (
             snapshot?.key === key
             && Array.isArray(snapshot.events)
             && typeof snapshot.current_stream_seq === 'number'
-            && (
-              !snapshotGeneration
-              || !streamGeneration.value
-              || snapshotGeneration === streamGeneration.value
-            )
             // Events delivered after registration are newer than a late
             // snapshot response. Never reset the live surface behind them.
-            && snapshot.current_stream_seq >= options.lastStreamSeq.value
+            && snapshotDecision.accepted
           ) {
             const snapshotTaskId = typeof snapshot.task_id === 'string'
               ? snapshot.task_id
@@ -709,7 +694,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
               snapshotTaskId && options.taskOwnership?.isSettled(snapshotTaskId),
             )
             if (!settledSnapshot) onLiveSnapshot?.(snapshot)
-            options.lastStreamSeq.value = Math.max(0, snapshot.current_stream_seq)
+            syncCursor(snapshotDecision.cursor)
             snapshotTaskLive = Boolean(snapshot.task_id) && !settledSnapshot
           }
         }

--- a/opensquilla-webui/src/modules/conversationRuntime.test.ts
+++ b/opensquilla-webui/src/modules/conversationRuntime.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest'
+import { createConversationRuntime, type ConversationCursor } from './conversationRuntime'
+
+function cursor(runtime: ReturnType<typeof createConversationRuntime>, seed: Partial<ConversationCursor> = {}) {
+  return runtime.createCursor('session-a', seed)
+}
+
+describe('ConversationRuntime', () => {
+  const runtime = createConversationRuntime()
+
+  it('accepts increasing event sequences and rejects duplicates', () => {
+    const first = runtime.acceptEvent(cursor(runtime), {
+      sessionKey: 'session-a',
+      streamSeq: 4,
+    })
+    expect(first.accepted).toBe(true)
+    expect(first.cursor.streamSeq).toBe(4)
+
+    const duplicate = runtime.acceptEvent(first.cursor, {
+      sessionKey: 'session-a',
+      streamSeq: 4,
+    })
+    expect(duplicate.accepted).toBe(false)
+    expect(duplicate.reason).toBe('duplicate-sequence')
+  })
+
+  it('rejects events from another session without changing the cursor', () => {
+    const initial = cursor(runtime, { streamSeq: 9 })
+    const decision = runtime.acceptEvent(initial, {
+      sessionKey: 'session-b',
+      streamGeneration: 'foreign-generation',
+      streamSeq: 10,
+    })
+    expect(decision.accepted).toBe(false)
+    expect(decision.reason).toBe('session-mismatch')
+    expect(decision.cursor).toEqual(initial)
+  })
+
+  it('adopts the first generation unless a visible restart makes the old cursor unsafe', () => {
+    const normal = runtime.observeGeneration(cursor(runtime, { streamSeq: 3 }), {
+      streamGeneration: 'g1',
+      streamSeq: 8,
+    })
+    expect(normal.changed).toBe(true)
+    expect(normal.reset).toBe(false)
+    expect(normal.cursor.streamSeq).toBe(3)
+
+    const restarted = runtime.observeGeneration(cursor(runtime, { streamSeq: 8 }), {
+      streamGeneration: 'g1',
+      streamSeq: 2,
+    })
+    expect(restarted.reset).toBe(true)
+    expect(restarted.cursor.streamSeq).toBe(0)
+  })
+
+  it('resets sequence when an established generation changes', () => {
+    const initial = cursor(runtime, { streamGeneration: 'g1', streamSeq: 19 })
+    const transition = runtime.acceptEvent(initial, {
+      streamGeneration: 'g2',
+      streamSeq: 1,
+    })
+    expect(transition.accepted).toBe(true)
+    expect(transition.changed).toBe(true)
+    expect(transition.reset).toBe(true)
+    expect(transition.cursor.streamGeneration).toBe('g2')
+    expect(transition.cursor.streamSeq).toBe(1)
+  })
+
+  it('recognizes a replay gap even when the first sequence is not lower', () => {
+    const transition = runtime.observeGeneration(cursor(runtime, { streamSeq: 3 }), {
+      streamGeneration: 'g1',
+      streamSeq: 3,
+      replayGapReason: 'stream_generation_changed',
+    })
+    expect(transition.reset).toBe(true)
+  })
+
+  it('keeps stale session epochs out of the live stream', () => {
+    const initial = cursor(runtime, { sessionEpoch: 5, streamSeq: 2 })
+    const decision = runtime.acceptEvent(initial, {
+      sessionEpoch: 4,
+      streamSeq: 3,
+    })
+    expect(decision.accepted).toBe(false)
+    expect(decision.reason).toBe('stale-epoch')
+    expect(runtime.isStaleEpoch(initial, 4)).toBe(true)
+  })
+
+  it('advances the epoch monotonically', () => {
+    const initial = cursor(runtime, { sessionEpoch: 2 })
+    const advanced = runtime.advanceEpoch(initial, 7)
+    expect(advanced.changed).toBe(true)
+    expect(advanced.cursor.sessionEpoch).toBe(7)
+    expect(runtime.advanceEpoch(advanced.cursor, 6).changed).toBe(false)
+  })
+
+  it('accepts a snapshot only when it cannot overwrite newer live events', () => {
+    const initial = cursor(runtime, { streamGeneration: 'g1', streamSeq: 12 })
+    const behind = runtime.acceptSnapshot(initial, {
+      sessionKey: 'session-a',
+      streamGeneration: 'g1',
+      currentStreamSeq: 11,
+    })
+    expect(behind.accepted).toBe(false)
+    expect(behind.reason).toBe('snapshot-behind')
+
+    const current = runtime.acceptSnapshot(initial, {
+      sessionKey: 'session-a',
+      streamGeneration: 'g1',
+      currentStreamSeq: 15,
+    })
+    expect(current.accepted).toBe(true)
+    expect(current.cursor.streamSeq).toBe(15)
+  })
+
+  it('rejects snapshots from a different generation or without a cursor', () => {
+    const initial = cursor(runtime, { streamGeneration: 'g1' })
+    expect(runtime.acceptSnapshot(initial, {
+      streamGeneration: 'g2',
+      currentStreamSeq: 2,
+    }).reason).toBe('generation-mismatch')
+    expect(runtime.acceptSnapshot(initial, {}).reason).toBe('invalid-snapshot')
+  })
+
+  it('applies replay cursors and signals history recovery', () => {
+    const initial = cursor(runtime, { streamSeq: 5 })
+    const replay = runtime.applyReplayCursor(initial, {
+      currentStreamSeq: 3,
+      replayComplete: false,
+    })
+    expect(replay.requiresHistory).toBe(true)
+    expect(replay.cursor.streamSeq).toBe(5)
+
+    const reset = runtime.applyReplayCursor(cursor(runtime), {
+      currentStreamSeq: 2,
+    }, true)
+    expect(reset.requiresHistory).toBe(true)
+    expect(reset.cursor.streamSeq).toBe(2)
+  })
+
+  it('resets all session-local cursor state for a route handoff', () => {
+    const initial = cursor(runtime, {
+      sessionEpoch: 9,
+      streamGeneration: 'g7',
+      streamSeq: 42,
+    })
+    const reset = runtime.reset(initial, 'session-b')
+    expect(reset).toEqual({
+      sessionKey: 'session-b',
+      sessionEpoch: 0,
+      streamGeneration: null,
+      streamSeq: 0,
+    })
+  })
+})

--- a/opensquilla-webui/src/modules/conversationRuntime.ts
+++ b/opensquilla-webui/src/modules/conversationRuntime.ts
@@ -1,0 +1,355 @@
+/**
+ * Transport-independent conversation consistency rules.
+ *
+ * This module is deliberately free of Vue, RpcClient and generated Contract
+ * imports.  It owns the small but subtle state machine shared by bootstrap,
+ * snapshot replay and live event consumers:
+ *
+ *   session epoch  ->  stream generation  ->  monotonic stream sequence
+ *
+ * Adapters translate wire aliases into ConversationCursorSignal before
+ * entering this seam.  Consumers receive a decision and a new cursor; they do
+ * not need to know why a stale frame was rejected or why a Gateway restart
+ * resets the numeric sequence.  Keeping the policy here prevents the same
+ * race rules from being reimplemented in every composable.
+ */
+
+export interface ConversationCursor {
+  readonly sessionKey: string
+  readonly sessionEpoch: number
+  readonly streamGeneration: string | null
+  readonly streamSeq: number
+}
+
+/** Canonical, wire-independent cursor facts supplied by an adapter. */
+export interface ConversationCursorSignal {
+  readonly sessionKey?: string | null
+  readonly sessionEpoch?: number | null
+  readonly streamGeneration?: string | null
+  readonly streamSeq?: number | null
+  readonly currentStreamSeq?: number | null
+  readonly replayComplete?: boolean | null
+  readonly replayGapReason?: string | null
+}
+
+export type ConversationCursorRejection =
+  | 'session-mismatch'
+  | 'stale-epoch'
+  | 'duplicate-sequence'
+  | 'snapshot-behind'
+  | 'generation-mismatch'
+  | 'invalid-snapshot'
+
+export interface ConversationGenerationTransition {
+  readonly cursor: ConversationCursor
+  readonly changed: boolean
+  /** True when the old numeric cursor can no longer be compared safely. */
+  readonly reset: boolean
+}
+
+export interface ConversationEventDecision extends ConversationGenerationTransition {
+  readonly accepted: boolean
+  readonly reason?: ConversationCursorRejection
+}
+
+export interface ConversationSnapshotDecision {
+  readonly cursor: ConversationCursor
+  readonly accepted: boolean
+  readonly reason?: ConversationCursorRejection
+}
+
+export interface ConversationReplayTransition {
+  readonly cursor: ConversationCursor
+  /** The caller should reload durable history when this is true. */
+  readonly requiresHistory: boolean
+}
+
+export interface ConversationEpochTransition {
+  readonly cursor: ConversationCursor
+  readonly changed: boolean
+}
+
+export interface ConversationRuntime {
+  createCursor(sessionKey: string, seed?: Partial<ConversationCursor>): ConversationCursor
+  reset(cursor: ConversationCursor, sessionKey?: string): ConversationCursor
+  observeGeneration(
+    cursor: ConversationCursor,
+    signal: ConversationCursorSignal,
+  ): ConversationGenerationTransition
+  acceptEvent(
+    cursor: ConversationCursor,
+    signal: ConversationCursorSignal,
+    options?: { observeGeneration?: boolean },
+  ): ConversationEventDecision
+  acceptSnapshot(
+    cursor: ConversationCursor,
+    signal: ConversationCursorSignal,
+  ): ConversationSnapshotDecision
+  /** Adopt a known authoritative snapshot after the caller reset its view. */
+  restoreSnapshot(
+    cursor: ConversationCursor,
+    signal: ConversationCursorSignal,
+  ): ConversationCursor
+  applyReplayCursor(
+    cursor: ConversationCursor,
+    signal: ConversationCursorSignal,
+    generationReset?: boolean,
+  ): ConversationReplayTransition
+  advanceEpoch(
+    cursor: ConversationCursor,
+    sessionEpoch: number | null | undefined,
+  ): ConversationEpochTransition
+  isStaleEpoch(cursor: ConversationCursor, sessionEpoch: number | null | undefined): boolean
+}
+
+const EMPTY_CURSOR: Omit<ConversationCursor, 'sessionKey'> = {
+  sessionEpoch: 0,
+  streamGeneration: null,
+  streamSeq: 0,
+}
+
+function copyCursor(cursor: ConversationCursor, patch: Partial<ConversationCursor> = {}): ConversationCursor {
+  return Object.freeze({ ...cursor, ...patch })
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function presentText(value: unknown): string | null {
+  // Keep legacy v4 comparison semantics: a non-empty string is significant
+  // exactly as received. Contract validation may reject whitespace-only
+  // values later, but this seam must not rewrite an existing wire value.
+  return typeof value === 'string' && value ? value : null
+}
+
+function signalSequence(signal: ConversationCursorSignal): number | null {
+  return finiteNumber(signal.streamSeq)
+}
+
+function snapshotSequence(signal: ConversationCursorSignal): number | null {
+  return finiteNumber(signal.currentStreamSeq ?? signal.streamSeq)
+}
+
+function sessionMatches(cursor: ConversationCursor, signal: ConversationCursorSignal): boolean {
+  const incoming = presentText(signal.sessionKey)
+  return !incoming || !cursor.sessionKey || incoming === cursor.sessionKey
+}
+
+function generationChangedRequiresReset(
+  cursor: ConversationCursor,
+  signal: ConversationCursorSignal,
+  previousGeneration: string | null,
+): boolean {
+  if (previousGeneration !== null) return true
+  const sequence = signalSequence(signal) ?? snapshotSequence(signal)
+  const visibleGap = signal.replayGapReason === 'stream_generation_changed'
+  return visibleGap || (sequence !== null && sequence < cursor.streamSeq)
+}
+
+/**
+ * Build the runtime as a pure policy object.  State remains owned by the
+ * composition root for now, which makes this seam easy to introduce without
+ * changing Vue reactivity or the public client API.  A later slice can move
+ * the cursor store behind this same interface without changing callers.
+ */
+export function createConversationRuntime(): ConversationRuntime {
+  function createCursor(sessionKey: string, seed: Partial<ConversationCursor> = {}): ConversationCursor {
+    return Object.freeze({
+      sessionKey,
+      // Keep finite legacy values comparable while the v4 adapter is being
+      // migrated. New generated Contract frames are stricter integers.
+      sessionEpoch: finiteNumber(seed.sessionEpoch) ?? EMPTY_CURSOR.sessionEpoch,
+      streamGeneration: presentText(seed.streamGeneration) ?? EMPTY_CURSOR.streamGeneration,
+      streamSeq: finiteNumber(seed.streamSeq) ?? EMPTY_CURSOR.streamSeq,
+    })
+  }
+
+  function reset(cursor: ConversationCursor, sessionKey = cursor.sessionKey): ConversationCursor {
+    return createCursor(sessionKey)
+  }
+
+  function observeGeneration(
+    cursor: ConversationCursor,
+    signal: ConversationCursorSignal,
+  ): ConversationGenerationTransition {
+    const generation = presentText(signal.streamGeneration)
+    if (!generation || generation === cursor.streamGeneration) {
+      return { cursor, changed: false, reset: false }
+    }
+    const resetSequence = generationChangedRequiresReset(
+      cursor,
+      signal,
+      cursor.streamGeneration,
+    )
+    return {
+      cursor: copyCursor(cursor, {
+        streamGeneration: generation,
+        ...(resetSequence ? { streamSeq: 0 } : {}),
+      }),
+      changed: true,
+      reset: resetSequence,
+    }
+  }
+
+  function acceptEvent(
+    originalCursor: ConversationCursor,
+    signal: ConversationCursorSignal,
+    options: { observeGeneration?: boolean } = {},
+  ): ConversationEventDecision {
+    // Identity and epoch fences run before generation adoption. A late frame
+    // from another session (or an older epoch) must never be able to advance
+    // the active stream's generation or reset its sequence ledger.
+    if (!sessionMatches(originalCursor, signal)) {
+      return {
+        cursor: originalCursor,
+        changed: false,
+        reset: false,
+        accepted: false,
+        reason: 'session-mismatch',
+      }
+    }
+    if (isStaleEpoch(originalCursor, signal.sessionEpoch)) {
+      return {
+        cursor: originalCursor,
+        changed: false,
+        reset: false,
+        accepted: false,
+        reason: 'stale-epoch',
+      }
+    }
+    let cursor = originalCursor
+    let generationReset = false
+    let generationChanged = false
+    if (options.observeGeneration !== false) {
+      const transition = observeGeneration(cursor, signal)
+      cursor = transition.cursor
+      generationReset = transition.reset
+      generationChanged = transition.changed
+    }
+    const sequence = signalSequence(signal)
+    if (sequence !== null && sequence <= cursor.streamSeq) {
+      return {
+        cursor,
+        changed: generationChanged,
+        reset: generationReset,
+        accepted: false,
+        reason: 'duplicate-sequence',
+      }
+    }
+    return {
+      cursor: sequence === null ? cursor : copyCursor(cursor, { streamSeq: sequence }),
+      changed: generationChanged,
+      reset: generationReset,
+      accepted: true,
+    }
+  }
+
+  function acceptSnapshot(
+    cursor: ConversationCursor,
+    signal: ConversationCursorSignal,
+  ): ConversationSnapshotDecision {
+    if (!sessionMatches(cursor, signal)) {
+      return { cursor, accepted: false, reason: 'session-mismatch' }
+    }
+    const incomingGeneration = presentText(signal.streamGeneration)
+    if (
+      incomingGeneration
+      && cursor.streamGeneration
+      && incomingGeneration !== cursor.streamGeneration
+    ) {
+      return { cursor, accepted: false, reason: 'generation-mismatch' }
+    }
+    const sequence = snapshotSequence(signal)
+    if (sequence === null) {
+      return { cursor, accepted: false, reason: 'invalid-snapshot' }
+    }
+    if (sequence < cursor.streamSeq) {
+      return { cursor, accepted: false, reason: 'snapshot-behind' }
+    }
+    return {
+      cursor: copyCursor(cursor, {
+        streamSeq: Math.max(0, sequence),
+      }),
+      accepted: true,
+    }
+  }
+
+  function applyReplayCursor(
+    cursor: ConversationCursor,
+    signal: ConversationCursorSignal,
+    generationReset = false,
+  ): ConversationReplayTransition {
+    const rawSequence = snapshotSequence(signal)
+    const sequence = rawSequence === null ? null : Math.max(0, rawSequence)
+    if (sequence === null) {
+      return {
+        cursor,
+        requiresHistory: signal.replayComplete === false || generationReset,
+      }
+    }
+    const requiresHistory = signal.replayComplete === false || generationReset
+    if (!requiresHistory) {
+      return {
+        cursor: copyCursor(cursor, { streamSeq: Math.max(cursor.streamSeq, sequence) }),
+        requiresHistory: false,
+      }
+    }
+    return {
+      cursor: copyCursor(cursor, {
+        streamSeq: generationReset && cursor.streamSeq === 0
+          ? sequence
+          : Math.max(cursor.streamSeq, sequence),
+      }),
+      requiresHistory: true,
+    }
+  }
+
+  function restoreSnapshot(
+    cursor: ConversationCursor,
+    signal: ConversationCursorSignal,
+  ): ConversationCursor {
+    if (!sessionMatches(cursor, signal)) return cursor
+    const sequence = snapshotSequence(signal)
+    if (sequence === null) return cursor
+    return copyCursor(cursor, {
+      streamSeq: Math.max(0, sequence),
+    })
+  }
+
+  function advanceEpoch(
+    cursor: ConversationCursor,
+    sessionEpoch: number | null | undefined,
+  ): ConversationEpochTransition {
+    const next = finiteNumber(sessionEpoch)
+    if (next === null || next <= cursor.sessionEpoch) {
+      return { cursor, changed: false }
+    }
+    return {
+      cursor: copyCursor(cursor, { sessionEpoch: next }),
+      changed: true,
+    }
+  }
+
+  function isStaleEpoch(
+    cursor: ConversationCursor,
+    sessionEpoch: number | null | undefined,
+  ): boolean {
+    // Legacy task/event frames use -1 as an explicit pre-session sentinel;
+    // it is still older than the initial epoch 0 and must be rejected.
+    const incoming = finiteNumber(sessionEpoch)
+    return incoming !== null && incoming < cursor.sessionEpoch
+  }
+
+  return {
+    createCursor,
+    reset,
+    observeGeneration,
+    acceptEvent,
+    acceptSnapshot,
+    restoreSnapshot,
+    applyReplayCursor,
+    advanceEpoch,
+    isStaleEpoch,
+  }
+}

--- a/opensquilla-webui/src/utils/chat/streamEvents.ts
+++ b/opensquilla-webui/src/utils/chat/streamEvents.ts
@@ -1,8 +1,58 @@
 import type { SessionEventPayload, StreamEventEnvelope } from '@/types/rpc'
+import {
+  createConversationRuntime,
+  type ConversationCursorSignal,
+} from '@/modules/conversationRuntime'
 
 export interface StreamSeqDecision {
   accepted: boolean
   nextStreamSeq: number
+}
+
+/**
+ * Translate legacy v4 spellings at the transport edge.  ConversationRuntime
+ * intentionally accepts only these canonical facts, so aliases do not leak
+ * into domain Modules.  Invalid optional cursor values are omitted to retain
+ * the v4 client's historical leniency for unversioned events.
+ */
+export function conversationCursorSignal(source: unknown): ConversationCursorSignal {
+  const value = source && typeof source === 'object'
+    ? source as Record<string, unknown>
+    : {}
+  const text = (...keys: string[]): string | undefined => {
+    for (const key of keys) {
+      const candidate = value[key]
+      // Do not trim legacy identifiers at this compatibility edge. The old
+      // helpers compared the first truthy wire spelling byte-for-byte; domain
+      // Contract validation can tighten this in a later versioned adapter.
+      if (typeof candidate === 'string' && candidate) return candidate
+    }
+    return undefined
+  }
+  const numberValue = (...keys: string[]): number | undefined => {
+    for (const key of keys) {
+      const candidate = value[key]
+      if (
+        typeof candidate === 'number'
+        && Number.isFinite(candidate)
+      ) return candidate
+    }
+    return undefined
+  }
+  const signal: ConversationCursorSignal = {
+    sessionKey: text('key', 'session_key', 'sessionKey'),
+    sessionEpoch: numberValue('epoch'),
+    streamGeneration: text('stream_generation', 'streamGeneration'),
+    streamSeq: numberValue('stream_seq', 'streamSeq'),
+    currentStreamSeq: numberValue('current_stream_seq', 'currentStreamSeq'),
+    replayComplete: typeof value.replay_complete === 'boolean'
+      ? value.replay_complete
+      : typeof value.replayComplete === 'boolean'
+        ? value.replayComplete
+        : undefined,
+    replayGapReason: text('replay_gap_reason', 'replayGapReason'),
+  }
+  return signal
 }
 
 export type NormalizeRunStatus = (status: string) => string
@@ -15,12 +65,15 @@ export const STOPPED_STREAM_TASK_ID = '__opensquilla_stopped_stream_task__'
 // reopening an empty work card after the answer has already completed.
 export const FINISHED_STREAM_TASK_ID = '__opensquilla_finished_stream_task__'
 
+const cursorRuntime = createConversationRuntime()
+
 export function payloadSessionKey(payload: StreamEventEnvelope | null | undefined): string {
   return payload?.key || payload?.session_key || payload?.sessionKey || ''
 }
 
 export function isCurrentSessionPayload(payload: StreamEventEnvelope | null | undefined, sessionKey: string): boolean {
-  const key = payloadSessionKey(payload)
+  const signal = conversationCursorSignal(payload)
+  const key = signal.sessionKey || ''
   return !key || !sessionKey || key === sessionKey
 }
 
@@ -54,9 +107,10 @@ export function isCurrentTaskPayload(
 }
 
 export function isStaleEpoch(payload: StreamEventEnvelope | null | undefined, currentEpoch: number): boolean {
-  const ep = payload?.epoch
-  if (typeof ep !== 'number' || !Number.isFinite(ep)) return false
-  return ep < currentEpoch
+  return cursorRuntime.isStaleEpoch(
+    cursorRuntime.createCursor('', { sessionEpoch: currentEpoch }),
+    conversationCursorSignal(payload).sessionEpoch,
+  )
 }
 
 export function acceptStreamSeq(
@@ -64,17 +118,15 @@ export function acceptStreamSeq(
   sessionKey: string,
   lastStreamSeq: number,
 ): StreamSeqDecision {
-  if (!isCurrentSessionPayload(payload, sessionKey)) {
-    return { accepted: false, nextStreamSeq: lastStreamSeq }
+  const decision = cursorRuntime.acceptEvent(
+    cursorRuntime.createCursor(sessionKey, { streamSeq: lastStreamSeq }),
+    conversationCursorSignal(payload),
+    { observeGeneration: false },
+  )
+  return {
+    accepted: decision.accepted,
+    nextStreamSeq: decision.cursor.streamSeq,
   }
-  const seq = payload?.stream_seq
-  if (typeof seq !== 'number' || !Number.isFinite(seq)) {
-    return { accepted: true, nextStreamSeq: lastStreamSeq }
-  }
-  if (seq <= lastStreamSeq) {
-    return { accepted: false, nextStreamSeq: lastStreamSeq }
-  }
-  return { accepted: true, nextStreamSeq: seq }
 }
 
 export function taskGroupId(payload: SessionEventPayload | null | undefined): string {

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -937,6 +937,7 @@ import {
 } from '@/composables/chat/sessionBootstrapAdmission'
 import { useChatSessionRuntime } from '@/composables/chat/useChatSessionRuntime'
 import { useChatSessionSubscription } from '@/composables/chat/useChatSessionSubscription'
+import { createConversationRuntime } from '@/modules/conversationRuntime'
 import {
   useChatSlashCommands,
   type DurableMetaDraft,
@@ -1630,6 +1631,10 @@ const runStatus = ref<ChatRunStatus>({ status: 'idle', label: t('chat.status.idl
 // Epoch / seq
 const currentEpoch = ref(0)
 const lastStreamSeq = ref(0)
+// One transport-independent cursor policy is shared by the subscription and
+// event adapters.  The refs remain the reactive projection consumed by older
+// composables until the later ConversationRuntime migration removes them.
+const conversationRuntime = createConversationRuntime()
 const activeTaskGroups = ref<Set<string>>(new Set())
 // Task id whose output the live stream renders; binds late events to the
 // current turn so a prior task can't leak into it (issue 344).
@@ -2514,6 +2519,7 @@ let applyPendingUserInputSnapshot: typeof chatPlans.applyBootstrap = () => {}
 let applyGoalSnapshot: (snapshot: SessionMessagesSubscribeResponse) => void = () => {}
 const chatSessionSubscription = useChatSessionSubscription({
   rpc,
+  conversationRuntime,
   sessionKey,
   lastStreamSeq,
   runStatus,
@@ -3765,9 +3771,11 @@ function onPlanQuestionnaireTouchEnd() {
 }
 
 const rpcEventHandlers = useChatRpcEventHandlers({
+  conversationRuntime,
   sessionKey,
   currentEpoch,
   lastStreamSeq,
+  streamGeneration,
   observeStreamGeneration,
   activeTaskGroups,
   taskOwnership,

--- a/src/opensquilla/application/conversation_runtime.py
+++ b/src/opensquilla/application/conversation_runtime.py
@@ -1,0 +1,157 @@
+"""Transport-neutral conversation snapshot application seam.
+
+The Gateway used to combine stream lookup, event projection and terminal-task
+ownership in the RPC handler.  This module owns that policy behind two narrow
+Ports.  It deliberately knows nothing about WebSocket connections, v4 field
+aliases, ``RpcContext`` or the concrete ``SessionStreamRegistry``.  A later
+bootstrap/hydration slice can reuse the same Ports without making the UI or
+the engine depend on Gateway details.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationSnapshotEvent:
+    """One transport-neutral event retained in a live-turn snapshot."""
+
+    name: str
+    payload: Mapping[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class LiveConversationSnapshot:
+    """Input returned by the stream Port."""
+
+    task_id: str | None
+    stream_generation: str
+    current_stream_seq: int
+    events: tuple[ConversationSnapshotEvent, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectedConversationSnapshot:
+    """Projected snapshot consumed by a Gateway Adapter."""
+
+    task_id: str | None
+    stream_generation: str
+    current_stream_seq: int
+    events: tuple[ConversationSnapshotEvent, ...]
+
+
+class ConversationSnapshotReader(Protocol):
+    """Port for the in-memory/live stream implementation."""
+
+    def read_live_snapshot(self, session_key: str) -> LiveConversationSnapshot: ...
+
+
+ConversationEventProjector = Callable[
+    [str, Mapping[str, Any], frozenset[str]],
+    tuple[str, Mapping[str, Any]] | None,
+]
+
+
+class ConversationSnapshotApplication:
+    """Apply event projection and terminal ownership rules once.
+
+    The reader and projector are replaceable.  In production the Gateway
+    adapter supplies the current stream registry and capability-aware v4
+    projector; application tests can substitute small fakes without starting
+    a socket or constructing a full ``RpcContext``.
+    """
+
+    def __init__(
+        self,
+        *,
+        reader: ConversationSnapshotReader,
+        projector: ConversationEventProjector,
+    ) -> None:
+        self._reader = reader
+        self._projector = projector
+
+    def read(
+        self,
+        session_key: str,
+        *,
+        client_caps: frozenset[str] = frozenset(),
+    ) -> ProjectedConversationSnapshot:
+        source = self._reader.read_live_snapshot(session_key)
+        projected: list[ConversationSnapshotEvent] = []
+        for event in source.events:
+            # A projector is an adapter-owned compatibility hook. Give it a
+            # shallow copy so a legacy projection cannot mutate the live
+            # stream buffer that a later subscriber will replay.
+            result = self._projector(event.name, dict(event.payload), client_caps)
+            if result is None:
+                continue
+            event_name, event_payload = result
+            projected.append(
+                ConversationSnapshotEvent(
+                    name=event_name,
+                    payload=dict(event_payload),
+                )
+            )
+
+        # A terminal reset/error is the authoritative end of the live turn,
+        # even if the underlying stream still retains its last task id.  Keep
+        # this rule in the application seam so every transport gets the same
+        # ownership result.
+        terminal = any(
+            event.payload.get("terminal") is True
+            for event in projected
+        )
+        return ProjectedConversationSnapshot(
+            task_id=None if terminal else source.task_id,
+            stream_generation=source.stream_generation,
+            current_stream_seq=source.current_stream_seq,
+            events=tuple(projected),
+        )
+
+
+class InMemoryConversationSnapshotReader:
+    """Small adapter-friendly reader for tests and local composition."""
+
+    def __init__(self, snapshots: Mapping[str, LiveConversationSnapshot]) -> None:
+        self._snapshots = snapshots
+
+    def read_live_snapshot(self, session_key: str) -> LiveConversationSnapshot:
+        return self._snapshots.get(
+            session_key,
+            LiveConversationSnapshot(
+                task_id=None,
+                stream_generation="",
+                current_stream_seq=0,
+                events=(),
+            ),
+        )
+
+
+def snapshot_events(
+    events: Iterable[object],
+) -> tuple[ConversationSnapshotEvent, ...]:
+    """Convert a concrete stream event sequence at the adapter boundary."""
+
+    converted: list[ConversationSnapshotEvent] = []
+    for event in events:
+        name = getattr(event, "event_name", None)
+        payload = getattr(event, "payload", None)
+        if not isinstance(name, str) or not isinstance(payload, Mapping):
+            raise TypeError("live conversation snapshot contains a malformed event")
+        converted.append(ConversationSnapshotEvent(name=name, payload=dict(payload)))
+    return tuple(converted)
+
+
+__all__ = [
+    "ConversationEventProjector",
+    "ConversationSnapshotApplication",
+    "ConversationSnapshotEvent",
+    "ConversationSnapshotReader",
+    "InMemoryConversationSnapshotReader",
+    "LiveConversationSnapshot",
+    "ProjectedConversationSnapshot",
+    "snapshot_events",
+]

--- a/src/opensquilla/gateway/adapters/conversation_runtime.py
+++ b/src/opensquilla/gateway/adapters/conversation_runtime.py
@@ -1,0 +1,112 @@
+"""Gateway adapter for the transport-neutral conversation snapshot seam."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any, cast
+
+from opensquilla.application.conversation_runtime import (
+    ConversationEventProjector,
+    ConversationSnapshotApplication,
+    LiveConversationSnapshot,
+    ProjectedConversationSnapshot,
+    snapshot_events,
+)
+
+
+class SessionStreamSnapshotAdapter:
+    """Expose only live-snapshot data required by the Application Module."""
+
+    def __init__(self, streams: object) -> None:
+        self._streams = streams
+
+    def read_live_snapshot(self, session_key: str) -> LiveConversationSnapshot:
+        # Keep the old handler's failure behaviour at this boundary: a broken
+        # stream registry must not silently turn a real error into an empty
+        # successful snapshot.  The concrete registry supplies these fields;
+        # casts narrow its opaque shape without importing it into the
+        # application module.
+        read = getattr(self._streams, "live_snapshot")
+        snapshot = read(session_key)
+        return LiveConversationSnapshot(
+            task_id=cast(str | None, getattr(snapshot, "task_id")),
+            stream_generation=cast(str, getattr(snapshot, "stream_generation")),
+            current_stream_seq=cast(int, getattr(snapshot, "current_stream_seq")),
+            events=snapshot_events(
+                cast(Iterable[object], getattr(snapshot, "events"))
+            ),
+        )
+
+
+def build_conversation_snapshot_application(
+    streams: object,
+    *,
+    projector: ConversationEventProjector,
+) -> ConversationSnapshotApplication:
+    """Compose the snapshot application without importing Gateway types into it."""
+
+    return ConversationSnapshotApplication(
+        reader=SessionStreamSnapshotAdapter(streams),
+        projector=projector,
+    )
+
+
+def build_v4_conversation_snapshot_application(
+    streams: object,
+) -> ConversationSnapshotApplication:
+    """Compose the v4 adapter without exposing projection to the RPC handler."""
+
+    from opensquilla.gateway.protocol import project_session_event_for_client
+
+    def project(
+        event_name: str,
+        payload: Mapping[str, Any],
+        caps: frozenset[str],
+    ) -> tuple[str, dict[str, Any]] | None:
+        projected = project_session_event_for_client(
+            event_name,
+            dict(payload),
+            client_caps=caps,
+        )
+        if projected is None:
+            return None
+        projected_name, projected_payload = projected
+        if not isinstance(projected_payload, Mapping):
+            # The current live stream only carries object payloads.  Keep the
+            # old renderer's failure boundary explicit if a future producer
+            # violates that invariant instead of silently inventing fields.
+            raise TypeError(
+                f"conversation event {projected_name!r} payload must be an object"
+            )
+        return projected_name, dict(projected_payload)
+
+    return build_conversation_snapshot_application(streams, projector=project)
+
+
+def snapshot_result_to_v4(
+    session_key: str,
+    snapshot: ProjectedConversationSnapshot,
+) -> dict[str, Any]:
+    """Render the existing v4 response envelope at the adapter boundary."""
+
+    return {
+        "key": session_key,
+        "task_id": snapshot.task_id,
+        "stream_generation": snapshot.stream_generation,
+        "current_stream_seq": snapshot.current_stream_seq,
+        "events": [
+            {
+                "event": event.name,
+                "payload": dict(event.payload),
+            }
+            for event in snapshot.events
+        ],
+    }
+
+
+__all__ = [
+    "SessionStreamSnapshotAdapter",
+    "build_conversation_snapshot_application",
+    "build_v4_conversation_snapshot_application",
+    "snapshot_result_to_v4",
+]

--- a/src/opensquilla/gateway/rpc_sessions.py
+++ b/src/opensquilla/gateway/rpc_sessions.py
@@ -54,6 +54,10 @@ from opensquilla.engine.steps.router_decision_record import (
     drain_pending_flushes_for_sessions,
 )
 from opensquilla.gateway import attachment_ingest as _attachment_ingest
+from opensquilla.gateway.adapters.conversation_runtime import (
+    build_v4_conversation_snapshot_application,
+    snapshot_result_to_v4,
+)
 from opensquilla.gateway.adapters.session_preview import (
     SystemClock,
     build_session_preview_application,
@@ -11381,40 +11385,18 @@ async def _handle_sessions_messages_hydrate(params: dict | None, ctx: RpcContext
 async def _handle_sessions_messages_snapshot(params: dict | None, ctx: RpcContext) -> dict:
     """Return a compact active-turn base before a client subscribes for deltas."""
 
-    from opensquilla.gateway.protocol import project_session_event_for_client
     from opensquilla.gateway.websocket import get_registry
 
     key = _require_key(params)
-    snapshot = get_session_streams().live_snapshot(key)
     connection = get_registry().get(ctx.conn_id)
     client_caps: frozenset[str] = getattr(connection, "client_caps", frozenset())
-    projected_events = []
-    for event in snapshot.events:
-        projected = project_session_event_for_client(
-            event.event_name,
-            event.payload,
-            client_caps=client_caps,
-        )
-        if projected is not None:
-            projected_events.append(projected)
-    projected_terminal = any(
-        event_payload.get("terminal") is True
-        for _event_name, event_payload in projected_events
-        if isinstance(event_payload, dict)
+    application = build_v4_conversation_snapshot_application(
+        get_session_streams(),
     )
-    return {
-        "key": key,
-        "task_id": None if projected_terminal else snapshot.task_id,
-        "stream_generation": snapshot.stream_generation,
-        "current_stream_seq": snapshot.current_stream_seq,
-        "events": [
-            {
-                "event": event_name,
-                "payload": dict(event_payload),
-            }
-            for event_name, event_payload in projected_events
-        ],
-    }
+    return snapshot_result_to_v4(
+        key,
+        application.read(key, client_caps=client_caps),
+    )
 
 
 @_d.method("sessions.messages.unsubscribe", scope="operator.read")

--- a/tests/test_application/test_conversation_runtime.py
+++ b/tests/test_application/test_conversation_runtime.py
@@ -1,0 +1,159 @@
+"""Tests for the transport-independent conversation snapshot seam."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from opensquilla.application.conversation_runtime import (
+    ConversationSnapshotApplication,
+    ConversationSnapshotEvent,
+    InMemoryConversationSnapshotReader,
+    LiveConversationSnapshot,
+    snapshot_events,
+)
+
+
+@dataclass(frozen=True)
+class ConcreteEvent:
+    event_name: str
+    payload: dict[str, Any]
+    stream_seq: int = 0
+
+
+def snapshot(
+    *events: ConversationSnapshotEvent,
+    task_id: str | None = "task-1",
+) -> LiveConversationSnapshot:
+    return LiveConversationSnapshot(
+        task_id=task_id,
+        stream_generation="generation-1",
+        current_stream_seq=len(events),
+        events=events,
+    )
+
+
+def identity_projector(
+    name: str,
+    payload: Mapping[str, Any],
+    _caps: frozenset[str],
+) -> tuple[str, Mapping[str, Any]]:
+    return name, payload
+
+
+@pytest.mark.asyncio
+async def test_read_projects_events_and_clears_terminal_task_owner() -> None:
+    terminal_payload = {"terminal": True, "message": "done"}
+    reader = InMemoryConversationSnapshotReader(
+        {
+            "session-a": snapshot(
+                ConversationSnapshotEvent("session.event.answer", {"text": "ok"}),
+                ConversationSnapshotEvent("session.event.error", terminal_payload),
+            )
+        }
+    )
+    app = ConversationSnapshotApplication(reader=reader, projector=identity_projector)
+
+    result = app.read("session-a", client_caps=frozenset({"events.v2"}))
+
+    assert result.task_id is None
+    assert result.stream_generation == "generation-1"
+    assert result.current_stream_seq == 2
+    assert [event.name for event in result.events] == [
+        "session.event.answer",
+        "session.event.error",
+    ]
+    assert result.events[1].payload == terminal_payload
+
+
+def test_read_skips_events_filtered_by_the_capability_projector() -> None:
+    reader = InMemoryConversationSnapshotReader(
+        {"session-a": snapshot(ConversationSnapshotEvent("private", {"value": 1}))}
+    )
+
+    def projector(
+        name: str,
+        payload: Mapping[str, Any],
+        caps: frozenset[str],
+    ) -> tuple[str, Mapping[str, Any]] | None:
+        if name == "private" and "private-events" not in caps:
+            return None
+        return name, payload
+
+    result = ConversationSnapshotApplication(reader=reader, projector=projector).read(
+        "session-a"
+    )
+
+    assert result.task_id == "task-1"
+    assert result.events == ()
+
+
+def test_read_copies_projected_payload_without_mutating_the_source() -> None:
+    payload = {"nested": {"value": 1}}
+    source = snapshot(ConversationSnapshotEvent("event", payload))
+    reader = InMemoryConversationSnapshotReader({"session-a": source})
+
+    def projector(
+        name: str,
+        event_payload: Mapping[str, Any],
+        _caps: frozenset[str],
+    ) -> tuple[str, Mapping[str, Any]]:
+        mutable = event_payload
+        assert isinstance(mutable, dict)
+        mutable["adapter_seen"] = True
+        return name, mutable
+
+    result = ConversationSnapshotApplication(reader=reader, projector=projector).read(
+        "session-a"
+    )
+
+    assert result.events[0].payload["adapter_seen"] is True
+    assert "adapter_seen" not in payload
+
+
+def test_missing_session_is_an_empty_non_running_snapshot() -> None:
+    app = ConversationSnapshotApplication(
+        reader=InMemoryConversationSnapshotReader({}),
+        projector=identity_projector,
+    )
+
+    result = app.read("missing")
+
+    assert result.task_id is None
+    assert result.stream_generation == ""
+    assert result.current_stream_seq == 0
+    assert result.events == ()
+
+
+def test_snapshot_events_converts_concrete_stream_events_at_the_adapter_boundary() -> None:
+    payload = {"text": "hello"}
+    events = snapshot_events(
+        [
+            ConcreteEvent("session.event.text_delta", payload, 1),
+            ConcreteEvent("session.event.answer", {"terminal": True}, 2),
+        ]
+    )
+
+    assert events == (
+        ConversationSnapshotEvent("session.event.text_delta", payload),
+        ConversationSnapshotEvent("session.event.answer", {"terminal": True}),
+    )
+    assert events[0].payload is not payload
+
+
+def test_snapshot_events_rejects_malformed_event_shapes() -> None:
+    with pytest.raises(TypeError, match="malformed event"):
+        snapshot_events(
+            [
+                ConcreteEvent("", {}),
+                type("Bad", (), {"event_name": 1, "payload": {}})(),
+            ]
+        )
+
+    with pytest.raises(TypeError, match="malformed event"):
+        snapshot_events(
+            [type("BadPayload", (), {"event_name": "event", "payload": []})()]
+        )

--- a/tests/test_gateway/test_conversation_runtime_adapter.py
+++ b/tests/test_gateway/test_conversation_runtime_adapter.py
@@ -1,0 +1,86 @@
+"""Tests for the Gateway side of the conversation snapshot seam."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from opensquilla.gateway.adapters.conversation_runtime import (
+    SessionStreamSnapshotAdapter,
+    build_conversation_snapshot_application,
+    snapshot_result_to_v4,
+)
+
+
+def test_stream_adapter_projects_only_the_snapshot_port() -> None:
+    source_payload = {"text": "hello"}
+    streams = SimpleNamespace(
+        live_snapshot=lambda key: SimpleNamespace(
+            task_id="task-1",
+            stream_generation="generation-1",
+            current_stream_seq=4,
+            events=[
+                SimpleNamespace(
+                    event_name="session.event.text_delta",
+                    payload=source_payload,
+                    stream_seq=4,
+                )
+            ],
+        )
+    )
+
+    snapshot = SessionStreamSnapshotAdapter(streams).read_live_snapshot("session-a")
+
+    assert snapshot.task_id == "task-1"
+    assert snapshot.current_stream_seq == 4
+    assert snapshot.events[0].name == "session.event.text_delta"
+    assert snapshot.events[0].payload == source_payload
+    assert snapshot.events[0].payload is not source_payload
+
+
+def test_application_and_renderer_keep_the_existing_v4_shape() -> None:
+    streams = SimpleNamespace(
+        live_snapshot=lambda _key: SimpleNamespace(
+            task_id="task-1",
+            stream_generation="generation-1",
+            current_stream_seq=2,
+            events=[
+                SimpleNamespace(
+                    event_name="session.event.answer",
+                    payload={"text": "ok"},
+                    stream_seq=2,
+                ),
+                SimpleNamespace(
+                    event_name="session.event.error",
+                    payload={"terminal": True},
+                    stream_seq=3,
+                ),
+            ],
+        )
+    )
+
+    def projector(
+        name: str,
+        payload: dict[str, Any],
+        caps: frozenset[str],
+    ) -> tuple[str, dict[str, Any]] | None:
+        if name == "session.event.answer" and "answers" not in caps:
+            return None
+        return name, payload
+
+    application = build_conversation_snapshot_application(
+        streams,
+        projector=projector,
+    )
+    result = application.read("session-a", client_caps=frozenset({"answers"}))
+
+    assert snapshot_result_to_v4("session-a", result) == {
+        "key": "session-a",
+        "task_id": None,
+        "stream_generation": "generation-1",
+        "current_stream_seq": 2,
+        "events": [
+            {"event": "session.event.answer", "payload": {"text": "ok"}},
+            {"event": "session.event.error", "payload": {"terminal": True}},
+        ],
+    }


### PR DESCRIPTION
## Summary

- extract a transport-independent `ConversationRuntime` cursor policy for the WebUI
- extract live conversation snapshot projection and terminal ownership into an application module
- keep v4 WebSocket frames, event producers, public client APIs, storage schema, and runtime behavior unchanged

## Why

Conversation bootstrap, subscription, snapshot, and event handlers each carried part of the same epoch/generation/sequence rules.  The new module is a narrow seam: adapters translate legacy wire aliases, the module decides identity and cursor ordering, and the existing reactive refs remain the compatibility projection until the later lease/runtime slices.

The Gateway snapshot handler likewise mixed stream lookup, capability projection, terminal-task ownership, and v4 rendering.  `ConversationSnapshotApplication` now owns the policy behind a small reader/projector Port; the v4 adapter is the only layer that knows the concrete stream registry and wire projector.

## Compatibility and scope

- no WebSocket protocol or connection-lifecycle change
- no change to `TurnRunner`, `TaskRuntime`, send/cancel/steer/subscribe, database schema, or event producers
- legacy snake/camel aliases, unversioned events, replay/generation handling, and existing error behavior remain supported
- no generated wire types enter Vue, composables, or the application module
- no shadow handler or second business implementation

## Verification

- WebUI unit: 393 files, 5038 tests passed
- backend application/Gateway/session/concurrency/architecture tests: 432 passed
- full Python mypy: 1017 source files, no issues
- Ruff: changed Python files clean
- WebUI typecheck and architecture/security/style gates passed
- GitNexus index (S10 worktree): 113,130 nodes, 217,333 edges, 4,372 clusters, 300 flows
  - `ConversationRuntime`: 4 direct / 11 total upstream symbols, LOW exact risk
  - `ConversationSnapshotApplication`: 1 direct upstream adapter, LOW exact risk
  - cycle inventory unchanged at 13 known cycles

The full legacy snapshot tests remain green, including capability projection and terminal reset without mutating the stream buffer.
