### PR TITLE
refactor(gateway): register goals status/set contracts

### DIFF
--- a/src/opensquilla/contracts/adapters/goals_contract.py
+++ b/src/opensquilla/contracts/adapters/goals_contract.py
@@ -12,10 +12,18 @@ from typing import Any, cast
 
 from pydantic import ValidationError
 
-from opensquilla.contracts.generated.v4.goals_set import LegacyParams as GoalsSetLegacyParams
+from opensquilla.contracts.generated.v4.goals_set import (
+    LegacyNonObjectParams as GoalsSetLegacyNonObjectParams,
+)
+from opensquilla.contracts.generated.v4.goals_set import (
+    LegacyParams as GoalsSetLegacyParams,
+)
 from opensquilla.contracts.generated.v4.goals_set import Params as GoalsSetParams
 from opensquilla.contracts.generated.v4.goals_set import Result as GoalsSetResult
 from opensquilla.contracts.generated.v4.goals_set_metadata import GOALS_SET_METHOD
+from opensquilla.contracts.generated.v4.goals_status import (
+    LegacyNonObjectParams as GoalsStatusLegacyNonObjectParams,
+)
 from opensquilla.contracts.generated.v4.goals_status import Params as GoalsStatusParams
 from opensquilla.contracts.generated.v4.goals_status import Result as GoalsStatusResult
 from opensquilla.contracts.generated.v4.goals_status_metadata import GOALS_STATUS_METHOD
@@ -32,6 +40,36 @@ def _errors(exc: ValidationError) -> tuple[dict[str, Any], ...]:
             exc.errors(include_url=False, include_context=False, include_input=False),
         )
     )
+
+
+def goals_status_params_contract_errors(params: Any) -> tuple[dict[str, Any], ...]:
+    """Observe status request drift without replacing Gateway error semantics."""
+
+    try:
+        if isinstance(params, Mapping):
+            GoalsStatusParams.model_validate(dict(params))
+        elif params is not None:
+            GoalsStatusLegacyNonObjectParams.model_validate(params)
+    except ValidationError as exc:
+        return _errors(exc)
+    return ()
+
+
+def goals_set_params_contract_errors(params: Any) -> tuple[dict[str, Any], ...]:
+    """Observe set request drift while forwarding legacy values unchanged."""
+
+    try:
+        if isinstance(params, Mapping):
+            values = dict(params)
+            try:
+                GoalsSetParams.model_validate(values)
+            except ValidationError:
+                GoalsSetLegacyParams.model_validate(values)
+        elif params is not None:
+            GoalsSetLegacyNonObjectParams.model_validate(params)
+    except ValidationError as exc:
+        return _errors(exc)
+    return ()
 
 
 def validate_goals_status_params(params: Any) -> dict[str, Any]:

