### PR TITLE
Add extra_headers for OpenAI-family LLM providers

### DIFF
--- a/src/opensquilla/gateway/adapters/setup_mutations.py
+++ b/src/opensquilla/gateway/adapters/setup_mutations.py
@@ -249,6 +249,7 @@ class GatewaySetupRuntimePort(SetupRuntimePort):
                 base_url=runtime.base_url,
                 proxy=runtime.proxy,
                 provider_routing=runtime.provider_routing,
+                extra_headers=dict(getattr(runtime, "extra_headers", None) or {}),
             )
         )
 

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -3268,6 +3268,9 @@ async def build_services(
                     base_url=resolved_base,
                     proxy=proxy,
                     provider_routing=llm_runtime.provider_routing,
+                    extra_headers=dict(
+                        getattr(llm_runtime, "extra_headers", None) or {}
+                    ),
                 )
             )
         )

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -430,6 +430,11 @@ class LlmProviderConfig(BaseSettings):
     api_key_env: str = ""
     base_url: str = "https://tokenrhythm.studio/v1"
     proxy: str = ""  # explicit HTTP proxy URL (e.g. http://127.0.0.1:7890)
+    # Operator-defined extra HTTP headers for upstream model requests
+    # (e.g. routing gateways that require a session header). Never store
+    # secrets here; Authorization is always managed separately and cannot
+    # be overridden through this field.
+    extra_headers: dict[str, str] = Field(default_factory=dict)
     max_tokens: int = 0  # 0 = auto-resolve from model catalog; >0 = explicit override
     # 0 = auto-resolve from model catalog; >0 = explicit context-window override
     # in tokens. Drives the provider-context budget ladder and context usage

--- a/src/opensquilla/gateway/llm_runtime.py
+++ b/src/opensquilla/gateway/llm_runtime.py
@@ -42,6 +42,7 @@ class LlmRuntimeConfig:
     base_url: str
     proxy: str
     provider_routing: dict[str, str]
+    extra_headers: dict[str, str] = field(default_factory=dict)
     api_key_from_env: bool = False
     api_key_env_name: str = ""
     base_url_from_env: bool = False
@@ -340,6 +341,7 @@ def resolve_llm_runtime_config(config: Any) -> LlmRuntimeConfig:
             provider,
             getattr(llm, "provider_routing", {}),
         ),
+        extra_headers=dict(getattr(llm, "extra_headers", None) or {}),
         api_key_from_env=credential.source == "env",
         api_key_env_name=credential.env_name,
         base_url_from_env=base_url_from_env,

--- a/src/opensquilla/gateway/provider_runtime.py
+++ b/src/opensquilla/gateway/provider_runtime.py
@@ -24,6 +24,7 @@ def resolve_provider_selector_config(config: Any) -> ProviderConfig | None:
         base_url=runtime.base_url,
         proxy=runtime.proxy,
         provider_routing=runtime.provider_routing,
+        extra_headers=dict(getattr(runtime, "extra_headers", None) or {}),
     )
 
 

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -2997,6 +2997,24 @@ def _prompt_json_schema_config(
     )
 
 
+# Header names an operator must never override via ``extra_headers``: losing
+# them breaks auth and response framing for every adapter. Compared
+# case-insensitively because httpx normalises header names on the wire.
+_RESERVED_EXTRA_HEADER_NAMES = frozenset({"authorization", "content-type", "accept"})
+
+
+def merge_extra_headers(
+    headers: dict[str, str], extra: Mapping[str, str] | None
+) -> dict[str, str]:
+    """Merge operator-defined headers (e.g. a session header a routing
+    gateway requires), keeping adapter-managed framing intact."""
+    for name, value in (extra or {}).items():
+        if str(name).lower() in _RESERVED_EXTRA_HEADER_NAMES:
+            continue
+        headers[str(name)] = str(value)
+    return headers
+
+
 class OpenAIProvider:
     """Streams from OpenAI-compatible Chat Completions API (SSE)."""
 
