### PR TITLE
refactor(webui): extract TurnCommands seam

### DIFF
--- a/opensquilla-webui/scripts/rpc-debt/session-chat.mjs
+++ b/opensquilla-webui/scripts/rpc-debt/session-chat.mjs
@@ -43,7 +43,10 @@ export const debt = {
   'src/composables/chat/useChatPlans.ts': { call: 4, on: 6 },
   'src/composables/chat/useChatRouteFeedback.ts': { call: 1 },
   'src/composables/chat/useChatRunModePreference.ts': { call: 4 },
-  'src/composables/chat/useChatSend.ts': { call: 9 },
+  // TurnCommands now owns send/cancel/steer method selection.  The one
+  // remaining call is the unrelated meta-draft compatibility path, which is
+  // intentionally deferred to the Meta domain slice.
+  'src/composables/chat/useChatSend.ts': { call: 1 },
   'src/composables/chat/useChatSessionSubscription.ts': { call: 7, waitForConnection: 3 },
   'src/composables/chat/useChatSlashCommands.ts': { call: 6 },
   'src/composables/chat/useChatUsageWidget.ts': { call: 2 },
@@ -78,7 +81,9 @@ export const debt = {
     call: 5,
     on: 1,
     supportsEvent: 1,
-    supportsMethod: 12,
+    // Turn capability probes are owned by TurnCommands; the remaining
+    // method probes belong to non-Turn domains and migrate independently.
+    supportsMethod: 10,
     waitForConnection: 2,
     httpRequest: 1,
     httpApiEndpoint: 1,

--- a/opensquilla-webui/src/adapters/gateway/gatewayAdapters.test.ts
+++ b/opensquilla-webui/src/adapters/gateway/gatewayAdapters.test.ts
@@ -25,6 +25,7 @@ describe('Gateway Adapter composition', () => {
       'sessionDirectoryChanges',
       'sessionLifecycle',
       'sessionRouting',
+      'turnCommands',
     ])
     expect(adapters).not.toHaveProperty('rpc')
     expect(adapters).not.toHaveProperty('events')
@@ -38,5 +39,12 @@ describe('Gateway Adapter composition', () => {
     await adapters.sessionDirectoryChanges.resume()
     expect(call).toHaveBeenCalledTimes(2)
     changesSubscription.close()
+
+    await adapters.turnCommands.cancel({ sessionKey: 'agent:main:test', source: 'test' })
+    expect(call).toHaveBeenLastCalledWith(
+      'chat.abort',
+      { sessionKey: 'agent:main:test', source: 'test' },
+      undefined,
+    )
   })
 })

--- a/opensquilla-webui/src/adapters/gateway/gatewayAdapters.ts
+++ b/opensquilla-webui/src/adapters/gateway/gatewayAdapters.ts
@@ -2,11 +2,13 @@ import type { SessionDirectory } from '@/modules/sessionDirectory'
 import type { SessionDirectoryChanges } from '@/modules/sessionDirectoryChanges'
 import type { SessionLifecycle } from '@/modules/sessionLifecycle'
 import type { SessionRouting } from '@/modules/sessionRouting'
+import type { TurnCommands } from '@/modules/turnCommands'
 import { createPrivateGatewayTransports } from './privateTransports'
 import { createV4SessionDirectory } from './sessionDirectoryV4'
 import { createV4SessionDirectoryChanges } from './sessionDirectoryChangesV4'
 import { createV4SessionLifecycle } from './sessionLifecycleV4'
 import { createV4SessionRouting } from './sessionRoutingV4'
+import { createV4TurnCommands } from './turnCommandsV4'
 
 type RpcStoreTransportSource = Parameters<typeof createPrivateGatewayTransports>[0]
 
@@ -15,6 +17,7 @@ export interface GatewayAdapters {
   readonly sessionDirectoryChanges: SessionDirectoryChanges
   readonly sessionLifecycle: SessionLifecycle
   readonly sessionRouting: SessionRouting
+  readonly turnCommands: TurnCommands
 }
 
 /** Wire Gateway-backed domain Adapters without leaking generic transports. */
@@ -29,5 +32,6 @@ export function createGatewayAdapters(source: RpcStoreTransportSource): GatewayA
     ),
     sessionLifecycle: createV4SessionLifecycle(transports.rpc),
     sessionRouting: createV4SessionRouting(transports.rpc, transports.events),
+    turnCommands: createV4TurnCommands(transports.rpc),
   }
 }

