### PR TITLE
Resolve Skill sources and discover installable directories before downloading

### DIFF
--- a/opensquilla-webui/src/components/skills/SkillsAddDrawer.vue
+++ b/opensquilla-webui/src/components/skills/SkillsAddDrawer.vue
@@ -174,6 +174,18 @@
                       class="sk-add-lifecycle"
                       :data-tone="item.lifecycleTone"
                     >{{ item.lifecycleLabel }}</span>
+                    <div v-if="item.status === 'selection_required'" role="group" :aria-label="t('cronSkills.registry.selectSkillDirectory')">
+                      <p>{{ t('cronSkills.registry.selectSkillDirectory') }}</p>
+                      <button
+                        v-for="candidate in item.candidates"
+                        :key="candidate.identifier"
+                        type="button"
+                        class="btn btn--sm btn--ghost"
+                        :disabled="installControlsBlocked"
+                        data-testid="skills-select-directory"
+                        @click="emit('retry', item.id, false, candidate.identifier)"
+                      >{{ candidate.path || candidate.name }}</button>
+                    </div>
                     <details v-if="item.diagnostics.length" class="sk-add-diagnostics">
                       <summary>{{ t('cronSkills.registry.diagnostics', { count: item.diagnostics.length }) }}</summary>
                       <div v-for="diagnostic in item.diagnostics" :key="`${diagnostic.phase}:${diagnostic.code}`">
