### PR TITLE
refactor(webui): expose typed conversation event ingress

### DIFF
--- a/opensquilla-webui/src/adapters/gateway/conversationEventTransport.test.ts
+++ b/opensquilla-webui/src/adapters/gateway/conversationEventTransport.test.ts
@@ -37,38 +37,57 @@ describe('conversation event transport adapter', () => {
 
   it('decodes aliases before dispatch while preserving raw wildcard observation', () => {
     const { rpc, transport } = harness()
-    const text = vi.fn()
+    const event = vi.fn()
     const any = vi.fn()
-    transport.subscribe({ onTextDelta: text, onAny: any })
+    transport.subscribe({ onEvent: event, onAny: any })
 
     const payload = { sessionKey: 'agent:main:alpha', streamSeq: 3, text: 'hi' }
     rpc.emit('*', 'text_delta', payload, { replayed: false })
 
-    expect(text).toHaveBeenCalledWith(payload, { replayed: false })
+    expect(event).toHaveBeenCalledTimes(1)
+    expect(event.mock.calls[0]?.[0]).toMatchObject({
+      kind: 'conversation',
+      wireName: 'text_delta',
+      payload,
+      meta: { replayed: false },
+      decoded: { kind: 'known', name: 'session.event.text_delta', legacy: true },
+    })
     expect(any).toHaveBeenCalledWith('text_delta', payload)
   })
 
   it('keeps directory changes in the same listener without treating them as conversation frames', () => {
     const { rpc, transport } = harness()
-    const changed = vi.fn()
+    const event = vi.fn()
     const any = vi.fn()
-    transport.subscribe({ onSessionsChanged: changed, onAny: any })
+    transport.subscribe({ onEvent: event, onAny: any })
     const payload = { key: 'agent:main:alpha', reason: 'renamed' }
 
     rpc.emit('*', 'sessions.changed', payload, {})
 
-    expect(changed).toHaveBeenCalledWith(payload, {})
+    expect(event).toHaveBeenCalledWith({
+      kind: 'sessions-changed',
+      wireName: 'sessions.changed',
+      decoded: null,
+      payload,
+      meta: {},
+    })
     expect(any).toHaveBeenCalledWith('sessions.changed', payload)
   })
 
   it('quarantines malformed frames but does not break the wildcard stream', () => {
     const { rpc, transport } = harness()
+    const event = vi.fn()
     const error = vi.fn()
     const any = vi.fn()
-    transport.subscribe({ onDecodeError: error, onAny: any })
+    transport.subscribe({ onEvent: event, onDecodeError: error, onAny: any })
 
     rpc.emit('*', 'presence', { value: true }, {})
 
+    expect(event).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'invalid',
+      wireName: 'presence',
+      payload: { value: true },
+    }))
     expect(error).toHaveBeenCalledTimes(1)
     expect(any).toHaveBeenCalledWith('presence', { value: true })
   })
@@ -83,4 +102,3 @@ describe('conversation event transport adapter', () => {
     expect(state).toHaveBeenCalledWith('connected')
   })
 })
-

--- a/opensquilla-webui/src/adapters/gateway/conversationEventTransport.ts
+++ b/opensquilla-webui/src/adapters/gateway/conversationEventTransport.ts
@@ -5,43 +5,42 @@ import {
 } from './conversationEventsV4'
 
 /**
- * The WebSocket client exposes one untyped wildcard event stream.  Keep that
- * transport detail in this adapter: composables receive named callbacks and
- * never register wire event strings themselves.
- *
- * The callback payload deliberately remains `unknown` here.  The adapter is
- * responsible for framing, aliases, and validation; the domain consumer owns
- * the payload projection and can preserve the existing v4 shapes during the
- * migration.
+ * A decoded event message is the only event shape that leaves the v4 adapter.
+ * `wireName` and `payload` are retained for compatibility with the existing
+ * reducer (which still understands a few legacy spellings), while `decoded`
+ * carries the validated/canonical projection for new consumers.  Keeping the
+ * raw values here avoids forcing a behavior change while the reducer is moved
+ * behind the ConversationRuntime seam in the next slice.
  */
