### PR TITLE
refactor(webui): isolate read catalog domain boundaries

### DIFF
--- a/opensquilla-webui/scripts/rpc-debt/independent.mjs
+++ b/opensquilla-webui/scripts/rpc-debt/independent.mjs
@@ -1,20 +1,6 @@
 export const lane = 'independent'
 
 export const debt = {
-  'src/components/SupportDiagnosticsMenu.vue': {
-    call: 1,
-    waitForConnection: 1,
-    httpRequest: 1,
-    httpApiEndpoint: 1,
-    httpAuthToken: 1,
-    httpAuthorizationHeader: 1,
-  },
-  'src/components/UpdateBanner.vue': {
-    httpRequest: 1,
-    httpApiEndpoint: 1,
-    httpAuthToken: 1,
-    httpAuthorizationHeader: 1,
-  },
   'src/components/workbench/AppWorkbench.vue': {
     on: 2,
     httpRequest: 1,
@@ -32,17 +18,6 @@ export const debt = {
   'src/composables/cron/useCronForm.ts': { call: 1 },
   'src/composables/cron/useCronJobs.ts': { call: 3, on: 1, waitForConnection: 1 },
   'src/composables/cron/useCronRuns.ts': { call: 1 },
-  'src/composables/skills/useSkillDetailController.ts': { call: 1 },
-  'src/composables/skills/useSkillProposals.ts': { call: 10 },
-  'src/composables/skills/useSkillRegistry.ts': { call: 5, supportsMethod: 1 },
-  'src/composables/skills/useSkillsCatalog.ts': { call: 1, waitForConnection: 1 },
-  'src/composables/usage/useUsageQuery.ts': {
-    call: 3,
-    markMethodUnavailable: 2,
-    supportsMethod: 1,
-    waitForConnection: 1,
-  },
-  'src/composables/useAgentOptions.ts': { call: 2 },
   'src/composables/workbench/useArtifactPreviewResource.ts': {
     httpRequest: 1,
     httpApiEndpoint: 1,
@@ -50,10 +25,7 @@ export const debt = {
     httpAuthorizationHeader: 1,
     httpSessionKeyHeader: 1,
   },
-  'src/views/AgentsView.vue': { call: 3 },
-  'src/views/LogsView.vue': { call: 2, waitForConnection: 1 },
-  'src/views/OverviewView.vue': { call: 2, waitForConnection: 1 },
-  'src/views/SkillsView.vue': { call: 1, waitForConnection: 1 },
+  'src/views/OverviewView.vue': { call: 1 },
   'src/utils/workbench/artifactPreviewLease.ts': {
     httpRequest: 3,
     httpApiEndpoint: 3,

--- a/opensquilla-webui/scripts/rpc-debt/session-chat.mjs
+++ b/opensquilla-webui/scripts/rpc-debt/session-chat.mjs
@@ -59,7 +59,4 @@ export const debt = {
     httpAuthorizationHeader: 1,
     httpSessionKeyHeader: 1,
   },
-  'src/views/SessionsView.vue': {
-    call: 1,
-  },
 }

--- a/opensquilla-webui/src/App.sidebar-contract.test.ts
+++ b/opensquilla-webui/src/App.sidebar-contract.test.ts
@@ -51,7 +51,7 @@ describe('App sidebar chrome contract', () => {
 
   it('bounds automatic sidebar RPCs after chat bootstrap admission', () => {
     expect(appSource).toContain('useSessions(sessionDirectory)')
-    expect(appSource).toContain('useAgentOptions(optionalSessionRpcCallOptions)')
+    expect(appSource).toContain('useAgentOptions(agentCatalog, optionalSessionRpcCallOptions)')
     expect(appSource).toContain('SESSION_DIRECTORY_CHANGES_KEY')
     expect(appSource).toContain('sessionDirectoryChanges.resume()')
     expect(appSource).not.toContain('useSessionListSubscription')

--- a/opensquilla-webui/src/App.vue
+++ b/opensquilla-webui/src/App.vue
@@ -528,6 +528,7 @@ import {
   optionalSessionRpcCallOptions,
 } from './composables/chat/sessionBootstrapAdmission'
 import { markCronFinishNotified } from './utils/cron/notifications'
+import { AGENT_CATALOG_KEY } from './modules/agentCatalog'
 import {
   buildChatSessionTitles,
   isSensibleChatTitle,
@@ -548,6 +549,9 @@ const sessionLifecycle = injectedSessionLifecycle
 const injectedApprovalCenter = inject(APPROVAL_CENTER_KEY)
 if (!injectedApprovalCenter) throw new Error('ApprovalCenter was not provided')
 const approvalCenter = injectedApprovalCenter
+const injectedAgentCatalog = inject(AGENT_CATALOG_KEY)
+if (!injectedAgentCatalog) throw new Error('AgentCatalog was not provided')
+const agentCatalog = injectedAgentCatalog
 const shortcutsStore = useShortcutsStore()
 const artifactImageLightbox = provideArtifactImageLightbox()
 const { t } = useI18n()
@@ -735,7 +739,7 @@ function handleCronRunFinished(payload: unknown) {
 installSessionNavigationDiagConsole()
 
 // Shared agents.list state + fetch (singleton) for sidebar session metadata.
-const { agents, loadAgents } = useAgentOptions(optionalSessionRpcCallOptions)
+const { agents, loadAgents } = useAgentOptions(agentCatalog, optionalSessionRpcCallOptions)
 const mobileKeyboardOpen = ref(false)
 const commandPaletteOpen = ref(false)
 const localChatSessions = ref<Record<string, { effectiveAgentId: string; title: string; updatedAt: number }>>({})

--- a/opensquilla-webui/src/adapters/gateway/agentCatalogV4.test.ts
+++ b/opensquilla-webui/src/adapters/gateway/agentCatalogV4.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createV4AgentCatalog } from './agentCatalogV4'
+
+describe('v4 AgentCatalog Adapter', () => {
+  it('projects the catalog and maps semantic mutations', async () => {
+    const call = vi.fn(async (method: string) => (
+      method === 'agents.list'
+        ? { agents: [{ id: 'main', name: 'Main Agent' }] }
+        : { status: 'ok' }
+    ))
+    const catalog = createV4AgentCatalog({
+      request: call,
+      ready: vi.fn(async () => {}),
+    } as Parameters<typeof createV4AgentCatalog>[0])
+
+    await expect(catalog.list()).resolves.toEqual([{ id: 'main', name: 'Main Agent' }])
+    await catalog.create({ id: 'researcher', name: 'Researcher' })
+    await catalog.update({ id: 'researcher', enabled: false })
+    await catalog.remove('researcher')
+
+    expect(call).toHaveBeenNthCalledWith(2, 'agents.create', {
+      id: 'researcher',
+      name: 'Researcher',
+    }, expect.any(Object))
+    expect(call).toHaveBeenNthCalledWith(3, 'agents.update', {
+      id: 'researcher',
+      enabled: false,
+    }, expect.any(Object))
+    expect(call).toHaveBeenNthCalledWith(4, 'agents.delete', { id: 'researcher' }, expect.any(Object))
+  })
+})

--- a/opensquilla-webui/src/adapters/gateway/agentCatalogV4.ts
+++ b/opensquilla-webui/src/adapters/gateway/agentCatalogV4.ts
@@ -1,0 +1,58 @@
+import type { RpcCallOptions } from '@/lib/rpc'
+import type { AgentCatalog, AgentMutationResult } from '@/modules/agentCatalog'
+import type { Agent } from '@/types/agents'
+
+interface RpcTransport {
+  request<T = unknown>(method: string, params?: Record<string, unknown>, options?: RpcCallOptions): Promise<T>
+  ready(options?: { signal?: AbortSignal }): Promise<void>
+}
+
+const callOptions = (signal?: AbortSignal): RpcCallOptions => ({
+  timeoutMs: 15_000,
+  timeoutAction: 'reject',
+  abortAction: 'reject',
+  ...(signal ? { signal } : {}),
+})
+
+const record = (value: unknown): Record<string, unknown> => (
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+)
+
+export function createV4AgentCatalog(rpc: RpcTransport): AgentCatalog {
+  return {
+    async list(options) {
+      await rpc.ready({ signal: options?.signal })
+      const result = record(await rpc.request(
+        'agents.list',
+        undefined,
+        callOptions(options?.signal),
+      ))
+      return Array.isArray(result.agents)
+        ? result.agents.filter(item => item && typeof item === 'object' && !Array.isArray(item)) as Agent[]
+        : []
+    },
+    async create(input, options) {
+      return record(await rpc.request(
+        'agents.create',
+        { ...input },
+        callOptions(options?.signal),
+      )) as AgentMutationResult
+    },
+    async update(input, options) {
+      return record(await rpc.request(
+        'agents.update',
+        { ...input },
+        callOptions(options?.signal),
+      )) as AgentMutationResult
+    },
+    async remove(agentId, options) {
+      return record(await rpc.request(
+        'agents.delete',
+        { id: agentId },
+        callOptions(options?.signal),
+      )) as AgentMutationResult
+    },
+  }
+}

--- a/opensquilla-webui/src/adapters/gateway/gatewayAdapters.test.ts
+++ b/opensquilla-webui/src/adapters/gateway/gatewayAdapters.test.ts
@@ -43,6 +43,9 @@ describe('Gateway Adapter composition', () => {
       'workspaceCatalog',
       'sandboxRuntime',
       'sessionConversation',
+      'observability',
+      'skillCatalog',
+      'agentCatalog',
     ])
     expect(adapters).not.toHaveProperty('rpc')
     expect(adapters).not.toHaveProperty('events')

--- a/opensquilla-webui/src/adapters/gateway/gatewayAdapters.ts
+++ b/opensquilla-webui/src/adapters/gateway/gatewayAdapters.ts
@@ -13,7 +13,7 @@ import { createV4TurnCommands } from './turnCommandsV4'
 import { createV4PendingInputQueue } from './pendingInputQueueV4'
 import { createApprovalCenterV4 } from './approvalCenterV4'
 import type { ApprovalCenter } from '@/modules/approvalCenter'
-import type { HttpRequestOptions } from './privateHttpTransport'
+import type { HttpTransport } from './privateHttpTransport'
 import type { GoalCenter } from '@/modules/goalCenter'
 import { createV4GoalCenter } from './goalCenterV4'
 import { createV4GoalContinuity } from './goalContinuityV4'
@@ -36,6 +36,12 @@ import type { SandboxRuntime } from '@/modules/sandboxRuntime'
 import { createV4SandboxRuntime } from './sandboxRuntimeV4'
 import type { SessionConversation } from '@/modules/sessionConversation'
 import { createV4SessionConversation } from './sessionConversationV4'
+import type { Observability } from '@/modules/observability'
+import { createV4Observability } from './observabilityV4'
+import type { SkillCatalog } from '@/modules/skillCatalog'
+import { createV4SkillCatalog } from './skillCatalogV4'
+import type { AgentCatalog } from '@/modules/agentCatalog'
+import { createV4AgentCatalog } from './agentCatalogV4'
 
 type RpcStoreTransportSource = Parameters<typeof createPrivateGatewayTransports>[0]
 
@@ -58,14 +64,13 @@ export interface GatewayAdapters {
   readonly workspaceCatalog: WorkspaceCatalog
   readonly sandboxRuntime: SandboxRuntime
   readonly sessionConversation: SessionConversation
-}
-
-interface GatewayHttpSource {
-  requestJson<T = unknown>(endpoint: string, options?: HttpRequestOptions): Promise<T>
+  readonly observability: Observability
+  readonly skillCatalog: SkillCatalog
+  readonly agentCatalog: AgentCatalog
 }
 
 export interface GatewayAdapterOptions {
-  http?: GatewayHttpSource
+  http?: HttpTransport
 }
 
 /** Wire Gateway-backed domain Adapters without leaking generic transports. */
@@ -74,8 +79,14 @@ export function createGatewayAdapters(
   options: GatewayAdapterOptions = {},
 ): GatewayAdapters {
   const transports = createPrivateGatewayTransports(source)
-  const http = options.http ?? {
+  const http: HttpTransport = options.http ?? {
     requestJson: async () => {
+      throw new Error('Gateway HTTP transport is unavailable.')
+    },
+    requestBinary: async () => {
+      throw new Error('Gateway HTTP transport is unavailable.')
+    },
+    requestBlob: async () => {
       throw new Error('Gateway HTTP transport is unavailable.')
     },
   }
@@ -105,6 +116,9 @@ export function createGatewayAdapters(
       subscribe: (event, handler) => transports.events.subscribe(event, handler),
     }),
     sessionConversation: createV4SessionConversation(transports.rpc, transports.events),
+    observability: createV4Observability(transports.rpc, http),
+    skillCatalog: createV4SkillCatalog(transports.rpc),
+    agentCatalog: createV4AgentCatalog(transports.rpc),
   }
   return adapters
 }

--- a/opensquilla-webui/src/adapters/gateway/observabilityV4.test.ts
+++ b/opensquilla-webui/src/adapters/gateway/observabilityV4.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createV4Observability } from './observabilityV4'
+
+function transport(call: ReturnType<typeof vi.fn>, supports = true) {
+  const markUnsupported = vi.fn()
+  return {
+    value: {
+      request: call,
+      ready: vi.fn(async () => {}),
+      supports: vi.fn(() => supports),
+      markUnsupported,
+    },
+    markUnsupported,
+  }
+}
+
+describe('v4 Observability Adapter', () => {
+  it('projects usage.query and preserves the semantic range request', async () => {
+    const call = vi.fn(async () => ({
+      schemaVersion: 1,
+      source: 'usage_ledger',
+      range: { preset: 'last_7_calendar_days', timezone: 'Asia/Shanghai' },
+      totals: { inputTokens: 2, outputTokens: 3, costNanos: 5_000_000 },
+      coverage: { status: 'complete' },
+    }))
+    const rpc = transport(call)
+    const adapter = createV4Observability(
+      rpc.value as Parameters<typeof createV4Observability>[0], {
+      requestJson: vi.fn(),
+      requestBinary: vi.fn(),
+      },
+    )
+
+    const snapshot = await adapter.usage('7', { timezone: 'Asia/Shanghai' })
+
+    expect(call).toHaveBeenCalledWith('usage.query', {
+      schemaVersion: 1,
+      range: { preset: 'last_7_calendar_days' },
+      timezone: 'Asia/Shanghai',
+      include: { days: true, models: true, sessions: true },
+    }, expect.any(Object))
+    expect(snapshot.totals).toMatchObject({ input: 2, output: 3, cost: 0.005 })
+  })
+
+  it('falls back only when the optional query capability is absent', async () => {
+    const missing = Object.assign(new Error('Method not found'), { code: 'METHOD_NOT_FOUND' })
+    const call = vi.fn(async (method: string) => {
+      if (method === 'usage.query') throw missing
+      return { totalSessions: 4, totalTokens: 9, totalCostUsd: 0.25, sessions: [] }
+    })
+    const rpc = transport(call)
+    const adapter = createV4Observability(
+      rpc.value as Parameters<typeof createV4Observability>[0], {
+      requestJson: vi.fn(),
+      requestBinary: vi.fn(),
+      },
+    )
+
+    const snapshot = await adapter.usage('all', { timezone: 'UTC' })
+
+    expect(rpc.markUnsupported).toHaveBeenCalledWith('usage.query')
+    expect(snapshot.mode).toBe('session_approximation')
+    expect(snapshot.totals).toMatchObject({ sessions: 4, totalTokens: 9, cost: 0.25 })
+  })
+
+  it('owns readiness, log, update, and support-bundle transport details', async () => {
+    const call = vi.fn(async (method: string) => {
+      if (method === 'doctor.status') return { status: 'ready', ready: true }
+      if (method === 'logs.status') return { gateway_file_log: { enabled: true } }
+      if (method === 'logs.tail') return { lines: ['ready'], cursor: 4 }
+      throw new Error(`unexpected method ${method}`)
+    })
+    const http = {
+      requestJson: vi.fn(async () => ({
+        current: '1.0.0',
+        latest: '1.1.0',
+        available: true,
+        url: 'https://example.test/release',
+        checkedAt: '2026-09-01T00:00:00Z',
+      })),
+      requestBinary: vi.fn(async () => ({
+        metadata: { filename: 'support.zip' },
+        blob: async () => new Blob(['bundle']),
+      })),
+    }
+    const adapter = createV4Observability(
+      transport(call).value as Parameters<typeof createV4Observability>[0],
+      http as Parameters<typeof createV4Observability>[1],
+    )
+
+    await expect(adapter.readiness({ deep: true })).resolves.toMatchObject({ ready: true })
+    await expect(adapter.logStatus()).resolves.toMatchObject({ gateway_file_log: { enabled: true } })
+    await expect(adapter.tailLogs({ cursor: 0 })).resolves.toEqual({ entries: ['ready'], cursor: 4 })
+    await expect(adapter.updateNotice()).resolves.toMatchObject({ latest: '1.1.0' })
+    const bundle = await adapter.downloadSupportBundle({ includeContent: false })
+
+    expect(http.requestJson).toHaveBeenCalledWith('/api/system/update', expect.objectContaining({ method: 'GET' }))
+    expect(http.requestBinary).toHaveBeenCalledWith('/api/v1/diagnostics/bundle', expect.objectContaining({
+      method: 'POST',
+      json: { include_content: false, days: 1 },
+    }))
+    expect(bundle.filename).toBe('support.zip')
+  })
+})

--- a/opensquilla-webui/src/adapters/gateway/observabilityV4.ts
+++ b/opensquilla-webui/src/adapters/gateway/observabilityV4.ts
@@ -1,0 +1,238 @@
+import type { RpcCallOptions } from '@/lib/rpc'
+import type {
+  GatewayLogBatch,
+  GatewayLogEntry,
+  GatewayLogStatus,
+  Observability,
+  ReadinessReport,
+  UpdateNotice,
+} from '@/modules/observability'
+import type {
+  UsageQueryResponse,
+  UsageRangeSelection,
+  UsageStatusData,
+} from '@/types/usage'
+import {
+  browserTimeZone,
+  normalizeUsageQueryResponse,
+  normalizeUsageStatusResponse,
+  usagePresetForRange,
+} from '@/composables/usage/useUsageQuery'
+
+interface RpcTransport {
+  request<T = unknown>(method: string, params?: Record<string, unknown>, options?: RpcCallOptions): Promise<T>
+  ready(options?: { signal?: AbortSignal }): Promise<void>
+  supports(method: string): boolean
+  markUnsupported(method: string): void
+}
+
+interface HttpTransport {
+  requestJson<T>(endpoint: string, options?: {
+    method?: 'GET'
+    timeoutMs?: number
+    signal?: AbortSignal
+  }): Promise<T>
+  requestBinary(endpoint: string, options: {
+    method: 'POST'
+    json: unknown
+    signal?: AbortSignal
+  }): Promise<{
+    readonly metadata: { readonly filename?: string }
+    blob(): Promise<Blob>
+  }>
+}
+
+const USAGE_QUERY_METHOD = 'usage.query'
+const USAGE_STATUS_METHOD = 'usage.status'
+const DOCTOR_STATUS_METHOD = 'doctor.status'
+const LOGS_STATUS_METHOD = 'logs.status'
+const LOGS_TAIL_METHOD = 'logs.tail'
+
+const callOptions = (signal?: AbortSignal): RpcCallOptions => ({
+  timeoutMs: 15_000,
+  timeoutAction: 'reject',
+  abortAction: 'reject',
+  ...(signal ? { signal } : {}),
+})
+
+const asRecord = (value: unknown): Record<string, unknown> => (
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+)
+
+function methodNotFound(error: unknown): boolean {
+  const code = typeof error === 'object' && error && 'code' in error
+    ? String((error as { code?: unknown }).code ?? '')
+    : ''
+  const message = error instanceof Error ? error.message : String(error)
+  return code === 'METHOD_NOT_FOUND' || /method not found/i.test(message)
+}
+
+function invalidTimezone(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return /unknown iana timezone|invalid timezone|time zone/i.test(message)
+}
+
+function usageQueryParams(
+  range: UsageRangeSelection,
+  timezone: string,
+  options: Parameters<Observability['usage']>[1],
+): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    range: { preset: usagePresetForRange(range) },
+    timezone,
+    include: {
+      days: options?.days ?? true,
+      models: options?.models ?? true,
+      sessions: options?.sessions ?? true,
+    },
+  }
+}
+
+function updateNotice(value: unknown): UpdateNotice | null | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+  const raw = value as Record<string, unknown>
+  if (
+    typeof raw.current !== 'string'
+    || typeof raw.available !== 'boolean'
+    || (raw.latest !== null && typeof raw.latest !== 'string')
+    || (raw.url !== null && typeof raw.url !== 'string')
+    || (raw.checkedAt !== null && typeof raw.checkedAt !== 'string')
+  ) return undefined
+  if (!raw.available) return null
+  if (typeof raw.latest !== 'string' || !raw.latest.trim()) return undefined
+  return {
+    current: raw.current,
+    latest: raw.latest,
+    available: true,
+    url: typeof raw.url === 'string' && raw.url ? raw.url : undefined,
+  }
+}
+
+export function createV4Observability(rpc: RpcTransport, http: HttpTransport): Observability {
+  return {
+    async usage(range, options = {}) {
+      await rpc.ready({ signal: options.signal })
+      const timezone = options.timezone || browserTimeZone()
+      const requestedPreset = usagePresetForRange(range)
+      const matchingLedgerCache = options.cachedSnapshot?.source === 'usage_ledger'
+        && options.cachedSnapshot.range.preset === requestedPreset
+        ? options.cachedSnapshot
+        : null
+      let transientQueryFailure = false
+      if (rpc.supports(USAGE_QUERY_METHOD)) {
+        try {
+          return normalizeUsageQueryResponse(await rpc.request<UsageQueryResponse>(
+            USAGE_QUERY_METHOD,
+            usageQueryParams(range, timezone, options),
+            callOptions(options.signal),
+          ))
+        } catch (error) {
+          if (methodNotFound(error)) {
+            rpc.markUnsupported(USAGE_QUERY_METHOD)
+          } else if (timezone !== 'UTC' && invalidTimezone(error)) {
+            try {
+              const snapshot = normalizeUsageQueryResponse(await rpc.request<UsageQueryResponse>(
+                USAGE_QUERY_METHOD,
+                usageQueryParams(range, 'UTC', options),
+                callOptions(options.signal),
+              ))
+              return {
+                ...snapshot,
+                timezoneFallback: {
+                  requestedTimezone: timezone,
+                  effectiveTimezone: snapshot.timezone,
+                  reason: 'invalid_timezone',
+                },
+              }
+            } catch (utcError) {
+              if (methodNotFound(utcError)) rpc.markUnsupported(USAGE_QUERY_METHOD)
+              else transientQueryFailure = true
+            }
+          } else {
+            transientQueryFailure = true
+          }
+        }
+      }
+      try {
+        const status = await rpc.request<UsageStatusData>(
+          USAGE_STATUS_METHOD,
+          undefined,
+          callOptions(options.signal),
+        )
+        if (transientQueryFailure && matchingLedgerCache) return matchingLedgerCache
+        return normalizeUsageStatusResponse(
+          status,
+          options.fallbackRange || range,
+          timezone,
+        )
+      } catch (error) {
+        if (matchingLedgerCache) return matchingLedgerCache
+        throw error
+      }
+    },
+    async readiness(options) {
+      await rpc.ready({ signal: options.signal })
+      return asRecord(await rpc.request(
+        DOCTOR_STATUS_METHOD,
+        { agentId: options.agentId || 'main', deep: options.deep },
+        callOptions(options.signal),
+      )) as ReadinessReport
+    },
+    async logStatus(options) {
+      await rpc.ready({ signal: options?.signal })
+      return asRecord(await rpc.request(
+        LOGS_STATUS_METHOD,
+        {},
+        callOptions(options?.signal),
+      )) as GatewayLogStatus
+    },
+    async tailLogs(options) {
+      await rpc.ready({ signal: options.signal })
+      const raw = asRecord(await rpc.request(
+        LOGS_TAIL_METHOD,
+        {
+          cursor: options.cursor,
+          limit: options.limit ?? 500,
+          level: options.level ?? null,
+        },
+        callOptions(options.signal),
+      ))
+      const entries = Array.isArray(raw.lines)
+        ? raw.lines
+        : Array.isArray(raw.entries) ? raw.entries : []
+      return {
+        entries: entries.filter(item => typeof item === 'string'
+          || (item !== null && typeof item === 'object' && !Array.isArray(item))) as GatewayLogEntry[],
+        cursor: Number.isInteger(raw.cursor) ? Number(raw.cursor) : null,
+      } satisfies GatewayLogBatch
+    },
+    async updateNotice(options) {
+      try {
+        return updateNotice(await http.requestJson('/api/system/update', {
+          method: 'GET',
+          timeoutMs: 5_000,
+          signal: options?.signal,
+        }))
+      } catch {
+        return undefined
+      }
+    },
+    async downloadSupportBundle(options) {
+      const response = await http.requestBinary('/api/v1/diagnostics/bundle', {
+        method: 'POST',
+        json: {
+          include_content: options.includeContent,
+          days: options.days ?? 1,
+        },
+        signal: options.signal,
+      })
+      return {
+        blob: await response.blob(),
+        filename: response.metadata.filename || 'opensquilla-bundle.zip',
+      }
+    },
+  }
+}

--- a/opensquilla-webui/src/adapters/gateway/skillCatalogV4.test.ts
+++ b/opensquilla-webui/src/adapters/gateway/skillCatalogV4.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createV4SkillCatalog } from './skillCatalogV4'
+
+function adapter(call: ReturnType<typeof vi.fn>, supports = true) {
+  return createV4SkillCatalog({
+    request: call,
+    ready: vi.fn(async () => {}),
+    supports: vi.fn(() => supports),
+  } as Parameters<typeof createV4SkillCatalog>[0])
+}
+
+describe('v4 SkillCatalog Adapter', () => {
+  it('maps catalog reads and exact lifecycle identity', async () => {
+    const call = vi.fn(async (method: string) => (
+      method === 'skills.list'
+        ? { skills: [{ name: 'managed-skill', instance_id: 'managed:1' }] }
+        : { name: 'managed-skill', content: '# managed' }
+    ))
+    const catalog = adapter(call)
+
+    await expect(catalog.list()).resolves.toEqual([{ name: 'managed-skill', instance_id: 'managed:1' }])
+    await catalog.detail({ name: 'managed-skill', instance_id: 'managed:1', install_id: 'install-1' })
+
+    expect(call).toHaveBeenLastCalledWith('skills.get', {
+      name: 'managed-skill',
+      includeLifecycle: true,
+      instanceId: 'managed:1',
+      installId: 'install-1',
+    }, expect.any(Object))
+  })
+
+  it('keeps operation identity and risk acknowledgement inside install semantics', async () => {
+    const call = vi.fn(async () => ({ success: true, installed: true }))
+    const catalog = adapter(call)
+
+    await catalog.install({
+      identifier: '@acme/demo',
+      source: 'clawhub',
+      operationId: 'operation-1',
+      riskConfirmation: 'confirmation-token',
+    })
+
+    expect(call).toHaveBeenCalledWith('skills.install', {
+      identifier: '@acme/demo',
+      source: 'clawhub',
+      operationId: 'operation-1',
+      force: true,
+      riskConfirmation: 'confirmation-token',
+    }, expect.any(Object))
+  })
+
+  it('combines proposal projections without making one optional read fatal', async () => {
+    const call = vi.fn(async (method: string) => {
+      if (method === 'exec.proposals.list') return { proposals: [{ proposal_id: 'p-1' }] }
+      if (method === 'exec.proposals.auto_enabled.list') throw new Error('legacy gateway')
+      return { settings: { available: true, enabled: false } }
+    })
+    const catalog = adapter(call)
+
+    await expect(catalog.proposals()).resolves.toMatchObject({
+      proposals: [{ proposal_id: 'p-1' }],
+      autoEnabledSkills: [],
+      settings: { available: true, enabled: false },
+    })
+  })
+})

--- a/opensquilla-webui/src/adapters/gateway/skillCatalogV4.ts
+++ b/opensquilla-webui/src/adapters/gateway/skillCatalogV4.ts
@@ -1,0 +1,169 @@
+import type { RpcCallOptions } from '@/lib/rpc'
+import type {
+  SkillCatalog,
+  SkillInstallResult,
+  SkillProposalAction,
+  SkillProposalDetail,
+  SkillReloadResult,
+  SkillRegistrySearchResult,
+} from '@/modules/skillCatalog'
+import type {
+  AutoEnabledSkill,
+  Proposal,
+  ProposalsSettings,
+  RegistryResult,
+  Skill,
+  SkillDiagnostic,
+} from '@/types/skills'
+
+interface RpcTransport {
+  request<T = unknown>(method: string, params?: Record<string, unknown>, options?: RpcCallOptions): Promise<T>
+  ready(options?: { signal?: AbortSignal }): Promise<void>
+  supports(method: string): boolean
+}
+
+const callOptions = (signal?: AbortSignal): RpcCallOptions => ({
+  timeoutMs: 30_000,
+  timeoutAction: 'reject',
+  abortAction: 'reject',
+  ...(signal ? { signal } : {}),
+})
+
+const record = (value: unknown): Record<string, unknown> => (
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+)
+
+const objects = <T>(value: unknown): T[] => (
+  Array.isArray(value)
+    ? value.filter(item => item !== null && typeof item === 'object' && !Array.isArray(item)) as T[]
+    : []
+)
+
+export function createV4SkillCatalog(rpc: RpcTransport): SkillCatalog {
+  return {
+    async list(options) {
+      await rpc.ready({ signal: options?.signal })
+      const result = record(await rpc.request(
+        'skills.list',
+        { includeLifecycle: true },
+        callOptions(options?.signal),
+      ))
+      return objects<Skill>(result.skills)
+    },
+    async detail(skill, options) {
+      const result = record(await rpc.request('skills.get', {
+        name: skill.name,
+        includeLifecycle: true,
+        ...(skill.instance_id ? { instanceId: skill.instance_id } : {}),
+        ...(skill.install_id ? { installId: skill.install_id } : {}),
+      }, callOptions(options?.signal)))
+      return result as unknown as Skill
+    },
+    async search(query, options) {
+      const result = record(await rpc.request('skills.search', {
+        query,
+        limit: options?.limit ?? 20,
+        source: options?.source || 'clawhub',
+      }, callOptions(options?.signal)))
+      return {
+        results: objects<RegistryResult>(result.results),
+        diagnostics: objects<SkillDiagnostic>(result.diagnostics),
+        message: typeof result.message === 'string' ? result.message : '',
+      } satisfies SkillRegistrySearchResult
+    },
+    async reload(options) {
+      return record(await rpc.request(
+        'skills.reload',
+        undefined,
+        callOptions(options?.signal),
+      )) as unknown as SkillReloadResult
+    },
+    async install(request) {
+      return record(await rpc.request('skills.install', {
+        identifier: request.identifier,
+        source: request.source,
+        ...(request.operationId ? { operationId: request.operationId } : {}),
+        ...(request.riskConfirmation
+          ? { force: true, riskConfirmation: request.riskConfirmation }
+          : {}),
+      }, callOptions(request.signal))) as unknown as SkillInstallResult
+    },
+    supportsInstallCancellation() {
+      return rpc.supports('skills.install.cancel')
+    },
+    async cancelInstall(operationId, options) {
+      return record(await rpc.request(
+        'skills.install.cancel',
+        { operationId },
+        callOptions(options?.signal),
+      )) as unknown as SkillInstallResult
+    },
+    async installDependencies(request) {
+      return record(await rpc.request('skills.deps.install', {
+        name: request.name,
+        install_id: request.dependencyId,
+        ...(request.skillInstallId ? { installId: request.skillInstallId } : {}),
+        ...(request.instanceId ? { instanceId: request.instanceId } : {}),
+      }, callOptions(request.signal))) as unknown as SkillInstallResult
+    },
+    async uninstall(request) {
+      return record(await rpc.request('skills.uninstall', {
+        ...(request.name ? { name: request.name } : {}),
+        ...(request.installId ? { installId: request.installId } : {}),
+      }, callOptions(request.signal))) as unknown as SkillInstallResult
+    },
+    async proposals(options) {
+      const [listed, enabled, settings] = await Promise.allSettled([
+        rpc.request('exec.proposals.list', undefined, callOptions(options?.signal)),
+        rpc.request('exec.proposals.auto_enabled.list', undefined, callOptions(options?.signal)),
+        rpc.request('exec.proposals.settings.get', undefined, callOptions(options?.signal)),
+      ])
+      const listedRecord = listed.status === 'fulfilled' ? record(listed.value) : {}
+      const enabledRecord = enabled.status === 'fulfilled' ? record(enabled.value) : {}
+      const settingsRecord = settings.status === 'fulfilled' ? record(settings.value) : {}
+      return {
+        proposals: objects<Proposal>(listedRecord.proposals),
+        autoEnabledSkills: objects<AutoEnabledSkill>(enabledRecord.skills),
+        settings: settingsRecord.settings && typeof settingsRecord.settings === 'object'
+          ? settingsRecord.settings as ProposalsSettings
+          : null,
+      }
+    },
+    async updateProposalSettings(changes, options) {
+      return record(await rpc.request(
+        'exec.proposals.settings.set',
+        { ...changes },
+        callOptions(options?.signal),
+      )) as SkillProposalAction
+    },
+    async proposal(proposalId, options) {
+      return record(await rpc.request(
+        'exec.proposals.show',
+        { proposal_id: proposalId },
+        callOptions(options?.signal),
+      )) as SkillProposalDetail
+    },
+    async acceptProposal(proposalId, options) {
+      return record(await rpc.request('exec.proposals.accept', {
+        proposal_id: proposalId,
+        ...(options?.force ? { force: true } : {}),
+      }, callOptions(options?.signal))) as SkillProposalAction
+    },
+    async rejectProposal(proposalId, options) {
+      return record(await rpc.request(
+        'exec.proposals.reject',
+        { proposal_id: proposalId },
+        callOptions(options?.signal),
+      )) as SkillProposalAction
+    },
+    async disableAutoEnabledSkill(name, options) {
+      return record(await rpc.request(
+        'exec.proposals.auto_enabled.disable',
+        { name },
+        callOptions(options?.signal),
+      )) as SkillProposalAction
+    },
+  }
+}

--- a/opensquilla-webui/src/components/SupportDiagnosticsMenu.test.ts
+++ b/opensquilla-webui/src/components/SupportDiagnosticsMenu.test.ts
@@ -5,13 +5,11 @@ import type { App } from 'vue'
 const mocks = vi.hoisted(() => ({
   route: { path: '/overview' },
   routerPush: vi.fn(),
-  rpcCall: vi.fn(),
-  waitForConnection: vi.fn(),
+  readiness: vi.fn(),
+  downloadSupportBundle: vi.fn(),
   pushToast: vi.fn(),
   copyText: vi.fn(),
   downloadBlob: vi.fn(),
-  filenameFromContentDisposition: vi.fn(),
-  fetch: vi.fn(),
   messages: {
     'monitorSupport.title': 'Support & diagnostics',
     'monitorSupport.menuLabel': 'Support and diagnostics actions',
@@ -62,13 +60,6 @@ vi.mock('vue-i18n', () => ({
   }),
 }))
 
-vi.mock('@/stores/rpc', () => ({
-  useRpcStore: () => ({
-    call: mocks.rpcCall,
-    waitForConnection: mocks.waitForConnection,
-  }),
-}))
-
 vi.mock('@/composables/useToasts', () => ({
   useToasts: () => ({ pushToast: mocks.pushToast }),
 }))
@@ -76,7 +67,6 @@ vi.mock('@/composables/useToasts', () => ({
 vi.mock('@/utils/browser', () => ({
   copyTextWithFallback: mocks.copyText,
   downloadBlob: mocks.downloadBlob,
-  filenameFromContentDisposition: mocks.filenameFromContentDisposition,
 }))
 
 vi.mock('@/components/Icon.vue', async () => {
@@ -104,9 +94,14 @@ async function flush() {
 async function mountMenu() {
   const { createApp } = await import('vue')
   const Component = (await import('./SupportDiagnosticsMenu.vue')).default
+  const { OBSERVABILITY_KEY } = await import('@/modules/observability')
   const el = document.createElement('div')
   document.body.appendChild(el)
   const app = createApp(Component)
+  app.provide(OBSERVABILITY_KEY, {
+    readiness: mocks.readiness,
+    downloadSupportBundle: mocks.downloadSupportBundle,
+  } as never)
   app.mount(el)
   mountedApps.push({ app, el })
   await flush()
@@ -119,22 +114,16 @@ beforeEach(() => {
   vi.clearAllMocks()
   mocks.route.path = '/overview'
 
-  mocks.waitForConnection.mockResolvedValue(undefined)
-  mocks.rpcCall.mockResolvedValue({
+  mocks.readiness.mockResolvedValue({
     status: 'degraded',
     configPath: ['', 'Users', 'dummyuser', '.opensquilla', 'config.toml'].join('/'),
     gatewayUrl: 'ws://127.0.0.1:18791/ws',
   })
   mocks.copyText.mockResolvedValue(undefined)
-  mocks.filenameFromContentDisposition.mockReturnValue('opensquilla-support.zip')
-  mocks.fetch.mockResolvedValue({
-    ok: true,
-    blob: vi.fn(async () => new Blob(['bundle'])),
-    headers: new Headers({
-      'content-disposition': 'attachment; filename="opensquilla-support.zip"',
-    }),
+  mocks.downloadSupportBundle.mockResolvedValue({
+    blob: new Blob(['bundle']),
+    filename: 'opensquilla-support.zip',
   })
-  vi.stubGlobal('fetch', mocks.fetch)
 })
 
 afterEach(() => {
@@ -227,8 +216,7 @@ describe('SupportDiagnosticsMenu', () => {
     el.querySelector<HTMLButtonElement>('[data-testid="support-copy-readiness"]')!.click()
     await flush()
 
-    expect(mocks.waitForConnection).toHaveBeenCalledTimes(1)
-    expect(mocks.rpcCall).toHaveBeenCalledWith('doctor.status', {
+    expect(mocks.readiness).toHaveBeenCalledWith({
       agentId: 'main',
       deep: true,
     })
@@ -260,17 +248,8 @@ describe('SupportDiagnosticsMenu', () => {
     confirm!.click()
     await flush()
 
-    expect(mocks.fetch).toHaveBeenCalledTimes(1)
-    const [url, init] = mocks.fetch.mock.calls[0] as [string, RequestInit]
-    expect(url).toBe('/api/v1/diagnostics/bundle')
-    expect(init.method).toBe('POST')
-    expect(init.credentials).toBe('same-origin')
-    expect(init.headers).toEqual({
-      'Content-Type': 'application/json',
-      Authorization: 'Bearer test-owner-token',
-    })
-    expect(JSON.parse(String(init.body))).toEqual({
-      include_content: false,
+    expect(mocks.downloadSupportBundle).toHaveBeenCalledWith({
+      includeContent: false,
       days: 1,
     })
     expect(mocks.downloadBlob).toHaveBeenCalledWith(expect.any(Blob), 'opensquilla-support.zip')

--- a/opensquilla-webui/src/components/SupportDiagnosticsMenu.vue
+++ b/opensquilla-webui/src/components/SupportDiagnosticsMenu.vue
@@ -86,27 +86,28 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, ref, watch } from 'vue'
+import { inject, nextTick, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import DiagnosticsBundleDialog from '@/components/DiagnosticsBundleDialog.vue'
 import Icon from '@/components/Icon.vue'
 import { useDocumentEvent } from '@/composables/useDocumentEvent'
 import { useToasts } from '@/composables/useToasts'
-import { useRpcStore } from '@/stores/rpc'
 import {
   copyTextWithFallback,
   downloadBlob,
-  filenameFromContentDisposition,
 } from '@/utils/browser'
 import { normalizeHomePaths } from '@/utils/overviewDiagnostics'
+import { OBSERVABILITY_KEY } from '@/modules/observability'
 
 const SUPPORT_BUNDLE_DAYS = 1
 
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
-const rpc = useRpcStore()
+const injectedObservability = inject(OBSERVABILITY_KEY)
+if (!injectedObservability) throw new Error('Observability was not provided')
+const observability = injectedObservability
 const { pushToast } = useToasts()
 const menuOpen = ref(false)
 const bundleDialogOpen = ref(false)
@@ -196,8 +197,7 @@ async function copyReadinessReport() {
   await nextTick()
   triggerRef.value?.focus()
   try {
-    await rpc.waitForConnection()
-    const data = await rpc.call<Record<string, unknown>>('doctor.status', {
+    const data = await observability.readiness({
       agentId: 'main',
       deep: true,
     })
@@ -222,29 +222,11 @@ async function downloadBundle(options: { includeContent: boolean }) {
   closeBundleDialog()
   bundleInFlight.value = true
   try {
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-    // Match the owner-authenticated diagnostics route used by the prior Logs
-    // action. Some hardened/embedded contexts reject sessionStorage access.
-    let token = ''
-    try { token = sessionStorage.getItem('opensquilla.wsToken') || '' } catch {}
-    if (token) headers.Authorization = `Bearer ${token}`
-    const response = await fetch('/api/v1/diagnostics/bundle', {
-      method: 'POST',
-      headers,
-      credentials: 'same-origin',
-      body: JSON.stringify({
-        include_content: options.includeContent,
-        days: SUPPORT_BUNDLE_DAYS,
-      }),
+    const bundle = await observability.downloadSupportBundle({
+      includeContent: options.includeContent,
+      days: SUPPORT_BUNDLE_DAYS,
     })
-    if (!response.ok) {
-      pushToast(t('monitorSupport.bundleFailed'), { tone: 'danger' })
-      return
-    }
-    const blob = await response.blob()
-    const filename = filenameFromContentDisposition(response.headers.get('content-disposition'))
-      || 'opensquilla-bundle.zip'
-    downloadBlob(blob, filename)
+    downloadBlob(bundle.blob, bundle.filename)
     pushToast(t('monitorSupport.bundleReady'), { tone: 'ok' })
   } catch {
     pushToast(t('monitorSupport.bundleFailed'), { tone: 'danger' })

--- a/opensquilla-webui/src/components/UpdateBanner.test.ts
+++ b/opensquilla-webui/src/components/UpdateBanner.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, type App as VueApp } from 'vue'
 import i18n from '@/i18n'
 import UpdateBanner from './UpdateBanner.vue'
+import { OBSERVABILITY_KEY, type UpdateNotice } from '@/modules/observability'
 
 const platformMocks = vi.hoisted(() => ({
   desktopUpdateManaged: vi.fn(),
@@ -75,6 +76,39 @@ async function mountBanner(): Promise<{ app: VueApp; el: HTMLDivElement }> {
   document.body.appendChild(el)
   const app = createApp(UpdateBanner)
   app.use(i18n)
+  app.provide(OBSERVABILITY_KEY, {
+    async updateNotice(options?: { signal?: AbortSignal }): Promise<UpdateNotice | null | undefined> {
+      const headers: Record<string, string> = {}
+      const token = sessionStorage.getItem('opensquilla.wsToken') || ''
+      if (token) headers.Authorization = `Bearer ${token}`
+      try {
+        const response = await fetch('/api/system/update', {
+          cache: 'no-store',
+          headers,
+          signal: options?.signal,
+        })
+        if (!response.ok) return undefined
+        const raw = await response.json() as Partial<UpdatePayload>
+        if (
+          typeof raw.current !== 'string'
+          || typeof raw.available !== 'boolean'
+          || (raw.latest !== null && typeof raw.latest !== 'string')
+          || (raw.url !== null && typeof raw.url !== 'string')
+          || (raw.checkedAt !== null && typeof raw.checkedAt !== 'string')
+        ) return undefined
+        if (!raw.available) return null
+        if (typeof raw.latest !== 'string' || !raw.latest.trim()) return undefined
+        return {
+          current: raw.current,
+          latest: raw.latest,
+          available: true,
+          url: typeof raw.url === 'string' && raw.url ? raw.url : undefined,
+        }
+      } catch {
+        return undefined
+      }
+    },
+  } as never)
   app.mount(el)
   apps.add(app)
   await flushAsync()

--- a/opensquilla-webui/src/components/UpdateBanner.vue
+++ b/opensquilla-webui/src/components/UpdateBanner.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, inject, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from './Icon.vue'
 import { getPlatform } from '@/platform'
+import { OBSERVABILITY_KEY, type UpdateNotice } from '@/modules/observability'
 
 // Passive "a newer version is available" notice. The gateway injects the update
 // info into #opensquilla-data (data-update) only when a newer published release
@@ -20,24 +21,10 @@ const isDesktop = platform.id === 'desktop'
 
 const DISMISS_KEY = 'opensquilla-update-dismissed'
 const RELEASES_FALLBACK = 'https://github.com/opensquilla/opensquilla/releases'
-const UPDATE_STATUS_URL = '/api/system/update'
 const POLL_INTERVAL_MS = 15 * 60 * 1000
 const REQUEST_TIMEOUT_MS = 5 * 1000
 
-interface UpdateInfo {
-  current?: string
-  latest?: string
-  available?: boolean
-  url?: string
-}
-
-interface UpdateStatusPayload {
-  current: string
-  latest: string | null
-  available: boolean
-  url: string | null
-  checkedAt: string | null
-}
+type UpdateInfo = UpdateNotice
 
 function readUpdate(): UpdateInfo | null {
   try {
@@ -53,29 +40,10 @@ function readUpdate(): UpdateInfo | null {
   }
 }
 
-function normalizeUpdateStatus(payload: unknown): UpdateInfo | null | undefined {
-  if (!payload || typeof payload !== 'object') return undefined
-  const raw = payload as Partial<UpdateStatusPayload>
-  if (
-    typeof raw.current !== 'string'
-    || typeof raw.available !== 'boolean'
-    || (raw.latest !== null && typeof raw.latest !== 'string')
-    || (raw.url !== null && typeof raw.url !== 'string')
-    || (raw.checkedAt !== null && typeof raw.checkedAt !== 'string')
-  ) {
-    return undefined
-  }
-  if (!raw.available) return null
-  if (typeof raw.latest !== 'string' || !raw.latest.trim()) return undefined
-  return {
-    current: raw.current,
-    latest: raw.latest,
-    available: true,
-    url: typeof raw.url === 'string' && raw.url ? raw.url : undefined,
-  }
-}
-
 const info = ref<UpdateInfo | null>(readUpdate())
+const injectedObservability = inject(OBSERVABILITY_KEY)
+if (!injectedObservability) throw new Error('Observability was not provided')
+const observability = injectedObservability
 
 // Assume managed on desktop until the shell confirms otherwise, preventing a
 // native/manual desktop notice from flashing beside the passive banner.
@@ -87,17 +55,6 @@ let activeController: AbortController | null = null
 let activeRequestTimeout: number | null = null
 let inFlight: Promise<void> | null = null
 
-function authHeaders(): Record<string, string> {
-  const headers: Record<string, string> = {}
-  try {
-    const token = sessionStorage.getItem('opensquilla.wsToken') || ''
-    if (token) headers.Authorization = `Bearer ${token}`
-  } catch {
-    // sessionStorage unavailable (private mode) — let gateway auth decide.
-  }
-  return headers
-}
-
 async function refreshUpdateInfo(): Promise<void> {
   if (inFlight) return inFlight
 
@@ -108,14 +65,7 @@ async function refreshUpdateInfo(): Promise<void> {
 
   const request = (async () => {
     try {
-      const response = await fetch(UPDATE_STATUS_URL, {
-        cache: 'no-store',
-        headers: authHeaders(),
-        signal: controller.signal,
-      })
-      if (!response.ok) return
-
-      const next = normalizeUpdateStatus(await response.json())
+      const next = await observability.updateNotice({ signal: controller.signal })
       // undefined means an invalid response: preserve the last known status.
       if (mounted && next !== undefined) info.value = next
     } catch {

--- a/opensquilla-webui/src/components/skills/SkillGroup.lifecycle.test.ts
+++ b/opensquilla-webui/src/components/skills/SkillGroup.lifecycle.test.ts
@@ -4,7 +4,7 @@ import { createApp, h, nextTick, ref } from 'vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import i18n from '@/i18n'
 import { useSkillsCatalog } from '@/composables/skills/useSkillsCatalog'
-import type { useRpcStore } from '@/stores/rpc'
+import type { SkillCatalog } from '@/modules/skillCatalog'
 import SkillGroup from './SkillGroup.vue'
 
 const apps: ReturnType<typeof createApp>[] = []
@@ -16,20 +16,16 @@ afterEach(() => {
 
 describe('SkillGroup lifecycle compatibility', () => {
   it('loads and renders an old Gateway skills.list response without lifecycle fields', async () => {
-    const rpc = {
-      waitForConnection: vi.fn(async () => {}),
-      call: vi.fn(async () => ({
-        skills: [{
+    const list = vi.fn(async () => ([{
           name: 'legacy-community-skill',
           description: 'Loaded from an older Gateway response',
           layer: 'managed',
           status: 'ready',
           eligible: true,
-        }],
-      })),
-    } as unknown as ReturnType<typeof useRpcStore>
+        }]))
+    const skillCatalog = { list } as unknown as SkillCatalog
     const loadProposals = vi.fn(async () => {})
-    const catalog = useSkillsCatalog(rpc, {
+    const catalog = useSkillsCatalog(skillCatalog, {
       proposals: ref([]),
       autoEnabledSkills: ref([]),
       proposalsSettings: ref({
@@ -43,7 +39,7 @@ describe('SkillGroup lifecycle compatibility', () => {
     })
 
     await expect(catalog.loadData()).resolves.toBe(true)
-    expect(rpc.call).toHaveBeenCalledWith('skills.list', { includeLifecycle: true })
+    expect(list).toHaveBeenCalledOnce()
     expect(loadProposals).toHaveBeenCalledOnce()
     expect(catalog.allSkills.value).toHaveLength(1)
     expect(catalog.allSkills.value[0]?.lifecycle).toBeUndefined()

--- a/opensquilla-webui/src/composables/agents/useAgentsData.ts
+++ b/opensquilla-webui/src/composables/agents/useAgentsData.ts
@@ -1,26 +1,36 @@
-import { onActivated, onDeactivated, onUnmounted, computed } from 'vue'
-import { useRequest } from '@/composables/useRequest'
+import { onActivated, onDeactivated, onUnmounted, ref } from 'vue'
 import i18n from '@/i18n'
 import type { Agent } from '@/types/agents'
+import type { AgentCatalog } from '@/modules/agentCatalog'
 
 const POLL_MS = 30000
 
-interface AgentsListResponse {
-  agents?: Agent[]
-}
+export function useAgentsData(catalog: AgentCatalog) {
+  const agents = ref<Agent[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  let requestGeneration = 0
 
-export function useAgentsData() {
-  // Error state + the loading flag come from useRequest; failures surface as an
-  // inline ErrorState and a single de-duped toast. `immediate: false` because the
-  // view is kept-alive: onActivated (below) owns the first load too, so letting
-  // useRequest also auto-fetch on mount would double-fire agents.list on first
-  // paint (onMounted and onActivated both run on the first display).
-  const { data, loading, error, refresh, execute } = useRequest<AgentsListResponse>(
-    'agents.list',
-    undefined,
-    { errorLabel: i18n.global.t('console.agents.loadFailed'), immediate: false },
-  )
-  const agents = computed<Agent[]>(() => data.value?.agents ?? [])
+  async function load(showLoading: boolean): Promise<void> {
+    const generation = ++requestGeneration
+    if (showLoading) loading.value = true
+    try {
+      const listed = await catalog.list()
+      if (generation !== requestGeneration) return
+      agents.value = [...listed]
+      error.value = null
+    } catch (cause) {
+      if (generation !== requestGeneration) return
+      error.value = cause instanceof Error
+        ? cause.message
+        : i18n.global.t('console.agents.loadFailed')
+    } finally {
+      if (showLoading && generation === requestGeneration) loading.value = false
+    }
+  }
+
+  const execute = () => load(true)
+  const refresh = () => load(false)
 
   // The consuming view is kept-alive (route meta.keepAlive), so the poll must
   // bind on activation and release on deactivation — it must not keep firing

--- a/opensquilla-webui/src/composables/skills/useSkillDetailController.test.ts
+++ b/opensquilla-webui/src/composables/skills/useSkillDetailController.test.ts
@@ -36,13 +36,31 @@ function completeOutcome(): SkillDependencyInstallOutcome {
   }
 }
 
-function mountController(options: Parameters<typeof useSkillDetailController>[0]) {
+function mountController(options: Parameters<typeof useSkillDetailController>[0] | {
+  rpc: { call(method: string, params?: Record<string, unknown>): Promise<unknown> }
+  installDeps: Parameters<typeof useSkillDetailController>[0]['installDeps']
+  closeDelayMs?: number
+}) {
+  const normalized = 'rpc' in options
+    ? {
+        catalog: {
+          detail: (skill: Skill) => options.rpc.call('skills.get', {
+            name: skill.name,
+            includeLifecycle: true,
+            ...(skill.instance_id ? { instanceId: skill.instance_id } : {}),
+            ...(skill.install_id ? { installId: skill.install_id } : {}),
+          }),
+        } as Parameters<typeof useSkillDetailController>[0]['catalog'],
+        installDeps: options.installDeps,
+        closeDelayMs: options.closeDelayMs,
+      }
+    : options
   let controller!: SkillDetailController
   const host = document.createElement('div')
   document.body.appendChild(host)
   const app = createApp(defineComponent({
     setup() {
-      controller = useSkillDetailController(options)
+      controller = useSkillDetailController(normalized)
       return () => h('div')
     },
   }))

--- a/opensquilla-webui/src/composables/skills/useSkillDetailController.ts
+++ b/opensquilla-webui/src/composables/skills/useSkillDetailController.ts
@@ -1,6 +1,7 @@
 import { onUnmounted, ref, type Ref } from 'vue'
 import i18n from '@/i18n'
 import type { Skill, SkillDependencyInstallOutcome } from '@/types/skills'
+import type { SkillCatalog } from '@/modules/skillCatalog'
 import {
   installActionsForCurrentDependencies,
   normalizeSkill,
@@ -8,12 +9,8 @@ import {
   skillDependencySummary,
 } from '@/composables/skills/useSkillsCatalog'
 
-interface SkillDetailRpc {
-  call(method: string, params?: Record<string, unknown>): Promise<unknown>
-}
-
 interface SkillDetailControllerOptions {
-  rpc: SkillDetailRpc
+  catalog: SkillCatalog
   installDeps: (
     name: string,
     installId: string,
@@ -68,15 +65,7 @@ export function useSkillDetailController(
   }
 
   async function fetchLatest(seed: Skill): Promise<Skill> {
-    const params: Record<string, unknown> = {
-      name: seed.name,
-      includeLifecycle: true,
-    }
-    if (seed.instance_id) params.instanceId = seed.instance_id
-    if (seed.install_id) params.installId = seed.install_id
-    const detail = await options.rpc.call('skills.get', {
-      ...params,
-    }) as Skill
+    const detail = await options.catalog.detail(seed)
     // Eligible rows omit legacy missing_* fields. Clear the seed diagnostics
     // before merging so a transition to ready cannot retain stale list data.
     return normalizeSkill({

--- a/opensquilla-webui/src/composables/skills/useSkillProposals.ts
+++ b/opensquilla-webui/src/composables/skills/useSkillProposals.ts
@@ -1,6 +1,6 @@
 import { computed, ref, type ComputedRef, type Ref } from 'vue'
 import i18n from '@/i18n'
-import type { useRpcStore } from '@/stores/rpc'
+import type { SkillCatalog } from '@/modules/skillCatalog'
 import { useConfirm } from '@/composables/useConfirm'
 import { useToasts } from '@/composables/useToasts'
 import {
@@ -8,33 +8,6 @@ import {
   type SkillMutationGate,
 } from '@/composables/skills/useSkillMutationGate'
 import type { AutoEnabledSkill, Proposal, ProposalsSettings } from '@/types/skills'
-
-interface ProposalsListData {
-  proposals?: Proposal[]
-}
-
-interface AutoEnabledListData {
-  skills?: AutoEnabledSkill[]
-}
-
-interface ProposalSettingsData {
-  settings?: ProposalsSettings
-  status?: string
-  reason?: string
-}
-
-interface ProposalShowData {
-  status?: string
-  reason?: string
-  skill_md?: string
-  gates?: Record<string, unknown>
-  auto_enable_audit?: Proposal['auto_enable_audit']
-}
-
-interface ProposalActionData {
-  status?: string
-  reason?: string
-}
 
 export interface SkillProposals {
   proposals: Ref<Proposal[]>
@@ -59,7 +32,7 @@ const DEFAULT_PROPOSAL_SETTINGS: ProposalsSettings = {
 }
 
 export function useSkillProposals(
-  rpc: ReturnType<typeof useRpcStore>,
+  catalog: SkillCatalog,
   loadData: () => Promise<void>,
   mutationGate: SkillMutationGate = createSkillMutationGate(),
 ): SkillProposals {
@@ -77,21 +50,13 @@ export function useSkillProposals(
 
   async function loadProposals() {
     try {
-      const data = await rpc.call<ProposalsListData>('exec.proposals.list')
-      proposals.value = data.proposals || []
+      const snapshot = await catalog.proposals()
+      proposals.value = [...snapshot.proposals]
+      autoEnabledSkills.value = [...snapshot.autoEnabledSkills]
+      proposalsSettings.value = snapshot.settings || proposalsSettings.value
     } catch {
       proposals.value = []
-    }
-    try {
-      const data = await rpc.call<AutoEnabledListData>('exec.proposals.auto_enabled.list')
-      autoEnabledSkills.value = data.skills || []
-    } catch {
       autoEnabledSkills.value = []
-    }
-    try {
-      const data = await rpc.call<ProposalSettingsData>('exec.proposals.settings.get')
-      proposalsSettings.value = data.settings || proposalsSettings.value
-    } catch {
       proposalsSettings.value = { ...DEFAULT_PROPOSAL_SETTINGS }
     }
   }
@@ -99,7 +64,7 @@ export function useSkillProposals(
   async function toggleAutoPropose(key: string, value: boolean) {
     if (!mutationGate.acquire('proposal')) return
     try {
-      const out = await rpc.call<ProposalSettingsData>('exec.proposals.settings.set', { [key]: value })
+      const out = await catalog.updateProposalSettings({ [key]: value })
       if (out && out.status === 'error') {
         pushToast(t('cronSkills.proposals.toastSettingsFailed', { reason: out.reason || t('cronSkills.proposals.unknown') }), { tone: 'danger' })
         return
@@ -116,7 +81,7 @@ export function useSkillProposals(
   async function setAutoEnableRisk(value: string) {
     if (!mutationGate.acquire('proposal')) return
     try {
-      const out = await rpc.call<ProposalSettingsData>('exec.proposals.settings.set', { auto_enable_max_risk: value })
+      const out = await catalog.updateProposalSettings({ auto_enable_max_risk: value })
       if (out && out.status === 'error') {
         pushToast(t('cronSkills.proposals.toastSettingsFailed', { reason: out.reason || t('cronSkills.proposals.unknown') }), { tone: 'danger' })
         return
@@ -131,7 +96,7 @@ export function useSkillProposals(
 
   async function showProposal(proposalId: string): Promise<Proposal | null> {
     try {
-      const data = await rpc.call<ProposalShowData>('exec.proposals.show', { proposal_id: proposalId })
+      const data = await catalog.proposal(proposalId)
       if (data.status !== 'ok') {
         pushToast(t('cronSkills.proposals.toastShowFailed', { reason: data.reason || t('cronSkills.proposals.unknown') }), { tone: 'danger' })
         return null
@@ -146,7 +111,7 @@ export function useSkillProposals(
   async function acceptProposal(proposalId: string) {
     if (!mutationGate.acquire('proposal')) return
     try {
-      let data = await rpc.call<ProposalActionData>('exec.proposals.accept', { proposal_id: proposalId })
+      let data = await catalog.acceptProposal(proposalId)
       if (data.status === 'refused' && data.reason && data.reason.indexOf('gates') !== -1) {
         const ok = await confirm({
           title: t('cronSkills.proposals.acceptAnywayTitle'),
@@ -154,7 +119,7 @@ export function useSkillProposals(
           primaryLabel: t('cronSkills.proposals.forceAccept'),
         })
         if (!ok) return
-        data = await rpc.call<ProposalActionData>('exec.proposals.accept', { proposal_id: proposalId, force: true })
+        data = await catalog.acceptProposal(proposalId, { force: true })
       }
       if (data.status !== 'ok') {
         pushToast(t('cronSkills.proposals.toastAcceptFailed', { reason: data.reason || data.status }), { tone: 'danger' })
@@ -177,7 +142,7 @@ export function useSkillProposals(
     if (!ok) return
     if (!mutationGate.acquire('proposal')) return
     try {
-      const data = await rpc.call<ProposalActionData>('exec.proposals.reject', { proposal_id: proposalId })
+      const data = await catalog.rejectProposal(proposalId)
       if (data.status !== 'ok') {
         pushToast(t('cronSkills.proposals.toastRejectFailed', { reason: data.reason || data.status }), { tone: 'danger' })
         return
@@ -199,7 +164,7 @@ export function useSkillProposals(
     if (!ok) return
     if (!mutationGate.acquire('proposal')) return
     try {
-      const data = await rpc.call<ProposalActionData>('exec.proposals.auto_enabled.disable', { name })
+      const data = await catalog.disableAutoEnabledSkill(name)
       if (data.status !== 'ok') {
         pushToast(t('cronSkills.proposals.toastDisableFailed', { reason: data.reason || data.status }), { tone: 'danger' })
         return

--- a/opensquilla-webui/src/composables/skills/useSkillRegistry.test.ts
+++ b/opensquilla-webui/src/composables/skills/useSkillRegistry.test.ts
@@ -7,16 +7,95 @@ import {
   skillInstallRequiresRiskAcknowledgement,
   skillInstallWasRateLimited,
   skillRegistryOperationKey,
-  useSkillRegistry,
+  useSkillRegistry as useSkillRegistryModel,
 } from './useSkillRegistry'
 import { createSkillMutationGate } from './useSkillMutationGate'
-import { useSkillProposals } from './useSkillProposals'
+import { useSkillProposals as useSkillProposalsModel } from './useSkillProposals'
+import type { SkillCatalog } from '@/modules/skillCatalog'
 
 const pushToast = vi.hoisted(() => vi.fn())
 
 vi.mock('@/composables/useToasts', () => ({
   useToasts: () => ({ pushToast }),
 }))
+
+type RpcCall = (method: string, params?: Record<string, unknown>) => Promise<any>
+
+function catalogFromCall(
+  call: RpcCall,
+  supportsMethod: (method: string) => boolean = () => false,
+): SkillCatalog {
+  return {
+    list: async () => (await call('skills.list', { includeLifecycle: true })).skills || [],
+    detail: skill => call('skills.get', { name: skill.name, includeLifecycle: true }),
+    search: async (query, options) => {
+      const result = await call('skills.search', {
+        query,
+        limit: options?.limit ?? 20,
+        source: options?.source || 'clawhub',
+      })
+      return {
+        results: result.results || [],
+        diagnostics: result.diagnostics || [],
+        message: result.message || '',
+      }
+    },
+    reload: () => call('skills.reload'),
+    install: request => call('skills.install', {
+      identifier: request.identifier,
+      source: request.source,
+      ...(request.operationId ? { operationId: request.operationId } : {}),
+      ...(request.riskConfirmation
+        ? { force: true, riskConfirmation: request.riskConfirmation }
+        : {}),
+    }),
+    supportsInstallCancellation: () => supportsMethod('skills.install.cancel'),
+    cancelInstall: operationId => call('skills.install.cancel', { operationId }),
+    installDependencies: request => call('skills.deps.install', {
+      name: request.name,
+      install_id: request.dependencyId,
+      ...(request.skillInstallId ? { installId: request.skillInstallId } : {}),
+      ...(request.instanceId ? { instanceId: request.instanceId } : {}),
+    }),
+    uninstall: request => call('skills.uninstall', {
+      ...(request.name ? { name: request.name } : {}),
+      ...(request.installId ? { installId: request.installId } : {}),
+    }),
+    proposals: async () => ({
+      proposals: (await call('exec.proposals.list')).proposals || [],
+      autoEnabledSkills: (await call('exec.proposals.auto_enabled.list')).skills || [],
+      settings: (await call('exec.proposals.settings.get')).settings || null,
+    }),
+    updateProposalSettings: changes => call('exec.proposals.settings.set', { ...changes }),
+    proposal: proposalId => call('exec.proposals.show', { proposal_id: proposalId }),
+    acceptProposal: (proposalId, options) => call('exec.proposals.accept', {
+      proposal_id: proposalId,
+      ...(options?.force ? { force: true } : {}),
+    }),
+    rejectProposal: proposalId => call('exec.proposals.reject', { proposal_id: proposalId }),
+    disableAutoEnabledSkill: name => call('exec.proposals.auto_enabled.disable', { name }),
+  }
+}
+
+function asCatalog(source: SkillCatalog | { call: RpcCall; supportsMethod?: (method: string) => boolean }) {
+  return 'call' in source
+    ? catalogFromCall(source.call, source.supportsMethod)
+    : source
+}
+
+function useSkillRegistry(
+  source: SkillCatalog | { call: RpcCall; supportsMethod?: (method: string) => boolean },
+  ...rest: Parameters<typeof useSkillRegistryModel> extends [unknown, ...infer Tail] ? Tail : never
+) {
+  return useSkillRegistryModel(asCatalog(source), ...rest)
+}
+
+function useSkillProposals(
+  source: SkillCatalog | { call: RpcCall; supportsMethod?: (method: string) => boolean },
+  ...rest: Parameters<typeof useSkillProposalsModel> extends [unknown, ...infer Tail] ? Tail : never
+) {
+  return useSkillProposalsModel(asCatalog(source), ...rest)
+}
 
 afterEach(() => {
   vi.restoreAllMocks()

--- a/opensquilla-webui/src/composables/skills/useSkillRegistry.ts
+++ b/opensquilla-webui/src/composables/skills/useSkillRegistry.ts
@@ -1,6 +1,6 @@
 import { computed, ref, type ComputedRef, type Ref } from 'vue'
 import i18n from '@/i18n'
-import type { useRpcStore } from '@/stores/rpc'
+import type { SkillCatalog, SkillInstallResult } from '@/modules/skillCatalog'
 import { useToasts } from '@/composables/useToasts'
 import {
   createSkillMutationGate,
@@ -10,38 +10,9 @@ import type {
   RegistryResult,
   SkillDependencyInstallOutcome,
   SkillDiagnostic,
-  SkillLifecycle,
-  SkillSourceResolution,
 } from '@/types/skills'
 
-interface RegistrySearchData {
-  results?: RegistryResult[]
-  diagnostics?: SkillDiagnostic[]
-  message?: string
-}
-
-export interface InstallResult {
-  success: boolean
-  cancelled?: boolean
-  unchanged?: boolean
-  name?: string
-  message?: string
-  installed?: boolean
-  active?: boolean
-  instruction_usable?: boolean
-  installId?: string
-  lifecycle?: SkillLifecycle
-  resolution?: SkillSourceResolution
-  diagnostics?: SkillDiagnostic[]
-  rollbackPerformed?: boolean
-  catalogGeneration?: number
-  effectiveFrom?: 'next_turn' | 'next_start' | string
-  missing_still?: {
-    bins?: string[]
-    env?: string[]
-    env_any?: string[][]
-  }
-}
+export type InstallResult = SkillInstallResult
 
 export type SkillInstallQueueStatus =
   | 'queued'
@@ -240,7 +211,7 @@ export interface SkillRegistry {
 }
 
 export function useSkillRegistry(
-  rpc: ReturnType<typeof useRpcStore>,
+  catalog: SkillCatalog,
   loadData: () => Promise<boolean>,
   mutationGate: SkillMutationGate = createSkillMutationGate(),
 ): SkillRegistry {
@@ -260,8 +231,7 @@ export function useSkillRegistry(
   const runningSource = ref<SkillInstallSource | null>(null)
   const cancellingSource = ref<SkillInstallSource | null>(null)
   const installCancellationSupported = computed(() =>
-    typeof rpc.supportsMethod === 'function'
-    && rpc.supportsMethod('skills.install.cancel'))
+    catalog.supportsInstallCancellation())
   const activeInstallOperation = ref<{
     id: string
     itemId: string
@@ -287,14 +257,13 @@ export function useSkillRegistry(
     registryDiagnostics.value = []
     registrySearchError.value = ''
     try {
-      const data = await rpc.call<RegistrySearchData>('skills.search', {
-        query,
+      const data = await catalog.search(query, {
         limit: 20,
         source: 'clawhub',
       })
       if (requestId !== searchRequestId) return
-      registryResults.value = data.results || []
-      registryDiagnostics.value = data.diagnostics || []
+      registryResults.value = [...data.results]
+      registryDiagnostics.value = [...data.diagnostics]
       registrySearchError.value = data.message || ''
     } catch (err) {
       if (requestId !== searchRequestId) return
@@ -392,12 +361,12 @@ export function useSkillRegistry(
         }
       }
       try {
-        const res = await rpc.call<InstallResult>('skills.install', {
+        const res = await catalog.install({
           identifier: item.identifier,
           source: item.source,
           ...(operationId ? { operationId } : {}),
           ...(riskConfirmation
-            ? { force: true, riskConfirmation }
+            ? { riskConfirmation }
             : {}),
         })
         item.result = res
@@ -501,7 +470,7 @@ export function useSkillRegistry(
         installed: installResult.installed ?? installResult.success,
         lifecycle: installResult.lifecycle,
         instruction_usable: installResult.instruction_usable,
-        diagnostics: installResult.diagnostics,
+        diagnostics: installResult.diagnostics ? [...installResult.diagnostics] : undefined,
       }
     })
   }
@@ -556,9 +525,7 @@ export function useSkillRegistry(
       }
     }
     try {
-      await rpc.call<InstallResult>('skills.install.cancel', {
-        operationId: operation.id,
-      })
+      await catalog.cancelInstall(operation.id)
     } catch (err) {
       if (activeInstallOperation.value?.id === operation.id) {
         activeItem.status = 'installing'
@@ -590,19 +557,19 @@ export function useSkillRegistry(
     if (!name || !installId || !mutationGate.acquire('dependency_install')) return failed()
     installingDepsId.value = installId
     try {
-      const res = await rpc.call<InstallResult>('skills.deps.install', {
+      const res = await catalog.installDependencies({
         name,
-        install_id: installId,
-        ...(skillInstallId ? { installId: skillInstallId } : {}),
+        dependencyId: installId,
+        ...(skillInstallId ? { skillInstallId } : {}),
         ...(instanceId ? { instanceId } : {}),
       })
       if (res.success) {
         pushToast(res.message || t('cronSkills.registry.installed'), { tone: 'ok' })
         const still = res.missing_still || {}
         const missingStill = {
-          bins: still.bins || [],
-          env: still.env || [],
-          env_any: still.env_any || [],
+          bins: [...(still.bins || [])],
+          env: [...(still.env || [])],
+          env_any: (still.env_any || []).map(group => [...group]),
         }
         const stillMissing = missingStill.bins.length
           + missingStill.env.length
@@ -632,7 +599,7 @@ export function useSkillRegistry(
     if ((!name && !installId) || !mutationGate.acquire('uninstall')) return false
     uninstallingName.value = name
     try {
-      const res = await rpc.call<InstallResult>('skills.uninstall', {
+      const res = await catalog.uninstall({
         ...(name ? { name } : {}),
         ...(installId ? { installId } : {}),
       })

--- a/opensquilla-webui/src/composables/skills/useSkillsCatalog.ts
+++ b/opensquilla-webui/src/composables/skills/useSkillsCatalog.ts
@@ -1,6 +1,6 @@
 import { computed, ref, type ComputedRef, type Ref } from 'vue'
 import i18n from '@/i18n'
-import type { useRpcStore } from '@/stores/rpc'
+import type { SkillCatalog } from '@/modules/skillCatalog'
 import type {
   AutoEnabledSkill,
   ProposalsSettings,
@@ -11,10 +11,6 @@ import type {
   SkillLayerGroup,
   SkillStatTile,
 } from '@/types/skills'
-
-interface SkillsListData {
-  skills?: Skill[]
-}
 
 export interface SkillsCatalogOptions {
   proposals: Ref<unknown[]>
@@ -455,7 +451,7 @@ export function skillLayerHelp(layer: string | undefined): string {
 }
 
 export function useSkillsCatalog(
-  rpc: ReturnType<typeof useRpcStore>,
+  catalog: SkillCatalog,
   options: SkillsCatalogOptions,
 ): SkillsCatalog {
   const t = i18n.global.t
@@ -538,13 +534,8 @@ export function useSkillsCatalog(
 
   async function loadData() {
     try {
-      await rpc.waitForConnection()
-    } catch {
-      return false
-    }
-    try {
-      const data = await rpc.call<SkillsListData>('skills.list', { includeLifecycle: true })
-      allSkills.value = (data.skills || []).map(normalizeSkill)
+      const skills = await catalog.list()
+      allSkills.value = skills.map(normalizeSkill)
       await options.loadProposals()
       return true
     } catch (err) {

--- a/opensquilla-webui/src/composables/usage/useUsageData.setRange.test.ts
+++ b/opensquilla-webui/src/composables/usage/useUsageData.setRange.test.ts
@@ -8,18 +8,10 @@ import { useUsageData } from './useUsageData'
 import { requestUsageSnapshot } from './useUsageQuery'
 import type { UsageSnapshot } from '@/types/usage'
 import type { SessionDirectory } from '@/modules/sessionDirectory'
-
-const rpcTransport = vi.hoisted(() => ({
-  call: vi.fn(),
-  waitForConnection: vi.fn(async () => {}),
-}))
+import type { Observability } from '@/modules/observability'
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: vi.fn() }),
-}))
-
-vi.mock('@/stores/rpc', () => ({
-  useRpcStore: () => rpcTransport,
 }))
 
 vi.mock('./useUsageQuery', () => ({
@@ -95,7 +87,7 @@ function mountUsageData() {
     resolve: vi.fn().mockResolvedValue({ key: 'agent:main:webchat:default', id: 'default' }),
     search: vi.fn().mockResolvedValue({ sessions: [], messages: [] }),
   }
-  const api = scope.run(() => useUsageData(directory))!
+  const api = scope.run(() => useUsageData(directory, {} as Observability))!
   return { api, directory, scope }
 }
 
@@ -112,8 +104,6 @@ beforeEach(() => {
   i18n.global.locale.value = 'en'
   localStorage.setItem(RANGE_KEY, '7')
   vi.mocked(requestUsageSnapshot).mockReset()
-  rpcTransport.call.mockReset()
-  rpcTransport.waitForConnection.mockClear()
 })
 
 afterEach(() => {
@@ -132,7 +122,6 @@ describe('useUsageData range selection under concurrent refreshes', () => {
     await api.loadData()
 
     expect(directory.listPage).toHaveBeenCalledWith({ limit: 200 })
-    expect(rpcTransport.waitForConnection).not.toHaveBeenCalled()
   })
 
   it('does not describe complete all-time task totals as a date-range approximation', async () => {

--- a/opensquilla-webui/src/composables/usage/useUsageData.ts
+++ b/opensquilla-webui/src/composables/usage/useUsageData.ts
@@ -16,8 +16,8 @@ import {
 } from '@/composables/usage/taskDisplayName'
 import { formatUsageCost, effectiveCnyPerUsd } from '@/composables/usage/nativeBilling'
 import { buildUsageCsv } from '@/composables/usage/usageCsv'
-import { useRpcStore } from '@/stores/rpc'
 import type { SessionDirectory } from '@/modules/sessionDirectory'
+import type { Observability } from '@/modules/observability'
 import { downloadText } from '@/utils/browser'
 import i18n from '@/i18n'
 import type {
@@ -62,14 +62,15 @@ const TABLE_COLUMN_KEYS: Array<{ key: string; labelKey: string }> = [
 
 const SORTABLE_COLS = ['session', 'updated_at', 'input_tokens', 'output_tokens', 'cost_usd', 'model']
 
-export function useUsageData(sessionDirectory: SessionDirectory) {
+export function useUsageData(
+  sessionDirectory: SessionDirectory,
+  observability: Observability,
+) {
 // ---------------------------------------------------------------------------
 // Stores & Router
 // ---------------------------------------------------------------------------
 
 const router = useRouter()
-const rpc = useRpcStore()
-
 // ---------------------------------------------------------------------------
 // State
 // ---------------------------------------------------------------------------
@@ -299,7 +300,7 @@ async function requestLoad(): Promise<LoadOutcome> {
   try {
     const [snapshot, nextTaskTitles] = await Promise.all([
       requestUsageSnapshot(
-        rpc,
+        observability,
         range.value as UsageRangeSelection,
         { cachedSnapshot: usageSnapshot.value },
       ),
@@ -428,7 +429,6 @@ function sortVal(row: SessionRow, key: string): string | number {
 }
 
 async function requestTaskTitles(): Promise<Map<string, string>> {
-  if (typeof rpc.call !== 'function') return taskTitles.value
   try {
     const page = await sessionDirectory.listPage({ limit: 200 })
     const titles = new Map<string, string>()

--- a/opensquilla-webui/src/composables/usage/useUsageQuery.test.ts
+++ b/opensquilla-webui/src/composables/usage/useUsageQuery.test.ts
@@ -4,16 +4,24 @@ import {
   normalizeUsageQueryResponse,
   requestUsageSnapshot,
   usagePresetForRange,
-  type UsageRpc,
 } from './useUsageQuery'
+import type { Observability } from '@/modules/observability'
+import { createV4Observability } from '@/adapters/gateway/observabilityV4'
 
-function rpcWith(call: UsageRpc['call'], supports = true): UsageRpc {
-  return {
-    supportsMethod: vi.fn(() => supports),
-    markMethodUnavailable: vi.fn(),
-    waitForConnection: vi.fn(async () => {}),
-    call,
-  }
+type RpcCall = <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+type TestObservability = Observability & { markMethodUnavailable: ReturnType<typeof vi.fn> }
+
+function rpcWith(call: RpcCall, supports = true): TestObservability {
+  const markMethodUnavailable = vi.fn()
+  return Object.assign(createV4Observability({
+    request: call,
+    ready: vi.fn(async () => {}),
+    supports: vi.fn(() => supports),
+    markUnsupported: markMethodUnavailable,
+  }, {
+    requestJson: vi.fn(),
+    requestBinary: vi.fn(),
+  }), { markMethodUnavailable })
 }
 
 describe('usage.query compatibility client', () => {
@@ -51,7 +59,7 @@ describe('usage.query compatibility client', () => {
         days: [],
         coverage: { status: 'complete' },
       }
-    }) as UsageRpc['call']
+    }) as RpcCall
     const rpc = rpcWith(call)
 
     const result = await requestUsageSnapshot(rpc, '7', { timezone: 'Asia/Shanghai' })
@@ -61,7 +69,7 @@ describe('usage.query compatibility client', () => {
       range: { preset: 'last_7_calendar_days' },
       timezone: 'Asia/Shanghai',
       include: { days: true, models: true, sessions: true },
-    })
+    }, expect.any(Object))
     expect(result.mode).toBe('ledger_exact')
     expect(result.totals.cost).toBeCloseTo(0.0092, 9)
   })
@@ -235,7 +243,7 @@ describe('usage.query compatibility client', () => {
         legacyUnattributed: { includedInTotals: true, totals: { costNanos: 2_000_000 } },
       },
       sessions: [],
-    })) as UsageRpc['call']
+    })) as RpcCall
 
     const result = await requestUsageSnapshot(rpcWith(call), 'all', { timezone: 'UTC' })
 
@@ -249,7 +257,7 @@ describe('usage.query compatibility client', () => {
     const call = vi.fn(async (method: string) => {
       expect(method).toBe('usage.status')
       return { totalSessions: 2, totalTokens: 7, totalCostUsd: 0.4, sessions: [] }
-    }) as UsageRpc['call']
+    }) as RpcCall
 
     const result = await requestUsageSnapshot(rpcWith(call, false), 'all', { timezone: 'UTC' })
 
@@ -263,14 +271,14 @@ describe('usage.query compatibility client', () => {
     const call = vi.fn(async (method: string) => {
       if (method === 'usage.query') throw missing
       return { sessions: [] }
-    }) as UsageRpc['call']
+    }) as RpcCall
     const rpc = rpcWith(call)
 
     const result = await requestUsageSnapshot(rpc, '7', { timezone: 'UTC' })
 
     expect(rpc.markMethodUnavailable).toHaveBeenCalledWith('usage.query')
-    expect(call).toHaveBeenNthCalledWith(1, 'usage.query', expect.any(Object))
-    expect(call).toHaveBeenNthCalledWith(2, 'usage.status')
+    expect(call).toHaveBeenNthCalledWith(1, 'usage.query', expect.any(Object), expect.any(Object))
+    expect(call).toHaveBeenNthCalledWith(2, 'usage.status', undefined, expect.any(Object))
     expect(result.mode).toBe('session_approximation')
   })
 
@@ -287,7 +295,7 @@ describe('usage.query compatibility client', () => {
         totals: { costNanos: 1_000_000 },
         coverage: { status: 'complete' },
       }
-    }) as UsageRpc['call']
+    }) as RpcCall
 
     const result = await requestUsageSnapshot(rpcWith(call), 'today', {
       timezone: 'Mars/Olympus',
@@ -296,10 +304,10 @@ describe('usage.query compatibility client', () => {
     expect(call).toHaveBeenCalledTimes(2)
     expect(call).toHaveBeenNthCalledWith(1, 'usage.query', expect.objectContaining({
       timezone: 'Mars/Olympus',
-    }))
+    }), expect.any(Object))
     expect(call).toHaveBeenNthCalledWith(2, 'usage.query', expect.objectContaining({
       timezone: 'UTC',
-    }))
+    }), expect.any(Object))
     expect(result.source).toBe('usage_ledger')
     expect(result.timezone).toBe('UTC')
     expect(result.timezoneFallback).toEqual({
@@ -318,15 +326,15 @@ describe('usage.query compatibility client', () => {
     })
     const call = vi.fn(async (method: string) => {
       throw new Error(method === 'usage.query' ? 'query temporarily unavailable' : 'gateway busy')
-    }) as UsageRpc['call']
+    }) as RpcCall
 
     const result = await requestUsageSnapshot(rpcWith(call), '7', {
       timezone: 'Asia/Shanghai',
       cachedSnapshot: cached,
     })
 
-    expect(call).toHaveBeenNthCalledWith(1, 'usage.query', expect.any(Object))
-    expect(call).toHaveBeenNthCalledWith(2, 'usage.status')
+    expect(call).toHaveBeenNthCalledWith(1, 'usage.query', expect.any(Object), expect.any(Object))
+    expect(call).toHaveBeenNthCalledWith(2, 'usage.status', undefined, expect.any(Object))
     expect(result).toBe(cached)
   })
 
@@ -340,7 +348,7 @@ describe('usage.query compatibility client', () => {
     const call = vi.fn(async (method: string) => {
       if (method === 'usage.query') throw new Error('query temporarily unavailable')
       return { totalCostUsd: 99, sessions: [] }
-    }) as UsageRpc['call']
+    }) as RpcCall
 
     const result = await requestUsageSnapshot(rpcWith(call), 'all', {
       timezone: 'UTC',

--- a/opensquilla-webui/src/composables/usage/useUsageQuery.ts
+++ b/opensquilla-webui/src/composables/usage/useUsageQuery.ts
@@ -1,4 +1,4 @@
-import type { RpcClientError } from '@/lib/rpc'
+import type { Observability } from '@/modules/observability'
 import type {
   ModelBreakdownItem,
   ModelCard,
@@ -16,16 +16,8 @@ import type {
   NativeBilledByCurrency,
 } from '@/types/usage'
 
-const USAGE_QUERY_METHOD = 'usage.query'
 const NANO_USD = 1_000_000_000
 const MICRO_USD = 1_000_000
-
-export interface UsageRpc {
-  supportsMethod: (method: string) => boolean
-  markMethodUnavailable: (method: string) => void
-  waitForConnection: (timeoutMs?: number) => Promise<void>
-  call: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
-}
 
 export interface UsageQueryOptions {
   days?: boolean
@@ -494,98 +486,10 @@ function sessionTimestamp(row: SessionRow): number | null {
   return null
 }
 
-function isMethodNotFound(error: unknown): boolean {
-  const rpcError = error as RpcClientError | undefined
-  return rpcError?.code === 'METHOD_NOT_FOUND'
-    || /method not found/i.test(error instanceof Error ? error.message : String(error))
-}
-
-function isInvalidTimezone(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error)
-  return /unknown iana timezone|invalid timezone|time zone/i.test(message)
-}
-
-function queryParams(
-  range: UsageRangeSelection,
-  timezone: string,
-  options: UsageQueryOptions,
-): Record<string, unknown> {
-  return {
-    schemaVersion: 1,
-    range: { preset: usagePresetForRange(range) },
-    timezone,
-    include: {
-      days: options.days ?? true,
-      models: options.models ?? true,
-      sessions: options.sessions ?? true,
-    },
-  }
-}
-
 export async function requestUsageSnapshot(
-  rpc: UsageRpc,
+  observability: Observability,
   range: UsageRangeSelection,
   options: UsageQueryOptions = {},
 ): Promise<UsageSnapshot> {
-  await rpc.waitForConnection()
-  const timezone = options.timezone || browserTimeZone()
-  const requestedPreset = usagePresetForRange(range)
-  const cachedSnapshot = options.cachedSnapshot
-  const matchingLedgerCache = cachedSnapshot?.source === 'usage_ledger'
-    && cachedSnapshot.range.preset === requestedPreset
-    ? cachedSnapshot
-    : null
-  let transientQueryFailure = false
-  if (rpc.supportsMethod(USAGE_QUERY_METHOD)) {
-    try {
-      const response = await rpc.call<UsageQueryResponse>(
-        USAGE_QUERY_METHOD,
-        queryParams(range, timezone, options),
-      )
-      return normalizeUsageQueryResponse(response)
-    } catch (error) {
-      if (isMethodNotFound(error)) {
-        rpc.markMethodUnavailable(USAGE_QUERY_METHOD)
-      } else if (timezone !== 'UTC' && isInvalidTimezone(error)) {
-        try {
-          const response = await rpc.call<UsageQueryResponse>(
-            USAGE_QUERY_METHOD,
-            queryParams(range, 'UTC', options),
-          )
-          const snapshot = normalizeUsageQueryResponse(response)
-          return {
-            ...snapshot,
-            timezoneFallback: {
-              requestedTimezone: timezone,
-              effectiveTimezone: snapshot.timezone,
-              reason: 'invalid_timezone',
-            },
-          }
-        } catch (utcError) {
-          if (isMethodNotFound(utcError)) {
-            rpc.markMethodUnavailable(USAGE_QUERY_METHOD)
-          } else {
-            transientQueryFailure = true
-          }
-        }
-      } else {
-        transientQueryFailure = true
-      }
-      // Mixed-version upgrades must keep rendering. Any query failure falls
-      // back to the legacy endpoint; if that also fails, its error is surfaced.
-    }
-  }
-  try {
-    const status = await rpc.call<UsageStatusData>('usage.status')
-    // A previous ledger result is more trustworthy than a fresh session-lifetime
-    // approximation. Keep it for transient query failures, but still accept the
-    // legacy endpoint when the capability genuinely disappeared.
-    if (transientQueryFailure && matchingLedgerCache) return matchingLedgerCache
-    return normalizeUsageStatusResponse(status, options.fallbackRange || range, timezone)
-  } catch (error) {
-    // Background refresh failures should not erase a successful, same-range
-    // ledger result. With no suitable cache, preserve the original error path.
-    if (matchingLedgerCache) return matchingLedgerCache
-    throw error
-  }
+  return observability.usage(range, options)
 }

--- a/opensquilla-webui/src/composables/useAgentOptions.ts
+++ b/opensquilla-webui/src/composables/useAgentOptions.ts
@@ -1,11 +1,8 @@
 import { ref } from 'vue'
-import {
-  waitForSessionRpcConnection,
-} from '@/composables/chat/sessionBootstrapAdmission'
-import { useRpcStore } from '@/stores/rpc'
 import { normalizeAgentId } from '@/utils/chat/sessionKeys'
-import type { AgentOption, AgentsListResponse } from '@/types/rpc'
+import type { AgentOption } from '@/types/rpc'
 import type { RpcCallOptions } from '@/lib/rpc'
+import type { AgentCatalog } from '@/modules/agentCatalog'
 
 /** The implicit default agent every chat surface can always start against. */
 const MAIN_AGENT: AgentOption = { id: 'main', name: 'Main Agent' }
@@ -22,26 +19,20 @@ let loadPromise: Promise<void> | null = null
  * Shared `agents.list` fetch for sidebar session metadata. IDs are normalized
  * once here so every sidebar consumer sees the same canonical value.
  */
-export function useAgentOptions(readCallOptions?: RpcCallOptions) {
-  const rpc = useRpcStore()
-
+export function useAgentOptions(
+  catalog: AgentCatalog,
+  readCallOptions?: RpcCallOptions,
+) {
   function loadAgents(): Promise<void> {
     if (loadPromise) return loadPromise
     loadPromise = (async () => {
       agentListError.value = false
       try {
-        await waitForSessionRpcConnection(rpc, readCallOptions)
-        const data = readCallOptions
-          ? await rpc.call<AgentsListResponse>(
-              'agents.list',
-              undefined,
-              readCallOptions,
-            )
-          : await rpc.call<AgentsListResponse>('agents.list')
-        agents.value = (data?.agents || [])
+        const listed = await catalog.list({ signal: readCallOptions?.signal })
+        agents.value = listed
           .map(a => ({
-            id: normalizeAgentId(a.id || a.agentId || a.name || ''),
-            name: a.name || a.id || a.agentId || 'Agent',
+            id: normalizeAgentId(a.id || a.name || ''),
+            name: a.name || a.id || 'Agent',
             model: a.model || '',
           }))
           .filter((a: AgentOption) => !!a.id)

--- a/opensquilla-webui/src/main.ts
+++ b/opensquilla-webui/src/main.ts
@@ -25,6 +25,9 @@ import { MIGRATION_OPERATIONS_KEY } from './modules/migrationOperations'
 import { WORKSPACE_CATALOG_KEY } from './modules/workspaceCatalog'
 import { SANDBOX_RUNTIME_KEY } from './modules/sandboxRuntime'
 import { SESSION_CONVERSATION_KEY } from './modules/sessionConversation'
+import { OBSERVABILITY_KEY } from './modules/observability'
+import { SKILL_CATALOG_KEY } from './modules/skillCatalog'
+import { AGENT_CATALOG_KEY } from './modules/agentCatalog'
 import 'katex/dist/katex.min.css'
 import './assets/base.css'
 import './themes/tokens' // eagerly bundles every value theme's token block
@@ -80,6 +83,9 @@ app.provide(MIGRATION_OPERATIONS_KEY, gatewayAdapters.migrationOperations)
 app.provide(WORKSPACE_CATALOG_KEY, gatewayAdapters.workspaceCatalog)
 app.provide(SANDBOX_RUNTIME_KEY, gatewayAdapters.sandboxRuntime)
 app.provide(SESSION_CONVERSATION_KEY, gatewayAdapters.sessionConversation)
+app.provide(OBSERVABILITY_KEY, gatewayAdapters.observability)
+app.provide(SKILL_CATALOG_KEY, gatewayAdapters.skillCatalog)
+app.provide(AGENT_CATALOG_KEY, gatewayAdapters.agentCatalog)
 router.afterEach(() => {
   rpcStore.applyLinkTokenFromUrl()
 })

--- a/opensquilla-webui/src/modules/agentCatalog.ts
+++ b/opensquilla-webui/src/modules/agentCatalog.ts
@@ -1,0 +1,21 @@
+import type { InjectionKey } from 'vue'
+import type { Agent } from '@/types/agents'
+
+export interface AgentMutationResult {
+  readonly status?: string
+  readonly agent?: Agent
+  readonly [key: string]: unknown
+}
+
+export interface AgentCatalog {
+  list(options?: { readonly signal?: AbortSignal }): Promise<readonly Agent[]>
+  create(input: Readonly<Record<string, unknown>>, options?: {
+    readonly signal?: AbortSignal
+  }): Promise<AgentMutationResult>
+  update(input: Readonly<Record<string, unknown>>, options?: {
+    readonly signal?: AbortSignal
+  }): Promise<AgentMutationResult>
+  remove(agentId: string, options?: { readonly signal?: AbortSignal }): Promise<AgentMutationResult>
+}
+
+export const AGENT_CATALOG_KEY: InjectionKey<AgentCatalog> = Symbol('AgentCatalog')

--- a/opensquilla-webui/src/modules/observability.ts
+++ b/opensquilla-webui/src/modules/observability.ts
@@ -1,0 +1,95 @@
+import type { InjectionKey } from 'vue'
+import type {
+  UsageRangeSelection,
+  UsageSnapshot,
+} from '@/types/usage'
+
+export interface UsageSnapshotOptions {
+  readonly days?: boolean
+  readonly models?: boolean
+  readonly sessions?: boolean
+  readonly timezone?: string
+  readonly fallbackRange?: UsageRangeSelection
+  readonly cachedSnapshot?: UsageSnapshot | null
+  readonly signal?: AbortSignal
+}
+
+export interface ReadinessReport {
+  readonly status?: string
+  readonly ready?: boolean
+  readonly gatewayUrl?: string
+  readonly [key: string]: unknown
+}
+
+export interface GatewayLogStatus {
+  readonly gateway_file_log?: {
+    readonly enabled?: boolean
+    readonly path?: string
+  }
+  readonly raw_turn_call_log?: {
+    readonly enabled?: boolean
+    readonly source?: string
+    readonly directory?: { readonly path?: string }
+  }
+  readonly diagnostics_enabled?: {
+    readonly effective?: boolean
+    readonly detail?: string
+  }
+}
+
+export interface GatewayLogRecord {
+  readonly level?: string
+  readonly lvl?: string
+  readonly message?: string
+  readonly msg?: string
+  readonly timestamp?: string | number
+  readonly ts?: string | number
+  readonly raw?: string
+  readonly [key: string]: unknown
+}
+
+export type GatewayLogEntry = string | GatewayLogRecord
+
+export interface GatewayLogBatch {
+  readonly entries: readonly GatewayLogEntry[]
+  readonly cursor: number | null
+}
+
+export interface UpdateNotice {
+  readonly current?: string
+  readonly latest?: string
+  readonly available?: boolean
+  readonly url?: string
+}
+
+export interface SupportBundle {
+  readonly blob: Blob
+  readonly filename: string
+}
+
+export interface Observability {
+  usage(
+    range: UsageRangeSelection,
+    options?: UsageSnapshotOptions,
+  ): Promise<UsageSnapshot>
+  readiness(options: {
+    readonly deep: boolean
+    readonly agentId?: string
+    readonly signal?: AbortSignal
+  }): Promise<ReadinessReport>
+  logStatus(options?: { readonly signal?: AbortSignal }): Promise<GatewayLogStatus>
+  tailLogs(options: {
+    readonly cursor: number
+    readonly limit?: number
+    readonly level?: string | null
+    readonly signal?: AbortSignal
+  }): Promise<GatewayLogBatch>
+  updateNotice(options?: { readonly signal?: AbortSignal }): Promise<UpdateNotice | null | undefined>
+  downloadSupportBundle(options: {
+    readonly includeContent: boolean
+    readonly days?: number
+    readonly signal?: AbortSignal
+  }): Promise<SupportBundle>
+}
+
+export const OBSERVABILITY_KEY: InjectionKey<Observability> = Symbol('Observability')

--- a/opensquilla-webui/src/modules/skillCatalog.ts
+++ b/opensquilla-webui/src/modules/skillCatalog.ts
@@ -1,0 +1,121 @@
+import type { InjectionKey } from 'vue'
+import type {
+  AutoEnabledSkill,
+  Proposal,
+  ProposalsSettings,
+  RegistryResult,
+  Skill,
+  SkillDiagnostic,
+  SkillLifecycle,
+  SkillSourceResolution,
+} from '@/types/skills'
+
+export interface SkillInstallResult {
+  readonly success: boolean
+  readonly cancelled?: boolean
+  readonly unchanged?: boolean
+  readonly name?: string
+  readonly message?: string
+  readonly installed?: boolean
+  readonly active?: boolean
+  readonly instruction_usable?: boolean
+  readonly installId?: string
+  readonly lifecycle?: SkillLifecycle
+  readonly resolution?: SkillSourceResolution
+  readonly diagnostics?: readonly SkillDiagnostic[]
+  readonly rollbackPerformed?: boolean
+  readonly catalogGeneration?: number
+  readonly effectiveFrom?: 'next_turn' | 'next_start' | string
+  readonly missing_still?: {
+    readonly bins?: readonly string[]
+    readonly env?: readonly string[]
+    readonly env_any?: readonly (readonly string[])[]
+  }
+}
+
+export interface SkillRegistrySearchResult {
+  readonly results: readonly RegistryResult[]
+  readonly diagnostics: readonly SkillDiagnostic[]
+  readonly message: string
+}
+
+export interface SkillReloadError {
+  readonly path?: string
+  readonly message?: string
+  readonly kept_previous?: boolean
+}
+
+export interface SkillReloadResult {
+  readonly success: boolean
+  readonly changed: boolean
+  readonly partial: boolean
+  readonly generation: number
+  readonly added?: readonly string[]
+  readonly removed?: readonly string[]
+  readonly modified?: readonly string[]
+  readonly errors?: readonly SkillReloadError[]
+}
+
+export interface SkillProposalSnapshot {
+  readonly proposals: readonly Proposal[]
+  readonly autoEnabledSkills: readonly AutoEnabledSkill[]
+  readonly settings: ProposalsSettings | null
+}
+
+export interface SkillProposalDetail extends Partial<Proposal> {
+  readonly status?: string
+  readonly reason?: string
+}
+
+export interface SkillProposalAction {
+  readonly status?: string
+  readonly reason?: string
+  readonly settings?: ProposalsSettings
+}
+
+export interface SkillCatalog {
+  list(options?: { readonly signal?: AbortSignal }): Promise<readonly Skill[]>
+  detail(skill: Pick<Skill, 'name' | 'instance_id' | 'install_id'>, options?: {
+    readonly signal?: AbortSignal
+  }): Promise<Skill>
+  search(query: string, options?: {
+    readonly limit?: number
+    readonly source?: string
+    readonly signal?: AbortSignal
+  }): Promise<SkillRegistrySearchResult>
+  reload(options?: { readonly signal?: AbortSignal }): Promise<SkillReloadResult>
+  install(request: {
+    readonly identifier: string
+    readonly source: string
+    readonly operationId?: string
+    readonly riskConfirmation?: string
+    readonly signal?: AbortSignal
+  }): Promise<SkillInstallResult>
+  supportsInstallCancellation(): boolean
+  cancelInstall(operationId: string, options?: { readonly signal?: AbortSignal }): Promise<SkillInstallResult>
+  installDependencies(request: {
+    readonly name: string
+    readonly dependencyId: string
+    readonly skillInstallId?: string
+    readonly instanceId?: string
+    readonly signal?: AbortSignal
+  }): Promise<SkillInstallResult>
+  uninstall(request: {
+    readonly name?: string
+    readonly installId?: string
+    readonly signal?: AbortSignal
+  }): Promise<SkillInstallResult>
+  proposals(options?: { readonly signal?: AbortSignal }): Promise<SkillProposalSnapshot>
+  updateProposalSettings(changes: Readonly<Record<string, boolean | string>>, options?: {
+    readonly signal?: AbortSignal
+  }): Promise<SkillProposalAction>
+  proposal(proposalId: string, options?: { readonly signal?: AbortSignal }): Promise<SkillProposalDetail>
+  acceptProposal(proposalId: string, options?: {
+    readonly force?: boolean
+    readonly signal?: AbortSignal
+  }): Promise<SkillProposalAction>
+  rejectProposal(proposalId: string, options?: { readonly signal?: AbortSignal }): Promise<SkillProposalAction>
+  disableAutoEnabledSkill(name: string, options?: { readonly signal?: AbortSignal }): Promise<SkillProposalAction>
+}
+
+export const SKILL_CATALOG_KEY: InjectionKey<SkillCatalog> = Symbol('SkillCatalog')

--- a/opensquilla-webui/src/views/AgentsView.vue
+++ b/opensquilla-webui/src/views/AgentsView.vue
@@ -280,10 +280,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, nextTick } from 'vue'
+import { ref, computed, inject, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
-import { useRpcStore } from '@/stores/rpc'
 import Icon from '@/components/Icon.vue'
 import ErrorState from '@/components/ErrorState.vue'
 import LoadingSpinner from '@/components/LoadingSpinner.vue'
@@ -292,17 +291,20 @@ import { isAgentBuiltin, useAgentDrawer } from '@/composables/agents/useAgentDra
 import { useDialogA11y } from '@/composables/useDialogA11y'
 import type { Agent } from '@/types/agents'
 import { useToasts } from '@/composables/useToasts'
+import { AGENT_CATALOG_KEY } from '@/modules/agentCatalog'
 
 // ---------------------------------------------------------------------------
 // State
 // ---------------------------------------------------------------------------
 
 const { t } = useI18n()
-const rpc = useRpcStore()
+const injectedAgentCatalog = inject(AGENT_CATALOG_KEY)
+if (!injectedAgentCatalog) throw new Error('AgentCatalog was not provided')
+const agentCatalog = injectedAgentCatalog
 const { pushToast } = useToasts()
 const router = useRouter()
 
-const { agents, loadData, loading, error } = useAgentsData()
+const { agents, loadData, loading, error } = useAgentsData(agentCatalog)
 const newId = ref('')
 const newName = ref('')
 
@@ -393,7 +395,7 @@ async function onInlineAdd() {
   const payload: Record<string, unknown> = { id }
   if (name) payload.name = name
   try {
-    await rpc.call('agents.create', payload)
+    await agentCatalog.create(payload)
     pushToast(t('console.agents.toastCreated', { id }), { tone: 'ok' })
     newId.value = ''
     newName.value = ''
@@ -430,7 +432,7 @@ async function onSave() {
       saving.value = false
       return
     }
-    await rpc.call('agents.update', payload)
+    await agentCatalog.update(payload)
     pushToast(t('console.agents.toastUpdated', { id: drawerAgentId.value }), { tone: 'ok' })
     await loadData()
     const updated = agents.value.find(a => a.id === drawerAgentId.value)
@@ -463,7 +465,7 @@ async function deleteAgent(id?: string) {
   )
   if (!ok) return
   try {
-    await rpc.call('agents.delete', { id })
+    await agentCatalog.remove(id)
     pushToast(t('console.agents.toastDeleted', { id }), { tone: 'ok' })
     await loadData()
   } catch (err: unknown) {

--- a/opensquilla-webui/src/views/LogsView.test.ts
+++ b/opensquilla-webui/src/views/LogsView.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { KeepAlive, computed, createApp, defineComponent, h, nextTick, ref } from 'vue'
 import { createMemoryHistory, createRouter } from 'vue-router'
+import { OBSERVABILITY_KEY } from '@/modules/observability'
 
 const rpcMocks = vi.hoisted(() => ({
   call: vi.fn(),
@@ -129,6 +130,20 @@ async function mountLogs(): Promise<MountedLogs> {
   await router.push('/logs')
   await router.isReady()
   app.use(router)
+  app.provide(OBSERVABILITY_KEY, {
+    logStatus: () => rpcMocks.call('logs.status', {}),
+    async tailLogs(options: { cursor: number; limit?: number; level?: string | null }) {
+      const data = await rpcMocks.call('logs.tail', {
+        cursor: options.cursor,
+        limit: options.limit ?? 500,
+        level: options.level ?? null,
+      })
+      return {
+        entries: data.lines || data.entries || [],
+        cursor: data.cursor ?? null,
+      }
+    },
+  } as never)
   app.mount(el)
   const result: MountedLogs = {
     el,

--- a/opensquilla-webui/src/views/LogsView.vue
+++ b/opensquilla-webui/src/views/LogsView.vue
@@ -209,10 +209,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, onActivated, onDeactivated, watch, nextTick } from 'vue'
+import { ref, computed, inject, onMounted, onUnmounted, onActivated, onDeactivated, watch, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { RouterLink } from 'vue-router'
-import { useRpcStore } from '@/stores/rpc'
+import { OBSERVABILITY_KEY, type GatewayLogStatus } from '@/modules/observability'
 import { useFixedWindow } from '@/composables/useFixedWindow'
 import Icon from '@/components/Icon.vue'
 import ControlSwitch from '@/components/ControlSwitch.vue'
@@ -234,41 +234,6 @@ interface LogLine {
   raw?: string
 }
 
-interface LogTailResponse {
-  lines?: LogEntry[]
-  entries?: LogEntry[]
-  cursor?: number
-}
-
-interface LogEntry {
-  level?: string
-  lvl?: string
-  message?: string
-  msg?: string
-  timestamp?: string | number
-  ts?: string | number
-  raw?: string
-  [key: string]: unknown
-}
-
-interface LogStatus {
-  gateway_file_log?: {
-    enabled?: boolean
-    path?: string
-  }
-  raw_turn_call_log?: {
-    enabled?: boolean
-    source?: string
-    directory?: {
-      path?: string
-    }
-  }
-  diagnostics_enabled?: {
-    effective?: boolean
-    detail?: string
-  }
-}
-
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -287,14 +252,16 @@ const WINDOW_MIN_WIDTH = '(min-width: 481px)'
 // ---------------------------------------------------------------------------
 
 const { t } = useI18n()
-const rpc = useRpcStore()
+const injectedObservability = inject(OBSERVABILITY_KEY)
+if (!injectedObservability) throw new Error('Observability was not provided')
+const observability = injectedObservability
 const allLines = ref<LogLine[]>([])
 const cursor = ref(0)
 const searchText = ref('')
 const debouncedSearch = ref('')
 let searchTimer: ReturnType<typeof setTimeout> | null = null
 const autoFollow = ref(true)
-const status = ref<LogStatus | null>(null)
+const status = ref<GatewayLogStatus | null>(null)
 const activeLevels = ref<Set<string>>(new Set(DEFAULT_LEVELS))
 const displayRef = ref<HTMLElement | null>(null)
 const loadState = ref<'loading' | 'ready' | 'error'>('loading')
@@ -509,8 +476,6 @@ async function loadData() {
   stopPolling()
   loadState.value = 'loading'
   try {
-    await rpc.waitForConnection()
-    if (!isActive) return
     cursor.value = 0
     allLines.value = []
     await loadStatus()
@@ -527,7 +492,7 @@ async function loadData() {
 async function loadStatus() {
   if (!isActive) return
   try {
-    status.value = await rpc.call<LogStatus>('logs.status', {})
+    status.value = await observability.logStatus()
   } catch {
     status.value = null
   }
@@ -536,14 +501,12 @@ async function loadStatus() {
 async function poll() {
   if (!isActive) return
   if (pollInFlight) return
-  const rpcClient = rpc.client
-  if (!rpcClient) return
   if (document.hidden) return
   pollInFlight = true
   try {
-    const data = await rpc.call<LogTailResponse>('logs.tail', { limit: 500, cursor: cursor.value, level: null })
+    const data = await observability.tailLogs({ limit: 500, cursor: cursor.value, level: null })
     if (!isActive) return
-    const lines: LogEntry[] = data.lines || data.entries || []
+    const lines = data.entries
     if (lines.length > 0) {
       if (data.cursor != null) {
         cursor.value = data.cursor

--- a/opensquilla-webui/src/views/OverviewView.diagnostics.test.ts
+++ b/opensquilla-webui/src/views/OverviewView.diagnostics.test.ts
@@ -161,6 +161,8 @@ async function mountOverview(options: MountOptions = {}) {
   type SessionDirectoryTransport = Parameters<typeof createV4SessionDirectory>[0]
   const { SESSION_DIRECTORY_KEY } = await import('@/modules/sessionDirectory')
   const { PROVIDER_CONFIGURATION_KEY } = await import('@/modules/providerConfiguration')
+  const { OBSERVABILITY_KEY } = await import('@/modules/observability')
+  const { createV4Observability } = await import('@/adapters/gateway/observabilityV4')
   const active = ref(true)
   const TestHost = defineComponent({
     name: 'OverviewTestHost',
@@ -216,6 +218,15 @@ async function mountOverview(options: MountOptions = {}) {
       }
     }),
   } as unknown as import('@/modules/providerConfiguration').ProviderConfiguration)
+  app.provide(OBSERVABILITY_KEY, createV4Observability({
+    request: rpcCall,
+    ready: vi.fn(async () => {}),
+    supports: vi.fn(() => true),
+    markUnsupported: vi.fn(),
+  }, {
+    requestJson: vi.fn(),
+    requestBinary: vi.fn(),
+  }))
   app.mount(el)
   mountedApps.push({ app, el })
 
@@ -331,7 +342,7 @@ describe('OverviewView status lifecycle', () => {
   })
 
   it('lets an authoritative stored-session count decrease after deletion', async () => {
-    const { el, flush } = await mountOverview({
+    const { el, flush, rpcCall } = await mountOverview({
       sessionsListHandler: (callIndex) => ({
         sessions: [{ key: 'agent:main:webchat:remaining', title: 'Remaining' }],
         count: callIndex === 0 ? 200 : 1,
@@ -343,6 +354,9 @@ describe('OverviewView status lifecycle', () => {
     expect(card?.querySelector('.control-stat__value')?.textContent).toBe('201')
 
     el.querySelector<HTMLButtonElement>('.ov-status-actions .btn--ghost')!.click()
+    await vi.waitFor(() => {
+      expect(rpcCall.mock.calls.filter(([method]) => method === 'sessions.list')).toHaveLength(2)
+    })
     await flush()
 
     expect(card?.querySelector('.control-stat__value')?.textContent).toBe('1')

--- a/opensquilla-webui/src/views/OverviewView.vue
+++ b/opensquilla-webui/src/views/OverviewView.vue
@@ -196,6 +196,7 @@ import { requestUsageSnapshot } from '@/composables/usage/useUsageQuery'
 import { effectiveCnyPerUsd } from '@/composables/usage/nativeBilling'
 import { SESSION_DIRECTORY_KEY } from '@/modules/sessionDirectory'
 import { PROVIDER_CONFIGURATION_KEY, type ProviderStatusRow } from '@/modules/providerConfiguration'
+import { OBSERVABILITY_KEY } from '@/modules/observability'
 import type { UsageSnapshot } from '@/types/usage'
 import { useToasts } from '@/composables/useToasts'
 import { isOwnedGatewayConnection } from '@/composables/useCliInvocation'
@@ -279,6 +280,9 @@ const sessionDirectory = injectedSessionDirectory
 const injectedProviderConfiguration = inject(PROVIDER_CONFIGURATION_KEY)
 if (!injectedProviderConfiguration) throw new Error('ProviderConfiguration was not provided')
 const providerConfiguration = injectedProviderConfiguration
+const injectedObservability = inject(OBSERVABILITY_KEY)
+if (!injectedObservability) throw new Error('Observability was not provided')
+const observability = injectedObservability
 const { pushToast } = useToasts()
 const platform = usePlatform()
 
@@ -357,7 +361,7 @@ const costLine = computed<string>(() => {
 
 async function refreshUsage(epoch: UsageLoadEpoch): Promise<UsageData | null> {
   try {
-    const snapshot = await requestUsageSnapshot(rpc, 'all', {
+    const snapshot = await requestUsageSnapshot(observability, 'all', {
       days: false,
       models: false,
       sessions: false,
@@ -655,8 +659,7 @@ async function loadHealth({ deep, silent = false }: HealthLoadOptions) {
   }
 
   try {
-    await rpc.waitForConnection()
-    const response = await rpc.call<HealthReport>('doctor.status', { agentId: 'main', deep })
+    const response = await observability.readiness({ agentId: 'main', deep }) as HealthReport
     const data = withoutLegacyMigrationFinding(response)
     if (!data.gatewayUrl) data.gatewayUrl = gatewayContextUrl()
     healthError.value = null

--- a/opensquilla-webui/src/views/SessionsView.vue
+++ b/opensquilla-webui/src/views/SessionsView.vue
@@ -129,7 +129,6 @@
 import { computed, inject, onActivated, onDeactivated, onUnmounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
-import { useRpcStore } from '@/stores/rpc'
 import Icon from '@/components/Icon.vue'
 import ErrorState from '@/components/ErrorState.vue'
 import LoadingSpinner from '@/components/LoadingSpinner.vue'
@@ -158,12 +157,10 @@ import { SESSION_DIRECTORY_KEY } from '@/modules/sessionDirectory'
 import { SESSION_DIRECTORY_CHANGES_KEY } from '@/modules/sessionDirectoryChanges'
 import { SESSION_LIFECYCLE_KEY } from '@/modules/sessionLifecycle'
 import { APPROVAL_CENTER_KEY, type ApprovalEvent } from '@/modules/approvalCenter'
+import { OBSERVABILITY_KEY } from '@/modules/observability'
+import { AGENT_CATALOG_KEY } from '@/modules/agentCatalog'
 
 type FilterId = 'all' | 'chats' | 'automations' | 'channels'
-
-interface AgentsListResponse {
-  agents?: Array<{ id?: string; name?: string }>
-}
 
 const FILTER_CHIPS: Array<{ id: FilterId; labelKey: string }> = [
   { id: 'all', labelKey: 'sessions.filter.all' },
@@ -184,7 +181,6 @@ const SESSIONS_VIEW_SYNC_SOURCE = 'sessions-view'
 
 const { t } = useI18n()
 const router = useRouter()
-const rpc = useRpcStore()
 const injectedSessionDirectory = inject(SESSION_DIRECTORY_KEY)
 if (!injectedSessionDirectory) throw new Error('SessionDirectory was not provided')
 const sessionDirectory = injectedSessionDirectory
@@ -197,6 +193,12 @@ const sessionLifecycle = injectedSessionLifecycle
 const injectedApprovalCenter = inject(APPROVAL_CENTER_KEY)
 if (!injectedApprovalCenter) throw new Error('ApprovalCenter was not provided')
 const approvalCenter = injectedApprovalCenter
+const injectedObservability = inject(OBSERVABILITY_KEY)
+if (!injectedObservability) throw new Error('Observability was not provided')
+const observability = injectedObservability
+const injectedAgentCatalog = inject(AGENT_CATALOG_KEY)
+if (!injectedAgentCatalog) throw new Error('AgentCatalog was not provided')
+const agentCatalog = injectedAgentCatalog
 const { confirm } = useConfirm()
 const {
   sessionsList,
@@ -300,10 +302,10 @@ const inspectAgentName = computed(() => {
 async function loadAgents() {
   const generation = ++agentsRequestGeneration
   try {
-    const data = await rpc.call<AgentsListResponse>('agents.list')
+    const agents = await agentCatalog.list()
     if (generation !== agentsRequestGeneration) return
     agentNames.value = new Map(
-      (data?.agents || [])
+      agents
         .filter(agent => agent.id)
         .map(agent => [String(agent.id), String(agent.name || agent.id)]))
     agentsLoaded.value = true
@@ -329,7 +331,7 @@ async function refreshApprovals() {
 
 async function refreshCost() {
   try {
-    const snapshot = await requestUsageSnapshot(rpc, 'today', {
+    const snapshot = await requestUsageSnapshot(observability, 'today', {
       days: false,
       models: false,
       sessions: false,

--- a/opensquilla-webui/src/views/SkillsView.stats.test.ts
+++ b/opensquilla-webui/src/views/SkillsView.stats.test.ts
@@ -20,7 +20,7 @@ async function mountSkillsView(reloadResult: Record<string, unknown> | Promise<R
   const setStatusFilter = vi.fn()
   const loadData = vi.fn(async () => loadDataResult)
   const scrollIntoView = vi.fn()
-  const rpcCall = vi.fn(async () => reloadResult)
+  const rpcCall = vi.fn(async (_method: string) => reloadResult)
   const waitForConnection = vi.fn(async () => {})
   const pushToast = vi.fn()
 
@@ -205,6 +205,10 @@ async function mountSkillsView(reloadResult: Record<string, unknown> | Promise<R
   const app = createApp(Root)
   app.use(pinia)
   app.use(i18n)
+  const { SKILL_CATALOG_KEY } = await import('@/modules/skillCatalog')
+  app.provide(SKILL_CATALOG_KEY, {
+    reload: () => rpcCall('skills.reload'),
+  } as never)
   app.mount(el)
   await nextTick()
 

--- a/opensquilla-webui/src/views/SkillsView.vue
+++ b/opensquilla-webui/src/views/SkillsView.vue
@@ -196,7 +196,7 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, onActivated, onDeactivated, onUnmounted, ref } from 'vue'
+import { inject, nextTick, onActivated, onDeactivated, onUnmounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/Icon.vue'
 import ControlSwitch from '@/components/ControlSwitch.vue'
@@ -212,31 +212,15 @@ import { createSkillMutationGate } from '@/composables/skills/useSkillMutationGa
 import { useSkillRegistry } from '@/composables/skills/useSkillRegistry'
 import { skillLayerHelp, skillLayerLabel, useSkillsCatalog } from '@/composables/skills/useSkillsCatalog'
 import { useToasts } from '@/composables/useToasts'
-import { useRpcStore } from '@/stores/rpc'
 import type { Proposal, Skill } from '@/types/skills'
-
-interface SkillReloadError {
-  name?: string
-  path?: string
-  message?: string
-  kept_previous?: boolean
-}
-
-interface SkillReloadResult {
-  success: boolean
-  changed: boolean
-  partial: boolean
-  generation: number
-  added?: string[]
-  removed?: string[]
-  modified?: string[]
-  errors?: SkillReloadError[]
-}
+import { SKILL_CATALOG_KEY, type SkillReloadResult } from '@/modules/skillCatalog'
 
 const { t } = useI18n()
 const skillsOverviewOpen = ref(false)
 const { pushToast } = useToasts()
-const rpc = useRpcStore()
+const injectedSkillCatalog = inject(SKILL_CATALOG_KEY)
+if (!injectedSkillCatalog) throw new Error('SkillCatalog was not provided')
+const skillCatalog = injectedSkillCatalog
 const addSkillOpen = ref(false)
 const reloading = ref(false)
 const selectedProposal = ref<Proposal | null>(null)
@@ -245,7 +229,7 @@ const proposalsPanelRef = ref<InstanceType<typeof PendingSkillProposals> | null>
 let loadData: () => Promise<boolean>
 const mutationGate = createSkillMutationGate()
 
-const proposalsModel = useSkillProposals(rpc, async () => { await loadData() }, mutationGate)
+const proposalsModel = useSkillProposals(skillCatalog, async () => { await loadData() }, mutationGate)
 const {
   proposals,
   autoEnabledSkills,
@@ -260,7 +244,7 @@ const {
   disableAutoEnabled,
 } = proposalsModel
 
-const catalog = useSkillsCatalog(rpc, {
+const catalog = useSkillsCatalog(skillCatalog, {
   proposals,
   autoEnabledSkills,
   proposalsSettings,
@@ -292,8 +276,7 @@ async function manualReload() {
   if (reloading.value || !mutationGate.acquire('reload')) return
   reloading.value = true
   try {
-    await rpc.waitForConnection()
-    const result = await rpc.call<SkillReloadResult>('skills.reload')
+    const result = await skillCatalog.reload()
     // Always redraw from the catalog the Gateway is actually serving. On a
     // failed publish this is the prior last-known-good generation.
     const listed = await loadData()
@@ -330,7 +313,7 @@ async function manualReload() {
   }
 }
 
-const registry = useSkillRegistry(rpc, loadData, mutationGate)
+const registry = useSkillRegistry(skillCatalog, loadData, mutationGate)
 const {
   registryQuery,
   githubUrl,
@@ -356,7 +339,7 @@ const {
   uninstallSkill,
 } = registry
 
-const skillDetail = useSkillDetailController({ rpc, installDeps })
+const skillDetail = useSkillDetailController({ catalog: skillCatalog, installDeps })
 const {
   selectedSkill,
   selectedSkillLoading,

--- a/opensquilla-webui/src/views/UsageView.vue
+++ b/opensquilla-webui/src/views/UsageView.vue
@@ -110,11 +110,15 @@ import ErrorState from '@/components/ErrorState.vue'
 import LoadingSpinner from '@/components/LoadingSpinner.vue'
 import { useUsageData } from '@/composables/usage/useUsageData'
 import { SESSION_DIRECTORY_KEY } from '@/modules/sessionDirectory'
+import { OBSERVABILITY_KEY } from '@/modules/observability'
 
 const { t } = useI18n()
 const injectedSessionDirectory = inject(SESSION_DIRECTORY_KEY)
 if (!injectedSessionDirectory) throw new Error('SessionDirectory was not provided')
 const sessionDirectory = injectedSessionDirectory
+const injectedObservability = inject(OBSERVABILITY_KEY)
+if (!injectedObservability) throw new Error('Observability was not provided')
+const observability = injectedObservability
 
 const {
   currency,
@@ -164,7 +168,7 @@ const {
   rowBreakdownTotalTokens,
   rowBreakdownTotalCost,
   rowBreakdownAnyProrated,
-} = useUsageData(sessionDirectory)
+} = useUsageData(sessionDirectory, observability)
 
 // Manual refresh shows a busy state; loadData (also the poll/mount handler) now
 // returns the refresh promise, so a local flag spans just the user-driven load.


### PR DESCRIPTION
## Scope

Isolate the WebUI-reachable read/catalog surfaces behind three semantic domain boundaries:

- `Observability` owns usage, readiness, logs, update notice, and support bundle projections.
- `SkillCatalog` owns installed skills, registry search/install lifecycle, and proposal workflows.
- `AgentCatalog` owns agent discovery and mutations.

The PR is intentionally organized as three reversible commit phases: Module/Adapter foundation, consumer switch, then legacy transport-debt deletion.

## Target

`main`

## Linked issue

None

## Method-to-Module manifest

| Domain use case | Current wire/bridge | Current backend implementation | Target Module method | Port / Adapter | Consumers | Deleted debt |
| --- | --- | --- | --- | --- | --- | --- |
| Usage projection | `usage.query`, legacy `usage.status` | `rpc_usage.py` / usage query service | `Observability.usage` | private RPC transport / `observabilityV4` | Usage, Overview, Sessions | raw RPC, capability cache, connection wait |
| Readiness | `doctor.status` | `rpc_doctor.py` | `Observability.readiness` | private RPC transport / `observabilityV4` | Overview, Support menu | raw RPC and connection wait |
| Gateway logs | `logs.status`, `logs.tail` | `rpc_logs.py` | `Observability.logStatus`, `tailLogs` | private RPC transport / `observabilityV4` | Logs | raw RPC and connection wait |
| Update notice | `GET /api/system/update` | existing HTTP route | `Observability.updateNotice` | private HTTP transport / `observabilityV4` | Update banner | endpoint, token, header, fetch |
| Support bundle | `POST /api/v1/diagnostics/bundle` | existing diagnostics route | `Observability.downloadSupportBundle` | private HTTP transport / `observabilityV4` | Support menu | endpoint, token, header, fetch |
| Skill catalog/detail | `skills.list`, `skills.get` | `SkillManagementService` / pinned loader | `SkillCatalog.list`, `detail` | private RPC transport / `skillCatalogV4` | Skills view/detail | raw RPC and connection wait |
| Skill registry lifecycle | `skills.search`, `skills.reload`, `skills.install*`, `skills.deps.install`, `skills.uninstall` | `SkillManagementService` | semantic search/reload/install/cancel/dependency/uninstall methods | private RPC transport / `skillCatalogV4` | Skill registry | raw RPC and capability checks |
| Skill proposals | `exec.proposals.*` | proposal library RPC handlers | proposal snapshot/actions | private RPC transport / `skillCatalogV4` | Skill proposal UI | raw RPC |
| Agent catalog | `agents.list/create/update/delete` | `AgentRegistry` / `rpc_agents.py` | `AgentCatalog.list/create/update/remove` | private RPC transport / `agentCatalogV4` | Agents, Sessions, app sidebar | raw RPC |

Application consumers now mock only semantic domain interfaces. The existing backend services remain the sole business implementations; this PR does not add duplicate handler layers or pass `RpcContext` into WebUI domain APIs.

## Validation

- `npm run check:architecture`
- `npm run typecheck`
- `npm run test:unit -- --run` — 415 files, 5,148 tests passed
- `npm run build`
- `.venv/bin/pytest -q tests/test_ci/test_rpc_architecture_contracts.py tests/test_ci/test_architecture_import_contracts.py` — 18 passed
- `git diff --check`
- GitNexus impact manifest against exact `origin/main@14273706c5ad1f8cfd607ee087c8102d160c1491`: 42 files, 93 symbols, 0 affected processes, LOW risk

The transport debt gate moves from 194 to 145 exact operations (`RPC=87`, `HTTP=58`).

## Compatibility and safety

- Existing Gateway v4 method names, HTTP endpoints, payloads, authentication, and response behavior are preserved.
- `usage.query` still falls back to `usage.status` only when the optional query capability is genuinely unavailable; transient errors preserve the prior cache semantics.
- No database schema, WebSocket envelope, `TurnRunner`, `TaskRuntime`, Agent Loop, filesystem behavior, or platform-specific process behavior changes.
- The change is platform-neutral and preserves existing desktop/browser HTTP authentication through the shared transport.
- Existing CLI, MCP, and older WebUI clients are unaffected because backend handlers and wire behavior do not change.

## Release note

Not required; internal architecture refactor with no intended user-visible behavior change.

## Third-party origin

None. No third-party code or assets were copied.
