### PR TITLE
Refactor sandbox runtime domain boundaries

### DIFF
--- a/opensquilla-webui/scripts/rpc-debt/platform.mjs
+++ b/opensquilla-webui/scripts/rpc-debt/platform.mjs
@@ -9,12 +9,7 @@ export const debt = {
   },
   'src/composables/channels/useChannelEditor.ts': { call: 1, waitForConnection: 1 },
   'src/composables/channels/useChannelMembers.ts': { call: 5, waitForConnection: 1 },
-  'src/composables/chat/useSandboxSetupRecovery.ts': {
-    call: 1,
-    callReference: 1,
-    waitForConnectionReference: 1,
-  },
-  'src/composables/settings/useSandboxSettings.ts': { call: 10, waitForConnection: 6 },
+  'src/composables/settings/useSandboxSettings.ts': { call: 1, waitForConnection: 1 },
   'src/composables/setup/channelRpc.ts': { call: 2 },
   'src/composables/setup/useMemoryLearningSettings.ts': { call: 1 },
   'src/stores/sandboxSetup.ts': { call: 2, waitForConnection: 1 },

--- a/opensquilla-webui/scripts/rpc-debt/session-chat.mjs
+++ b/opensquilla-webui/scripts/rpc-debt/session-chat.mjs
@@ -55,13 +55,12 @@ export const debt = {
     httpSessionKeyHeader: 1,
   },
   'src/views/ChatView.vue': {
-    call: 4,
-    on: 1,
+    call: 2,
     supportsEvent: 1,
     // Turn capability probes are owned by TurnCommands; Goal mode probes are
     // owned by GoalCenter; the remaining method probes migrate independently.
     supportsMethod: 5,
-    waitForConnection: 2,
+    waitForConnection: 1,
     httpRequest: 1,
     httpApiEndpoint: 1,
     httpAuthToken: 1,

--- a/opensquilla-webui/src/adapters/gateway/gatewayAdapters.test.ts
+++ b/opensquilla-webui/src/adapters/gateway/gatewayAdapters.test.ts
@@ -41,6 +41,7 @@ describe('Gateway Adapter composition', () => {
       'setupWorkflow',
       'migrationOperations',
       'workspaceCatalog',
+      'sandboxRuntime',
     ])
     expect(adapters).not.toHaveProperty('rpc')
     expect(adapters).not.toHaveProperty('events')

--- a/opensquilla-webui/src/adapters/gateway/gatewayAdapters.ts
+++ b/opensquilla-webui/src/adapters/gateway/gatewayAdapters.ts
@@ -32,6 +32,8 @@ import type { MigrationOperations } from '@/modules/migrationOperations'
 import { createV4MigrationOperations } from './migrationOperationsV4'
 import type { WorkspaceCatalog } from '@/modules/workspaceCatalog'
 import { createV4WorkspaceCatalog } from './workspaceCatalogV4'
+import type { SandboxRuntime } from '@/modules/sandboxRuntime'
+import { createV4SandboxRuntime } from './sandboxRuntimeV4'
 
 type RpcStoreTransportSource = Parameters<typeof createPrivateGatewayTransports>[0]
 
@@ -52,6 +54,7 @@ export interface GatewayAdapters {
   readonly setupWorkflow: SetupWorkflow
   readonly migrationOperations: MigrationOperations
   readonly workspaceCatalog: WorkspaceCatalog
+  readonly sandboxRuntime: SandboxRuntime
 }
 
 interface GatewayHttpSource {
@@ -94,6 +97,10 @@ export function createGatewayAdapters(
     setupWorkflow: createV4SetupWorkflow(transports.rpc),
     migrationOperations: createV4MigrationOperations(transports.rpc),
     workspaceCatalog: createV4WorkspaceCatalog(transports.rpc),
+    sandboxRuntime: createV4SandboxRuntime({
+      ...transports.rpc,
+      subscribe: (event, handler) => transports.events.subscribe(event, handler),
+    }),
   }
   return adapters
 }

--- a/opensquilla-webui/src/adapters/gateway/sandboxRuntimeV4.test.ts
+++ b/opensquilla-webui/src/adapters/gateway/sandboxRuntimeV4.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createV4SandboxRuntime } from './sandboxRuntimeV4'
+
+describe('createV4SandboxRuntime', () => {
+  it('maps domain operations to the private sandbox wire methods', async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === 'sandbox.policy.get') return { schemaVersion: 2, policyVersion: 0 }
+      if (method === 'sandbox.run_mode.preference.set') return { runMode: 'safe', source: 'preference' }
+      return { state: 'ready', platform: 'linux', message: 'ready', requiresAdmin: false }
+    })
+    const runtime = createV4SandboxRuntime({ request: request as never })
+
+    await expect(runtime.policy()).resolves.toEqual({ schemaVersion: 2, policyVersion: 0 })
+    await expect(runtime.setRunMode('safe')).resolves.toEqual({
+      runMode: 'safe',
+      source: 'preference',
+    })
+    expect(request).toHaveBeenNthCalledWith(1, 'sandbox.policy.get', undefined, expect.anything())
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      'sandbox.run_mode.preference.set',
+      { runMode: 'safe' },
+      expect.anything(),
+    )
+  })
+
+  it('normalizes malformed setup payloads to null and forwards event projections', async () => {
+    const handler = vi.fn()
+    const close = vi.fn()
+    const runtime = createV4SandboxRuntime({
+      request: vi.fn(async () => ({ nope: true })) as never,
+      subscribe: vi.fn((_event, callback) => {
+        callback({ runMode: 'safe', source: 'preference' })
+        return { close }
+      }),
+    })
+
+    await expect(runtime.setupStatus()).resolves.toBeNull()
+    const unsubscribe = runtime.subscribeRunModePreferenceChanged(handler)
+    expect(handler).toHaveBeenCalledWith({ runMode: 'safe', source: 'preference' })
+    unsubscribe()
+    expect(close).toHaveBeenCalledOnce()
+  })
+})