+export type ConversationEventTransportMessage =
+  | {
+      kind: 'conversation'
+      wireName: string
+      decoded: DecodedConversationEvent
+      payload: unknown
+      meta: unknown
+    }
+  | {
+      kind: 'sessions-changed'
+      wireName: 'sessions.changed'
+      decoded: null
+      payload: unknown
+      meta: unknown
+    }
+  | {
+      /** A malformed/unrelated frame kept for the legacy wildcard reducer. */
+      kind: 'invalid'
+      wireName: string
+      decoded: null
+      payload: unknown
+      meta: unknown
+      error: unknown
+    }
+
 export interface ConversationEventTransportHandlers {
-  onAnswerGenerationReset?: (payload: unknown, meta?: unknown) => void
-  onTextDelta?: (payload: unknown, meta?: unknown) => void
-  onToolUseStart?: (payload: unknown, meta?: unknown) => void
-  onToolUseDelta?: (payload: unknown, meta?: unknown) => void
-  onToolUseEnd?: (payload: unknown, meta?: unknown) => void
-  onToolResult?: (payload: unknown, meta?: unknown) => void
-  onArtifact?: (payload: unknown, meta?: unknown) => void
-  onStateChange?: (payload: unknown, meta?: unknown) => void
-  onRunHeartbeat?: (payload: unknown, meta?: unknown) => void
-  onProviderActivity?: (payload: unknown, meta?: unknown) => void
-  onCompaction?: (payload: unknown, meta?: unknown) => void
-  onWarning?: (payload: unknown, meta?: unknown) => void
-  onInputDisposition?: (payload: unknown, meta?: unknown) => void
-  onCronResult?: (payload: unknown, meta?: unknown) => void
-  onSubagentCompletion?: (payload: unknown, meta?: unknown) => void
-  onEpochChanged?: (payload: unknown, meta?: unknown) => void
-  onSessionsChanged?: (payload: unknown, meta?: unknown) => void
-  onTaskQueued?: (payload: unknown, meta?: unknown) => void
-  onTaskRunning?: (payload: unknown, meta?: unknown) => void
-  onTaskGroupWaiting?: (payload: unknown, meta?: unknown) => void
-  onTaskGroupSynthesizing?: (payload: unknown, meta?: unknown) => void
-  onTaskGroupDone?: (payload: unknown, meta?: unknown) => void
-  onTaskGroupFailed?: (payload: unknown, meta?: unknown) => void
-  onRouterDecision?: (payload: unknown, meta?: unknown) => void
-  onEnsembleProgress?: (payload: unknown, meta?: unknown) => void
-  onRouterControlReplay?: (payload: unknown, meta?: unknown) => void
-  /** Preserve the legacy observation path for terminal/thinking/future events. */
+  /** One typed ingress for the Conversation reducer/application seam. */
+  onEvent?: (message: ConversationEventTransportMessage) => void
+  /** Preserve raw observation for diagnostics and watchdogs only. */
   onAny?: (rawEvent: string, rawPayload: unknown) => void
   onConnectionState?: (state: string) => void
   onDecodeError?: (error: unknown, rawEvent: string, rawPayload: unknown) => void
@@ -49,52 +48,6 @@ export interface ConversationEventTransportHandlers {
 
 type RpcSubscriptionClient = {
   on(event: string, handler: RpcEventHandler): () => void
-}
-
-type NamedHandler = keyof Omit<
-  ConversationEventTransportHandlers,
-  'onAny' | 'onConnectionState' | 'onDecodeError'
->
-
-/** Wire names stay in one place, next to the decoder that owns them. */
-const NAMED_HANDLERS: Readonly<Record<string, NamedHandler>> = Object.freeze({
-  'session.event.answer_generation_reset': 'onAnswerGenerationReset',
-  'session.event.text_delta': 'onTextDelta',
-  'session.event.tool_use_start': 'onToolUseStart',
-  'session.event.tool_use_delta': 'onToolUseDelta',
-  'session.event.tool_use_end': 'onToolUseEnd',
-  'session.event.tool_result': 'onToolResult',
-  'session.event.artifact': 'onArtifact',
-  'session.event.state_change': 'onStateChange',
-  'session.event.run_heartbeat': 'onRunHeartbeat',
-  'session.event.provider_activity': 'onProviderActivity',
-  'session.event.compaction': 'onCompaction',
-  'session.event.warning': 'onWarning',
-  'session.event.input_disposition': 'onInputDisposition',
-  'session.event.cron_result': 'onCronResult',
-  'session.event.subagent_completion': 'onSubagentCompletion',
-  'session.epoch_changed': 'onEpochChanged',
-  'task.queued': 'onTaskQueued',
-  'task.running': 'onTaskRunning',
-  'session.event.task_group.waiting': 'onTaskGroupWaiting',
-  'session.event.task_group.synthesizing': 'onTaskGroupSynthesizing',
-  'session.event.task_group.done': 'onTaskGroupDone',
-  'session.event.task_group.failed': 'onTaskGroupFailed',
-  'session.event.router_decision': 'onRouterDecision',
-  'session.event.ensemble_progress': 'onEnsembleProgress',
-  'session.event.router_control_replay': 'onRouterControlReplay',
-})
-
-function dispatchNamed(
-  handlers: ConversationEventTransportHandlers,
-  decoded: DecodedConversationEvent,
-  payload: unknown,
-  meta: unknown,
-) {
-  if (decoded.kind !== 'known') return
-  const handlerName = NAMED_HANDLERS[decoded.name]
-  if (!handlerName) return
-  handlers[handlerName]?.(payload, meta)
 }
 
 /** Create the one WebSocket event listener used by the Conversation lane. */
@@ -114,18 +67,38 @@ export function createConversationEventTransport(rpc: RpcSubscriptionClient) {
       // handled here as a directory event until the Session Event lane merges
       // both manifests; it must still pass through the same single listener.
       if (eventName === 'sessions.changed') {
-        handlers.onSessionsChanged?.(rawPayload, rawMeta)
+        handlers.onEvent?.({
+          kind: 'sessions-changed',
+          wireName: 'sessions.changed',
+          decoded: null,
+          payload: rawPayload,
+          meta: rawMeta,
+        })
         handlers.onAny?.(eventName, rawPayload)
         return
       }
 
       try {
         const decoded = decodeConversationEvent(eventName, rawPayload, rawMeta)
-        dispatchNamed(handlers, decoded, rawPayload, rawMeta)
+        handlers.onEvent?.({
+          kind: 'conversation',
+          wireName: eventName,
+          decoded,
+          payload: rawPayload,
+          meta: rawMeta,
+        })
       } catch (error) {
         // A malformed or unrelated frame must not take down the shared event
-        // stream. Preserve the old wildcard observation path and report the
-        // contract violation for diagnostics.
+        // stream. Preserve the old wildcard observation path through the
+        // `invalid` message and report the contract violation for diagnostics.
+        handlers.onEvent?.({
+          kind: 'invalid',
+          wireName: eventName,
+          decoded: null,
+          payload: rawPayload,
+          meta: rawMeta,
+          error,
+        })
         handlers.onDecodeError?.(error, eventName, rawPayload)
       }
       handlers.onAny?.(eventName, rawPayload)
@@ -149,4 +122,3 @@ export function createConversationEventTransport(rpc: RpcSubscriptionClient) {
 
   return { subscribe, unsubscribe }
 }
-

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
@@ -12,6 +12,7 @@ import {
   FINISHED_STREAM_TASK_ID,
   PENDING_STREAM_TASK_ID,
 } from '@/utils/chat/streamEvents'
+import { decodeConversationEvent } from '@/adapters/gateway/conversationEventsV4'
 
 function createHarness(options: {
   messages?: ChatMessage[]
@@ -209,6 +210,39 @@ describe('useChatRpcEventHandlers route-card ownership', () => {
       })
     } finally {
       stop()
+    }
+  })
+})
+
+describe('useChatRpcEventHandlers decoded conversation ingress', () => {
+  it('routes a validated event through the named projection and wildcard reducer once', () => {
+    const harness = createHarness()
+    const payload = {
+      session_key: 'agent:main:test',
+      turn_id: 'turn-decoded',
+      stream_seq: 1,
+      text: 'decoded answer',
+      model_call_id: 'call-1',
+      iteration: 1,
+    }
+    try {
+      harness.api.onConversationEvent({
+        kind: 'conversation',
+        wireName: 'session.event.text_delta',
+        decoded: decodeConversationEvent('session.event.text_delta', payload, {}),
+        payload,
+        meta: {},
+      })
+
+      expect(harness.stream.appendDelta).toHaveBeenCalledTimes(1)
+      expect(harness.stream.appendDelta).toHaveBeenCalledWith(
+        'decoded answer',
+        undefined,
+        { modelCallId: 'call-1', iteration: 1 },
+      )
+      expect(harness.lastStreamSeq.value).toBe(1)
+    } finally {
+      harness.stop()
     }
   })
 })

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
@@ -29,7 +29,7 @@ import type {
   TurnCommittedPayload,
   WarningPayload,
 } from '@/types/rpc'
