### PR TITLE
refactor(build): separate WebUI artifact staging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -59,6 +59,7 @@ install.ps1
 
 # --- Build artefacts --------------------------------------------------------
 dist
+opensquilla-webui/dist
 build
 *.egg-info
 **/node_modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,7 @@ jobs:
       - name: Verify generated dist is not tracked
         shell: bash
         run: |
-          tracked="$(git ls-files 'src/opensquilla/gateway/static/dist/**')"
+          tracked="$(git ls-files 'opensquilla-webui/dist/**' 'src/opensquilla/gateway/static/dist/**')"
           if [[ -n "${tracked}" ]]; then
             echo "ERROR: generated Web UI dist must not be committed:" >&2
             printf '%s\n' "${tracked}" >&2
@@ -343,11 +343,15 @@ jobs:
           # strips harmless Finder metadata before the manifest is written.
           printf 'CI-only Finder metadata\n' > public/.DS_Store
           npm run build:artifact
-          if [[ -e ../src/opensquilla/gateway/static/dist/.DS_Store ]]; then
+          if [[ -e dist/.DS_Store || -e ../src/opensquilla/gateway/static/dist/.DS_Store ]]; then
             echo "ERROR: Finder metadata survived WebUI artifact normalization" >&2
             exit 1
           fi
           npm run verify:release-dist
+
+      - name: Verify staged backend copy
+        working-directory: opensquilla-webui
+        run: node scripts/stage-dist.mjs --check
 
       - name: Upload verified frontend artifact
         uses: actions/upload-artifact@v4
@@ -355,7 +359,7 @@ jobs:
           # Stable across rerun attempts: "re-run failed jobs" does not rerun
           # an already-successful producer, so consumers must reuse its name.
           name: opensquilla-webui-dist
-          path: src/opensquilla/gateway/static/dist/
+          path: opensquilla-webui/dist/
           if-no-files-found: error
           # GitHub permits reruns for 30 days; keep the producer artifact for
           # the full window so a failed-only consumer rerun can still reuse it.
@@ -381,10 +385,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: opensquilla-webui-dist
-          path: src/opensquilla/gateway/static/dist/
+          path: opensquilla-webui/dist/
 
       - name: Set up Node.js
-        if: ${{ contains(fromJSON(needs.plan-ci.outputs.required_suites), 'frontend-validation') }}
         uses: actions/setup-node@v4
         with:
           node-version-file: opensquilla-webui/.node-version
@@ -395,6 +398,10 @@ jobs:
         if: ${{ contains(fromJSON(needs.plan-ci.outputs.required_suites), 'frontend-validation') }}
         working-directory: opensquilla-webui
         run: npm ci
+
+      - name: Stage verified frontend artifact for Python consumers
+        working-directory: opensquilla-webui
+        run: node scripts/stage-dist.mjs
 
       - name: Set up Python for Contract generation
         if: ${{ contains(fromJSON(needs.plan-ci.outputs.required_suites), 'frontend-validation') }}
@@ -499,6 +506,7 @@ jobs:
           fi
           python scripts/verify_webui_artifact.py \
             --forbid-personal-bgm \
+            --dist src/opensquilla/gateway/static/dist \
             --wheel "${wheels[0]}"
 
   gateway-contract-windows:
@@ -580,7 +588,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: opensquilla-webui-dist
-          path: src/opensquilla/gateway/static/dist/
+          path: opensquilla-webui/dist/
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -605,6 +613,10 @@ jobs:
       - name: Install frontend dependencies
         working-directory: opensquilla-webui
         run: npm ci
+
+      - name: Stage verified frontend artifact for Gateway
+        working-directory: opensquilla-webui
+        run: node scripts/stage-dist.mjs
 
       - name: Resolve Playwright browser revision
         id: playwright-browser
@@ -1265,7 +1277,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: opensquilla-webui-dist
-          path: src/opensquilla/gateway/static/dist/
+          path: opensquilla-webui/dist/
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -1286,9 +1298,13 @@ jobs:
             desktop/electron/package-lock.json
             opensquilla-webui/package-lock.json
 
+      - name: Stage verified frontend artifact for Desktop
+        working-directory: opensquilla-webui
+        run: node scripts/stage-dist.mjs
+
       - name: Verify downloaded frontend artifact on consumer OS
         shell: bash
-        run: node opensquilla-webui/scripts/verify-dist.mjs src/opensquilla/gateway/static/dist
+        run: node opensquilla-webui/scripts/verify-dist.mjs opensquilla-webui/dist
 
       - name: Restore Electron binary cache
         id: electron-cache

--- a/.github/workflows/wheelhouse-release.yml
+++ b/.github/workflows/wheelhouse-release.yml
@@ -30,6 +30,8 @@ jobs:
     name: Build verified Web UI artifact
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    outputs:
+      webui_mode: ${{ steps.webui-contract.outputs.mode }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,8 +46,16 @@ jobs:
           set -euo pipefail
           if [[ -f opensquilla-webui/.node-version \
              && -f opensquilla-webui/package-lock.json \
-             && -f opensquilla-webui/scripts/verify-dist.mjs ]]; then
+             && -f opensquilla-webui/scripts/verify-dist.mjs \
+             && -f opensquilla-webui/scripts/stage-dist.mjs ]]; then
             echo "mode=source-built" >> "${GITHUB_OUTPUT}"
+          elif [[ -f opensquilla-webui/.node-version \
+               && -f opensquilla-webui/package-lock.json \
+               && -f opensquilla-webui/scripts/verify-dist.mjs ]]; then
+            # Tags from the pre-staging era still build Vite directly into the
+            # Python package path. Keep those tags repairable without asking
+            # them to execute a script that did not exist at that revision.
+            echo "mode=legacy-source-built" >> "${GITHUB_OUTPUT}"
           elif [[ -f src/opensquilla/gateway/static/dist/index.html ]]; then
             # Tags created before generated artifacts were removed from Git
             # remain repairable through the documented existing-tag input.
