### PR TITLE
fix(webui): isolate router cards across replay and reconnect

### DIFF
--- a/opensquilla-webui/src/composables/chat/useChatRenderedMessages.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRenderedMessages.ts
@@ -273,8 +273,8 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
 
   function stableRouterStripRenderKey(
     turnIdentity: string,
-    message: Pick<ChatMessage, 'routerModelCallId' | 'messageId'>
-      | Pick<ChatRenderedMessage, 'routerModelCallId' | 'messageId' | 'sourceIndex' | 'id'>,
+    message: Pick<ChatMessage, 'routerModelCallId' | 'messageId' | 'clientId'>
+      | Pick<ChatRenderedMessage, 'routerModelCallId' | 'messageId' | 'sourceIndex' | 'id' | 'clientId'>,
     messageId?: string,
     index = 0,
   ): string {
@@ -284,10 +284,15 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
     const eventId = routerStripEventId(message, messageId, index)
     const eventIdentity = `${identityPrefix}event:${eventId}`
     const callIdentity = callId ? `${identityPrefix}call:${callId}` : ''
+    // A provisional card acquires its real event id in place. Keep the same
+    // row mounted, then teach the event/call aliases to reuse its original key.
+    const localIdentity = message.clientId ? `${identityPrefix}local:${message.clientId}` : ''
     const key = (callIdentity ? stableRouterKeys.get(callIdentity) : undefined)
+      || (localIdentity ? stableRouterKeys.get(localIdentity) : undefined)
       || stableRouterKeys.get(eventIdentity)
       || routerStripRenderKey(turnIdentity, message, messageId, index)
     stableRouterKeys.set(eventIdentity, key)
+    if (localIdentity) stableRouterKeys.set(localIdentity, key)
     if (callIdentity) stableRouterKeys.set(callIdentity, key)
     return key
   }
