### PR TITLE
refactor(webui): extract bootstrap queue coordination

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatSessionBootstrap.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionBootstrap.ts
@@ -15,33 +15,21 @@ import {
   type SessionPhaseResult,
 } from '@/composables/chat/sessionBootstrapContract'
 import {
+  createConversationBootstrapCriticalQueue,
   createConversationBootstrapPhase,
   createConversationBootstrapCoordinator,
+  rearmConversationBootstrapCriticalQueue,
   type ConversationBootstrapPhase,
+  type ConversationBootstrapCriticalQueue,
   type ConversationBootstrapHandoffOutcome,
   type ConversationBootstrapRunToken,
+  waitForConversationBootstrapRetry,
 } from '@/modules/conversationBootstrapCoordinator'
 
 type PhaseRuntime<T> = ConversationBootstrapPhase<T>
 
-interface CriticalRequestQueue {
-  promise: Promise<void>
-  resolve: () => void
-  released: boolean
-  historyRequired: boolean
-  liveSocketGeneration: number | null
-  historySocketGeneration: number | null
-  liveTerminal: boolean
-  historyTerminal: boolean
-}
-
 interface ActiveBootstrapState {
-  criticalQueue: CriticalRequestQueue
-  liveQueueSequence: number
-  liveQueueWaiters: Set<{
-    minimum: number
-    resolve: (ready: boolean) => void
-  }>
+  criticalQueue: ConversationBootstrapCriticalQueue
   freshLiveOutageForHistoryRetry: boolean
   awaitingReplacementConnection: boolean
   lateReplacementRecoveryUsed: boolean
@@ -155,49 +143,12 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
     }
   }
 
-  function releaseCriticalRequestsIfReady(run: ActiveBootstrap) {
-    const queue = run.criticalQueue
-    if (queue.released) return
-    const liveQueued = queue.liveSocketGeneration !== null
-    const historyQueued = (
-      !queue.historyRequired
-      || queue.historySocketGeneration !== null
-    )
-    const queuedOnSameSocket = (
-      liveQueued
-      && historyQueued
-      && (
-        !queue.historyRequired
-        || queue.liveSocketGeneration === queue.historySocketGeneration
-      )
-    )
-    const terminalWithoutQueue = (
-      (queue.liveTerminal || (queue.historyRequired && queue.historyTerminal))
-      && (liveQueued || queue.liveTerminal)
-      && (
-        !queue.historyRequired
-        || historyQueued
-        || queue.historyTerminal
-      )
-    )
-    if (!queuedOnSameSocket && !terminalWithoutQueue) return
-    queue.released = true
-    queue.resolve()
-  }
-
   function markLiveSubscribeSent(
     run: ActiveBootstrap,
     socketGeneration: number,
   ) {
     if (!isCurrent(run)) return
-    run.criticalQueue.liveSocketGeneration = socketGeneration
-    run.liveQueueSequence += 1
-    for (const waiter of [...run.liveQueueWaiters]) {
-      if (run.liveQueueSequence < waiter.minimum) continue
-      run.liveQueueWaiters.delete(waiter)
-      waiter.resolve(true)
-    }
-    releaseCriticalRequestsIfReady(run)
+    run.criticalQueue.markLiveSubscribeSent(socketGeneration)
     tryRecoverHistoryOnLateReplacement(run)
   }
 
@@ -206,39 +157,7 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
     socketGeneration: number,
   ) {
     if (!isCurrent(run)) return
-    run.criticalQueue.historySocketGeneration = socketGeneration
-    releaseCriticalRequestsIfReady(run)
-  }
-
-  async function waitForLiveSubscribeSent(
-    run: ActiveBootstrap,
-    minimum: number,
-    deadlineAt: number,
-  ): Promise<boolean> {
-    if (!isCurrent(run)) return false
-    if (run.liveQueueSequence >= minimum) return true
-    const remaining = deadlineAt - Date.now()
-    if (remaining <= 0) return false
-    return new Promise(resolve => {
-      let settled = false
-      const waiter = {
-        minimum,
-        resolve: (ready: boolean) => finish(ready),
-      }
-      const finish = (ready: boolean) => {
-        if (settled) return
-        settled = true
-        clearTimeout(timer)
-        run.controller.signal.removeEventListener('abort', onAbort)
-        run.liveQueueWaiters.delete(waiter)
-        resolve(ready)
-      }
-      const onAbort = () => finish(false)
-      const timer = setTimeout(() => finish(false), remaining)
-      run.liveQueueWaiters.add(waiter)
-      run.controller.signal.addEventListener('abort', onAbort, { once: true })
-      if (run.liveQueueSequence >= minimum) finish(true)
-    })
+    run.criticalQueue.markHistoryRequestSent(socketGeneration)
   }
 
   function requiresFreshLiveQueue(error: unknown): boolean {
@@ -251,27 +170,16 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
     )
   }
 