@@ -56,7 +66,7 @@ jobs:
           fi
 
       - name: Set up Node.js
-        if: steps.webui-contract.outputs.mode == 'source-built'
+        if: steps.webui-contract.outputs.mode != 'legacy-committed'
         uses: actions/setup-node@v4
         with:
           node-version-file: opensquilla-webui/.node-version
@@ -64,12 +74,12 @@ jobs:
           cache-dependency-path: opensquilla-webui/package-lock.json
 
       - name: Install Web UI dependencies
-        if: steps.webui-contract.outputs.mode == 'source-built'
+        if: steps.webui-contract.outputs.mode != 'legacy-committed'
         working-directory: opensquilla-webui
         run: npm ci
 
       - name: Build and verify Web UI
-        if: steps.webui-contract.outputs.mode == 'source-built'
+        if: steps.webui-contract.outputs.mode != 'legacy-committed'
         working-directory: opensquilla-webui
         run: |
           npm run build
@@ -103,10 +113,24 @@ jobs:
           print("Validated legacy committed Web UI artifact")
           PY
 
-      - name: Upload Web UI artifact
+      - name: Upload source-owned Web UI artifact
+        if: steps.webui-contract.outputs.mode == 'source-built'
         uses: actions/upload-artifact@v4
         with:
-          # Keep the name stable when only failed consumer jobs are rerun.
+          # The source-owned directory is the hand-off boundary; consumers
+          # explicitly stage it into the Python package.
+          name: opensquilla-release-webui-dist
+          path: opensquilla-webui/dist/
+          if-no-files-found: error
+          retention-days: 31
+          overwrite: true
+
+      - name: Upload legacy Web UI artifact
+        if: steps.webui-contract.outputs.mode != 'source-built'
+        uses: actions/upload-artifact@v4
+        with:
+          # Existing tags may still contain a committed artifact. Keep that
+          # repair path compatible while new builds use opensquilla-webui/dist.
           name: opensquilla-release-webui-dist
           path: src/opensquilla/gateway/static/dist/
           if-no-files-found: error
@@ -139,7 +163,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: opensquilla-release-webui-dist
-          path: src/opensquilla/gateway/static/dist/
+          path: ${{ needs.build-control-ui.outputs.webui_mode == 'source-built' && 'opensquilla-webui/dist/' || 'src/opensquilla/gateway/static/dist/' }}
 
       - name: Hydrate router assets
         shell: bash
@@ -174,8 +198,18 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up Node.js for Web UI staging
+        if: needs.build-control-ui.outputs.webui_mode == 'source-built'
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: opensquilla-webui/.node-version
+
       - name: Install uv
         run: python -m pip install uv
+
+      - name: Stage verified Web UI artifact for packaging
+        if: needs.build-control-ui.outputs.webui_mode == 'source-built'
+        run: node opensquilla-webui/scripts/stage-dist.mjs
 
       - name: Check tag version
         if: ${{ github.event_name == 'push' || github.event.inputs.tag != '' }}
@@ -217,6 +251,7 @@ jobs:
           if [[ -f scripts/verify_webui_artifact.py ]]; then
             python scripts/verify_webui_artifact.py \
               --forbid-personal-bgm \
+              --dist src/opensquilla/gateway/static/dist \
               --wheel "${wheels[0]}"
           else
             WHEEL_PATH="${wheels[0]}" python - <<'PY'
@@ -328,7 +363,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: opensquilla-release-webui-dist
-          path: src/opensquilla/gateway/static/dist/
+          path: ${{ needs.build-control-ui.outputs.webui_mode == 'source-built' && 'opensquilla-webui/dist/' || 'src/opensquilla/gateway/static/dist/' }}
 
       - name: Hydrate router assets
         run: git lfs pull --include="src/opensquilla/squilla_router/models/**"
@@ -349,6 +384,10 @@ jobs:
           node-version: "22.12.0"
           cache: npm
           cache-dependency-path: desktop/electron/package-lock.json
+
+      - name: Stage verified Web UI artifact for Desktop
+        if: needs.build-control-ui.outputs.webui_mode == 'source-built'
+        run: node opensquilla-webui/scripts/stage-dist.mjs
 
       - name: Install Electron dependencies
         working-directory: desktop/electron
@@ -459,7 +498,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: opensquilla-release-webui-dist
-          path: src/opensquilla/gateway/static/dist/
+          path: ${{ needs.build-control-ui.outputs.webui_mode == 'source-built' && 'opensquilla-webui/dist/' || 'src/opensquilla/gateway/static/dist/' }}
 
       - name: Hydrate router assets
         shell: bash
@@ -481,6 +520,10 @@ jobs:
           node-version: "22.12.0"
           cache: npm
           cache-dependency-path: desktop/electron/package-lock.json