--- a/opensquilla-webui/src/adapters/gateway/turnCommandsV4.test.ts
+++ b/opensquilla-webui/src/adapters/gateway/turnCommandsV4.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createV4TurnCommands } from './turnCommandsV4'
+import type { TurnCommandsTransport } from './turnCommandsV4'
+
+describe('v4 TurnCommands Adapter', () => {
+  it('maps semantic admission to chat.send without changing the payload', async () => {
+    const request = vi.fn(async <T = unknown>() => (
+      { sessionKey: 'agent:main:test', task_id: 'task-1' } as T
+    )) as TurnCommandsTransport['request']
+    const commands = createV4TurnCommands({ request, supports: () => true })
+    const params = {
+      message: 'hello',
+      sessionKey: 'agent:main:test',
+      clientRequestId: 'request-1',
+      queueMode: 'followup',
+    }
+
+    await expect(commands.send({ kind: 'new-turn', params })).resolves.toEqual({
+      sessionKey: 'agent:main:test',
+      task_id: 'task-1',
+    })
+    expect(request).toHaveBeenCalledWith('chat.send', params)
+  })
+
+  it('selects the durable pending-input endpoint only for staged admission', async () => {
+    const request = vi.fn(async <T = unknown>() => ({ accepted: true } as T)) as
+      TurnCommandsTransport['request']
+    const commands = createV4TurnCommands({ request, supports: () => true })
+    const params = {
+      key: 'agent:main:test',
+      pendingInputId: 'pending-1',
+      clientRequestId: 'request-1',
+      requestFingerprint: 'fingerprint-1',
+    }
+
+    await commands.send({ kind: 'pending-input', params })
+    expect(request).toHaveBeenCalledWith(
+      'sessions.pending_inputs.dispatch',
+      params,
+    )
+  })
+
+  it('keeps abort scoped to the semantic request and chooses pending steer by identity', async () => {
+    const request = vi.fn(async <T = unknown>() => (
+      { accepted: true, aborted: true } as T
+    )) as TurnCommandsTransport['request']
+    const commands = createV4TurnCommands({
+      request,
+      supports: method => method !== 'sessions.pending_inputs.steer',
+    })
+    await commands.cancel({
+      sessionKey: 'agent:main:test',
+      taskId: 'task-1',
+      scope: 'task',
+      source: 'webui_stop',
+    })
+    await commands.steer({
+      key: 'agent:main:test',
+      message: 'adjust',
+      expected_turn_id: 'turn-1',
+      client_request_id: 'request-2',
+      client_message_id: 'message-2',
+      pendingInputId: 'pending-1',
+    })
+    expect(request).toHaveBeenNthCalledWith(
+      1,
+      'chat.abort',
+      {
+        sessionKey: 'agent:main:test',
+        taskId: 'task-1',
+        scope: 'task',
+        source: 'webui_stop',
+      },
+    )
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      'sessions.pending_inputs.steer',
+      expect.objectContaining({ pendingInputId: 'pending-1' }),
+    )
+    expect(commands.supports('same-turn-steer')).toBe(true)
+    expect(commands.supports('durable-steer')).toBe(false)
+  })
+})