@@ -709,6 +714,7 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
     ) return null
     return {
       id: `router-turn-${turnIdx}`,
+      clientId: msg.clientId,
       role: 'router',
       displayRole: 'router',
       roleLabel: 'Router',
@@ -720,7 +726,7 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
       isRouterStrip: true,
       routerTurnKey: stableRouterStripRenderKey(
         turnIdentity,
-        { routerModelCallId: routerModelCallIdFromMessage(msg), messageId },
+        { routerModelCallId: routerModelCallIdFromMessage(msg), messageId, clientId: msg.clientId },
         messageId,
         index,
       ),
@@ -824,6 +830,7 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
     if (!options.routerVisualEffectsEnabled.value) return null
     return {
       id: `router-turn-${turnIdx}`,
+      clientId: msg.clientId,
       role: 'router',
       displayRole: 'router',
       roleLabel: 'Router',
@@ -835,7 +842,7 @@ export function useChatRenderedMessages(options: UseChatRenderedMessagesOptions)
       isRouterStrip: true,
       routerTurnKey: stableRouterStripRenderKey(
         turnIdentity,
-        { routerModelCallId: routerModelCallIdFromMessage(msg), messageId },
+        { routerModelCallId: routerModelCallIdFromMessage(msg), messageId, clientId: msg.clientId },
         messageId,
         index,
       ),

--- a/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.test.ts
@@ -153,6 +153,82 @@ describe('router decision identity', () => {
 })
 
 describe('appendEnsembleProgress', () => {
+  it('promotes a same-turn provisional card when its real decision arrives', () => {
+    const { runtime, messagesRef } = makeRuntime([
+      { role: 'user', text: 'q', ts: 0, turnId: 'turn-1' },
+    ])
+
+    runtime.appendEnsembleProgress({
+      event_type: 'proposer_finish',
+      turn_id: 'turn-1',
+      proposer_provider: 'openrouter',
+      proposer_model: 'qwen/qwen3.7-plus',
+    })
+    const provisional = messagesRef.value.find(message => message.role === 'router')!
+    ;(provisional as ChatMessage & { routerExecutionModel?: string }).routerExecutionModel = 'fallback-model'
+
+    runtime.queueRouterDecision({
+      turn_id: 'turn-1',
+      stream_seq: 12,
+      tier: 'c1',
+      model: 'provider/selected',
+      source: 'squilla_router',
+    })
+
+    const routers = messagesRef.value.filter(message => message.role === 'router')
+    expect(routers).toHaveLength(1)
+    expect(routers[0]).toMatchObject({
+      messageId: 'router-sess-12',
+      turnId: 'turn-1',
+      routerDecision: { model: 'provider/selected' },
+    })
+    expect(routers[0]?.ensemble?.models).toHaveLength(1)
+    expect((routers[0] as ChatMessage & { routerExecutionModel?: string }).routerExecutionModel)
+      .toBe('fallback-model')
+  })
+
+  it('does not promote a provisional card across a router control replay boundary', () => {
+    const { runtime, messagesRef } = makeRuntime([
+      { role: 'user', text: 'q', ts: 0, turnId: 'turn-1' },
+    ])
+
+    runtime.appendEnsembleProgress({
+      event_type: 'proposer_start',
+      turn_id: 'turn-1',
+      proposer_provider: 'openrouter',
+      proposer_model: 'qwen/qwen3.7-plus',
+    })
+    runtime.handleRouterControlReplay()
+    runtime.queueRouterDecision({
+      turn_id: 'turn-1',
+      stream_seq: 13,
+      tier: 'c1',
+      model: 'provider/replayed',
+      source: 'squilla_router',
+    })
+
+    expect(messagesRef.value.filter(message => message.role === 'router')).toHaveLength(2)
+  })
+
+  it('promotes a handoff card without dropping its identity', () => {
+    const { runtime, messagesRef } = makeRuntime([
+      { role: 'user', text: 'q', ts: 0, turnId: 'turn-1' },
+    ])
+
+    runtime.markEnsembleHandoff()
+    runtime.queueRouterDecision({
+      turn_id: 'turn-1',
+      stream_seq: 14,
+      tier: 'c1',
+      model: 'provider/selected',
+      source: 'squilla_router',
+    })
+
+    const routers = messagesRef.value.filter(message => message.role === 'router')
+    expect(routers).toHaveLength(1)
+    expect(routers[0]).toMatchObject({ messageId: 'router-sess-14', turnId: 'turn-1' })
+  })
+
   it('normalizes every internal candidate label to the public Proposer role', () => {
     const { runtime, messagesRef } = makeRuntime([{ role: 'user', text: 'q', ts: 0 }])
 

--- a/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.test.ts
@@ -14,9 +14,10 @@ function makeRuntime(
   const scrollToBottom = vi.fn()
   const activeTurnUsesEnsemble = ref(modelRoutingMode === 'llm_ensemble')
   const activeTurnId = ref('turn-current')
+  const sessionKey = ref('sess')
   const runtime = useChatRouterDecisionRuntime({
     messages: messagesRef,
-    sessionKey: ref('sess'),
+    sessionKey,
     isStreaming: ref(isStreaming),
     autoScroll: ref(autoScroll),
     activeTurnUsesEnsemble,
@@ -35,8 +36,106 @@ function makeRuntime(
     scrollToBottom,
     activeTurnUsesEnsemble,
     activeTurnId,
+    sessionKey,
   }
 }
+
+describe('router attempt ownership', () => {
+  const progress = (turnId = 'turn-current') => ({
+    turn_id: turnId, event_type: 'proposer_start' as const,
+    proposer_provider: 'provider', proposer_model: 'candidate',
+  })
+  const decision = (seq: number, turnId = 'turn-current') => ({
+    turn_id: turnId, stream_seq: seq, tier: 'c1', model: 'provider/selected', source: 'squilla_router',
+  })
+
+  it('uses the same boundary identity for live and snapshot replay', () => {
+    const { runtime, messagesRef } = makeRuntime([{ role: 'user', text: 'q', ts: 0, turnId: 'turn-current' }])
+    runtime.handleRouterControlReplay({ turn_id: 'turn-current', stream_seq: 10 })
+    runtime.appendEnsembleProgress(progress())
+    runtime.resetRouterReplayCursor()
+    runtime.handleRouterControlReplay({ turn_id: 'turn-current' }, 10)
+    runtime.appendEnsembleProgress(progress())
+    runtime.queueRouterDecision(decision(12))
+    const cards = messagesRef.value.filter(message => message.role === 'router')
+    expect(cards).toHaveLength(1)
+    expect(cards[0]?.messageId).toBe('router-sess-12')
+  })
+
+  it('keeps unsequenced replay boundaries separate instead of guessing their identity', () => {
+    const { runtime, messagesRef } = makeRuntime([{ role: 'user', text: 'q', ts: 0, turnId: 'turn-current' }])
+    runtime.appendEnsembleProgress(progress())
+    runtime.handleRouterControlReplay()
+    runtime.appendEnsembleProgress(progress())
+    runtime.queueRouterDecision(decision(12))
+    const cards = messagesRef.value.filter(message => message.role === 'router')
+    expect(cards).toHaveLength(2)
+    expect(cards[0]?.messageId).not.toBe(cards[1]?.messageId)
+    expect(cards[1]?.messageId).toBe('router-sess-12')
+  })
+
+  it('does not reuse a replay boundary from a different stream generation', () => {
+    const { runtime, messagesRef } = makeRuntime([{ role: 'user', text: 'q', ts: 0, turnId: 'turn-current' }])
+    runtime.handleRouterControlReplay({ turn_id: 'turn-current', stream_seq: 10, stream_generation: 'a' })
+    runtime.appendEnsembleProgress(progress())
+    runtime.handleRouterControlReplay({ turn_id: 'turn-current', stream_seq: 10, stream_generation: 'b' })
+    runtime.appendEnsembleProgress(progress())
+    runtime.queueRouterDecision(decision(12))
+    expect(messagesRef.value.filter(message => message.role === 'router')).toHaveLength(2)
+  })
+
+  it('keeps replay ownership per turn when another turn receives a late decision', () => {
+    const { runtime, messagesRef } = makeRuntime([{ role: 'user', text: 'q', ts: 0, turnId: 'first' }])
+    runtime.appendEnsembleProgress(progress('first'))
+    messagesRef.value.push({ role: 'user', text: 'q2', ts: 1, turnId: 'second' })
+    runtime.handleRouterControlReplay({ turn_id: 'second', stream_seq: 10 })
+    runtime.appendEnsembleProgress(progress('second'))
+    runtime.queueRouterDecision(decision(11, 'first'))
+    runtime.queueRouterDecision(decision(12, 'second'))
+    const cards = messagesRef.value.filter(message => message.role === 'router')
+    expect(cards).toHaveLength(2)
+    expect(cards.map(card => [card.turnId, card.messageId])).toEqual([
+      ['first', 'router-sess-11'], ['second', 'router-sess-12'],
+    ])
+  })
+
+  it('does not promote a history row that only resembles a local provisional card', () => {
+    const { runtime, messagesRef } = makeRuntime([{
+      role: 'router', text: '', ts: 0, turnId: 'turn-current',
+      messageId: 'router-sess-ensemble-1', provenanceKind: 'router_decision',
+      routerDecision: { tier: 'c1', model: 'provider/old', source: 'llm_ensemble' },
+      restoredFromHistory: true,
+    }])
+    runtime.queueRouterDecision(decision(12))
+    expect(messagesRef.value.filter(message => message.role === 'router')).toHaveLength(2)
+  })
+
+  it('does not promote a provisional card twice for different real decisions', () => {
+    const { runtime, messagesRef } = makeRuntime([{ role: 'user', text: 'q', ts: 0, turnId: 'turn-current' }])
+    runtime.appendEnsembleProgress(progress())
+    runtime.queueRouterDecision(decision(11))
+    runtime.queueRouterDecision(decision(12))
+    expect(messagesRef.value.filter(message => message.role === 'router').map(card => card.messageId))
+      .toEqual(['router-sess-11', 'router-sess-12'])
+  })
+
+  it('drops pending decisions and ownership after switching sessions', () => {
+    const { runtime, messagesRef, sessionKey } = makeRuntime([{ role: 'user', text: 'q', ts: 0, turnId: 'turn-current' }])
+    runtime.queueRouterDecision({ ...decision(10), key: 'sess' })
+    runtime.handleRouterControlReplay({ turn_id: 'turn-current', stream_seq: 11 })
+    runtime.queueRouterDecision({ ...decision(12), key: 'sess' })
+    sessionKey.value = 'new'
+    messagesRef.value = [{ role: 'user', text: 'q2', ts: 0, turnId: 'turn-current' }]
+    runtime.flushPendingRouterDecision()
+    runtime.appendEnsembleProgress({ ...progress(), key: 'sess' })
+    runtime.queueRouterDecision({ ...decision(13), key: 'sess' })
+    expect(messagesRef.value).toHaveLength(1)
+    runtime.appendEnsembleProgress({ ...progress(), key: 'new' })
+    runtime.queueRouterDecision({ ...decision(14), key: 'new' })
+    expect(messagesRef.value.filter(message => message.role === 'router').map(card => card.messageId))
+      .toEqual(['router-new-14'])
+  })
+})
 
 describe('router decision identity', () => {
   it('reuses the live stream identity when the same decision is replayed from a snapshot', () => {

--- a/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.test.ts
@@ -49,6 +49,33 @@ describe('router attempt ownership', () => {
     turn_id: turnId, stream_seq: seq, tier: 'c1', model: 'provider/selected', source: 'squilla_router',
   })
 
+  it('attaches untagged progress to the current tagged decision', () => {
+    const { runtime, messagesRef } = makeRuntime([{ role: 'user', text: 'q', ts: 0, turnId: 'turn-current' }])
+    runtime.queueRouterDecision(decision(10))
+    runtime.appendEnsembleProgress({
+      event_type: 'proposer_start', proposer_provider: 'provider', proposer_model: 'candidate',
+    })
+    const cards = messagesRef.value.filter(message => message.role === 'router')
+    expect(cards).toHaveLength(1)
+    expect(cards[0]?.ensemble?.models[0]?.model).toBe('candidate')
+  })
+
+  it('assigns untagged progress after replay to a new provisional card', () => {
+    const { runtime, messagesRef } = makeRuntime([{ role: 'user', text: 'q', ts: 0, turnId: 'turn-current' }])
+    runtime.queueRouterDecision(decision(10))
+    runtime.appendEnsembleProgress({ ...progress(), proposer_model: 'first' })
+    runtime.handleRouterControlReplay({ turn_id: 'turn-current', stream_seq: 20 })
+    runtime.appendEnsembleProgress({
+      event_type: 'proposer_start', proposer_provider: 'provider', proposer_model: 'second',
+    })
+    runtime.queueRouterDecision(decision(22))
+    const cards = messagesRef.value.filter(message => message.role === 'router')
+    expect(cards).toHaveLength(2)
+    expect(cards.map(card => card.messageId)).toEqual(['router-sess-10', 'router-sess-22'])
+    expect(cards.map(card => card.ensemble?.models.map(model => model.model)))
+      .toEqual([['first'], ['second']])
+  })
+
   it('uses the same boundary identity for live and snapshot replay', () => {
     const { runtime, messagesRef } = makeRuntime([{ role: 'user', text: 'q', ts: 0, turnId: 'turn-current' }])
     runtime.handleRouterControlReplay({ turn_id: 'turn-current', stream_seq: 10 })

--- a/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.ts
@@ -39,6 +39,8 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
     messageId: string
   } | null>(null)
   let localRouterMessageSeq = 0
+  let routerReplayGeneration = 0
+  const provisionalRouterMessageGenerations = new Map<string, number>()
 
   // Router and ensemble events can arrive throughout a long streamed answer.
   // They should follow the live edge only while the reader has elected to stay
@@ -48,6 +50,7 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
   }
 
   function handleRouterControlReplay() {
+    routerReplayGeneration += 1
     if (!options.isStreaming.value) options.startStreaming()
     pendingRouterDecision.value = null
     options.resetStreamForRouterReplay()
@@ -173,6 +176,27 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
     const turnId = payloadTurnId(payload)
     const acceptedDecision = freezeAcceptedRoutingMode(decision, turnId)
     if (options.messages.value.some(message => message.messageId === messageId)) return
+
+    if (turnId) {
+      for (let i = options.messages.value.length - 1; i >= 0; i--) {
+        const message = options.messages.value[i]
+        const provisionalMessageId = message.messageId || ''
+        if (
+          message.role === 'router'
+          && message.provenanceKind === 'router_decision'
+          && provisionalMessageId.startsWith(`router-${options.sessionKey.value}-`)
+          && message.turnId === turnId
+          && provisionalRouterMessageGenerations.get(provisionalMessageId) === routerReplayGeneration
+        ) {
+          message.routerDecision = acceptedDecision
+          message.messageId = messageId
+          message.turnId = turnId
+          provisionalRouterMessageGenerations.delete(provisionalMessageId)
+          scrollToBottomIfFollowing()
+          return
+        }
+      }
+    }
 
     options.messages.value.push({
       role: 'router',
@@ -306,6 +330,7 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
       ...(turnId ? { turnId } : {}),
     }
     options.messages.value.push(message)
+    provisionalRouterMessageGenerations.set(message.messageId!, routerReplayGeneration)
     return message
   }
 
@@ -346,7 +371,7 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
     let target = findLiveRouterMessage(turnId)
 
     if (!target) {
-      options.messages.value.push({
+      const provisionalMessage: ChatMessage = {
         role: 'router',
         text: '',
         ts: new Date().toISOString(),
@@ -355,7 +380,9 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
         messageId: `router-${options.sessionKey.value}-ensemble`,
         ensemble: emptyEnsemble(),
         ...(turnId ? { turnId } : {}),
-      })
+      }
+      options.messages.value.push(provisionalMessage)
+      provisionalRouterMessageGenerations.set(provisionalMessage.messageId!, routerReplayGeneration)
       // Re-read through the reactive array so nested mutations below trigger.
       target = options.messages.value[options.messages.value.length - 1]
     }

--- a/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.ts
@@ -436,7 +436,9 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
     const member = memberFromEnsembleProgress(payload)
     if (!member) return
 
-    const turnId = payloadTurnId(payload)
+    // Older accepted progress events omit the turn/task id. Use the same
+    // transcript anchor as handoff and call binding, including after replay.
+    const turnId = payloadTurnId(payload) || latestExplicitTurnId()
     let target = findLiveRouterMessage(turnId)
 
     if (!target) {

--- a/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRouterDecisionRuntime.ts
@@ -1,5 +1,6 @@
 import type {
   ConversationEnsembleProgress,
+  ConversationEventIdentity,
   ConversationRoutingDecision,
 } from '@/modules/conversationEventContent'
 import { ref, type Ref } from 'vue'
@@ -39,8 +40,54 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
     messageId: string
   } | null>(null)
   let localRouterMessageSeq = 0
-  let routerReplayGeneration = 0
-  const provisionalRouterMessageGenerations = new Map<string, number>()
+  let localReplaySeq = 0
+  let routerSessionKey = options.sessionKey.value
+  const replayKeys = new Map<string, string>()
+  const routerMessageAttempts = new Map<string, {
+    turnId: string
+    replayKey: string
+    provisional: boolean
+  }>()
+
+  function syncRouterSession() {
+    if (routerSessionKey === options.sessionKey.value) return
+    routerSessionKey = options.sessionKey.value
+    replayKeys.clear()
+    routerMessageAttempts.clear()
+    pendingRouterDecision.value = null
+  }
+
+  function replayKeyForTurn(turnId: string): string {
+    syncRouterSession()
+    return replayKeys.get(turnId) || ''
+  }
+
+  function rememberRouterMessage(message: ChatMessage, provisional: boolean) {
+    const turnId = message.turnId || ''
+    if (provisional) message.clientId = message.messageId
+    routerMessageAttempts.set(message.messageId!, {
+      turnId,
+      replayKey: replayKeyForTurn(turnId),
+      provisional,
+    })
+  }
+
+  function belongsToCurrentAttempt(message: ChatMessage, turnId: string): boolean {
+    const replayKey = replayKeyForTurn(turnId)
+    const attempt = routerMessageAttempts.get(message.messageId || '')
+    // History rows have no local attempt metadata. A replay must never reuse
+    // one as the destination for a new physical attempt's live state.
+    return attempt
+      ? attempt.turnId === turnId && attempt.replayKey === replayKey
+      : !replayKey
+  }
+
+  function resetRouterReplayCursor() {
+    syncRouterSession()
+    // An authoritative snapshot starts at the beginning of the turn. Keep
+    // card ownership, but rewind the cursor before replaying its boundaries.
+    replayKeys.clear()
+  }
 
   // Router and ensemble events can arrive throughout a long streamed answer.
   // They should follow the live edge only while the reader has elected to stay
@@ -49,8 +96,16 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
     if (options.autoScroll.value) options.scrollToBottom()
   }
 
-  function handleRouterControlReplay() {
-    routerReplayGeneration += 1
+  function handleRouterControlReplay(payload: ConversationEventIdentity = {}, identityStreamSeq?: number) {
+    syncRouterSession()
+    if (payload.key && payload.key !== options.sessionKey.value) return
+    const turnId = payloadTurnId(payload) || latestExplicitTurnId()
+    const seq = validIdentityStreamSeq(payload.stream_seq) ?? validIdentityStreamSeq(identityStreamSeq)
+    // Snapshot restoration supplies the original sequence as identity even
+    // though it removes it from the payload to bypass live cursor deduplication.
+    replayKeys.set(turnId, seq === null
+      ? `local:${++localReplaySeq}`
+      : JSON.stringify([payload.stream_generation || '', seq]))
     if (!options.isStreaming.value) options.startStreaming()
     pendingRouterDecision.value = null
     options.resetStreamForRouterReplay()
@@ -58,7 +113,7 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
     scrollToBottomIfFollowing()
   }
 
-  function payloadTurnId(payload: ConversationRoutingDecision | ConversationEnsembleProgress): string {
+  function payloadTurnId(payload: ConversationEventIdentity): string {
     return String(payload.turn_id || payload.task_id || '').trim()
   }
 
@@ -77,6 +132,7 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
         message.role === 'router'
         && message.provenanceKind === 'router_decision'
         && (!targetTurnId || message.turnId === targetTurnId)
+        && belongsToCurrentAttempt(message, targetTurnId)
       ) {
         return message
       }
@@ -95,12 +151,17 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
   ) {
     const normalizedCallId = String(modelCallId || '').trim()
     if (!normalizedCallId) return
+    targetTurnId = String(targetTurnId || latestExplicitTurnId()).trim()
+    // Text/thinking may precede the decision, including just after a replay.
+    // Create the same provisional handoff card before binding its call identity.
+    if (!findRouterMessageForTurn(targetTurnId)) markEnsembleHandoff(targetTurnId)
     for (let i = options.messages.value.length - 1; i >= 0; i--) {
       const message = options.messages.value[i]
       if (
         message.role === 'router'
         && message.provenanceKind === 'router_decision'
         && (!targetTurnId || message.turnId === targetTurnId)
+        && belongsToCurrentAttempt(message, targetTurnId)
       ) {
         if (message.routerModelCallId === normalizedCallId) return
         if (!message.routerModelCallId) {
@@ -186,19 +247,21 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
           && message.provenanceKind === 'router_decision'
           && provisionalMessageId.startsWith(`router-${options.sessionKey.value}-`)
           && message.turnId === turnId
-          && provisionalRouterMessageGenerations.get(provisionalMessageId) === routerReplayGeneration
+          && routerMessageAttempts.get(provisionalMessageId)?.provisional
+          && belongsToCurrentAttempt(message, turnId)
         ) {
           message.routerDecision = acceptedDecision
           message.messageId = messageId
           message.turnId = turnId
-          provisionalRouterMessageGenerations.delete(provisionalMessageId)
+          routerMessageAttempts.delete(provisionalMessageId)
+          rememberRouterMessage(message, false)
           scrollToBottomIfFollowing()
           return
         }
       }
     }
 
-    options.messages.value.push({
+    const message: ChatMessage = {
       role: 'router',
       text: '',
       ts: new Date().toISOString(),
@@ -206,11 +269,15 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
       provenanceKind: 'router_decision',
       messageId,
       ...(turnId ? { turnId } : {}),
-    })
+    }
+    rememberRouterMessage(message, false)
+    options.messages.value.push(message)
     scrollToBottomIfFollowing()
   }
 
   function queueRouterDecision(payload: ConversationRoutingDecision, identityStreamSeq?: number) {
+    syncRouterSession()
+    if (payload.key && payload.key !== options.sessionKey.value) return
     const normalizedDecision = normalizeRouterDecision(payload)
     if (!normalizedDecision) return
     const decision = freezeAcceptedRoutingMode(
@@ -227,6 +294,7 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
   }
 
   function flushPendingRouterDecision() {
+    syncRouterSession()
     const pending = pendingRouterDecision.value
     if (!pending) return
     pendingRouterDecision.value = null
@@ -317,34 +385,33 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
     return findRouterMessageForTurn(targetTurnId)
   }
 
-  function synthesizeHandoffRouterMessage(): ChatMessage {
-    const turnId = latestExplicitTurnId()
+  function synthesizeHandoffRouterMessage(turnId: string): ChatMessage {
     const message: ChatMessage = {
       role: 'router',
       text: '',
       ts: new Date().toISOString(),
       routerDecision: { tier: 'c1', model: '', source: 'llm_ensemble' },
       provenanceKind: 'router_decision',
-      messageId: `router-${options.sessionKey.value}-ensemble-handoff`,
+      messageId: `router-${options.sessionKey.value}-ensemble-handoff-${++localRouterMessageSeq}`,
       routerState: 'handoff',
       ...(turnId ? { turnId } : {}),
     }
+    rememberRouterMessage(message, true)
     options.messages.value.push(message)
-    provisionalRouterMessageGenerations.set(message.messageId!, routerReplayGeneration)
     return message
   }
 
-  function markEnsembleHandoff() {
+  function markEnsembleHandoff(targetTurnId = latestExplicitTurnId()) {
     if (!options.isStreaming.value) return
-    let target = findLiveRouterMessage()
+    let target = findLiveRouterMessage(targetTurnId)
     if (!target) {
       const expectedTurnId = String(options.activeTurnId.value || '').trim()
       if (
         !options.activeTurnUsesEnsemble.value
         || !expectedTurnId
-        || latestExplicitTurnId() !== expectedTurnId
+        || targetTurnId !== expectedTurnId
       ) return
-      target = synthesizeHandoffRouterMessage()
+      target = synthesizeHandoffRouterMessage(targetTurnId)
     }
     if (options.activeTurnUsesEnsemble.value && target.routerDecision) {
       const decision = normalizeRouterDecision(target.routerDecision)
@@ -364,6 +431,8 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
   // the strip reveals members incrementally. Mirrors appendRouterDecision: find
   // the in-flight router message, else synthesize one.
   function appendEnsembleProgress(payload: ConversationEnsembleProgress) {
+    syncRouterSession()
+    if (payload.key && payload.key !== options.sessionKey.value) return
     const member = memberFromEnsembleProgress(payload)
     if (!member) return
 
@@ -377,12 +446,12 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
         ts: new Date().toISOString(),
         routerDecision: { tier: 'c1', model: member.model, source: 'llm_ensemble' },
         provenanceKind: 'router_decision',
-        messageId: `router-${options.sessionKey.value}-ensemble`,
+        messageId: `router-${options.sessionKey.value}-ensemble-${++localRouterMessageSeq}`,
         ensemble: emptyEnsemble(),
         ...(turnId ? { turnId } : {}),
       }
+      rememberRouterMessage(provisionalMessage, true)
       options.messages.value.push(provisionalMessage)
-      provisionalRouterMessageGenerations.set(provisionalMessage.messageId!, routerReplayGeneration)
       // Re-read through the reactive array so nested mutations below trigger.
       target = options.messages.value[options.messages.value.length - 1]
     }
@@ -398,6 +467,7 @@ export function useChatRouterDecisionRuntime(options: UseChatRouterDecisionRunti
   return {
     pendingDecision: pendingRouterDecision,
     handleRouterControlReplay,
+    resetRouterReplayCursor,
     queueRouterDecision,
     flushPendingRouterDecision,
     clearPendingRouterDecision,

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick, ref } from 'vue'
 import { useChatRpcEventHandlers, type ChatRpcStreamApi } from './useChatRpcEventHandlers'
+import { useChatRouterDecisionRuntime } from './useChatRouterDecisionRuntime'
+import { useChatRenderedMessages } from './useChatRenderedMessages'
 import type { SessionBootstrapRun } from './useChatSessionBootstrap'
 import type {
   ChatMessage,
@@ -37,6 +39,7 @@ function createHarness(options: {
   getCompactionPlacement?: (compactionId: string) => 'activity' | 'standalone' | undefined
   observeStreamGeneration?: (signal: ConversationCursorSignal) => boolean
   supportsTurnCommitted?: boolean
+  withRouterRuntime?: boolean
 } = {}) {
   const messages = ref<ChatMessage[]>(options.messages ?? [])
   const sessionKey = ref('agent:main:test')
@@ -74,9 +77,19 @@ function createHarness(options: {
     hideThinkingIndicator: vi.fn(),
     appendFrame: vi.fn(),
   }
-  const markEnsembleHandoff = vi.fn()
-  const bindRouterDecisionToModelCall = vi.fn()
-  const queueRouterDecision = vi.fn()
+  const routerRuntime = options.withRouterRuntime ? useChatRouterDecisionRuntime({
+    messages, sessionKey, isStreaming: stream.isStreaming,
+    autoScroll: ref(false), activeTurnUsesEnsemble: ref(true), activeTurnId: ref('turn-live'),
+    streamBubble: stream.streamBubble, streamHasVisibleOutput: stream.streamHasVisibleOutput,
+    startStreaming: stream.startStreaming,
+    resetStreamForRouterReplay: () => { stream.streamHasVisibleOutput.value = false },
+    resetStreamIdleTimer: stream.resetStreamIdleTimer,
+    setStreamActivity: stream.setStreamActivity,
+    scrollToBottom: vi.fn(),
+  }) : undefined
+  const markEnsembleHandoff = vi.fn(routerRuntime?.markEnsembleHandoff)
+  const bindRouterDecisionToModelCall = vi.fn(routerRuntime?.bindRouterDecisionToModelCall)
+  const queueRouterDecision = vi.fn(routerRuntime?.queueRouterDecision)
   const schedulePendingDrainAfterTerminal = vi.fn()
   const scheduleHistorySync = vi.fn()
   const showCompactionToast = vi.fn()
@@ -116,11 +129,12 @@ function createHarness(options: {
     applySessionRunState,
     queueRouterDecision,
     bindRouterDecisionToModelCall,
-    appendEnsembleProgress: vi.fn(),
+    appendEnsembleProgress: vi.fn(routerRuntime?.appendEnsembleProgress),
     markEnsembleHandoff,
-    flushPendingRouterDecision: vi.fn(),
-    clearPendingRouterDecision: vi.fn(),
-    handleRouterControlReplay: vi.fn(),
+    flushPendingRouterDecision: vi.fn(routerRuntime?.flushPendingRouterDecision),
+    clearPendingRouterDecision: vi.fn(routerRuntime?.clearPendingRouterDecision),
+    handleRouterControlReplay: vi.fn(routerRuntime?.handleRouterControlReplay),
+    resetRouterReplayCursor: vi.fn(routerRuntime?.resetRouterReplayCursor),
     showCompactionToast,
     getCompactionPlacement: options.getCompactionPlacement,
     showWarningToast,
@@ -182,6 +196,157 @@ function createHarness(options: {
     stop: () => { detach(); scope.stop() },
   }
 }
+
+describe('router card recovery projection', () => {
+  const key = 'agent:main:test'
+  const turnId = 'turn-live'
+  const envelope = (seq: number) => ({ key, task_id: turnId, turn_id: turnId, stream_seq: seq })
+  const decision = (seq: number) => ({
+    ...envelope(seq), tier: 'c1', model: 'provider/selected', source: 'squilla_router',
+  })
+  const progress = (seq: number, model = 'candidate') => ({
+    ...envelope(seq), event_type: 'proposer_finish' as const,
+    proposer_provider: 'provider', proposer_model: model,
+  })
+  function setup() {
+    const h = createHarness({
+      withRouterRuntime: true,
+      messages: [{ role: 'user', text: 'hello', ts: 0, turnId }],
+    })
+    h.activeStreamTaskId.value = turnId
+    return h
+  }
+  function renderedCards(h: ReturnType<typeof setup>) {
+    return useChatRenderedMessages({
+      messages: h.messages, sessionKey: h.sessionKey,
+      routerSlots: ref([]), routerModels: ref({}), routerTierConfigs: ref({}),
+      routerVisualEffectsEnabled: ref(true), routerVisualMode: ref('real_candidates'),
+      modelRoutingMode: ref('llm_ensemble'), renderMarkdown: text => text,
+      stripGeneratedArtifactMarkers: text => text, stripTimePrefix: text => text,
+      isSubagentCompletionMessage: () => false,
+    }).renderedMessages
+  }
+
+  it('keeps the provisional row mounted when it acquires real event and call identities', () => {
+    const h = setup()
+    const emit = h.api.handlers.onWireEventFixture
+    const rendered = renderedCards(h)
+    try {
+      emit('session.event.ensemble_progress', progress(10))
+      const originalKey = rendered.value.find(message => message.isRouterStrip)?.routerTurnKey
+      expect(originalKey).toBeTruthy()
+      emit('session.event.router_decision', decision(11))
+      expect(rendered.value.filter(message => message.isRouterStrip)).toHaveLength(1)
+      expect(rendered.value.find(message => message.isRouterStrip)?.routerTurnKey).toBe(originalKey)
+      emit('session.event.text_delta', { ...envelope(12), text: 'answer', model_call_id: '1.0' })
+      expect(rendered.value.find(message => message.isRouterStrip)?.routerTurnKey).toBe(originalKey)
+    } finally { h.stop() }
+  })
+
+  it('keeps the next attempt\'s early progress and physical call off the previous card', () => {
+    const h = setup()
+    const emit = h.api.handlers.onWireEventFixture
+    try {
+      emit('session.event.router_decision', decision(10))
+      emit('session.event.ensemble_progress', progress(11, 'first'))
+      emit('session.event.text_delta', { ...envelope(12), text: 'first', model_call_id: '1.0', iteration: 1 })
+      emit('session.event.router_control_replay', envelope(20))
+      emit('session.event.ensemble_progress', progress(21, 'second'))
+      emit('session.event.text_delta', { ...envelope(22), text: 'second', model_call_id: '2.0', iteration: 2 })
+      emit('session.event.router_decision', decision(23))
+
+      const cards = h.messages.value.filter(message => message.role === 'router')
+      expect(cards).toHaveLength(2)
+      expect(cards.map(card => card.ensemble?.models.map(model => model.model))).toEqual([['first'], ['second']])
+      expect(cards.map(card => card.routerModelCallId)).toEqual(['1.0', '2.0'])
+      expect(renderedCards(h).value.filter(message => message.isRouterStrip)).toHaveLength(2)
+    } finally { h.stop() }
+  })
+
+  it.each(['text_delta', 'thinking'] as const)('binds %s before a replay decision even without progress', (event) => {
+    const h = setup()
+    const emit = h.api.handlers.onWireEventFixture
+    try {
+      emit('session.event.router_decision', decision(10))
+      emit('session.event.text_delta', { ...envelope(11), text: 'first', model_call_id: '1.0' })
+      emit('session.event.router_control_replay', envelope(20))
+      emit(`session.event.${event}`, { ...envelope(21), text: 'second', model_call_id: '2.0', iteration: 2 })
+      emit('session.event.router_decision', decision(22))
+
+      const cards = h.messages.value.filter(message => message.role === 'router')
+      expect(cards).toHaveLength(2)
+      expect(cards.map(card => card.routerModelCallId)).toEqual(['1.0', '2.0'])
+      expect(cards[1]).toMatchObject({ messageId: `router-${key}-22`, routerIteration: 2 })
+    } finally { h.stop() }
+  })
+
+  it('preserves task-only call identity when legacy events omit turn_id', () => {
+    const h = setup()
+    const emit = h.api.handlers.onWireEventFixture
+    try {
+      emit('session.event.text_delta', {
+        key, task_id: turnId, stream_seq: 10, text: 'answer', model_call_id: '1.0',
+      })
+      emit('session.event.router_decision', {
+        key, task_id: turnId, stream_seq: 11, tier: 'c1', model: 'provider/selected', source: 'squilla_router',
+      })
+      const cards = h.messages.value.filter(message => message.role === 'router')
+      expect(cards).toHaveLength(1)
+      expect(cards[0]).toMatchObject({ turnId, messageId: `router-${key}-11`, routerModelCallId: '1.0' })
+    } finally { h.stop() }
+  })
+
+  it('replays a full snapshot repeatedly without duplicating or mixing attempts', () => {
+    const h = setup()
+    const emit = h.api.handlers.onWireEventFixture
+    const events = [
+      { semanticKind: 'router-decision' as const, payload: decision(10) },
+      { semanticKind: 'ensemble-progress' as const, payload: progress(11, 'first') },
+      { semanticKind: 'router-control-replay' as const, payload: envelope(20) },
+      { semanticKind: 'ensemble-progress' as const, payload: progress(21, 'second') },
+    ]
+    try {
+      emit('session.event.router_decision', decision(10))
+      emit('session.event.ensemble_progress', progress(11, 'first'))
+      emit('session.event.router_control_replay', envelope(20))
+      emit('session.event.ensemble_progress', progress(21, 'second'))
+      for (let replay = 0; replay < 2; replay++) {
+        h.api.restoreLiveTurnSnapshot({ sessionKey: key, taskId: turnId, events })
+      }
+      emit('session.event.router_decision', decision(22))
+      h.api.restoreLiveTurnSnapshot({
+        sessionKey: key, taskId: turnId,
+        events: [...events, { semanticKind: 'router-decision', payload: decision(22) }],
+      })
+
+      const cards = h.messages.value.filter(message => message.role === 'router')
+      expect(cards).toHaveLength(2)
+      expect(cards.map(card => card.messageId)).toEqual([`router-${key}-10`, `router-${key}-22`])
+      expect(cards.map(card => card.ensemble?.models.map(model => model.model))).toEqual([['first'], ['second']])
+      expect(renderedCards(h).value.filter(message => message.isRouterStrip)).toHaveLength(2)
+    } finally { h.stop() }
+  })
+
+  it('does not populate a new session from an old session\'s late events or snapshot', () => {
+    const h = setup()
+    const emit = h.api.handlers.onWireEventFixture
+    try {
+      emit('session.event.ensemble_progress', progress(10))
+      h.messages.value = []
+      h.sessionKey.value = 'agent:main:new'
+      h.activeStreamTaskId.value = ''
+      emit('session.event.ensemble_progress', progress(11))
+      emit('session.event.router_decision', decision(12))
+      emit('session.event.router_control_replay', envelope(13))
+      h.api.restoreLiveTurnSnapshot({
+        sessionKey: key, taskId: turnId,
+        events: [{ semanticKind: 'ensemble-progress', payload: progress(11) }],
+      })
+      expect(h.messages.value).toEqual([])
+      expect(renderedCards(h).value).toEqual([])
+    } finally { h.stop() }
+  })
+})
 
 describe('live task steer capability', () => {
   const capability = {

--- a/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
+++ b/opensquilla-webui/src/composables/chat/useChatRpcEventHandlers.ts
@@ -160,10 +160,11 @@ export interface UseChatRpcEventHandlersOptions {
     turnId?: string,
   ) => void
   appendEnsembleProgress: (payload: ConversationEnsembleProgress) => void
-  markEnsembleHandoff: () => void
+  markEnsembleHandoff: (turnId?: string) => void
   flushPendingRouterDecision: () => void
   clearPendingRouterDecision: () => void
-  handleRouterControlReplay: () => void
+  handleRouterControlReplay: (payload: ConversationEventIdentity, identityStreamSeq?: number) => void
+  resetRouterReplayCursor?: () => void
   showCompactionToast: (
     payload: ConversationCompactionContent,
     meta?: Record<string, unknown>,
@@ -827,6 +828,7 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
     activeStreamTaskId.value = typeof snapshot.taskId === 'string'
       ? snapshot.taskId
       : ''
+    options.resetRouterReplayCursor?.()
 
     const replayEntries: BufferedPendingReplayEntry[] = (snapshot.events || [])
       .flatMap((entry, order): BufferedPendingReplayEntry[] => {
@@ -1432,9 +1434,9 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
     options.bindRouterDecisionToModelCall?.(
       modelCallId,
       iteration,
-      String(payload.turn_id || ''),
+      String(payload.turn_id || payload.task_id || ''),
     )
-    options.markEnsembleHandoff()
+    options.markEnsembleHandoff(String(payload.turn_id || payload.task_id || '') || undefined)
     const identity: ChatStreamModelCallIdentity | undefined = modelCallId || iteration > 0
       ? { modelCallId, iteration }
       : undefined
@@ -1460,7 +1462,7 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
     if (!isCurrentTaskPayload(payload)) return
     if (!acceptStreamSeq(payload)) return
     stream.resetStreamIdleTimer()
-    options.markEnsembleHandoff()
+    options.markEnsembleHandoff(String(payload.turn_id || payload.task_id || '') || undefined)
     stream.appendToolCall(payload)
   }
 
@@ -1472,7 +1474,7 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
     if (!isCurrentTaskPayload(payload)) return
     if (!acceptStreamSeq(payload)) return
     stream.resetStreamIdleTimer()
-    options.markEnsembleHandoff()
+    options.markEnsembleHandoff(String(payload.turn_id || payload.task_id || '') || undefined)
     stream.appendToolDelta(payload)
   }
 
@@ -1484,7 +1486,7 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
     if (!isCurrentTaskPayload(payload)) return
     if (!acceptStreamSeq(payload)) return
     stream.resetStreamIdleTimer()
-    options.markEnsembleHandoff()
+    options.markEnsembleHandoff(String(payload.turn_id || payload.task_id || '') || undefined)
     stream.appendToolEnd?.(payload)
   }
 
@@ -1522,7 +1524,7 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
     const activeState = ['thinking', 'streaming', 'tool_calling', 'tool_use', 'running'].includes(String(to))
     if (!stream.isStreaming.value && activeState) stream.startStreaming()
     if (!stream.isStreaming.value) return
-    if (activeState) options.markEnsembleHandoff()
+    if (activeState) options.markEnsembleHandoff(String(payload.turn_id || payload.task_id || '') || undefined)
     if (to === 'thinking') {
       if (stream.streamBubble.value && !stream.streamHasVisibleOutput.value) {
         recordActivityPhase('Planning next step')
@@ -1578,7 +1580,7 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
 
     if (!stream.isStreaming.value) stream.startStreaming()
     stream.resetStreamIdleTimer()
-    options.markEnsembleHandoff()
+    options.markEnsembleHandoff(String(payload.turn_id || payload.task_id || '') || undefined)
 
     if (phase === 'requesting') {
       recordActivityPhase('Waiting for model', 'provider:requesting')
@@ -1970,7 +1972,7 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
     if (!isCurrentGenerationPayload(payload)) return
     if (!isCurrentTaskPayload(payload)) return
     if (!acceptStreamSeq(payload)) return
-    options.handleRouterControlReplay()
+    options.handleRouterControlReplay(payload, replayActivityOrder)
   }
 
   function handleSemanticEvent(
@@ -2132,7 +2134,7 @@ export function useChatRpcEventHandlers(options: UseChatRpcEventHandlersOptions)
       options.bindRouterDecisionToModelCall?.(
         String(thinkingPayload.model_call_id || ''),
         Number(thinkingPayload.iteration || 0),
-        String(thinkingPayload.turn_id || ''),
+        String(thinkingPayload.turn_id || thinkingPayload.task_id || ''),
       )
       appendThinkingDelta(thinkingText, payload)
       return

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -2221,6 +2221,7 @@ const chatRouterDecisionRuntime = useChatRouterDecisionRuntime({
 const {
   pendingDecision,
   handleRouterControlReplay,
+  resetRouterReplayCursor,
   queueRouterDecision,
   appendEnsembleProgress,
   markEnsembleHandoff,
@@ -3869,6 +3870,7 @@ const rpcEventHandlers = useChatRpcEventHandlers({
   flushPendingRouterDecision,
   clearPendingRouterDecision,
   handleRouterControlReplay,
+  resetRouterReplayCursor,
   showCompactionToast,
   getCompactionPlacement: id => getCompactionPlacement(id) || undefined,
   showWarningToast: message => pushToast(message || t('chat.warning.default'), { tone: 'warn', duration: 5000 }),


### PR DESCRIPTION
## Scope

Progress or handoff arriving before a router decision can render two cards for one attempt. After a router-control replay, early candidates and physical call identity can also land on the previous card, while reconnect snapshots can prevent provisional-card promotion.

Promote the same attempt's provisional card in place, bind progress/handoff/calls to that attempt, and identify replay boundaries using the existing original stream sequence and generation. Snapshot restoration rewinds the routing cursor while retaining card ownership, so repeated snapshots remain idempotent. Preserve the provisional client identity through promotion to keep the rendered row mounted.

Scope boundary: shared WebUI routing state, event integration, and render identity.

Non-goals: native host changes, backend/wire-schema changes, or claiming the intermittent Windows New Task report is fully resolved.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: Refs #1477

Includes the original provisional-card fix from #1502 and adds replay/snapshot ownership corrections. The issue remains open for the separately reported intermittent New Task symptom; the identified old-session event and snapshot controls added here pass.

## Release Note

Release note: Router progress now stays on one card per attempt through delayed decisions and reconnects, and retries retain their own candidates and physical call state.

## Tests

Ruff: N/A — no Python changes.

Pytest: N/A — no Python changes; no full backend suite run.

Build: `npm run build` passed, including architecture/security/theme/i18n guards, `vue-tsc`, and production artifact/bundle verification.

Regression tests: added.

Seven focused Vitest files passed, 286 tests total: router runtime, RPC handlers, rendered messages, task ownership, issue344 event fences, message-list virtualization, and history anchors. Added cases cover early progress/text/thinking after replay, repeated full snapshots, legacy task-only identity and untagged ensemble progress, sequence-free boundary isolation, cross-turn/session isolation, preservation of execution metadata, and stable render keys through promotion.

The tests use synthetic events and remain offline, deterministic, and credential-free. Validation ran on macOS. Windows, macOS, and Linux use the same TypeScript implementation; there are no OS-specific branches in this change. No native Windows desktop smoke run was performed.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

No configuration, persistence format, public event schema, startup dependency, or provider invocation changes. Older events without stable sequence identity keep distinct replay attempts separate. Local routing ownership is cleared on session changes. No secrets, private runtime data, local artifacts, or machine-specific paths are included.

## Third-Party Origin

Third-party origin: adapted/ported

Includes mikemikimike's original Apache-2.0 repository contribution from #1502, commit `399349b4ebae773336a4ec15291bb87e1112048f`, preserved as an attributed cherry-pick. The follow-up commit corrects ownership and adds regression coverage. No new external dependency or vendored code.

## Documentation Changes

None.