@@ -3015,12 +3033,14 @@ class OpenAIProvider:
         compat: OpenAICompatPolicy | None = None,
         replay_provider_state: bool = True,
         provider_id: str | None = None,
+        extra_headers: Mapping[str, str] | None = None,
     ) -> None:
         self._api_key = clean_header_secret(api_key, label="LLM API key")
         self._model = model
         self._base_url = base_url.rstrip("/")
         self._proxy = _resolve_llm_proxy(proxy)
         self._org_id = org_id
+        self._extra_headers = dict(extra_headers or {})
         if not provider_kind:
             # Fallback for direct construction only (tests, ad-hoc
             # embedding): every production path flows through
@@ -3630,6 +3650,7 @@ class OpenAIProvider:
                 cfg.provider_request_correlation,
             )
         )
+        merge_extra_headers(headers, self._extra_headers)
         correlation = cfg.provider_request_correlation
         if (
             self._provider_kind == "openrouter"
@@ -6059,6 +6080,7 @@ class OpenAIProvider:
             else {}
         )
         headers.update(provider_app_headers(self._base_url))
+        merge_extra_headers(headers, self._extra_headers)
         safe_request_error: Exception | None = None
         cancelled_request_error: asyncio.CancelledError | None = None
         client: Any = None

--- a/src/opensquilla/provider/openai_responses.py
+++ b/src/opensquilla/provider/openai_responses.py
@@ -29,7 +29,12 @@ from .error_redaction import (
     redacted_httpx_error,
 )
 from .failures import retry_after_from_headers