-import type { ChatRpcSubscriptionHandlers } from '@/composables/chat/useChatRpcSubscriptions'
+import type { ConversationEventTransportMessage } from '@/adapters/gateway/conversationEventTransport'
 import {
   isAuthoritativeSessionSubscription,
   type SessionSubscriptionOutcome,
@@ -2578,6 +2578,124 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
     }
   }
 
+  /**
+   * Consume the single decoded ingress emitted by the private v4 adapter.
+   *
+   * The reducer deliberately remains unchanged in this slice: named handlers
+   * run first, followed by the legacy wildcard path, matching the listener
+   * order that existed before the transport seam. `wireName` is retained only
+   * for that compatibility path; new consumers can rely on `decoded.name` and
+   * its validated metadata without knowing how the frame was transported.
+   */
+  function handleConversationEvent(message: ConversationEventTransportMessage) {
+    if (message.kind === 'sessions-changed') {
+      handleRpcSessionsChanged(message.payload as SessionEventPayload)
+      handleRpcAny(message.wireName, message.payload)
+      return
+    }
+
+    if (message.kind === 'invalid') {
+      // Keep the pre-contract wildcard behavior for malformed or unrelated
+      // frames. The adapter has already quarantined the decode error, but an
+      // older event that the reducer knows how to handle must not disappear
+      // during the migration.
+      handleRpcAny(message.wireName, message.payload)
+      return
+    }
+
+    const event = message.decoded
+    if (event.kind === 'known') {
+      switch (event.name) {
+        case 'session.event.answer_generation_reset':
+          handleRpcAnswerGenerationReset(message.payload as AnswerGenerationResetPayload)
+          break
+        case 'session.event.text_delta':
+          handleRpcTextDelta(message.payload as TextDeltaPayload)
+          break
+        case 'session.event.tool_use_start':
+          handleRpcToolUseStart(message.payload as ToolUsePayload)
+          break
+        case 'session.event.tool_use_delta':
+          handleRpcToolUseDelta(message.payload as ToolDeltaPayload)
+          break
+        case 'session.event.tool_use_end':
+          handleRpcToolUseEnd(message.payload as ToolEndPayload)
+          break
+        case 'session.event.tool_result':
+          handleRpcToolResult(message.payload as ToolResultPayload)
+          break
+        case 'session.event.artifact':
+          handleRpcArtifact(message.payload as ArtifactPayload)
+          break
+        case 'session.event.state_change':
+          handleRpcStateChange(message.payload as SessionEventPayload)
+          break
+        case 'session.event.run_heartbeat':
+          handleRpcRunHeartbeat(message.payload as SessionEventPayload)
+          break
+        case 'session.event.provider_activity':
+          handleRpcProviderActivity(message.payload as ProviderActivityPayload)
+          break
+        case 'session.event.compaction':
+          handleRpcCompaction(message.payload as CompactionPayload, message.meta)
+          break
+        case 'session.event.warning':
+          handleRpcWarning(message.payload as WarningPayload)
+          break
+        case 'session.event.input_disposition':
+          handleRpcInputDisposition(message.payload as InputDispositionPayload)
+          break
+        case 'session.event.cron_result':
+          handleRpcCronResult(message.payload as CronResultPayload)
+          break
+        case 'session.event.subagent_completion':
+          handleRpcSubagentCompletion(message.payload as SubagentCompletionPayload)
+          break
+        case 'session.epoch_changed':
+          handleRpcEpochChanged(message.payload as SessionEventPayload)
+          break
+        case 'task.queued':
+          handleRpcTaskQueued(message.payload as SessionEventPayload)
+          break
+        case 'task.running':
+          handleRpcTaskRunning(message.payload as SessionEventPayload)
+          break
+        case 'session.event.task_group.waiting':
+          handleRpcTaskGroupWaiting(message.payload as SessionEventPayload)
+          break
+        case 'session.event.task_group.synthesizing':
+          handleRpcTaskGroupSynthesizing(message.payload as SessionEventPayload)
+          break
+        case 'session.event.task_group.done':
+          handleRpcTaskGroupDone(message.payload as SessionEventPayload)
+          break
+        case 'session.event.task_group.failed':
+          handleRpcTaskGroupFailed(message.payload as SessionEventPayload)
+          break
+        case 'session.event.router_decision':
+          handleRpcRouterDecision(message.payload as RouterDecisionPayload)
+          break
+        case 'session.event.ensemble_progress':
+          handleRpcEnsembleProgress(message.payload as EnsembleProgressPayload)
+          break
+        case 'session.event.router_control_replay':
+          handleRpcRouterControlReplay(message.payload as SessionEventPayload)
+          break
+        default:
+          // Thinking, terminal, approval and future additive events are owned
+          // by the wildcard reducer below until their domain projections are
+          // split into dedicated modules.
+          break
+      }
+    }
+
+    // Preserve the old wildcard path for terminal/task lifecycle events and
+    // for the reducer's cross-cutting sequence/ownership checks. This call is
+    // intentionally after the named projection, matching RpcClient listener
+    // registration order before S12.
+    handleRpcAny(message.wireName, message.payload)
+  }
+
   let connectionLostNoted = false
   let connectionLostNotice: ChatMessage | null = null
   let connectionStateGeneration = 0