--- a/opensquilla-webui/src/adapters/gateway/turnCommandsV4.ts
+++ b/opensquilla-webui/src/adapters/gateway/turnCommandsV4.ts
@@ -1,0 +1,128 @@
+import type { RpcCallOptions } from '@/lib/rpc'
+import {
+  type TurnSendRequest,
+  type TurnCancelRequest,
+  type TurnCancelResponse,
+  type TurnCommandCapability,
+  type TurnCommands,
+  type TurnCommandRequestOptions,
+} from '@/modules/turnCommands'
+import type {
+  ChatSendResponse,
+  SessionSteerV2Params,
+  SessionSteerV2Response,
+} from '@/types/rpc'
+
+/** Narrow wire port owned by this Adapter. */
+export interface TurnCommandsTransport {
+  request<T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    options?: RpcCallOptions,
+  ): Promise<T>
+  supports?(method: string): boolean
+}
+
+const CHAT_SEND_METHOD = 'chat.send'
+const CHAT_ABORT_METHOD = 'chat.abort'
+const STEER_METHOD = 'sessions.steer.v2'
+const PENDING_INPUT_DISPATCH_METHOD = 'sessions.pending_inputs.dispatch'
+const PENDING_INPUT_STEER_METHOD = 'sessions.pending_inputs.steer'
+
+function requestOptions(options?: TurnCommandRequestOptions): RpcCallOptions | undefined {
+  return options?.signal ? { signal: options.signal } : undefined
+}
+
+function forward<T>(
+  transport: TurnCommandsTransport,
+  method: string,
+  params: Record<string, unknown>,
+  options?: TurnCommandRequestOptions,
+): Promise<T> {
+  const rpcOptions = requestOptions(options)
+  return rpcOptions
+    ? transport.request<T>(method, params, rpcOptions)
+    : transport.request<T>(method, params)
+}
+
+/**
+ * Adapt semantic turn commands to the unchanged v4 JSON wire.
+ *
+ * This is intentionally a compatibility Adapter, not a second implementation:
+ * it only selects legacy method aliases and forwards the exact payloads.
+ */
+export function createV4TurnCommands(transport: TurnCommandsTransport): TurnCommands {
+  const supportsMethod = (method: string): boolean => (
+    transport.supports?.(method) ?? false
+  )
+
+  return {
+    send: async (
+      request: TurnSendRequest,
+      options?: TurnCommandRequestOptions,
+    ): Promise<ChatSendResponse> => {
+      if (request.kind === 'pending-input') {
+        return forward<ChatSendResponse>(
+          transport,
+          PENDING_INPUT_DISPATCH_METHOD,
+          request.params as unknown as Record<string, unknown>,
+          options,
+        )
+      }
+      return forward<ChatSendResponse>(
+        transport,
+        CHAT_SEND_METHOD,
+        request.params as unknown as Record<string, unknown>,
+        options,
+      )
+    },
+
+    cancel: (
+      request: TurnCancelRequest,
+      options?: TurnCommandRequestOptions,
+    ) => forward<TurnCancelResponse>(
+      transport,
+      CHAT_ABORT_METHOD,
+      request as unknown as Record<string, unknown>,
+      options,
+    ),
+
+    steer: (
+      request: SessionSteerV2Params,
+      options?: TurnCommandRequestOptions,
+    ) => forward<SessionSteerV2Response>(
+      transport,
+      request.pendingInputId ? PENDING_INPUT_STEER_METHOD : STEER_METHOD,
+      request as unknown as Record<string, unknown>,
+      options,
+    ),
+
+    supports: (capability: TurnCommandCapability): boolean => {
+      if (capability === 'same-turn-steer') return supportsMethod(STEER_METHOD)
+      return supportsMethod(PENDING_INPUT_STEER_METHOD)
+    },
+  }
+}
+
+/**
+ * Keep the method mapping testable without exposing a generic RPC client from
+ * the application Module.  This helper is useful for transitional call-site
+ * tests while production composition uses `createPrivateGatewayTransports`.
+ */
+export function createV4TurnCommandsFromRpcClient(client: {
+  call<T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+    options?: RpcCallOptions,
+  ): Promise<T>
+  supportsMethod?(method: string): boolean
+}, supportsMethod?: (method: string) => boolean): TurnCommands {
+  return createV4TurnCommands({
+    request: (method, params, options) => options
+      ? client.call(method, params, options)
+      : client.call(method, params),
+    supports: method => supportsMethod?.(method)
+      ?? client.supportsMethod?.(method)
+      ?? false,
+  })
+}

--- a/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.attachments.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick, ref, watch } from 'vue'
 
 import { useChatSend, type UseChatSendOptions } from './useChatSend'
