### PR TITLE
refactor(webui): own conversation events with logical hub

### DIFF
--- a/opensquilla-webui/src/adapters/gateway/conversationEventTransport.ts
+++ b/opensquilla-webui/src/adapters/gateway/conversationEventTransport.ts
@@ -1,4 +1,5 @@
 import type { RpcEventHandler } from '@/lib/rpc'
+import type { ConversationEventSourceHandlers } from '@/modules/conversationEventHub'
 import {
   decodeConversationEvent,
   type DecodedConversationEvent,
@@ -37,13 +38,32 @@ export type ConversationEventTransportMessage =
       error: unknown
     }
 
-export interface ConversationEventTransportHandlers {
+export interface ConversationEventTransportHandlers
+  extends ConversationEventSourceHandlers<ConversationEventTransportMessage> {
   /** One typed ingress for the Conversation reducer/application seam. */
-  onEvent?: (message: ConversationEventTransportMessage) => void
-  /** Preserve raw observation for diagnostics and watchdogs only. */
-  onAny?: (rawEvent: string, rawPayload: unknown) => void
-  onConnectionState?: (state: string) => void
-  onDecodeError?: (error: unknown, rawEvent: string, rawPayload: unknown) => void
+}
+
+/**
+ * Extract the positive session identity at the adapter edge. Aliases stay
+ * here; the hub can then fence a keyed handle without teaching the domain
+ * module about JSON-RPC field spellings. Directory invalidations are global by
+ * design and therefore return null.
+ */
+export function conversationEventSessionKey(
+  message: ConversationEventTransportMessage,
+): string | null {
+  if (message.kind === 'sessions-changed') return null
+  if (message.kind === 'conversation' && message.decoded.sessionKey) {
+    return message.decoded.sessionKey
+  }
+  const payload = message.payload
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null
+  const value = payload as Record<string, unknown>
+  for (const name of ['key', 'session_key', 'sessionKey']) {
+    const candidate = value[name]
+    if (typeof candidate === 'string' && candidate) return candidate
+  }
+  return null
 }
 
 type RpcSubscriptionClient = {

--- a/opensquilla-webui/src/composables/chat/useChatRpcSubscriptions.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcSubscriptions.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest'
+import { useChatRpcSubscriptions } from './useChatRpcSubscriptions'
+import type { RpcEventHandler } from '@/lib/rpc'
+
+function rpcHarness() {
+  const listeners = new Map<string, Set<RpcEventHandler>>()
+  const rpc = {
+    on(event: string, handler: RpcEventHandler) {
+      const bucket = listeners.get(event) ?? new Set<RpcEventHandler>()
+      bucket.add(handler)
+      listeners.set(event, bucket)
+      return () => bucket.delete(handler)
+    },
+    emit(event: string, ...args: unknown[]) {
+      for (const handler of listeners.get(event) ?? []) handler(...args)
+    },
+    count(event: string) {
+      return listeners.get(event)?.size ?? 0
+    },
+  }
+  return rpc
+}
+
+describe('useChatRpcSubscriptions', () => {
+  it('bridges one logical subscription through the event hub and detaches idempotently', () => {
+    const rpc = rpcHarness()
+    const event = vi.fn()
+    const any = vi.fn()
+    const state = vi.fn()
+    const bridge = useChatRpcSubscriptions(rpc, {
+      onEvent: event,
+      onAny: any,
+      onConnectionState: state,
+    })
+
+    const detach = bridge.subscribe()
+    expect(rpc.count('*')).toBe(1)
+    expect(rpc.count('_state')).toBe(1)
+    rpc.emit('*', 'session.event.text_delta', {
+      session_key: 'agent:main:test',
+      stream_seq: 1,
+      text: 'hello',
+    }, {})
+    rpc.emit('_state', 'connected')
+    expect(event).toHaveBeenCalledTimes(1)
+    expect(any).toHaveBeenCalledWith('session.event.text_delta', expect.any(Object))
+    expect(state).toHaveBeenCalledWith('connected')
+
+    detach()
+    detach()
+    expect(rpc.count('*')).toBe(0)
+    expect(rpc.count('_state')).toBe(0)
+  })
+
+  it('allows a second logical handle without a second WebSocket listener', () => {
+    const rpc = rpcHarness()
+    const primary = vi.fn()
+    const secondary = vi.fn()
+    const bridge = useChatRpcSubscriptions(rpc, { onEvent: primary })
+    const primaryDetach = bridge.subscribe()
+    const secondaryStream = bridge.open('agent:main:secondary', secondary)
+
+    expect(rpc.count('*')).toBe(1)
+    rpc.emit('*', 'session.event.text_delta', {
+      session_key: 'agent:main:secondary',
+      stream_seq: 1,
+      text: 'secondary',
+    }, {})
+    expect(primary).toHaveBeenCalledTimes(1)
+    expect(secondary).toHaveBeenCalledTimes(1)
+
+    secondaryStream.unsubscribe()
+    primaryDetach()
+    expect(rpc.count('*')).toBe(0)
+  })
+
+  it('changes only the logical session fence when the visible route changes', () => {
+    const rpc = rpcHarness()
+    const event = vi.fn()
+    let currentKey = 'agent:main:alpha'
+    const bridge = useChatRpcSubscriptions(
+      rpc,
+      { onEvent: event },
+      { getSessionKey: () => currentKey },
+    )
+    bridge.subscribe()
+
+    rpc.emit('*', 'session.event.text_delta', {
+      session_key: 'agent:main:beta', stream_seq: 1, text: 'hidden',
+    }, {})
+    expect(event).not.toHaveBeenCalled()
+
+    currentKey = 'agent:main:beta'
+    bridge.setSessionKey(currentKey)
+    rpc.emit('*', 'session.event.text_delta', {
+      session_key: 'agent:main:beta', stream_seq: 2, text: 'visible',
+    }, {})
+    expect(event).toHaveBeenCalledTimes(1)
+    expect(rpc.count('*')).toBe(1)
+    bridge.unsubscribe()
+  })
+})

--- a/opensquilla-webui/src/composables/chat/useChatRpcSubscriptions.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcSubscriptions.ts
@@ -1,6 +1,11 @@
 import type { RpcEventHandler } from '@/lib/rpc'
 import {
+  createConversationEventHub,
+  type ConversationEventHandle,
+} from '@/modules/conversationEventHub'
+import {
   createConversationEventTransport,
+  conversationEventSessionKey,
   type ConversationEventTransportHandlers,
   type ConversationEventTransportMessage,
 } from '@/adapters/gateway/conversationEventTransport'
@@ -23,26 +28,90 @@ export type ChatRpcSubscriptionHandlers = {
   onDecodeError?: ConversationEventTransportHandlers['onDecodeError']
 }
 
+export interface ChatRpcSubscriptionOptions {
+  /** Return the currently visible session key for logical event fencing. */
+  getSessionKey?: () => string
+}
+
 export function useChatRpcSubscriptions(
   rpc: RpcSubscriptionClient,
   handlers: ChatRpcSubscriptionHandlers,
+  options: ChatRpcSubscriptionOptions = {},
 ) {
   const transport = createConversationEventTransport(rpc)
-  let unsubscribeTransport: (() => void) | null = null
+  const hub = createConversationEventHub(transport, {
+    sessionKey: conversationEventSessionKey,
+  })
+  let activeHandle: ConversationEventHandle<ConversationEventTransportMessage> | null = null
+  let activeKey = ''
+  let detachEvent: (() => void) | null = null
+  let detachAny: (() => void) | null = null
+  let detachState: (() => void) | null = null
+  let detachDecodeError: (() => void) | null = null
 
   function subscribe(): () => void {
     unsubscribe()
-    unsubscribeTransport = transport.subscribe(handlers)
+    // The empty-key handle preserves the existing Conversation-wide reducer
+    // view when no key provider is supplied. ChatView supplies its current
+    // session key, so positively tagged events from another session are fenced
+    // before they reach the reducer.
+    activeKey = String(options.getSessionKey?.() || '')
+    activeHandle = hub.open(activeKey)
+    detachEvent = activeHandle.observe(handlers.onEvent)
+    if (handlers.onAny) detachAny = hub.observeAny(handlers.onAny)
+    if (handlers.onConnectionState) {
+      detachState = hub.observeConnectionState(handlers.onConnectionState)
+    }
+    if (handlers.onDecodeError) {
+      detachDecodeError = hub.observeDecodeError(handlers.onDecodeError)
+    }
     return unsubscribe
   }
 
   function unsubscribe() {
-    unsubscribeTransport?.()
-    unsubscribeTransport = null
+    detachEvent?.()
+    detachEvent = null
+    detachAny?.()
+    detachAny = null
+    detachState?.()
+    detachState = null
+    detachDecodeError?.()
+    detachDecodeError = null
+    activeHandle?.close()
+    activeHandle = null
+  }
+
+  /** Switch the logical owner without touching the physical source. */
+  function setSessionKey(key: string) {
+    activeKey = String(key || '')
+    if (!activeHandle) return
+    detachEvent?.()
+    detachEvent = null
+    activeHandle.close()
+    activeHandle = hub.open(activeKey)
+    detachEvent = activeHandle.observe(handlers.onEvent)
+  }
+
+  /** Open an additional logical stream without acquiring another WebSocket. */
+  function open(
+    key: string,
+    listener: (message: ConversationEventTransportMessage) => void = handlers.onEvent,
+  ) {
+    const handle = hub.open(key)
+    const detach = handle.observe(listener)
+    return {
+      handle,
+      unsubscribe: () => {
+        detach()
+        handle.close()
+      },
+    }
   }
 
   return {
     subscribe,
     unsubscribe,
+    open,
+    setSessionKey,
   }
 }

--- a/opensquilla-webui/src/composables/chat/useChatSessionSubscription.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionSubscription.ts
@@ -13,7 +13,10 @@ import {
   createConversationRuntime,
   type ConversationRuntime,
 } from '@/modules/conversationRuntime'
-import { createConversationSubscriptionLeaseRegistry } from '@/modules/conversationSubscriptionLease'
+import {
+  createConversationSubscriptionLifecycle,
+  type ConversationSubscriptionAttempt,
+} from '@/modules/conversationSubscriptionLifecycle'
 import { conversationCursorSignal } from '@/utils/chat/streamEvents'
 import type { RpcCallOptions, RpcConnectionWaitOptions } from '@/lib/rpc'
 import type { ChatTaskOwnershipApi } from '@/composables/chat/useChatTaskOwnership'
@@ -127,19 +130,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
   const isHydrating = ref(false)
   const streamGeneration = ref<string | null>(null)
   const conversationRuntime = options.conversationRuntime ?? createConversationRuntime()
-  const subscriptionLeases = createConversationSubscriptionLeaseRegistry()
-  let subscriptionAttempt = 0
-  let activeSubscription: {
-    key: string
-    sinceStreamGeneration: string | null
-    sinceStreamSeq: number
-    bootstrapGeneration: number
-    bootstrapAttempt: number
-    token: symbol
-    lease: ReturnType<typeof subscriptionLeases.acquire>
-    outcome: Promise<SessionSubscriptionOutcome>
-  } | null = null
-  let activeController: AbortController | null = null
+  const subscriptionLifecycle = createConversationSubscriptionLifecycle<SessionSubscriptionOutcome>()
   let activeMetadataController: AbortController | null = null
   let metadataHydrationSequence = 0
 
@@ -169,7 +160,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
   }
 
   function retireLeasesFromPriorGenerations() {
-    subscriptionLeases.retirePriorGenerations(options.rpc.connectionGeneration)
+    subscriptionLifecycle.retirePriorGenerations(options.rpc.connectionGeneration)
   }
 
   function subscribeSession(
@@ -183,49 +174,23 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
     const key = options.sessionKey.value
     const sinceStreamGeneration = streamGeneration.value
     const sinceStreamSeq = options.lastStreamSeq.value
-    const bootstrapGeneration = bootstrap?.generation ?? -1
-    const bootstrapAttempt = bootstrap?.attempt ?? -1
-    if (
-      activeSubscription?.key === key
-      && activeSubscription.sinceStreamGeneration === sinceStreamGeneration
-      && activeSubscription.sinceStreamSeq === sinceStreamSeq
-      && activeSubscription.bootstrapGeneration === bootstrapGeneration
-      && activeSubscription.bootstrapAttempt === bootstrapAttempt
-    ) {
-      return activeSubscription.outcome
-    }
-    activeController?.abort()
-    const controller = new AbortController()
-    activeController = controller
-    const relayAbort = () => controller.abort()
-    if (bootstrap?.signal.aborted) controller.abort()
-    else bootstrap?.signal.addEventListener('abort', relayAbort, { once: true })
-    const attemptContext = bootstrap
-      ? { ...bootstrap, signal: controller.signal }
-      : undefined
-    const lease = subscriptionLeases.acquire(key)
-    const outcome = runSubscription(
+    const identity = {
       key,
       sinceStreamGeneration,
       sinceStreamSeq,
-      lease.token,
-      lease,
-      controller,
-      attemptContext,
-    ).finally(() => {
-      bootstrap?.signal.removeEventListener('abort', relayAbort)
-    })
-    activeSubscription = {
-      key,
-      sinceStreamGeneration,
-      sinceStreamSeq,
-      bootstrapGeneration,
-      bootstrapAttempt,
-      token: lease.token,
-      lease,
-      outcome,
+      bootstrapGeneration: bootstrap?.generation ?? -1,
+      bootstrapAttempt: bootstrap?.attempt ?? -1,
     }
-    return outcome
+    return subscriptionLifecycle.start(
+      identity,
+      bootstrap?.signal,
+      attempt => runSubscription(
+        attempt,
+        bootstrap
+          ? { ...bootstrap, signal: attempt.controller.signal }
+          : undefined,
+      ),
+    )
   }
 
   function generationFrom(source: unknown): string | null {
@@ -390,7 +355,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
 
   function scheduleDeferredHydration(
     key: string,
-    attempt: number,
+    attemptContext: ConversationSubscriptionAttempt,
     metadataHydration: number,
     metadataGeneration: number | undefined,
     bootstrap: SessionBootstrapPhaseContext,
@@ -399,7 +364,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
       try {
         await bootstrap.waitForCriticalRequestsQueued?.()
         if (
-          attempt !== subscriptionAttempt
+          !subscriptionLifecycle.isCurrent(attemptContext, key)
           || metadataHydration !== metadataHydrationSequence
           || key !== options.sessionKey.value
           || bootstrap.signal.aborted
@@ -420,7 +385,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
           hydrationCallOptions(hydrationContext),
         )
         if (
-          attempt !== subscriptionAttempt
+          !subscriptionLifecycle.isCurrent(attemptContext, key)
           || metadataHydration !== metadataHydrationSequence
           || key !== options.sessionKey.value
           || bootstrap.signal.aborted
@@ -434,7 +399,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
         applyHydratedSubscriptionState(key, metadataGeneration, hydration)
       } catch (cause) {
         if (
-          attempt === subscriptionAttempt
+          subscriptionLifecycle.isCurrent(attemptContext, key)
           && metadataHydration === metadataHydrationSequence
           && key === options.sessionKey.value
           && !bootstrap.signal.aborted
@@ -452,15 +417,15 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
   }
 
   async function runSubscription(
-    key: string,
-    sinceStreamGeneration: string | null,
-    sinceStreamSeq: number,
-    token: symbol,
-    lease: ReturnType<typeof subscriptionLeases.acquire>,
-    controller: AbortController,
+    attemptContext: ConversationSubscriptionAttempt,
     bootstrap?: SessionBootstrapPhaseContext,
   ): Promise<SessionSubscriptionOutcome> {
-    const attempt = ++subscriptionAttempt
+    const {
+      key,
+      sinceStreamGeneration,
+      sinceStreamSeq,
+      lease,
+    } = attemptContext
     const metadataHydration = ++metadataHydrationSequence
     const metadataGeneration = options.beginSessionMetadataResolution?.(key)
     let skipSnapshotOnRetry = Boolean(bootstrap?.skipSnapshot)
@@ -475,7 +440,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
       } else {
         await options.rpc.waitForConnection()
       }
-      if (attempt !== subscriptionAttempt || key !== options.sessionKey.value) {
+      if (!subscriptionLifecycle.isCurrent(attemptContext, key)) {
         return { ...UNAVAILABLE_SUBSCRIPTION, cancelled: true }
       }
       const params: SessionMessagesSubscribeParams = {
@@ -568,21 +533,21 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
         && subscribeResult.value?.subscribed !== false
         && lease.state === 'acquiring'
       ) {
-        subscriptionLeases.activate(lease)
+        subscriptionLifecycle.leases.activate(lease)
       } else if (
         subscribeResult.status === 'rejected'
         && lease.state === 'acquiring'
       ) {
-        subscriptionLeases.retire(lease)
+        subscriptionLifecycle.leases.retire(lease)
       }
-      if (attempt !== subscriptionAttempt || key !== options.sessionKey.value) {
+      if (!subscriptionLifecycle.isCurrent(attemptContext, key)) {
         return { ...UNAVAILABLE_SUBSCRIPTION, cancelled: true }
       }
 
       if (subscribeResult.status === 'rejected') throw subscribeResult.reason
       const res = subscribeResult.value
       if (res && res.subscribed === false) {
-        subscriptionLeases.retire(lease)
+        subscriptionLifecycle.leases.retire(lease)
         throw new Error('No subscription manager available')
       }
       const generationReset = reconcileSubscriptionGeneration(
@@ -650,7 +615,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
       if (bootstrap) {
         scheduleDeferredHydration(
           key,
-          attempt,
+          attemptContext,
           metadataHydration,
           metadataGeneration,
           bootstrap,
@@ -686,10 +651,10 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
         backgroundOnly: false,
       }
     } catch (err: unknown) {
-      if (lease.state === 'acquiring') subscriptionLeases.retire(lease)
+      if (lease.state === 'acquiring') subscriptionLifecycle.leases.retire(lease)
       console.warn('Session stream subscription failed:', err instanceof Error ? err.message : err)
       const cancelled = (
-        attempt !== subscriptionAttempt
+        !subscriptionLifecycle.isCurrent(attemptContext, key)
         || key !== options.sessionKey.value
         || bootstrap?.signal.aborted
         || isRpcAbort(err)
@@ -698,7 +663,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
         metadataGeneration !== undefined
         && !cancelled
         && (!bootstrap || bootstrap.attempt === 1)
-        && attempt === subscriptionAttempt
+        && subscriptionLifecycle.isCurrent(attemptContext, key)
         && key === options.sessionKey.value
       ) {
         options.onSessionMetadataError?.(key, metadataGeneration)
@@ -710,9 +675,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
         skipSnapshotOnRetry,
       }
     } finally {
-      if (attempt === subscriptionAttempt) isHydrating.value = false
-      if (activeSubscription?.token === token) activeSubscription = null
-      if (activeController === controller) activeController = null
+      if (subscriptionLifecycle.isCurrent(attemptContext, key)) isHydrating.value = false
     }
   }
 
@@ -795,13 +758,10 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
   }
 
   function cancelActiveSubscription() {
-    ++subscriptionAttempt
+    subscriptionLifecycle.cancel()
     ++metadataHydrationSequence
-    activeController?.abort()
-    activeController = null
     activeMetadataController?.abort()
     activeMetadataController = null
-    activeSubscription = null
     isHydrating.value = false
   }
 
@@ -809,11 +769,11 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
     cancelActiveSubscription()
     if (!key) return
     retireLeasesFromPriorGenerations()
-    const lease = subscriptionLeases.latestReleasable(key)
+    const lease = subscriptionLifecycle.leases.latestReleasable(key)
     if (!lease) return
     if (lease.releasePromise) return lease.releasePromise
     lease.state = 'releasing'
-    subscriptionLeases.clearActive(lease)
+    subscriptionLifecycle.leases.clearActive(lease)
     const expectedGeneration = lease.socketGeneration
     const currentGeneration = options.rpc.connectionGeneration
     // No subscribe frame was sent, or the physical connection that owned it
@@ -826,7 +786,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
         && currentGeneration !== expectedGeneration
       )
     ) {
-      subscriptionLeases.retire(lease)
+      subscriptionLifecycle.leases.retire(lease)
       return
     }
     const release = (async () => {
@@ -865,7 +825,7 @@ export function useChatSessionSubscription(options: UseChatSessionSubscriptionOp
           cause instanceof Error ? cause.message : cause,
         )
       } finally {
-        subscriptionLeases.retire(lease)
+        subscriptionLifecycle.leases.retire(lease)
       }
     })()
     lease.releasePromise = release

--- a/opensquilla-webui/src/modules/conversationEventHub.test.ts
+++ b/opensquilla-webui/src/modules/conversationEventHub.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createConversationEventHub,
+  type ConversationEventSourceHandlers,
+} from './conversationEventHub'
+
+type Message = { key?: string, value: number }
+
+function sourceHarness() {
+  let active: ConversationEventSourceHandlers<Message> | null = null
+  let subscriptions = 0
+  let detachments = 0
+  const source = {
+    subscribe(handlers: ConversationEventSourceHandlers<Message>) {
+      subscriptions += 1
+      active = handlers
+      return () => {
+        detachments += 1
+        active = null
+      }
+    },
+    emit(message: Message) {
+      active?.onEvent?.(message)
+    },
+    state(value: string) {
+      active?.onConnectionState?.(value)
+    },
+    any(event: string, payload: unknown) {
+      active?.onAny?.(event, payload)
+    },
+    counts() {
+      return { subscriptions, detachments }
+    },
+  }
+  return source
+}
+
+describe('conversation event hub', () => {
+  it('multiplexes logical handles over one source and fences keyed events', () => {
+    const source = sourceHarness()
+    const hub = createConversationEventHub(source, {
+      sessionKey: message => message.key,
+    })
+    const alpha = hub.open('alpha')
+    const beta = hub.open('beta')
+    const alphaEvents: Message[] = []
+    const betaEvents: Message[] = []
+    alpha.observe(message => alphaEvents.push(message))
+    beta.observe(message => betaEvents.push(message))
+
+    source.emit({ key: 'alpha', value: 1 })
+    source.emit({ key: 'beta', value: 2 })
+    source.emit({ value: 3 })
+
+    expect(alphaEvents.map(item => item.value)).toEqual([1, 3])
+    expect(betaEvents.map(item => item.value)).toEqual([2, 3])
+    expect(source.counts()).toEqual({ subscriptions: 1, detachments: 0 })
+  })
+
+  it('keeps the physical source alive until the last logical owner closes', () => {
+    const source = sourceHarness()
+    const hub = createConversationEventHub(source)
+    const first = hub.open('')
+    const second = hub.open('')
+    const firstListener = vi.fn()
+    const secondListener = vi.fn()
+    first.observe(firstListener)
+    second.observe(secondListener)
+
+    first.close()
+    source.emit({ value: 1 })
+    expect(firstListener).not.toHaveBeenCalled()
+    expect(secondListener).toHaveBeenCalledWith({ value: 1 })
+    expect(source.counts()).toEqual({ subscriptions: 1, detachments: 0 })
+
+    second.close()
+    expect(source.counts()).toEqual({ subscriptions: 1, detachments: 1 })
+    second.close()
+    expect(source.counts()).toEqual({ subscriptions: 1, detachments: 1 })
+  })
+
+  it('forwards diagnostics and supports idempotent observer removal', () => {
+    const source = sourceHarness()
+    const hub = createConversationEventHub(source)
+    const state = vi.fn()
+    const any = vi.fn()
+    const offState = hub.observeConnectionState(state)
+    const offAny = hub.observeAny(any)
+
+    source.state('connected')
+    expect(state).toHaveBeenCalledWith('connected')
+    source.any('presence', { value: true })
+    expect(any).toHaveBeenCalledWith('presence', { value: true })
+    offState()
+    offState()
+    offAny()
+    offAny()
+    expect(source.counts()).toEqual({ subscriptions: 1, detachments: 1 })
+  })
+
+  it('dispose closes handles and prevents reconnection', () => {
+    const source = sourceHarness()
+    const hub = createConversationEventHub(source)
+    const handle = hub.open('')
+    const listener = vi.fn()
+    handle.observe(listener)
+    hub.dispose()
+    source.emit({ value: 4 })
+    expect(listener).not.toHaveBeenCalled()
+    expect(source.counts()).toEqual({ subscriptions: 1, detachments: 1 })
+    expect(handle.observe(listener)).not.toThrow()
+  })
+})

--- a/opensquilla-webui/src/modules/conversationEventHub.ts
+++ b/opensquilla-webui/src/modules/conversationEventHub.ts
@@ -1,0 +1,185 @@
+/**
+ * Transport-neutral ownership for a live Conversation event source.
+ *
+ * A source may be a WebSocket adapter today or an in-memory/replay source in
+ * tests. The hub owns exactly one source subscription and fans messages out to
+ * logical handles. Closing a handle therefore cannot close the physical
+ * transport used by another handle (or by a reconnecting composition root).
+ */
+
+export interface ConversationEventSourceHandlers<TEvent> {
+  onEvent?: (event: TEvent) => void
+  onAny?: (rawEvent: string, rawPayload: unknown) => void
+  onConnectionState?: (state: string) => void
+  onDecodeError?: (error: unknown, rawEvent: string, rawPayload: unknown) => void
+}
+
+export interface ConversationEventSource<TEvent> {
+  subscribe(handlers: ConversationEventSourceHandlers<TEvent>): () => void
+}
+
+export interface ConversationEventHandle<TEvent> {
+  readonly key: string
+  observe(listener: (event: TEvent) => void): () => void
+  close(): void
+}
+
+export interface ConversationEventHub<TEvent> {
+  /** Open a logical stream. An empty key means “all events”. */
+  open(key: string): ConversationEventHandle<TEvent>
+  /** Observe transport diagnostics without owning a logical stream. */
+  observeAny(listener: (rawEvent: string, rawPayload: unknown) => void): () => void
+  observeConnectionState(listener: (state: string) => void): () => void
+  observeDecodeError(listener: (error: unknown, rawEvent: string, rawPayload: unknown) => void): () => void
+  /** Explicitly release the source and all logical handles. */
+  dispose(): void
+}
+
+export interface ConversationEventHubOptions<TEvent> {
+  /** Return the session identity carried by an event, or null if untagged. */
+  sessionKey?: (event: TEvent) => string | null | undefined
+}
+
+type HandleState<TEvent> = {
+  key: string
+  listeners: Set<(event: TEvent) => void>
+  closed: boolean
+}
+
+const NOOP = () => {}
+
+/**
+ * Build a lazy, multiplexing event hub. The source is connected when the
+ * first observer is attached and disconnected after the last observer/handle
+ * is gone. All close/unsubscribe operations are idempotent.
+ */
+export function createConversationEventHub<TEvent>(
+  source: ConversationEventSource<TEvent>,
+  options: ConversationEventHubOptions<TEvent> = {},
+): ConversationEventHub<TEvent> {
+  const handles = new Set<HandleState<TEvent>>()
+  const anyListeners = new Set<(rawEvent: string, rawPayload: unknown) => void>()
+  const stateListeners = new Set<(state: string) => void>()
+  const decodeErrorListeners = new Set<(
+    error: unknown,
+    rawEvent: string,
+    rawPayload: unknown,
+  ) => void>()
+  let detachSource: (() => void) | null = null
+  let disposed = false
+
+  const matches = (handle: HandleState<TEvent>, event: TEvent): boolean => {
+    if (!handle.key) return true
+    const key = options.sessionKey?.(event)
+    // Untagged legacy/task frames remain observable. This preserves v4's
+    // historical wildcard behavior while positively fencing another session.
+    return !key || key === handle.key
+  }
+
+  function ensureSource() {
+    if (disposed || detachSource) return
+    detachSource = source.subscribe({
+      onEvent: (event) => {
+        for (const handle of [...handles]) {
+          if (handle.closed || !matches(handle, event)) continue
+          for (const listener of [...handle.listeners]) listener(event)
+        }
+      },
+      onAny: (rawEvent, rawPayload) => {
+        for (const listener of [...anyListeners]) listener(rawEvent, rawPayload)
+      },
+      onConnectionState: (state) => {
+        for (const listener of [...stateListeners]) listener(state)
+      },
+      onDecodeError: (error, rawEvent, rawPayload) => {
+        for (const listener of [...decodeErrorListeners]) {
+          listener(error, rawEvent, rawPayload)
+        }
+      },
+    })
+  }
+
+  function maybeDetachSource() {
+    if (
+      handles.size > 0
+      || anyListeners.size > 0
+      || stateListeners.size > 0
+      || decodeErrorListeners.size > 0
+    ) return
+    detachSource?.()
+    detachSource = null
+  }
+
+  function observeSet<TListener>(
+    set: Set<TListener>,
+    listener: TListener,
+  ): () => void {
+    if (disposed) return NOOP
+    set.add(listener)
+    ensureSource()
+    let active = true
+    return () => {
+      if (!active) return
+      active = false
+      set.delete(listener)
+      maybeDetachSource()
+    }
+  }
+
+  function open(key: string): ConversationEventHandle<TEvent> {
+    const state: HandleState<TEvent> = {
+      key: String(key || ''),
+      listeners: new Set(),
+      closed: false,
+    }
+    handles.add(state)
+
+    return {
+      get key() { return state.key },
+      observe(listener) {
+        if (state.closed || disposed) return NOOP
+        handles.add(state)
+        state.listeners.add(listener)
+        ensureSource()
+        let active = true
+        return () => {
+          if (!active) return
+          active = false
+          state.listeners.delete(listener)
+          if (state.listeners.size === 0) {
+            handles.delete(state)
+            maybeDetachSource()
+          }
+        }
+      },
+      close() {
+        if (state.closed) return
+        state.closed = true
+        state.listeners.clear()
+        handles.delete(state)
+        maybeDetachSource()
+      },
+    }
+  }
+
+  return {
+    open,
+    observeAny: listener => observeSet(anyListeners, listener),
+    observeConnectionState: listener => observeSet(stateListeners, listener),
+    observeDecodeError: listener => observeSet(decodeErrorListeners, listener),
+    dispose() {
+      if (disposed) return
+      disposed = true
+      for (const handle of handles) {
+        handle.closed = true
+        handle.listeners.clear()
+      }
+      handles.clear()
+      anyListeners.clear()
+      stateListeners.clear()
+      decodeErrorListeners.clear()
+      detachSource?.()
+      detachSource = null
+    },
+  }
+}

--- a/opensquilla-webui/src/modules/conversationSubscriptionLifecycle.test.ts
+++ b/opensquilla-webui/src/modules/conversationSubscriptionLifecycle.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createConversationSubscriptionLifecycle } from './conversationSubscriptionLifecycle'
+
+const identity = (key = 'agent:main:test') => ({
+  key,
+  sinceStreamGeneration: null,
+  sinceStreamSeq: 0,
+  bootstrapGeneration: -1,
+  bootstrapAttempt: -1,
+})
+
+describe('conversation subscription lifecycle', () => {
+  it('deduplicates an identical active attempt', async () => {
+    const lifecycle = createConversationSubscriptionLifecycle<number>()
+    const run = vi.fn(async () => 7)
+    const first = lifecycle.start(identity(), undefined, run)
+    const second = lifecycle.start(identity(), undefined, run)
+
+    expect(second).toBe(first)
+    expect(await first).toBe(7)
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('aborts the predecessor and fences its late completion', async () => {
+    const lifecycle = createConversationSubscriptionLifecycle<string>()
+    let predecessor!: ReturnType<typeof lifecycle.start>
+    const predecessorSignal = vi.fn()
+    predecessor = lifecycle.start(identity('alpha'), undefined, async attempt => {
+      attempt.controller.signal.addEventListener('abort', predecessorSignal)
+      await new Promise<void>(resolve => setTimeout(resolve, 0))
+      return 'old'
+    })
+    const successor = lifecycle.start(identity('beta'), undefined, async attempt => {
+      expect(lifecycle.isCurrent(attempt, 'beta')).toBe(true)
+      return 'new'
+    })
+
+    await Promise.all([predecessor, successor])
+    expect(predecessorSignal).toHaveBeenCalledTimes(1)
+    expect(await successor).toBe('new')
+  })
+
+  it('relays external cancellation without owning the transport', async () => {
+    const lifecycle = createConversationSubscriptionLifecycle<void>()
+    const external = new AbortController()
+    let signal!: AbortSignal
+    const promise = lifecycle.start(identity(), external.signal, async attempt => {
+      signal = attempt.controller.signal
+      await new Promise<void>(resolve => setTimeout(resolve, 0))
+    })
+    external.abort()
+    await promise
+    expect(signal.aborted).toBe(true)
+  })
+
+  it('keeps a finished attempt current for detached hydration until cancelled', async () => {
+    const lifecycle = createConversationSubscriptionLifecycle<boolean>()
+    let attemptRef: Parameters<typeof lifecycle.isCurrent>[0] | undefined
+    const promise = lifecycle.start(identity(), undefined, async attempt => {
+      attemptRef = attempt
+      return true
+    })
+    await promise
+    expect(attemptRef).toBeDefined()
+    expect(lifecycle.isCurrent(attemptRef!, 'agent:main:test')).toBe(true)
+    lifecycle.cancel()
+    expect(lifecycle.isCurrent(attemptRef!, 'agent:main:test')).toBe(false)
+  })
+})

--- a/opensquilla-webui/src/modules/conversationSubscriptionLifecycle.ts
+++ b/opensquilla-webui/src/modules/conversationSubscriptionLifecycle.ts
@@ -1,0 +1,127 @@
+import {
+  createConversationSubscriptionLeaseRegistry,
+  type ConversationSubscriptionLease,
+  type ConversationSubscriptionLeaseRegistry,
+} from './conversationSubscriptionLease'
+
+export interface ConversationSubscriptionIdentity {
+  key: string
+  sinceStreamGeneration: string | null
+  sinceStreamSeq: number
+  bootstrapGeneration: number
+  bootstrapAttempt: number
+}
+
+export interface ConversationSubscriptionAttempt
+  extends ConversationSubscriptionIdentity {
+  readonly id: number
+  readonly token: symbol
+  readonly controller: AbortController
+  readonly lease: ConversationSubscriptionLease
+}
+
+export interface ConversationSubscriptionLifecycle<TOutcome> {
+  start(
+    identity: ConversationSubscriptionIdentity,
+    externalSignal: AbortSignal | undefined,
+    run: (attempt: ConversationSubscriptionAttempt) => Promise<TOutcome>,
+  ): Promise<TOutcome>
+  cancel(): void
+  isCurrent(attempt: ConversationSubscriptionAttempt, key: string): boolean
+  finish(attempt: ConversationSubscriptionAttempt): void
+  retirePriorGenerations(currentGeneration?: number): void
+  readonly leases: ConversationSubscriptionLeaseRegistry
+}
+
+type ActiveOperation<TOutcome> = {
+  attempt: ConversationSubscriptionAttempt
+  promise: Promise<TOutcome>
+}
+
+function sameIdentity(
+  left: ConversationSubscriptionIdentity,
+  right: ConversationSubscriptionIdentity,
+): boolean {
+  return left.key === right.key
+    && left.sinceStreamGeneration === right.sinceStreamGeneration
+    && left.sinceStreamSeq === right.sinceStreamSeq
+    && left.bootstrapGeneration === right.bootstrapGeneration
+    && left.bootstrapAttempt === right.bootstrapAttempt
+}
+
+/**
+ * Own the cancellation/identity boundary for one Conversation subscription.
+ *
+ * The transport/application callback receives a stable attempt object and is
+ * free to perform its existing subscribe → snapshot → hydrate work. The
+ * lifecycle module owns the part that must not be duplicated by each caller:
+ * deduplication, abort relays, monotonic attempt fencing, and lease registry
+ * access. It never knows RPC method names or Vue state.
+ */
+export function createConversationSubscriptionLifecycle<TOutcome>(): ConversationSubscriptionLifecycle<TOutcome> {
+  const leases = createConversationSubscriptionLeaseRegistry()
+  let nextId = 0
+  let currentId = 0
+  let active: ActiveOperation<TOutcome> | null = null
+
+  function cancel() {
+    currentId += 1
+    active?.attempt.controller.abort()
+    active = null
+  }
+
+  function finish(attempt: ConversationSubscriptionAttempt) {
+    if (active?.attempt.id === attempt.id) active = null
+  }
+
+  function start(
+    identity: ConversationSubscriptionIdentity,
+    externalSignal: AbortSignal | undefined,
+    run: (attempt: ConversationSubscriptionAttempt) => Promise<TOutcome>,
+  ): Promise<TOutcome> {
+    if (active && sameIdentity(active.attempt, identity)) return active.promise
+    cancel()
+
+    const controller = new AbortController()
+    const relayAbort = () => controller.abort()
+    if (externalSignal?.aborted) controller.abort()
+    else externalSignal?.addEventListener('abort', relayAbort, { once: true })
+
+    const attempt: ConversationSubscriptionAttempt = {
+      ...identity,
+      id: ++nextId,
+      token: Symbol('conversation-subscription-attempt'),
+      controller,
+      lease: leases.acquire(identity.key),
+    }
+    currentId = attempt.id
+
+    let promise: Promise<TOutcome>
+    try {
+      promise = run(attempt)
+    } catch (error) {
+      promise = Promise.reject(error)
+    }
+    const settled = promise.finally(() => {
+      externalSignal?.removeEventListener('abort', relayAbort)
+      finish(attempt)
+    })
+    active = { attempt, promise: settled }
+    return settled
+  }
+
+  return {
+    start,
+    cancel,
+    isCurrent(attempt, key) {
+      return currentId === attempt.id
+        && attempt.key === key
+        && !attempt.controller.signal.aborted
+    },
+    finish,
+    retirePriorGenerations(currentGeneration) {
+      leases.retirePriorGenerations(currentGeneration)
+    },
+    leases,
+  }
+}

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -4087,6 +4087,8 @@ const chatRpcSubscriptions = useChatRpcSubscriptions(rpc, {
       stallWatchdog.noteEvent(rawEvent, payloadObj)
     }
   },
+}, {
+  getSessionKey: () => sessionKey.value,
 })
 
 // Session switches drop the previous session's stall tracking entirely.
@@ -4094,6 +4096,10 @@ watch(sessionKey, () => {
   stallWatchdog.reset()
   clearAssistantActivityExpansionState()
 })
+
+// Keep event delivery fenced to the visible logical session. The hub swaps
+// only its handle; the shared WebSocket and diagnostic listeners stay alive.
+watch(sessionKey, key => chatRpcSubscriptions.setSessionKey(key))
 
 // MetaSkill run UI: preflight checkpoint + run-progress ribbon, driven by the
 // four session.event.meta_* frames (delivered via the '*' wildcard, so this


### PR DESCRIPTION
## Summary

- add a transport-neutral `ConversationEventHub` with logical handles and one source subscription
- make the existing private v4 event adapter a hub source
- switch the composition root to a session-key handle while keeping a single physical source
- extract subscription-attempt ownership (dedupe, abort relay, generation fencing, and leases) into a transport-neutral lifecycle
- guarantee that closing one logical handle never closes the shared WebSocket/event source owned by another handle

## Why this slice

The previous slice removed the callback fan-out, but the composition bridge still owned the source listener directly and `useChatSessionSubscription` still kept its own lifecycle bookkeeping. This slice moves both responsibilities into reusable seams: one physical source, many logical consumers, explicit session-key fencing, idempotent close, shared diagnostics, and a single owner for subscription attempts, abort propagation, generation fencing, and leases. It is the seam required before moving bootstrap/subscription state behind the runtime adapter.

## Compatibility and scope

- v4 WebSocket frames, event names, payloads, connection state, and producer behavior are unchanged.
- The bridge now opens the visible session-key handle; untagged legacy/task frames remain observable, and directory invalidations stay global.
- Untagged legacy/task frames remain observable; positively tagged events for another key are fenced by keyed handles.
- No changes to TurnRunner, TaskRuntime, send/cancel/steer, storage, database schema, or Gateway handlers.
- No second transport and no generated wire imports in the module.
- Deferred hydration keeps its existing behavior: an attempt remains current after its main promise settles until it is cancelled or superseded.

## Validation

- WebUI unit: 398 files, 5,059 tests passed locally
- focused hub/lifecycle/adapter/bridge/subscription tests: 37 lifecycle/subscription tests and 88 hub/adapter/bridge/handler tests passed
- `vue-tsc --noEmit` passed
- full architecture, security, theme, i18n, and RPC gates passed
- RPC debt unchanged (no new raw registrations): 418 exact operations
- `git diff --check` passed

## Next slice

S12-C will move the remaining bootstrap/application state behind the runtime adapter. This PR deliberately preserves the existing wire state machine and does not change Gateway producers.
