### PR TITLE
refactor(webui): own goal mode availability in module

### DIFF
--- a/opensquilla-webui/scripts/rpc-debt/session-chat.mjs
+++ b/opensquilla-webui/scripts/rpc-debt/session-chat.mjs
@@ -78,9 +78,9 @@ export const debt = {
     call: 5,
     on: 1,
     supportsEvent: 1,
-    // Turn capability probes are owned by TurnCommands; the remaining
-    // method probes belong to non-Turn domains and migrate independently.
-    supportsMethod: 9,
+    // Turn capability probes are owned by TurnCommands; Goal mode probes are
+    // owned by GoalCenter; the remaining method probes migrate independently.
+    supportsMethod: 7,
     waitForConnection: 2,
     httpRequest: 1,
     httpApiEndpoint: 1,

--- a/opensquilla-webui/src/adapters/gateway/goalCenterV4.test.ts
+++ b/opensquilla-webui/src/adapters/gateway/goalCenterV4.test.ts
@@ -14,6 +14,15 @@ function transport(response: unknown, supported = true) {
 }
 
 describe('createV4GoalCenter', () => {
+  it('keeps goal-mode availability behind the semantic module boundary', () => {
+    const source = {
+      supports: (method: string) => method === 'goals.set' || method === 'goals.capabilities',
+      request: async <T>(_method: string, _params?: Record<string, unknown>) => undefined as T,
+    }
+    const center = createV4GoalCenter(source)
+    expect(center.available('goal-mode')).toBe(true)
+  })
+
   it('validates and projects goals.status without exposing wire aliases', async () => {
     const source = transport({ session_key: 'agent:demo', session_id: 's1', epoch: 2, goal: { status: 'active', goal_id: 'g1', objective: 'ship', session_key: 'agent:demo', session_id: 's1', epoch: 2, state_revision: 3, objective_revision: 1, progress_revision: 0, active_task_id: null, source_user_message_id: 'm1', turns_started: 2, usage: { total_tokens: 4 } } })
     const center = createV4GoalCenter(source)

--- a/opensquilla-webui/src/adapters/gateway/goalCenterV4.ts
+++ b/opensquilla-webui/src/adapters/gateway/goalCenterV4.ts
@@ -59,7 +59,13 @@ function optionsFor(signal: AbortSignal | undefined): RpcCallOptions | undefined
 
 export function createV4GoalCenter(transport: GoalCenterTransport): GoalCenter {
   return {
-    available(operation = 'status') { return transport.supports?.(operation === 'set' ? GOALS_SET_METHOD : GOALS_STATUS_METHOD) ?? true },
+    available(operation = 'status') {
+      if (!transport.supports) return true
+      if (operation === 'goal-mode') {
+        return transport.supports(GOALS_SET_METHOD) && transport.supports('goals.capabilities')
+      }
+      return transport.supports(operation === 'set' ? GOALS_SET_METHOD : GOALS_STATUS_METHOD)
+    },
     async status(sessionKey, options): Promise<GoalStatusResult> {
       const params: GoalStatusParams = { sessionKey }
       if (!validateGoalStatusParams(params)) throw new GoalCenterError('invalid', 'goals.status params violated Contract')

--- a/opensquilla-webui/src/modules/goalCenter.ts
+++ b/opensquilla-webui/src/modules/goalCenter.ts
@@ -82,7 +82,8 @@ export class GoalCenterError extends Error {
 }
 
 export interface GoalCenter {
-  available(operation?: 'status' | 'set'): boolean
+  /** Report whether the requested Goal UX operation is available. */
+  available(operation?: 'status' | 'set' | 'goal-mode'): boolean
   status(sessionKey: string, options?: { signal?: AbortSignal }): Promise<GoalStatusResult>
   set(input: GoalSetInput, options?: { signal?: AbortSignal }): Promise<GoalSetResult>
 }

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -4414,10 +4414,7 @@ const planUiAvailable = computed(() =>
   rpc.supportsMethod('plans.setMode')
   && rpc.supportsMethod('plans.capabilities'),
 )
-const goalUiAvailable = computed(() =>
-  rpc.supportsMethod('goals.set')
-  && rpc.supportsMethod('goals.capabilities'),
-)
+const goalUiAvailable = computed(() => goalCenter.available('goal-mode'))
 const goalComposerExisting = computed(() => (
   currentGoalRun.value !== null
   && !goalStatusIsTerminal(currentGoalRun.value.status)


### PR DESCRIPTION
## 目的
把 Goal 模式的可用性判断从 `ChatView.vue` 收回 `GoalCenter` 语义接口，继续推进页面与 v4 RPC 细节分离。

## 本 PR 做什么
- `GoalCenter.available('goal-mode')` 统一判断 Goal mode 所需的 `goals.set` 与 capability availability。
- `ChatView.vue` 不再直接调用 `rpc.supportsMethod('goals.set' / 'goals.capabilities')`。
- 更新 session-chat RPC debt 基线（9 → 7），增加 adapter 单测。
- 保持当前同步显示、混合版本 fallback 和 Goal 行为不变。

## 明确不在本 PR
- 不新增 `goals.capabilities` schema 或 generated wire。
- 不修改 Gateway、GoalService、transport、数据库或执行开关语义。
- `executionEnabled` 仍不参与 Goal mode availability；capability RPC Contract 另开后续小 PR。

## 基线与验证
- 基于已合入 S18 的 `origin/main` `fed61b7d32cbce905b1d729e9a28a7fa41e6ecfa`。
- `goalCenterV4.test.ts`：13 passed。
- WebUI architecture guard、RPC debt guard、typecheck、i18n/theme checks 全部通过。
- 仅 5 个 WebUI 文件，未触及后端。