### PR TITLE
refactor(webui): extract bootstrap ownership coordinator

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatSessionBootstrap.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionBootstrap.ts
@@ -14,15 +14,15 @@ import {
   type SessionLivePhase,
   type SessionPhaseResult,
 } from '@/composables/chat/sessionBootstrapContract'
+import {
+  createConversationBootstrapPhase,
+  createConversationBootstrapCoordinator,
+  type ConversationBootstrapPhase,
+  type ConversationBootstrapHandoffOutcome,
+  type ConversationBootstrapRunToken,
+} from '@/modules/conversationBootstrapCoordinator'
 
-interface PhaseRuntime<T> {
-  attempts: number
-  deadlineAt: number
-  running: boolean
-  promise: Promise<T>
-  result: T | null
-  skipSnapshot: boolean
-}
+type PhaseRuntime<T> = ConversationBootstrapPhase<T>
 
 interface CriticalRequestQueue {
   promise: Promise<void>
@@ -35,11 +35,7 @@ interface CriticalRequestQueue {
   historyTerminal: boolean
 }
 
-interface ActiveBootstrap {
-  generation: number
-  key: string
-  includeHistory: boolean
-  controller: AbortController
+interface ActiveBootstrapState {
   criticalQueue: CriticalRequestQueue
   liveQueueSequence: number
   liveQueueWaiters: Set<{
@@ -54,6 +50,8 @@ interface ActiveBootstrap {
   history: PhaseRuntime<SessionPhaseResult>
   live: PhaseRuntime<SessionSubscriptionOutcome>
 }
+
+type ActiveBootstrap = ConversationBootstrapRunToken & ActiveBootstrapState
 
 export interface SessionBootstrapRun {
   generation: number
@@ -86,75 +84,45 @@ const UNAVAILABLE_LIVE_RESULT: SessionSubscriptionOutcome = {
 }
 
 function historyRuntime(deadlineAt: number): PhaseRuntime<SessionPhaseResult> {
-  return {
-    attempts: 0,
-    deadlineAt,
-    running: false,
-    promise: Promise.resolve(EMPTY_HISTORY_RESULT),
-    result: null,
-    skipSnapshot: false,
-  }
+  return createConversationBootstrapPhase(deadlineAt, EMPTY_HISTORY_RESULT)
 }
 
 function liveRuntime(deadlineAt: number): PhaseRuntime<SessionSubscriptionOutcome> {
-  return {
-    attempts: 0,
-    deadlineAt,
-    running: false,
-    promise: Promise.resolve(UNAVAILABLE_LIVE_RESULT),
-    result: null,
-    skipSnapshot: false,
-  }
+  return createConversationBootstrapPhase(deadlineAt, UNAVAILABLE_LIVE_RESULT)
 }
 
 export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions) {
   const historyPhase = ref<SessionHistoryPhase>('idle')
   const livePhase = ref<SessionLivePhase>('idle')
-  let generation = 0
   let active: ActiveBootstrap | null = null
-  // A successful live phase arms exactly one new automatic recovery budget
-  // for the next external disconnect. A terminal recovery stays terminal
-  // across the RpcClient's background reconnect cycles until the user retries.
-  let connectionRecoveryArmed = false
-  let pendingHandoff: { targetKey: string; epoch: number } | null = null
-  let deferredConnectionStates: Array<{
-    state: string
-    includeHistory: boolean
-  }> = []
+  const ownership = createConversationBootstrapCoordinator<ActiveBootstrap>({
+    budgetMs: SESSION_BOOTSTRAP_BUDGET_MS,
+  })
 
   function setSessionHandoffTarget(
     targetKey: string | null,
     epoch: number,
-    outcome: 'committed' | 'unchanged' | 'failed' | 'superseded' = 'failed',
+    outcome: ConversationBootstrapHandoffOutcome = 'failed',
   ): SessionBootstrapRun | undefined {
     if (targetKey) {
-      if (!pendingHandoff || epoch >= pendingHandoff.epoch) {
-        pendingHandoff = { targetKey, epoch }
-      }
+      ownership.setHandoffTarget(targetKey, epoch)
       return
     }
-    if (pendingHandoff && epoch < pendingHandoff.epoch) return
-    pendingHandoff = null
-    const deferred = deferredConnectionStates
-    deferredConnectionStates = []
+    const resolution = ownership.resolveHandoff(epoch, outcome)
+    if (!resolution.accepted) return
     // A committed target starts its own bootstrap before the handoff closes.
     // Replaying older transport transitions would duplicate or preempt that B
     // registration. A rollback keeps A, so replay is required there.
     if (outcome === 'committed') return
     let resumed: SessionBootstrapRun | undefined
-    for (const event of deferred) {
+    for (const event of resolution.deferred) {
       resumed = handleConnectionState(event.state, event.includeHistory) ?? resumed
     }
     return resumed
   }
 
   function isCurrent(run: ActiveBootstrap): boolean {
-    return (
-      active === run
-      && generation === run.generation
-      && options.sessionKey.value === run.key
-      && !run.controller.signal.aborted
-    )
+    return ownership.isCurrent(run, options.sessionKey.value)
   }
 
   function contextFor(
@@ -420,7 +388,7 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
         if (lastResult.skipSnapshotOnRetry) phase.skipSnapshot = true
         if (lastResult.authoritative) {
           livePhase.value = 'ready'
-          connectionRecoveryArmed = true
+          ownership.armRecovery()
           return lastResult
         }
         if (
@@ -485,12 +453,7 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
   }
 
   function createRun(key: string, includeHistory: boolean): ActiveBootstrap {
-    const deadlineAt = Date.now() + SESSION_BOOTSTRAP_BUDGET_MS
-    const run: ActiveBootstrap = {
-      generation: ++generation,
-      key,
-      includeHistory,
-      controller: new AbortController(),
+    const run = ownership.start(key, includeHistory, token => ({
       criticalQueue: createCriticalQueue(includeHistory),
       liveQueueSequence: 0,
       liveQueueWaiters: new Set(),
@@ -499,12 +462,10 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
       lateReplacementRecoveryUsed: false,
       lateReplacementHistoryRecoveryPhase: null,
       lateReplacementHistoryRecoveryUsed: false,
-      history: historyRuntime(deadlineAt),
-      live: liveRuntime(deadlineAt),
-    }
-    active?.controller.abort()
+      history: historyRuntime(token.deadlineAt),
+      live: liveRuntime(token.deadlineAt),
+    }))
     active = run
-    connectionRecoveryArmed = false
     return run
   }
 
@@ -525,7 +486,7 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
     const includeHistory = optionsForStart.includeHistory !== false
     if (!key) {
       return {
-        generation,
+        generation: ownership.generation,
         criticalRequestsQueued: Promise.resolve(),
         history: Promise.resolve(EMPTY_HISTORY_RESULT),
         live: Promise.resolve(UNAVAILABLE_LIVE_RESULT),
@@ -646,11 +607,8 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
   }
 
   function cancelSessionBootstrap(unsubscribe = true) {
-    const cancelled = active
-    ++generation
+    const cancelled = ownership.cancel() ?? active
     active = null
-    connectionRecoveryArmed = false
-    cancelled?.controller.abort()
     if (cancelled) {
       cancelled.criticalQueue.resolve()
       for (const waiter of cancelled.liveQueueWaiters) waiter.resolve(false)
@@ -682,27 +640,17 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
     includeHistory = true,
   ): SessionBootstrapRun | undefined {
     if (
-      pendingHandoff
-      && pendingHandoff.targetKey !== options.sessionKey.value
+      ownership.shouldDeferConnectionState(options.sessionKey.value)
     ) {
       // Transport events may race a delayed queue/adoption handoff. Keep the
       // source run intact and replay only the latest physical state after the
       // handoff commits or rolls back; never restart source A while B is the
       // declared target.
-      const previous = deferredConnectionStates[deferredConnectionStates.length - 1]
-      if (state === 'disconnected') {
-        // A later outage supersedes any already-deferred flap. Retain only the
-        // transition needed to recover the eventual target exactly once.
-        deferredConnectionStates = [{ state, includeHistory }]
-      } else if (previous?.state === state) {
-        previous.includeHistory ||= includeHistory
-      } else {
-        deferredConnectionStates.push({ state, includeHistory })
-      }
+      ownership.deferConnectionState(state, includeHistory)
       return active
         ? { ...publicRun(active), deferred: true }
         : {
-            generation,
+            generation: ownership.generation,
             criticalRequestsQueued: Promise.resolve(),
             history: Promise.resolve(EMPTY_HISTORY_RESULT),
             live: Promise.resolve(UNAVAILABLE_LIVE_RESULT),
@@ -743,14 +691,16 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
           }
           run.live.promise = runLivePhase(run)
         }
-        if (liveWillRecover) connectionRecoveryArmed = false
+        if (liveWillRecover) ownership.disarmRecovery()
         return publicRun(run)
       }
       // Once a recovery budget reaches a terminal degraded state, background
       // reconnect churn must not turn the honest terminal state back into an
       // endless "connecting" indicator. Only an authoritative live phase can
       // arm a fresh outage budget.
-      if (!connectionRecoveryArmed) return currentRun ? publicRun(run) : undefined
+      if (!ownership.consumeRecoveryBudget()) {
+        return currentRun ? publicRun(run) : undefined
+      }
       // This is a new outage after an authoritative connection. Start its
       // wall-clock budget immediately; do not wait indefinitely for _state
       // "connected" before the coordinator begins counting.

--- a/opensquilla-webui/src/modules/conversationBootstrapCoordinator.test.ts
+++ b/opensquilla-webui/src/modules/conversationBootstrapCoordinator.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createConversationBootstrapPhase,
+  createConversationBootstrapCoordinator,
+  type ConversationBootstrapRunToken,
+} from './conversationBootstrapCoordinator'
+
+type Run = ConversationBootstrapRunToken & { label: string }
+
+function coordinator(now = 1_000) {
+  return createConversationBootstrapCoordinator<Run>({
+    now: () => now,
+    budgetMs: 15_000,
+  })
+}
+
+describe('ConversationBootstrapCoordinator', () => {
+  it('creates neutral phase bookkeeping without owning execution', async () => {
+    const phase = createConversationBootstrapPhase(2_000, { ok: true })
+    expect(phase.attempts).toBe(0)
+    expect(phase.running).toBe(false)
+    expect(phase.deadlineAt).toBe(2_000)
+    expect(phase.result).toBeNull()
+    expect(phase.skipSnapshot).toBe(false)
+    await expect(phase.promise).resolves.toEqual({ ok: true })
+  })
+
+  it('fences predecessor runs and keeps one absolute deadline per run', () => {
+    const api = coordinator()
+    const first = api.start('session:a', true, () => ({ label: 'first' }))
+    expect(first.generation).toBe(1)
+    expect(first.deadlineAt).toBe(16_000)
+    expect(api.current()).toBe(first)
+    expect(api.isCurrent(first, 'session:a')).toBe(true)
+
+    const second = api.start('session:b', false, () => ({ label: 'second' }))
+    expect(first.controller.signal.aborted).toBe(true)
+    expect(api.current()).toBe(second)
+    expect(api.generation).toBe(2)
+    expect(api.isCurrent(first, 'session:a')).toBe(false)
+    expect(api.isCurrent(second, 'session:a')).toBe(false)
+    expect(api.isCurrent(second, 'session:b')).toBe(true)
+  })
+
+  it('cancels the active run and invalidates callbacks exactly once', () => {
+    const api = coordinator()
+    const run = api.start('session:a', true, () => ({ label: 'run' }))
+    const cancelled = api.cancel()
+
+    expect(cancelled).toBe(run)
+    expect(run.controller.signal.aborted).toBe(true)
+    expect(api.current()).toBeNull()
+    expect(api.generation).toBe(2)
+    expect(api.isCurrent(run, 'session:a')).toBe(false)
+    expect(api.cancel()).toBeNull()
+    expect(api.generation).toBe(3)
+  })
+
+  it('defers and coalesces physical transitions until a handoff resolves', () => {
+    const api = coordinator()
+    expect(api.setHandoffTarget('session:b', 2)).toBe(true)
+    expect(api.setHandoffTarget('session:c', 1)).toBe(false)
+    expect(api.shouldDeferConnectionState('session:a')).toBe(true)
+    expect(api.shouldDeferConnectionState('session:b')).toBe(false)
+
+    api.deferConnectionState('connected', false)
+    api.deferConnectionState('connected', true)
+    api.deferConnectionState('disconnected', false)
+    api.deferConnectionState('connected', true)
+
+    const stale = api.resolveHandoff(1, 'failed')
+    expect(stale).toEqual({ accepted: false, deferred: [] })
+    expect(api.shouldDeferConnectionState('session:a')).toBe(true)
+
+    const failed = api.resolveHandoff(2, 'failed')
+    expect(failed.accepted).toBe(true)
+    expect(failed.deferred).toEqual([
+      { state: 'disconnected', includeHistory: false },
+      { state: 'connected', includeHistory: true },
+    ])
+    expect(api.shouldDeferConnectionState('session:a')).toBe(false)
+    expect(api.resolveHandoff(2, 'failed').deferred).toEqual([])
+  })
+
+  it('drops deferred transitions for a committed target', () => {
+    const api = coordinator()
+    api.setHandoffTarget('session:b', 1)
+    api.deferConnectionState('disconnected', true)
+
+    expect(api.resolveHandoff(1, 'committed')).toEqual({
+      accepted: true,
+      deferred: [],
+    })
+  })
+
+  it('grants one recovery budget after an authoritative phase', () => {
+    const api = coordinator()
+    expect(api.consumeRecoveryBudget()).toBe(false)
+    api.armRecovery()
+    expect(api.consumeRecoveryBudget()).toBe(true)
+    expect(api.consumeRecoveryBudget()).toBe(false)
+    api.armRecovery()
+    api.disarmRecovery()
+    expect(api.consumeRecoveryBudget()).toBe(false)
+  })
+
+  it('does not require a transport or reactive runtime', () => {
+    const api = coordinator()
+    const abort = vi.fn()
+    const run = api.start('session:a', true, token => ({
+      label: 'pure',
+      abort: () => abort(token.generation),
+    }))
+    run.abort()
+    expect(abort).toHaveBeenCalledWith(1)
+  })
+})

--- a/opensquilla-webui/src/modules/conversationBootstrapCoordinator.ts
+++ b/opensquilla-webui/src/modules/conversationBootstrapCoordinator.ts
@@ -1,0 +1,238 @@
+/**
+ * Transport-neutral ownership for a conversation bootstrap run.
+ *
+ * A bootstrap combines two asynchronous phases (history and live) and can be
+ * interrupted by a route handoff or by a physical connection flap.  The
+ * phase implementation still lives in the legacy composable for now, but the
+ * identity rules belong here so another transport or application adapter
+ * cannot accidentally reimplement them:
+ *
+ *   one active key -> monotonic generation -> abort the predecessor
+ *   handoff epoch -> deferred connection transitions -> explicit replay
+ *
+ * This module intentionally has no Vue, RpcClient, generated wire, or RPC
+ * method imports.  It is an ownership seam, not a transport wrapper.
+ */
+
+export interface ConversationBootstrapRunToken {
+  readonly generation: number
+  readonly key: string
+  /** The deadline is absolute so retries cannot extend one bootstrap budget. */
+  readonly deadlineAt: number
+  /** Include-history may be upgraded by a caller reusing the same run. */
+  includeHistory: boolean
+  readonly controller: AbortController
+}
+
+/** Mutable phase bookkeeping shared by history/live execution adapters. */
+export interface ConversationBootstrapPhase<T> {
+  attempts: number
+  readonly deadlineAt: number
+  running: boolean
+  promise: Promise<T>
+  result: T | null
+  skipSnapshot: boolean
+}
+
+/**
+ * Initialise a phase without importing a transport or reactive state layer.
+ * The execution callback remains in the wrapper until a later slice moves
+ * retry policy here; this factory keeps its bookkeeping shape canonical.
+ */
+export function createConversationBootstrapPhase<T>(
+  deadlineAt: number,
+  initialResult: T,
+): ConversationBootstrapPhase<T> {
+  return {
+    attempts: 0,
+    deadlineAt,
+    running: false,
+    promise: Promise.resolve(initialResult),
+    result: null,
+    skipSnapshot: false,
+  }
+}
+
+export interface ConversationBootstrapConnectionState {
+  readonly state: string
+  readonly includeHistory: boolean
+}
+
+export type ConversationBootstrapHandoffOutcome =
+  | 'committed'
+  | 'unchanged'
+  | 'failed'
+  | 'superseded'
+
+export interface ConversationBootstrapHandoffResolution {
+  /** False means the caller supplied an older epoch and must do nothing. */
+  readonly accepted: boolean
+  /** States to replay after a rollback/failed handoff. */
+  readonly deferred: readonly ConversationBootstrapConnectionState[]
+}
+
+export interface ConversationBootstrapCoordinator<TRun extends ConversationBootstrapRunToken> {
+  /** Monotonic identity used for no-key/empty-run responses as well. */
+  readonly generation: number
+  /** Current run, if one has been started. */
+  current(): TRun | null
+  /** Start a new run and invalidate the previous one. */
+  start<TState extends object>(
+    key: string,
+    includeHistory: boolean,
+    createState: (token: ConversationBootstrapRunToken) => TState,
+  ): TRun & TState
+  /** Abort and forget the active run; returns it for caller-side cleanup. */
+  cancel(): TRun | null
+  /** Identity and abort fence shared by every phase callback. */
+  isCurrent(run: ConversationBootstrapRunToken, key: string): boolean
+
+  /** Record that navigation owns a newer target until it commits/rolls back. */
+  setHandoffTarget(targetKey: string | null, epoch: number): boolean
+  /** Resolve a handoff and return only the transitions that should be replayed. */
+  resolveHandoff(
+    epoch: number,
+    outcome: ConversationBootstrapHandoffOutcome,
+  ): ConversationBootstrapHandoffResolution
+  /** Whether a physical transition must wait for the declared handoff target. */
+  shouldDeferConnectionState(currentKey: string): boolean
+  /** Coalesce deferred transport states while a handoff is pending. */
+  deferConnectionState(state: string, includeHistory: boolean): void
+
+  /** A successful live phase grants one background outage recovery budget. */
+  armRecovery(): void
+  disarmRecovery(): void
+  consumeRecoveryBudget(): boolean
+}
+
+export interface ConversationBootstrapCoordinatorOptions {
+  /** Keep time injectable so pure tests do not depend on wall-clock timing. */
+  now?: () => number
+  /** Absolute run budget. A caller may pass zero for a deadline-free test. */
+  budgetMs: number
+}
+
+/**
+ * Build the ownership coordinator.  `createState` lets the legacy wrapper
+ * attach its phase/queue state without making this module know those types.
+ * The returned object is the token itself, so identity checks remain strict
+ * even while the wrapper gradually moves state behind this seam.
+ */
+export function createConversationBootstrapCoordinator<
+  TRun extends ConversationBootstrapRunToken = ConversationBootstrapRunToken,
+>(
+  options: ConversationBootstrapCoordinatorOptions,
+): ConversationBootstrapCoordinator<TRun> {
+  const now = options.now ?? (() => Date.now())
+  let generation = 0
+  let active: TRun | null = null
+  let pendingHandoff: { targetKey: string; epoch: number } | null = null
+  let deferredConnectionStates: ConversationBootstrapConnectionState[] = []
+  let recoveryArmed = false
+
+  function start<TState extends object>(
+    key: string,
+    includeHistory: boolean,
+    createState: (token: ConversationBootstrapRunToken) => TState,
+  ): TRun & TState {
+    active?.controller.abort()
+    const token: ConversationBootstrapRunToken = {
+      generation: ++generation,
+      key,
+      deadlineAt: now() + Math.max(0, options.budgetMs),
+      includeHistory,
+      controller: new AbortController(),
+    }
+    const run = Object.assign(token, createState(token)) as TRun & TState
+    active = run as unknown as TRun
+    recoveryArmed = false
+    return run
+  }
+
+  function cancel(): TRun | null {
+    const cancelled = active
+    ++generation
+    active = null
+    recoveryArmed = false
+    cancelled?.controller.abort()
+    return cancelled
+  }
+
+  function setHandoffTarget(targetKey: string | null, epoch: number): boolean {
+    if (!targetKey) return true
+    if (pendingHandoff && epoch < pendingHandoff.epoch) return false
+    pendingHandoff = { targetKey, epoch }
+    return true
+  }
+
+  function resolveHandoff(
+    epoch: number,
+    outcome: ConversationBootstrapHandoffOutcome,
+  ): ConversationBootstrapHandoffResolution {
+    if (pendingHandoff && epoch < pendingHandoff.epoch) {
+      return { accepted: false, deferred: [] }
+    }
+    pendingHandoff = null
+    const deferred = deferredConnectionStates
+    deferredConnectionStates = []
+    return {
+      accepted: true,
+      deferred: outcome === 'committed' ? [] : deferred,
+    }
+  }
+
+  function deferConnectionState(state: string, includeHistory: boolean) {
+    if (state === 'disconnected') {
+      // A later outage supersedes an already deferred flap. Replaying only
+      // this terminal transition is enough to recover the eventual target.
+      deferredConnectionStates = [{ state, includeHistory }]
+      return
+    }
+    const previous = deferredConnectionStates[deferredConnectionStates.length - 1]
+    if (previous?.state === state) {
+      if (includeHistory && !previous.includeHistory) {
+        deferredConnectionStates[deferredConnectionStates.length - 1] = {
+          state: previous.state,
+          includeHistory: true,
+        }
+      }
+      return
+    }
+    deferredConnectionStates.push({ state, includeHistory })
+  }
+
+  return {
+    get generation() {
+      return generation
+    },
+    current: () => active,
+    start,
+    cancel,
+    isCurrent(run, key) {
+      return active === run
+        && generation === run.generation
+        && run.key === key
+        && !run.controller.signal.aborted
+    },
+    setHandoffTarget,
+    resolveHandoff,
+    shouldDeferConnectionState(currentKey) {
+      return Boolean(
+        pendingHandoff
+        && pendingHandoff.targetKey !== currentKey,
+      )
+    },
+    deferConnectionState,
+    armRecovery() {
+      recoveryArmed = true
+    },
+    disarmRecovery() {
+      recoveryArmed = false
+    },
+    consumeRecoveryBudget() {
+      if (!recoveryArmed) return false
+      recoveryArmed = false
+      return true
+    },
+  }
+}


### PR DESCRIPTION
## Summary

- extract conversation bootstrap run ownership into a transport-neutral coordinator
- centralize generation/deadline, cancellation fencing, handoff deferral, and one-shot recovery budget
- keep `useChatSessionBootstrap` public API and existing history/live retry execution unchanged
- add pure coordinator and phase-bookkeeping tests

## Why

`useChatSessionBootstrap` currently mixes Vue phase projection, transport callbacks, retry execution, and session ownership.  This slice establishes a deep ownership seam before moving the remaining bootstrap state machine.  A future adapter can reuse the same generation and handoff rules without importing Vue, `RpcClient`, generated wire types, or RPC names.

## Compatibility and scope

- based directly on `origin/main` `83063037af434f818069b8687d155af611a9b480` (PR #1491)
- v4 WebSocket wire, Gateway, database, TurnRunner, TaskRuntime, and command semantics are unchanged
- no generated Contract imports are introduced into the module
- `useChatSessionBootstrap` exports and all existing connection/retry behavior remain intact
- retry timers, critical-request queue execution, and Vue phase refs remain in the wrapper for a later S12-C3 slice

## Validation

- focused bootstrap/coordinator/ownership tests: 48 passed
- full WebUI unit suite: 400 files, 5,070 tests passed (one existing optional localhost probe reports `EPERM` but does not fail the suite)
- `vue-tsc --noEmit` passed
- `npm run check:architecture` passed, including RPC debt gate (418 exact operations)

## Risk and rollback

The coordinator only replaces local identity bookkeeping and is covered by the existing bootstrap race tests.  Reverting this PR restores the previous local ownership implementation without a wire or data migration.