--- a/opensquilla-webui/src/adapters/gateway/sandboxRuntimeV4.ts
+++ b/opensquilla-webui/src/adapters/gateway/sandboxRuntimeV4.ts
@@ -1,0 +1,122 @@
+import type { RpcCallOptions } from '@/lib/rpc'
+import type {
+  SandboxCapabilityReport,
+  SandboxPolicy,
+  SandboxPolicyDefaults,
+  SandboxRunMode,
+  SandboxRuntimePackStatus,
+  SandboxSetupStatusPayload,
+  SandboxTokenRecord,
+} from '@/types/sandbox'
+import type { SandboxRuntime } from '@/modules/sandboxRuntime'
+
+interface SandboxTransport {
+  request<T = unknown>(method: string, params?: Record<string, unknown>, options?: RpcCallOptions): Promise<T>
+  ready?: (options?: { timeoutMs?: number }) => Promise<void>
+  subscribe?: (event: string, handler: (payload: unknown) => void) => { close(): void }
+}
+
+const METHODS = {
+  status: 'sandbox.status',
+  setupStatus: 'sandbox.setup.status',
+  ensureSetup: 'sandbox.setup.ensure',
+  capability: 'sandbox.capability.status',
+  policy: 'sandbox.policy.get',
+  policyDefaults: 'sandbox.policy.defaults',
+  policyUpdate: 'sandbox.policy.update',
+  runModeGet: 'sandbox.run_mode.preference.get',
+  runModeSet: 'sandbox.run_mode.preference.set',
+  runtimeStatus: 'sandbox.runtime.status',
+  runtimeInstall: 'sandbox.runtime.install',
+  runtimeCancel: 'sandbox.runtime.cancel',
+  runtimeRemove: 'sandbox.runtime.remove',
+  runtimeDiscard: 'sandbox.runtime.discard_download',
+  tokensList: 'sandbox.tokens.list',
+  tokensCreate: 'sandbox.tokens.create',
+  tokensRevoke: 'sandbox.tokens.revoke',
+  resume: 'sandbox.resume',
+} as const
+
+function options(): RpcCallOptions {
+  return { timeoutMs: 15_000, timeoutAction: 'reject', abortAction: 'reject' }
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+}
+
+function setupStatus(value: unknown): SandboxSetupStatusPayload | null {
+  const raw = record(value)
+  const state = raw.state
+  if (!['not_setup', 'setting_up', 'ready', 'failed', 'unavailable'].includes(String(state))) return null
+  return {
+    state: state as SandboxSetupStatusPayload['state'],
+    platform: String(raw.platform ?? ''),
+    message: String(raw.message ?? ''),
+    requiresAdmin: raw.requiresAdmin === true || raw.requires_admin === true,
+    ...(typeof raw.detail === 'string' ? { detail: raw.detail } : {}),
+  }
+}
+
+function runtimeStatus(value: unknown): SandboxRuntimePackStatus | null {
+  const raw = record(value)
+  const candidate: Record<string, unknown> = record(raw.status).schemaVersion
+    ? record(raw.status)
+    : raw
+  if (candidate.schemaVersion !== 1 || !Array.isArray(candidate.components)) return null
+  return candidate as unknown as SandboxRuntimePackStatus
+}
+
+export function createV4SandboxRuntime(transport: SandboxTransport): SandboxRuntime {
+  const request = async <T>(method: string, params?: Record<string, unknown>) => {
+    if (transport.ready) await transport.ready({ timeoutMs: 15_000 })
+    return await transport.request<T>(method, params, options())
+  }
+
+  return {
+    async status() { return record(await request(METHODS.status)) },
+    async setupStatus() { return setupStatus(await request(METHODS.setupStatus)) },
+    async ensureSetup() { return setupStatus(await request(METHODS.ensureSetup)) },
+    async capability(requestOptions) {
+      return await request<SandboxCapabilityReport>(METHODS.capability, requestOptions?.refresh ? { refresh: true } : undefined)
+    },
+    async policy() { return await request<SandboxPolicy>(METHODS.policy) },
+    async policyDefaults() { return await request<Partial<SandboxPolicyDefaults>>(METHODS.policyDefaults) },
+    async updatePolicy(basePolicyVersion, policy) {
+      return await request<SandboxPolicy>(METHODS.policyUpdate, { basePolicyVersion, policy })
+    },
+    async runModePreference() {
+      return await request<{ runMode: SandboxRunMode; source?: string }>(METHODS.runModeGet)
+    },
+    async setRunMode(mode) {
+      return await request<{ runMode: SandboxRunMode; source?: string }>(METHODS.runModeSet, { runMode: mode })
+    },
+    subscribeRunModePreferenceChanged(handler) {
+      if (!transport.subscribe) return () => undefined
+      const subscription = transport.subscribe('sandbox.run_mode.preference.changed', value => {
+        const raw = record(value)
+        if (raw.runMode === 'safe' || raw.runMode === 'full') {
+          handler({ runMode: raw.runMode, ...(typeof raw.source === 'string' ? { source: raw.source } : {}) })
+        }
+      })
+      return () => subscription.close()
+    },
+    async runtimeStatus() { return runtimeStatus(await request(METHODS.runtimeStatus)) },
+    async installRuntime(componentId) { return await request(METHODS.runtimeInstall, { componentId }) },
+    async cancelRuntime(componentId, operationId) { return await request(METHODS.runtimeCancel, { componentId, operationId }) },
+    async removeRuntime(componentId) { return await request(METHODS.runtimeRemove, { componentId }) },
+    async discardRuntimeDownload(componentId) { return await request(METHODS.runtimeDiscard, { componentId }) },
+    async listTokens() { return await request<{ tokens: SandboxTokenRecord[] }>(METHODS.tokensList) },
+    async createToken(name, hostExecute = true) {
+      return await request<{ token: string; record: SandboxTokenRecord }>(METHODS.tokensCreate, { name, hostExecute })
+    },
+    async revokeToken(publicId) {
+      return await request<{ publicId: string; revoked: boolean }>(METHODS.tokensRevoke, { publicId })
+    },
+    async resume(sessionKey) {
+      return await request<{ sessionKey: string; resumed: boolean; autonomousPaused: boolean }>(METHODS.resume, { sessionKey })
+    },
+  }
+}

--- a/opensquilla-webui/src/components/settings/SandboxSettingsPanel.test.ts
+++ b/opensquilla-webui/src/components/settings/SandboxSettingsPanel.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { App } from 'vue'
+import { SANDBOX_RUNTIME_KEY } from '@/modules/sandboxRuntime'
+import { createV4SandboxRuntime } from '@/adapters/gateway/sandboxRuntimeV4'
 import type { SandboxRuntimePackStatus } from '@/types/sandbox'
 
 const mounted: App[] = []
