### PR TITLE
test(windows): give synthetic recovery harness a bounded startup margin

### DIFF
--- a/tests/test_ci/test_upgrade_baselines.py
+++ b/tests/test_ci/test_upgrade_baselines.py
@@ -124,26 +124,32 @@ def test_packaged_recovery_preserves_original_failure_after_cleanup(
         + "}\n",
         encoding="utf-8",
     )
-    result = subprocess.run(
-        [
-            node,
-            str(tmp_path / "test-packaged-session-recovery.mjs"),
-            "--executable",
-            str(tmp_path / "synthetic.exe"),
-            "--user-data-dir",
-            str(tmp_path / "profile"),
-            "--session-key",
-            "synthetic-main",
-            "--switch-session-key",
-            "synthetic-peer",
-            "--label",
-            "synthetic",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-        timeout=10,
-    )
+    # This is a synthetic error/cleanup contract, not a recovery-latency check.
+    # Allow Windows CI headroom for Node startup and captured-pipe completion.
+    try:
+        result = subprocess.run(
+            [
+                node,
+                str(tmp_path / "test-packaged-session-recovery.mjs"),
+                "--executable",
+                str(tmp_path / "synthetic.exe"),
+                "--user-data-dir",
+                str(tmp_path / "profile"),
+                "--session-key",
+                "synthetic-main",
+                "--switch-session-key",
+                "synthetic-peer",
+                "--label",
+                "synthetic",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30 if os.name == "nt" else 10,
+        )
+    except subprocess.TimeoutExpired as error:
+        error.add_note(f"Captured stdout: {error.stdout!r}\nCaptured stderr: {error.stderr!r}")
+        raise
     assert result.returncode != 0
     assert "packaged_session_recovery_failed_before_cleanup" in result.stderr
     assert "synthetic-cleanup-ran" in result.stderr


### PR DESCRIPTION
## Scope

Scope boundary: Give the synthetic packaged-recovery error/cleanup test a 30-second Node subprocess watchdog on Windows; keep the 10-second budget on other platforms. Attach captured stdout/stderr to TimeoutExpired and re-raise it, preserving all existing cleanup and original-error assertions.

PR #1517 failed in `Windows high-risk (recovery-migration)` because this test hit its 10-second subprocess timeout while Python was waiting for captured stdout. The CI report recorded 10.187 seconds for the failing case; the other parameter cases passed in 2.319 and 0.103 seconds. This test uses synthetic launch/cleanup helpers and does not measure product recovery latency. The wider Windows watchdog provides runner headroom; the precise source of the runner delay remains unconfirmed.

Failure evidence: https://github.com/TokenRhythm/opensquilla/actions/runs/34214667596/job/102023657954

Non-goals: Product recovery deadlines, workflow job timeouts, worker counts, retries, and other subprocess tests.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Narrow CI test fix prompted by the failure on PR #1517; no separate issue exists.

## Release Note

Release note: NONE

## Tests

Ruff: `ruff check tests/test_ci/test_upgrade_baselines.py` and `ruff format --check tests/test_ci/test_upgrade_baselines.py` passed.

Pytest: Native Windows, Python 3.12.13: `python -m pytest tests/test_ci/test_upgrade_baselines.py -q --durations=5` — 56 passed, 17 skipped in 56.74s. Platform-specific macOS/POSIX cases were skipped.

Build: Not needed; test-only change.

Regression tests: not needed — existing three parameter cases retain all behavioral assertions. Additional local fault-injection probes verified Windows/POSIX budgets (30s/10s), re-raising the identical TimeoutExpired, captured byte/empty output diagnostics, and no retry.

Notes: `git diff --check` passed. The hosted-runner timing failure was not reproduced locally; remote Windows CI remains the validation for the revised watchdog. No real Electron installation or Gateway launch is exercised by the modified synthetic test.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

Only the test file is changed. No secrets, local artifacts, or private fixtures are included.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

Not applicable.
