### PR TITLE
refactor: centralize conversation event transport and lease policy

### DIFF
--- a/opensquilla-webui/scripts/lib/rpc-architecture-gate.mjs
+++ b/opensquilla-webui/scripts/lib/rpc-architecture-gate.mjs
@@ -41,6 +41,9 @@ const isRpcTransportImplementation = rel => (
   rel === 'src/stores/rpc.ts'
   || rel === 'src/lib/rpc.ts'
   || rel === 'src/adapters/gateway/privateTransports.ts'
+  // This adapter is the private wildcard listener for the v4 event stream;
+  // exposing its raw `on` calls to a composable would defeat the seam.
+  || rel === 'src/adapters/gateway/conversationEventTransport.ts'
 )
 
 function scriptBody(rel, body) {

--- a/opensquilla-webui/scripts/rpc-debt/session-chat.mjs
+++ b/opensquilla-webui/scripts/rpc-debt/session-chat.mjs
@@ -42,7 +42,6 @@ export const debt = {
   'src/composables/chat/useChatPendingQueue.ts': { call: 6 },
   'src/composables/chat/useChatPlans.ts': { call: 4, on: 6 },
   'src/composables/chat/useChatRouteFeedback.ts': { call: 1 },
-  'src/composables/chat/useChatRpcSubscriptions.ts': { on: 28 },
   'src/composables/chat/useChatRunModePreference.ts': { call: 4 },
   'src/composables/chat/useChatSend.ts': { call: 9 },
   'src/composables/chat/useChatSessionSubscription.ts': { call: 7, waitForConnection: 3 },

--- a/opensquilla-webui/src/adapters/gateway/conversationEventTransport.test.ts
+++ b/opensquilla-webui/src/adapters/gateway/conversationEventTransport.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RpcEventHandler } from '@/lib/rpc'
+import { createConversationEventTransport } from './conversationEventTransport'
+
+type ListenerMap = Map<string, Set<RpcEventHandler>>
+
+function harness() {
+  const listeners: ListenerMap = new Map()
+  const rpc = {
+    on(event: string, handler: RpcEventHandler) {
+      const bucket = listeners.get(event) ?? new Set<RpcEventHandler>()
+      bucket.add(handler)
+      listeners.set(event, bucket)
+      return () => bucket.delete(handler)
+    },
+    emit(event: string, ...args: unknown[]) {
+      for (const handler of listeners.get(event) ?? []) handler(...args)
+    },
+    registered(event: string) {
+      return listeners.get(event)?.size ?? 0
+    },
+  }
+  return { rpc, transport: createConversationEventTransport(rpc) }
+}
+
+describe('conversation event transport adapter', () => {
+  it('uses one wildcard listener and one connection-state listener', () => {
+    const { rpc, transport } = harness()
+    const detach = transport.subscribe({})
+
+    expect(rpc.registered('*')).toBe(1)
+    expect(rpc.registered('_state')).toBe(1)
+    detach()
+    expect(rpc.registered('*')).toBe(0)
+    expect(rpc.registered('_state')).toBe(0)
+  })
+
+  it('decodes aliases before dispatch while preserving raw wildcard observation', () => {
+    const { rpc, transport } = harness()
+    const text = vi.fn()
+    const any = vi.fn()
+    transport.subscribe({ onTextDelta: text, onAny: any })
+
+    const payload = { sessionKey: 'agent:main:alpha', streamSeq: 3, text: 'hi' }
+    rpc.emit('*', 'text_delta', payload, { replayed: false })
+
+    expect(text).toHaveBeenCalledWith(payload, { replayed: false })
+    expect(any).toHaveBeenCalledWith('text_delta', payload)
+  })
+
+  it('keeps directory changes in the same listener without treating them as conversation frames', () => {
+    const { rpc, transport } = harness()
+    const changed = vi.fn()
+    const any = vi.fn()
+    transport.subscribe({ onSessionsChanged: changed, onAny: any })
+    const payload = { key: 'agent:main:alpha', reason: 'renamed' }
+
+    rpc.emit('*', 'sessions.changed', payload, {})
+
+    expect(changed).toHaveBeenCalledWith(payload, {})
+    expect(any).toHaveBeenCalledWith('sessions.changed', payload)
+  })
+
+  it('quarantines malformed frames but does not break the wildcard stream', () => {
+    const { rpc, transport } = harness()
+    const error = vi.fn()
+    const any = vi.fn()
+    transport.subscribe({ onDecodeError: error, onAny: any })
+
+    rpc.emit('*', 'presence', { value: true }, {})
+
+    expect(error).toHaveBeenCalledTimes(1)
+    expect(any).toHaveBeenCalledWith('presence', { value: true })
+  })
+
+  it('forwards connection state through the same lifecycle owner', () => {
+    const { rpc, transport } = harness()
+    const state = vi.fn()
+    transport.subscribe({ onConnectionState: state })
+
+    rpc.emit('_state', 'connected')
+
+    expect(state).toHaveBeenCalledWith('connected')
+  })
+})
+

--- a/opensquilla-webui/src/adapters/gateway/conversationEventTransport.ts
+++ b/opensquilla-webui/src/adapters/gateway/conversationEventTransport.ts
@@ -1,0 +1,152 @@
+import type { RpcEventHandler } from '@/lib/rpc'
+import {
+  decodeConversationEvent,
+  type DecodedConversationEvent,
+} from './conversationEventsV4'
+
+/**
+ * The WebSocket client exposes one untyped wildcard event stream.  Keep that
+ * transport detail in this adapter: composables receive named callbacks and
+ * never register wire event strings themselves.
+ *
+ * The callback payload deliberately remains `unknown` here.  The adapter is
+ * responsible for framing, aliases, and validation; the domain consumer owns
+ * the payload projection and can preserve the existing v4 shapes during the
+ * migration.
+ */
+export interface ConversationEventTransportHandlers {
+  onAnswerGenerationReset?: (payload: unknown, meta?: unknown) => void
+  onTextDelta?: (payload: unknown, meta?: unknown) => void
+  onToolUseStart?: (payload: unknown, meta?: unknown) => void
+  onToolUseDelta?: (payload: unknown, meta?: unknown) => void
+  onToolUseEnd?: (payload: unknown, meta?: unknown) => void
+  onToolResult?: (payload: unknown, meta?: unknown) => void
+  onArtifact?: (payload: unknown, meta?: unknown) => void
+  onStateChange?: (payload: unknown, meta?: unknown) => void
+  onRunHeartbeat?: (payload: unknown, meta?: unknown) => void
+  onProviderActivity?: (payload: unknown, meta?: unknown) => void
+  onCompaction?: (payload: unknown, meta?: unknown) => void
+  onWarning?: (payload: unknown, meta?: unknown) => void
+  onInputDisposition?: (payload: unknown, meta?: unknown) => void
+  onCronResult?: (payload: unknown, meta?: unknown) => void
+  onSubagentCompletion?: (payload: unknown, meta?: unknown) => void
+  onEpochChanged?: (payload: unknown, meta?: unknown) => void
+  onSessionsChanged?: (payload: unknown, meta?: unknown) => void
+  onTaskQueued?: (payload: unknown, meta?: unknown) => void
+  onTaskRunning?: (payload: unknown, meta?: unknown) => void
+  onTaskGroupWaiting?: (payload: unknown, meta?: unknown) => void
+  onTaskGroupSynthesizing?: (payload: unknown, meta?: unknown) => void
+  onTaskGroupDone?: (payload: unknown, meta?: unknown) => void
+  onTaskGroupFailed?: (payload: unknown, meta?: unknown) => void
+  onRouterDecision?: (payload: unknown, meta?: unknown) => void
+  onEnsembleProgress?: (payload: unknown, meta?: unknown) => void
+  onRouterControlReplay?: (payload: unknown, meta?: unknown) => void
+  /** Preserve the legacy observation path for terminal/thinking/future events. */
+  onAny?: (rawEvent: string, rawPayload: unknown) => void
+  onConnectionState?: (state: string) => void
+  onDecodeError?: (error: unknown, rawEvent: string, rawPayload: unknown) => void
+}
+
+type RpcSubscriptionClient = {
+  on(event: string, handler: RpcEventHandler): () => void
+}
+
+type NamedHandler = keyof Omit<
+  ConversationEventTransportHandlers,
+  'onAny' | 'onConnectionState' | 'onDecodeError'
+>
+
+/** Wire names stay in one place, next to the decoder that owns them. */
+const NAMED_HANDLERS: Readonly<Record<string, NamedHandler>> = Object.freeze({
+  'session.event.answer_generation_reset': 'onAnswerGenerationReset',
+  'session.event.text_delta': 'onTextDelta',
+  'session.event.tool_use_start': 'onToolUseStart',
+  'session.event.tool_use_delta': 'onToolUseDelta',
+  'session.event.tool_use_end': 'onToolUseEnd',
+  'session.event.tool_result': 'onToolResult',
+  'session.event.artifact': 'onArtifact',
+  'session.event.state_change': 'onStateChange',
+  'session.event.run_heartbeat': 'onRunHeartbeat',
+  'session.event.provider_activity': 'onProviderActivity',
+  'session.event.compaction': 'onCompaction',
+  'session.event.warning': 'onWarning',
+  'session.event.input_disposition': 'onInputDisposition',
+  'session.event.cron_result': 'onCronResult',
+  'session.event.subagent_completion': 'onSubagentCompletion',
+  'session.epoch_changed': 'onEpochChanged',
+  'task.queued': 'onTaskQueued',
+  'task.running': 'onTaskRunning',
+  'session.event.task_group.waiting': 'onTaskGroupWaiting',
+  'session.event.task_group.synthesizing': 'onTaskGroupSynthesizing',
+  'session.event.task_group.done': 'onTaskGroupDone',
+  'session.event.task_group.failed': 'onTaskGroupFailed',
+  'session.event.router_decision': 'onRouterDecision',
+  'session.event.ensemble_progress': 'onEnsembleProgress',
+  'session.event.router_control_replay': 'onRouterControlReplay',
+})
+
+function dispatchNamed(
+  handlers: ConversationEventTransportHandlers,
+  decoded: DecodedConversationEvent,
+  payload: unknown,
+  meta: unknown,
+) {
+  if (decoded.kind !== 'known') return
+  const handlerName = NAMED_HANDLERS[decoded.name]
+  if (!handlerName) return
+  handlers[handlerName]?.(payload, meta)
+}
+
+/** Create the one WebSocket event listener used by the Conversation lane. */
+export function createConversationEventTransport(rpc: RpcSubscriptionClient) {
+  let detach: (() => void) | null = null
+
+  function subscribe(handlers: ConversationEventTransportHandlers): () => void {
+    detach?.()
+    const onEvent: RpcEventHandler = (
+      rawEvent: unknown,
+      rawPayload: unknown,
+      rawMeta: unknown,
+    ) => {
+      const eventName = typeof rawEvent === 'string' ? rawEvent : String(rawEvent ?? '')
+
+      // `sessions.changed` has its own Contract family.  It is intentionally
+      // handled here as a directory event until the Session Event lane merges
+      // both manifests; it must still pass through the same single listener.
+      if (eventName === 'sessions.changed') {
+        handlers.onSessionsChanged?.(rawPayload, rawMeta)
+        handlers.onAny?.(eventName, rawPayload)
+        return
+      }
+
+      try {
+        const decoded = decodeConversationEvent(eventName, rawPayload, rawMeta)
+        dispatchNamed(handlers, decoded, rawPayload, rawMeta)
+      } catch (error) {
+        // A malformed or unrelated frame must not take down the shared event
+        // stream. Preserve the old wildcard observation path and report the
+        // contract violation for diagnostics.
+        handlers.onDecodeError?.(error, eventName, rawPayload)
+      }
+      handlers.onAny?.(eventName, rawPayload)
+    }
+
+    const offWildcard = rpc.on('*', onEvent)
+    const offState = rpc.on('_state', (state: unknown) => {
+      handlers.onConnectionState?.(String(state))
+    })
+    detach = () => {
+      offWildcard()
+      offState()
+      detach = null
+    }
+    return detach
+  }
+
+  function unsubscribe() {
+    detach?.()
+  }
+
+  return { subscribe, unsubscribe }
+}
+

--- a/opensquilla-webui/src/composables/chat/useChatRpcSubscriptions.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcSubscriptions.ts
@@ -16,10 +16,13 @@ import type {
   ToolUsePayload,
   WarningPayload,
 } from '@/types/rpc'
-import type { RpcEventHandler } from '@/lib/rpc'
+import {
+  createConversationEventTransport,
+  type ConversationEventTransportHandlers,
+} from '@/adapters/gateway/conversationEventTransport'
 
 type RpcSubscriptionClient = {
-  on(event: string, handler: RpcEventHandler): () => void
+  on(event: string, handler: (...args: unknown[]) => void): () => void
 }
 
 export type ChatRpcSubscriptionHandlers = {
@@ -57,46 +60,57 @@ export function useChatRpcSubscriptions(
   rpc: RpcSubscriptionClient,
   handlers: ChatRpcSubscriptionHandlers,
 ) {
-  let unsubs: Array<() => void> = []
+  const transport = createConversationEventTransport(rpc)
+  let unsubscribeTransport: (() => void) | null = null
+
+  function payloadHandler<T>(
+    handler: (payload: T, meta?: unknown) => void,
+  ) {
+    return (payload: unknown, meta?: unknown) => handler(payload as T, meta)
+  }
+
+  function transportHandlers(): ConversationEventTransportHandlers {
+    return {
+      onAnswerGenerationReset: payloadHandler(handlers.onAnswerGenerationReset),
+      onTextDelta: payloadHandler(handlers.onTextDelta),
+      onToolUseStart: payloadHandler(handlers.onToolUseStart),
+      onToolUseDelta: payloadHandler(handlers.onToolUseDelta),
+      onToolUseEnd: payloadHandler(handlers.onToolUseEnd),
+      onToolResult: payloadHandler(handlers.onToolResult),
+      onArtifact: payloadHandler(handlers.onArtifact),
+      onStateChange: payloadHandler(handlers.onStateChange),
+      onRunHeartbeat: payloadHandler(handlers.onRunHeartbeat),
+      onProviderActivity: payloadHandler(handlers.onProviderActivity),
+      onCompaction: payloadHandler(handlers.onCompaction),
+      onWarning: payloadHandler(handlers.onWarning),
+      onInputDisposition: payloadHandler(handlers.onInputDisposition),
+      onCronResult: payloadHandler(handlers.onCronResult),
+      onSubagentCompletion: payloadHandler(handlers.onSubagentCompletion),
+      onEpochChanged: payloadHandler(handlers.onEpochChanged),
+      onSessionsChanged: payloadHandler(handlers.onSessionsChanged),
+      onTaskQueued: payloadHandler(handlers.onTaskQueued),
+      onTaskRunning: payloadHandler(handlers.onTaskRunning),
+      onTaskGroupWaiting: payloadHandler(handlers.onTaskGroupWaiting),
+      onTaskGroupSynthesizing: payloadHandler(handlers.onTaskGroupSynthesizing),
+      onTaskGroupDone: payloadHandler(handlers.onTaskGroupDone),
+      onTaskGroupFailed: payloadHandler(handlers.onTaskGroupFailed),
+      onRouterDecision: payloadHandler(handlers.onRouterDecision),
+      onEnsembleProgress: payloadHandler(handlers.onEnsembleProgress),
+      onRouterControlReplay: payloadHandler(handlers.onRouterControlReplay),
+      onAny: handlers.onAny,
+      onConnectionState: handlers.onConnectionState,
+    }
+  }
 
   function subscribe(): () => void {
     unsubscribe()
-    unsubs = [
-      rpc.on('session.event.answer_generation_reset', handlers.onAnswerGenerationReset),
-      rpc.on('session.event.text_delta', handlers.onTextDelta),
-      rpc.on('session.event.tool_use_start', handlers.onToolUseStart),
-      rpc.on('session.event.tool_use_delta', handlers.onToolUseDelta),
-      rpc.on('session.event.tool_use_end', handlers.onToolUseEnd),
-      rpc.on('session.event.tool_result', handlers.onToolResult),
-      rpc.on('session.event.artifact', handlers.onArtifact),
-      rpc.on('session.event.state_change', handlers.onStateChange),
-      rpc.on('session.event.run_heartbeat', handlers.onRunHeartbeat),
-      rpc.on('session.event.provider_activity', handlers.onProviderActivity),
-      rpc.on('session.event.compaction', handlers.onCompaction),
-      rpc.on('session.event.warning', handlers.onWarning),
-      rpc.on('session.event.input_disposition', handlers.onInputDisposition),
-      rpc.on('session.event.cron_result', handlers.onCronResult),
-      rpc.on('session.event.subagent_completion', handlers.onSubagentCompletion),
-      rpc.on('session.epoch_changed', handlers.onEpochChanged),
-      rpc.on('sessions.changed', handlers.onSessionsChanged),
-      rpc.on('task.queued', handlers.onTaskQueued),
-      rpc.on('task.running', handlers.onTaskRunning),
-      rpc.on('session.event.task_group.waiting', handlers.onTaskGroupWaiting),
-      rpc.on('session.event.task_group.synthesizing', handlers.onTaskGroupSynthesizing),
-      rpc.on('session.event.task_group.done', handlers.onTaskGroupDone),
-      rpc.on('session.event.task_group.failed', handlers.onTaskGroupFailed),
-      rpc.on('session.event.router_decision', handlers.onRouterDecision),
-      rpc.on('session.event.ensemble_progress', handlers.onEnsembleProgress),
-      rpc.on('session.event.router_control_replay', handlers.onRouterControlReplay),
-      rpc.on('*', handlers.onAny),
-      rpc.on('_state', handlers.onConnectionState),
-    ]
+    unsubscribeTransport = transport.subscribe(transportHandlers())
     return unsubscribe
   }
 
   function unsubscribe() {
-    unsubs.forEach(fn => fn())
-    unsubs = []
+    unsubscribeTransport?.()
+    unsubscribeTransport = null
   }
 
   return {

--- a/opensquilla-webui/src/composables/chat/useChatSessionSubscription.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionSubscription.ts
@@ -13,6 +13,7 @@ import {
   createConversationRuntime,
   type ConversationRuntime,
 } from '@/modules/conversationRuntime'
+import { createConversationSubscriptionLeaseRegistry } from '@/modules/conversationSubscriptionLease'
 import { conversationCursorSignal } from '@/utils/chat/streamEvents'
 import type { RpcCallOptions, RpcConnectionWaitOptions } from '@/lib/rpc'
 import type { ChatTaskOwnershipApi } from '@/composables/chat/useChatTaskOwnership'
@@ -47,20 +48,6 @@ type RpcClient = {
     expectedGeneration: number,
     reason: string,
   ) => boolean
-}
-
-export type SessionSubscriptionLeaseState =
-  | 'acquiring'
-  | 'active'
-  | 'releasing'
-  | 'retired'
-
-interface SessionSubscriptionLease {
-  token: symbol
-  key: string
-  state: SessionSubscriptionLeaseState
-  socketGeneration: number | null
-  releasePromise: Promise<void> | null
 }
 
 export interface UseChatSessionSubscriptionOptions {
@@ -140,6 +127,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
   const isHydrating = ref(false)
   const streamGeneration = ref<string | null>(null)
   const conversationRuntime = options.conversationRuntime ?? createConversationRuntime()
+  const subscriptionLeases = createConversationSubscriptionLeaseRegistry()
   let subscriptionAttempt = 0
   let activeSubscription: {
     key: string
@@ -148,11 +136,9 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
     bootstrapGeneration: number
     bootstrapAttempt: number
     token: symbol
-    lease: SessionSubscriptionLease
+    lease: ReturnType<typeof subscriptionLeases.acquire>
     outcome: Promise<SessionSubscriptionOutcome>
   } | null = null
-  const subscriptionLeases = new Set<SessionSubscriptionLease>()
-  let activeLease: SessionSubscriptionLease | null = null
   let activeController: AbortController | null = null
   let activeMetadataController: AbortController | null = null
   let metadataHydrationSequence = 0
@@ -182,49 +168,8 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
     return callOptions
   }
 
-  function retireLease(lease: SessionSubscriptionLease) {
-    lease.state = 'retired'
-    subscriptionLeases.delete(lease)
-    if (activeLease === lease) activeLease = null
-  }
-
   function retireLeasesFromPriorGenerations() {
-    const currentGeneration = options.rpc.connectionGeneration
-    if (typeof currentGeneration !== 'number') return
-    for (const lease of subscriptionLeases) {
-      if (
-        lease.socketGeneration !== null
-        && lease.socketGeneration !== currentGeneration
-      ) {
-        retireLease(lease)
-      }
-    }
-  }
-
-  function activateLease(lease: SessionSubscriptionLease) {
-    if (lease.state !== 'acquiring') return
-    // Gateway registration is a set keyed by (connection, session). A newer
-    // successful acquire for the same key subsumes earlier non-releasing
-    // leases, while a closing A1 remains distinct from a later A2 acquire.
-    for (const candidate of subscriptionLeases) {
-      if (
-        candidate !== lease
-        && candidate.key === lease.key
-        && (candidate.state === 'acquiring' || candidate.state === 'active')
-      ) {
-        retireLease(candidate)
-      }
-    }
-    lease.state = 'active'
-    activeLease = lease
-  }
-
-  function latestReleasableLease(key: string): SessionSubscriptionLease | null {
-    const matches = [...subscriptionLeases].filter(lease => (
-      lease.key === key
-      && (lease.state === 'acquiring' || lease.state === 'active')
-    ))
-    return matches.length > 0 ? matches[matches.length - 1]! : null
+    subscriptionLeases.retirePriorGenerations(options.rpc.connectionGeneration)
   }
 
   function subscribeSession(
@@ -258,21 +203,12 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
     const attemptContext = bootstrap
       ? { ...bootstrap, signal: controller.signal }
       : undefined
-    const token = Symbol('session-subscription')
-    const lease: SessionSubscriptionLease = {
-      token,
-      key,
-      state: 'acquiring',
-      socketGeneration: null,
-      releasePromise: null,
-    }
-    subscriptionLeases.add(lease)
-    activeLease = lease
+    const lease = subscriptionLeases.acquire(key)
     const outcome = runSubscription(
       key,
       sinceStreamGeneration,
       sinceStreamSeq,
-      token,
+      lease.token,
       lease,
       controller,
       attemptContext,
@@ -285,7 +221,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
       sinceStreamSeq,
       bootstrapGeneration,
       bootstrapAttempt,
-      token,
+      token: lease.token,
       lease,
       outcome,
     }
@@ -520,7 +456,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
     sinceStreamGeneration: string | null,
     sinceStreamSeq: number,
     token: symbol,
-    lease: SessionSubscriptionLease,
+    lease: ReturnType<typeof subscriptionLeases.acquire>,
     controller: AbortController,
     bootstrap?: SessionBootstrapPhaseContext,
   ): Promise<SessionSubscriptionOutcome> {
@@ -632,12 +568,12 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
         && subscribeResult.value?.subscribed !== false
         && lease.state === 'acquiring'
       ) {
-        activateLease(lease)
+        subscriptionLeases.activate(lease)
       } else if (
         subscribeResult.status === 'rejected'
         && lease.state === 'acquiring'
       ) {
-        retireLease(lease)
+        subscriptionLeases.retire(lease)
       }
       if (attempt !== subscriptionAttempt || key !== options.sessionKey.value) {
         return { ...UNAVAILABLE_SUBSCRIPTION, cancelled: true }
@@ -646,7 +582,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
       if (subscribeResult.status === 'rejected') throw subscribeResult.reason
       const res = subscribeResult.value
       if (res && res.subscribed === false) {
-        retireLease(lease)
+        subscriptionLeases.retire(lease)
         throw new Error('No subscription manager available')
       }
       const generationReset = reconcileSubscriptionGeneration(
@@ -750,7 +686,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
         backgroundOnly: false,
       }
     } catch (err: unknown) {
-      if (lease.state === 'acquiring') retireLease(lease)
+      if (lease.state === 'acquiring') subscriptionLeases.retire(lease)
       console.warn('Session stream subscription failed:', err instanceof Error ? err.message : err)
       const cancelled = (
         attempt !== subscriptionAttempt
@@ -873,11 +809,11 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
     cancelActiveSubscription()
     if (!key) return
     retireLeasesFromPriorGenerations()
-    const lease = latestReleasableLease(key)
+    const lease = subscriptionLeases.latestReleasable(key)
     if (!lease) return
     if (lease.releasePromise) return lease.releasePromise
     lease.state = 'releasing'
-    if (activeLease === lease) activeLease = null
+    subscriptionLeases.clearActive(lease)
     const expectedGeneration = lease.socketGeneration
     const currentGeneration = options.rpc.connectionGeneration
     // No subscribe frame was sent, or the physical connection that owned it
@@ -890,7 +826,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
         && currentGeneration !== expectedGeneration
       )
     ) {
-      retireLease(lease)
+      subscriptionLeases.retire(lease)
       return
     }
     const release = (async () => {
@@ -929,7 +865,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
           cause instanceof Error ? cause.message : cause,
         )
       } finally {
-        retireLease(lease)
+        subscriptionLeases.retire(lease)
       }
     })()
     lease.releasePromise = release

--- a/opensquilla-webui/src/modules/conversationSubscriptionLease.test.ts
+++ b/opensquilla-webui/src/modules/conversationSubscriptionLease.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { createConversationSubscriptionLeaseRegistry } from './conversationSubscriptionLease'
+
+describe('conversation subscription lease registry', () => {
+  it('keeps a newer acquire separate until it is active', () => {
+    const registry = createConversationSubscriptionLeaseRegistry()
+    const first = registry.acquire('agent:main:alpha')
+    const second = registry.acquire('agent:main:alpha')
+
+    expect(registry.latestReleasable('agent:main:alpha')).toBe(second)
+    expect(first.state).toBe('acquiring')
+    registry.activate(second)
+    expect(first.state).toBe('retired')
+    expect(second.state).toBe('active')
+    expect(registry.active).toBe(second)
+  })
+
+  it('does not retire a releasing predecessor when a replacement activates', () => {
+    const registry = createConversationSubscriptionLeaseRegistry()
+    const predecessor = registry.acquire('agent:main:alpha')
+    registry.activate(predecessor)
+    predecessor.state = 'releasing'
+    const replacement = registry.acquire('agent:main:alpha')
+
+    registry.activate(replacement)
+
+    expect(predecessor.state).toBe('releasing')
+    expect(replacement.state).toBe('active')
+    expect(registry.size).toBe(2)
+  })
+
+  it('retires leases owned by an obsolete socket generation', () => {
+    const registry = createConversationSubscriptionLeaseRegistry()
+    const oldLease = registry.acquire('agent:main:old')
+    oldLease.socketGeneration = 2
+    const currentLease = registry.acquire('agent:main:new')
+    currentLease.socketGeneration = 3
+
+    registry.retirePriorGenerations(3)
+
+    expect(oldLease.state).toBe('retired')
+    expect(currentLease.state).toBe('acquiring')
+    expect(registry.size).toBe(1)
+  })
+
+  it('only returns live leases and clears active ownership explicitly', () => {
+    const registry = createConversationSubscriptionLeaseRegistry()
+    const lease = registry.acquire('agent:main:alpha')
+    registry.clearActive(lease)
+    lease.state = 'releasing'
+
+    expect(registry.active).toBeNull()
+    expect(registry.latestReleasable('agent:main:alpha')).toBeNull()
+    registry.retire(lease)
+    expect(registry.size).toBe(0)
+  })
+})
+

--- a/opensquilla-webui/src/modules/conversationSubscriptionLease.ts
+++ b/opensquilla-webui/src/modules/conversationSubscriptionLease.ts
@@ -1,0 +1,110 @@
+/**
+ * Logical subscription ownership for one Conversation stream.
+ *
+ * A lease is deliberately independent from the physical WebSocket.  Route
+ * changes may retire an old lease while a replacement lease is acquiring on
+ * the same connection; only the generation that actually sent the subscribe
+ * frame may release it.  Keeping these invariants in a small module makes the
+ * lifecycle testable without Vue, RpcClient, or Gateway implementation code.
+ */
+export type ConversationSubscriptionLeaseState =
+  | 'acquiring'
+  | 'active'
+  | 'releasing'
+  | 'retired'
+
+export interface ConversationSubscriptionLease {
+  readonly token: symbol
+  readonly key: string
+  state: ConversationSubscriptionLeaseState
+  socketGeneration: number | null
+  releasePromise: Promise<void> | null
+}
+
+export interface ConversationSubscriptionLeaseRegistry {
+  acquire(key: string): ConversationSubscriptionLease
+  activate(lease: ConversationSubscriptionLease): void
+  retire(lease: ConversationSubscriptionLease): void
+  retirePriorGenerations(currentGeneration?: number): void
+  latestReleasable(key: string): ConversationSubscriptionLease | null
+  clearActive(lease: ConversationSubscriptionLease): void
+  readonly active: ConversationSubscriptionLease | null
+  readonly size: number
+}
+
+export function createConversationSubscriptionLeaseRegistry(): ConversationSubscriptionLeaseRegistry {
+  const leases = new Set<ConversationSubscriptionLease>()
+  let activeLease: ConversationSubscriptionLease | null = null
+
+  function retire(lease: ConversationSubscriptionLease) {
+    if (lease.state === 'retired') return
+    lease.state = 'retired'
+    leases.delete(lease)
+    if (activeLease === lease) activeLease = null
+  }
+
+  function activate(lease: ConversationSubscriptionLease) {
+    if (lease.state !== 'acquiring') return
+    // Gateway registration is a set keyed by (connection, session). A newer
+    // successful acquire for the same key subsumes earlier non-releasing
+    // leases, while a closing A1 remains distinct from a later A2 acquire.
+    for (const candidate of leases) {
+      if (
+        candidate !== lease
+        && candidate.key === lease.key
+        && (candidate.state === 'acquiring' || candidate.state === 'active')
+      ) {
+        retire(candidate)
+      }
+    }
+    lease.state = 'active'
+    activeLease = lease
+  }
+
+  function retirePriorGenerations(currentGeneration?: number) {
+    if (typeof currentGeneration !== 'number') return
+    for (const lease of leases) {
+      if (
+        lease.socketGeneration !== null
+        && lease.socketGeneration !== currentGeneration
+      ) {
+        retire(lease)
+      }
+    }
+  }
+
+  return {
+    acquire(key: string) {
+      const lease: ConversationSubscriptionLease = {
+        token: Symbol('conversation-subscription'),
+        key,
+        state: 'acquiring',
+        socketGeneration: null,
+        releasePromise: null,
+      }
+      leases.add(lease)
+      activeLease = lease
+      return lease
+    },
+    activate,
+    retire,
+    retirePriorGenerations,
+    latestReleasable(key: string) {
+      const matches = [...leases].filter(lease => (
+        lease.key === key
+        && (lease.state === 'acquiring' || lease.state === 'active')
+      ))
+      return matches.length > 0 ? matches[matches.length - 1]! : null
+    },
+    clearActive(lease: ConversationSubscriptionLease) {
+      if (activeLease === lease) activeLease = null
+    },
+    get active() {
+      return activeLease
+    },
+    get size() {
+      return leases.size
+    },
+  }
+}
+


### PR DESCRIPTION
## Summary

- centralize WebUI conversation event delivery behind one private v4 Gateway Adapter
- move logical subscription lease ownership and socket-generation fencing into a pure module
- keep existing event payload callbacks, v4 WebSocket frames, and subscription behavior unchanged

## Why

The chat composable previously registered 28 wire events directly and mixed lease state transitions with bootstrap/hydration work. This slice creates two deeper seams:

1. `conversationEventTransport` is the only raw wildcard listener. It validates and canonicalizes legacy event aliases through the S9 Contract decoder, dispatches named callbacks, and retains the old wildcard diagnostics path.
2. `conversationSubscriptionLease` owns acquiring/active/releasing/retired transitions, same-key replacement rules, and generation fencing without importing Vue, RpcClient, or Gateway implementation details.

The existing application handlers and v4 payloads remain the compatibility projection. Consumer migration and event-union typing are intentionally separate follow-up work.

## Compatibility and scope

- no WebSocket protocol or connection-lifecycle change
- no change to event producers, TurnRunner, TaskRuntime, send/cancel/steer, storage schema, or Gateway handlers
- legacy event names, snake/camel payload aliases, `sessions.changed`, and wildcard diagnostics remain supported
- only the private Gateway Adapter imports the generated conversation-event Contract
- no shadow handler, duplicate business implementation, or second transport
- the branch is based on S10's merged `main` commit; S10 is not duplicated in this diff

## Verification

- WebUI unit: 395 files, 5,047 tests passed
- focused event transport, lease, subscription, and decoder tests: 42 passed
- WebUI typecheck: passed
- RPC architecture gate: passed; debt reduced from 446 to 418 exact operations (`on` registrations in the chat subscription composable: 28 → 0)
- S10 baseline and backend suites remain unchanged and green

## Follow-up

The next Conversation slice will consume the decoded event union at the adapter boundary, migrate handlers away from raw event names/DTOs, and delete the compatibility dispatch glue after real-WebSocket E2E coverage is green.