@@ -383,6 +395,7 @@ import type {
 import {
   GITHUB_BATCH_MAX_REFERENCES,
   skillInstallRequiresRiskAcknowledgement,
+  skillInstallCandidates,
   skillRegistryOperationKey,
 } from '@/composables/skills/useSkillRegistry'
 import { skillLifecyclePresentation } from '@/composables/skills/useSkillsCatalog'
@@ -410,7 +423,7 @@ const emit = defineEmits<{
   search: []
   installGithub: []
   install: [identifier: string, source: string, displayName: string]
-  retry: [id: string, acknowledgeRisk?: boolean]
+  retry: [id: string, acknowledgeRisk?: boolean, candidateIdentifier?: string]
   cancelInstall: [source: SkillInstallSource]
   clearActivity: [source: SkillInstallSource]
 }>()
@@ -694,6 +707,7 @@ const queueRows = computed(() => currentItems.value.map((item) => {
   return {
     ...item,
     requiresRiskAcknowledgement: skillInstallRequiresRiskAcknowledgement(item.result),
+    candidates: skillInstallCandidates(item.result),
     operationLabel: operationFailed
       ? t(item.result?.installed
         ? 'cronSkills.registry.existingInstallPreserved'

--- a/opensquilla-webui/src/composables/skills/useSkillRegistry.test.ts
+++ b/opensquilla-webui/src/composables/skills/useSkillRegistry.test.ts
@@ -937,3 +937,30 @@ describe('useSkillRegistry install state', () => {
     ])
   })
 })
+
+
+describe('Skill directory selection', () => {
+  it('only installs a server candidate and clears old risk acknowledgement', async () => {
+    const identifier = `acme/pack@${'a'.repeat(40)}:skills/demo/SKILL.md`
+    const call = vi.fn(async () => ({
+      success: false, message: 'Choose directory',
+      riskConfirmation: 'obsolete-token',
+      diagnostics: [{ code: 'SOURCE_TREE_AMBIGUOUS', details: {
+        selectionRequired: true, repository: 'acme/pack', immutableRevision: 'a'.repeat(40),
+        candidates: [{ name: 'demo', path: 'skills/demo', identifier }],
+      } }],
+    }))
+    const registry = useSkillRegistry({ call }, vi.fn(async () => true))
+    registry.githubUrl.value = 'https://github.com/acme/pack'
+    await registry.installGithub()
+    const item = registry.installActivities.value.github.items[0]
+    expect(item.status).toBe('selection_required')
+    await registry.retryQueueItem(item.id, true, 'https://evil.invalid/skill')
+    expect(call).toHaveBeenCalledTimes(1)
+    call.mockResolvedValueOnce({ success: true, message: 'Installed' } as never)
+    await registry.retryQueueItem(item.id, true, identifier)
+    expect(call).toHaveBeenLastCalledWith('skills.install', { identifier, source: 'github' })
+    expect(item.status).toBe('installed')
+    expect(registry.githubUrl.value).toBe('')
+  })
+})

--- a/opensquilla-webui/src/composables/skills/useSkillRegistry.ts
+++ b/opensquilla-webui/src/composables/skills/useSkillRegistry.ts
@@ -24,6 +24,7 @@ export type SkillInstallQueueStatus =
   | 'deferred'
   | 'unknown'
   | 'failed'
+  | 'selection_required'
 
 export interface SkillInstallQueueItem {
   id: string
@@ -48,6 +49,34 @@ export function skillInstallRiskConfirmation(
     candidate.code === 'SCAN_CONFIRMATION_REQUIRED')
   const token = diagnostic?.details?.confirmationToken
   return typeof token === 'string' ? token.trim() : ''
+}
+
+export interface SkillDirectoryCandidate {
+  name: string
+  path: string
+  identifier: string
+}
+
+export function skillInstallCandidates(result: InstallResult | undefined): SkillDirectoryCandidate[] {
+  const details = result?.diagnostics?.find(item =>
+    item.code === 'SOURCE_TREE_AMBIGUOUS' && item.details?.selectionRequired === true)?.details
+  if (!details || typeof details.repository !== 'string'
+    || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(details.repository)
+    || typeof details.immutableRevision !== 'string'
+    || !/^[0-9a-f]{40}$/.test(details.immutableRevision)
+    || !Array.isArray(details.candidates) || details.candidates.length > 100) return []
+  const candidates: SkillDirectoryCandidate[] = []
+  for (const candidate of details.candidates) {
+    if (!candidate || typeof candidate !== 'object') return []
+    const { name, path, identifier } = candidate as Record<string, unknown>
+    if (typeof name !== 'string' || !name || name.length > 256
+      || typeof path !== 'string' || path.length > 1024
+      || (path && path.split('/').some(part => !part || part === '.' || part === '..'))
+      || /[\\\x00-\x1f]/.test(path)
+      || identifier !== `${details.repository}@${details.immutableRevision}:${path ? `${path}/` : ''}SKILL.md`) return []
+    candidates.push({ name, path, identifier: identifier as string })
+  }
+  return candidates
 }
 
 export type SkillInstallSource = 'clawhub' | 'github'
@@ -198,7 +227,7 @@ export interface SkillRegistry {
   searchRegistry: () => Promise<void>
   installGithub: () => Promise<void>
   installSkill: (identifier: string, source: string, displayName?: string) => Promise<void>
-  retryQueueItem: (id: string, acknowledgeRisk?: boolean) => Promise<void>
+  retryQueueItem: (id: string, acknowledgeRisk?: boolean, candidateIdentifier?: string) => Promise<void>
   cancelInstall: (source: SkillInstallSource) => Promise<void>
   clearInstallActivity: (source: SkillInstallSource) => void
   installDeps: (
@@ -375,7 +404,7 @@ export function useSkillRegistry(
           ? 'cancelled'
           : res.success
             ? (res.unchanged ? 'unchanged' : 'installed')
-            : 'failed'
+            : skillInstallCandidates(res).length ? 'selection_required' : 'failed'
         item.error = res.success || res.cancelled
           ? ''
           : (res.message || t('cronSkills.registry.installFailed'))
@@ -479,17 +508,30 @@ export function useSkillRegistry(
     await runNewBatch([{ identifier, source, displayName }])
   }
 
-  async function retryQueueItem(id: string, acknowledgeRisk = false) {
+  async function retryQueueItem(id: string, acknowledgeRisk = false, candidateIdentifier = '') {
     const source = (['clawhub', 'github'] as const).find(candidate =>
       installActivities.value[candidate].items.some(item => item.id === id))
     if (!source) return
     const item = installActivities.value[source].items.find(candidate => candidate.id === id)
-    if (!item || (item.status !== 'failed' && item.status !== 'cancelled')) return
-    const riskConfirmation = acknowledgeRisk
+    if (!item) return
+    const candidate = candidateIdentifier && item.source === 'github'
+      ? skillInstallCandidates(item.result).find(row => row.identifier === candidateIdentifier)
+      : undefined
+    if (candidateIdentifier && (!candidate || item.status !== 'selection_required')) return
+    if (!candidate && item.status !== 'failed' && item.status !== 'cancelled') return
+    const riskConfirmation = acknowledgeRisk && !candidate
       ? skillInstallRiskConfirmation(item.result)
       : ''
-    if (acknowledgeRisk && !riskConfirmation) return
+    if (acknowledgeRisk && !candidate && !riskConfirmation) return
     if (!mutationGate.acquire('install_queue')) return
+    if (candidate) {
+      githubUrl.value = githubUrl.value.split(/\r?\n/).map(line =>
+        line.trim() === item.identifier ? candidate.identifier : line).join('\n')
+      item.identifier = candidate.identifier
+      item.displayName = candidate.name
+      item.result = undefined
+      item.error = ''
+    }
     installActivities.value[source].refreshWarning = ''
     installActivities.value[source].phase = 'installing'
     runningSource.value = source

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -2981,7 +2981,9 @@
       "clearActivity": "Aktivität löschen",
       "expandActivity": "Installationsaktivität erweitern",
       "collapseActivity": "Installationsaktivität einklappen",
+      "selectSkillDirectory": "Skill-Verzeichnis auswählen",
       "queueStatus": {
+        "selection_required": "Verzeichnis auswählen",
         "queued": "Wartend",
         "installing": "Wird installiert",
         "cancelling": "Wird abgebrochen",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -3069,7 +3069,9 @@
       "clearActivity": "Clear activity",
       "expandActivity": "Expand install activity",
       "collapseActivity": "Collapse install activity",
+      "selectSkillDirectory": "Select a Skill directory",
       "queueStatus": {
+        "selection_required": "Choose directory",
         "queued": "Queued",
         "installing": "Installing",
         "cancelling": "Cancelling",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -2981,7 +2981,9 @@
       "clearActivity": "Borrar actividad",
       "expandActivity": "Expandir actividad de instalación",
       "collapseActivity": "Contraer actividad de instalación",
+      "selectSkillDirectory": "Selecciona un directorio de habilidades",
       "queueStatus": {
+        "selection_required": "Elegir directorio",
         "queued": "En cola",
         "installing": "Instalando",
         "cancelling": "Cancelando",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -2981,7 +2981,9 @@
       "clearActivity": "Effacer l’activité",
       "expandActivity": "Développer l’activité d’installation",
       "collapseActivity": "Réduire l’activité d’installation",
+      "selectSkillDirectory": "Sélectionnez un dossier de compétence",
       "queueStatus": {
+        "selection_required": "Choisir un dossier",
         "queued": "En attente",
         "installing": "Installation",
         "cancelling": "Annulation",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -2981,7 +2981,9 @@
       "clearActivity": "履歴を消去",
       "expandActivity": "インストール状況を展開",
       "collapseActivity": "インストール状況を折りたたむ",
+      "selectSkillDirectory": "スキルのディレクトリを選択",
       "queueStatus": {
+        "selection_required": "ディレクトリの選択待ち",
         "queued": "待機中",
         "installing": "インストール中",
         "cancelling": "キャンセル中",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -3069,7 +3069,9 @@
       "clearActivity": "清除活动",
       "expandActivity": "展开安装活动",
       "collapseActivity": "收起安装活动",
+      "selectSkillDirectory": "请选择技能目录",
       "queueStatus": {
+        "selection_required": "待选择目录",
         "queued": "等待中",
         "installing": "安装中",
         "cancelling": "正在取消",

--- a/src/opensquilla/application/skill_management.py
+++ b/src/opensquilla/application/skill_management.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import NotRequired, Protocol, TypedDict
 
+from opensquilla.application.skill_source import resolve_install_source
+
 
 @dataclass(frozen=True, slots=True)
 class InstallSkill:
     identifier: str
-    source: str = "clawhub"
+    source: str | None = None
     operation_id: str = ""
     force: bool = False
     replace_source: bool = False
@@ -18,6 +20,7 @@ class InstallSkill:
     def __post_init__(self) -> None:
         if not self.identifier:
             raise ValueError("skill identifier is required")
+        object.__setattr__(self, "source", resolve_install_source(self.identifier, self.source))
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/opensquilla/application/skill_source.py
+++ b/src/opensquilla/application/skill_source.py
@@ -1,0 +1,23 @@
+"""Source selection shared by all Community Skill installation surfaces."""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+_GITHUB_HOSTS = frozenset({"github.com", "www.github.com", "raw.githubusercontent.com"})
+
+
+def resolve_install_source(identifier: str, source: str | None = None) -> str:
+    """Infer only explicit GitHub URLs; keep ambiguous registry slugs unchanged."""
+    if source is not None:
+        return source.strip() or "clawhub"
+    value = identifier.strip()
+    if value.startswith("github.com/"):
+        value = "https://" + value
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return "clawhub"
+    if parsed.scheme in {"http", "https"} and parsed.netloc.lower() in _GITHUB_HOSTS:
+        return "github"
+    return "clawhub"

--- a/src/opensquilla/cli/skills_cmd.py
+++ b/src/opensquilla/cli/skills_cmd.py
@@ -884,8 +884,8 @@ def skills_reload(
 @skills_app.command("install")
 def skills_install(
     identifier: str = typer.Argument(..., help="Skill name or identifier"),
-    source: str = typer.Option(
-        "clawhub",
+    source: str | None = typer.Option(
+        None,
         "--source",
         "-s",
         help=(
@@ -913,6 +913,9 @@ def skills_install(
 ) -> None:
     """Install a skill from a Community source."""
 
+    from opensquilla.skills.install_source import resolve_install_source
+
+    source = resolve_install_source(identifier, source)
     if risk_confirmation and not force:
         raise typer.BadParameter("--risk-confirmation requires --force")
 

--- a/src/opensquilla/gateway/adapters/skill_management.py
+++ b/src/opensquilla/gateway/adapters/skill_management.py
@@ -32,8 +32,8 @@ class GatewaySkillManagementAdapter:
         identifier = params["identifier"]
         if not isinstance(identifier, str):
             raise ValueError("params.identifier must be a string")
-        source = params.get("source", "clawhub")
-        if not isinstance(source, str):
+        source = params.get("source")
+        if "source" in params and not isinstance(source, str):
             raise ValueError("params.source must be a string")
         command = InstallSkill(
             identifier=identifier,

--- a/src/opensquilla/gateway/rpc_skills.py
+++ b/src/opensquilla/gateway/rpc_skills.py
@@ -1363,7 +1363,7 @@ async def _run_skill_install(
         return {"success": False, "message": "No skill installer configured"}
 
     identifier = command.identifier
-    source_id = command.source
+    source_id = command.source or "clawhub"
     force = command.force
     replace_source = command.replace_source
     risk_confirmation = command.risk_confirmation

--- a/src/opensquilla/skills/hub/github.py
+++ b/src/opensquilla/skills/hub/github.py
@@ -105,6 +105,79 @@ class _GitHubSkillRef:
         return f"https://github.com/{self.repo_full}/tree/{self.ref}"
 
 
+def _select_skill_tree(
+    entries: list[Any],
+    ref: _GitHubSkillRef,
+    resolution: SourceResolution,
+    *,
+    tree_path_prefix: str = "",
+) -> tuple[_GitHubSkillRef, SourceResolution]:
+    """Discover complete, immutable candidate paths before downloading any files."""
+    names = (
+        {_MANIFEST_NAME, "skill.md", "skills.md"}
+        if resolution.allow_legacy_manifest_names
+        else {_MANIFEST_NAME}
+    )
+    manifests: list[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise source_invalid_response_error(
+                phase=DiagnosticPhase.FETCH, source_name="GitHub",
+            )
+        raw_path = str(entry.get("path") or "")
+        path = f"{tree_path_prefix}/{raw_path}" if tree_path_prefix else raw_path
+        relative = _relative_to_skill_dir(path, ref.skill_dir)
+        if relative is None or PurePosixPath(path).name not in names:
+            continue
+        try:
+            normalized = normalize_relative_path(path).as_posix()
+        except ArchiveNormalizationError as exc:
+            raise SkillSourceFetchError.diagnostic(
+                "ARTIFACT_PATH_UNSAFE", "GitHub returned an unsafe manifest path.",
+                phase=DiagnosticPhase.SECURITY, path=path,
+            ) from exc
+        if entry.get("type") == "blob":
+            manifests.append(normalized)
+    manifests.sort()
+    if not manifests:
+        raise SkillSourceFetchError.diagnostic(
+            "MANIFEST_MISSING", "The selected GitHub directory contains no Skill manifest.",
+            phase=DiagnosticPhase.MANIFEST,
+            hint="Choose a directory containing SKILL.md.",
+        )
+    if len(manifests) != 1:
+        candidates = []
+        for path in manifests[:100]:
+            directory = str(PurePosixPath(path).parent)
+            directory = "" if directory == "." else directory
+            candidate = replace(ref, path=directory)
+            candidates.append({
+                "name": PurePosixPath(directory).name or ref.repo,
+                "path": directory,
+                "identifier": candidate.canonical_identifier,
+            })
+        raise SkillSourceFetchError.diagnostic(
+            "SOURCE_TREE_AMBIGUOUS", "Select one Skill directory from this GitHub repository.",
+            phase=DiagnosticPhase.ARCHIVE,
+            details={
+                "manifests": manifests[:100], "selectionRequired": True,
+                "repository": ref.repo_full, "immutableRevision": ref.ref,
+                "candidateCount": len(manifests), "candidates": candidates,
+            },
+            hint="Install an exact candidate directory or specify a Skill subpath.",
+        )
+    directory = str(PurePosixPath(manifests[0]).parent)
+    directory = "" if directory == "." else directory
+    if directory == ref.skill_dir:
+        return ref, resolution
+    selected = replace(ref, path=directory)
+    return selected, replace(
+        resolution, canonical_identifier=selected.canonical_identifier,
+        skill_path=directory, upstream_url=selected.homepage,
+        package_identifier=f"{selected.repo_full.casefold()}:{directory}",
+    )
+
+
 def _clean_repo_name(repo: str) -> str:
     return repo[:-4] if repo.endswith(".git") else repo
 
@@ -641,6 +714,9 @@ class GitHubSource(SkillSource):
                             hint="Reduce the number of files in the selected Skill directory.",
                         )
 
+                ref, resolution = _select_skill_tree(
+                    tree_data["tree"], ref, resolution, tree_path_prefix=tree_path_prefix,
+                )
                 files: dict[str, str | bytes] = {}
                 selected: list[tuple[str, str, int, int]] = []
                 declared_total = 0

--- a/src/opensquilla/skills/install_source.py
+++ b/src/opensquilla/skills/install_source.py
@@ -1,0 +1,3 @@
+"""Compatibility import for transport-neutral Skill source selection."""
+
+from opensquilla.application.skill_source import resolve_install_source as resolve_install_source

--- a/src/opensquilla/tools/builtin/skill_tools.py
+++ b/src/opensquilla/tools/builtin/skill_tools.py
@@ -594,7 +594,7 @@ def create_skill_tools(
     @tool(
         name="skill_install_community",
         description=(
-            "Install a Community skill from ClawHub or another configured source. "
+            "Install a Community skill from a GitHub URL, ClawHub, or another configured source. "
             "Use only when the user clearly asked to install a specific skill identifier "
             "or chose one exact result from skill_search_community. Do not use skill_create "
             "for Community installs."
@@ -603,13 +603,12 @@ def create_skill_tools(
             "identifier": {
                 "type": "string",
                 "description": (
-                    "Exact source identifier or slug returned by skill_search_community."
+                    "GitHub repository or Skill directory URL, or an exact registry identifier."
                 ),
             },
             "source": {
                 "type": "string",
-                "description": "Source id, usually 'clawhub'.",
-                "default": "clawhub",
+                "description": "Optional source id. GitHub URLs infer github; slugs infer clawhub.",
             },
             "force": {
                 "type": "boolean",
@@ -641,7 +640,7 @@ def create_skill_tools(
     )
     async def skill_install_community(
         identifier: str,
-        source: str = "clawhub",
+        source: str | None = None,
         force: bool = False,
         risk_confirmation: str = "",
         replace_source: bool = False,
@@ -658,7 +657,9 @@ def create_skill_tools(
         clean_risk_confirmation = risk_confirmation.strip()
         if clean_risk_confirmation and not force:
             raise ToolError("risk_confirmation requires force=true")
-        source_id = str(source or "clawhub").strip() or "clawhub"
+        from opensquilla.skills.install_source import resolve_install_source
+
+        source_id = resolve_install_source(clean_identifier, source)
 
         installer: Any = management_service
         if installer is None:

--- a/tests/test_ci/test_architecture_import_contracts.py
+++ b/tests/test_ci/test_architecture_import_contracts.py
@@ -8,6 +8,9 @@ from pathlib import Path
 PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "src" / "opensquilla"
 
 APPROVED_PACKAGE_IMPORTS: frozenset[tuple[str, str]] = frozenset({
+    # Source adapters consume the transport-neutral install command's pure
+    # identifier parser; application never imports the Skill implementation.
+    ("skills", "application"),
     ("agents", "gateway"),
     ("agents", "identity"),
     ("agents", "onboarding"),

--- a/tests/test_skill_install_source.py
+++ b/tests/test_skill_install_source.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from opensquilla.application.skill_management import InstallSkill
+from opensquilla.skills.install_source import resolve_install_source
+
+
+@pytest.mark.parametrize(("identifier", "source", "expected"), [
+    ("https://github.com/acme/pack", None, "github"),
+    ("https://www.github.com/acme/pack", None, "github"),
+    ("github.com/acme/pack", None, "github"),
+    ("https://raw.githubusercontent.com/acme/pack/main/SKILL.md", None, "github"),
+    ("demo", None, "clawhub"),
+    ("acme/pack", None, "clawhub"),
+    ("https://github.com.evil.example/acme/pack", None, "clawhub"),
+    ("https://github.com@evil.example/acme/pack", None, "clawhub"),
+    ("https://github.com/acme/pack", "clawhub", "clawhub"),
+    ("https://github.com/acme/pack", "", "clawhub"),
+    ("demo", "custom", "custom"),
+])
+def test_source_inference_preserves_explicit_source(identifier, source, expected):
+    assert resolve_install_source(identifier, source) == expected
+    assert InstallSkill(identifier, source=source).source == expected

--- a/tests/test_skills_hub_github.py
+++ b/tests/test_skills_hub_github.py
@@ -692,3 +692,44 @@ async def test_invalid_identifier_is_not_reported_as_remote_not_found(tmp_path: 
     result = await service.install("not-a-github-reference", "github")
 
     assert [item.code for item in result.diagnostics] == ["SOURCE_IDENTIFIER_INVALID"]
+
+
+@pytest.mark.asyncio
+async def test_repository_discovers_unique_skill_before_downloading(monkeypatch) -> None:
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _AsyncClient)
+    monkeypatch.setattr(_AsyncClient, "requests", [])
+    monkeypatch.setattr(_AsyncClient, "tree_entries", [
+        row for row in _AsyncClient.tree_entries
+        if row["path"] != "skills/other/SKILL.md"
+    ])
+    bundle = await GitHubSource().fetch("https://github.com/acme/skillpack")
+    assert bundle is not None
+    assert set(bundle.files) == {"SKILL.md", "scripts/run.py", "assets/logo.bin"}
+    assert bundle.resolution.requested_identifier == "https://github.com/acme/skillpack"
+    assert bundle.resolution.skill_path == "skills/demo"
+    assert bundle.resolution.canonical_identifier == (
+        f"acme/skillpack@{_COMMIT}:skills/demo/SKILL.md"
+    )
+    assert not any("unrelated" in url for url, _ in _AsyncClient.requests)
+
+
+@pytest.mark.asyncio
+async def test_repository_candidates_are_pinned_without_body_downloads(monkeypatch) -> None:
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _AsyncClient)
+    monkeypatch.setattr(_AsyncClient, "requests", [])
+    source = GitHubSource()
+    resolution = await source.resolve("https://github.com/acme/skillpack")
+    with pytest.raises(SkillSourceFetchError) as caught:
+        await source.fetch_resolved(resolution)
+    diagnostic = caught.value.diagnostics[0]
+    assert diagnostic.code == "SOURCE_TREE_AMBIGUOUS"
+    assert diagnostic.details["candidates"] == [
+        {"name": name, "path": f"skills/{name}",
+         "identifier": f"acme/skillpack@{_COMMIT}:skills/{name}/SKILL.md"}
+        for name in ("demo", "other")
+    ]
+    assert not any("raw.githubusercontent.com" in url for url, _ in _AsyncClient.requests)


### PR DESCRIPTION
GitHub repository URLs previously defaulted to ClawHub in some entry points, and directory ambiguity was detected only after downloading file contents. This change infers omitted sources consistently across Agent, CLI, and Gateway, discovers Skill manifests at a fixed commit before body downloads, and lets the WebUI select a server-generated, commit-pinned directory.

Target: main. Linked issue: None. Release note: source inference and directory selection improve Community Skill installation; no version metadata change.

Validation: 163 focused Python tests, 51 WebUI tests, WebUI architecture/i18n/type checks, Ruff and diff checks passed. CI has passed all Linux offline shards, all Windows high-risk shards, and Skill contracts on Linux, macOS and Windows. All PR CI checks passed; the merge queue is validating the combined tree before merge.

Safety and compatibility: existing explicit source parameters, install RPC fields, serial queues, and risk confirmation remain compatible. Changing a candidate clears the prior confirmation. Candidate paths resolve against an immutable commit; truncated repository trees require an explicit subdirectory. Source inference is platform-neutral. Third-party origin: original implementation; no third-party code copied.