-from .openai import _http_error_body_text, _resolve_llm_proxy, _versioned_api_url
+from .openai import (
+    _http_error_body_text,
+    _resolve_llm_proxy,
+    _versioned_api_url,
+    merge_extra_headers,
+)
 from .protocol import ProviderConnectionConfig, ProviderMetadata
 from .request_proof import (
     RESPONSES_REQUEST_ENVELOPE,
@@ -209,6 +214,7 @@ class OpenAIResponsesProvider:
         org_id: str | None = None,
         proxy: str | None = None,
         provider_id: str | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> None:
         self._api_key = clean_header_secret(api_key, label="LLM API key")
         self._model = model
@@ -216,6 +222,7 @@ class OpenAIResponsesProvider:
         self._org_id = org_id
         self._proxy = _resolve_llm_proxy(proxy)
         self.provider_id = (provider_id or self.provider_name).strip()
+        self._extra_headers = dict(extra_headers or {})
 
     @property
     def model(self) -> str:
@@ -362,6 +369,7 @@ class OpenAIResponsesProvider:
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
+        merge_extra_headers(headers, self._extra_headers)
         if self._org_id:
             headers["OpenAI-Organization"] = self._org_id
 
@@ -934,6 +942,7 @@ class OpenAIResponsesProvider:
         (e.g. onboarding discovery) can classify it.
         """
         headers = {"Authorization": f"Bearer {self._api_key}"}
+        merge_extra_headers(headers, self._extra_headers)
         try:
             async with httpx.AsyncClient(
                 timeout=30,
@@ -993,6 +1002,7 @@ class OpenAIResponsesProvider:
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
+        merge_extra_headers(headers, self._extra_headers)
         if self._org_id:
             headers["OpenAI-Organization"] = self._org_id
         endpoint = self._api_url("/v1/responses/compact")

--- a/src/opensquilla/provider/selector.py
+++ b/src/opensquilla/provider/selector.py
@@ -37,6 +37,10 @@ class ProviderConfig:
     org_id: str = ""
     proxy: str = ""  # explicit HTTP proxy URL
     provider_routing: dict[str, str] = field(default_factory=dict)
+    # Operator-defined extra HTTP headers, merged into upstream requests by
+    # adapters that support them (OpenAI-family). Adapter-managed framing
+    # (Authorization/Content-Type/Accept) always wins.
+    extra_headers: dict[str, str] = field(default_factory=dict)
     # False for cross-provider tier execution: provider-bound continuity
     # state minted elsewhere (thinking blocks / thought signatures) must not
     # be replayed to a provider that did not produce it.
@@ -237,6 +241,7 @@ class ProviderBuildContext:
     org_id: str = ""
     proxy: str = ""
     provider_routing: Mapping[str, str] = field(default_factory=dict)
+    extra_headers: Mapping[str, str] = field(default_factory=dict)
     replay_provider_state: bool = True
     # OllamaProvider knob; never populated today because ProviderConfig has
     # no num_ctx field — kept visible so the gap is explicit.
@@ -258,6 +263,7 @@ def _build_context(cfg: ProviderConfig, spec: ProviderSpec) -> ProviderBuildCont
         org_id=cfg.org_id,
         proxy=cfg.proxy,
         provider_routing=dict(cfg.provider_routing),
+        extra_headers=dict(cfg.extra_headers),
         replay_provider_state=cfg.replay_provider_state,
         auth_header_style=spec.auth_header_style,
         compat=spec.compat,
@@ -307,6 +313,8 @@ def _build_openai_compat(ctx: ProviderBuildContext) -> LLMProvider:
         kwargs["proxy"] = ctx.proxy
     if ctx.provider_routing:
         kwargs["provider_routing"] = ctx.provider_routing
+    if ctx.extra_headers:
+        kwargs["extra_headers"] = dict(ctx.extra_headers)
     return OpenAIProvider(**kwargs)
 
 
@@ -327,6 +335,8 @@ def _build_openai_responses(ctx: ProviderBuildContext) -> LLMProvider:
         kwargs["org_id"] = ctx.org_id
     if ctx.proxy:
         kwargs["proxy"] = ctx.proxy
+    if ctx.extra_headers:
+        kwargs["extra_headers"] = dict(ctx.extra_headers)
     return OpenAIResponsesProvider(**kwargs)
 
 

--- a/tests/test_provider_extra_headers.py
+++ b/tests/test_provider_extra_headers.py
@@ -1,0 +1,243 @@
+"""Operator-defined extra request headers for OpenAI-family providers.
+
+Some routing gateways in front of a model API require extra headers (e.g.
+opencode Zen/Go answers ``400 MissingSessionID`` on ``/responses`` without
+``x-opencode-session``). ``extra_headers`` carries them from provider config
+to the wire; adapter-managed framing (Authorization/Content-Type/Accept)
+always wins. Every test below runs offline against a mocked transport.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import httpx
+
+from opensquilla.gateway.config import LlmProviderConfig
+from opensquilla.provider import ChatConfig, Message
+from opensquilla.provider.openai import OpenAIProvider, merge_extra_headers
+from opensquilla.provider.openai_responses import OpenAIResponsesProvider
+from opensquilla.provider.registry import get_provider_spec
+from opensquilla.provider.selector import (
+    ProviderConfig,
+    _build_context,
+    _build_openai_compat,
+    _build_openai_responses,
+)
+
+EXTRA = {"x-opencode-session": "session-under-test"}
+
+
+def _capture_transport(
+    monkeypatch: Any,
+    module: str,
+    response: httpx.Response,
+    calls: list[httpx.Request],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return response
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(
+        f"opensquilla.provider.{module}.httpx.AsyncClient",
+        patched_async_client,
+    )
+
+
+def _responses_completed() -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "id": "resp_test",
+            "model": "m",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "ok"}],
+                }
+            ],
+            "usage": {
+                "input_tokens": 5,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens": 2,
+                "output_tokens_details": {"reasoning_tokens": 0},
+                "total_tokens": 7,
+            },
+        },
+    )
+
+
+def _chat_sse_text(text: str) -> bytes:
+    chunks = [
+        {"choices": [{"delta": {"content": text}, "finish_reason": None}]},
+        {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+    ]
+    body = b"".join(f"data: {json.dumps(chunk)}\n\n".encode() for chunk in chunks)
+    return body + b"data: [DONE]\n\n"
+
+
+def test_merge_extra_headers_passes_custom_headers() -> None:
+    headers = {"Authorization": "Bearer k"}
+    out = merge_extra_headers(headers, EXTRA)
+    assert out["x-opencode-session"] == "session-under-test"
+    assert out["Authorization"] == "Bearer k"
+
+
+def test_merge_extra_headers_protects_reserved_names() -> None:
+    headers = {
+        "Authorization": "Bearer k",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+    out = merge_extra_headers(
+        headers,
+        {
+            "Authorization": "Bearer evil",
+            "CONTENT-TYPE": "text/plain",
+            "accept": "text/html",
+            "x-opencode-session": "s",
+        },
+    )
+    assert out["Authorization"] == "Bearer k"
+    assert out["Content-Type"] == "application/json"
+    assert out["Accept"] == "application/json"
+    assert out["x-opencode-session"] == "s"
+
+
+def test_merge_extra_headers_none_safe() -> None:
+    headers = {"Authorization": "Bearer k"}
+    assert merge_extra_headers(headers, None) == {"Authorization": "Bearer k"}
+
+
+def test_responses_chat_sends_extra_headers(monkeypatch: Any) -> None:
+    calls: list[httpx.Request] = []
+    _capture_transport(
+        monkeypatch, "openai_responses", _responses_completed(), calls
+    )
+    provider = OpenAIResponsesProvider(
+        api_key="test", model="m", extra_headers=dict(EXTRA)
+    )
+
+    async def _run() -> list[Any]:
+        return [
+            event
+            async for event in provider.chat(
+                [Message(role="user", content="hi")], config=ChatConfig()
+            )
+        ]
+
+    asyncio.run(_run())
+    assert calls, "expected at least one upstream request"
+    sent = calls[-1].headers
+    assert sent["x-opencode-session"] == "session-under-test"
+    assert sent["authorization"] == "Bearer test"
+
+
+def test_responses_list_models_sends_extra_headers(monkeypatch: Any) -> None:
+    calls: list[httpx.Request] = []
+    _capture_transport(
+        monkeypatch,
+        "openai_responses",
+        httpx.Response(200, json={"data": []}),
+        calls,
+    )
+    provider = OpenAIResponsesProvider(
+        api_key="test", model="m", extra_headers=dict(EXTRA)
+    )
+    asyncio.run(provider.list_models())
+    assert calls, "expected a catalog request"
+    assert calls[-1].headers["x-opencode-session"] == "session-under-test"
+
+
+def test_chat_completions_sends_extra_headers(monkeypatch: Any) -> None:
+    calls: list[httpx.Request] = []
+    _capture_transport(
+        monkeypatch,
+        "openai",
+        httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=_chat_sse_text("ok"),
+        ),
+        calls,
+    )
+    provider = OpenAIProvider(
+        api_key="k", model="m", provider_kind="openai", extra_headers=dict(EXTRA)
+    )
+
+    async def _run() -> list[Any]:
+        return [
+            event
+            async for event in provider.chat(
+                [Message(role="user", content="hi")], config=ChatConfig()
+            )
+        ]
+
+    asyncio.run(_run())
+    assert calls, "expected at least one upstream request"
+    sent = calls[-1].headers
+    assert sent["x-opencode-session"] == "session-under-test"
+    assert sent["authorization"] == "Bearer k"
+
+
+def test_chat_list_models_sends_extra_headers(monkeypatch: Any) -> None:
+    calls: list[httpx.Request] = []
+    _capture_transport(
+        monkeypatch,
+        "openai",
+        httpx.Response(200, json={"data": []}),
+        calls,
+    )
+    provider = OpenAIProvider(
+        api_key="k", model="m", provider_kind="openai", extra_headers=dict(EXTRA)
+    )
+    asyncio.run(provider.list_models())
+    assert calls, "expected a catalog request"
+    assert calls[-1].headers["x-opencode-session"] == "session-under-test"
+
+
+def test_selector_plumbing_carries_extra_headers() -> None:
+    spec = get_provider_spec("openai_responses")
+    cfg = ProviderConfig(
+        provider="openai_responses",
+        model="m",
+        api_key="k",
+        extra_headers=dict(EXTRA),
+    )
+    ctx = _build_context(cfg, spec)
+    assert ctx.extra_headers == EXTRA
+    provider = _build_openai_responses(ctx)
+    assert isinstance(provider, OpenAIResponsesProvider)
+    assert provider._extra_headers == EXTRA
+
+
+def test_compat_factory_carries_extra_headers() -> None:
+    spec = get_provider_spec("openai")
+    cfg = ProviderConfig(
+        provider="openai", model="m", api_key="k", extra_headers=dict(EXTRA)
+    )
+    ctx = _build_context(cfg, spec)
+    provider = _build_openai_compat(ctx)
+    assert isinstance(provider, OpenAIProvider)
+    assert provider._extra_headers == EXTRA
+
+
+def test_llm_provider_config_accepts_extra_headers() -> None:
+    assert LlmProviderConfig().extra_headers == {}
+    cfg = LlmProviderConfig(
+        provider="openai_responses",
+        model="m",
+        extra_headers={"x-opencode-session": "s"},
+    )
+    assert cfg.extra_headers == {"x-opencode-session": "s"}


### PR DESCRIPTION
## Summary

Adds operator-defined `extra_headers` for OpenAI-family text providers
(`openai` chat-completions and `openai_responses`), plumbed from `[llm]`
config through the runtime (`LlmRuntimeConfig`) and selector
(`ProviderConfig` / `ProviderBuildContext`) into request headers.
Adapter-managed framing (`Authorization` / `Content-Type` / `Accept`)
always wins; the merge is case-insensitive.

## Motivation (verified against a live gateway)

The opencode Zen/Go gateway requires `x-opencode-session` on `/responses`
and answers `400 MissingSessionID` without it:

```json
{"type":"error","error":{"type":"MissingSessionID","message":"Error from provider (Console Go): Request is missing x-opencode-session and cannot be routed efficiently."}}
```

OpenSquilla had no way to send custom headers — no CLI flag, no schema
field (`headers` exists only on `MemoryEmbeddingRemoteConfig`) — so any
model behind such a gateway was unusable through it. Verified live with
`curl`: same key + endpoint + model fails without the header and succeeds
with it. After this change (plus the header in config), `opensquilla agent`
completes against that gateway.

## Usage

```toml
[llm]
provider = "openai_responses"
model = "muse-spark-1.3-contributor"
api_key_env = "GOKEY"
base_url = "https://opencode.ai/zen/go/v1"
extra_headers = { x-opencode-session = "my-session" }
```

Never store secrets in `extra_headers`; `Authorization` cannot be
overridden through it. CLI wizard / Web UI fields for this are intentionally
left out to keep this change small — happy to follow up if wanted.

## Tests

- New `tests/test_provider_extra_headers.py`: 10 offline tests
  (MockTransport wire assertions for both adapters including `list_models`,
  reserved-header protection, selector plumbing, config parsing). 10/10 pass.
- `ruff check` clean on all touched files.
- Related suites green: `test_provider_openai_responses` +
  `test_provider_selector` (56 passed), `test_provider_stream_contract` +
  `test_gateway_config_default_provider` (43 passed).
- Full suite and webui build not run locally (no frontend changes; full
  suite includes live tests — leaving those to CI).

Linked Issues: None
