### PR TITLE
Preview uploaded chat images before and after sending

### DIFF
--- a/opensquilla-webui/e2e/attachment-drag-upload.spec.ts
+++ b/opensquilla-webui/e2e/attachment-drag-upload.spec.ts
@@ -148,21 +148,22 @@ async function readDownloadBytes(download: Download): Promise<Buffer> {
   return Buffer.concat(chunks)
 }
 
-async function openMockedChat(page: Page, capturedSends: CapturedSend[], options: MockRpcOptions = {}) {
+async function openMockedChat(page: Page, capturedSends: CapturedSend[], options: MockRpcOptions = {}, url = CONTROL_URL) {
   await mockApprovals(page)
   await mockRpc(page, capturedSends, options)
-  await page.goto(CONTROL_URL)
+  await page.goto(url)
   await expect(page.locator('.chat-textarea')).toBeVisible()
   await expect(page.locator('.conn-pill.connected')).toBeVisible()
 }
 
-async function dropFiles(page: Page, files: Array<{ name: string; type: string; text?: string; size?: number }>) {
+async function dropFiles(page: Page, files: Array<{ name: string; type: string; text?: string; size?: number; base64?: string }>) {
   await page.evaluate((fileSpecs) => {
     const dataTransfer = new DataTransfer()
     for (const spec of fileSpecs) {
-      const parts = spec.size
-        ? [new Uint8Array(spec.size)]
-        : [spec.text || 'drag upload']
+      const decoded = spec.base64 ? Uint8Array.from(atob(spec.base64), char => char.charCodeAt(0)) : undefined
+      const bytes = spec.size ? new Uint8Array(spec.size) : decoded
+      if (bytes && decoded) bytes.set(decoded)
+      const parts = bytes ? [bytes] : [spec.text || 'drag upload']
       dataTransfer.items.add(new File(parts, spec.name, { type: spec.type }))
     }
     const chat = document.querySelector('.chat')
@@ -377,9 +378,119 @@ test.describe('attachment drag upload', () => {
     expect(await readDownloadBytes(download)).toEqual(Buffer.from('<html>'))
   })
 
-  test('keeps image history replay attachments as thumbnails', async ({ page }) => {
+  test('previews uploaded images before and immediately after sending', async ({ page }) => {
+    const capturedSends: CapturedSend[] = []
+    const downloads: Download[] = []
+    page.on('download', download => downloads.push(download))
+    await openMockedChat(page, capturedSends)
+
+    await dropFiles(page, [
+      { name: 'draft-image.png', type: 'image/png', base64: HISTORY_IMAGE_DATA },
+    ])
+    await expect(page.locator('.attachment-chip--busy')).toHaveCount(0)
+    const composerPreview = page.locator('.attachment-chip__preview')
+    await expect(composerPreview).toHaveAccessibleName('Open draft-image.png')
+    await composerPreview.focus()
+    await page.keyboard.press('Enter')
+
+    const preview = page.locator('.deliv-preview[role="dialog"]')
+    const previewImage = preview.locator('.deliv-preview__image')
+    await expect(preview).toBeVisible()
+    await expect(previewImage).toHaveAttribute('alt', 'draft-image.png')
+    await expect.poll(() => previewImage.evaluate((image: HTMLImageElement) => image.naturalWidth)).toBe(1)
+    expect(downloads).toHaveLength(0)
+    expect(capturedSends).toHaveLength(0)
+
+    await page.keyboard.press('Escape')
+    await expect(preview).toHaveCount(0)
+    await expect(composerPreview).toBeFocused()
+    await expect(page.locator('.attachment-chip')).toContainText('draft-image.png')
+
+    await page.locator('.chat-send-btn[aria-label="Send"]').click()
+    await expect.poll(() => capturedSends.length).toBe(1)
+    await expect(page.locator('.attachment-chip')).toHaveCount(0)
+    const sentPreview = page.locator('.msg-thumb-button')
+    await expect(sentPreview).toHaveAccessibleName('Open draft-image.png')
+    await sentPreview.click()
+    await expect(preview).toBeVisible()
+    await expect.poll(() => previewImage.evaluate((image: HTMLImageElement) => image.naturalWidth)).toBe(1)
+    expect(downloads).toHaveLength(0)
+  })
+
+  test('closes draft image previews when browser history switches agents', async ({ page }) => {
+    const capturedSends: CapturedSend[] = []
+    const downloads: Download[] = []
+    page.on('download', download => downloads.push(download))
+    await openMockedChat(page, capturedSends, {}, `${CONTROL_URL}?agent=research`)
+    await page.locator('.sidebar-new-session').click()
+    await expect(page).toHaveURL(/\/chat\/new\?agent=main$/)
+
+    await dropFiles(page, [
+      { name: 'main-draft.png', type: 'image/png', base64: HISTORY_IMAGE_DATA },
+    ])
+    await expect(page.locator('.attachment-chip--busy')).toHaveCount(0)
+    await page.locator('.attachment-chip__preview').click()
+    const preview = page.locator('.deliv-preview[role="dialog"]')
+    await expect(preview.locator('.deliv-preview__image')).toHaveAttribute('alt', 'main-draft.png')
+
+    await page.goBack()
+    await expect(page).toHaveURL(/\/chat\/new\?agent=research$/)
+    await expect(preview).toHaveCount(0)
+    await expect(page.locator('.attachment-chip')).toHaveCount(0)
+
+    await dropFiles(page, [
+      { name: 'research-draft.png', type: 'image/png', base64: HISTORY_IMAGE_DATA },
+    ])
+    await expect(page.locator('.attachment-chip--busy')).toHaveCount(0)
+    await page.locator('.attachment-chip__preview').click()
+    await expect(preview.locator('.deliv-preview__image')).toHaveAttribute('alt', 'research-draft.png')
+
+    await page.goForward()
+    await expect(page).toHaveURL(/\/chat\/new\?agent=main$/)
+    await expect(preview).toHaveCount(0)
+    await expect(page.locator('.attachment-chip')).toHaveCount(0)
+    expect(capturedSends).toHaveLength(0)
+    expect(downloads).toHaveLength(0)
+  })
+
+  test('closes draft image previews when a new task resets the same URL', async ({ page }) => {
+    const capturedSends: CapturedSend[] = []
+    const downloads: Download[] = []
+    page.on('download', download => downloads.push(download))
+    await page.addInitScript(() => {
+      localStorage.setItem('opensquilla.shortcuts', JSON.stringify({
+        'new-chat': { enabled: true },
+      }))
+    })
+    await openMockedChat(page, capturedSends, {}, `${CONTROL_URL}?agent=main`)
+    await page.locator('.chat-textarea').fill('Describe this draft image')
+    await dropFiles(page, [
+      { name: 'reset-draft.png', type: 'image/png', base64: HISTORY_IMAGE_DATA },
+    ])
+    await expect(page.locator('.attachment-chip--busy')).toHaveCount(0)
+    await page.locator('.attachment-chip__preview').click()
+    const preview = page.locator('.deliv-preview[role="dialog"]')
+    await expect(preview.locator('.deliv-preview__image')).toHaveAttribute('alt', 'reset-draft.png')
+    const draftUrl = page.url()
+    const shortcutHint = page.locator('.sidebar-new-session .sidebar-kbd')
+    await expect(shortcutHint).toHaveText(/^(Ctrl\+Shift\+K|⌘⇧K)$/)
+    const shortcut = (await shortcutHint.innerText()).includes('⌘') ? 'Meta+Shift+K' : 'Control+Shift+K'
+
+    await page.keyboard.press(shortcut)
+    await expect(page).toHaveURL(draftUrl)
+    await expect(page.locator('.chat-textarea')).toHaveValue('')
+    await expect(preview).toHaveCount(0)
+    await expect(page.locator('.attachment-chip')).toHaveCount(0)
+    await expect(page.locator('.chat-textarea')).toBeFocused()
+    expect(capturedSends).toHaveLength(0)
+    expect(downloads).toHaveLength(0)
+  })
+
+  test('previews image history attachments and downloads only from the preview action', async ({ page }) => {
     const capturedSends: CapturedSend[] = []
     const historyRequests: Array<Record<string, unknown>> = []
+    const downloads: Download[] = []
+    page.on('download', download => downloads.push(download))
     await openMockedChat(page, capturedSends, {
       replayHistoryAfterSend: true,
       historyAttachmentFixture: 'image',
@@ -400,6 +511,105 @@ test.describe('attachment drag upload', () => {
     await expect(thumb).toBeVisible()
     await expect(thumb).toHaveAttribute('src', `data:image/png;base64,${HISTORY_IMAGE_DATA}`)
     await expect(page.locator('.msg-attachments .msg-file-chip')).toHaveCount(0)
+
+    await page.getByRole('button', { name: 'Open photo.png', exact: true }).click()
+    const preview = page.locator('.deliv-preview[role="dialog"]')
+    const previewImage = preview.locator('.deliv-preview__image')
+    await expect(preview).toBeVisible()
+    await expect(previewImage).toHaveAttribute('alt', 'photo.png')
+    await expect.poll(() => previewImage.evaluate((image: HTMLImageElement) => image.naturalWidth)).toBe(1)
+    expect(downloads).toHaveLength(0)
+
+    const downloadPromise = page.waitForEvent('download')
+    await preview.locator('.deliv-preview__actions').getByRole('button', { name: 'Download', exact: true }).click()
+    const download = await downloadPromise
+    expect(download.suggestedFilename()).toBe('photo.png')
+    expect(await readDownloadBytes(download)).toEqual(Buffer.from(HISTORY_IMAGE_DATA, 'base64'))
+    expect(downloads).toHaveLength(1)
+  })
+
+  test('previews staged images locally before send and through authenticated history access', async ({ page }) => {
+    const capturedSends: CapturedSend[] = []
+    const historyRequests: Array<Record<string, unknown>> = []
+    const imageRequests: Array<{ authorization?: string; sessionKey?: string; url: string }> = []
+    const downloads: Download[] = []
+    page.on('download', download => downloads.push(download))
+    await page.addInitScript(() => {
+      sessionStorage.setItem('opensquilla.wsToken', 'token-e2e')
+    })
+    await page.route('**/api/v1/files/upload', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        file_uuid: 'u-e2e-staged-image',
+        filename: 'staged-image.png',
+        mime: 'image/png',
+        size: 2_000_001,
+      }),
+    }))
+    await page.route('**/api/v1/attachments/**', route => {
+      const request = route.request()
+      imageRequests.push({
+        authorization: request.headers().authorization,
+        sessionKey: request.headers()['x-opensquilla-session-key'],
+        url: request.url(),
+      })
+      return route.fulfill({
+        status: 200,
+        contentType: 'image/png',
+        headers: { 'content-disposition': 'attachment; filename="server-staged-image.png"' },
+        body: Buffer.from(HISTORY_IMAGE_DATA, 'base64'),
+      })
+    })
+    await openMockedChat(page, capturedSends, {
+      replayHistoryAfterSend: true,
+      historyAttachmentFixture: 'staged',
+      historyRequests,
+    })
+
+    await dropFiles(page, [
+      { name: 'staged-image.png', type: 'image/png', base64: HISTORY_IMAGE_DATA, size: 2_000_001 },
+    ])
+    await expect(page.locator('.attachment-chip--busy')).toHaveCount(0)
+    await page.locator('.attachment-chip__preview').click()
+    const preview = page.locator('.deliv-preview[role="dialog"]')
+    const previewImage = preview.locator('.deliv-preview__image')
+    await expect(preview).toBeVisible()
+    await expect.poll(() => previewImage.evaluate((image: HTMLImageElement) => image.naturalWidth)).toBe(1)
+    expect(imageRequests).toHaveLength(0)
+    expect(downloads).toHaveLength(0)
+    await page.keyboard.press('Escape')
+    await expect(preview).toHaveCount(0)
+
+    const historyCallsBeforeSend = historyRequests.length
+    await page.locator('.chat-send-btn[aria-label="Send"]').click()
+    await expect.poll(() => capturedSends.length).toBe(1)
+    await expect.poll(() => historyRequests.length).toBeGreaterThan(historyCallsBeforeSend)
+    expect(capturedSends[0].attachments?.[0]).toMatchObject({
+      file_uuid: 'u-e2e-staged-image',
+      name: 'staged-image.png',
+      mime: 'image/png',
+    })
+
+    await page.locator('.msg-attachments').getByRole('button', { name: 'Open staged-image.png', exact: true }).click()
+    await expect(preview).toBeVisible()
+    await expect.poll(() => previewImage.evaluate((image: HTMLImageElement) => image.naturalWidth)).toBe(1)
+    await expect.poll(() => imageRequests.length).toBe(1)
+    expect(downloads).toHaveLength(0)
+
+    const downloadPromise = page.waitForEvent('download')
+    await preview.locator('.deliv-preview__actions').getByRole('button', { name: 'Download', exact: true }).click()
+    const download = await downloadPromise
+    expect(download.suggestedFilename()).toBe('server-staged-image.png')
+    expect(await readDownloadBytes(download)).toEqual(Buffer.from(HISTORY_IMAGE_DATA, 'base64'))
+    expect(downloads).toHaveLength(1)
+    for (const request of imageRequests) {
+      expect(request.authorization).toBe('Bearer token-e2e')
+      expect(request.sessionKey).toBe(capturedSends[0].sessionKey)
+      const requested = new URL(request.url)
+      expect(requested.searchParams.has('token')).toBe(false)
+      expect(requested.searchParams.has('sessionKey')).toBe(false)
+    }
   })
 
   test('drops a large staged file through the authenticated upload path', async ({ page }) => {

--- a/opensquilla-webui/e2e/attachment-drag-upload.spec.ts
+++ b/opensquilla-webui/e2e/attachment-drag-upload.spec.ts
@@ -1,4 +1,10 @@
 import { expect, test, type Download, type Page } from '@playwright/test'
+import {
+  chatHistoryPayload,
+  sessionMessagesHydratePayload,
+  sessionMessagesSnapshotPayload,
+  sessionMessagesSubscribePayload,
+} from './support/session-read-fixtures'
 
 const CONTROL_URL = '/control/chat/new'
 const HISTORY_IMAGE_DATA = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII='
@@ -42,8 +48,13 @@ async function mockRpc(page: Page, capturedSends: CapturedSend[], options: MockR
     ws.onMessage(message => {
       try {
         const frame = JSON.parse(String(message))
+        if (frame?.type === 'ping') {
+          ws.send(JSON.stringify({ type: 'pong' }))
+          return
+        }
         if (frame?.type !== 'req') return
         const method = String(frame.method || '')
+        const sessionKey = String(frame.params?.key || frame.params?.sessionKey || '')
         if (method === 'connect') {
           ws.send(JSON.stringify({ protocol: 3, policy: { tick_interval_ms: 30000 } }))
           return
@@ -71,6 +82,7 @@ async function mockRpc(page: Page, capturedSends: CapturedSend[], options: MockR
               key: params.sessionKey || '',
               sessionKey: params.sessionKey || '',
               status: 'succeeded',
+              stream_generation: 'e2e-stream-generation',
               stream_seq: capturedSends.length,
             }))
           }
@@ -78,7 +90,7 @@ async function mockRpc(page: Page, capturedSends: CapturedSend[], options: MockR
         }
         if (method === 'chat.history') {
           options.historyRequests?.push(frame.params || {})
-          ws.send(wsResponse(String(frame.id), { messages: historyMessages, has_more: false }))
+          ws.send(wsResponse(String(frame.id), chatHistoryPayload(historyMessages)))
           return
         }
 
@@ -91,12 +103,9 @@ async function mockRpc(page: Page, capturedSends: CapturedSend[], options: MockR
             skills: {},
           },
           'sessions.list': { sessions: [], has_more: false },
-          'sessions.messages.subscribe': {
-            subscribed: true,
-            replay_complete: true,
-            current_stream_seq: 0,
-            run_status: 'idle',
-          },
+          'sessions.messages.subscribe': sessionMessagesSubscribePayload(sessionKey),
+          'sessions.messages.snapshot': sessionMessagesSnapshotPayload(sessionKey),
+          'sessions.messages.hydrate': sessionMessagesHydratePayload(sessionKey),
           'usage.status': { sessions: [] },
         }
 

--- a/opensquilla-webui/src/adapters/gateway/artifactPreviewV4.ts
+++ b/opensquilla-webui/src/adapters/gateway/artifactPreviewV4.ts
@@ -150,14 +150,12 @@ export function createArtifactPreview(
   async function run() {
     if (disposed || inFlight) return
     if (state.value === 'loaded' && objectUrl.value) return
-    const artifact = options.artifact()
-    const baseOrigin = baseOriginSource()
-    const request = bindArtifactBinaryRequest(http, artifact, {
-      baseOrigin,
+    const request = options.artifact ? bindArtifactBinaryRequest(http, options.artifact(), {
+      baseOrigin: baseOriginSource(),
       policy: options.requireSameOrigin ? 'same-origin' : 'allow-external',
       variant: options.variant === 'thumbnail' ? 'thumbnail' : 'content',
-    })
-    if (!request) {
+    }) : null
+    if (!request && !options.loadBlob) {
       state.value = 'error'
       errorCode.value = 'network'
       return
@@ -181,17 +179,26 @@ export function createArtifactPreview(
     let timedOut = false
 
     try {
-      const response = await request.execute({
-        sessionKey: options.sessionKey?.(),
-        signal: controller.signal,
-        // The preview controller owns its timeout so retries and UI state
-        // stay domain-defined instead of inheriting the transport default.
-        timeoutMs: 0,
-      })
+      let blob: Blob
+      if (options.loadBlob) {
+        blob = await options.loadBlob(controller.signal)
+        if (blob.size > maxBytes) {
+          throw new ArtifactPreviewLoadError('too_large', 'Preview exceeds size limit')
+        }
+      } else {
+        if (!request) throw new ArtifactPreviewLoadError('network', 'Preview is unavailable')
+        const response = await request.execute({
+          sessionKey: options.sessionKey?.(),
+          signal: controller.signal,
+          // The preview controller owns its timeout so retries and UI state
+          // stay domain-defined instead of inheriting the transport default.
+          timeoutMs: 0,
+        })
 
-      const blob = await readBlobWithProgress(response, p => {
-        if (seq === runSeq) progress.value = p
-      }, maxBytes)
+        blob = await readBlobWithProgress(response, p => {
+          if (seq === runSeq) progress.value = p
+        }, maxBytes)
+      }
       if (disposed || seq !== runSeq) return
       if (options.acceptBlob && !options.acceptBlob(blob)) {
         throw new ArtifactPreviewLoadError('unsupported', 'Preview media type is unsupported')

--- a/opensquilla-webui/src/adapters/gateway/attachmentAccessV4.ts
+++ b/opensquilla-webui/src/adapters/gateway/attachmentAccessV4.ts
@@ -1,4 +1,5 @@
 import type { DisplayAttachment } from '@/types/chat'
+import { isImageAttachmentMime } from '@/utils/chat/attachments'
 import type {
   ArtifactAccessRequest,
   ArtifactContentAccess,
@@ -108,7 +109,9 @@ export async function fetchDisplayAttachmentBlob(
     }
   }
 
-  const encoded = attachment.downloadData || attachment.data
+  const dataUrl = attachment.dataUrl?.match(/^data:(image\/[^;,]+);base64,([\s\S]*)$/i)
+  const imageData = dataUrl && isImageAttachmentMime(dataUrl[1]) ? dataUrl[2] : undefined
+  const encoded = attachment.downloadData || attachment.data || imageData
   if (encoded) {
     const bytes = base64Bytes(encoded)
     if (!bytes) {

--- a/opensquilla-webui/src/components/chat/ArtifactImageLightbox.test.ts
+++ b/opensquilla-webui/src/components/chat/ArtifactImageLightbox.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import i18n from '@/i18n'
+import type { DisplayAttachment } from '@/types/chat'
+import {
+  provideArtifactImageLightbox,
+  type ArtifactImageLightboxController,
+} from '@/composables/chat/useArtifactImageLightbox'
+import { downloadBlob } from '@/utils/browser'
+import { ARTIFACT_WORKBENCH_KEY, type ArtifactWorkbench } from '@/modules/artifactWorkbench'
+import { createV4ArtifactContentAccess } from '@/adapters/gateway/artifactAccessV4'
+import { createV4AttachmentContentAccess } from '@/adapters/gateway/attachmentAccessV4'
+import { createV4ArtifactPreviews } from '@/adapters/gateway/artifactPreviewsV4'
+import { httpBinaryResponse, httpTransportTestDouble, type TestHttpTransport } from '@/testing/httpTransport.test-helper'
+import ArtifactImageLightbox from './ArtifactImageLightbox.vue'
+
+vi.mock('@/utils/browser', async importOriginal => ({
+  ...await importOriginal<typeof import('@/utils/browser')>(),
+  downloadBlob: vi.fn(),
+}))
+
+let app: App | undefined
+let controller: ArtifactImageLightboxController
+let objectUrls: ReturnType<typeof vi.spyOn>
+let revokedUrls: ReturnType<typeof vi.spyOn>
+let requestBinary: ReturnType<typeof vi.fn<TestHttpTransport['requestBinary']>>
+
+function attachment(key: string, overrides: Partial<DisplayAttachment> = {}): DisplayAttachment {
+  return {
+    kind: 'inline', displayId: key, renderKey: key, name: `${key}.png`, mime: 'image/png',
+    data: 'aW1hZ2U=', ...overrides,
+  }
+}
+
+function mount() {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  app = createApp({
+    setup() {
+      controller = provideArtifactImageLightbox()
+      return () => h(ArtifactImageLightbox)
+    },
+  })
+  app.use(i18n)
+  const http = httpTransportTestDouble({ requestBinary })
+  app.provide(ARTIFACT_WORKBENCH_KEY, {
+    content: {
+      ...createV4ArtifactContentAccess(http),
+      ...createV4AttachmentContentAccess(http),
+    },
+    previews: createV4ArtifactPreviews(http),
+  } as ArtifactWorkbench)
+  app.mount(host)
+}
+
+function displayedImage() {
+  return document.querySelector<HTMLImageElement>('.deliv-preview__image')
+}
+
+beforeEach(() => {
+  i18n.global.locale.value = 'en'
+  requestBinary = vi.fn<TestHttpTransport['requestBinary']>()
+  let sequence = 0
+  objectUrls = vi.spyOn(URL, 'createObjectURL').mockImplementation(() => `blob:image-${++sequence}`)
+  revokedUrls = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  app?.unmount()
+  app = undefined
+  document.body.innerHTML = ''
+  sessionStorage.clear()
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+})
+
+describe('shared image preview', () => {
+  it.each(['', 'application/octet-stream'])('previews a local image with inferred MIME when File.type is %j', async type => {
+    mount()
+    const image = attachment('inferred', {
+      data: undefined,
+      localFile: new File(['original'], 'inferred.png', { type }),
+    })
+    controller.openAttachments({ attachment: image, navigationAttachments: [image], sessionKey: '' })
+    await vi.waitFor(() => expect(displayedImage()?.alt).toBe('inferred.png'))
+    const blob = objectUrls.mock.calls[0][0] as Blob
+    expect(blob.type).toBe('image/png')
+    expect(await blob.text()).toBe('original')
+  })
+
+  it('previews local attachments, navigates, downloads explicitly and restores focus', async () => {
+    mount()
+    const opener = document.createElement('button')
+    document.body.appendChild(opener)
+    opener.focus()
+    const file = new File(['original'], 'first.png', { type: 'image/png' })
+    const first = attachment('first', { localFile: file })
+    const second = attachment('second')
+    controller.openAttachments({
+      attachment: first,
+      navigationAttachments: [first, second, attachment('vector', { mime: 'image/svg+xml' })],
+      sessionKey: '',
+    })
+    await vi.waitFor(() => expect(displayedImage()?.getAttribute('src')).toBe('blob:image-1'))
+    expect(objectUrls).toHaveBeenCalledWith(file)
+    expect(requestBinary).not.toHaveBeenCalled()
+    expect(downloadBlob).not.toHaveBeenCalled()
+
+    // Background artifact refreshes must not replace an attachment gallery.
+    controller.updateNavigation([{ id: 'generated', mime: 'image/png' }], '')
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+    await vi.waitFor(() => expect(displayedImage()?.alt).toBe('second.png'))
+    await vi.waitFor(() => expect(displayedImage()?.getAttribute('src')).toBe('blob:image-2'))
+    expect(revokedUrls).toHaveBeenCalledWith('blob:image-1')
+    expect(document.querySelector<HTMLButtonElement>('.deliv-preview__nav--next')?.disabled).toBe(true)
+    document.querySelector<HTMLButtonElement>('.deliv-preview__actions button')?.click()
+    await vi.waitFor(() => expect(downloadBlob).toHaveBeenCalledOnce())
+    expect(vi.mocked(downloadBlob).mock.calls[0][1]).toBe('second.png')
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await nextTick()
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+    expect(document.activeElement).toBe(opener)
+    expect(revokedUrls).toHaveBeenCalledWith('blob:image-2')
+  })
+
+  it('loads history attachments through the scoped transport and preserves download filenames', async () => {
+    mount()
+    requestBinary.mockResolvedValue(httpBinaryResponse('original', {
+      contentType: 'image/png', filename: 'original.png',
+    }))
+    const image = attachment('history', {
+      kind: 'staged', data: undefined,
+      download_url: '/api/v1/attachments/fixture?token=old&sessionKey=old',
+    })
+    controller.openAttachments({ attachment: image, navigationAttachments: [image], sessionKey: 'fixture-session' })
+    await vi.waitFor(() => expect(displayedImage()).not.toBeNull())
+    expect(requestBinary).toHaveBeenCalledWith('/api/v1/attachments/fixture', expect.objectContaining({
+      sessionKey: 'fixture-session', signal: expect.any(AbortSignal), timeoutMs: 0,
+    }))
+    expect(downloadBlob).not.toHaveBeenCalled()
+    document.querySelector<HTMLButtonElement>('.deliv-preview__actions button')?.click()
+    await vi.waitFor(() => expect(downloadBlob).toHaveBeenCalledOnce())
+    expect(vi.mocked(downloadBlob).mock.calls[0][1]).toBe('original.png')
+    document.querySelector<HTMLElement>('.deliv-preview')?.click()
+    await nextTick()
+    expect(controller.request.value).toBeNull()
+  })
+
+  it('keeps generated artifact previews working through the same viewer', async () => {
+    mount()
+    requestBinary.mockResolvedValue(httpBinaryResponse('generated', {
+      contentType: 'image/png',
+    }))
+    const artifact = { id: 'generated', name: 'generated.png', mime: 'image/png' }
+    controller.open({ artifact, navigationArtifacts: [artifact], sessionKey: 'fixture-session' })
+    await vi.waitFor(() => expect(displayedImage()?.alt).toBe('generated.png'))
+    expect(requestBinary).toHaveBeenCalledWith('/api/v1/artifacts/generated', expect.objectContaining({
+      sessionKey: 'fixture-session',
+    }))
+    expect(downloadBlob).not.toHaveBeenCalled()
+  })
+})

--- a/opensquilla-webui/src/components/chat/ArtifactImageLightbox.vue
+++ b/opensquilla-webui/src/components/chat/ArtifactImageLightbox.vue
@@ -5,7 +5,7 @@
       class="deliv-preview"
       role="dialog"
       aria-modal="true"
-      :aria-label="t('chat.previewOf', { title: artifactFileTitle(active) })"
+      :aria-label="t('chat.previewOf', { title: imageTitle(active) })"
       @click.self="closePreview"
     >
       <div ref="lightboxPanel" class="deliv-preview__panel deliv-preview__panel--media">
@@ -15,7 +15,7 @@
             aria-live="polite"
             aria-atomic="true"
           >
-            {{ artifactFileTitle(active) }}
+            {{ imageTitle(active) }}
           </span>
           <button
             ref="lightboxCloseBtn"
@@ -44,7 +44,7 @@
             v-if="fullState === 'loaded' && fullUrl"
             class="deliv-preview__image"
             :src="fullUrl"
-            :alt="artifactFileTitle(active)"
+            :alt="imageTitle(active)"
             decoding="async"
           />
           <div
@@ -106,7 +106,7 @@
 import { computed, inject, nextTick, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/Icon.vue'
-import { useArtifactImageLightbox } from '@/composables/chat/useArtifactImageLightbox'
+import { useArtifactImageLightbox, type ImageLightboxItem } from '@/composables/chat/useArtifactImageLightbox'
 import { useDialogLayer } from '@/composables/useDialogA11y'
 import { useDocumentEvent } from '@/composables/useDocumentEvent'
 import { useToasts } from '@/composables/useToasts'
@@ -116,6 +116,7 @@ import {
   type ArtifactPreviewController,
   type ArtifactPreviewState,
 } from '@/modules/artifactWorkbench'
+import { isImageAttachmentMime, isImageDisplayAttachment } from '@/utils/chat/attachments'
 import {
   artifactCategory,
   artifactFileTitle,
@@ -128,7 +129,7 @@ const controller = useArtifactImageLightbox()
 const injectedArtifactWorkbench = inject(ARTIFACT_WORKBENCH_KEY)
 if (!injectedArtifactWorkbench) throw new Error('ArtifactWorkbench was not provided')
 const artifactWorkbench = injectedArtifactWorkbench
-const active = computed(() => controller.request.value?.artifact ?? null)
+const active = computed(() => controller.request.value?.image ?? null)
 const isOpen = computed(() => active.value !== null)
 const lightboxIsTopmost = useDialogLayer(isOpen)
 const lightboxCloseBtn = ref<HTMLButtonElement | null>(null)
@@ -149,26 +150,38 @@ function artifactKey(artifact: ArtifactPayload): string {
   )
 }
 
+function imageKey(image: ImageLightboxItem): string {
+  return image.kind === 'artifact'
+    ? `artifact:${artifactKey(image.artifact)}`
+    : `attachment:${image.attachment.renderKey}`
+}
+
+function imageTitle(image: ImageLightboxItem): string {
+  return image.kind === 'artifact' ? artifactFileTitle(image.artifact) : image.attachment.name
+}
+
 const navigationVisualArtifacts = computed(() => {
   const request = controller.request.value
   if (!request) return []
   const seen = new Set<string>()
-  const images: ArtifactPayload[] = []
-  for (const artifact of request.navigationArtifacts) {
-    if (artifactCategory(artifact) !== 'visual') continue
-    const key = artifactKey(artifact)
+  const images: ImageLightboxItem[] = []
+  for (const image of request.navigationImages) {
+    if (image.kind === 'artifact'
+      ? artifactCategory(image.artifact) !== 'visual'
+      : !isImageDisplayAttachment(image.attachment)) continue
+    const key = imageKey(image)
     if (!key || seen.has(key)) continue
     seen.add(key)
-    images.push(artifact)
+    images.push(image)
   }
-  if (!seen.has(artifactKey(request.artifact))) images.push(request.artifact)
+  if (!seen.has(imageKey(request.image))) images.push(request.image)
   return images
 })
 
 const activeImageIndex = computed(() => {
   if (!active.value) return -1
-  const key = artifactKey(active.value)
-  return navigationVisualArtifacts.value.findIndex(artifact => artifactKey(artifact) === key)
+  const key = imageKey(active.value)
+  return navigationVisualArtifacts.value.findIndex(image => imageKey(image) === key)
 })
 const canNavigateImages = computed(() => navigationVisualArtifacts.value.length > 1)
 const canGoPreviousImage = computed(() => activeImageIndex.value > 0)
@@ -186,13 +199,27 @@ function disposeFull() {
   fullUrl.value = ''
 }
 
-function loadFull(artifact: ArtifactPayload, sessionKey: string) {
+function loadFull(image: ImageLightboxItem, sessionKey: string) {
   disposeFull()
   fullController = artifactWorkbench.previews.create({
-    artifact: () => artifact,
     sessionKey: () => sessionKey,
     variant: 'content',
     fullSize: true,
+    ...(image.kind === 'attachment' ? {
+      loadBlob: async (signal: AbortSignal) => {
+        const result = await artifactWorkbench.content.fetchAttachment(image.attachment, {
+          sessionKey,
+          signal,
+        })
+        if (!result.ok) throw new Error(result.message)
+        if (result.source === 'local-file'
+          && (!result.blob.type || result.blob.type === 'application/octet-stream')) {
+          return result.blob.slice(0, result.blob.size, image.attachment.mime)
+        }
+        return result.blob
+      },
+      acceptBlob: (blob: Blob) => isImageAttachmentMime(blob.type),
+    } : { artifact: () => image.artifact }),
   })
   const preview = fullController
   stopFullState = watch(
@@ -280,36 +307,37 @@ function onLightboxKeydown(event: KeyboardEvent) {
 async function downloadActive() {
   const request = controller.request.value
   if (!request) return
-  const result = await artifactWorkbench.content.fetchArtifact(request.artifact, {
+  const options = {
     sessionKey: request.sessionKey,
-  })
+  }
+  const result = request.image.kind === 'artifact'
+    ? await artifactWorkbench.content.fetchArtifact(request.image.artifact, options)
+    : await artifactWorkbench.content.fetchAttachment(request.image.attachment, options)
   if (!result.ok) {
     pushToast(result.message || t('chat.toast.downloadFailed'), { tone: 'danger' })
     return
   }
-  downloadBlob(result.blob, String(request.artifact.name || artifactFileTitle(request.artifact)))
+  const filename = 'filename' in result && typeof result.filename === 'string'
+    ? result.filename
+    : imageTitle(request.image)
+  downloadBlob(result.blob, filename)
 }
 
-const activeResourceSignature = computed(() => {
+const activeResource = computed(() => {
   const request = controller.request.value
-  if (!request) return ''
-  return [
-    request.sessionKey,
-    artifactKey(request.artifact),
-    String(request.artifact.download_url || ''),
-  ].join('\u0000')
+  return request?.image ?? null
 })
 
 watch(
-  activeResourceSignature,
-  (signature, previousSignature) => {
+  activeResource,
+  (image, previousImage) => {
     const request = controller.request.value
-    if (!signature || !request) {
+    if (!image || !request) {
       disposeFull()
       return
     }
-    loadFull(request.artifact, request.sessionKey)
-    if (!previousSignature) nextTick(() => lightboxCloseBtn.value?.focus())
+    loadFull(image, request.sessionKey)
+    if (!previousImage) nextTick(() => lightboxCloseBtn.value?.focus())
   },
   { immediate: true },
 )

--- a/opensquilla-webui/src/components/chat/ChatComposer.image-preview.test.ts
+++ b/opensquilla-webui/src/components/chat/ChatComposer.image-preview.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import i18n from '@/i18n'
+import type { Attachment } from '@/types/chat'
+import ChatComposer from './ChatComposer.vue'
+
+const apps: App[] = []
+
+beforeEach(() => {
+  i18n.global.locale.value = 'en'
+})
+
+afterEach(() => {
+  apps.splice(0).forEach(app => app.unmount())
+  document.body.innerHTML = ''
+})
+
+function imageAttachment(overrides: Partial<Attachment> = {}): Attachment {
+  return {
+    kind: 'inline',
+    local_id: 1,
+    name: 'sample.png',
+    mime: 'image/png',
+    data: 'aW1hZ2U=',
+    dataUrl: 'data:image/png;base64,aW1hZ2U=',
+    ...overrides,
+  }
+}
+
+async function mountAttachment(attachment: Attachment) {
+  const previewImage = vi.fn()
+  const send = vi.fn()
+  const removeAttachment = vi.fn()
+  const retryAttachment = vi.fn()
+  const host = document.createElement('div')
+  document.body.append(host)
+  const app = createApp(ChatComposer, {
+    modelValue: 'Describe the image',
+    'onUpdate:modelValue': () => {},
+    attachments: [attachment],
+    busySendMode: 'queue',
+    hasSendContent: true,
+    isStreaming: false,
+    canStop: false,
+    isNewLanding: false,
+    placeholder: 'Send a message',
+    sendButtonTitle: 'Send',
+    runMode: 'trusted',
+    allowedRunModes: ['standard', 'trusted', 'full'],
+    runModeLocked: false,
+    runModeLockMessage: '',
+    sessionRoutingMode: 'llm_ensemble',
+    sessionRoutingBusy: false,
+    voiceBusy: false,
+    voiceRecording: false,
+    voiceReady: true,
+    onPreviewImage: previewImage,
+    onSend: send,
+    onRemoveAttachment: removeAttachment,
+    onRetryAttachment: retryAttachment,
+  })
+  apps.push(app)
+  app.use(i18n)
+  app.mount(host)
+  await nextTick()
+  return { host, previewImage, send, removeAttachment, retryAttachment }
+}
+
+describe('ChatComposer uploaded image preview', () => {
+  it.each(['inline', 'data URL', 'staged'] as const)('opens an unsent %s image without sending or removing it', async (source) => {
+    const attachment = imageAttachment(source === 'staged'
+      ? { kind: 'staged', data: undefined, dataUrl: undefined, file_uuid: 'file-1', file: new File(['image'], 'sample.png', { type: 'image/png' }) }
+      : source === 'data URL' ? { data: undefined } : {})
+    const { host, previewImage, send, removeAttachment, retryAttachment } = await mountAttachment(attachment)
+    const preview = host.querySelector<HTMLButtonElement>('.attachment-chip__preview')
+    expect(preview?.tagName).toBe('BUTTON')
+    expect(preview?.type).toBe('button')
+    expect(preview?.getAttribute('aria-label')).toBe('Open sample.png')
+    expect(preview?.querySelector('.attachment-chip__name')?.textContent).toBe('sample.png')
+    if (source === 'staged') expect(preview?.querySelector('img')).toBeNull()
+
+    preview?.click()
+    expect(previewImage).toHaveBeenCalledExactlyOnceWith(attachment)
+    expect(send).not.toHaveBeenCalled()
+    expect(removeAttachment).not.toHaveBeenCalled()
+    expect(retryAttachment).not.toHaveBeenCalled()
+
+    const remove = host.querySelector<HTMLButtonElement>('.attachment-remove')
+    expect(preview?.contains(remove)).toBe(false)
+    remove?.click()
+    expect(removeAttachment).toHaveBeenCalledExactlyOnceWith(0)
+    expect(previewImage).toHaveBeenCalledOnce()
+  })
+
+  it('keeps retry separate from the local image preview after an upload fails', async () => {
+    const attachment = imageAttachment({
+      kind: 'failed',
+      data: undefined,
+      dataUrl: undefined,
+      file: new File(['image'], 'sample.png', { type: 'image/png' }),
+    })
+    const { host, previewImage, send, removeAttachment, retryAttachment } = await mountAttachment(attachment)
+    const retry = host.querySelector<HTMLButtonElement>('[aria-label="Retry upload"]')
+    expect(retry).not.toBeNull()
+    retry?.click()
+    expect(retryAttachment).toHaveBeenCalledExactlyOnceWith(0)
+    expect(previewImage).not.toHaveBeenCalled()
+    expect(send).not.toHaveBeenCalled()
+    expect(removeAttachment).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['drawing.svg', 'image/svg+xml', 'aW1hZ2U='],
+    ['report.pdf', 'application/pdf', 'ZG9j'],
+    ['unavailable.png', 'image/png', undefined],
+  ])('does not offer an image preview for %s', async (name, mime, data) => {
+    const attachment = imageAttachment({ name, mime, data, dataUrl: undefined })
+    const { host, previewImage, send } = await mountAttachment(attachment)
+    expect(host.querySelector('.attachment-chip__preview')).toBeNull()
+    host.querySelector<HTMLElement>('.attachment-chip__name')?.click()
+    expect(previewImage).not.toHaveBeenCalled()
+    expect(send).not.toHaveBeenCalled()
+  })
+})

--- a/opensquilla-webui/src/components/chat/ChatComposer.vue
+++ b/opensquilla-webui/src/components/chat/ChatComposer.vue
@@ -20,13 +20,23 @@
             :data-mime="att.mime || ''"
             :title="attachmentTitle(att)"
           >
-            <span class="attachment-chip__icon" aria-hidden="true">
-              <span v-if="isAttachmentBusy(att)" class="spinner attachment-chip__spinner" />
-              <Icon v-else-if="att.kind === 'failed'" name="info" :size="15" />
-              <img v-else-if="isImageDisplayAttachment(att) && att.dataUrl" class="attachment-chip__thumb" :src="att.dataUrl" alt="" />
-              <Icon v-else :name="attachmentIcon(att)" :size="15" />
-            </span>
-            <span class="attachment-chip__name">{{ att.name }}</span>
+            <component
+              :is="attachmentCanPreview(att) ? 'button' : 'span'"
+              class="attachment-chip__primary"
+              :class="{ 'attachment-chip__preview': attachmentCanPreview(att) }"
+              :type="attachmentCanPreview(att) ? 'button' : undefined"
+              :title="attachmentCanPreview(att) ? t('chat.openTitle', { title: att.name }) : undefined"
+              :aria-label="attachmentCanPreview(att) ? t('chat.openTitle', { title: att.name }) : undefined"
+              @click.stop="previewImage(att)"
+            >
+              <span class="attachment-chip__icon" aria-hidden="true">
+                <span v-if="isAttachmentBusy(att)" class="spinner attachment-chip__spinner" />
+                <Icon v-else-if="att.kind === 'failed'" name="info" :size="15" />
+                <img v-else-if="isImageDisplayAttachment(att) && att.dataUrl" class="attachment-chip__thumb" :src="att.dataUrl" alt="" />
+                <Icon v-else :name="attachmentIcon(att)" :size="15" />
+              </span>
+              <span class="attachment-chip__name">{{ att.name }}</span>
+            </component>
             <span class="attachment-chip__meta">{{ attachmentMeta(att) }}</span>
             <button v-if="att.kind === 'failed' && att.file" class="attachment-action" :title="t('chat.retryUpload')" :aria-label="t('chat.retryUpload')" @click="emit('retryAttachment', i)">
               <Icon name="refresh" :size="12" />
@@ -547,6 +557,7 @@ const emit = defineEmits<{
   keydown: [event: KeyboardEvent]
   removeAttachment: [index: number]
   retryAttachment: [index: number]
+  previewImage: [attachment: Attachment]
   send: []
   setBusySendMode: [mode: 'queue' | 'steer']
   setRunMode: [mode: SandboxRunMode]
@@ -799,6 +810,14 @@ function openPromptCacheKeepalive() {
   if (!props.promptCacheKeepaliveSessionReady) return
   moreActionsOpen.value = false
   emit('openPromptCacheKeepalive')
+}
+
+function attachmentCanPreview(att: Attachment): boolean {
+  return isImageDisplayAttachment(att) && Boolean(att.file || att.data || att.dataUrl)
+}
+
+function previewImage(att: Attachment) {
+  if (attachmentCanPreview(att)) emit('previewImage', att)
 }
 
 function attachmentIcon(att: Attachment): IconName {
@@ -1239,6 +1258,33 @@ defineExpose<ChatComposerExpose>({
 
 .attachment-chip--busy {
   opacity: 0.7;
+}
+
+.attachment-chip__primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+
+button.attachment-chip__primary {
+  cursor: pointer;
+}
+
+button.attachment-chip__primary:hover {
+  color: var(--accent);
+}
+
+button.attachment-chip__primary:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .attachment-chip--failed {

--- a/opensquilla-webui/src/components/chat/ChatMessageList.vue
+++ b/opensquilla-webui/src/components/chat/ChatMessageList.vue
@@ -57,6 +57,7 @@
           @edit="$emit('editMessage', $event)"
           @edit-attachment="$emit('editAttachment', $event)"
           @preview-attachment="$emit('previewAttachment', $event)"
+          @preview-image="$emit('previewImage', $event, messages[entry.index].attachments || [])"
           @reuse-prompt-annotation="$emit('reusePromptAnnotation', $event)"
           @toggle-share="$emit('toggleShareMessage', $event)"
         />
@@ -219,6 +220,7 @@ const emit = defineEmits<{
   editMessage: [message: ChatRenderedMessage]
   editAttachment: [attachment: import('@/types/chat').DisplayAttachment]
   previewAttachment: [attachment: import('@/types/chat').DisplayAttachment]
+  previewImage: [attachment: import('@/types/chat').DisplayAttachment, attachments: import('@/types/chat').DisplayAttachment[]]
   reusePromptAnnotation: [annotation: PromptAnnotationSnapshot]
   regenerateMessage: [
     message: ChatRenderedMessage,

--- a/opensquilla-webui/src/components/chat/UserMessage.image-preview.test.ts
+++ b/opensquilla-webui/src/components/chat/UserMessage.image-preview.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import i18n from '@/i18n'
+import type { ChatRenderedMessage, DisplayAttachment } from '@/types/chat'
+import UserMessage from './UserMessage.vue'
+
+const apps: App[] = []
+
+beforeEach(() => {
+  i18n.global.locale.value = 'en'
+})
+
+afterEach(() => {
+  apps.splice(0).forEach(app => app.unmount())
+  document.body.innerHTML = ''
+})
+
+function imageAttachment(overrides: Partial<DisplayAttachment> = {}): DisplayAttachment {
+  return {
+    kind: 'inline',
+    displayId: 'image-1',
+    renderKey: 'image-1',
+    name: 'sample.png',
+    mime: 'image/png',
+    data: 'aW1hZ2U=',
+    ...overrides,
+  }
+}
+
+async function mountAttachment(attachment: DisplayAttachment, shareMode = false) {
+  const message: ChatRenderedMessage = {
+    id: 'message-1',
+    role: 'user',
+    displayRole: 'user',
+    roleLabel: 'You',
+    text: '',
+    timeStr: '',
+    showHeader: false,
+    attachments: [attachment],
+  }
+  const previewImage = vi.fn()
+  const downloadAttachment = vi.fn(async () => true)
+  const toggleShare = vi.fn()
+  const host = document.createElement('div')
+  document.body.append(host)
+  const app = createApp(UserMessage, {
+    message,
+    shareMode,
+    shareSelected: false,
+    shareMessageId: message.id,
+    stripTimePrefix: (value: string) => value,
+    copyMessage: async () => true,
+    downloadAttachment,
+    onPreviewImage: previewImage,
+    onToggleShare: toggleShare,
+  })
+  apps.push(app)
+  app.use(i18n)
+  app.mount(host)
+  await nextTick()
+  return { host, previewImage, downloadAttachment, toggleShare }
+}
+
+describe('UserMessage uploaded image preview', () => {
+  it.each<[string, DisplayAttachment]>([
+    ['inline thumbnail', imageAttachment()],
+    ['data URL thumbnail', imageAttachment({ data: undefined, dataUrl: 'data:image/png;base64,aW1hZ2U=' })],
+    ['staged image chip', imageAttachment({ kind: 'staged', data: undefined, download_url: '/api/v1/attachments/image-1' })],
+  ])('opens a %s and preserves a separate download action', async (_name, attachment) => {
+    const { host, previewImage, downloadAttachment } = await mountAttachment(attachment)
+    const open = host.querySelector<HTMLButtonElement>('[aria-label="Open sample.png"]')
+    const download = host.querySelector<HTMLButtonElement>('[aria-label="Download sample.png"]')
+    expect(open?.tagName).toBe('BUTTON')
+    expect(open?.type).toBe('button')
+    expect(download).not.toBeNull()
+    expect(open?.contains(download)).toBe(false)
+    expect(download?.contains(open)).toBe(false)
+
+    open?.click()
+    expect(previewImage).toHaveBeenCalledExactlyOnceWith(attachment)
+    expect(downloadAttachment).not.toHaveBeenCalled()
+
+    download?.click()
+    expect(downloadAttachment).toHaveBeenCalledExactlyOnceWith(attachment)
+    expect(previewImage).toHaveBeenCalledOnce()
+  })
+
+  it('opens the image without toggling message selection in share mode', async () => {
+    const attachment = imageAttachment()
+    const { host, previewImage, downloadAttachment, toggleShare } = await mountAttachment(attachment, true)
+    host.querySelector<HTMLButtonElement>('.msg-thumb-button')?.click()
+    expect(previewImage).toHaveBeenCalledExactlyOnceWith(attachment)
+    expect(downloadAttachment).not.toHaveBeenCalled()
+    expect(toggleShare).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['drawing.svg', 'image/svg+xml'],
+    ['report.pdf', 'application/pdf'],
+  ])('keeps %s on its existing download action', async (name, mime) => {
+    const attachment = imageAttachment({ name, mime })
+    const { host, previewImage, downloadAttachment } = await mountAttachment(attachment)
+    expect(host.querySelector('.msg-thumb')).toBeNull()
+    const download = host.querySelector<HTMLButtonElement>(`[aria-label="Download ${name}"]`)
+    expect(download).not.toBeNull()
+    download?.click()
+    expect(downloadAttachment).toHaveBeenCalledExactlyOnceWith(attachment)
+    expect(previewImage).not.toHaveBeenCalled()
+  })
+})

--- a/opensquilla-webui/src/components/chat/UserMessage.vue
+++ b/opensquilla-webui/src/components/chat/UserMessage.vue
@@ -86,25 +86,37 @@
       </div>
       <div v-if="message.attachments?.length" class="msg-attachments">
         <template v-for="attachment in message.attachments" :key="attachment.renderKey">
-          <button
+          <span
             v-if="isImageDisplayAttachment(attachment) && (attachment.dataUrl || attachment.data)"
-            type="button"
-            class="msg-thumb-button"
-            :title="attachmentDownloadLabel(attachment)"
-            :aria-label="attachmentDownloadLabel(attachment)"
-            :aria-busy="downloadingAttachments.has(attachment.renderKey)"
-            :disabled="downloadingAttachments.has(attachment.renderKey)"
-            @click.stop="downloadAttachment(attachment)"
+            class="msg-file-resource"
           >
-            <img
-              class="msg-thumb"
-              :src="attachmentImageSrc(attachment)"
-              :alt="attachment.name"
-            />
-            <span v-if="downloadingAttachments.has(attachment.renderKey)" class="msg-thumb-button__busy" aria-hidden="true">
-              <span class="spinner msg-file-chip__spinner" />
+            <button
+              type="button"
+              class="msg-thumb-button"
+              :title="attachmentPrimaryActionLabel(attachment)"
+              :aria-label="attachmentPrimaryActionLabel(attachment)"
+              @click.stop="emit('previewImage', attachment)"
+            >
+              <img
+                class="msg-thumb"
+                :src="attachmentImageSrc(attachment)"
+                :alt="attachment.name"
+              />
+            </button>
+            <span v-if="!shareMode" class="msg-file-resource__actions">
+              <button
+                type="button"
+                :title="attachmentDownloadLabel(attachment)"
+                :aria-label="attachmentDownloadLabel(attachment)"
+                :aria-busy="downloadingAttachments.has(attachment.renderKey)"
+                :disabled="downloadingAttachments.has(attachment.renderKey)"
+                @click.stop="downloadAttachment(attachment)"
+              >
+                <span v-if="downloadingAttachments.has(attachment.renderKey)" class="spinner msg-file-chip__spinner" aria-hidden="true" />
+                <Icon v-else name="download" :size="14" />
+              </button>
             </span>
-          </button>
+          </span>
           <span v-else class="msg-file-resource">
             <button
               type="button"
@@ -119,7 +131,7 @@
               <span class="msg-file-chip__icon" aria-hidden="true">
                 <span v-if="downloadingAttachments.has(attachment.renderKey)" class="spinner msg-file-chip__spinner" />
                 <Icon v-else-if="failedDownloads.has(attachment.renderKey)" name="refresh" :size="16" />
-                <Icon v-else name="fileText" :size="16" />
+                <Icon v-else :name="isImageDisplayAttachment(attachment) ? 'image' : 'fileText'" :size="16" />
               </span>
               <span class="msg-file-chip__body">
                 <span class="msg-file-chip__name">{{ attachment.name }}</span>
@@ -127,11 +139,11 @@
               </span>
             </button>
             <span
-              v-if="workbenchAttachmentResource(attachment) && !shareMode"
+              v-if="(isImageDisplayAttachment(attachment) || workbenchAttachmentResource(attachment)) && !shareMode"
               class="msg-file-resource__actions"
             >
               <button
-                v-if="attachmentCanOpen(attachment)"
+                v-if="isImageDisplayAttachment(attachment) || attachmentCanOpen(attachment)"
                 type="button"
                 :title="attachmentDownloadLabel(attachment)"
                 :aria-label="attachmentDownloadLabel(attachment)"
@@ -252,6 +264,7 @@ const emit = defineEmits<{
   edit: [message: ChatRenderedMessage]
   editAttachment: [attachment: DisplayAttachment]
   previewAttachment: [attachment: DisplayAttachment]
+  previewImage: [attachment: DisplayAttachment]
   toggleShare: [messageId: string]
   reusePromptAnnotation: [annotation: PromptAnnotationSnapshot]
 }>()
@@ -419,6 +432,7 @@ function attachmentOpenReason(attachment: DisplayAttachment): string {
 }
 
 function attachmentPrimaryActionLabel(attachment: DisplayAttachment): string {
+  if (isImageDisplayAttachment(attachment)) return t('chat.openTitle', { title: attachment.name })
   if (!attachmentCanOpen(attachment)) return attachmentDownloadLabel(attachment)
   const label = t('workbench.resources.open', { name: attachment.name })
   const reason = attachmentOpenReason(attachment)
@@ -430,6 +444,10 @@ function attachmentUnavailableReason(attachment: DisplayAttachment): string {
 }
 
 function activateAttachment(attachment: DisplayAttachment) {
+  if (isImageDisplayAttachment(attachment)) {
+    emit('previewImage', attachment)
+    return
+  }
   if (attachmentCanOpen(attachment)) {
     emit('previewAttachment', attachment)
     return
@@ -920,20 +938,6 @@ function activateAttachment(attachment: DisplayAttachment) {
 .msg-thumb-button:focus-visible {
   outline: none;
   box-shadow: var(--focus-ring);
-}
-
-.msg-thumb-button:disabled {
-  cursor: wait;
-}
-
-.msg-thumb-button__busy {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  place-items: center;
-  border-radius: var(--radius-card);
-  background: color-mix(in srgb, var(--bg-surface) 72%, transparent);
-  color: var(--accent);
 }
 
 .msg-file-chip__icon {

--- a/opensquilla-webui/src/composables/chat/useArtifactImageLightbox.ts
+++ b/opensquilla-webui/src/composables/chat/useArtifactImageLightbox.ts
@@ -7,10 +7,16 @@ import {
   type ShallowRef,
 } from 'vue'
 import type { ArtifactPayload } from '@/types/artifacts'
+import type { DisplayAttachment } from '@/types/chat'
+import { isImageDisplayAttachment } from '@/utils/chat/attachments'
+
+export type ImageLightboxItem =
+  | { kind: 'artifact', artifact: ArtifactPayload }
+  | { kind: 'attachment', attachment: DisplayAttachment }
 
 export interface ArtifactImageLightboxRequest {
-  artifact: ArtifactPayload
-  navigationArtifacts: readonly ArtifactPayload[]
+  image: ImageLightboxItem
+  navigationImages: readonly ImageLightboxItem[]
   sessionKey: string
   invoker: HTMLElement | null
 }
@@ -24,7 +30,12 @@ export interface ArtifactImageLightboxOpenRequest {
 export interface ArtifactImageLightboxController {
   request: Readonly<ShallowRef<ArtifactImageLightboxRequest | null>>
   open(request: ArtifactImageLightboxOpenRequest): void
-  show(artifact: ArtifactPayload): void
+  openAttachments(request: {
+    attachment: DisplayAttachment
+    navigationAttachments: readonly DisplayAttachment[]
+    sessionKey: string
+  }): void
+  show(image: ImageLightboxItem): void
   updateNavigation(navigationArtifacts: readonly ArtifactPayload[], sessionKey: string): void
   close(): void
 }
@@ -39,25 +50,38 @@ export function provideArtifactImageLightbox(): ArtifactImageLightboxController 
     request: shallowReadonly(request),
     open(nextRequest) {
       request.value = {
-        ...nextRequest,
-        navigationArtifacts: [...nextRequest.navigationArtifacts],
+        image: { kind: 'artifact', artifact: nextRequest.artifact },
+        navigationImages: nextRequest.navigationArtifacts.map(artifact => ({ kind: 'artifact', artifact })),
+        sessionKey: nextRequest.sessionKey,
         invoker: document.activeElement instanceof HTMLElement
           ? document.activeElement
           : null,
       }
     },
-    show(artifact) {
+    openAttachments(nextRequest) {
+      if (!isImageDisplayAttachment(nextRequest.attachment)) return
+      request.value = {
+        image: { kind: 'attachment', attachment: nextRequest.attachment },
+        navigationImages: nextRequest.navigationAttachments
+          .filter(isImageDisplayAttachment)
+          .map(attachment => ({ kind: 'attachment', attachment })),
+        sessionKey: nextRequest.sessionKey,
+        invoker: document.activeElement instanceof HTMLElement ? document.activeElement : null,
+      }
+    },
+    show(image) {
       if (!request.value) return
       request.value = {
         ...request.value,
-        artifact,
+        image,
       }
     },
     updateNavigation(navigationArtifacts, sessionKey) {
-      if (!request.value || request.value.sessionKey !== sessionKey) return
+      if (!request.value || request.value.sessionKey !== sessionKey
+        || request.value.image.kind !== 'artifact') return
       request.value = {
         ...request.value,
-        navigationArtifacts: [...navigationArtifacts],
+        navigationImages: navigationArtifacts.map(artifact => ({ kind: 'artifact', artifact })),
       }
     },
     close() {

--- a/opensquilla-webui/src/composables/chat/useArtifactPreview.test.ts
+++ b/opensquilla-webui/src/composables/chat/useArtifactPreview.test.ts
@@ -50,6 +50,30 @@ describe('createArtifactPreview', () => {
     controller.dispose()
   })
 
+  it('cancels attachment loading and ignores bytes returned after disposal', async () => {
+    let resolveBlob!: (blob: Blob) => void
+    let signal!: AbortSignal
+    const objectUrl = vi.spyOn(URL, 'createObjectURL')
+    const http = httpTransport(vi.fn())
+    const controller = createArtifactPreview(http, {
+      loadBlob: value => {
+        signal = value
+        return new Promise(resolve => { resolveBlob = resolve })
+      },
+      fullSize: true,
+    })
+    controller.load()
+    await vi.waitFor(() => expect(signal).toBeDefined())
+    controller.dispose()
+    expect(signal.aborted).toBe(true)
+    resolveBlob(new Blob(['image'], { type: 'image/png' }))
+    await Promise.resolve()
+    expect(objectUrl).not.toHaveBeenCalled()
+    expect(http.requestBinary).not.toHaveBeenCalled()
+    expect(controller.objectUrl.value).toBe('')
+    expect(controller.state.value).toBe('idle')
+  })
+
   it('aborts an active preview request when disposed', async () => {
     const observed: { signal?: AbortSignal } = {}
     const requestBinary = vi.fn(

--- a/opensquilla-webui/src/modules/artifactWorkbench.ts
+++ b/opensquilla-webui/src/modules/artifactWorkbench.ts
@@ -226,8 +226,7 @@ export interface ArtifactContentAccess {
 export type ArtifactPreviewState = 'idle' | 'loading' | 'loaded' | 'timeout' | 'error'
 export type ArtifactPreviewErrorCode = 'network' | 'too_large' | 'unsupported' | null
 
-export interface ArtifactPreviewOptions {
-  artifact: () => ArtifactPayload
+export type ArtifactPreviewOptions = {
   sessionKey?: () => string | undefined
   variant?: 'content' | 'thumbnail'
   fullSize?: boolean
@@ -236,7 +235,10 @@ export interface ArtifactPreviewOptions {
   maxBytes?: number
   requireSameOrigin?: boolean
   acceptBlob?: (blob: Blob) => boolean
-}
+} & (
+  | { artifact: () => ArtifactPayload; loadBlob?: never }
+  | { artifact?: never; loadBlob: (signal: AbortSignal) => Promise<Blob> }
+)
 
 export interface ArtifactPreviewController {
   state: Ref<ArtifactPreviewState>

--- a/opensquilla-webui/src/utils/chat/attachmentAccess.test.ts
+++ b/opensquilla-webui/src/utils/chat/attachmentAccess.test.ts
@@ -39,6 +39,30 @@ describe('attachmentAccessUrl', () => {
 })
 
 describe('fetchDisplayAttachmentBlob', () => {
+  it('reads legacy image data URLs without fetching them', async () => {
+    const http = httpTransport()
+    const result = await fetchDisplayAttachmentBlob(http, attachment({
+      mime: 'image/png',
+      dataUrl: 'data:image/png;base64,aW1hZ2U=',
+    }))
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(await result.blob.text()).toBe('image')
+      expect(result.blob.type).toBe('image/png')
+    }
+    expect(http.requestBinary).not.toHaveBeenCalled()
+  })
+
+  it('does not interpret active-document data URLs as inline images', async () => {
+    for (const mime of ['image/svg+xml', 'text/html']) {
+      const result = await fetchDisplayAttachmentBlob(httpTransport(), attachment({
+        mime: 'image/png',
+        dataUrl: `data:${mime};base64,aW1hZ2U=`,
+      }))
+      expect(result.ok).toBe(false)
+    }
+  })
+
   it('prefers the local file over inline bytes and staged URLs', async () => {
     const localFile = new File(['local'], '../local.html', { type: 'text/html' })
     const http = httpTransport()

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -226,6 +226,7 @@
           @edit-message="editMessage"
           @edit-attachment="editAttachmentResource"
           @preview-attachment="previewAttachmentResource"
+          @preview-image="previewImageAttachment"
           @reuse-prompt-annotation="reusePromptAnnotation"
           @regenerate-message="handleRegenerateMessage"
           @toggle-share-message="toggleShareMessage"
@@ -676,6 +677,7 @@
       @keydown="onTextareaKeydown"
       @remove-attachment="removeAttachment"
       @retry-attachment="retryAttachment"
+      @preview-image="previewPendingImage"
       @set-busy-send-mode="busySendMode = $event"
       @set-run-mode="setComposerRunMode"
       @set-session-routing-mode="setComposerSessionRoutingMode"
@@ -1086,6 +1088,7 @@ import {
 import {
   collectClipboardFiles,
   hasModelInputImageAttachment,
+  normalizeDisplayAttachment,
   isSendableAttachment,
   shouldCaptureFilePaste,
 } from '@/utils/chat/attachments'
@@ -2940,6 +2943,7 @@ const chatSessionRuntime = useChatSessionRuntime({
   restoreWidgetState,
   resetStreamLiveTurnState,
   resetDraftComposer: () => {
+    artifactImageLightbox.close()
     inputText.value = ''
     pendingAttachments.value = []
     resetComposerInputHistory()
@@ -4837,6 +4841,24 @@ function subagentBody(text: string): string {
 }
 
 /* ── Artifacts ─────────────────────────────────────────────────────── */
+
+function previewImageAttachment(attachment: DisplayAttachment, attachments: readonly DisplayAttachment[]) {
+  artifactImageLightbox.openAttachments({
+    attachment,
+    navigationAttachments: attachments,
+    sessionKey: sessionKey.value,
+  })
+}
+
+function previewPendingImage(attachment: Attachment) {
+  artifactImageLightbox.openAttachments({
+    attachment: normalizeDisplayAttachment(attachment),
+    navigationAttachments: pendingAttachments.value.map(attachment => normalizeDisplayAttachment(attachment)),
+    // Drafts have a provisional runtime key before a session exists in the URL.
+    // Keep local previews owned by the visible route used by App's dialog guard.
+    sessionKey: readSessionFromUrl(),
+  })
+}
 
 async function downloadAttachment(attachment: DisplayAttachment): Promise<boolean> {
   const result = await artifactWorkbench.content.fetchAttachment(attachment, {
@@ -6868,6 +6890,7 @@ watch(() => [route.path, route.query.agent, route.query.project], async () => {
   metaDraftRecovery.invalidate()
   const generation = draftProjectHydration.begin()
   if (!isDraftRoute()) return
+  artifactImageLightbox.close()
   if (!await syncDraftProjectFromRoute(generation)) return
   enterDraft()
   metaDraftRecovery.start(draftAgentId())


### PR DESCRIPTION
Clicking an uploaded chat image now opens the shared image viewer before or after sending. The viewer supports image navigation and an explicit download action, and closes when the owning session or draft changes.

## Scope

Scope boundary: Web UI image interactions, the existing artifact preview/content interfaces, and regression tests.

Non-goals: New backend endpoints or image editing tools.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: No public issue is linked to this fix.

## Release Note

Release note: Uploaded chat images can be previewed in the composer and message history, with a separate download action.

## Tests

Ruff: passed (`uv run ruff check src tests`).

Pytest: the default suite was interrupted after 3,363 passed and 136 skipped to investigate one router-model manifest failure. The worktree had unmaterialized Git LFS model files; after checking out the nine cached assets, the failed test passed individually. The full Python suite was not completed. GitHub CI remains the merge gate for this frontend change.

Build: Web UI type checks, architecture/security guards, production build, and `uv build --wheel` passed.

Regression tests: added. All 38 focused unit tests and all 10 Chromium attachment tests passed against the current main branch interfaces.

Notes: Coverage includes inline and staged attachments, inferred image MIME, authenticated reads, explicit downloads, cancellation, generated images, and draft navigation/reset. Tests use synthetic data and mocked RPC/HTTP responses without provider credentials.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

Image access continues through the existing private transport and its authentication/origin checks. This is platform-neutral frontend behavior for the shared web/desktop UI; no persisted state, configuration, or public protocol migration is required. Generated build artifacts and local runtime data are excluded from the commit.

## Third-Party Origin

Third-party origin: inspired-by

Details: Interaction research only. The implementation independently extends OpenSquilla's existing image viewer; no third-party code, comments, fixtures, documentation, or dependencies were copied or added.

## Documentation Changes

N/A: No documentation files changed.