--- a/src/opensquilla/gateway/adapters/goals_contract.py
+++ b/src/opensquilla/gateway/adapters/goals_contract.py
@@ -1,0 +1,86 @@
+"""Gateway registration adapters for the typed Goal query/command seam."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from opensquilla.contracts.adapters.goals_contract import (
+    GOALS_SET_METHOD,
+    GOALS_STATUS_METHOD,
+    GoalsContractError,
+    goals_set_params_contract_errors,
+    goals_status_params_contract_errors,
+    validate_goals_set_result,
+    validate_goals_status_result,
+)
+from opensquilla.contracts.generated.v4.gateway_contract_registry import (
+    GATEWAY_METHOD_CONTRACTS,
+)
+from opensquilla.gateway.adapters.contract_method import (
+    GatewayContractBinding,
+    GuestAllowedChecker,
+    MethodRegistry,
+    register_gateway_contract_method,
+)
+
+ErrorFactory = Callable[[str, str], Exception]
+
+_GOALS_STATUS_BINDING: GatewayContractBinding[dict[str, Any]] = GatewayContractBinding(
+    descriptor=GATEWAY_METHOD_CONTRACTS[GOALS_STATUS_METHOD],
+    observe_params=goals_status_params_contract_errors,
+    validate_result=validate_goals_status_result,
+    result_validation_errors=(GoalsContractError,),
+    response_error_message="goals.status response violated its v4 contract",
+    request_mismatch_event="goals.status.request_contract_mismatch",
+    response_violation_event="goals.status.contract_violation",
+)
+
+_GOALS_SET_BINDING: GatewayContractBinding[dict[str, Any]] = GatewayContractBinding(
+    descriptor=GATEWAY_METHOD_CONTRACTS[GOALS_SET_METHOD],
+    observe_params=goals_set_params_contract_errors,
+    validate_result=validate_goals_set_result,
+    result_validation_errors=(GoalsContractError,),
+    response_error_message="goals.set response violated its v4 contract",
+    request_mismatch_event="goals.set.request_contract_mismatch",
+    response_violation_event="goals.set.contract_violation",
+)
+
+
+def register_goals_status_contract[ContextT](
+    registry: MethodRegistry[ContextT],
+    implementation: Callable[[Any, ContextT], Awaitable[dict[str, Any]]],
+    *,
+    internal_error: ErrorFactory,
+    guest_allowed_checker: GuestAllowedChecker,
+) -> Callable[[Any, ContextT], Awaitable[dict[str, Any]]]:
+    """Register one validated wrapper around the existing status handler."""
+
+    return register_gateway_contract_method(
+        registry,
+        _GOALS_STATUS_BINDING,
+        implementation,
+        internal_error=internal_error,
+        guest_allowed_checker=guest_allowed_checker,
+    )
+
+
+def register_goals_set_contract[ContextT](
+    registry: MethodRegistry[ContextT],
+    implementation: Callable[[Any, ContextT], Awaitable[dict[str, Any]]],
+    *,
+    internal_error: ErrorFactory,
+    guest_allowed_checker: GuestAllowedChecker,
+) -> Callable[[Any, ContextT], Awaitable[dict[str, Any]]]:
+    """Register one validated wrapper around the existing set handler."""
+
+    return register_gateway_contract_method(
+        registry,
+        _GOALS_SET_BINDING,
+        implementation,
+        internal_error=internal_error,
+        guest_allowed_checker=guest_allowed_checker,
+    )
+
+
+__all__ = ["register_goals_set_contract", "register_goals_status_contract"]

--- a/src/opensquilla/gateway/rpc_goals.py
+++ b/src/opensquilla/gateway/rpc_goals.py
@@ -6,6 +6,11 @@ import uuid
 from collections.abc import Awaitable
 from typing import Any, cast
 
+from opensquilla.gateway.adapters.goals_contract import (
+    register_goals_set_contract,
+    register_goals_status_contract,
+)
+from opensquilla.gateway.guest_rpc_policy import is_guest_rpc_method_allowed
 from opensquilla.gateway.rpc import (
     RpcContext,
     RpcHandlerError,
@@ -195,13 +200,20 @@ async def _handle_goals_capabilities(params: dict | None, ctx: RpcContext) -> di
     }
 
 
-@_d.method("goals.status", scope="operator.read")
 async def _handle_goals_status(params: dict | None, ctx: RpcContext) -> dict:
     service = _goal_service(ctx)
     return await _translate_goal_errors(
         service.status(_session_key(params)),
         service=service,
     )
+
+
+_handle_goals_status_contract = register_goals_status_contract(
+    _d,
+    _handle_goals_status,
+    internal_error=RpcHandlerError,
+    guest_allowed_checker=is_guest_rpc_method_allowed,
+)
 
 
 def _uuid_v4_param(params: dict | None, *names: str) -> str:
@@ -232,7 +244,6 @@ def _objective_param(params: dict | None) -> str:
         ) from exc
 
 
-@_d.method("goals.set", scope="operator.write")
 async def _handle_goals_set(params: dict | None, ctx: RpcContext) -> dict:
     service = _goal_service(ctx)
     objective = _objective_param(params)
@@ -259,6 +270,14 @@ async def _handle_goals_set(params: dict | None, ctx: RpcContext) -> dict:
         ),
         service=service,
     )
+
+
+_handle_goals_set_contract = register_goals_set_contract(
+    _d,
+    _handle_goals_set,
+    internal_error=RpcHandlerError,
+    guest_allowed_checker=is_guest_rpc_method_allowed,
+)
 
 
 def _mutation_params(params: dict | None) -> tuple[str, str, int, str]:

--- a/tests/contracts/test_goals_contract.py
+++ b/tests/contracts/test_goals_contract.py
@@ -4,11 +4,31 @@ import pytest
 
 from opensquilla.contracts.adapters.goals_contract import (
     GoalsContractError,
+    goals_set_params_contract_errors,
+    goals_status_params_contract_errors,
     validate_goals_set_params,
     validate_goals_set_result,
     validate_goals_status_params,
     validate_goals_status_result,
 )
+
+
+def test_status_observer_reports_drift_without_raising() -> None:
+    assert goals_status_params_contract_errors({"session_key": "agent:demo"}) == ()
+    assert goals_status_params_contract_errors({"sessionKey": 1})
+    assert goals_status_params_contract_errors(None) == ()
+
+
+def test_set_observer_accepts_legacy_shape_and_reports_invalid_values() -> None:
+    assert goals_set_params_contract_errors(
+        {
+            "session_key": "agent:demo",
+            "message": "ship",
+            "client_request_id": "550e8400-e29b-41d4-a716-446655440000",
+            "client_message_id": "550e8400-e29b-41d4-a716-446655440001",
+        }
+    ) == ()
+    assert goals_set_params_contract_errors({"sessionKey": "agent:demo"})
 
 
 def test_status_accepts_legacy_session_key_alias() -> None:

--- a/tests/test_ci/test_rpc_architecture_contracts.py
+++ b/tests/test_ci/test_rpc_architecture_contracts.py
@@ -26,8 +26,10 @@ GENERATED_WIRE_IMPORT_ALLOWLIST = frozenset(
         # boundary; no Gateway handler or UI consumer may import them yet.
         "src/opensquilla/contracts/adapters/approval_center_contract.py",
         # S17 keeps the two migrated Goal operations behind GoalCenter; the
-        # remaining Goal mutations stay on the legacy path.
+        # remaining Goal mutations stay on the legacy path.  S18 adds the
+        # Gateway registration boundary without changing their implementation.
         "src/opensquilla/contracts/adapters/goals_contract.py",
+        "src/opensquilla/gateway/adapters/goals_contract.py",
     }
 )
 GENERATED_METADATA_IMPORT_ALLOWLIST = frozenset(
@@ -50,6 +52,11 @@ SESSIONS_SEARCH_METADATA_IMPORT_ALLOWLIST = frozenset(
     {
         "src/opensquilla/contracts/adapters/sessions_search_contract.py",
         "src/opensquilla/gateway/scopes.py",
+    }
+)
+GOALS_METADATA_IMPORT_ALLOWLIST = frozenset(
+    {
+        "src/opensquilla/contracts/adapters/goals_contract.py",
     }
 )
 SESSIONS_CHANGED_METADATA_IMPORT_ALLOWLIST = frozenset(
@@ -92,7 +99,7 @@ SESSIONS_LIST_GATEWAY_ADAPTER = (
     PACKAGE_ROOT / "gateway" / "adapters" / "sessions_list_contract.py"
 )
 RUNTIME_RPC_METHOD_BASELINE = 306
-STATIC_RPC_DECORATOR_BASELINE = 296
+STATIC_RPC_DECORATOR_BASELINE = 294
 
 # Physical lines in the sessions/runtime slice remain tracked for the final
 # closure measurement below.  The temporary S2a cumulative growth budget was
@@ -387,6 +394,14 @@ def test_schema_derived_method_metadata_consumers_are_exact() -> None:
             "opensquilla.contracts.generated.v4.sessions_delete_metadata",
             SESSIONS_DELETE_METADATA_IMPORT_ALLOWLIST,
         ),
+        "goals.status": (
+            "opensquilla.contracts.generated.v4.goals_status_metadata",
+            GOALS_METADATA_IMPORT_ALLOWLIST,
+        ),
+        "goals.set": (
+            "opensquilla.contracts.generated.v4.goals_set_metadata",
+            GOALS_METADATA_IMPORT_ALLOWLIST,
+        ),
     }
     for method, (module_name, allowlist) in allowlists.items():
         consumers = {
@@ -471,7 +486,8 @@ def _reaches(graph: dict[str, set[str]], start: str, target: str) -> bool:
 def test_contract_gateway_adapters_do_not_join_a_gateway_cycle() -> None:
     graph = _module_import_graph()
     resolve_adapter = PACKAGE_ROOT / "gateway" / "adapters" / "sessions_resolve_contract.py"
-    for adapter_path in (SESSIONS_LIST_GATEWAY_ADAPTER, resolve_adapter):
+    goals_adapter = PACKAGE_ROOT / "gateway" / "adapters" / "goals_contract.py"
+    for adapter_path in (SESSIONS_LIST_GATEWAY_ADAPTER, resolve_adapter, goals_adapter):
         adapter = _module_name(adapter_path)
         cycle_edges = sorted(
             dependency
@@ -556,6 +572,11 @@ def test_static_rpc_decorator_sites_are_exact_and_contract_methods_are_adapter_r
         for site in sites
         if site[2] in {"sessions.resolve", "SESSIONS_RESOLVE_METHOD"}
     ] == []
+    assert [
+        site
+        for site in sites
+        if site[2] in {"goals.status", "goals.set", "GOALS_STATUS_METHOD", "GOALS_SET_METHOD"}
+    ] == []
 
 
 def test_runtime_rpc_surface_is_exact_and_contract_methods_use_generic_adapter() -> None:
@@ -588,6 +609,26 @@ def test_runtime_rpc_surface_is_exact_and_contract_methods_use_generic_adapter()
     assert entry.required_scope == SESSIONS_RESOLVE_SCOPE
     assert entry.handler.__module__ == "opensquilla.gateway.adapters.contract_method"
     assert entry.handler.__name__ == "handle_contract_method"
+
+    from opensquilla.contracts.generated.v4.goals_set_metadata import (
+        GOALS_SET_METHOD,
+        GOALS_SET_SCOPE,
+    )
+    from opensquilla.contracts.generated.v4.goals_status_metadata import (
+        GOALS_STATUS_METHOD,
+        GOALS_STATUS_SCOPE,
+    )
+
+    for method, scope in (
+        (GOALS_STATUS_METHOD, GOALS_STATUS_SCOPE),
+        (GOALS_SET_METHOD, GOALS_SET_SCOPE),
+    ):
+        entry = registry.get_entry(method)
+        assert entry is not None
+        assert entry.name == method
+        assert entry.required_scope == scope
+        assert entry.handler.__module__ == "opensquilla.gateway.adapters.contract_method"
+        assert entry.handler.__name__ == "handle_contract_method"
 
 
 def test_cross_rpc_private_import_debt_is_exact() -> None:

--- a/tests/test_gateway/test_goal_rpc.py
+++ b/tests/test_gateway/test_goal_rpc.py
@@ -17,6 +17,10 @@ import pytest
 
 from opensquilla.engine.runtime import TurnRunner
 from opensquilla.engine.start_turn import reserve_turn_via_runtime
+from opensquilla.gateway.adapters.goals_contract import (
+    register_goals_set_contract,
+    register_goals_status_contract,
+)
 from opensquilla.gateway.auth import Principal
 from opensquilla.gateway.boot import dispatch_task_runtime_turn
 from opensquilla.gateway.config import (
@@ -26,9 +30,10 @@ from opensquilla.gateway.config import (
     SquillaRouterConfig,
 )
 from opensquilla.gateway.goal_service import GoalService
+from opensquilla.gateway.guest_rpc_policy import is_guest_rpc_method_allowed
 from opensquilla.gateway.project_workspace_runtime import AcceptedRunModeOverride
 from opensquilla.gateway.routing import build_web_route_envelope
-from opensquilla.gateway.rpc import RpcContext, RpcHandlerError
+from opensquilla.gateway.rpc import RpcContext, RpcHandlerError, RpcRegistry
 from opensquilla.gateway.rpc_config import _notify_goal_config_changed
 from opensquilla.gateway.rpc_goals import (
     _handle_goals_capabilities,
@@ -4920,3 +4925,76 @@ async def test_running_goal_edit_adopts_revision_in_same_task_without_transcript
         )
         assert await stack.runtime.has_session_work(SOURCE_KEY) is False
         assert await _table_count(stack.storage, "agent_tasks") == 1
+
+
+@pytest.mark.asyncio
+async def test_goal_contract_adapters_register_one_handler_per_operation() -> None:
+    registry = RpcRegistry()
+    status_result = {
+        "sessionKey": SOURCE_KEY,
+        "sessionId": "session-id",
+        "epoch": 0,
+        "goal": None,
+    }
+    set_result = {
+        "accepted": True,
+        "goal": {"status": "active"},
+    }
+    observed: list[tuple[str, Any]] = []
+
+    async def status_implementation(params: Any, _ctx: Any) -> dict[str, Any]:
+        observed.append(("status", params))
+        return status_result
+
+    async def set_implementation(params: Any, _ctx: Any) -> dict[str, Any]:
+        observed.append(("set", params))
+        return set_result
+
+    status_handler = register_goals_status_contract(
+        registry,
+        status_implementation,
+        internal_error=RpcHandlerError,
+        guest_allowed_checker=is_guest_rpc_method_allowed,
+    )
+    set_handler = register_goals_set_contract(
+        registry,
+        set_implementation,
+        internal_error=RpcHandlerError,
+        guest_allowed_checker=is_guest_rpc_method_allowed,
+    )
+
+    assert await status_handler({"session_key": SOURCE_KEY}, object()) is status_result
+    assert await set_handler({"session_key": SOURCE_KEY, "message": "ship"}, object()) is set_result
+    assert observed == [
+        ("status", {"session_key": SOURCE_KEY}),
+        ("set", {"session_key": SOURCE_KEY, "message": "ship"}),
+    ]
+    assert registry.get_entry("goals.status") is not None
+    assert registry.get_entry("goals.set") is not None
+    assert registry.get_entry("goals.status").handler is status_handler
+    assert registry.get_entry("goals.set").handler is set_handler
+
+
+@pytest.mark.asyncio
+async def test_goal_contract_adapter_maps_invalid_result_without_running_twice() -> None:
+    registry = RpcRegistry()
+    calls = 0
+
+    async def implementation(_params: Any, _ctx: Any) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        return {"accepted": True}
+
+    handler = register_goals_set_contract(
+        registry,
+        implementation,
+        internal_error=RpcHandlerError,
+        guest_allowed_checker=is_guest_rpc_method_allowed,
+    )
+
+    with pytest.raises(RpcHandlerError) as error:
+        await handler({"sessionKey": SOURCE_KEY}, object())
+
+    assert calls == 1
+    assert error.value.code == "INTERNAL_ERROR"
+    assert error.value.message == "goals.set response violated its v4 contract"


### PR DESCRIPTION
## 目的
把已在 #1510 完成 WebUI Contract 迁移的 `goals.status` / `goals.set` 接入 Gateway Contract Adapter，完成这一小块的前后端边界收口。

## 本 PR 做什么
- 新增 Goal Gateway registration adapter，使用生成的 method/scope/错误元数据。
- 保留现有 `GoalService`、handler 实现、v4 WebSocket wire、权限和错误语义。
- 旧请求参数继续原样转发；Contract 校验只做兼容性观测，响应校验失败映射为现有 `INTERNAL_ERROR`。
- 移除这两个方法的动态 decorator，运行时各保留一个通用 Contract handler。
- 增加生成物导入、注册表、循环依赖和单次调用测试。

## 明确不在本 PR
- `goals.capabilities`、edit/pause/resume/reattach/clear 及 Goal events。
- TurnRunner、TaskRuntime、transport、数据库 schema、WebUI 页面行为。
- gRPC/tRPC 或第二传输栈。

## 基线与兼容
- 基于 `origin/main` `db2d816beb26261eda53353d7d84e4378adbafb6`。
- 旧 WebUI/CLI/MCP 与新 Gateway 的 v4 wire 兼容保持不变。
- 不新增 generated wire 到 Vue 或业务实现。

## 验证
- `97 passed`：Goal contract、Gateway goal RPC、RPC architecture gates。
- `77 passed`：guest policy、WebSocket concurrency/close coordination、API sessions。
- mypy、ruff、`generate_gateway_contracts.py --check` 通过。

下一步 capability 探测会作为独立 PR，依赖本 PR 合入。