-  async function waitBeforeRetry(
+  function waitBeforeRetry(
     error: unknown,
     run: ActiveBootstrap,
     deadlineAt: number,
   ): Promise<boolean> {
-    const remaining = deadlineAt - Date.now()
-    if (remaining <= 0 || !isCurrent(run)) return false
-    const delayMs = Math.min(retryAfterMs(error), remaining)
-    if (delayMs <= 0) return true
-    return new Promise(resolve => {
-      let settled = false
-      const finish = (ready: boolean) => {
-        if (settled) return
-        settled = true
-        clearTimeout(timer)
-        run.controller.signal.removeEventListener('abort', onAbort)
-        resolve(ready)
-      }
-      const onAbort = () => finish(false)
-      const timer = setTimeout(() => finish(isCurrent(run)), delayMs)
-      run.controller.signal.addEventListener('abort', onAbort, { once: true })
+    return waitForConversationBootstrapRetry({
+      delayMs: retryAfterMs(error),
+      deadlineAt,
+      signal: run.controller.signal,
+      isCurrent: () => isCurrent(run),
     })
   }
 
@@ -297,17 +205,18 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
         ok: false,
         error: new RpcTimeoutError('chat.history', 0),
       }
-      let requiredLiveQueueSequence = Math.max(1, run.liveQueueSequence)
+      let requiredLiveQueueSequence = Math.max(1, run.criticalQueue.liveQueueSequence)
       while (phase.attempts < maxAttempts && isCurrent(run)) {
         if (Date.now() >= phase.deadlineAt) break
-        if (!await waitForLiveSubscribeSent(
-          run,
+        if (!await run.criticalQueue.waitForLiveSubscribeSent(
           requiredLiveQueueSequence,
           phase.deadlineAt,
+          run.controller.signal,
+          () => isCurrent(run),
         )) {
           break
         }
-        const liveQueueSequenceForAttempt = run.liveQueueSequence
+        const liveQueueSequenceForAttempt = run.criticalQueue.liveQueueSequence
         const attempt = phase.attempts as 0 | 1
         phase.attempts += 1
         const context = contextFor(run, phase, attempt)
@@ -348,8 +257,7 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
     }).finally(() => {
       // A disconnected or exhausted phase may terminate before it can send.
       // Optional UI traffic must not remain globally blocked in that case.
-      run.criticalQueue.historyTerminal = true
-      releaseCriticalRequestsIfReady(run)
+      run.criticalQueue.markHistoryTerminal()
       phase.running = false
       tryRecoverHistoryOnLateReplacement(run)
     })
@@ -404,59 +312,15 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
     })().finally(() => {
       // Match the history fallback above: failure to queue a critical request
       // is terminal for this attempt, not a reason to freeze the whole app.
-      run.criticalQueue.liveTerminal = true
-      releaseCriticalRequestsIfReady(run)
+      run.criticalQueue.markLiveTerminal()
       phase.running = false
     })
     return phase.promise
   }
 