@@ -2656,7 +2774,10 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
     }
   }
 
-  const handlers: ChatRpcSubscriptionHandlers = {
+  // Keep this object as a test-friendly compatibility surface for the reducer
+  // unit tests. Production ingress uses `onConversationEvent` below, so this
+  // object no longer defines the transport contract.
+  const handlers = {
     onAnswerGenerationReset: handleRpcAnswerGenerationReset,
     onTextDelta: handleRpcTextDelta,
     onToolUseStart: handleRpcToolUseStart,
@@ -2689,6 +2810,7 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
 
   return {
     handlers,
+    onConversationEvent: handleConversationEvent,
     bindActiveStreamTask,
     restoreLiveTurnSnapshot,
     streamThinkingText,

--- a/opensquilla-webui/src/composables/chat/useChatRpcSubscriptions.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcSubscriptions.ts
@@ -1,59 +1,26 @@
-import type {
-  AnswerGenerationResetPayload,
-  ArtifactPayload,
-  CompactionPayload,
-  CronResultPayload,
-  EnsembleProgressPayload,
-  InputDispositionPayload,
-  ProviderActivityPayload,
-  RouterDecisionPayload,
-  SessionEventPayload,
-  SubagentCompletionPayload,
-  TextDeltaPayload,
-  ToolDeltaPayload,
-  ToolEndPayload,
-  ToolResultPayload,
-  ToolUsePayload,
-  WarningPayload,
-} from '@/types/rpc'
+import type { RpcEventHandler } from '@/lib/rpc'
 import {
   createConversationEventTransport,
   type ConversationEventTransportHandlers,
+  type ConversationEventTransportMessage,
 } from '@/adapters/gateway/conversationEventTransport'
 
 type RpcSubscriptionClient = {
-  on(event: string, handler: (...args: unknown[]) => void): () => void
+  on(event: string, handler: RpcEventHandler): () => void
 }
 
+/**
+ * Composition-root bridge for the Conversation event lane.
+ *
+ * The bridge intentionally has no wire event names or payload DTOs. The v4
+ * adapter owns those details and emits one decoded message; this small bridge
+ * remains until ConversationRuntime.open() owns the subscription lifecycle.
+ */
 export type ChatRpcSubscriptionHandlers = {
-  onAnswerGenerationReset: (payload: AnswerGenerationResetPayload) => void
-  onTextDelta: (payload: TextDeltaPayload) => void
-  onToolUseStart: (payload: ToolUsePayload) => void
-  onToolUseDelta: (payload: ToolDeltaPayload) => void
-  onToolUseEnd: (payload: ToolEndPayload) => void
-  onToolResult: (payload: ToolResultPayload) => void
-  onArtifact: (payload: ArtifactPayload) => void
-  onStateChange: (payload: SessionEventPayload) => void
-  onRunHeartbeat: (payload: SessionEventPayload) => void
-  onProviderActivity: (payload: ProviderActivityPayload) => void
-  onCompaction: (payload: CompactionPayload, meta: unknown) => void
-  onWarning: (payload: WarningPayload) => void
-  onInputDisposition: (payload: InputDispositionPayload) => void
-  onCronResult: (payload: CronResultPayload) => void
-  onSubagentCompletion: (payload: SubagentCompletionPayload) => void
-  onEpochChanged: (payload: SessionEventPayload) => void
-  onSessionsChanged: (payload: SessionEventPayload) => void
-  onTaskQueued: (payload: SessionEventPayload) => void
-  onTaskRunning: (payload: SessionEventPayload) => void
-  onTaskGroupWaiting: (payload: SessionEventPayload) => void
-  onTaskGroupSynthesizing: (payload: SessionEventPayload) => void
-  onTaskGroupDone: (payload: SessionEventPayload) => void
-  onTaskGroupFailed: (payload: SessionEventPayload) => void
-  onRouterDecision: (payload: RouterDecisionPayload) => void
-  onEnsembleProgress: (payload: EnsembleProgressPayload) => void
-  onRouterControlReplay: (payload: SessionEventPayload) => void
-  onAny: (rawEvent: string, rawPayload: unknown) => void
-  onConnectionState: (state: string) => void
+  onEvent: (message: ConversationEventTransportMessage) => void
+  onAny?: ConversationEventTransportHandlers['onAny']
+  onConnectionState?: ConversationEventTransportHandlers['onConnectionState']
+  onDecodeError?: ConversationEventTransportHandlers['onDecodeError']
 }
 
 export function useChatRpcSubscriptions(
@@ -63,48 +30,9 @@ export function useChatRpcSubscriptions(
   const transport = createConversationEventTransport(rpc)
   let unsubscribeTransport: (() => void) | null = null
 
-  function payloadHandler<T>(
-    handler: (payload: T, meta?: unknown) => void,
-  ) {
-    return (payload: unknown, meta?: unknown) => handler(payload as T, meta)
-  }
-
-  function transportHandlers(): ConversationEventTransportHandlers {
-    return {
-      onAnswerGenerationReset: payloadHandler(handlers.onAnswerGenerationReset),
-      onTextDelta: payloadHandler(handlers.onTextDelta),
-      onToolUseStart: payloadHandler(handlers.onToolUseStart),
-      onToolUseDelta: payloadHandler(handlers.onToolUseDelta),
-      onToolUseEnd: payloadHandler(handlers.onToolUseEnd),
-      onToolResult: payloadHandler(handlers.onToolResult),
-      onArtifact: payloadHandler(handlers.onArtifact),
-      onStateChange: payloadHandler(handlers.onStateChange),
-      onRunHeartbeat: payloadHandler(handlers.onRunHeartbeat),
-      onProviderActivity: payloadHandler(handlers.onProviderActivity),
-      onCompaction: payloadHandler(handlers.onCompaction),
-      onWarning: payloadHandler(handlers.onWarning),
-      onInputDisposition: payloadHandler(handlers.onInputDisposition),
-      onCronResult: payloadHandler(handlers.onCronResult),
-      onSubagentCompletion: payloadHandler(handlers.onSubagentCompletion),
-      onEpochChanged: payloadHandler(handlers.onEpochChanged),
-      onSessionsChanged: payloadHandler(handlers.onSessionsChanged),
-      onTaskQueued: payloadHandler(handlers.onTaskQueued),
-      onTaskRunning: payloadHandler(handlers.onTaskRunning),
-      onTaskGroupWaiting: payloadHandler(handlers.onTaskGroupWaiting),
-      onTaskGroupSynthesizing: payloadHandler(handlers.onTaskGroupSynthesizing),
-      onTaskGroupDone: payloadHandler(handlers.onTaskGroupDone),
-      onTaskGroupFailed: payloadHandler(handlers.onTaskGroupFailed),
-      onRouterDecision: payloadHandler(handlers.onRouterDecision),
-      onEnsembleProgress: payloadHandler(handlers.onEnsembleProgress),
-      onRouterControlReplay: payloadHandler(handlers.onRouterControlReplay),
-      onAny: handlers.onAny,
-      onConnectionState: handlers.onConnectionState,
-    }
-  }
-
   function subscribe(): () => void {
     unsubscribe()
-    unsubscribeTransport = transport.subscribe(transportHandlers())
+    unsubscribeTransport = transport.subscribe(handlers)
     return unsubscribe
   }
 

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -4073,16 +4073,19 @@ const stallWatchdog = useChatStallWatchdog({ isStreaming, streamIdleGraceMs: str
 const { stallActive, stallSeconds } = stallWatchdog
 
 const chatRpcSubscriptions = useChatRpcSubscriptions(rpc, {
-  ...rpcEventHandlers.handlers,
+  // The private v4 adapter emits one validated event message. The reducer
+  // owns named projections and the legacy wildcard terminal path behind that
+  // single ingress, so the view no longer wires event names itself.
+  onEvent: rpcEventHandlers.onConversationEvent,
+  onConnectionState: rpcEventHandlers.handlers.onConnectionState,
   // The wildcard handler is the one funnel that sees every gateway event with
   // its name; feed the active session's events to the watchdog before the
-  // regular handler consumes them (same session filter as existing handlers).
+  // regular reducer consumes them (same session filter as existing handlers).
   onAny: (rawEvent, rawPayload) => {
     const payloadObj = (rawPayload && typeof rawPayload === 'object' ? rawPayload : {}) as SessionEventPayload
     if (payloadIsCurrentSession(payloadObj, sessionKey.value)) {
       stallWatchdog.noteEvent(rawEvent, payloadObj)
     }
-    rpcEventHandlers.handlers.onAny(rawEvent, rawPayload)
   },
 })
 


### PR DESCRIPTION
## Summary

- route the Conversation lane through one decoded message from the private v4 adapter
- keep the existing reducer, event ordering, legacy wildcard behavior, connection state, and v4 JSON wire unchanged
- remove the 27-event callback/DTO mapping from the composition bridge; raw event names remain only at the adapter compatibility edge
- preserve malformed/unrelated frames for the legacy wildcard reducer while reporting Contract diagnostics

## Scope

This is S12-A of the ConversationRuntime migration. It establishes the typed ingress seam; it does not yet move subscription ownership or rewrite the reducer. TurnRunner, TaskRuntime, send/cancel/steer, Gateway producers, database schema, and transport lifecycle are untouched.

The message retains `wireName` and the original payload only as a compatibility projection. New consumers can use the validated `decoded` event and metadata. The next S12 slice will move the reducer and subscription lease behind `ConversationRuntime` and remove this composition bridge.

## Compatibility

- v4 WebSocket frames and connection state are unchanged.
- Legacy aliases still reach the same handlers.
- Named handlers run before the wildcard reducer, matching the pre-S12 listener order.
- Invalid/unrelated frames still reach the wildcard path and cannot terminate the shared stream.

## Validation

- WebUI unit: 395 files, 5,048 tests passed locally (including the new decoded-ingress test)
- focused transport/handler tests: 81 passed
- `vue-tsc --noEmit` passed
- `npm run check:rpc-architecture` passed (418 exact debt operations; no new raw registrations)
- `git diff --check` passed

## Review notes

This PR is intentionally a seam, not a claim that the WebUI is fully separated. The remaining raw calls and non-Conversation domains stay on the debt ledger until their own vertical slices migrate.