@@ -79,7 +81,7 @@ const runtimePackStatus: SandboxRuntimePackStatus = {
 }
 
 async function settle() {
-  for (let index = 0; index < 8; index++) await Promise.resolve()
+  for (let index = 0; index < 32; index++) await Promise.resolve()
 }
 
 async function mountPanel(options: {
@@ -235,6 +237,13 @@ async function mountPanel(options: {
   const app = createApp(Component)
   app.use(createPinia())
   app.use(i18n)
+  app.provide(SANDBOX_RUNTIME_KEY, createV4SandboxRuntime({
+    request: (method, params) => (
+      params === undefined && method !== 'sandbox.capability.status'
+        ? call(method)
+        : call(method, params)
+    ),
+  }))
   app.mount(el)
   mounted.push(app)
   await settle()

--- a/opensquilla-webui/src/composables/chat/useChatRunModePreference.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRunModePreference.ts
@@ -4,6 +4,7 @@ import {
   waitForSessionRpcConnection,
 } from '@/composables/chat/sessionBootstrapAdmission'
 import type { RpcCallOptions, RpcConnectionWaitOptions } from '@/lib/rpc'
+import type { SandboxRuntime } from '@/modules/sandboxRuntime'
 import {
   SANDBOX_RUN_MODES,
   isRecognizedSandboxRunMode,
@@ -24,6 +25,7 @@ interface UseChatRunModePreferenceOptions {
   rpc: RunModePreferenceRpc
   hydrateCallOptions?: RpcCallOptions
   writeCallOptions?: RpcCallOptions
+  sandbox?: Pick<SandboxRuntime, 'runModePreference' | 'setRunMode'>
 }
 
 interface RunModePreferenceRpc {
@@ -162,13 +164,15 @@ export function useChatRunModePreference(options: UseChatRunModePreferenceOption
 
   async function hydrateRunModePreference(): Promise<SandboxRunMode> {
     await waitForSessionRpcConnection(options.rpc, options.hydrateCallOptions)
-    const payload = options.hydrateCallOptions
-      ? await options.rpc.call(
-          'sandbox.run_mode.preference.get',
-          undefined,
-          options.hydrateCallOptions,
-        )
-      : await options.rpc.call('sandbox.run_mode.preference.get')
+    const payload = options.sandbox
+      ? await options.sandbox.runModePreference()
+      : options.hydrateCallOptions
+        ? await options.rpc.call(
+            'sandbox.run_mode.preference.get',
+            undefined,
+            options.hydrateCallOptions,
+          )
+        : await options.rpc.call('sandbox.run_mode.preference.get')
     const source = payload && typeof payload === 'object'
       ? (payload as Record<string, unknown>).source
       : null
@@ -194,15 +198,17 @@ export function useChatRunModePreference(options: UseChatRunModePreferenceOption
 
     try {
       await waitForSessionRpcConnection(options.rpc, options.writeCallOptions)
-      const payload = options.writeCallOptions
-        ? await options.rpc.call(
-            'sandbox.run_mode.preference.set',
-            { runMode: requested },
-            options.writeCallOptions,
-          )
-        : await options.rpc.call('sandbox.run_mode.preference.set', {
-            runMode: requested,
-          })
+      const payload = options.sandbox
+        ? await options.sandbox.setRunMode(requested)
+        : options.writeCallOptions
+          ? await options.rpc.call(
+              'sandbox.run_mode.preference.set',
+              { runMode: requested },
+              options.writeCallOptions,
+            )
+          : await options.rpc.call('sandbox.run_mode.preference.set', {
+              runMode: requested,
+            })
       if (sequence !== writeSequence) return runMode.value
       return applyConfirmedPreference(
         modeFromPayload(payload),

--- a/opensquilla-webui/src/composables/chat/useSandboxSetupRecovery.ts
+++ b/opensquilla-webui/src/composables/chat/useSandboxSetupRecovery.ts
@@ -8,6 +8,7 @@ import type {
   SandboxRunMode,
   SandboxSetupStatusPayload,
 } from '@/types/sandbox'
+import type { SandboxRuntime } from '@/modules/sandboxRuntime'
 
 const SETUP_POLL_MS = 2000
 
@@ -17,7 +18,8 @@ type SandboxSetupRpc = {
 }
 
 export interface UseSandboxSetupRecoveryOptions {
-  rpc: SandboxSetupRpc
+  rpc?: SandboxSetupRpc
+  sandbox?: Pick<SandboxRuntime, 'setupStatus' | 'ensureSetup' | 'capability'>
   connectionState: Ref<string>
   runMode: Ref<SandboxRunMode>
   autoRefresh?: boolean
@@ -38,6 +40,11 @@ export function useSandboxSetupRecovery(options: UseSandboxSetupRecoveryOptions)
   let pollTimer: ReturnType<typeof setTimeout> | null = null
   let lastState = ''
   let lastUnavailableFingerprint = ''
+
+  function legacyCall(method: string, params?: Record<string, unknown>): Promise<unknown> {
+    if (!options.rpc) return Promise.reject(new Error('Sandbox runtime is unavailable.'))
+    return params === undefined ? options.rpc.call(method) : options.rpc.call(method, params)
+  }
 
   const active = computed(() => options.connectionState.value === 'connected')
   const visible = computed(() =>
@@ -92,7 +99,9 @@ export function useSandboxSetupRecovery(options: UseSandboxSetupRecoveryOptions)
     loading.value = status.value === null
     clearPoll()
     try {
-      const payload = normalizeSandboxSetupStatus(await options.rpc.call('sandbox.setup.status'))
+      const payload = normalizeSandboxSetupStatus(
+        await (options.sandbox ? options.sandbox.setupStatus() : legacyCall('sandbox.setup.status')),
+      )
       if (generation !== requestGeneration) return
       if (!payload) {
         // Keep following an already-authoritative setting_up state when a
@@ -128,9 +137,9 @@ export function useSandboxSetupRecovery(options: UseSandboxSetupRecoveryOptions)
     clearPoll()
     try {
       const result = await ensureSandboxReady(
-        options.rpc.call,
+        options.sandbox ?? legacyCall,
         null,
-        options.rpc.waitForConnection ?? null,
+        options.rpc?.waitForConnection ?? null,
       )
       if (generation !== requestGeneration) return false
       if (result.status) applyStatus(result.status)

--- a/opensquilla-webui/src/composables/sandboxSetupCoordinator.ts
+++ b/opensquilla-webui/src/composables/sandboxSetupCoordinator.ts
@@ -12,6 +12,12 @@ export type SandboxSetupCall = (
   params?: Record<string, unknown>,
 ) => Promise<unknown>
 
+export interface SandboxSetupOperations {
+  ensureSetup: () => Promise<unknown>
+  setupStatus: () => Promise<unknown>
+  capability: () => Promise<Pick<SandboxCapabilityReport, 'available'> | null>
+}
+
 export type SandboxSetupConnectionWait = () => Promise<unknown>
 
 export interface SandboxSetupResult {
@@ -35,7 +41,7 @@ export function normalizeSandboxSetupStatus(payload: unknown): SandboxSetupStatu
 }
 
 export async function ensureSandboxReady(
-  call: SandboxSetupCall,
+  operations: SandboxSetupCall | SandboxSetupOperations,
   verifyCapability: (() => Promise<Pick<SandboxCapabilityReport, 'available'> | null>) | null = null,
   waitForConnection: SandboxSetupConnectionWait | null = null,
 ): Promise<SandboxSetupResult> {
@@ -49,14 +55,18 @@ export async function ensureSandboxReady(
     }
     const report = verifyCapability
       ? await verifyCapability()
-      : await call('sandbox.capability.status', { refresh: true }) as { available?: unknown }
+      : typeof operations === 'function'
+        ? await operations('sandbox.capability.status', { refresh: true }) as { available?: unknown }
+        : await operations.capability()
     return report?.available === true
       ? { ready: true, status, outcome: 'ready' }
       : { ready: false, status, outcome: 'verification_failed' }
   }
 
   try {
-    const status = normalizeSandboxSetupStatus(await call('sandbox.setup.ensure'))
+    const status = normalizeSandboxSetupStatus(
+      await (typeof operations === 'function' ? operations('sandbox.setup.ensure') : operations.ensureSetup()),
+    )
     if (!status) return { ready: false, status: null, outcome: 'failed' }
     return await finish(status)
   } catch {
@@ -66,7 +76,9 @@ export async function ensureSandboxReady(
       // original response socket has gone away. Reconnect and ask the Gateway
       // for authoritative state instead of making the user repeat UAC.
       await waitForConnection()
-      const status = normalizeSandboxSetupStatus(await call('sandbox.setup.status'))
+      const status = normalizeSandboxSetupStatus(
+        await (typeof operations === 'function' ? operations('sandbox.setup.status') : operations.setupStatus()),
+      )
       if (!status) return { ready: false, status: null, outcome: 'failed' }
       return await finish(status)
     } catch {

--- a/opensquilla-webui/src/composables/settings/useSandboxSettings.ts
+++ b/opensquilla-webui/src/composables/settings/useSandboxSettings.ts
@@ -1,4 +1,4 @@
-import { computed, onScopeDispose, reactive, ref } from 'vue'
+import { computed, hasInjectionContext, inject, onScopeDispose, reactive, ref } from 'vue'
 
 import i18n from '@/i18n'
 import { useToasts } from '@/composables/useToasts'
@@ -25,6 +25,8 @@ import type {
   SandboxRuntimeSource,
   SandboxSetupStatusPayload,
 } from '@/types/sandbox'
+import { SANDBOX_RUNTIME_KEY, type SandboxRuntime } from '@/modules/sandboxRuntime'
+import { createV4SandboxRuntime } from '@/adapters/gateway/sandboxRuntimeV4'
 
 export type SandboxPolicySection = 'files' | 'commands' | 'network' | 'runtimes'
 export type { SandboxSetupOutcome } from '@/composables/sandboxSetupCoordinator'
@@ -205,6 +207,16 @@ function currentPolicyFromConflict(error: unknown): SandboxPolicy | null {
 
 export function useSandboxSettings() {
   const rpc = useRpcStore()
+  const sandbox: SandboxRuntime = (hasInjectionContext() ? inject(SANDBOX_RUNTIME_KEY, null) : null)
+    ?? createV4SandboxRuntime({
+      request: (method, params) => rpc.call(
+        method,
+        ...(params === undefined && method !== 'sandbox.capability.status'
+          ? []
+          : [params]),
+      ),
+      ready: () => rpc.waitForConnection(),
+    })
   const platform = usePlatform()
   const { pushToast } = useToasts()
   const loading = ref(false)
@@ -281,11 +293,10 @@ export function useSandboxSettings() {
     loading.value = true
     loadError.value = ''
     try {
-      await rpc.waitForConnection()
       const [policyPayload, defaultsPayload, runModePayload] = await Promise.all([
-        rpc.call<SandboxPolicy>('sandbox.policy.get'),
-        rpc.call<Partial<SandboxPolicyDefaults>>('sandbox.policy.defaults'),
-        rpc.call<{ runMode?: unknown }>('sandbox.run_mode.preference.get'),
+        sandbox.policy(),
+        sandbox.policyDefaults(),
+        sandbox.runModePreference(),
       ])
       baseline.value = clonePolicy(policyPayload)
       draft.value = clonePolicy(policyPayload)
@@ -315,11 +326,7 @@ export function useSandboxSettings() {
     capabilityLoading.value = true
     capabilityCheckFailed.value = false
     try {
-      await rpc.waitForConnection()
-      const report = await rpc.call<SandboxCapabilityReport>(
-        'sandbox.capability.status',
-        forceRefresh ? { refresh: true } : undefined,
-      )
+      const report = await sandbox.capability({ refresh: forceRefresh })
       if (disposed || requestGeneration !== capabilityRequestGeneration) return null
       capability.value = report
       return report
@@ -338,8 +345,7 @@ export function useSandboxSettings() {
   async function loadSetupStatus(): Promise<SandboxSetupStatusPayload | null> {
     if (!platform.capabilities.isDesktop || disposed) return null
     try {
-      await rpc.waitForConnection()
-      const status = normalizeSandboxSetupStatus(await rpc.call('sandbox.setup.status'))
+      const status = normalizeSandboxSetupStatus(await sandbox.setupStatus())
       if (!disposed && status) sandboxSetupStatus.value = status
       return status
     } catch {
@@ -363,9 +369,12 @@ export function useSandboxSettings() {
     sandboxSetupOutcome.value = 'idle'
     try {
       const result = await ensureSandboxReady(
-        (method, params) => rpc.call(method, params),
+        {
+          ensureSetup: () => sandbox.ensureSetup(),
+          setupStatus: () => sandbox.setupStatus(),
+          capability: () => sandbox.capability({ refresh: true }),
+        },
         () => loadCapability(true),
-        () => rpc.waitForConnection(10_000),
       )
       if (result.status) sandboxSetupStatus.value = result.status
       sandboxSetupOutcome.value = result.outcome
@@ -414,10 +423,7 @@ export function useSandboxSettings() {
     runtimeStatusLoading.value = true
     runtimeStatusError.value = ''
     try {
-      await rpc.waitForConnection()
-      const status = normalizeRuntimeStatusResponse(
-        await rpc.call<unknown>('sandbox.runtime.status'),
-      )
+      const status = normalizeRuntimeStatusResponse(await sandbox.runtimeStatus())
       if (disposed || requestGeneration !== runtimeStatusRequestGeneration) return null
       if (!status) throw new Error('Invalid runtime status response')
       runtimeStatus.value = status
@@ -466,12 +472,9 @@ export function useSandboxSettings() {
   }
 
   async function runRuntimeAction(
-    method: 'sandbox.runtime.install'
-      | 'sandbox.runtime.cancel'
-      | 'sandbox.runtime.discard_download'
-      | 'sandbox.runtime.remove',
+    action: () => Promise<unknown>,
     componentId: SandboxRuntimeComponentId,
-    params: Record<string, unknown>,
+    actionKind: 'install' | 'cancel' | 'discard' | 'remove',
     prepare?: () => Promise<boolean>,
   ): Promise<boolean> {
     if (runtimeActionPending[componentId] || runtimeStatusSupported.value === false) return false
@@ -482,8 +485,7 @@ export function useSandboxSettings() {
         runtimeActionError[componentId] = i18n.global.t('errors.saveFailed')
         return false
       }
-      await rpc.waitForConnection()
-      const response = await rpc.call<unknown>(method, params)
+      const response = await action()
       clearRuntimePoll()
       runtimeStatusRequestGeneration += 1
       runtimeStatusLoading.value = false
@@ -502,7 +504,7 @@ export function useSandboxSettings() {
       return true
     } catch (error) {
       runtimeActionError[componentId] = errorMessage(error)
-      if (method === 'sandbox.runtime.discard_download') void loadRuntimeStatus()
+      if (actionKind === 'discard') void loadRuntimeStatus()
       return false
     } finally {
       runtimeActionPending[componentId] = false
@@ -536,9 +538,9 @@ export function useSandboxSettings() {
 
   function installRuntime(componentId: SandboxRuntimeComponentId): Promise<boolean> {
     return runRuntimeAction(
-      'sandbox.runtime.install',
+      () => sandbox.installRuntime(componentId),
       componentId,
-      { componentId },
+      'install',
       () => ensureRuntimeEnabled(componentId),
     )
   }
@@ -548,20 +550,29 @@ export function useSandboxSettings() {
     operationId: string,
   ): Promise<boolean> {
     if (!operationId) return Promise.resolve(false)
-    return runRuntimeAction('sandbox.runtime.cancel', componentId, {
+    return runRuntimeAction(
+      () => sandbox.cancelRuntime(componentId, operationId),
       componentId,
-      operationId,
-    })
+      'cancel',
+    )
   }
 
   function removeRuntime(componentId: SandboxRuntimeComponentId): Promise<boolean> {
-    return runRuntimeAction('sandbox.runtime.remove', componentId, { componentId })
+    return runRuntimeAction(
+      () => sandbox.removeRuntime(componentId),
+      componentId,
+      'remove',
+    )
   }
 
   function discardRuntimeDownload(
     componentId: SandboxRuntimeComponentId,
   ): Promise<boolean> {
-    return runRuntimeAction('sandbox.runtime.discard_download', componentId, { componentId })
+    return runRuntimeAction(
+      () => sandbox.discardRuntimeDownload(componentId),
+      componentId,
+      'discard',
+    )
   }
 
   async function loadDesktopPreference(): Promise<void> {
@@ -597,10 +608,7 @@ export function useSandboxSettings() {
     defaultRunModePending.value = true
     return queueSave(async () => {
       try {
-        const payload = await rpc.call<{ runMode?: unknown }>(
-        'sandbox.run_mode.preference.set',
-          { runMode: mode },
-        )
+        const payload = await sandbox.setRunMode(mode)
         if (sequence === defaultRunModeSequence) {
           const savedMode: SandboxRunMode = payload.runMode === 'full' ? 'full' : 'safe'
           defaultRunModeBaseline.value = savedMode
@@ -663,10 +671,7 @@ export function useSandboxSettings() {
     try {
       const candidate = clonePolicy(submittedBaseline)
       Object.assign(candidate, { [section]: submittedSection })
-      const saved = await rpc.call<SandboxPolicy>('sandbox.policy.update', {
-        basePolicyVersion: submittedBaseline.policyVersion,
-        policy: candidate,
-      })
+      const saved = await sandbox.updatePolicy(submittedBaseline.policyVersion, candidate)
       const currentDraft = clonePolicy(draft.value)
       const sectionChangedWhileSaving = (
         JSON.stringify(currentDraft[section]) !== JSON.stringify(submittedSection)

--- a/opensquilla-webui/src/main.ts
+++ b/opensquilla-webui/src/main.ts
@@ -23,6 +23,7 @@ import { PROVIDER_CONFIGURATION_KEY } from './modules/providerConfiguration'
 import { SETUP_WORKFLOW_KEY } from './modules/setupWorkflow'
 import { MIGRATION_OPERATIONS_KEY } from './modules/migrationOperations'
 import { WORKSPACE_CATALOG_KEY } from './modules/workspaceCatalog'
+import { SANDBOX_RUNTIME_KEY } from './modules/sandboxRuntime'
 import 'katex/dist/katex.min.css'
 import './assets/base.css'
 import './themes/tokens' // eagerly bundles every value theme's token block
@@ -76,6 +77,7 @@ app.provide(PROVIDER_CONFIGURATION_KEY, gatewayAdapters.providerConfiguration)
 app.provide(SETUP_WORKFLOW_KEY, gatewayAdapters.setupWorkflow)
 app.provide(MIGRATION_OPERATIONS_KEY, gatewayAdapters.migrationOperations)
 app.provide(WORKSPACE_CATALOG_KEY, gatewayAdapters.workspaceCatalog)
+app.provide(SANDBOX_RUNTIME_KEY, gatewayAdapters.sandboxRuntime)
 router.afterEach(() => {
   rpcStore.applyLinkTokenFromUrl()
 })

--- a/opensquilla-webui/src/modules/sandboxRuntime.ts
+++ b/opensquilla-webui/src/modules/sandboxRuntime.ts
@@ -1,0 +1,35 @@
+import type { InjectionKey } from 'vue'
+import type {
+  SandboxCapabilityReport,
+  SandboxPolicy,
+  SandboxPolicyDefaults,
+  SandboxRunMode,
+  SandboxRuntimeComponentId,
+  SandboxRuntimePackStatus,
+  SandboxSetupStatusPayload,
+  SandboxTokenRecord,
+} from '@/types/sandbox'
+
+export interface SandboxRuntime {
+  status(): Promise<Record<string, unknown>>
+  setupStatus(): Promise<SandboxSetupStatusPayload | null>
+  ensureSetup(): Promise<SandboxSetupStatusPayload | null>
+  capability(options?: { refresh?: boolean }): Promise<SandboxCapabilityReport>
+  policy(): Promise<SandboxPolicy>
+  policyDefaults(): Promise<Partial<SandboxPolicyDefaults>>
+  updatePolicy(basePolicyVersion: number, policy: SandboxPolicy): Promise<SandboxPolicy>
+  runModePreference(): Promise<{ runMode: SandboxRunMode; source?: string }>
+  setRunMode(mode: SandboxRunMode): Promise<{ runMode: SandboxRunMode; source?: string }>
+  subscribeRunModePreferenceChanged(handler: (payload: { runMode: SandboxRunMode; source?: string }) => void): () => void
+  runtimeStatus(): Promise<SandboxRuntimePackStatus | null>
+  installRuntime(componentId: SandboxRuntimeComponentId): Promise<unknown>
+  cancelRuntime(componentId: SandboxRuntimeComponentId, operationId: string): Promise<unknown>
+  removeRuntime(componentId: SandboxRuntimeComponentId): Promise<unknown>
+  discardRuntimeDownload(componentId: SandboxRuntimeComponentId): Promise<unknown>
+  listTokens(): Promise<{ tokens: SandboxTokenRecord[] }>
+  createToken(name: string, hostExecute?: boolean): Promise<{ token: string; record: SandboxTokenRecord }>
+  revokeToken(publicId: string): Promise<{ publicId: string; revoked: boolean }>
+  resume(sessionKey: string): Promise<{ sessionKey: string; resumed: boolean; autonomousPaused: boolean }>
+}
+
+export const SANDBOX_RUNTIME_KEY: InjectionKey<SandboxRuntime> = Symbol('SandboxRuntime')

--- a/opensquilla-webui/src/stores/sandboxSetup.ts
+++ b/opensquilla-webui/src/stores/sandboxSetup.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { inject, ref } from 'vue'
 
 import i18n from '@/i18n'
 import { useToasts } from '@/composables/useToasts'
@@ -12,9 +12,11 @@ import type {
   SandboxRunMode,
   SandboxSetupStatusPayload,
 } from '@/types/sandbox'
+import { SANDBOX_RUNTIME_KEY } from '@/modules/sandboxRuntime'
 
 export const useSandboxSetupStore = defineStore('sandboxSetup', () => {
   const rpc = useRpcStore()
+  const sandbox = inject(SANDBOX_RUNTIME_KEY, null)
   const { pushToast } = useToasts()
   const ensuring = ref(false)
   const outcome = ref<SandboxSetupOutcome>('idle')
@@ -33,7 +35,7 @@ export const useSandboxSetupStore = defineStore('sandboxSetup', () => {
   async function runSetup(): Promise<boolean> {
     try {
       const result = await ensureSandboxReady(
-        (method, params) => rpc.call(method, params),
+        sandbox ?? ((method, params) => rpc.call(method, params)),
         null,
         () => rpc.waitForConnection(10_000),
       )
@@ -46,7 +48,8 @@ export const useSandboxSetupStore = defineStore('sandboxSetup', () => {
         return false
       }
       if (intendedMode.value === 'safe') {
-        await rpc.call('sandbox.run_mode.preference.set', { runMode: 'safe' })
+        if (sandbox) await sandbox.setRunMode('safe')
+        else await rpc.call('sandbox.run_mode.preference.set', { runMode: 'safe' })
       }
       pushToast(String(i18n.global.t('settings.sandbox.setup.readyToast')), {
         tone: 'ok',

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -810,6 +810,7 @@ import { SESSION_LIFECYCLE_KEY } from '@/modules/sessionLifecycle'
 import { PENDING_INPUT_QUEUE_KEY } from '@/modules/pendingInputQueue'
 import { APP_SETTINGS_KEY } from '@/modules/appSettings'
 import { PROVIDER_CONFIGURATION_KEY } from '@/modules/providerConfiguration'
+import { SANDBOX_RUNTIME_KEY } from '@/modules/sandboxRuntime'
 import { SETUP_WORKFLOW_KEY } from '@/modules/setupWorkflow'
 import { useSetupStatus } from '@/composables/setup/useSetupStatus'
 import { useAppStore } from '@/stores/app'
@@ -943,7 +944,6 @@ import {
   optionalSessionRpcAllowed,
   optionalSessionRpcCallOptions,
   runModeWriteRpcCallOptions,
-  sandboxSetupRpcCallOptions,
 } from '@/composables/chat/sessionBootstrapAdmission'
 import { useChatSessionRuntime } from '@/composables/chat/useChatSessionRuntime'
 import {
@@ -1215,6 +1215,7 @@ const metaRunCenter: MetaRunCenter = injectedMetaRunCenter
 const injectedAppSettings = inject(APP_SETTINGS_KEY)
 if (!injectedAppSettings) throw new Error('AppSettings was not provided')
 const injectedProviderConfiguration = inject(PROVIDER_CONFIGURATION_KEY)
+const injectedSandboxRuntime = inject(SANDBOX_RUNTIME_KEY)
 if (!injectedProviderConfiguration) throw new Error('ProviderConfiguration was not provided')
 const injectedSetupWorkflow = inject(SETUP_WORKFLOW_KEY)
 if (!injectedSetupWorkflow) throw new Error('SetupWorkflow was not provided')
@@ -1599,6 +1600,7 @@ const {
   applyRunModePreferenceChanged,
 } = useChatRunModePreference({
   rpc,
+  sandbox: injectedSandboxRuntime,
   hydrateCallOptions: optionalSessionRpcCallOptions,
   writeCallOptions: runModeWriteRpcCallOptions,
   runModePolicy: () => {
@@ -1622,11 +1624,7 @@ const requestedRunMode = computed<SandboxRunMode>(
 )
 
 const sandboxSetupRecovery = useSandboxSetupRecovery({
-  rpc: {
-    call: (method, params) =>
-      rpc.call(method, params, sandboxSetupRpcCallOptions),
-    waitForConnection: () => rpc.waitForConnection(10_000),
-  },
+  sandbox: injectedSandboxRuntime,
   connectionState: computed(() => rpc.state),
   runMode: requestedRunMode,
   autoRefresh: false,
@@ -5557,7 +5555,7 @@ async function resumeSandbox() {
   const key = sessionKey.value
   if (!key) return
   try {
-    await rpc.call('sandbox.resume', { sessionKey: key })
+    await injectedSandboxRuntime?.resume(key)
     messages.value.push({
       role: 'system',
       text: t('chat.sandboxResumed'),
@@ -6632,10 +6630,9 @@ onMounted(async () => {
   // Load elevated mode
   loadElevatedMode()
 
-  unsubs.push(rpc.on(
-    'sandbox.run_mode.preference.changed',
+  unsubs.push(injectedSandboxRuntime?.subscribeRunModePreferenceChanged(
     payload => applyRunModePreferenceChanged(payload),
-  ))
+  ) ?? (() => undefined))
 
   // Register event handlers before sessions.messages.subscribe can replay
   // buffered events, then start the two critical phases before any optional

--- a/src/opensquilla/application/sandbox_runtime.py
+++ b/src/opensquilla/application/sandbox_runtime.py
@@ -1,0 +1,132 @@
+"""Transport-neutral SandboxRuntime application module.
+
+The Gateway still owns the concrete sandbox implementation.  This module
+owns the use-case boundary and validation so UI adapters never need to know
+which sandbox package, policy store, or runtime-pack implementation is used.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+
+class SandboxRuntimePort(Protocol):
+    async def read_status(self) -> Mapping[str, Any]: ...
+
+    async def read_setup_status(self) -> Mapping[str, Any]: ...
+
+    async def ensure_setup(self) -> Mapping[str, Any]: ...
+
+    async def read_capability(self, *, refresh: bool) -> Mapping[str, Any]: ...
+
+    async def read_policy(self) -> Mapping[str, Any]: ...
+
+    async def read_policy_defaults(self) -> Mapping[str, Any]: ...
+
+    async def update_policy(
+        self,
+        base_policy_version: int,
+        policy: Mapping[str, Any],
+    ) -> Mapping[str, Any]: ...
+
+    async def read_run_mode(self) -> Mapping[str, Any]: ...
+
+    async def write_run_mode(self, mode: str) -> Mapping[str, Any]: ...
+
+    async def read_runtime_status(self) -> Mapping[str, Any]: ...
+
+
+class SandboxRuntime:
+    """Deep domain seam for sandbox posture, setup, policy and runtime reads."""
+
+    def __init__(self, port: SandboxRuntimePort) -> None:
+        self._port = port
+
+    async def status(self) -> dict[str, Any]:
+        return dict(await self._port.read_status())
+
+    async def setup_status(self) -> dict[str, Any]:
+        return dict(await self._port.read_setup_status())
+
+    async def ensure_setup(self) -> dict[str, Any]:
+        return dict(await self._port.ensure_setup())
+
+    async def capability(self, *, refresh: bool = False) -> dict[str, Any]:
+        return dict(await self._port.read_capability(refresh=bool(refresh)))
+
+    async def policy(self) -> dict[str, Any]:
+        return dict(await self._port.read_policy())
+
+    async def policy_defaults(self) -> dict[str, Any]:
+        return dict(await self._port.read_policy_defaults())
+
+    async def update_policy(
+        self,
+        base_policy_version: int,
+        policy: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        if isinstance(base_policy_version, bool) or not isinstance(base_policy_version, int):
+            raise ValueError("base policy version must be an integer")
+        if not isinstance(policy, Mapping):
+            raise ValueError("sandbox policy must be an object")
+        return dict(await self._port.update_policy(base_policy_version, dict(policy)))
+
+    async def run_mode(self) -> dict[str, Any]:
+        return dict(await self._port.read_run_mode())
+
+    async def set_run_mode(self, mode: str) -> dict[str, Any]:
+        normalized = str(mode or "").strip()
+        if normalized not in {"safe", "full"}:
+            raise ValueError("sandbox run mode must be safe or full")
+        return dict(await self._port.write_run_mode(normalized))
+
+    async def runtime_status(self) -> dict[str, Any]:
+        return dict(await self._port.read_runtime_status())
+
+
+class InMemorySandboxRuntimePort:
+    """Deterministic Port implementation for application-level tests."""
+
+    def __init__(
+        self,
+        *,
+        status: Mapping[str, Any] | None = None,
+        setup_status: Mapping[str, Any] | None = None,
+        capability: Mapping[str, Any] | None = None,
+        policy: Mapping[str, Any] | None = None,
+        policy_defaults: Mapping[str, Any] | None = None,
+        run_mode: str = "full",
+        runtime_status: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.status_value = dict(status or {})
+        self.setup_status_value = dict(setup_status or {})
+        self.capability_value = dict(capability or {})
+        self.policy_value = dict(policy or {})
+        self.policy_defaults_value = dict(policy_defaults or {})
+        self.run_mode_value = run_mode
+        self.runtime_status_value = dict(runtime_status or {})
+
+    async def read_status(self) -> Mapping[str, Any]: return self.status_value
+    async def read_setup_status(self) -> Mapping[str, Any]: return self.setup_status_value
+    async def ensure_setup(self) -> Mapping[str, Any]: return self.setup_status_value
+    async def read_capability(self, *, refresh: bool) -> Mapping[str, Any]:
+        return self.capability_value
+    async def read_policy(self) -> Mapping[str, Any]: return self.policy_value
+    async def read_policy_defaults(self) -> Mapping[str, Any]: return self.policy_defaults_value
+    async def update_policy(
+        self,
+        base_policy_version: int,
+        policy: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        self.policy_value = dict(policy)
+        return self.policy_value
+    async def read_run_mode(self) -> Mapping[str, Any]:
+        return {"runMode": self.run_mode_value, "source": "preference"}
+    async def write_run_mode(self, mode: str) -> Mapping[str, Any]:
+        self.run_mode_value = mode
+        return {"runMode": mode, "source": "preference"}
+    async def read_runtime_status(self) -> Mapping[str, Any]: return self.runtime_status_value
+
+
+__all__ = ["InMemorySandboxRuntimePort", "SandboxRuntime", "SandboxRuntimePort"]

--- a/src/opensquilla/gateway/adapters/sandbox_runtime.py
+++ b/src/opensquilla/gateway/adapters/sandbox_runtime.py
@@ -1,0 +1,70 @@
+"""Gateway Adapter for the transport-neutral SandboxRuntime module."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+
+from opensquilla.gateway.rpc import RpcContext
+
+SandboxRead = Callable[[RpcContext], Awaitable[Mapping[str, Any]]]
+SandboxCapabilityRead = Callable[[RpcContext, bool], Awaitable[Mapping[str, Any]]]
+SandboxPolicyUpdate = Callable[[RpcContext, int, Mapping[str, Any]], Awaitable[Mapping[str, Any]]]
+SandboxModeWrite = Callable[[RpcContext, str], Awaitable[Mapping[str, Any]]]
+
+
+class RpcContextSandboxRuntimePort:
+    """Bind existing sandbox implementations to narrow application Ports."""
+
+    def __init__(
+        self,
+        ctx: RpcContext,
+        *,
+        status: SandboxRead,
+        setup_status: SandboxRead,
+        ensure_setup: SandboxRead,
+        capability: SandboxCapabilityRead,
+        policy: SandboxRead,
+        policy_defaults: SandboxRead,
+        policy_update: SandboxPolicyUpdate,
+        run_mode: SandboxRead,
+        run_mode_write: SandboxModeWrite,
+        runtime_status: SandboxRead,
+    ) -> None:
+        self.ctx = ctx
+        self._status = status
+        self._setup_status = setup_status
+        self._ensure_setup = ensure_setup
+        self._capability = capability
+        self._policy = policy
+        self._policy_defaults = policy_defaults
+        self._policy_update = policy_update
+        self._run_mode = run_mode
+        self._run_mode_write = run_mode_write
+        self._runtime_status = runtime_status
+
+    async def read_status(self) -> Mapping[str, Any]: return await self._status(self.ctx)
+    async def read_setup_status(self) -> Mapping[str, Any]:
+        return await self._setup_status(self.ctx)
+    async def ensure_setup(self) -> Mapping[str, Any]: return await self._ensure_setup(self.ctx)
+    async def read_capability(self, *, refresh: bool) -> Mapping[str, Any]:
+        return await self._capability(self.ctx, refresh)
+    async def read_policy(self) -> Mapping[str, Any]: return await self._policy(self.ctx)
+    async def read_policy_defaults(self) -> Mapping[str, Any]:
+        return await self._policy_defaults(self.ctx)
+
+    async def update_policy(
+        self,
+        base_policy_version: int,
+        policy: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        return await self._policy_update(self.ctx, base_policy_version, policy)
+    async def read_run_mode(self) -> Mapping[str, Any]: return await self._run_mode(self.ctx)
+    async def write_run_mode(self, mode: str) -> Mapping[str, Any]:
+        return await self._run_mode_write(self.ctx, mode)
+
+    async def read_runtime_status(self) -> Mapping[str, Any]:
+        return await self._runtime_status(self.ctx)
+
+
+__all__ = ["RpcContextSandboxRuntimePort"]

--- a/src/opensquilla/gateway/rpc_sandbox.py
+++ b/src/opensquilla/gateway/rpc_sandbox.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from opensquilla.agents.scope import resolve_agent_workspace_dir
+from opensquilla.application.sandbox_runtime import SandboxRuntime
 from opensquilla.gateway.project_workspace_runtime import (
     authoritative_project_run_context,
     map_project_workspace_error,
@@ -689,9 +690,8 @@ def _explain_messages(status: dict[str, Any]) -> list[dict[str, str]]:
     ]
 
 
-def _sandbox_application(ctx: RpcContext) -> Any:
+def _sandbox_application(ctx: RpcContext) -> SandboxRuntime:
     """Compose the transport-neutral SandboxRuntime Module for this request."""
-    from opensquilla.application.sandbox_runtime import SandboxRuntime
     from opensquilla.gateway.adapters.sandbox_runtime import RpcContextSandboxRuntimePort
 
     async def status(c: RpcContext) -> Mapping[str, Any]:

--- a/src/opensquilla/gateway/rpc_sandbox.py
+++ b/src/opensquilla/gateway/rpc_sandbox.py
@@ -10,6 +10,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+from collections.abc import Mapping
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -688,15 +689,85 @@ def _explain_messages(status: dict[str, Any]) -> list[dict[str, str]]:
     ]
 
 
+def _sandbox_application(ctx: RpcContext) -> Any:
+    """Compose the transport-neutral SandboxRuntime Module for this request."""
+    from opensquilla.application.sandbox_runtime import SandboxRuntime
+    from opensquilla.gateway.adapters.sandbox_runtime import RpcContextSandboxRuntimePort
+
+    async def status(c: RpcContext) -> Mapping[str, Any]:
+        return status_payload(c.config)
+
+    async def setup_status(c: RpcContext) -> Mapping[str, Any]:
+        return (await current_sandbox_setup_runtime_status(c.config)).to_payload()
+
+    async def ensure_setup(c: RpcContext) -> Mapping[str, Any]:
+        return (await ensure_sandbox_setup_auto(c.config)).to_payload()
+
+    async def capability(c: RpcContext, refresh: bool) -> Mapping[str, Any]:
+        report = await current_sandbox_capability_report(c.config, force_refresh=refresh)
+        return report.to_payload()
+
+    async def policy(c: RpcContext) -> Mapping[str, Any]:
+        return _sandbox_policy_store(c).read().to_public_dict()
+
+    async def policy_defaults(c: RpcContext) -> Mapping[str, Any]:
+        # Legacy defaults remain implemented by the existing handler; this
+        # Port is deliberately narrow and does not hash runtime payloads.
+        return {"builtinDenyWritePaths": [str(path) for path in builtin_deny_write_paths()]}
+
+    async def policy_update(
+        c: RpcContext,
+        base: int,
+        value: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        try:
+            return _sandbox_policy_store(c).compare_and_swap(base, dict(value)).to_public_dict()
+        except PolicyVersionConflict as exc:
+            raise RpcHandlerError(
+                "POLICY_VERSION_CONFLICT",
+                "The sandbox policy changed in another client.",
+                details={"currentPolicy": exc.current_policy.to_public_dict()},
+            ) from exc
+
+    async def run_mode(c: RpcContext) -> Mapping[str, Any]:
+        mode, source = await resolve_default_run_mode(c.session_manager, c.config)
+        mode = coerce_run_mode_for_principal(mode, c.principal)
+        return {"runMode": mode.value, "source": source}
+
+    async def run_mode_write(c: RpcContext, mode: str) -> Mapping[str, Any]:
+        await _require_sandbox_setup_ready_for_mode(c, mode)
+        storage = _runtime_preference_storage(c)
+        confirmed = await storage.set_runtime_preference(RUN_MODE_PREFERENCE_KEY, mode)
+        payload = {"runMode": confirmed, "source": "preference"}
+        await _run_mode_preference_registry().broadcast(_RUN_MODE_PREFERENCE_CHANGED_EVENT, payload)
+        return payload
+
+    async def runtime_status(c: RpcContext) -> Mapping[str, Any]:
+        return await _runtime_status_payload(c)
+
+    return SandboxRuntime(RpcContextSandboxRuntimePort(
+        ctx,
+        status=status,
+        setup_status=setup_status,
+        ensure_setup=ensure_setup,
+        capability=capability,
+        policy=policy,
+        policy_defaults=policy_defaults,
+        policy_update=policy_update,
+        run_mode=run_mode,
+        run_mode_write=run_mode_write,
+        runtime_status=runtime_status,
+    ))
+
+
 @_d.method("sandbox.status", scope="operator.read")
 async def _handle_sandbox_status(params: dict | None, ctx: RpcContext) -> dict:
-    return status_payload(ctx.config)
+    return await _sandbox_application(ctx).status()
 
 
 @_d.method("sandbox.setup.status", scope="operator.read")
 async def _handle_sandbox_setup_status(params: dict | None, ctx: RpcContext) -> dict:
-    result = await current_sandbox_setup_runtime_status(ctx.config)
-    return result.to_payload()
+    return await _sandbox_application(ctx).setup_status()
 
 
 @_d.method("sandbox.capability.status", scope="operator.read")
@@ -706,18 +777,14 @@ async def _handle_sandbox_capability_status(params: dict | None, ctx: RpcContext
     refresh = (params or {}).get("refresh", False)
     if not isinstance(refresh, bool):
         raise ValueError("params.refresh must be a boolean")
-    report = await current_sandbox_capability_report(
-        ctx.config,
-        force_refresh=refresh,
-    )
-    return report.to_payload()
+    return await _sandbox_application(ctx).capability(refresh=refresh)
 
 
 @_d.method("sandbox.policy.get", scope="operator.read")
 async def _handle_sandbox_policy_get(params: dict | None, ctx: RpcContext) -> dict:
     if params is not None and not isinstance(params, dict):
         raise ValueError("params must be an object")
-    return _sandbox_policy_store(ctx).read().to_public_dict()
+    return await _sandbox_application(ctx).policy()
 
 
 @_d.method("sandbox.policy.defaults", scope="operator.read")
@@ -823,7 +890,7 @@ async def _runtime_status_payload(ctx: RpcContext) -> dict[str, object]:
 async def _handle_sandbox_runtime_status(params: dict | None, ctx: RpcContext) -> dict:
     if params is not None and not isinstance(params, dict):
         raise ValueError("params must be an object")
-    return await _runtime_status_payload(ctx)
+    return await _sandbox_application(ctx).runtime_status()
 
 
 @_d.method("sandbox.runtime.install", scope="operator.admin")
@@ -923,15 +990,7 @@ async def _handle_sandbox_policy_update(params: dict | None, ctx: RpcContext) ->
     policy = values.get("policy")
     if not isinstance(policy, dict):
         raise ValueError("params.policy must be an object")
-    try:
-        saved = _sandbox_policy_store(ctx).compare_and_swap(base_version, policy)
-    except PolicyVersionConflict as exc:
-        raise RpcHandlerError(
-            "POLICY_VERSION_CONFLICT",
-            "The sandbox policy changed in another client.",
-            details={"currentPolicy": exc.current_policy.to_public_dict()},
-        ) from exc
-    return saved.to_public_dict()
+    return await _sandbox_application(ctx).update_policy(base_version, policy)
 
 
 @_d.method("sandbox.tokens.list", scope="operator.read")
@@ -988,8 +1047,7 @@ async def _handle_sandbox_token_revoke(params: dict | None, ctx: RpcContext) -> 
 @_d.method("sandbox.setup.ensure", scope="operator.write")
 async def _handle_sandbox_setup_ensure(params: dict | None, ctx: RpcContext) -> dict:
     _require_owner(ctx, "sandbox.setup.ensure")
-    result = await ensure_sandbox_setup_auto(ctx.config)
-    return result.to_payload()
+    return await _sandbox_application(ctx).ensure_setup()
 
 
 @_d.method("sandbox.explain", scope="operator.read")
@@ -1068,9 +1126,7 @@ async def _handle_run_mode_preference_get(
 ) -> dict[str, str]:
     if params is not None and not isinstance(params, dict):
         raise ValueError("params must be an object")
-    mode, source = await resolve_default_run_mode(ctx.session_manager, ctx.config)
-    mode = coerce_run_mode_for_principal(mode, ctx.principal)
-    return {"runMode": mode.value, "source": source}
+    return await _sandbox_application(ctx).run_mode()
 
 
 @_d.method("sandbox.run_mode.preference.set", scope="operator.write")
@@ -1081,18 +1137,7 @@ async def _handle_run_mode_preference_set(
     _require_owner(ctx, "sandbox.run_mode.preference.set")
     params = _require_params(params)
     mode = normalize_run_mode(params.get("runMode"))
-    await _require_sandbox_setup_ready_for_mode(ctx, mode)
-    storage = _runtime_preference_storage(ctx)
-    confirmed = await storage.set_runtime_preference(
-        RUN_MODE_PREFERENCE_KEY,
-        mode.value,
-    )
-    payload = {"runMode": confirmed, "source": "preference"}
-    await _run_mode_preference_registry().broadcast(
-        _RUN_MODE_PREFERENCE_CHANGED_EVENT,
-        payload,
-    )
-    return payload
+    return await _sandbox_application(ctx).set_run_mode(mode.value)
 
 
 @_d.method("sandbox.run_context.get", scope="operator.read")

--- a/tests/test_application/test_sandbox_runtime.py
+++ b/tests/test_application/test_sandbox_runtime.py
@@ -1,0 +1,39 @@
+import pytest
+
+from opensquilla.application.sandbox_runtime import (
+    InMemorySandboxRuntimePort,
+    SandboxRuntime,
+)
+
+
+@pytest.mark.asyncio
+async def test_sandbox_runtime_keeps_policy_and_setup_wire_out_of_module() -> None:
+    port = InMemorySandboxRuntimePort(
+        setup_status={"state": "ready", "platform": "linux"},
+        capability={"available": True},
+        policy={"schemaVersion": 2, "policyVersion": 4},
+    )
+    runtime = SandboxRuntime(port)
+
+    assert (await runtime.setup_status())["state"] == "ready"
+    assert (await runtime.capability())["available"] is True
+    assert (await runtime.policy())["policyVersion"] == 4
+
+
+@pytest.mark.asyncio
+async def test_sandbox_runtime_validates_mode_and_policy_version() -> None:
+    runtime = SandboxRuntime(InMemorySandboxRuntimePort())
+
+    with pytest.raises(ValueError, match="run mode"):
+        await runtime.set_run_mode("unsafe")
+    with pytest.raises(ValueError, match="policy version"):
+        await runtime.update_policy(True, {})
+
+
+@pytest.mark.asyncio
+async def test_sandbox_runtime_updates_mode_through_port() -> None:
+    runtime = SandboxRuntime(InMemorySandboxRuntimePort())
+
+    result = await runtime.set_run_mode("safe")
+
+    assert result == {"runMode": "safe", "source": "preference"}


### PR DESCRIPTION
## Scope\nIntroduce the SandboxRuntime domain boundary as one large, internally ordered slice:\n- add transport-neutral Application Module and RpcContext Port for sandbox status, setup, capability, policy, run mode, and runtime status\n- add a typed WebUI SandboxRuntime Interface and private v4 Adapter\n- migrate sandbox settings, setup recovery, run-mode preference, ChatView resume/event handling, and setup store consumers\n- update exact transport debt ledger and add module/adapter tests\n\n## Method-to-Module manifest\n- sandbox.status / rpc_sandbox._handle_sandbox_status -> SandboxRuntime.status -> status projection Port -> v4 Adapter -> sandbox settings/diagnostics\n- sandbox.setup.status, sandbox.setup.ensure -> SandboxRuntime.setup_status/ensure_setup -> setup runtime Port -> v4 Adapter -> setup recovery/store\n- sandbox.capability.status -> SandboxRuntime.capability -> capability probe Port -> v4 Adapter -> settings/setup readiness\n- sandbox.policy.get/update -> SandboxRuntime.policy/update_policy -> policy store Port -> v4 Adapter -> SandboxSettingsPanel\n- sandbox.run_mode.preference.get/set -> SandboxRuntime.run_mode/set_run_mode -> preference storage Port -> v4 Adapter -> ChatView and settings\n- sandbox.runtime.status/install/cancel/remove/discard_download -> SandboxRuntime runtime operations -> runtime-pack Port -> v4 Adapter -> runtime settings rows\n- sandbox.resume and preference.changed -> SandboxRuntime resume/event projection -> private v4 transport -> ChatView\n\n## Branch target\nmain\n\n## Issue\nNone\n\n## Release note\nNo user-visible release note; this is an internal architecture migration preserving v4 method and event compatibility.\n\n## Tests\n- npm run typecheck\n- npm run test:unit -- --run sandbox runtime/settings/recovery/adapter tests\n- uv run pytest -q targeted Sandbox/Application/Gateway/CI architecture tests (139 passed)\n- uv run ruff check (passed)\n- uv run mypy (passed)\n- GitNexus staged detect_changes: low risk\n\n## Safety and compatibility\nNo database schema, v4 envelope, TurnRunner, TaskRuntime, or native sandbox implementation changes. Existing sandbox handlers remain the single implementation; adapters only validate/project wire data. Old and new clients retain existing methods and event names.\n\n## Third-party origin\nNone.