-  function createCriticalQueue(
-    historyRequired: boolean,
-    liveSocketGeneration: number | null = null,
-  ): CriticalRequestQueue {
-    let resolve = () => {}
-    const promise = new Promise<void>(done => {
-      resolve = done
-    })
-    return {
-      promise,
-      resolve,
-      released: false,
-      historyRequired,
-      liveSocketGeneration,
-      historySocketGeneration: null,
-      liveTerminal: false,
-      historyTerminal: !historyRequired,
-    }
-  }
-
-  function rearmCriticalQueue(
-    run: ActiveBootstrap,
-    historyRequired: boolean,
-    liveSocketGeneration: number | null = null,
-  ) {
-    const previousQueue = run.criticalQueue
-    const replacementQueue = createCriticalQueue(
-      historyRequired,
-      liveSocketGeneration,
-    )
-    run.criticalQueue = replacementQueue
-    // Existing consumers hold the previous promise. Keep it pending across a
-    // same-run reconnect and release it only after the replacement socket has
-    // queued its critical frames. Repeated reconnects form a chain to the
-    // newest epoch; cancellation resolves the current epoch and unwinds it.
-    void replacementQueue.promise.then(() => {
-      previousQueue.released = true
-      previousQueue.resolve()
-    })
-  }
-
   function createRun(key: string, includeHistory: boolean): ActiveBootstrap {
     const run = ownership.start(key, includeHistory, token => ({
-      criticalQueue: createCriticalQueue(includeHistory),
-      liveQueueSequence: 0,
-      liveQueueWaiters: new Set(),
+      criticalQueue: createConversationBootstrapCriticalQueue(includeHistory),
       freshLiveOutageForHistoryRetry: false,
       awaitingReplacementConnection: false,
       lateReplacementRecoveryUsed: false,
@@ -505,7 +369,11 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
         const liveSocketGeneration =
           active.criticalQueue.liveSocketGeneration
         active.includeHistory = true
-        rearmCriticalQueue(active, true, liveSocketGeneration)
+        active.criticalQueue = rearmConversationBootstrapCriticalQueue(
+          active.criticalQueue,
+          true,
+          liveSocketGeneration,
+        )
         active.history = historyRuntime(active.live.deadlineAt)
         active.history.promise = runHistoryPhase(active, false)
       }
@@ -590,7 +458,11 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
     run.lateReplacementHistoryRecoveryUsed = true
     run.lateReplacementHistoryRecoveryPhase = null
     resetHistoryPhaseForRetry(run)
-    rearmCriticalQueue(run, true, liveSocketGeneration)
+    run.criticalQueue = rearmConversationBootstrapCriticalQueue(
+      run.criticalQueue,
+      true,
+      liveSocketGeneration,
+    )
     run.history.promise = runHistoryPhase(run, true, 1)
   }
 
@@ -610,9 +482,7 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
     const cancelled = ownership.cancel() ?? active
     active = null
     if (cancelled) {
-      cancelled.criticalQueue.resolve()
-      for (const waiter of cancelled.liveQueueWaiters) waiter.resolve(false)
-      cancelled.liveQueueWaiters.clear()
+      cancelled.criticalQueue.cancel()
     }
     options.cancelHistory()
     options.cancelSubscription()
@@ -669,8 +539,8 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
         const liveWillRecover = run.live.running || liveWasReady
         if (liveWillRecover) {
           run.awaitingReplacementConnection = true
-          rearmCriticalQueue(
-            run,
+          run.criticalQueue = rearmConversationBootstrapCriticalQueue(
+            run.criticalQueue,
             run.includeHistory && run.history.running,
           )
           livePhase.value = 'connecting'
@@ -734,7 +604,10 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
           )
         ) return
         run.lateReplacementRecoveryUsed = true
-        rearmCriticalQueue(run, false)
+        run.criticalQueue = rearmConversationBootstrapCriticalQueue(
+          run.criticalQueue,
+          false,
+        )
         // This is a continuation of the same outage, not a user-initiated
         // retry. Grant exactly one attempt on the authenticated socket. The
         // connected event can win a route-switch race before the new run sees
@@ -771,7 +644,10 @@ export function useChatSessionBootstrap(options: UseChatSessionBootstrapOptions)
       // Keep an independently terminal history phase intact: restarting the
       // whole bootstrap here can hide its actionable error behind a fresh
       // loading state while replacement sockets continue to arrive.
-      rearmCriticalQueue(run, false)
+      run.criticalQueue = rearmConversationBootstrapCriticalQueue(
+        run.criticalQueue,
+        false,
+      )
       resetLivePhaseForManualRetry(run)
       run.live.promise = runLivePhase(run)
       armHistoryRecoveryForLateReplacement(run)

--- a/opensquilla-webui/src/modules/conversationBootstrapCoordinator.test.ts
+++ b/opensquilla-webui/src/modules/conversationBootstrapCoordinator.test.ts
@@ -1,12 +1,19 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  createConversationBootstrapCriticalQueue,
   createConversationBootstrapPhase,
   createConversationBootstrapCoordinator,
+  rearmConversationBootstrapCriticalQueue,
   type ConversationBootstrapRunToken,
+  waitForConversationBootstrapRetry,
 } from './conversationBootstrapCoordinator'
 
 type Run = ConversationBootstrapRunToken & { label: string }
+
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 function coordinator(now = 1_000) {
   return createConversationBootstrapCoordinator<Run>({
@@ -114,5 +121,108 @@ describe('ConversationBootstrapCoordinator', () => {
     }))
     run.abort()
     expect(abort).toHaveBeenCalledWith(1)
+  })
+
+  it('keeps queue sequence waiters alive across replacement epochs', async () => {
+    const first = createConversationBootstrapCriticalQueue(true)
+    const controller = new AbortController()
+    let settled = false
+    const waiter = first.waitForLiveSubscribeSent(
+      2,
+      Date.now() + 1_000,
+      controller.signal,
+      () => true,
+    ).then(ready => {
+      settled = true
+      return ready
+    })
+    const replacement = rearmConversationBootstrapCriticalQueue(first, true)
+
+    replacement.markLiveSubscribeSent(7)
+    await Promise.resolve()
+    expect(replacement.liveQueueSequence).toBe(1)
+    expect(settled).toBe(false)
+
+    replacement.markLiveSubscribeSent(7)
+    expect(await waiter).toBe(true)
+    replacement.markHistoryRequestSent(7)
+    await replacement.promise
+    await first.promise
+  })
+
+  it('releases queue waiters and the barrier on cancellation', async () => {
+    const queue = createConversationBootstrapCriticalQueue(true)
+    const controller = new AbortController()
+    const waiter = queue.waitForLiveSubscribeSent(
+      1,
+      Date.now() + 1_000,
+      controller.signal,
+      () => true,
+    )
+
+    queue.cancel()
+    expect(await waiter).toBe(false)
+    await queue.promise
+    expect(queue.released).toBe(true)
+  })
+
+  it('returns false when a live queue waiter reaches its deadline', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    const queue = createConversationBootstrapCriticalQueue(true)
+    const controller = new AbortController()
+    const waiter = queue.waitForLiveSubscribeSent(
+      1,
+      100,
+      controller.signal,
+      () => true,
+    )
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(await waiter).toBe(false)
+  })
+
+  it('opens a terminal barrier when critical phases cannot enqueue', async () => {
+    const queue = createConversationBootstrapCriticalQueue(true)
+    queue.markLiveTerminal()
+    queue.markHistoryTerminal()
+    await queue.promise
+    expect(queue.released).toBe(true)
+  })
+
+  it('bounds retry timers by deadline and abort/current ownership', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    const controller = new AbortController()
+    let current = true
+    const delayed = waitForConversationBootstrapRetry({
+      delayMs: 100,
+      deadlineAt: 500,
+      signal: controller.signal,
+      isCurrent: () => current,
+    })
+    await vi.advanceTimersByTimeAsync(99)
+    current = false
+    await vi.advanceTimersByTimeAsync(1)
+    expect(await delayed).toBe(false)
+
+    current = true
+    const bounded = waitForConversationBootstrapRetry({
+      delayMs: 500,
+      deadlineAt: 200,
+      signal: controller.signal,
+      isCurrent: () => current,
+    })
+    await vi.advanceTimersByTimeAsync(200)
+    expect(await bounded).toBe(true)
+
+    const aborted = waitForConversationBootstrapRetry({
+      delayMs: 100,
+      deadlineAt: 500,
+      signal: controller.signal,
+      isCurrent: () => true,
+    })
+    controller.abort()
+    expect(await aborted).toBe(false)
   })
 })