+
+      - name: Stage verified Web UI artifact for Desktop
+        if: needs.build-control-ui.outputs.webui_mode == 'source-built'
+        run: node opensquilla-webui/scripts/stage-dist.mjs
 
       - name: Install Electron dependencies
         working-directory: desktop/electron

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,9 +74,10 @@ npm --prefix opensquilla-webui run build
 uv build --wheel
 ```
 
-The Web UI build writes an ignored package artifact that `uv build --wheel`
-validates and embeds. Rebuild it after frontend changes; do not commit the
-generated `src/opensquilla/gateway/static/dist/` tree.
+The Web UI build writes the source-owned artifact under
+`opensquilla-webui/dist/`, then explicitly stages the verified bytes into the
+ignored package copy that `uv build --wheel` validates and embeds. Rebuild it
+after frontend changes; do not commit either generated tree.
 
 Default tests must be offline, deterministic, credential-free, and safe for forks. Do not add network, provider, browser, or channel requirements to the default pull request path.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,10 @@ ARG OPENSQUILLA_FORBID_PERSONAL_BGM=0
 WORKDIR /build/opensquilla-webui
 
 # Cache dependency installation independently from application source. Vite
-# writes the verified bundle to /build/src/.../static/dist; the final Python
-# stage copies only that artifact, never Node.js or node_modules.
+# writes the verified bundle to /build/opensquilla-webui/dist; the build script
+# then explicitly stages the same bytes into /build/src/.../static/dist. The
+# final Python stage copies only that staged artifact, never Node.js or
+# node_modules.
 COPY opensquilla-webui/package.json opensquilla-webui/package-lock.json ./
 RUN --mount=type=cache,target=/root/.npm,sharing=locked npm ci
 COPY opensquilla-webui/ ./

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -24,8 +24,9 @@ It covers:
 ## Web UI dependencies and bundled fonts
 
 OpenSquilla builds the Vue Control UI from npm dependencies and locally bundled
-fonts. Release artifacts contain the generated browser assets under
-`src/opensquilla/gateway/static/dist/`; the dependency sources and exact
+fonts. Release artifacts contain the generated browser assets from the
+source-owned `opensquilla-webui/dist/` tree (staged into
+`src/opensquilla/gateway/static/dist/` for Python packages); the dependency sources and exact
 resolved versions are recorded by `opensquilla-webui/package.json` and
 `opensquilla-webui/package-lock.json`.
 

--- a/desktop/electron/README.md
+++ b/desktop/electron/README.md
@@ -26,10 +26,12 @@ npm ci
 npm run dev
 ```
 
-Use Node.js 22.12 or newer. The Vue build under
-`src/opensquilla/gateway/static/dist/` is generated and ignored by Git; local
-Desktop packaging verifies it against the current frontend source before
-PyInstaller runs.
+Use Node.js 22.12 or newer. Vite writes the Vue build under
+`opensquilla-webui/dist/`; `npm run build` then verifies and explicitly stages
+the same bytes under `src/opensquilla/gateway/static/dist/` for Python
+packaging. Both directories are generated and ignored by Git. Local Desktop
+packaging consumes the source-owned artifact and verifies it before PyInstaller
+runs.
 
 On first run, the shell opens a setup window for provider, model, base URL, and
 API key. The key is encrypted with Electron `safeStorage` when available, and a

--- a/desktop/electron/scripts/build-gateway.mjs
+++ b/desktop/electron/scripts/build-gateway.mjs
@@ -10,7 +10,10 @@ const runtimeGatewayDir = join(packageRoot, 'runtime', 'gateway')
 const pyinstallerWorkDir = join(packageRoot, '.pyinstaller')
 const entryPath = join(scriptDir, 'gateway-entry.py')
 const caRuntimeHookPath = join(scriptDir, 'pyinstaller_runtime_hooks', 'ensure_ca_trust.py')
-const controlUiDistDir = join(repoRoot, 'src', 'opensquilla', 'gateway', 'static', 'dist')
+// The WebUI package owns its generated output.  Desktop packaging consumes
+// that verified artifact and copies it to the shared runtime location below;
+// PyInstaller must not treat the Python source tree as a Vite output folder.
+const controlUiDistDir = join(repoRoot, 'opensquilla-webui', 'dist')
 const controlUiVerifier = join(repoRoot, 'opensquilla-webui', 'scripts', 'verify-dist.mjs')
 const routerBundleDir = join(repoRoot, 'src', 'opensquilla', 'squilla_router', 'models', 'v4.2_phase3_inference')
 const addDataSeparator = process.platform === 'win32' ? ';' : ':'
