### PR TITLE
fix(compat): serialize SQLite fallback work across cancellation

### DIFF
--- a/src/opensquilla/compat/aiosqlite.py
+++ b/src/opensquilla/compat/aiosqlite.py
@@ -8,6 +8,8 @@ async API shape used by project call sites.
 from __future__ import annotations
 
 import asyncio
+import contextvars
+import functools
 import importlib
 import os
 import sqlite3
@@ -114,6 +116,32 @@ _native_available = _native_aiosqlite is not None
 _prefer_native: bool | None = None
 
 
+async def _run_locked[T](
+    lock: asyncio.Lock, func: Callable[..., T], *args: Any, **kwargs: Any
+) -> T:
+    """Keep the connection serialized until native work finishes, even on cancellation."""
+    await lock.acquire()
+    try:
+        context = contextvars.copy_context()
+        worker = asyncio.get_running_loop().run_in_executor(
+            None, functools.partial(context.run, func, *args, **kwargs)
+        )
+    except BaseException:
+        lock.release()
+        raise
+
+    def finished(result: asyncio.Future[T]) -> None:
+        lock.release()
+        # The caller may already have been cancelled; retrieve worker failures.
+        if not result.cancelled():
+            result.exception()
+
+    worker.add_done_callback(finished)
+    # A cancelled awaiter returns promptly, but cannot cancel the worker future
+    # or release its lock while SQLite is still using the connection/cursor.
+    return await asyncio.shield(worker)
+
+
 class _AsyncCursor:
     def __init__(self, cursor: sqlite3.Cursor, lock: asyncio.Lock) -> None:
         self._cursor = cursor
@@ -128,38 +156,30 @@ class _AsyncCursor:
         return self._cursor.lastrowid
 
     async def execute(self, sql: str, params: Iterable[Any] = ()) -> _AsyncCursor:
-        async with self._lock:
-            self._cursor = await asyncio.to_thread(self._cursor.execute, sql, tuple(params))
+        self._cursor = await _run_locked(self._lock, self._cursor.execute, sql, tuple(params))
         return self
 
     async def executemany(
         self, sql: str, seq_of_params: Iterable[Iterable[Any]]
     ) -> _AsyncCursor:
-        async with self._lock:
-            self._cursor = await asyncio.to_thread(
-                self._cursor.executemany,
-                sql,
-                cast(Any, seq_of_params),
-            )
+        self._cursor = await _run_locked(
+            self._lock, self._cursor.executemany, sql, cast(Any, seq_of_params)
+        )
         return self
 
     async def fetchone(self) -> Any:
-        async with self._lock:
-            return await asyncio.to_thread(self._cursor.fetchone)
+        return await _run_locked(self._lock, self._cursor.fetchone)
 
     async def fetchall(self) -> list[Any]:
-        async with self._lock:
-            return await asyncio.to_thread(self._cursor.fetchall)
+        return await _run_locked(self._lock, self._cursor.fetchall)
 
     async def fetchmany(self, size: int | None = None) -> list[Any]:
-        async with self._lock:
-            if size is None:
-                return await asyncio.to_thread(self._cursor.fetchmany)
-            return await asyncio.to_thread(self._cursor.fetchmany, size)
+        if size is None:
+            return await _run_locked(self._lock, self._cursor.fetchmany)
+        return await _run_locked(self._lock, self._cursor.fetchmany, size)
 
     async def close(self) -> None:
-        async with self._lock:
-            await asyncio.to_thread(self._cursor.close)
+        await _run_locked(self._lock, self._cursor.close)
 
     async def __aenter__(self) -> _AsyncCursor:
         return self
@@ -212,8 +232,7 @@ class _AsyncConnection:
         return self._conn.in_transaction
 
     async def _execute(self, sql: str, params: Iterable[Any] = ()) -> _AsyncCursor:
-        async with self._locked:
-            cursor = await asyncio.to_thread(self._conn.execute, sql, tuple(params))
+        cursor = await _run_locked(self._locked, self._conn.execute, sql, tuple(params))
         return _AsyncCursor(cursor, self._locked)
 
     def execute(self, sql: str, params: Iterable[Any] = ()) -> _CursorProxy:
@@ -222,45 +241,35 @@ class _AsyncConnection:
     async def _executemany(
         self, sql: str, seq_of_params: Iterable[Iterable[Any]]
     ) -> _AsyncCursor:
-        async with self._locked:
-            cursor = await asyncio.to_thread(
-                self._conn.executemany,
-                sql,
-                cast(Any, seq_of_params),
-            )
+        cursor = await _run_locked(
+            self._locked, self._conn.executemany, sql, cast(Any, seq_of_params)
+        )
         return _AsyncCursor(cursor, self._locked)
 
     def executemany(self, sql: str, seq_of_params: Iterable[Iterable[Any]]) -> _CursorProxy:
         return _CursorProxy(self._executemany(sql, seq_of_params))
 
     async def executescript(self, script: str) -> None:
-        async with self._locked:
-            await asyncio.to_thread(self._conn.executescript, script)
+        await _run_locked(self._locked, self._conn.executescript, script)
 
     async def commit(self) -> None:
-        async with self._locked:
-            await asyncio.to_thread(self._conn.commit)
+        await _run_locked(self._locked, self._conn.commit)
 
     async def rollback(self) -> None:
-        async with self._locked:
-            await asyncio.to_thread(self._conn.rollback)
+        await _run_locked(self._locked, self._conn.rollback)
 
     async def close(self) -> None:
-        async with self._locked:
-            await asyncio.to_thread(self._conn.close)
+        await _run_locked(self._locked, self._conn.close)
 
     async def cursor(self) -> _AsyncCursor:
-        async with self._locked:
-            cur = await asyncio.to_thread(self._conn.cursor)
+        cur = await _run_locked(self._locked, self._conn.cursor)
         return _AsyncCursor(cur, self._locked)
 
     async def enable_load_extension(self, enabled: bool) -> None:
-        async with self._locked:
-            await asyncio.to_thread(self._conn.enable_load_extension, enabled)
+        await _run_locked(self._locked, self._conn.enable_load_extension, enabled)
 
     async def load_extension(self, path: str) -> None:
-        async with self._locked:
-            await asyncio.to_thread(self._conn.load_extension, path)
+        await _run_locked(self._locked, self._conn.load_extension, path)
 
     async def create_function(
         self,
@@ -270,21 +279,20 @@ class _AsyncConnection:
         *,
         deterministic: bool = False,
     ) -> None:
-        async with self._locked:
-            await asyncio.to_thread(
-                self._conn.create_function,
-                name,
-                num_params,
-                func,
-                deterministic=deterministic,
-            )
+        await _run_locked(
+            self._locked,
+            self._conn.create_function,
+            name,
+            num_params,
+            func,
+            deterministic=deterministic,
+        )
 
     async def set_trace_callback(
         self,
         handler: Callable[[str], Any] | None,
     ) -> None:
-        async with self._locked:
-            await asyncio.to_thread(self._conn.set_trace_callback, handler)
+        await _run_locked(self._locked, self._conn.set_trace_callback, handler)
 
     async def __aenter__(self) -> _AsyncConnection:
         return self

--- a/tests/test_compat/test_aiosqlite.py
+++ b/tests/test_compat/test_aiosqlite.py
@@ -1,10 +1,102 @@
 from __future__ import annotations
 
+import asyncio
+import contextvars
 import importlib
+import threading
+from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 
 from opensquilla.compat import aiosqlite
+
+
+@pytest.mark.parametrize("use_cursor", [False, True], ids=["connection", "cursor"])
+@pytest.mark.parametrize("batch_fails", [False, True], ids=["success", "error"])
+async def test_cancelled_fallback_batch_finishes_before_rollback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, use_cursor: bool, batch_fails: bool
+) -> None:
+    monkeypatch.setattr(aiosqlite, "_FORCE_SQLITE3_FALLBACK", True)
+    conn = await aiosqlite.connect(str(tmp_path / "cancelled-batch.db"))
+    loop = asyncio.get_running_loop()
+    first_inserted = asyncio.Event()
+    release_batch = threading.Event()
+    batch_finished = threading.Event()
+
+    def rows() -> Iterator[tuple[int]]:
+        yield (1,)
+        loop.call_soon_threadsafe(first_inserted.set)
+        try:
+            assert release_batch.wait(timeout=10)
+            yield (2,)
+            if batch_fails:
+                yield (1,)  # A native IntegrityError after the caller has gone away.
+        finally:
+            batch_finished.set()
+
+    async def insert() -> None:
+        target = await conn.cursor() if use_cursor else conn
+        await target.executemany("INSERT INTO items VALUES (?)", rows())
+
+    batch: asyncio.Task[None] | None = None
+    rollback: asyncio.Task[None] | None = None
+    try:
+        await conn.execute("CREATE TABLE items (value INTEGER PRIMARY KEY)")
+        await conn.commit()
+        batch = asyncio.create_task(insert())
+        await asyncio.wait_for(first_inserted.wait(), timeout=5)
+        batch.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(batch, timeout=5)
+
+        rollback = asyncio.create_task(conn.rollback())
+        # The writer is stopped between rows, outside SQLite's internal mutex.
+        # A rollback must remain queued until the entire native batch finishes.
+        done, _ = await asyncio.wait({rollback}, timeout=0.25)
+        rollback_overtook_batch = bool(done)
+        release_batch.set()
+        assert await asyncio.to_thread(batch_finished.wait, 5)
+        await asyncio.wait_for(rollback, timeout=5)
+
+        async with conn.execute("SELECT value FROM items") as cursor:
+            assert await cursor.fetchall() == [], "cancelled writes escaped the rollback"
+        assert not rollback_overtook_batch
+        await conn.execute("INSERT INTO items VALUES (3)")
+        await conn.commit()
+    finally:
+        release_batch.set()
+        if batch is not None:
+            await asyncio.gather(batch, return_exceptions=True)
+        if rollback is not None:
+            await asyncio.gather(rollback, return_exceptions=True)
+        await conn.close()
+
+    # A fresh connection must see only the subsequent successful transaction.
+    async with aiosqlite.connect(str(tmp_path / "cancelled-batch.db")) as reader:
+        async with reader.execute("SELECT value FROM items") as cursor:
+            assert [row[0] for row in await cursor.fetchall()] == [3]
+
+
+async def test_fallback_preserves_context_and_releases_lock_after_sql_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(aiosqlite, "_FORCE_SQLITE3_FALLBACK", True)
+    request_id = contextvars.ContextVar("request_id", default="missing")
+    async with aiosqlite.connect(":memory:") as conn:
+        await conn.create_function("current_request", 0, request_id.get)
+        token = request_id.set("request-123")
+        try:
+            async with conn.execute("SELECT current_request()") as cursor:
+                row = await cursor.fetchone()
+                assert row is not None and row[0] == "request-123"
+        finally:
+            request_id.reset(token)
+        with pytest.raises(aiosqlite.OperationalError, match="no such table"):
+            await conn.execute("SELECT * FROM missing_table")
+        async with conn.execute("SELECT 42") as cursor:
+            row = await cursor.fetchone()
+            assert row is not None and row[0] == 42
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope

Cancelling a SQLite3 fallback operation releases its `asyncio.Lock` while the native worker thread continues. A subsequent rollback can run between rows of `executemany()`, letting later inserts survive the rollback. This affects both connection and cursor entry points.

Scope boundary: retain the shared connection lock until the native executor future completes. Shield that future from caller cancellation, release the lock from its completion callback, retrieve abandoned worker errors, and preserve context variables when dispatching work. Cancelled callers still receive `CancelledError` promptly; subsequent connection/cursor operations wait for the native operation to finish.

Non-goals: changing the native aiosqlite backend, transaction APIs, scheduler state transitions, or interrupting SQLite statements.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: independently found during persistence/cancellation review after #1576. Current issue/PR searches for SQLite, aiosqlite, and cancellation found no corresponding repair.

## Release Note

Release note: Prevent cancelled SQLite3 fallback operations from overlapping rollback or other connection operations and leaving partially committed data.

## Tests

Ruff: `python -m ruff check src tests` passed.

Type checking: `python -m mypy src/opensquilla --show-error-codes` passed for 1,553 source files.

Pytest:

- Four regression cases fail on unchanged base `bbd0c42`: connection/cursor batches, each with a successful or failing native completion after cancellation. A real file-backed SQLite database and an event-controlled parameter iterator demonstrate rows surviving rollback. All four pass with the fix; a reopened connection verifies persisted state after a subsequent successful transaction.
- Context propagation through a SQLite user-defined function and recovery after an ordinary SQL error are also covered.
- `python -m pytest tests/test_compat tests/test_scheduler -q --tb=short`: 194 passed.
- With `OPENSQUILLA_FORCE_SQLITE3_BACKEND=1` and `PYTHONUTF8=1`, `python -m pytest tests/test_compat tests/test_scheduler tests/test_persistence -q --tb=short --maxfail=3`: 352 passed, 4 skipped. Without UTF-8, two migration tests fail under the Windows GBK default; both failures were reproduced on unchanged base `bbd0c42`.
- The full repository test suite is not claimed to pass. An initial run was stopped for local memory pressure. A subsequent first-failure run reached 406 passed and 18 skipped before the existing Windows `test_stop_kills_leaderless_descendant_and_gateway_accepts_next_task` timed out waiting for `leader-ready`. The same failure was reproduced on unchanged base `bbd0c42`, with the same interpreter and UTF-8 environment.

Build: `npm --prefix opensquilla-webui run build` passed under Node.js 24.19.0, including artifact verification/staging (397 files); `uv build --wheel --python 3.13` passed.

Regression tests: added.

Notes: Windows, Python 3.13.14. The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

Only synthetic rows and temporary local databases are used. No credentials, private transcripts, or AI session artifacts are included.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] References point to existing repository files.
- [x] Examples use synthetic data and contain no secrets.
- [x] No public configuration or API changes require documentation updates.