+import { createV4TurnCommandsFromRpcClient } from '@/adapters/gateway/turnCommandsV4'
 import { useChatRpcEventHandlers } from './useChatRpcEventHandlers'
 import {
   snapshotSteerRequest,
@@ -111,6 +112,9 @@ function makeOptions(overrides: Partial<UseChatSendOptions> = {}) {
   const rpc = {
     call: vi.fn().mockResolvedValue({ sessionKey: 'agent:main:webchat:test' }),
   }
+  const turnCommands = overrides.turnCommands ?? createV4TurnCommandsFromRpcClient(
+    rpc as unknown as UseChatSendOptions['rpc'],
+  )
   const stream: UseChatSendOptions['stream'] = {
     isStreaming: ref(false),
     streamBubble: ref(false),
@@ -162,6 +166,7 @@ function makeOptions(overrides: Partial<UseChatSendOptions> = {}) {
     })
   const options: UseChatSendOptions = {
     rpc,
+    turnCommands,
     inputText: ref('hello'),
     messages,
     sessionKey: ref('agent:main:webchat:test'),
@@ -201,6 +206,12 @@ function makeOptions(overrides: Partial<UseChatSendOptions> = {}) {
     autoResizeTextarea: vi.fn(),
     scrollToBottom: vi.fn(),
     ...overrides,
+  }
+  if (!overrides.turnCommands) {
+    options.turnCommands = createV4TurnCommandsFromRpcClient(
+      options.rpc,
+      options.supportsMethod,
+    )
   }
   return { api: useChatSend(options), options, rpc, stream, pendingQueue }
 }

--- a/opensquilla-webui/src/composables/chat/useChatSend.documentContext.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.documentContext.test.ts
@@ -5,6 +5,7 @@ import type { ChatMessage } from '@/types/chat'
 import type { ChatDocumentContext } from '@/types/rpc'
 import type { UseChatSendOptions } from './useChatSend'
 import { useChatSend } from './useChatSend'
+import { createV4TurnCommandsFromRpcClient } from '@/adapters/gateway/turnCommandsV4'
 
 const SESSION_KEY = 'agent:main:webchat:document-context'
 
@@ -39,6 +40,9 @@ function createHarness(overrides: Partial<UseChatSendOptions> = {}) {
   }
   const options: UseChatSendOptions = {
     rpc,
+    turnCommands: createV4TurnCommandsFromRpcClient(
+      rpc as unknown as UseChatSendOptions['rpc'],
+    ),
     inputText: ref('Update the title and accent color.'),
     messages: ref<ChatMessage[]>([]),
     sessionKey: ref(SESSION_KEY),
@@ -86,6 +90,12 @@ function createHarness(overrides: Partial<UseChatSendOptions> = {}) {
     autoResizeTextarea: vi.fn(),
     scrollToBottom: vi.fn(),
     ...overrides,
+  }
+  if (!overrides.turnCommands) {
+    options.turnCommands = createV4TurnCommandsFromRpcClient(
+      options.rpc,
+      options.supportsMethod,
+    )
   }
   return { api: useChatSend(options), options, rpc }
 }

--- a/opensquilla-webui/src/composables/chat/useChatSend.promptAnnotations.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.promptAnnotations.test.ts
@@ -12,6 +12,7 @@ import type {
 } from '@/utils/chat/pendingInputWal'
 import type { UseChatSendOptions } from './useChatSend'
 import { useChatSend } from './useChatSend'
+import { createV4TurnCommandsFromRpcClient } from '@/adapters/gateway/turnCommandsV4'
 
 function snapshot(annotationId: string, sentOrder: number): PromptAnnotationSnapshot {
   return {
@@ -62,6 +63,9 @@ function createHarness(overrides: Partial<UseChatSendOptions> = {}) {
   }
   const options: UseChatSendOptions = {
     rpc,
+    turnCommands: createV4TurnCommandsFromRpcClient(
+      rpc as unknown as UseChatSendOptions['rpc'],
+    ),
     inputText: ref(''),
     messages: ref<ChatMessage[]>([]),
     sessionKey: ref('agent:main:webchat:test'),
@@ -112,6 +116,12 @@ function createHarness(overrides: Partial<UseChatSendOptions> = {}) {
     autoResizeTextarea: vi.fn(),
     scrollToBottom: vi.fn(),
     ...overrides,
+  }
+  if (!overrides.turnCommands) {
+    options.turnCommands = createV4TurnCommandsFromRpcClient(
+      options.rpc,
+      options.supportsMethod,
+    )
   }
   return { api: useChatSend(options), options, rpc }
 }

--- a/opensquilla-webui/src/composables/chat/useChatSend.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSend.ts
@@ -23,8 +23,12 @@ import type {
   ChatSendParams,
   ChatSendResponse,
   SessionSteerV2Params,
-  SessionSteerV2Response,
 } from '@/types/rpc'
+import type {
+  TurnSendRequest,
+  TurnCancelRequest,
+  TurnCommands,
+} from '@/modules/turnCommands'
 import type { ChatRpcStreamApi } from '@/composables/chat/useChatRpcEventHandlers'
 import type { ChatTaskOwnershipApi } from '@/composables/chat/useChatTaskOwnership'
 import type {
@@ -110,9 +114,8 @@ interface SendAttempt {
   // A Stop issued before durable acceptance is known belongs to this exact
   // idempotent request, not to whichever session happens to be visible later.
   stopRequested?: boolean
-  acceptanceRpc?: {
-    method: 'chat.send' | 'sessions.pending_inputs.dispatch'
-    params: Record<string, unknown>
+  acceptanceRequest?: {
+    request: TurnSendRequest
   }
   acceptanceResolved?: boolean
   acceptanceInFlight?: boolean
@@ -404,6 +407,13 @@ function chatSourceMetadata(options: UseChatSendOptions): ChatSendParams['_sourc
 
 export interface UseChatSendOptions {
   rpc: RpcClient
+  /** Semantic command port; v4 method aliases live in the Gateway Adapter. */
+  turnCommands: TurnCommands
+  /**
+   * @deprecated Test-only bridge for legacy harnesses; TurnCommands owns all
+   * turn capability checks in production. Remove with the S14 command
+   * Contract migration.
+   */
   supportsMethod?: (method: string) => boolean
   activeSteerCapability?: Readonly<Ref<ChatSteerCapability | null>>
   inputText: Ref<string>
@@ -836,7 +846,7 @@ export function useChatSend(options: UseChatSendOptions) {
     const activeTaskId = String(options.activeStreamTaskId.value || '').trim()
     const inputKinds = capability?.input_kinds
     return Boolean(
-      options.supportsMethod?.('sessions.steer.v2')
+      options.turnCommands.supports('same-turn-steer')
       && capability?.mode === 'same_turn'
       && expectedTurnId
       && activeTaskId === expectedTurnId
@@ -980,12 +990,12 @@ export function useChatSend(options: UseChatSendOptions) {
       const isCurrentRequest = options.sessionKey.value === attempt.requestSessionKey
       if (isCurrentRequest) options.taskOwnership?.requestStop(taskId)
       try {
-        const abort = await options.rpc.call<{ aborted?: boolean, reason?: string }>('chat.abort', {
+        const abort = await options.turnCommands.cancel({
           sessionKey: attempt.acceptedSessionKey || attempt.requestSessionKey,
           taskId,
           source: 'webui_stop',
           scope: 'task',
-        })
+        } satisfies TurnCancelRequest)
         if (abort?.aborted !== true) {
           if (isCurrentRequest) {
             await options.reconcileTaskOwnership?.()
@@ -1074,7 +1084,7 @@ export function useChatSend(options: UseChatSendOptions) {
   }
 
   function scheduleAcceptanceRecovery(attempt: SendAttempt) {
-    if ((attempt.acceptanceResolved && !attempt.stopRequested) || !attempt.acceptanceRpc) return
+    if ((attempt.acceptanceResolved && !attempt.stopRequested) || !attempt.acceptanceRequest) return
     const key = acceptanceAttemptKey(attempt)
     if (acceptanceRecoveryWorkers.has(key)) return
 
@@ -1093,9 +1103,8 @@ export function useChatSend(options: UseChatSendOptions) {
         if (attempt.acceptanceInFlight) continue
         attempt.acceptanceInFlight = true
         try {
-          const response = await options.rpc.call<ChatSendResponse>(
-            attempt.acceptanceRpc!.method,
-            attempt.acceptanceRpc!.params,
+          const response = await options.turnCommands.send(
+            attempt.acceptanceRequest!.request,
           )
           if (await settleRecoveredAcceptance(attempt, response)) return
         } catch (error: unknown) {
@@ -1694,10 +1703,10 @@ export function useChatSend(options: UseChatSendOptions) {
         let refreshedExpiredAttachments = false
         while (true) {
           try {
-            const response = await options.rpc.call<ChatSendResponse>(
-              'chat.send',
-              replayRecord.params,
-            )
+            const response = await options.turnCommands.send({
+              kind: 'new-turn',
+              params: replayRecord.params,
+            })
             const targetSessionKey = response.sessionKey || replayRecord.requestSessionKey
             await finalizeRecoveredHandoff(replayRecord, targetSessionKey)
             break
@@ -1896,7 +1905,7 @@ export function useChatSend(options: UseChatSendOptions) {
     const taskId = acceptedTaskId(response)
     if (!taskId && !force) return
     const acceptedSessionKey = response?.sessionKey || requestSessionKey
-    const params: Record<string, string> = {
+    const params: TurnCancelRequest = {
       sessionKey: acceptedSessionKey,
       source: force ? 'webui_stop' : 'webui_stale_send',
     }
@@ -1905,7 +1914,7 @@ export function useChatSend(options: UseChatSendOptions) {
     // instead of falling back to the legacy whole-session abort surface.
     if (force) params.scope = 'task'
     if (taskId) params.taskId = taskId
-    options.rpc.call<{ aborted?: boolean }>('chat.abort', params)
+    options.turnCommands.cancel(params)
       .then((response) => {
         if (force && !taskId) {
           void options.reconcileTaskOwnership?.()
@@ -1937,7 +1946,7 @@ export function useChatSend(options: UseChatSendOptions) {
       ? options.steerDelivery.attemptForItem(pendingItem)
       : null
     if (!requestSessionKey || !text.trim()) return 'not_sent'
-    if (!options.supportsMethod?.('sessions.steer.v2')) {
+    if (!options.turnCommands.supports('same-turn-steer')) {
       return recovered ? 'retryable_failure' : 'not_sent'
     }
     const durablePending = Boolean(
@@ -1953,7 +1962,7 @@ export function useChatSend(options: UseChatSendOptions) {
     )
     if (
       durablePending
-      && !options.supportsMethod?.('sessions.pending_inputs.steer')
+      && !options.turnCommands.supports('durable-steer')
     ) {
       return recovered ? 'retryable_failure' : 'not_sent'
     }
@@ -2045,12 +2054,7 @@ export function useChatSend(options: UseChatSendOptions) {
       pendingItem.steerAttempt = activeAttempt
     }
     try {
-      const response = await options.rpc.call<SessionSteerV2Response>(
-        params.pendingInputId
-          ? 'sessions.pending_inputs.steer'
-          : 'sessions.steer.v2',
-        params as unknown as Record<string, unknown>,
-      )
+      const response = await options.turnCommands.steer(params)
       const sessionChanged = options.sessionKey.value !== requestSessionKey
       if (sessionChanged && response.accepted === true) {
         options.steerDelivery.acknowledgeAcceptedOffscreen(pendingItem)
@@ -3034,25 +3038,25 @@ export function useChatSend(options: UseChatSendOptions) {
 
     try {
       const stagedPendingItem = serverStagedPendingItem
-      const acceptanceRpc = attempt.acceptanceRpc || {
-        method: stagedPendingItem
-          ? 'sessions.pending_inputs.dispatch' as const
-          : 'chat.send' as const,
-        params: stagedPendingItem
+      const acceptanceRequest = attempt.acceptanceRequest?.request || (
+        stagedPendingItem
           ? {
-              key: requestSessionKey,
-              pendingInputId: stagedPendingItem.pendingInputId,
-              clientRequestId: stagedPendingItem.pendingClientRequestId,
-              requestFingerprint: stagedPendingItem.pendingRequestFingerprint,
+              kind: 'pending-input' as const,
+              params: {
+                key: requestSessionKey,
+                pendingInputId: stagedPendingItem.pendingInputId!,
+                clientRequestId: stagedPendingItem.pendingClientRequestId!,
+                requestFingerprint: stagedPendingItem.pendingRequestFingerprint!,
+              },
             }
-          : attempt.params as unknown as Record<string, unknown>,
-      }
-      attempt.acceptanceRpc = acceptanceRpc
-      attempt.acceptanceInFlight = true
-      const res = await options.rpc.call<ChatSendResponse>(
-        acceptanceRpc.method,
-        acceptanceRpc.params,
+          : {
+              kind: 'new-turn' as const,
+              params: attempt.params,
+            }
       )
+      attempt.acceptanceRequest = { request: acceptanceRequest }
+      attempt.acceptanceInFlight = true
+      const res = await options.turnCommands.send(acceptanceRequest)
       acknowledgeAttemptPromptAnnotations(attempt, res)
       attempt.acceptanceResolved = true
       attempt.acceptedTaskId = acceptedTaskId(res)
@@ -3576,7 +3580,7 @@ export function useChatSend(options: UseChatSendOptions) {
         message.steerStopRequested = true
       }
     }
-    const abortParams: Record<string, string> = {
+    const abortParams: TurnCancelRequest = {
       sessionKey: abortSessionKey,
       source: 'webui_stop',
     }
@@ -3585,7 +3589,7 @@ export function useChatSend(options: UseChatSendOptions) {
     // intentionally retains legacy session-tree cancellation semantics.
     if (stoppedTurnId || taskAcceptancePending) abortParams.scope = 'task'
     if (stoppedTurnId) abortParams.taskId = stoppedTurnId
-    options.rpc.call<{ aborted?: boolean, reason?: string }>('chat.abort', abortParams)
+    options.turnCommands.cancel(abortParams)
       .then((response) => {
         if (response?.aborted === true) {
           options.scheduleHistorySync()
@@ -3803,9 +3807,11 @@ export function useChatSend(options: UseChatSendOptions) {
       workspaceId: null,
       params,
       hiddenControl: true,
-      acceptanceRpc: {
-        method: 'chat.send',
-        params: params as unknown as Record<string, unknown>,
+      acceptanceRequest: {
+        request: {
+          kind: 'new-turn',
+          params,
+        },
       },
     }
 
@@ -3822,7 +3828,10 @@ export function useChatSend(options: UseChatSendOptions) {
 
     try {
       attempt.acceptanceInFlight = true
-      const res = await options.rpc.call<ChatSendResponse>('chat.send', params)
+      const res = await options.turnCommands.send({
+        kind: 'new-turn',
+        params,
+      })
       attempt.acceptanceResolved = true
       attempt.acceptedTaskId = acceptedTaskId(res)
       attempt.acceptedSessionKey = res?.sessionKey || requestSessionKey

--- a/opensquilla-webui/src/composables/chat/useChatSessionHandoff.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionHandoff.test.ts
@@ -12,6 +12,7 @@ import {
   type ChatSendOutcome,
   type UseChatSendOptions,
 } from './useChatSend'
+import { createV4TurnCommandsFromRpcClient } from '@/adapters/gateway/turnCommandsV4'
 import { useChatSessionRuntime } from './useChatSessionRuntime'
 import { useChatSteerDelivery } from './useChatSteerDelivery'
 import type {
@@ -280,6 +281,7 @@ describe('chat send session handoff', () => {
         resolveSend = resolve as (value: unknown) => void
       })) as UseChatSendOptions['rpc']['call'],
     }
+    const turnCommands = createV4TurnCommandsFromRpcClient(rpc)
     const scheduleHistorySync = vi.fn()
     const steerDelivery = useChatSteerDelivery({
       messages,
@@ -289,6 +291,7 @@ describe('chat send session handoff', () => {
     })
     const send = useChatSend({
       rpc,
+      turnCommands,
       inputText,
       messages,
       sessionKey,

--- a/opensquilla-webui/src/main.ts
+++ b/opensquilla-webui/src/main.ts
@@ -10,6 +10,7 @@ import { SESSION_DIRECTORY_KEY } from './modules/sessionDirectory'
 import { SESSION_DIRECTORY_CHANGES_KEY } from './modules/sessionDirectoryChanges'
 import { SESSION_LIFECYCLE_KEY } from './modules/sessionLifecycle'
 import { SESSION_ROUTING_KEY } from './modules/sessionRouting'
+import { TURN_COMMANDS_KEY } from './modules/turnCommands'
 import 'katex/dist/katex.min.css'
 import './assets/base.css'
 import './themes/tokens' // eagerly bundles every value theme's token block
@@ -43,6 +44,7 @@ app.provide(
   gatewayAdapters.sessionLifecycle,
 )
 app.provide(SESSION_ROUTING_KEY, gatewayAdapters.sessionRouting)
+app.provide(TURN_COMMANDS_KEY, gatewayAdapters.turnCommands)
 router.afterEach(() => {
   rpcStore.applyLinkTokenFromUrl()
 })

--- a/opensquilla-webui/src/modules/turnCommands.ts
+++ b/opensquilla-webui/src/modules/turnCommands.ts
@@ -1,0 +1,77 @@
+import type { InjectionKey } from 'vue'
+
+// S13 deliberately keeps the existing command payload/response shapes so the
+// migration changes ownership, not wire semantics. These type-only imports are
+// a temporary seam: S14 replaces them with generated Contract/domain shapes
+// and removes the corresponding declarations from types/rpc.ts.
+import type {
+  ChatSendParams,
+  ChatSendResponse,
+  SessionSteerV2Params,
+  SessionSteerV2Response,
+} from '@/types/rpc'
+
+/** Options shared by turn commands without exposing transport details. */
+export interface TurnCommandRequestOptions {
+  signal?: AbortSignal
+}
+
+/** The two admission paths currently used by the WebUI. */
+export interface PendingInputDispatchRequest {
+  key: string
+  pendingInputId: string
+  clientRequestId: string
+  requestFingerprint: string
+}
+
+/**
+ * A request whose acceptance may need to be replayed after a lost response.
+ * `kind` is an application concern; v4 method names stay in the Adapter.
+ */
+export type TurnSendRequest =
+  | { kind: 'new-turn'; params: ChatSendParams }
+  | { kind: 'pending-input'; params: PendingInputDispatchRequest }
+
+export interface TurnCancelRequest {
+  sessionKey: string
+  source?: string
+  scope?: string
+  taskId?: string
+}
+
+export interface TurnCancelResponse {
+  aborted?: boolean
+  reason?: string
+  [key: string]: unknown
+}
+
+export type TurnCommandCapability = 'same-turn-steer' | 'durable-steer'
+
+/**
+ * Application-facing turn command seam.
+ *
+ * Consumers own admission state and idempotency decisions, but do not know
+ * which v4 alias carries a request. `send` covers both ordinary turn
+ * admission and dispatch of an already durable pending input: both are one
+ * domain operation (make this logical input eligible for execution), while
+ * the Adapter selects the transport route. The transitional response types
+ * still mirror the existing wire shape; S14 will replace them with generated
+ * Contract types after the command semantics are stable.
+ */
+export interface TurnCommands {
+  send(
+    request: TurnSendRequest,
+    options?: TurnCommandRequestOptions,
+  ): Promise<ChatSendResponse>
+  cancel(
+    request: TurnCancelRequest,
+    options?: TurnCommandRequestOptions,
+  ): Promise<TurnCancelResponse>
+  steer(
+    request: SessionSteerV2Params,
+    options?: TurnCommandRequestOptions,
+  ): Promise<SessionSteerV2Response>
+  supports(capability: TurnCommandCapability): boolean
+}
+
+export const TURN_COMMANDS_KEY: InjectionKey<TurnCommands> = Symbol('TurnCommands')

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -619,7 +619,7 @@
       :reorder-pending="pendingQueueReorderPending"
       :image-blocked-message="queuedImageSendBlockedMessage"
       :steer-available="sameTurnSteerAvailable"
-      :durable-steer-available="rpc.supportsMethod('sessions.pending_inputs.steer')"
+      :durable-steer-available="turnCommands.supports('durable-steer')"
       :steer-unavailable-message="sameTurnSteerUnavailableMessage"
       @clear="clearPendingQueue"
       @edit="editPendingMessage"
@@ -871,6 +871,7 @@ import { useChatElevatedMode } from '@/composables/chat/useChatElevatedMode'
 import { useChatFeatureToggles } from '@/composables/chat/useChatFeatureToggles'
 import { useChatSessionRouting } from '@/composables/chat/useChatSessionRouting'
 import { SESSION_ROUTING_KEY, type SessionRouting } from '@/modules/sessionRouting'
+import { TURN_COMMANDS_KEY, type TurnCommands } from '@/modules/turnCommands'
 import { useChatHistory } from '@/composables/chat/useChatHistory'
 import { useChatMarkdownExport } from '@/composables/chat/useChatMarkdownExport'
 import { useChatMessageActions } from '@/composables/chat/useChatMessageActions'
@@ -1184,6 +1185,9 @@ const sessionDirectory = injectedSessionDirectory
 const injectedSessionLifecycle = inject(SESSION_LIFECYCLE_KEY)
 if (!injectedSessionLifecycle) throw new Error('SessionLifecycle was not provided')
 const sessionLifecycle = injectedSessionLifecycle
+const injectedTurnCommands = inject(TURN_COMMANDS_KEY)
+if (!injectedTurnCommands) throw new Error('TurnCommands was not provided')
+const turnCommands: TurnCommands = injectedTurnCommands
 
 async function resolveCreatedSessionAvailability(sessionKey: string): Promise<boolean> {
   try {
@@ -3260,7 +3264,7 @@ resetComposerInputHistory = chatComposerShortcuts.resetInputHistory
 
 const chatSend = useChatSend({
   rpc,
-  supportsMethod: method => rpc.supportsMethod(method),
+  turnCommands,
   activeSteerCapability,
   inputText,
   messages,
@@ -3582,7 +3586,7 @@ const sameTurnSteerUnavailableMessage = computed(() => {
   if (sameTurnSteerAvailable.value) return ''
   const reason = steerUnavailableReason({
     isStreaming: isStreaming.value,
-    methodAvailable: rpc.supportsMethod('sessions.steer.v2'),
+    methodAvailable: turnCommands.supports('same-turn-steer'),
     modelRoutingMode: modelRoutingMode.value,
     capability: activeSteerCapability.value,
     activeTaskId: activeStreamTaskId.value,

--- a/tests/test_ci/test_rpc_architecture_contracts.py
+++ b/tests/test_ci/test_rpc_architecture_contracts.py
@@ -143,9 +143,10 @@ F2_FOUNDATION_RUNTIME_FILES = (
 # lifecycle now each register one reviewed domain Adapter in the composition
 # root; the 12-line increase is the deliberate cumulative seam cost for those
 # two slices. Session routing adds one more adapter registration and its typed
-# composition-root seam (4 lines); keep this allowance explicit rather than
-# turning the foundation exception into an open-ended budget.
-F2_FOUNDATION_RUNTIME_LOC_CEILING = 1_158
+# composition-root seam (4 lines), and TurnCommands adds the same 4-line
+# composition seam. Keep both reviewed increments explicit rather than turning
+# the foundation exception into an open-ended budget.
+F2_FOUNDATION_RUNTIME_LOC_CEILING = 1_162
 
 # Existing cross-rpc private imports are architectural debt. This exact ledger
 # prevents growth and also fails stale when an import is removed, so reductions


### PR DESCRIPTION
## Summary

- add the semantic `TurnCommands` port (`send`, `cancel`, `steer`, capability queries) at the WebUI composition boundary
- add a private v4 Gateway Adapter that owns the five legacy turn method names and forwards the existing payloads unchanged
- migrate `useChatSend` and the two ChatView turn capability probes; remove eight raw turn calls from the application-facing path
- keep the one unrelated `meta.drafts.discard` call for its later Meta domain slice

## Architecture boundary

This is the S13 ownership seam, not the final command Contract migration. The Adapter is the only production location containing `chat.send`, `chat.abort`, `sessions.steer.v2`, and pending-input method names. Transitional request/response types still import `types/rpc`; S14 will replace those with generated language-neutral command Contracts and delete the legacy DTOs. The compatibility test helper is test-only.

No Gateway, WebSocket v4 wire, database, TurnRunner, TaskRuntime, or command behavior changes are included. Existing aliases, payloads, permission/error behavior, idempotent replay, and pending-input routing are preserved.

## Evidence

- exact raw turn operations in the debt ledger: 9 → 1 (the remaining call is Meta drafts)
- targeted TurnCommands/useChatSend/handoff tests: 265 passed
- full WebUI unit tests: 5,064 passed; the only suite-level failure is the pre-existing Ajv `ucs2length` dependency/environment issue
- WebUI typecheck and architecture gate passed

Based directly on `origin/main` at `4766513e18e0bd8265a2375fd89437389e4a8612`.
