### PR TITLE
[Bug] Make isolated Cron sessions read-only

### DIFF
--- a/opensquilla-webui/src/adapters/gateway/sessionDirectoryV4.test.ts
+++ b/opensquilla-webui/src/adapters/gateway/sessionDirectoryV4.test.ts
@@ -10,6 +10,7 @@ import { SESSIONS_LIST_METHOD } from '@/contracts/generated/v4/sessionsList'
 import { SESSIONS_RESOLVE_METHOD } from '@/contracts/generated/v4/sessionsResolve'
 import { SESSIONS_SEARCH_METHOD } from '@/contracts/generated/v4/sessionsSearch'
 import type { SessionDirectory } from '@/modules/sessionDirectory'
+import { isCronSessionKey } from '@/modules/sessionDirectory'
 import { useSessions } from '@/composables/useSessions'
 
 type SessionDirectoryTransport = Parameters<typeof createV4SessionDirectory>[0]
@@ -44,6 +45,12 @@ function fixtureCase(document: string, caseId: string): WireFixture {
 }
 
 describe('v4 SessionDirectory Adapter', () => {
+  it('recognizes isolated cron session keys as read-only', () => {
+    expect(isCronSessionKey('cron:job-1:run:1')).toBe(true)
+    expect(isCronSessionKey(' CRON:job-1:run:1 ')).toBe(true)
+    expect(isCronSessionKey('agent:main:webchat:one')).toBe(false)
+  })
+
   it('uses the pinned legacy Gateway wire without requiring a new envelope', async () => {
     const request = fixtureCase('requests.json', 'request.page-first')
     const response = fixtureCase('responses.json', 'response.empty-page')

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -3346,6 +3346,7 @@
     "sendQueues": "Senden (wird nach der aktuellen Antwort in die Warteschlange gestellt)",
     "sendSteers": "Senden (lenkt die aktuelle Antwort jetzt)",
     "sendQueuesUntilCompaction": "Senden (in Warteschlange, bis die Verdichtung abgeschlossen ist)",
+    "cronSessionReadOnly": "Cron-Sitzungen sind schreibgeschützt und können keine neuen Nachrichten empfangen.",
     "stopResponse": "Aktuelle Antwort stoppen",
     "stopResponseEsc": "Aktuelle Antwort stoppen (Esc)",
     "stoppingResponse": "Wird sicher beendet… Neue Nachrichten werden eingereiht.",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -3436,6 +3436,7 @@
     "sendQueues": "Send (queues for after current response)",
     "sendSteers": "Send (steers the current response now)",
     "sendQueuesUntilCompaction": "Send (queues until compaction finishes)",
+    "cronSessionReadOnly": "Cron sessions are read-only and cannot receive new turns.",
     "stopResponse": "Stop current response",
     "stopResponseEsc": "Stop current response (Esc)",
     "stoppingResponse": "Stopping safely… New messages will be queued.",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -3346,6 +3346,7 @@
     "sendQueues": "Enviar (se pone en cola hasta después de la respuesta actual)",
     "sendSteers": "Enviar (redirige la respuesta actual ahora)",
     "sendQueuesUntilCompaction": "Enviar (se pone en cola hasta que termine la compactación)",
+    "cronSessionReadOnly": "Las sesiones de Cron son de solo lectura y no pueden recibir nuevos turnos.",
     "stopResponse": "Detener respuesta actual",
     "stopResponseEsc": "Detener respuesta actual (Esc)",
     "stoppingResponse": "Deteniendo de forma segura… Los mensajes nuevos se pondrán en cola.",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -3346,6 +3346,7 @@
     "sendQueues": "Envoyer (mise en file après la réponse actuelle)",
     "sendSteers": "Envoyer (réoriente la réponse actuelle maintenant)",
     "sendQueuesUntilCompaction": "Envoyer (mise en file jusqu'à la fin du compactage)",
+    "cronSessionReadOnly": "Les sessions Cron sont en lecture seule et ne peuvent pas recevoir de nouveaux tours.",
     "stopResponse": "Arrêter la réponse actuelle",
     "stopResponseEsc": "Arrêter la réponse actuelle (Échap)",
     "stoppingResponse": "Arrêt sécurisé en cours… Les nouveaux messages seront mis en file.",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -3346,6 +3346,7 @@
     "sendQueues": "送信（現在の応答後にキューへ追加）",
     "sendSteers": "送信（現在の応答を今すぐ誘導）",
     "sendQueuesUntilCompaction": "送信（圧縮の完了までキューへ追加）",
+    "cronSessionReadOnly": "Cron セッションは読み取り専用で、新しいターンを受け付けません。",
     "stopResponse": "現在の応答を停止",
     "stopResponseEsc": "現在の応答を停止（Esc）",
     "stoppingResponse": "安全に停止しています… 新しいメッセージはキューに入ります。",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -3436,6 +3436,7 @@
     "sendQueues": "发送（排队等待当前回复结束）",
     "sendSteers": "发送（立即引导当前回复）",
     "sendQueuesUntilCompaction": "发送（排队等待压缩完成）",
+    "cronSessionReadOnly": "定时任务会话为只读，不能接收新的对话轮次。",
     "stopResponse": "停止当前回复",
     "stopResponseEsc": "停止当前回复（Esc）",
     "stoppingResponse": "正在安全停止… 新消息将进入队列。",

--- a/opensquilla-webui/src/modules/sessionDirectory.ts
+++ b/opensquilla-webui/src/modules/sessionDirectory.ts
@@ -25,6 +25,11 @@ export interface SessionItem {
   hasContractGaps: boolean
 }
 
+/** Cron runs are isolated, scheduled sessions and are intentionally read-only. */
+export function isCronSessionKey(key: string): boolean {
+  return key.trim().toLowerCase().startsWith('cron:')
+}
+
 export interface SessionPage {
   items: SessionItem[]
   hasMore: boolean

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -545,6 +545,13 @@
          composer instead of pinning it to the bottom, so the menu must not
          anchor to the chat container's bottom edge. -->
     <div class="chat-composer-dock">
+    <div
+      v-if="isCronSession"
+      class="chat-composer-read-only"
+      role="status"
+      aria-live="polite"
+    >{{ t('chat.cronSessionReadOnly') }}</div>
+    <template v-else>
     <!-- Durable execution progress belongs to the work surface, not to the
          transcript. Keeping it immediately above the composer also lets a
          execution surfaces reuse this dock across multiple turns. -->
@@ -747,6 +754,7 @@
       @close="projectPickerOpen = false"
       @choose="chooseProjectPath"
     />
+    </template>
     </div>
 
     <ToolResultModal
@@ -805,6 +813,7 @@ import { useRpcStore } from '@/stores/rpc'
 import {
   SESSION_DIRECTORY_KEY,
   SessionDirectoryError,
+  isCronSessionKey,
 } from '@/modules/sessionDirectory'
 import { SESSION_LIFECYCLE_KEY } from '@/modules/sessionLifecycle'
 import { PENDING_INPUT_QUEUE_KEY } from '@/modules/pendingInputQueue'
@@ -1275,6 +1284,7 @@ function cancelActiveProjectValidation() {
 const isCompactViewport = useMediaQuery('(max-width: 480px)')
 const isDesktopViewport = useMediaQuery('(min-width: 769px)')
 const landingAgentId = computed(() => agentIdFromSessionKey(sessionKey.value))
+const isCronSession = computed(() => isCronSessionKey(sessionKey.value))
 // True when the current draft opened with prefilled composer text (Sessions
 // Hub task input); the landing suggestion chips stay out of the way then.
 const landingPrefilled = ref(false)
@@ -7124,5 +7134,11 @@ watch(
   width: 100%;
   height: 1px;
   pointer-events: none;
+}
+
+.chat-composer-read-only {
+  padding: 0.75rem 1rem;
+  color: var(--text-muted);
+  text-align: center;
 }
 </style>

--- a/src/opensquilla/gateway/rpc_sessions.py
+++ b/src/opensquilla/gateway/rpc_sessions.py
@@ -120,7 +120,11 @@ from opensquilla.gateway.session_services import (
     set_session_epoch,
 )
 from opensquilla.gateway.session_streams import get_session_streams
-from opensquilla.gateway.session_view import build_session_view_item, derive_transcript_title
+from opensquilla.gateway.session_view import (
+    _surface,
+    build_session_view_item,
+    derive_transcript_title,
+)
 from opensquilla.gateway.subagent_announce import (
     quiesce_background_completion_sessions,
 )
@@ -3946,6 +3950,19 @@ async def _handle_sessions_send_impl_inner(
                     previous_acceptance.receipt.accepted_session_key,
                 )
             return replay_response
+
+    if session_intent is SessionIntent.CONTINUE:
+        existing_session = await storage.get_session(key)
+        if existing_session is not None:
+            origin = getattr(existing_session, "origin", None)
+            origin_map = origin if isinstance(origin, dict) else {}
+            if _surface(existing_session, key, origin_map) == "cron":
+                raise RpcHandlerError(
+                    "SESSION_NOT_INTERACTIVE",
+                    "Cron isolated sessions are read-only and cannot receive new turns.",
+                    retryable=False,
+                    accepted=False,
+                )
 
     if prompt_annotation_ids or document_context_request is not None:
         existing_annotation_session = await storage.get_session(key)

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -3789,6 +3789,28 @@ class TestSessionsSend:
         assert res.error.code == "NOT_FOUND"
 
     @pytest.mark.asyncio
+    async def test_send_rejects_cron_session_before_acceptance(self, dispatcher):
+        cron_session = FakeSession(
+            session_key="cron:job-1:run:1",
+            session_id="cron-run-1",
+            origin={"kind": "cron"},
+        )
+        manager = FakeSessionManager([cron_session])
+        ctx = make_ctx(session_manager=manager, turn_runner=_RecordingTurnRunner())
+
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.send",
+            {"key": cron_session.session_key, "message": "Unexpected follow-up"},
+            ctx,
+        )
+
+        assert res.ok is False
+        assert res.error.code == "SESSION_NOT_INTERACTIVE"
+        assert manager.applied_intents == []
+        assert manager.created_messages == []
+
+    @pytest.mark.asyncio
     async def test_send_rejects_too_many_attachments(self, dispatcher, ctx_with_sessions, session):
         # The per-turn cap is 10; 11 must be rejected.
         res = await dispatcher.dispatch(


### PR DESCRIPTION
## Scope

Scope boundary: Prevent isolated Cron sessions from accepting follow-up turns through the Gateway or Web UI.

Non-goals: Change Cron scheduling, transcript display, or interactivity for chat, CLI, channel, or subagent sessions.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Fixes #1520

## Release Note

Release note: NONE

## Tests

Ruff: `uv run --frozen ruff check src/opensquilla/gateway/rpc_sessions.py tests/test_gateway/test_rpc_sessions.py` passed. The pinned environment's Ruff formatter reports the two existing files would be reformatted by its newer formatter; unrelated full-file formatting was not included.

Pytest: `uv run --frozen pytest tests/test_gateway/test_rpc_sessions.py -q --tb=short` passed (301 tests). The full `PYTHONUTF8=1 uv run --frozen pytest -x -vv --tb=long` run reached 1,672 passed and 67 skipped before the pre-existing `tests/test_ci/test_rpc_architecture_contracts.py::test_f2_foundation_runtime_stays_within_explicit_ceiling` failure (1,216 lines versus the 1,200-line baseline ceiling); the same failure reproduces on `origin/main`.

Build: `npm run build` and `uv build --wheel` passed.

Regression tests: added

Notes: The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: contributors are not expected to provide secrets or run credentialed live checks. Maintainers may run `Live Release E2E` for provider, browser, gateway, channel, or release smoke coverage.

## Safety

No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, or AI session artifacts are included.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.