### PR TITLE
test(desktop): avoid PID-reuse false timeouts in orphan recovery

### DIFF
--- a/desktop/electron/scripts/e2e-shutdown-helpers.mjs
+++ b/desktop/electron/scripts/e2e-shutdown-helpers.mjs
@@ -1,5 +1,35 @@
 import { setTimeout as delay } from 'node:timers/promises'
 import { terminateWindowsProcessTree } from '../dist/windows-process-tree.js'
+import {
+  desktopGatewayStartIdentityConflict,
+  desktopProcessStartIdentity,
+} from '../dist/desktop-gateway-ownership.js'
+
+// A recycled PID belongs to a different process, not a Gateway that failed to
+// exit. Unknown identities never prove exit; a denied PID probe means present.
+export function gatewayProcessSnapshot(record, {
+  probePid = pid => process.kill(pid, 0),
+  readStartIdentity = desktopProcessStartIdentity,
+} = {}) {
+  let pidPresent = true
+  try {
+    probePid(record.pid)
+  } catch (error) {
+    pidPresent = error?.code !== 'ESRCH'
+  }
+  const liveStartIdentity = pidPresent ? readStartIdentity(record.pid) : null
+  const identityConflict = desktopGatewayStartIdentityConflict(
+    record.start_identity, liveStartIdentity,
+  )
+  return {
+    pid: record.pid,
+    recordedStartIdentity: record.start_identity,
+    liveStartIdentity,
+    pidPresent,
+    identityConflict,
+    alive: pidPresent && !identityConflict,
+  }
+}
 
 const FORCED_PROCESS_EXIT_TIMEOUT_MS = 5_000
 const WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS = 5_000

--- a/desktop/electron/scripts/test-ci-case-telemetry.mjs
+++ b/desktop/electron/scripts/test-ci-case-telemetry.mjs
@@ -17,6 +17,7 @@ import {
   closeElectronWithDeadline,
   closeHttpServerWithDeadline,
   desktopShutdownEvidenceSince,
+  gatewayProcessSnapshot,
   trackHttpServerConnections,
 } from './e2e-shutdown-helpers.mjs'
 import { terminateWindowsProcessTree } from '../dist/windows-process-tree.js'
