### PR TITLE
fix(cli): honor an explicit --router on configure provider

### DIFF
--- a/src/opensquilla/cli/onboard_cmd.py
+++ b/src/opensquilla/cli/onboard_cmd.py
@@ -1644,6 +1644,12 @@ def configure_command(
                         "presetId": preset,
                     },
                 )
+                if router:
+                    # An explicit --router is authoritative (the help promises
+                    # recommended | openrouter-mix | disabled); an omitted one
+                    # keeps the stored/synthesized router state untouched on a
+                    # re-save, mirroring the `onboard --provider` contract.
+                    engine.apply("router", {"mode": router})
                 result = engine.persist()
                 _print_saved_path(result.path)
                 _print_restart_guidance(result, config_path)

--- a/tests/test_cli/test_onboard_cmd_headless_semantics.py
+++ b/tests/test_cli/test_onboard_cmd_headless_semantics.py
@@ -272,6 +272,100 @@ def test_configure_provider_key_rotation_keeps_model_base_url_and_proxy(
     assert cfg.llm.api_key == "sk-new"
 
 
+def test_configure_provider_explicit_router_disabled_is_authoritative(
+    tmp_path, monkeypatch
+):
+    # Issue #1341: `configure provider --router disabled` on a fresh config
+    # used to drop the flag and synthesize the default tier ladder instead.
+    # The explicit flag must be authoritative, matching the command help.
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "configure",
+            "provider",
+            "--provider",
+            "vllm",
+            "--model",
+            "qa-model",
+            "--base-url",
+            "http://127.0.0.1:18001/v1",
+            "--router",
+            "disabled",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    cfg = load_config(target)
+    assert cfg.squilla_router.enabled is False
+
+
+def test_configure_provider_omitted_router_keeps_disabled_state(
+    tmp_path, monkeypatch
+):
+    # Keep-current contract: a provider re-save without --router must never
+    # re-enable a deliberately disabled router.
+    target = tmp_path / "c.toml"
+    target.write_text(
+        "[llm]\n"
+        'provider = "vllm"\n'
+        'model = "qa-model"\n'
+        "\n"
+        "[squilla_router]\n"
+        "enabled = false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "configure",
+            "provider",
+            "--provider",
+            "vllm",
+            "--api-key",
+            "sk-new",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    cfg = load_config(target)
+    assert cfg.squilla_router.enabled is False
+    assert cfg.llm.api_key == "sk-new"
+
+
+def test_configure_provider_invalid_router_mode_exits_2(tmp_path, monkeypatch):
+    # Plumb-through makes an invalid --router a real mutation error: it must
+    # exit 2 with the mode validation message instead of being ignored.
+    target = tmp_path / "c.toml"
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_CONFIG_PATH", str(target))
+
+    result = runner.invoke(
+        app,
+        [
+            "onboard",
+            "configure",
+            "provider",
+            "--provider",
+            "vllm",
+            "--model",
+            "qa-model",
+            "--base-url",
+            "http://127.0.0.1:18001/v1",
+            "--router",
+            "nonsense",
+        ],
+    )
+
+    assert result.exit_code == 2, result.output
+    assert "router mode" in _plain(result.stderr)
+
+
 def test_onboard_provider_key_rotation_keeps_base_url_and_proxy(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
Fixes #1341

## Summary

- The headless `configure provider` branch applied the provider payload and persisted immediately, so an explicit `--router disabled` was silently dropped: a fresh profile reported `routerMode: "recommended"` and synthesized the default c0–c3 tier ladder instead of disabling the router.
- The explicit flag is now plumbed through to the router mutation after the provider apply (same order as the `onboard --provider` path).

## Semantics

- Explicit `--router <mode>` is authoritative, matching the command help (`recommended | openrouter-mix | disabled`).
- Omitted `--router` keeps the stored/synthesized router state untouched on a re-save (a provider key rotation never re-enables a disabled router).
- An invalid mode now exits 2 with the mode validation message instead of being silently ignored.

## Tests

- `tests/test_cli/test_onboard_cmd_headless_semantics.py`:
  - fresh-config repro: `configure provider --router disabled` yields `[squilla_router] enabled = false`;
  - keep-current: a provider re-save without `--router` leaves a disabled router disabled;
  - invalid `--router` exits 2 naming the mode constraint.
- Focused suites: 42 passed (headless semantics) + 341 passed (related onboard/mutation suites); `ruff` clean.
- Manually verified on Windows: the released 0.5.4 CLI reports `routerMode: "recommended"` for the issue's repro command; after this fix the same command reports `"disabled"` and writes `enabled = false` to `config.toml`.