### PR TITLE
refactor(webui): share conversation runtime ownership

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatRpcSubscriptions.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcSubscriptions.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import { useChatRpcSubscriptions } from './useChatRpcSubscriptions'
 import type { RpcEventHandler } from '@/lib/rpc'
+import { createConversationEventHub } from '@/modules/conversationEventHub'
+import type { ConversationEventTransportMessage } from '@/adapters/gateway/conversationEventTransport'
 
 function rpcHarness() {
   const listeners = new Map<string, Set<RpcEventHandler>>()
@@ -97,6 +99,41 @@ describe('useChatRpcSubscriptions', () => {
     }, {})
     expect(event).toHaveBeenCalledTimes(1)
     expect(rpc.count('*')).toBe(1)
+    bridge.unsubscribe()
+  })
+
+  it('uses the composition runtime source instead of creating another RPC listener', () => {
+    const rpc = rpcHarness()
+    const sourceState: {
+      emit: ((message: ConversationEventTransportMessage) => void) | null
+    } = { emit: null }
+    const hub = createConversationEventHub<ConversationEventTransportMessage>({
+      subscribe(handlers) {
+        sourceState.emit = handlers.onEvent ?? null
+        return () => { sourceState.emit = null }
+      },
+    }, {
+      sessionKey: message => (
+        message.kind === 'conversation' ? message.decoded.sessionKey : null
+      ),
+    })
+    const event = vi.fn()
+    const bridge = useChatRpcSubscriptions(
+      rpc,
+      { onEvent: event },
+      { runtime: { events: hub }, getSessionKey: () => 'agent:main:a' },
+    )
+    bridge.subscribe()
+
+    expect(rpc.count('*')).toBe(0)
+    sourceState.emit?.({
+      kind: 'sessions-changed',
+      wireName: 'sessions.changed',
+      decoded: null,
+      payload: {},
+      meta: {},
+    })
+    expect(event).toHaveBeenCalledOnce()
     bridge.unsubscribe()
   })
 })

--- a/opensquilla-webui/src/composables/chat/useChatRpcSubscriptions.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcSubscriptions.ts
@@ -2,7 +2,9 @@ import type { RpcEventHandler } from '@/lib/rpc'
 import {
   createConversationEventHub,
   type ConversationEventHandle,
+  type ConversationEventHub,
 } from '@/modules/conversationEventHub'