--- a/opensquilla-webui/src/modules/conversationBootstrapCoordinator.ts
+++ b/opensquilla-webui/src/modules/conversationBootstrapCoordinator.ts
@@ -34,6 +34,246 @@ export interface ConversationBootstrapPhase<T> {
   skipSnapshot: boolean
 }
 
+export interface ConversationBootstrapCriticalQueue {
+  /** Resolves after the critical frames are queued on a compatible socket. */
+  readonly promise: Promise<void>
+  readonly historyRequired: boolean
+  readonly liveSocketGeneration: number | null
+  readonly historySocketGeneration: number | null
+  readonly liveQueueSequence: number
+  readonly released: boolean
+  markLiveSubscribeSent(socketGeneration: number): void
+  markHistoryRequestSent(socketGeneration: number): void
+  markLiveTerminal(): void
+  markHistoryTerminal(): void
+  /** Resolve this queue and every waiter when the owning run is cancelled. */
+  cancel(): void
+  waitForLiveSubscribeSent(
+    minimum: number,
+    deadlineAt: number,
+    signal: AbortSignal,
+    isCurrent: () => boolean,
+  ): Promise<boolean>
+  /** Used internally to bridge an older queue to its replacement epoch. */
+  release(): void
+}
+
+interface CriticalQueueSequenceLedger {
+  sequence: number
+  waiters: Set<{
+    minimum: number
+    resolve: (ready: boolean) => void
+  }>
+}
+
+const queueSequenceLedgers = new WeakMap<object, CriticalQueueSequenceLedger>()
+
+export interface ConversationBootstrapRetryWaitOptions {
+  delayMs: number
+  deadlineAt: number
+  signal: AbortSignal
+  isCurrent: () => boolean
+}
+
+/**
+ * Wait for a bounded retry without coupling the timer to an RPC client.
+ * `isCurrent` is supplied by the owner because a route key can change before
+ * the transport emits its cancellation event.
+ */
+export function waitForConversationBootstrapRetry(
+  options: ConversationBootstrapRetryWaitOptions,
+): Promise<boolean> {
+  const remaining = options.deadlineAt - Date.now()
+  if (remaining <= 0 || !options.isCurrent()) return Promise.resolve(false)
+  // Keep the caller's retry policy intact while bounding it by the absolute
+  // bootstrap deadline (the legacy wrapper used the same min operation).
+  const delayMs = Math.min(Math.max(0, options.delayMs), remaining)
+  if (delayMs <= 0) return Promise.resolve(true)
+  return new Promise(resolve => {
+    let settled = false
+    const finish = (ready: boolean) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      options.signal.removeEventListener('abort', onAbort)
+      resolve(ready)
+    }
+    const onAbort = () => finish(false)
+    const timer = setTimeout(
+      () => finish(options.isCurrent()),
+      delayMs,
+    )
+    options.signal.addEventListener('abort', onAbort, { once: true })
+    if (options.signal.aborted) finish(false)
+  })
+}
+
+/**
+ * Build the critical-frame barrier shared by history and live phases.
+ * A queue releases only when live (and, when required, history) has been
+ * placed on the same socket, or when the phase has terminated without being
+ * able to queue.  This keeps optional reads from blocking live delivery.
+ */
+export function createConversationBootstrapCriticalQueue(
+  historyRequired: boolean,
+  liveSocketGeneration: number | null = null,
+  initialLiveQueueSequence = 0,
+  sequenceLedger?: CriticalQueueSequenceLedger,
+): ConversationBootstrapCriticalQueue {
+  let resolvePromise: () => void = () => {}
+  const promise = new Promise<void>(resolve => {
+    resolvePromise = resolve
+  })
+  let released = false
+  let historySocketGeneration: number | null = null
+  let liveTerminal = false
+  let historyTerminal = !historyRequired
+  const ledger = sequenceLedger ?? {
+    sequence: Math.max(0, initialLiveQueueSequence),
+    waiters: new Set<{
+      minimum: number
+      resolve: (ready: boolean) => void
+    }>(),
+  }
+
+  function releaseIfReady() {
+    if (released) return
+    const liveQueued = liveSocketGeneration !== null
+    const historyQueued = (
+      !historyRequired
+      || historySocketGeneration !== null
+    )
+    const queuedOnSameSocket = (
+      liveQueued
+      && historyQueued
+      && (
+        !historyRequired
+        || liveSocketGeneration === historySocketGeneration
+      )
+    )
+    const terminalWithoutQueue = (
+      (liveTerminal || (historyRequired && historyTerminal))
+      && (liveQueued || liveTerminal)
+      && (
+        !historyRequired
+        || historyQueued
+        || historyTerminal
+      )
+    )
+    if (!queuedOnSameSocket && !terminalWithoutQueue) return
+    released = true
+    resolvePromise()
+  }
+
+  function release() {
+    if (released) return
+    released = true
+    resolvePromise()
+  }
+
+  function cancel() {
+    release()
+    for (const waiter of ledger.waiters) waiter.resolve(false)
+    ledger.waiters.clear()
+  }
+
+  const queue: ConversationBootstrapCriticalQueue = {
+    promise,
+    get historyRequired() {
+      return historyRequired
+    },
+    get liveSocketGeneration() {
+      return liveSocketGeneration
+    },
+    get historySocketGeneration() {
+      return historySocketGeneration
+    },
+    get liveQueueSequence() {
+      return ledger.sequence
+    },
+    get released() {
+      return released
+    },
+    markLiveSubscribeSent(socketGeneration) {
+      liveSocketGeneration = socketGeneration
+      ledger.sequence += 1
+      for (const waiter of [...ledger.waiters]) {
+        if (ledger.sequence < waiter.minimum) continue
+        ledger.waiters.delete(waiter)
+        waiter.resolve(true)
+      }
+      releaseIfReady()
+    },
+    markHistoryRequestSent(socketGeneration) {
+      historySocketGeneration = socketGeneration
+      releaseIfReady()
+    },
+    markLiveTerminal() {
+      liveTerminal = true
+      releaseIfReady()
+    },
+    markHistoryTerminal() {
+      historyTerminal = true
+      releaseIfReady()
+    },
+    cancel,
+    release,
+    waitForLiveSubscribeSent(minimum, deadlineAt, signal, isCurrent) {
+      if (!isCurrent() || signal.aborted) return Promise.resolve(false)
+      if (ledger.sequence >= minimum) return Promise.resolve(true)
+      const remaining = deadlineAt - Date.now()
+      if (remaining <= 0) return Promise.resolve(false)
+      return new Promise(resolve => {
+        let settled = false
+        const waiter = {
+          minimum,
+          resolve: (ready: boolean) => finish(ready),
+        }
+        const finish = (ready: boolean) => {
+          if (settled) return
+          settled = true
+          clearTimeout(timer)
+          signal.removeEventListener('abort', onAbort)
+          ledger.waiters.delete(waiter)
+          resolve(ready)
+        }
+        const onAbort = () => finish(false)
+        // A timeout means that this queue epoch never observed the required
+        // live frame.  It must stay a negative result even when ownership is
+        // still current; callers use that distinction to stop the phase
+        // rather than treating an unqueued request as ready.
+        const timer = setTimeout(() => finish(false), remaining)
+        ledger.waiters.add(waiter)
+        signal.addEventListener('abort', onAbort, { once: true })
+        if (signal.aborted || !isCurrent()) finish(false)
+        else if (ledger.sequence >= minimum) finish(true)
+      })
+    },
+  }
+  queueSequenceLedgers.set(queue, ledger)
+  return queue
+}
+
+/**
+ * Start a replacement socket epoch while preserving consumers waiting on the
+ * predecessor promise.  Once the replacement barrier opens, the predecessor
+ * opens as well; cancellation of the replacement unwinds both promises.
+ */
+export function rearmConversationBootstrapCriticalQueue(
+  previous: ConversationBootstrapCriticalQueue,
+  historyRequired: boolean,
+  liveSocketGeneration: number | null = null,
+): ConversationBootstrapCriticalQueue {
+  const replacement = createConversationBootstrapCriticalQueue(
+    historyRequired,
+    liveSocketGeneration,
+    previous.liveQueueSequence,
+    queueSequenceLedgers.get(previous),
+  )
+  void replacement.promise.then(() => previous.release())
+  return replacement
+}
+
 /**
  * Initialise a phase without importing a transport or reactive state layer.
  * The execution callback remains in the wrapper until a later slice moves


### PR DESCRIPTION
## Summary

- extract the bootstrap critical-frame barrier, live queue sequence/waiters, replacement epoch chaining, and bounded retry wait into the transport-neutral `conversationBootstrapCoordinator`
- keep `useChatSessionBootstrap` responsible for phase execution, retry policy, and Vue projection while preserving its public API
- preserve v4 WebSocket behavior, same-socket live/history ordering, cancellation, and terminal fallback; no Gateway, database, Turn, or business implementation changes
- make live waiter deadline semantics explicit (`false`) and cover the regression

## Scope and compatibility

This is an S12-C3 seam extraction based directly on `origin/main` at `4766513e18e0bd8265a2375fd89437389e4a8612`. It changes ownership and removes duplicated coordination code only. The coordinator imports no Gateway, RPC, Vue, storage, or runtime implementation. Existing callers and wire behavior remain unchanged.

## Evidence

- focused bootstrap/ownership tests: 53/53
- non-contract WebUI unit suite: 399 files, 5066 tests passed
- `vue-tsc --noEmit`
- `npm run check:architecture`
- authored wrapper coordination code reduced by about 124 net lines; coordinator owns the reusable barrier and retry seam

The local contract suite has a pre-existing dependency failure (`ajv/dist/runtime/ucs2length`); it is unrelated to this change.
