### PR TITLE
fix(tests): use native_io_path for pending attachment reads on Windows

### DIFF
--- a/tests/test_gateway/test_turn_ingress_rpc.py
+++ b/tests/test_gateway/test_turn_ingress_rpc.py
@@ -60,6 +60,7 @@ from opensquilla.gateway.session_model_routing import (
 from opensquilla.gateway.task_runtime import TaskRuntime
 from opensquilla.gateway.turn_ingress import request_fingerprint
 from opensquilla.gateway.uploads import UploadStore, get_upload_store, set_upload_store
+from opensquilla.paths import native_io_path
 from opensquilla.session.goals import GoalCommandRequest, StartGoalMutation, new_goal
 from opensquilla.session.manager import SessionManager
 from opensquilla.session.models import (
@@ -1646,7 +1647,7 @@ async def test_pending_attachment_survives_restart_dispatches_once_and_cleans_ow
                 "pending-rpc-durable-attachment",
                 digest,
             )
-            assert owner_path.read_bytes() == payload
+            assert native_io_path(owner_path).read_bytes() == payload
 
             # The expiring upload is gone and the process-local upload store is
             # replaced, matching a Gateway restart. Dispatch must use only the
@@ -1687,11 +1688,12 @@ async def test_pending_attachment_survives_restart_dispatches_once_and_cleans_ow
             assert replayed.ok is True
             assert replayed.payload["message_id"] == accepted.payload["message_id"]
             assert not owner_path.exists()
-            assert transcript_material_path(
+            canonical_path = transcript_material_path(
                 Path(stack.context.config.attachments.media_root or ""),
                 stack.session_id,
                 digest,
-            ).read_bytes() == payload
+            )
+            assert native_io_path(canonical_path).read_bytes() == payload
             assert _table_counts(stack.db_path) == {
                 "transcript_entries": 1,
                 "agent_tasks": 1,
@@ -1745,7 +1747,7 @@ async def test_pending_attachment_cancel_removes_only_its_private_owner(
                 stack.session_id,
                 digest,
             )
-            assert owner_path.read_bytes() == payload
+            assert native_io_path(owner_path).read_bytes() == payload
             assert not canonical_path.exists()
 
             cancelled = await get_dispatcher().dispatch(
@@ -1804,7 +1806,7 @@ async def test_session_delete_reclaims_pending_attachment_owner(
                 "pending-rpc-delete-attachment",
                 digest,
             )
-            assert owner_path.read_bytes() == payload
+            assert native_io_path(owner_path).read_bytes() == payload
 
             deleted = await get_dispatcher().dispatch(
                 "pending-attachment-session-delete",


### PR DESCRIPTION
> Superseded by #1727, which carries this Windows long-path test fix onto current main and also fixes the newer revision-precondition and cleanup assertions. #1727 merged through the protected merge queue as `00071e166037a9ba09da9a70ce057954a4498d4d`; the merge commit is verified on main. This original PR is closed as superseded, not merged.

## Problem  Three pending-attachment RPC tests in `tests/test_gateway/test_turn_ingress_rpc.py` fail on Windows with `FileNotFoundError` even though the material file exists on disk:  - `test_pending_attachment_survives_restart_dispatches_once_and_cleans_owner` - `test_pending_attachment_cancel_removes_only_its_private_owner` - `test_session_delete_reclaims_pending_attachment_owner`  The staged owner paths are ~297 characters (`media/transcripts/<session-uuid>/.pending-chat-inputs/<64-hex owner digest>/<64-hex content sha>`), past `MAX_PATH` (260). The production writer goes through `native_io_path()` (extended-length `\\?\` prefix) and succeeds, but the test assertions read the bare pathlib object, which the Win32 layer refuses — so the assert sees "no such file" while the file is actually there.  Live reproduction confirmed this: `Test-Path` on the bare path returned `False` while the same path with the `\\?\` prefix returned `True`. The DB-level assertions (which never touch disk) pass; only the bare `read_bytes()` asserts fail.  ## Fix  Route the four affected test assertions through `native_io_path()`, matching the convention documented in `paths.py` ("use this value only at the filesystem or SQLite boundary"). No product code changes.  ## Verification  - Test file: **71 passed** on Windows (previously 3 failed / 68 passed) - ruff: clean - Pre-existing upstream bug: the same 3 failures reproduce on clean `main` in an isolated worktree, unrelated to any in-flight PR.