@@ -28,6 +29,37 @@ const outputPath = join(root, 'reports', 'cases.jsonl')
 const emitted = []
 
 try {
+  for (const scheme of [
+    'windows-creation-filetime:', 'linux-proc-start-ticks:', 'posix-ps-lstart:',
+  ]) {
+    const record = { pid: 1234, start_identity: `${scheme}old` }
+    const probePid = pid => assert.equal(pid, record.pid)
+    const recycled = gatewayProcessSnapshot(record, {
+      probePid,
+      readStartIdentity: () => `${scheme}new`,
+    })
+    assert.equal(recycled.pidPresent, true)
+    assert.equal(recycled.identityConflict, true)
+    assert.equal(recycled.alive, false, 'PID reuse must not keep the old Gateway alive')
+    for (const liveStartIdentity of [record.start_identity, null, 'runtime-start:unknown']) {
+      assert.equal(gatewayProcessSnapshot(record, {
+        probePid,
+        readStartIdentity: () => liveStartIdentity,
+      }).alive, true, 'matching or unprovable identities must keep waiting')
+    }
+    assert.equal(gatewayProcessSnapshot(record, {
+      probePid: () => { throw Object.assign(new Error('missing'), { code: 'ESRCH' }) },
+      readStartIdentity: () => { assert.fail('an absent PID needs no identity probe') },
+    }).alive, false)
+    assert.equal(gatewayProcessSnapshot(record, {
+      probePid: () => { throw Object.assign(new Error('denied'), { code: 'EPERM' }) },
+      readStartIdentity: () => null,
+    }).alive, true, 'a denied probe is not exit evidence')
+  }
+  assert.equal(gatewayProcessSnapshot({ pid: 1234, start_identity: 'runtime-start:old' }, {
+    probePid: () => {},
+    readStartIdentity: () => 'windows-creation-filetime:new',
+  }).alive, true, 'an opaque recorded identity cannot prove PID reuse')
   const telemetry = startCaseTelemetry({
     caseName: 'direct-case',
     os: 'TestOS',

--- a/desktop/electron/scripts/test-desktop-gateway-orphan-recovery-flow.mjs
+++ b/desktop/electron/scripts/test-desktop-gateway-orphan-recovery-flow.mjs
@@ -11,6 +11,7 @@ import { _electron as electron } from 'playwright'
 import {
   loadDesktopGatewayOwnershipRecord,
   requestVerifiedDesktopGatewayShutdown,
+  sameDesktopGatewayOwnershipInstance,
   verifyDesktopGatewayOwnership,
   waitForDesktopGatewayOwnershipRelease,
 } from '../dist/desktop-gateway-ownership.js'
@@ -19,6 +20,7 @@ import {
   canAcceptWindowsElectronShutdownFallback,
   closeElectronWithDeadline,
   desktopShutdownEvidenceSince,
+  gatewayProcessSnapshot,
 } from './e2e-shutdown-helpers.mjs'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
@@ -118,6 +120,7 @@ async function phaseDiagnostics(app, userDataDir, phase) {
     process: appProcessState(app),
     windows,
     ownership: await ownershipDiagnostics(userDataDir),
+    gatewayProcesses: ownedInstances.map(({ record }) => gatewayProcessSnapshot(record)),
   }
 }
 
@@ -222,15 +225,6 @@ async function ownershipDirectory(userDataDir, app, phase) {
   }, 'Desktop Gateway ownership record', phase.remainingMs('ownership-record'), () => (
     phaseDiagnostics(app, userDataDir, phase)
   ))
-}
-
-function processAlive(pid) {
-  try {
-    process.kill(pid, 0)
-    return true
-  } catch (error) {
-    return error?.code !== 'ESRCH'
-  }
 }
 
 async function waitForDesktopRenderer(app, userDataDir, phase) {
@@ -434,7 +428,10 @@ try {
   const secondRecord = await waitFor(async () => {
     assertAppRunning(secondApp, orphanRecoveryStartup, 'replacement-ownership-record')
     const loaded = loadDesktopGatewayOwnershipRecord(secondOwnershipDir)
-    if (loaded.status !== 'valid' || loaded.record.pid === firstRecord.pid) return null
+    if (
+      loaded.status !== 'valid'
+      || sameDesktopGatewayOwnershipInstance(loaded.record, firstRecord)
+    ) return null
     return await verifyDesktopGatewayOwnership(loaded.record)
       ? loaded.record
       : null
@@ -443,10 +440,10 @@ try {
   ), () => phaseDiagnostics(secondApp, userDataDir, orphanRecoveryStartup))
   ownedInstances.push({ ownershipDir: secondOwnershipDir, record: secondRecord })
 
-  assert.notEqual(secondRecord.pid, firstRecord.pid)
+  assert.notEqual(secondRecord.instance_nonce, firstRecord.instance_nonce)
   await waitFor(() => {
     assertAppRunning(secondApp, orphanRecoveryStartup, 'orphan-process-exit')
-    return !processAlive(firstRecord.pid)
+    return !gatewayProcessSnapshot(firstRecord).alive
   }, 'orphan Gateway process exit', orphanRecoveryStartup.remainingMs(
     'orphan-process-exit',
   ), () => phaseDiagnostics(secondApp, userDataDir, orphanRecoveryStartup))
@@ -478,7 +475,10 @@ try {
   const thirdRecord = await waitFor(() => {
     assertAppRunning(secondApp, childCrashRecovery, 'replacement-after-child-crash')
     const loaded = loadDesktopGatewayOwnershipRecord(secondOwnershipDir)
-    if (loaded.status !== 'valid' || loaded.record.pid === secondRecord.pid) return null
+    if (
+      loaded.status !== 'valid'
+      || sameDesktopGatewayOwnershipInstance(loaded.record, secondRecord)
+    ) return null
     return verifyDesktopGatewayOwnership(loaded.record).then(verified => (
       verified ? loaded.record : null
     ))
@@ -500,7 +500,7 @@ try {
     secondApp,
     userDataDir,
   )
-  assert.notEqual(thirdRecord.pid, secondRecord.pid)
+  assert.notEqual(thirdRecord.instance_nonce, secondRecord.instance_nonce)
   assert.equal(thirdRecord.port, secondRecord.port)
   assert.equal(secondPage.url(), rendererUrlBeforeCrash)
   assert.equal(
@@ -515,7 +515,7 @@ try {
   )
   await waitFor(() => {
     assertAppRunning(secondApp, childCrashRecovery, 'crashed-gateway-process-exit')
-    return !processAlive(secondRecord.pid)
+    return !gatewayProcessSnapshot(secondRecord).alive
   }, 'crashed Gateway process exit', childCrashRecovery.remainingMs(
     'crashed-gateway-process-exit',
   ), () => phaseDiagnostics(secondApp, userDataDir, childCrashRecovery))
@@ -539,7 +539,7 @@ try {
     const fallbackAccepted = canAcceptWindowsElectronShutdownFallback({
       shutdown: successShutdown,
       ...successShutdown.shutdownEvidence,
-    }) && ownershipReleased && !processAlive(thirdRecord.pid)
+    }) && ownershipReleased && !gatewayProcessSnapshot(thirdRecord).alive
     if (!fallbackAccepted) throw successShutdown.error
     console.warn(JSON.stringify({
       event: 'desktop_e2e_windows_shell_wrapper_reaped_after_commit',
@@ -567,7 +567,10 @@ try {
     await closeDesktopForPhase(app, userDataDir, 'finally-first-electron-shutdown')
   }
   for (const { ownershipDir, record } of ownedInstances.reverse()) {
-    if (processAlive(record.pid) && await verifyDesktopGatewayOwnership(record).catch(() => false)) {
+    if (
+      gatewayProcessSnapshot(record).alive
+      && await verifyDesktopGatewayOwnership(record).catch(() => false)
+    ) {
       await requestVerifiedDesktopGatewayShutdown(record).catch(() => false)
       await waitForDesktopGatewayOwnershipRelease(ownershipDir, record, {
         timeoutMs: 10_000,
@@ -577,7 +580,7 @@ try {
   }
   // Never remove a synthetic profile from underneath a process that did not
   // accept the bounded cleanup request; retain it for CI diagnostics instead.
-  const stillLive = ownedInstances.filter(({ record }) => processAlive(record.pid))
+  const stillLive = ownedInstances.filter(({ record }) => gatewayProcessSnapshot(record).alive)
   if (flowSucceeded && stillLive.length === 0) {
     // Chromium can retain DIPS briefly after Electron exits on Windows.
     await removeSyntheticProfile(isolationRoot)

--- a/tests/test_desktop/test_electron_startup_contract.py
+++ b/tests/test_desktop/test_electron_startup_contract.py
@@ -3277,11 +3277,17 @@ def test_desktop_orphan_recovery_has_a_real_electron_process_flow() -> None:
     assert "'orphan Desktop Gateway ownership verification'" in script
     assert "electronChildCleanup.remainingMs('verify-orphan-survived')" in script
     assert "await launchDesktop(" in script
-    assert "loaded.record.pid === firstRecord.pid" in script
+    assert "sameDesktopGatewayOwnershipInstance(loaded.record, firstRecord)" in script
     assert "verifyDesktopGatewayOwnership(loaded.record)" in script
     assert "'verified replacement Desktop Gateway ownership record'" in script
     assert "process.kill(secondRecord.pid, 'SIGKILL')" in script
-    assert "loaded.record.pid === secondRecord.pid" in script
+    assert "sameDesktopGatewayOwnershipInstance(loaded.record, secondRecord)" in script
+    assert "assert.notEqual(secondRecord.instance_nonce, firstRecord.instance_nonce)" in script
+    assert "assert.notEqual(thirdRecord.instance_nonce, secondRecord.instance_nonce)" in script
+    assert "return !gatewayProcessSnapshot(firstRecord).alive" in script
+    assert "return !gatewayProcessSnapshot(secondRecord).alive" in script
+    assert "function processAlive(pid)" not in script
+    assert "gatewayProcesses: ownedInstances.map" in script
     assert "assert.equal(thirdRecord.port, secondRecord.port)" in script
     assert "assert.equal(secondPage.url(), rendererUrlBeforeCrash)" in script
     assert "'renderer-observed-child-crash'" in script
@@ -3306,7 +3312,7 @@ def test_desktop_orphan_recovery_has_a_real_electron_process_flow() -> None:
     assert "closeElectronWithDeadline" in script
     assert "desktopShutdownEvidenceSince" in script
     assert "canAcceptWindowsElectronShutdownFallback" in script
-    assert "ownershipReleased && !processAlive(thirdRecord.pid)" in script
+    assert "ownershipReleased && !gatewayProcessSnapshot(thirdRecord).alive" in script
     assert "'successful-electron-shutdown'" in script
     assert "'finally-second-electron-shutdown'" in script
     assert "'finally-first-electron-shutdown'" in script


### PR DESCRIPTION
## Scope

Scope boundary: Make the Desktop orphan-recovery E2E track Gateway process instances rather than bare PIDs.

The Windows ownership job on PR #1517 exhausted its 245-second phase at `orphan Gateway process exit` after a replacement Gateway and connected renderer were already available. The test used `process.kill(pid, 0)`, so an unrelated process reusing an old Gateway PID could keep that assertion false indefinitely. Replacement detection also incorrectly required a different PID.

Reuse the existing PID/start-time identity probes to distinguish a departed Gateway from a recycled PID. Unknown or incomparable identities remain conservative; an existing original process still fails the bounded wait. Require a distinct verified ownership instance and launch nonce for each replacement. Use the same instance-aware checks for shutdown and cleanup, and include recorded/live start identities in phase diagnostics.

Failure evidence: https://github.com/TokenRhythm/opensquilla/actions/runs/34219194746/job/102038403778

Evidence boundary: The original CI artifact did not record the old PID's live start identity, so PID reuse cannot be established retrospectively for that run. This patch corrects the reproducible PID-only detection defect and preserves diagnostics for a genuine process-exit stall.

Non-goals: Product lifecycle behavior, phase/job timeout increases, retries, or bypassing authenticated Gateway shutdown.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Separate CI test repair prompted by the Windows ownership failure on PR #1517.

## Release Note

Release note: NONE

## Tests

Ruff: `ruff check tests/test_desktop/test_electron_startup_contract.py` passed; `git diff --check` passed.

Pytest: Native Windows, Python 3.12.13: full `tests/test_desktop/test_electron_startup_contract.py` — 129 passed. The 2 affected contracts also passed after removing unrelated formatting changes.

Build: Desktop TypeScript build and full WebUI production build passed.

Regression tests: added — deterministic same-identity, recycled-PID, absent-PID, permission-denied, unknown and opaque identity cases in the existing Desktop telemetry suite. `node scripts/test-ci-case-telemetry.mjs` and `node scripts/test-desktop-gateway-ownership.mjs` passed.

Notes: Native Windows process-start probe verified that the old PID-only check reports a live unrelated process while the new check rejects a synthetic earlier owner and still recognizes the current owner. Real Windows Electron `node scripts/test-desktop-gateway-orphan-recovery-flow.mjs` passed through main-process crash, verified orphan recovery, child crash/restart, renderer reconnection, graceful exit, and synthetic-profile cleanup (`ok: true`). Local runtime: Node 24.15.0 / Electron from the locked dependencies; this is source-development E2E, not packaged release validation. The CI planner includes Windows ownership E2E for these paths; fresh hosted CI is pending.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

Only test scripts and their existing test contracts changed. No real profiles, credentials, or local diagnostic artifacts are included.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

Not applicable.