@@ -258,9 +261,8 @@ function externalizeControlUiArtifact() {
   cpSync(controlUiDistDir, sharedDistDir, { recursive: true })
 
   // --collect-all opensquilla is intentionally retained for the rest of the
-  // package data. PyInstaller therefore stages static/dist inside the frozen
-  // app first; remove only that duplicate after copying the verified artifact
-  // to the shared Desktop location.
+  // package data. The WebUI is deliberately not added to that collection: the
+  // verified artifact lives once at the shared Desktop location.
   for (const manifestPath of findFilesByName(runtimeGatewayDir, 'webui-artifact-manifest.json')) {
     const artifactDir = dirname(manifestPath)
     if (resolve(artifactDir) === resolve(sharedDistDir)) continue
@@ -369,8 +371,6 @@ const args = [
   caRuntimeHookPath,
   '--add-data',
   `${join(repoRoot, 'migrations')}${addDataSeparator}opensquilla/_migrations`,
-  '--add-data',
-  `${controlUiDistDir}${addDataSeparator}opensquilla/gateway/static/dist`,
   ...lightgbmBinaryArgs,
   ...macOpenMpBinaryArgs,
   entryPath,

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -1286,7 +1286,7 @@ function bootPagePath(): string {
 function desktopRendererDistPath(): string {
   return app.isPackaged
     ? join(packagedRuntimeRoot(), 'gateway', 'control-ui-dist')
-    : join(repoRoot, 'src', 'opensquilla', 'gateway', 'static', 'dist')
+    : join(repoRoot, 'opensquilla-webui', 'dist')
 }
 
 function desktopGatewayUnavailableResponse(): Response {

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -28,12 +28,13 @@ class CustomBuildHook(BuildHookInterface):
         sys.path.insert(0, str(root))
         try:
             from scripts.verify_webui_artifact import (
+                STAGED_DIST_RELATIVE,
                 verify_dist,
                 verify_sdist_source_inventory,
             )
 
             verify_dist(
-                root / "src/opensquilla/gateway/static/dist",
+                root / STAGED_DIST_RELATIVE,
                 webui_root=root / "opensquilla-webui",
                 # Source archives are easy to redistribute accidentally. Keep
                 # standard sdists privacy-safe even when a checkout contains

--- a/opensquilla-webui/package.json
+++ b/opensquilla-webui/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "npm run typecheck && npm run build:artifact",
-    "build:artifact": "vite build && node scripts/normalize-dist.mjs && node scripts/check-theme-bundle.mjs && node scripts/check-runtime-bundle.mjs && node scripts/verify-dist.mjs --write",
+    "build:artifact": "vite build && node scripts/normalize-dist.mjs && node scripts/check-theme-bundle.mjs && node scripts/check-runtime-bundle.mjs && node scripts/verify-dist.mjs --write && node scripts/stage-dist.mjs",
     "verify:dist": "node scripts/verify-dist.mjs",
     "verify:release-dist": "node scripts/verify-dist.mjs --forbid-personal-bgm",
     "preview": "vite preview",

--- a/opensquilla-webui/scripts/check-runtime-bundle.mjs
+++ b/opensquilla-webui/scripts/check-runtime-bundle.mjs
@@ -3,7 +3,7 @@ import { dirname, extname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
-const distDir = resolve(scriptDir, '../../src/opensquilla/gateway/static/dist')
+const distDir = resolve(scriptDir, '../dist')
 const assetsDir = resolve(distDir, 'assets')
 
 function javascriptFiles(root) {

--- a/opensquilla-webui/scripts/check-theme-bundle.mjs
+++ b/opensquilla-webui/scripts/check-theme-bundle.mjs
@@ -8,7 +8,8 @@ import { fileURLToPath } from 'node:url'
 // entry JS/CSS referenced by index.html), while still being emitted as their own
 // on-demand chunks. Run after `vite build`.
 const root = fileURLToPath(new URL('..', import.meta.url))
-const dist = join(root, '..', 'src', 'opensquilla', 'gateway', 'static', 'dist')
+// Vite owns the source artifact; packaging stages it explicitly afterwards.
+const dist = join(root, 'dist')
 const themesDir = join(root, 'src', 'themes')
 const indexHtml = join(dist, 'index.html')
 

--- a/opensquilla-webui/scripts/normalize-dist.mjs
+++ b/opensquilla-webui/scripts/normalize-dist.mjs
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
-const distDir = resolve(import.meta.dirname, '../../src/opensquilla/gateway/static/dist')
+const distDir = resolve(import.meta.dirname, '../dist')
 const textFilePattern = /\.(css|html|js|map)$/
 
 function normalizeNewlines(value) {

--- a/opensquilla-webui/scripts/stage-dist.mjs
+++ b/opensquilla-webui/scripts/stage-dist.mjs
@@ -1,0 +1,151 @@
+/**
+ * Copy one verified WebUI artifact into the backend package staging area.
+ *
+ * Vite owns `opensquilla-webui/dist`; the Python package never becomes a Vite
+ * build output.  This small, dependency-free seam is deliberately usable by
+ * local builds and every CI consumer (Linux, macOS, and Windows).
+ */
+
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs'
+import { dirname, relative, resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { verifyDist } from './verify-dist.mjs'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const webuiRoot = resolve(scriptDir, '..')
+const defaultSource = resolve(webuiRoot, 'dist')
+const defaultDestination = resolve(
+  webuiRoot,
+  '../src/opensquilla/gateway/static/dist',
+)
+
+function usage() {
+  return [
+    'usage: node stage-dist.mjs [--check] [--source <dir>] [--destination <dir>] [--webui-root <dir>]',
+    '',
+    'Verify the WebUI artifact in <source> and stage it for Python packaging.',
+  ].join('\n')
+}
+
+function parseArgs(argv) {
+  let source = defaultSource
+  let destination = defaultDestination
+  let sourceRoot = webuiRoot
+  let check = false
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--check') {
+      check = true
+      continue
+    }
+    if (arg === '--source' || arg === '--destination') {
+      const value = argv[index + 1]
+      if (!value) throw new Error(`${arg} requires a directory\n\n${usage()}`)
+      if (arg === '--source') source = resolve(value)
+      else destination = resolve(value)
+      index += 1
+      continue
+    }
+    if (arg === '--webui-root') {
+      const value = argv[index + 1]
+      if (!value) throw new Error(`${arg} requires a directory\n\n${usage()}`)
+      sourceRoot = resolve(value)
+      index += 1
+      continue
+    }
+    if (arg === '-h' || arg === '--help') {
+      console.log(usage())
+      process.exit(0)
+    }
+    throw new Error(`unknown argument: ${arg}\n\n${usage()}`)
+  }
+  return { source, destination, sourceRoot, check }
+}
+
+function assertDirectory(root, label) {
+  if (!existsSync(root) || !lstatSync(root).isDirectory()) {
+    throw new Error(`${label} directory is missing: ${root}`)
+  }
+}
+
+function listFiles(root) {
+  const files = []
+  function walk(directory) {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = resolve(directory, entry.name)
+      if (entry.isSymbolicLink() || lstatSync(path).isSymbolicLink()) {
+        throw new Error(`WebUI artifact must not contain symlinks: ${path}`)
+      }
+      if (entry.isDirectory()) walk(path)
+      else if (entry.isFile()) files.push(path)
+    }
+  }
+  walk(root)
+  return files.sort((left, right) => Buffer.compare(
+    Buffer.from(relative(root, left).split(sep).join('/'), 'utf8'),
+    Buffer.from(relative(root, right).split(sep).join('/'), 'utf8'),
+  ))
+}
+
+function bytesEqual(left, right) {
+  if (!existsSync(left) || !existsSync(right)) return false
+  const leftFiles = listFiles(left)
+  const rightFiles = listFiles(right)
+  if (leftFiles.length !== rightFiles.length) return false
+  for (let index = 0; index < leftFiles.length; index += 1) {
+    const leftRelative = relative(left, leftFiles[index]).split(sep).join('/')
+    const rightRelative = relative(right, rightFiles[index]).split(sep).join('/')
+    if (leftRelative !== rightRelative) return false
+    if (!readFileSync(leftFiles[index]).equals(readFileSync(rightFiles[index]))) {
+      return false
+    }
+  }
+  return true
+}
+
+function stage(source, destination, sourceRoot) {
+  // Keep the source and destination distinct.  A same-directory copy would
+  // silently make the staging contract meaningless.
+  if (resolve(source) === resolve(destination)) {
+    throw new Error(`WebUI source and staging destination must differ: ${source}`)
+  }
+  assertDirectory(source, 'WebUI artifact')
+  verifyDist(source, { sourceRoot })
+  mkdirSync(dirname(destination), { recursive: true })
+  rmSync(destination, { recursive: true, force: true })
+  cpSync(source, destination, { recursive: true, force: true, errorOnExist: false })
+  if (!bytesEqual(source, destination)) {
+    throw new Error(`staged WebUI artifact differs from source: ${destination}`)
+  }
+}
+
+function main(argv) {
+  const { source, destination, sourceRoot, check } = parseArgs(argv)
+  assertDirectory(source, 'WebUI artifact')
+  verifyDist(source, { sourceRoot })
+  if (check) {
+    if (!bytesEqual(source, destination)) {
+      throw new Error(`staged WebUI artifact is missing or stale: ${destination}`)
+    }
+    console.log(`WebUI artifact staging is current: ${destination}`)
+    return
+  }
+  stage(source, destination, sourceRoot)
+  console.log(`Staged verified WebUI artifact: ${source} -> ${destination}`)
+}
+
+try {
+  main(process.argv.slice(2))
+} catch (error) {
+  console.error(`stage-dist: ${error instanceof Error ? error.message : error}`)
+  process.exit(1)
+}

--- a/opensquilla-webui/scripts/verify-dist.mjs
+++ b/opensquilla-webui/scripts/verify-dist.mjs
@@ -15,10 +15,7 @@ export const MANIFEST_NAME = 'webui-artifact-manifest.json'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const webuiRoot = resolve(scriptDir, '..')
-const defaultDistDir = resolve(
-  scriptDir,
-  '../../src/opensquilla/gateway/static/dist',
-)
+const defaultDistDir = resolve(webuiRoot, 'dist')
 const sourceInputRoots = [
   '.node-version',
   '.env',
@@ -188,7 +185,7 @@ function referencedEntryAssets(indexHtml) {
   return references
 }
 
-export function writeManifest(distDir = defaultDistDir) {
+export function writeManifest(distDir = defaultDistDir, { sourceRoot = webuiRoot } = {}) {
   const root = resolve(distDir)
   for (const entry of ['index.html', 'desktop.html']) {
     if (!existsSync(resolve(root, entry))) {
@@ -197,7 +194,7 @@ export function writeManifest(distDir = defaultDistDir) {
   }
   const manifest = {
     schemaVersion: 1,
-    sourceFingerprint: sourceFingerprint(),
+    sourceFingerprint: sourceFingerprint(sourceRoot),
     files: recordsFor(root),
   }
   writeFileSync(
@@ -210,7 +207,7 @@ export function writeManifest(distDir = defaultDistDir) {
 
 export function verifyDist(
   distDir = defaultDistDir,
-  { forbidPersonalBgm = false } = {},
+  { forbidPersonalBgm = false, sourceRoot = webuiRoot } = {},
 ) {
   const root = resolve(distDir)
   const indexPath = resolve(root, 'index.html')
@@ -234,7 +231,7 @@ export function verifyDist(
   ) {
     throw new Error(`Unsupported Web UI artifact manifest: ${manifestPath}`)
   }
-  const currentSourceFingerprint = sourceFingerprint()
+  const currentSourceFingerprint = sourceFingerprint(sourceRoot)
   if (manifest.sourceFingerprint !== currentSourceFingerprint) {
     throw new Error(
       'Web UI artifact is stale for the current frontend source. Rebuild it with `npm run build`.',

--- a/opensquilla-webui/vite.config.ts
+++ b/opensquilla-webui/vite.config.ts
@@ -54,7 +54,10 @@ export default defineConfig({
     },
   },
   build: {
-    outDir: resolve(__dirname, '../src/opensquilla/gateway/static/dist'),
+    // Keep the generated artifact owned by the WebUI package.  Packaging and
+    // desktop jobs explicitly stage this verified directory into the Python
+    // package; Vite itself must not write into the backend source tree.
+    outDir: resolve(__dirname, 'dist'),
     emptyOutDir: true,
     sourcemap: true,
     rollupOptions: {

--- a/scripts/verify_webui_artifact.py
+++ b/scripts/verify_webui_artifact.py
@@ -16,7 +16,11 @@ MANIFEST_NAME = "webui-artifact-manifest.json"
 WHEEL_PREFIX = "opensquilla/gateway/static/dist/"
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_WEBUI_ROOT = REPOSITORY_ROOT / "opensquilla-webui"
-DEFAULT_DIST_DIR = REPOSITORY_ROOT / "src/opensquilla/gateway/static/dist"
+# The WebUI package owns the generated output.  ``src/.../static/dist`` is a
+# deliberately explicit staging destination used only by package builders and
+# runtime consumers; it is not a Vite build directory.
+DEFAULT_DIST_DIR = DEFAULT_WEBUI_ROOT / "dist"
+STAGED_DIST_RELATIVE = Path("src/opensquilla/gateway/static/dist")
 SOURCE_INPUT_ROOTS = (
     ".node-version",
     ".env",
@@ -355,7 +359,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         "--dist",
         type=Path,
         default=DEFAULT_DIST_DIR,
-        help="generated WebUI directory",
+        help="generated WebUI directory (defaults to opensquilla-webui/dist)",
     )
     parser.add_argument(
         "--webui-root",

--- a/tests/test_ci/test_bgm_asset_hygiene.py
+++ b/tests/test_ci/test_bgm_asset_hygiene.py
@@ -6,6 +6,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MUSIC_ROOTS = (
     "opensquilla-webui/public/music",
+    "opensquilla-webui/dist/music",
     "src/opensquilla/gateway/static/dist/music",
 )
 AUDIO_EXTENSIONS = ("mp3", "m4a", "ogg", "flac", "wav")

--- a/tests/test_ci/test_dockerignore_context.py
+++ b/tests/test_ci/test_dockerignore_context.py
@@ -51,6 +51,10 @@ def test_dockerignore_filters_real_build_context(tmp_path: Path) -> None:
         context / "src/opensquilla/gateway/static/dist/assets/stale-hash.js",
         "stale bundle\n",
     )
+    _write(
+        context / "opensquilla-webui/dist/assets/stale-hash.js",
+        "stale source bundle\n",
+    )
 
     # Nested dotfiles and private BGM remain supported inputs. The former is
     # harmless build metadata; the latter is deliberately allowed for local
@@ -88,3 +92,4 @@ def test_dockerignore_filters_real_build_context(tmp_path: Path) -> None:
     assert not (copied / "config/tls/server.pem").exists()
     assert not (copied / "config/tls/server.key").exists()
     assert not (copied / "src/opensquilla/gateway/static/dist").exists()
+    assert not (copied / "opensquilla-webui/dist").exists()

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -599,7 +599,10 @@ def test_ci_rejects_tracked_frontend_dist_and_builds_a_verified_artifact() -> No
     text = ci_path.read_text(encoding="utf-8")
 
     assert "Verify generated dist is not tracked" in text
-    assert "git ls-files 'src/opensquilla/gateway/static/dist/**'" in text
+    assert (
+        "git ls-files 'opensquilla-webui/dist/**' 'src/opensquilla/gateway/static/dist/**'"
+        in text
+    )
     assert "generated Web UI dist must not be committed" in text
     assert "Build verified frontend artifact" in text
     assert "> public/.DS_Store" in text
@@ -616,6 +619,8 @@ def test_ci_rejects_tracked_frontend_dist_and_builds_a_verified_artifact() -> No
     assert '--wheel "${wheels[0]}"' in text
     assert "Upload verified frontend artifact" in text
     assert "name: opensquilla-webui-dist" in text
+    assert "path: opensquilla-webui/dist/" in text
+    assert "Stage verified frontend artifact for Python consumers" in text
     assert "overwrite: true" in text
     workflow = _workflow("ci.yml")
     upload = next(
@@ -652,7 +657,9 @@ def test_ci_rejects_tracked_frontend_dist_and_builds_a_verified_artifact() -> No
     assert "npm run build\n" not in producer["run"]
     assert typecheck["run"] == "npm run typecheck"
     assert "'frontend-validation'" in typecheck["if"]
-    assert setup_node["if"] == typecheck["if"]
+    # Node is also needed to run the dependency-free staging seam when only
+    # the wheel round-trip suite is selected.
+    assert "if" not in setup_node
     assert install_node["if"] == typecheck["if"]
     assert unit_tests["if"] == typecheck["if"]
     assert upload["with"]["retention-days"] >= 31
@@ -1293,8 +1300,7 @@ def test_desktop_recovery_e2e_runs_compiled_flows_on_all_release_platforms() -> 
     assert steps.index(download) < steps.index(setup_node) < steps.index(verify_frontend)
     assert verify_frontend["shell"] == "bash"
     assert verify_frontend["run"] == (
-        "node opensquilla-webui/scripts/verify-dist.mjs "
-        "src/opensquilla/gateway/static/dist"
+        "node opensquilla-webui/scripts/verify-dist.mjs opensquilla-webui/dist"
     )
     assert build["run"] == "npm run build"
     assert session_recovery["working-directory"] == "opensquilla-webui"
@@ -1716,7 +1722,13 @@ def test_webui_chat_recovery_runs_the_verified_dist_through_gateway() -> None:
 
     assert job["needs"] == ["plan-ci", "frontend-artifact"]
     assert download["with"]["name"] == "opensquilla-webui-dist"
-    assert download["with"]["path"] == "src/opensquilla/gateway/static/dist/"
+    assert download["with"]["path"] == "opensquilla-webui/dist/"
+    stage = next(
+        step
+        for step in steps
+        if step.get("name") == "Stage verified frontend artifact for Gateway"
+    )
+    assert stage["working-directory"] == "opensquilla-webui"
     assert steps.index(download) < steps.index(install_gateway) < steps.index(run)
     assert install_gateway["run"] == "uv sync --frozen"
     assert job["env"]["OPENSQUILLA_PLAYWRIGHT_MANAGE_WEBUI"] == "gateway"
@@ -2088,7 +2100,11 @@ def test_release_jobs_share_one_rerun_stable_verified_webui_artifact() -> None:
     jobs = workflow["jobs"]
     artifact_name = "opensquilla-release-webui-dist"
     build_steps = jobs["build-control-ui"]["steps"]
-    upload = next(step for step in build_steps if step.get("name") == "Upload Web UI artifact")
+    upload = next(
+        step
+        for step in build_steps
+        if step.get("name") == "Upload source-owned Web UI artifact"
+    )
     release_build = next(
         step for step in build_steps if step.get("name") == "Build and verify Web UI"
     )
@@ -2100,14 +2116,20 @@ def test_release_jobs_share_one_rerun_stable_verified_webui_artifact() -> None:
     )
 
     assert upload["with"]["name"] == artifact_name
+    assert upload["with"]["path"] == "opensquilla-webui/dist/"
     assert upload["with"]["if-no-files-found"] == "error"
     assert upload["with"]["retention-days"] >= 31
     assert upload["with"]["overwrite"] is True
     assert "npm run verify:release-dist" in release_build["run"]
-    assert release_build["if"] == "steps.webui-contract.outputs.mode == 'source-built'"
+    assert release_build["if"] == "steps.webui-contract.outputs.mode != 'legacy-committed'"
     assert "legacy-committed" in detect["run"]
+    assert "legacy-source-built" in detect["run"]
+    assert "scripts/stage-dist.mjs" in detect["run"]
     assert "src/opensquilla/gateway/static/dist/index.html" in detect["run"]
     assert legacy["if"] == "steps.webui-contract.outputs.mode == 'legacy-committed'"
+    assert jobs["build-control-ui"]["outputs"]["webui_mode"] == (
+        "${{ steps.webui-contract.outputs.mode }}"
+    )
     assert 'data.get("tracks") == []' in legacy["run"]
     for job_name in (
         "build-release-assets",
@@ -2121,10 +2143,17 @@ def test_release_jobs_share_one_rerun_stable_verified_webui_artifact() -> None:
             for step in job["steps"]
             if step.get("name") == "Download verified Web UI artifact"
         )
-        assert download["with"] == {
-            "name": artifact_name,
-            "path": "src/opensquilla/gateway/static/dist/",
-        }
+        assert download["with"]["name"] == artifact_name
+        assert "needs.build-control-ui.outputs.webui_mode" in download["with"]["path"]
+        assert "opensquilla-webui/dist/" in download["with"]["path"]
+        assert "src/opensquilla/gateway/static/dist/" in download["with"]["path"]
+        stage = next(
+            step
+            for step in job["steps"]
+            if step.get("name") == "Stage verified Web UI artifact for packaging"
+            or step.get("name") == "Stage verified Web UI artifact for Desktop"
+        )
+        assert stage["if"] == "needs.build-control-ui.outputs.webui_mode == 'source-built'"
 
     all_uploads = [
         step

--- a/tests/test_compose_yaml_shape.py
+++ b/tests/test_compose_yaml_shape.py
@@ -88,6 +88,7 @@ def test_dockerignore_prevents_stale_webui_and_nested_secrets_from_entering_cont
 
     assert {
         "src/opensquilla/gateway/static/dist",
+        "dist",
         ".env*",
         "**/.env*",
         ".npmrc",

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -2726,6 +2726,7 @@ def test_desktop_gateway_build_and_verifier_cover_runtime_capabilities() -> None
     assert "assertRuntimeSetReady" not in build_gateway
     assert "fetch-bundled-runtimes.mjs" not in build_gateway
     assert "function externalizeControlUiArtifact()" in build_gateway
+    assert "join(repoRoot, 'opensquilla-webui', 'dist')" in build_gateway
     assert "join(runtimeGatewayDir, 'control-ui-dist')" in build_gateway
     assert "cpSync(controlUiDistDir, sharedDistDir" in build_gateway
     assert "exactly one shared Web UI artifact" in build_gateway

--- a/tests/test_packaging/test_pyproject_invariants.py
+++ b/tests/test_packaging/test_pyproject_invariants.py
@@ -7,6 +7,7 @@ is also a user-visible install contract.
 
 from __future__ import annotations
 
+import json
 import tomllib
 from pathlib import Path
 
@@ -167,6 +168,20 @@ def test_standard_distributions_require_verified_generated_webui() -> None:
     ]
     assert (PYPROJECT.parent / "hatch_build.py").is_file()
     assert (PYPROJECT.parent / "scripts" / "verify_webui_artifact.py").is_file()
+    assert (PYPROJECT.parent / "opensquilla-webui" / "scripts" / "stage-dist.mjs").is_file()
+
+
+def test_webui_build_owns_dist_and_stages_the_package_copy() -> None:
+    vite = (PYPROJECT.parent / "opensquilla-webui" / "vite.config.ts").read_text(
+        encoding="utf-8"
+    )
+    package = json.loads(
+        (PYPROJECT.parent / "opensquilla-webui" / "package.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert "outDir: resolve(__dirname, 'dist')" in vite
+    assert "scripts/stage-dist.mjs" in package["scripts"]["build:artifact"]
 
 
 def test_homebrew_head_install_builds_the_generated_webui_before_python() -> None:

--- a/tests/test_scripts/test_stage_webui_artifact.py
+++ b/tests/test_scripts/test_stage_webui_artifact.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.verify_webui_artifact import source_fingerprint
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STAGER = REPO_ROOT / "opensquilla-webui" / "scripts" / "stage-dist.mjs"
+
+
+def _write_manifest(webui_root: Path, dist: Path) -> None:
+    records = []
+    for path in sorted(dist.rglob("*")):
+        if not path.is_file() or path.name == "webui-artifact-manifest.json":
+            continue
+        content = path.read_bytes()
+        records.append(
+            {
+                "path": path.relative_to(dist).as_posix(),
+                "size": len(content),
+                "sha256": hashlib.sha256(content).hexdigest(),
+            }
+        )
+    records.sort(key=lambda item: item["path"].encode("utf-8"))
+    (dist / "webui-artifact-manifest.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "sourceFingerprint": source_fingerprint(webui_root),
+                "files": records,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_stage_dist_copies_verified_source_owned_artifact(tmp_path: Path) -> None:
+    webui = tmp_path / "opensquilla-webui"
+    source = webui / "dist"
+    staged = tmp_path / "src/opensquilla/gateway/static/dist"
+    (webui / "src").mkdir(parents=True)
+    (webui / ".node-version").write_text("22.12.0\n", encoding="utf-8")
+    (webui / "package.json").write_text("{}\n", encoding="utf-8")
+    (webui / "src/App.vue").write_text("<template>probe</template>\n", encoding="utf-8")
+    (source / "assets").mkdir(parents=True)
+    (source / "index.html").write_text(
+        '<script type="module" src="assets/app.js"></script>'
+        '<link rel="stylesheet" href="assets/app.css">',
+        encoding="utf-8",
+    )
+    (source / "desktop.html").write_text(
+        '<script type="module" src="assets/app.js"></script>'
+        '<link rel="stylesheet" href="assets/app.css">',
+        encoding="utf-8",
+    )
+    (source / "assets/app.js").write_text("export {};\n", encoding="utf-8")
+    (source / "assets/app.css").write_text("body{}\n", encoding="utf-8")
+    _write_manifest(webui, source)
+
+    result = subprocess.run(
+        [
+            "node",
+            str(STAGER),
+            "--source",
+            str(source),
+            "--destination",
+            str(staged),
+            "--webui-root",
+            str(webui),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert staged.is_dir()
+    assert (staged / "webui-artifact-manifest.json").read_bytes() == (
+        source / "webui-artifact-manifest.json"
+    ).read_bytes()
+
+    check = subprocess.run(
+        [
+            "node",
+            str(STAGER),
+            "--check",
+            "--source",
+            str(source),
+            "--destination",
+            str(staged),
+            "--webui-root",
+            str(webui),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert check.returncode == 0, check.stderr
+
+    # A real stage replaces the destination, so files removed from the source
+    # cannot survive in the package copy.  This protects wheel builds from a
+    # stale asset left by an earlier Vite build.
+    stale_asset = staged / "assets/removed-by-next-build.js"
+    stale_asset.write_text("stale\n", encoding="utf-8")
+    restage = subprocess.run(
+        [
+            "node",
+            str(STAGER),
+            "--source",
+            str(source),
+            "--destination",
+            str(staged),
+            "--webui-root",
+            str(webui),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert restage.returncode == 0, restage.stderr
+    assert not stale_asset.exists()
+
+    (staged / "assets/app.js").write_text("export { changed };\n", encoding="utf-8")
+    stale = subprocess.run(
+        [
+            "node",
+            str(STAGER),
+            "--check",
+            "--source",
+            str(source),
+            "--destination",
+            str(staged),
+            "--webui-root",
+            str(webui),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert stale.returncode != 0
+    assert "missing or stale" in stale.stderr
+
+    # The manifest binds the artifact to the exact source tree.  A consumer
+    # must reject a source/stage pair that no longer belongs together.
+    (webui / "src/App.vue").write_text("<template>changed</template>\n", encoding="utf-8")
+    source_stale = subprocess.run(
+        [
+            "node",
+            str(STAGER),
+            "--check",
+            "--source",
+            str(source),
+            "--destination",
+            str(staged),
+            "--webui-root",
+            str(webui),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert source_stale.returncode != 0
+    assert "stale for the current frontend source" in source_stale.stderr


### PR DESCRIPTION
## Summary

- make `opensquilla-webui/dist/` the Vite-owned generated artifact
- add a dependency-free, verified staging seam to copy the artifact into the Python package only when packaging/runtime consumers need it
- update CI, release, Docker, Hatch, and Electron consumers while preserving `/static/dist`, artifact names, and legacy release-tag repair
- add source/staged byte-equivalence, stale cleanup, and workflow/package contract tests

## What this changes

The WebUI build no longer writes directly into the backend source tree. `npm run build` still produces the package-ready result by running `stage-dist.mjs` after normalization and verification, so source installs and local wheel builds keep their existing behavior. CI and release jobs upload the source-owned artifact and explicitly stage it in each consumer job. Existing artifact names (`opensquilla-webui-dist` and `opensquilla-release-webui-dist`) are unchanged for rerun compatibility.

Electron development reads `opensquilla-webui/dist`; packaged Electron continues to consume exactly one verified `runtime/gateway/control-ui-dist` copy. The Gateway URL and `OPENSQUILLA_CONTROL_UI_DIST` resolver are unchanged. Release tags from before this seam are handled explicitly: pre-staging source-built tags keep their historical backend output, while older committed-artifact tags upload/download `src/opensquilla/gateway/static/dist`; neither path invokes a script that did not exist at that revision.

No RPC, transport, Gateway business implementation, database, or application runtime behavior is changed.

## Validation

- `npm run build:artifact`
- `npm run typecheck`
- `actionlint .github/workflows/ci.yml .github/workflows/wheelhouse-release.yml`
- 274 targeted Python tests (including staging, packaging, workflow, Electron, and Gateway static tests)
- verified wheel and sdist-to-wheel WebUI artifact round trips with the pinned Hatch toolchain

The commit is based directly on the current `origin/main` (`e476608f1ecefb48e4105f607c7c25568bed1280`), which includes S12-C3. The PR was re-anchored after that merge; its diff against `main` remains limited to the WebUI artifact path and its consumers.