+import type { ConversationSessionRuntime } from '@/modules/conversationSessionRuntime'
 import {
   createConversationEventTransport,
   conversationEventSessionKey,
@@ -19,7 +21,9 @@ type RpcSubscriptionClient = {
  *
  * The bridge intentionally has no wire event names or payload DTOs. The v4
  * adapter owns those details and emits one decoded message; this small bridge
- * remains until ConversationRuntime.open() owns the subscription lifecycle.
+ * remains as a compatibility bridge while the composition root owns a shared
+ * ConversationSessionRuntime. It never creates a second source when that
+ * runtime is supplied.
  */
 export type ChatRpcSubscriptionHandlers = {
   onEvent: (message: ConversationEventTransportMessage) => void
@@ -31,6 +35,8 @@ export type ChatRpcSubscriptionHandlers = {
 export interface ChatRpcSubscriptionOptions {
   /** Return the currently visible session key for logical event fencing. */
   getSessionKey?: () => string
+  /** Shared runtime owner; avoids a second event source for this composition root. */
+  runtime?: Pick<ConversationSessionRuntime<ConversationEventTransportMessage, never>, 'events'>
 }
 
 export function useChatRpcSubscriptions(
@@ -38,10 +44,11 @@ export function useChatRpcSubscriptions(
   handlers: ChatRpcSubscriptionHandlers,
   options: ChatRpcSubscriptionOptions = {},
 ) {
-  const transport = createConversationEventTransport(rpc)
-  const hub = createConversationEventHub(transport, {
-    sessionKey: conversationEventSessionKey,
-  })
+  const hub: ConversationEventHub<ConversationEventTransportMessage> =
+    options.runtime?.events
+    ?? createConversationEventHub(createConversationEventTransport(rpc), {
+      sessionKey: conversationEventSessionKey,
+    })
   let activeHandle: ConversationEventHandle<ConversationEventTransportMessage> | null = null
   let activeKey = ''
   let detachEvent: (() => void) | null = null

--- a/opensquilla-webui/src/composables/chat/useChatSessionSubscription.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionSubscription.ts
@@ -13,6 +13,7 @@ import {
   createConversationRuntime,
   type ConversationRuntime,
 } from '@/modules/conversationRuntime'
+import type { ConversationSessionRuntime } from '@/modules/conversationSessionRuntime'
 import {
   createConversationSubscriptionLifecycle,
   type ConversationSubscriptionAttempt,
@@ -57,6 +58,11 @@ export interface UseChatSessionSubscriptionOptions {
   rpc: RpcClient
   /** Shared domain policy; omitted callers receive an equivalent local seam. */
   conversationRuntime?: ConversationRuntime
+  /** Shared Conversation owner; preferred over the legacy cursor-only option. */
+  conversationSessionRuntime?: Pick<
+    ConversationSessionRuntime<unknown, SessionSubscriptionOutcome>,
+    'cursor' | 'subscriptions'
+  >
   sessionKey: Ref<string>
   lastStreamSeq: Ref<number>
   runStatus: Ref<ChatRunStatus>
@@ -129,8 +135,11 @@ const UNAVAILABLE_SUBSCRIPTION: SessionSubscriptionOutcome = {
 export function useChatSessionSubscription(options: UseChatSessionSubscriptionOptions) {
   const isHydrating = ref(false)
   const streamGeneration = ref<string | null>(null)
-  const conversationRuntime = options.conversationRuntime ?? createConversationRuntime()
-  const subscriptionLifecycle = createConversationSubscriptionLifecycle<SessionSubscriptionOutcome>()
+  const conversationRuntime = options.conversationSessionRuntime?.cursor
+    ?? options.conversationRuntime
+    ?? createConversationRuntime()
+  const subscriptionLifecycle = options.conversationSessionRuntime?.subscriptions
+    ?? createConversationSubscriptionLifecycle<SessionSubscriptionOutcome>()
   let activeMetadataController: AbortController | null = null
   let metadataHydrationSequence = 0
 

--- a/opensquilla-webui/src/modules/conversationSessionRuntime.test.ts
+++ b/opensquilla-webui/src/modules/conversationSessionRuntime.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createConversationSessionRuntime,
+  type ConversationSessionRuntime,
+} from './conversationSessionRuntime'
+
+type Event = { key?: string; value: number }
+type Outcome = { authoritative: boolean }
+
+function sourceHarness() {
+  let subscriptions = 0
+  let detachments = 0
+  let handlers: ((event: Event) => void) | null = null
+  const source = {
+    subscribe(next: { onEvent?: (event: Event) => void }) {
+      subscriptions += 1
+      handlers = next.onEvent ?? null
+      return () => {
+        detachments += 1
+        handlers = null
+      }
+    },
+  }
+  return {
+    source,
+    emit(event: Event) { handlers?.(event) },
+    counts: () => ({ subscriptions, detachments }),
+  }
+}
+
+function runtime(source: ReturnType<typeof sourceHarness>['source']) {
+  return createConversationSessionRuntime<Event, Outcome>({
+    source,
+    events: { sessionKey: event => event.key },
+  })
+}
+
+describe('ConversationSessionRuntime', () => {
+  it('shares one event source and one cursor policy across logical handles', () => {
+    const harness = sourceHarness()
+    const services = runtime(harness.source)
+    const first = services.events.open('a')
+    const second = services.events.open('b')
+    const firstEvents: Event[] = []
+    const secondEvents: Event[] = []
+    first.observe(event => firstEvents.push(event))
+    second.observe(event => secondEvents.push(event))
+
+    harness.emit({ key: 'a', value: 1 })
+    harness.emit({ key: 'b', value: 2 })
+
+    expect(firstEvents.map(event => event.value)).toEqual([1])
+    expect(secondEvents.map(event => event.value)).toEqual([2])
+    expect(harness.counts()).toEqual({ subscriptions: 1, detachments: 0 })
+    expect(services.cursor.createCursor('a').sessionKey).toBe('a')
+
+    first.close()
+    expect(harness.counts()).toEqual({ subscriptions: 1, detachments: 0 })
+    second.close()
+    expect(harness.counts()).toEqual({ subscriptions: 1, detachments: 1 })
+  })
+
+  it('owns subscription attempts independently from event handle closure', async () => {
+    const harness = sourceHarness()
+    const services: ConversationSessionRuntime<Event, Outcome> = runtime(harness.source)
+    const first = services.subscriptions.start(
+      {
+        key: 'a',
+        sinceStreamGeneration: null,
+        sinceStreamSeq: 0,
+        bootstrapGeneration: 1,
+        bootstrapAttempt: 0,
+      },
+      undefined,
+      async attempt => {
+        await new Promise<void>(resolve => {
+          attempt.controller.signal.addEventListener('abort', () => resolve(), { once: true })
+        })
+        return { authoritative: false }
+      },
+    )
+    const eventHandle = services.events.open('a')
+    eventHandle.close()
+    services.subscriptions.cancel()
+    await expect(first).resolves.toEqual({ authoritative: false })
+  })
+
+  it('dispose is idempotent, detaches events, and cancels attempts', async () => {
+    const harness = sourceHarness()
+    const services = runtime(harness.source)
+    const errors = vi.fn()
+    services.events.observeDecodeError(errors)
+    let aborted = false
+    const pending = services.subscriptions.start(
+      {
+        key: 'a',
+        sinceStreamGeneration: null,
+        sinceStreamSeq: 0,
+        bootstrapGeneration: 1,
+        bootstrapAttempt: 0,
+      },
+      undefined,
+      async attempt => {
+        await new Promise<void>(resolve => {
+          attempt.controller.signal.addEventListener('abort', () => {
+            aborted = true
+            resolve()
+          }, { once: true })
+        })
+        return { authoritative: false }
+      },
+    )
+
+    services.dispose()
+    services.dispose()
+    await pending
+
+    expect(aborted).toBe(true)
+    expect(harness.counts()).toEqual({ subscriptions: 1, detachments: 1 })
+  })
+})

--- a/opensquilla-webui/src/modules/conversationSessionRuntime.ts
+++ b/opensquilla-webui/src/modules/conversationSessionRuntime.ts
@@ -1,0 +1,68 @@
+import {
+  createConversationEventHub,
+  type ConversationEventHub,
+  type ConversationEventHubOptions,
+  type ConversationEventSource,
+} from './conversationEventHub'
+import {
+  createConversationRuntime,
+  type ConversationRuntime,
+} from './conversationRuntime'
+import {
+  createConversationSubscriptionLifecycle,
+  type ConversationSubscriptionLifecycle,
+} from './conversationSubscriptionLifecycle'
+
+/**
+ * The transport/application seam for one Conversation composition root.
+ *
+ * The object deliberately contains policies and ownership, not Vue refs or
+ * wire names. A view may project `cursor` state into refs, while adapters own
+ * the event source and subscription calls. Keeping the three related pieces
+ * together prevents a second composable from accidentally creating a second
+ * lease registry or cursor policy for the same physical conversation.
+ */
+export interface ConversationSessionRuntime<TEvent, TSubscriptionOutcome> {
+  /** Pure session-epoch/generation/sequence policy. */
+  readonly cursor: ConversationRuntime
+  /** One physical source, multiplexed into logical event handles. */
+  readonly events: ConversationEventHub<TEvent>
+  /** One owner for subscription attempts and logical leases. */
+  readonly subscriptions: ConversationSubscriptionLifecycle<TSubscriptionOutcome>
+  /** Release the event source and invalidate an in-flight subscription. */
+  dispose(): void
+}
+
+export interface ConversationSessionRuntimeOptions<TEvent> {
+  source: ConversationEventSource<TEvent>
+  events?: ConversationEventHubOptions<TEvent>
+  cursor?: ConversationRuntime
+}
+
+/**
+ * Build the shared Conversation services once at the composition root.
+ *
+ * `source` is an adapter boundary: this module does not import RpcClient or
+ * generated wire types. Tests and future transports can provide an in-memory
+ * source without changing the application-facing modules.
+ */
+export function createConversationSessionRuntime<TEvent, TSubscriptionOutcome>(
+  options: ConversationSessionRuntimeOptions<TEvent>,
+): ConversationSessionRuntime<TEvent, TSubscriptionOutcome> {
+  const cursor = options.cursor ?? createConversationRuntime()
+  const events = createConversationEventHub(options.source, options.events)
+  const subscriptions = createConversationSubscriptionLifecycle<TSubscriptionOutcome>()
+  let disposed = false
+
+  return {
+    cursor,
+    events,
+    subscriptions,
+    dispose() {
+      if (disposed) return
+      disposed = true
+      subscriptions.cancel()
+      events.dispose()
+    },
+  }
+}

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -936,8 +936,18 @@ import {
   sandboxSetupRpcCallOptions,
 } from '@/composables/chat/sessionBootstrapAdmission'
 import { useChatSessionRuntime } from '@/composables/chat/useChatSessionRuntime'
-import { useChatSessionSubscription } from '@/composables/chat/useChatSessionSubscription'
-import { createConversationRuntime } from '@/modules/conversationRuntime'
+import {
+  useChatSessionSubscription,
+  type SessionSubscriptionOutcome,
+} from '@/composables/chat/useChatSessionSubscription'
+import {
+  createConversationSessionRuntime,
+} from '@/modules/conversationSessionRuntime'
+import {
+  createConversationEventTransport,
+  conversationEventSessionKey,
+  type ConversationEventTransportMessage,
+} from '@/adapters/gateway/conversationEventTransport'
 import {
   useChatSlashCommands,
   type DurableMetaDraft,
@@ -1631,10 +1641,17 @@ const runStatus = ref<ChatRunStatus>({ status: 'idle', label: t('chat.status.idl
 // Epoch / seq
 const currentEpoch = ref(0)
 const lastStreamSeq = ref(0)
-// One transport-independent cursor policy is shared by the subscription and
-// event adapters.  The refs remain the reactive projection consumed by older
-// composables until the later ConversationRuntime migration removes them.
-const conversationRuntime = createConversationRuntime()
+// One Conversation owner is shared by the subscription and event adapters.
+// Its cursor policy remains projected into legacy refs, while the event source
+// and subscription leases stay behind the transport-neutral runtime seam.
+const conversationSessionRuntime = createConversationSessionRuntime<
+  ConversationEventTransportMessage,
+  SessionSubscriptionOutcome
+>({
+  source: createConversationEventTransport(rpc),
+  events: { sessionKey: conversationEventSessionKey },
+})
+const conversationRuntime = conversationSessionRuntime.cursor
 const activeTaskGroups = ref<Set<string>>(new Set())
 // Task id whose output the live stream renders; binds late events to the
 // current turn so a prior task can't leak into it (issue 344).
@@ -2519,7 +2536,7 @@ let applyPendingUserInputSnapshot: typeof chatPlans.applyBootstrap = () => {}
 let applyGoalSnapshot: (snapshot: SessionMessagesSubscribeResponse) => void = () => {}
 const chatSessionSubscription = useChatSessionSubscription({
   rpc,
-  conversationRuntime,
+  conversationSessionRuntime: conversationSessionRuntime,
   sessionKey,
   lastStreamSeq,
   runStatus,
@@ -4089,6 +4106,7 @@ const chatRpcSubscriptions = useChatRpcSubscriptions(rpc, {
   },
 }, {
   getSessionKey: () => sessionKey.value,
+  runtime: conversationSessionRuntime,
 })
 
 // Session switches drop the previous session's stall tracking entirely.
@@ -6753,6 +6771,7 @@ onUnmounted(() => {
   metaDraftRecovery.invalidate()
   draftProjectHydration.invalidate()
   cancelSessionBootstrap()
+  conversationSessionRuntime.dispose()
   pendingSessionOptionalReads = null
   releaseOptionalRpcAdmission?.()
   releaseOptionalRpcAdmission = null


### PR DESCRIPTION
## Summary

- add a transport-neutral `ConversationSessionRuntime` that owns the cursor policy, event hub, and subscription lifecycle for one composition root
- make `ChatView` create one runtime and pass its ports to the event bridge and session subscription adapter
- keep compatibility fallbacks for isolated callers and existing tests
- add ownership and source-multiplexing tests

## Why this slice

S12-B extracted the event hub and subscription-attempt lifecycle, but the
composition root still created those owners independently. That left it easy
for a second consumer to acquire another source or lease registry. This slice
introduces the explicit runtime seam before bootstrap/application state moves
behind it. The module imports no Vue, RpcClient, generated Contract, Gateway,
storage, or TurnRunner code.

## Compatibility and scope

- v4 WebSocket frames, event names, payloads, connection state, and producer
  behavior are unchanged.
- Existing callers without a runtime keep the old local adapter path during the
  migration; the ChatView production composition uses one shared runtime.
- No changes to Gateway, database schema, TurnRunner, TaskRuntime, send,
  cancel, steer, or subscription wire semantics.
- `dispose()` is idempotent and only releases the event source and local
  subscription attempt owner; it does not close a shared RpcClient socket.

## Validation

- WebUI unit: 399 files, 5,063 tests passed locally
- focused runtime/bridge/subscription tests: 51 passed
- `npm exec vue-tsc -- --noEmit` passed
- `npm run check:architecture` passed (RPC debt remains 418 exact operations)

## Follow-up

The next S12-C slice can move bootstrap phase/reconnect state behind this
runtime using a port-based coordinator. This PR intentionally leaves the
existing bootstrap state machine and UI phase projection unchanged.