### PR TITLE
ci: reuse validated queue suites and report queue failures to PRs

### DIFF
--- a/.github/ci/suites.v1.json
+++ b/.github/ci/suites.v1.json
@@ -172,7 +172,8 @@
         "opensquilla-webui/**",
         "pyproject.toml",
         "scripts/contracts/**",
-        "src/opensquilla/contracts/generated/v4/**",
+        "src/opensquilla/__init__.py",
+        "src/opensquilla/contracts/**",
         "tests/contracts/**",
         "tests/fixtures/contracts/gateway/v4/**",
         "uv.lock"
@@ -196,6 +197,7 @@
     },
     "tui": {
       "execution_inputs": [
+        "opensquilla-webui/.node-version",
         "src/opensquilla/cli/tui/**",
         "packages/opensquilla-tui-host/**",
         "scripts/build_tui_host_companion.py",

--- a/.github/scripts/check_ci_results.py
+++ b/.github/scripts/check_ci_results.py
@@ -7,6 +7,7 @@ import json
 import os
 import sys
 from collections.abc import Mapping
+from pathlib import Path
 from typing import Final
 
 PLANNER_RESULT: Final[tuple[str, str]] = ("RESULT_PLANNER", "Plan CI suites")
@@ -158,6 +159,8 @@ def check_ci_results(env: Mapping[str, str]) -> list[str]:
 
     _validate_suite_result_contract(errors)
     required_suites = _read_required_suites(env, errors)
+    if env.get("QUEUE_PARTIAL") == "true":
+        _check_partial_coverage(env, required_suites, errors)
 
     required_results = {
         variable
@@ -174,6 +177,37 @@ def check_ci_results(env: Mapping[str, str]) -> list[str]:
         )
 
     return errors
+
+
+def _check_partial_coverage(
+    env: Mapping[str, str], executed: set[str], errors: list[str]
+) -> None:
+    """A partial run still owes EVERY full-matrix suite, by proof or execution."""
+    if env.get("GITHUB_EVENT_NAME") != "merge_group":
+        errors.append("Partial evidence is valid only for merge_group.")
+    if env.get("QUEUE_EVIDENCE_RESULT") != "success":
+        errors.append("Partial evidence verifier must succeed.")
+    if env.get("QUEUE_CANARY_RESULT") != "success":
+        errors.append("Partial queue combined-tree canary must succeed.")
+    if not env.get("QUEUE_SOURCE_RUN_ID", "").isdigit() or int(
+        env.get("QUEUE_SOURCE_RUN_ID", "0")
+    ) <= 0:
+        errors.append("Partial evidence source run is missing.")
+    try:
+        reused = json.loads(env.get("QUEUE_REUSED_SUITES", ""))
+        if (
+            not isinstance(reused, list) or not reused
+            or any(not isinstance(suite, str) for suite in reused)
+            or reused != sorted(set(reused))
+            or not set(reused) <= {"frontend-validation", "tui"}
+        ):
+            raise ValueError("invalid reused suites")
+        manifest = Path(__file__).resolve().parents[1] / "ci" / "suites.v1.json"
+        full = set(json.loads(manifest.read_text(encoding="utf-8"))["full_suites"])
+        if executed & set(reused) or executed | set(reused) != full:
+            errors.append("Executed and reused suites must partition the full queue matrix.")
+    except (OSError, ValueError, KeyError, TypeError):
+        errors.append("Partial queue coverage is invalid.")
 
 
 def main() -> int:

--- a/.github/scripts/check_ci_results.py
+++ b/.github/scripts/check_ci_results.py
@@ -161,6 +161,12 @@ def check_ci_results(env: Mapping[str, str]) -> list[str]:
     required_suites = _read_required_suites(env, errors)
     if env.get("QUEUE_PARTIAL") == "true":
         _check_partial_coverage(env, required_suites, errors)
+    elif env.get("GITHUB_EVENT_NAME") == "merge_group":
+        try:
+            if required_suites != _full_queue_suites():
+                errors.append("Queue without partial proof must execute the full matrix.")
+        except (OSError, ValueError, KeyError, TypeError):
+            errors.append("Full queue coverage manifest is invalid.")
 
     required_results = {
         variable
@@ -177,6 +183,11 @@ def check_ci_results(env: Mapping[str, str]) -> list[str]:
         )
 
     return errors
+
+
+def _full_queue_suites() -> set[str]:
+    manifest = Path(__file__).resolve().parents[1] / "ci" / "suites.v1.json"
+    return set(json.loads(manifest.read_text(encoding="utf-8"))["full_suites"])
 
 
 def _check_partial_coverage(
@@ -202,8 +213,7 @@ def _check_partial_coverage(
             or not set(reused) <= {"frontend-validation", "tui"}
         ):
             raise ValueError("invalid reused suites")
-        manifest = Path(__file__).resolve().parents[1] / "ci" / "suites.v1.json"
-        full = set(json.loads(manifest.read_text(encoding="utf-8"))["full_suites"])
+        full = _full_queue_suites()
         if executed & set(reused) or executed | set(reused) != full:
             errors.append("Executed and reused suites must partition the full queue matrix.")
     except (OSError, ValueError, KeyError, TypeError):

--- a/.github/scripts/ci_attestation.py
+++ b/.github/scripts/ci_attestation.py
@@ -41,6 +41,9 @@ COMPOSITION_BASELINE_SUITES: Final = frozenset({"readme-locale", "workflow-lint"
 COMPOSITION_COMBINED_SMOKE_TRUST_ROOT: Final = frozenset()
 TRUST_POLICY_MANIFEST: Final = ".github/ci/trust-policy.v1.json"
 TRUST_POLICY_SCHEMA_VERSION: Final = 1
+# Initially reuse only suites with audited, bounded inputs and fixed matrices.
+# Producers and Python/native integration suites continue to execute in the queue.
+PARTIAL_REUSE_SUITES: Final = frozenset({"frontend-validation", "tui"})
 
 
 class AttestationError(RuntimeError):
@@ -945,7 +948,7 @@ def validate_candidate(
             raise AttestationError("attestation tested tree does not match the queue")
         if tested_base_sha != queue_base_sha:
             raise AttestationError("attestation tested base does not match the queue")
-    elif match_kind == "composed":
+    elif match_kind in {"composed", "partial"}:
         if reconstructed_queue_tree != queue_tree_sha:
             raise AttestationError("pull request head and queue base do not reconstruct queue tree")
         if tested_base_sha == queue_base_sha:
@@ -1030,6 +1033,52 @@ def validate_candidate(
             raise AttestationError("current pull request target changed")
 
 
+def partial_queue_plan(
+    *, repo: Path, attestation: Mapping[str, Any], queue_base_sha: str
+) -> Mapping[str, Any]:
+    """Partition a FULL queue plan; never borrow coverage from the queue base.
+
+    The caller must authenticate the PR run before consuming this plan. A suite
+    needs identical execution inputs and the entire required platform matrix.
+    Unproved suites run in full, including artifact producers and shared jobs.
+    """
+    tested_base = _require_sha(attestation.get("base_sha"), "tested base SHA")
+    if subprocess.run(
+        ["git", "merge-base", "--is-ancestor", tested_base, queue_base_sha],
+        cwd=repo, capture_output=True, check=False,
+    ).returncode != 0:
+        raise AttestationError("partial evidence base is not an ancestor of queue base")
+    delta = _changed_paths(repo, tested_base, queue_base_sha)
+    if not delta or _plan_paths(repo, delta).get("full_fallback") is not False:
+        raise AttestationError("partial evidence base delta requires full fallback")
+    full = dict(_plan_paths(repo, [".ci/run-all"]))
+    suites = _validated_suites(attestation)
+    digests = _validated_execution_digests(attestation, suites)
+    cells = _validated_platform_matrix(attestation, suites)
+    reused = sorted(
+        suite for suite in PARTIAL_REUSE_SUITES & suites
+        if digests[suite] == full["suite_execution_digests"].get(suite)
+        and [cell for cell in cells if cell["suite"] == suite]
+        == [cell for cell in full["platform_matrix"] if cell["suite"] == suite]
+    )
+    if not reused:
+        raise AttestationError(
+            "only exact-tree pull request evidence may be reused: no reusable suites"
+        )
+    full["reused_suites"] = reused
+    full["required_suites"] = sorted(set(full["required_suites"]) - set(reused))
+    full["platform_matrix"] = [c for c in full["platform_matrix"] if c["suite"] not in reused]
+    full["suite_execution_digests"] = {
+        key: value for key, value in full["suite_execution_digests"].items() if key not in reused
+    }
+    full["reason_codes"] = ["verified_partial_pr_evidence"]
+    full.pop("plan_digest")
+    full["plan_digest"] = hashlib.sha256(
+        json.dumps(full, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    return full
+
+
 def verify_queue(
     *,
     repo: Path,
@@ -1044,6 +1093,9 @@ def verify_queue(
     details.update(
         candidate_count=0,
         artifact_name="",
+        partial="false",
+        partial_plan="",
+        reused_suites="[]",
         combined_smoke_suites=_canonical_suite_json(),
     )
     merge_group = event.get("merge_group")
@@ -1157,10 +1209,7 @@ def verify_queue(
                 tested_tree = _require_sha(
                     attestation.get("tested_tree_sha"), "attested tree SHA"
                 )
-                if tested_tree != queue_tree_sha:
-                    raise AttestationError(
-                        "only exact-tree pull request evidence may be reused"
-                    )
+                partial = tested_tree != queue_tree_sha
                 if attestation.get("source_event") != "pull_request":
                     raise AttestationError(
                         "only pull request evidence may be reused by the queue"
@@ -1174,7 +1223,7 @@ def verify_queue(
                     queue_tree_sha=queue_tree_sha,
                     queue_base_sha=queue_base_sha,
                     queue_policy_digest=queue_policy,
-                    match_kind="exact",
+                    match_kind="partial" if partial else "exact",
                     current_pull_request=current_pull_request,
                     reconstructed_queue_tree=reconstructed_tree,
                     repo=repo,
@@ -1196,6 +1245,20 @@ def verify_queue(
                 if latest_run_id != run_id:
                     raise AttestationError(
                         "evidence workflow run is not the latest authoritative PR run"
+                    )
+                if partial:
+                    plan = partial_queue_plan(
+                        repo=repo, attestation=attestation, queue_base_sha=queue_base_sha
+                    )
+                    details.update(
+                        reason_code="reusable_partial", partial="true",
+                        partial_plan=json.dumps(plan, sort_keys=True, separators=(",", ":")),
+                        reused_suites=json.dumps(plan["reused_suites"], separators=(",", ":")),
+                    )
+                    return (
+                        False,
+                        "trusted PR suites reused; remaining full queue suites must pass",
+                        run_id,
                     )
                 details["reason_code"] = "reusable_exact"
                 reason = "matching trusted exact-base, exact-tree PR CI evidence"
@@ -1508,6 +1571,9 @@ def _verify_queue_command(args: argparse.Namespace) -> int:
         Path(args.github_output) if args.github_output else None,
         {
             "reusable": str(reusable).lower(),
+            "partial": details.get("partial", "false"),
+            "partial_plan": details.get("partial_plan", ""),
+            "reused_suites": details.get("reused_suites", "[]"),
             "reason": reason,
             "reason_code": details.get("reason_code", "artifact_invalid"),
             "source_run_id": source_run_id or "",

--- a/.github/scripts/plan_ci.py
+++ b/.github/scripts/plan_ci.py
@@ -371,7 +371,11 @@ _FIXED_PLATFORM_MATRIX: Final[dict[str, tuple[tuple[str, str], ...]]] = {
     "workflow-lint": (("ubuntu-latest", "default"),),
     "readme-locale": (("ubuntu-latest", "default"),),
     "frontend-artifact": (("ubuntu-latest", "artifact"),),
-    "frontend-validation": (("ubuntu-latest", "validation"),),
+    "frontend-validation": (
+        ("ubuntu-latest", "validation"),
+        ("ubuntu-latest", "contract-verification"),
+        ("windows-latest", "contract-determinism"),
+    ),
     "wheel-webui-roundtrip": (("ubuntu-latest", "package"),),
     "webui-chat-recovery": (("ubuntu-latest", "chromium"),),
     "tui": (("ubuntu-latest", "default"),),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
     timeout-minutes: 5
     outputs:
       reusable: ${{ steps.verify.outputs.reusable || 'false' }}
+      partial: ${{ steps.verify.outputs.partial || 'false' }}
+      partial_plan: ${{ steps.verify.outputs.partial_plan }}
+      reused_suites: ${{ steps.verify.outputs.reused_suites || '[]' }}
       reason: ${{ steps.verify.outputs.reason || steps.mode.outputs.reason }}
       reason_code: ${{ steps.verify.outputs.reason_code || steps.mode.outputs.reason_code }}
       source_run_id: ${{ steps.verify.outputs.source_run_id }}
@@ -96,6 +99,7 @@ jobs:
           QUEUE_HEAD_SHA: ${{ steps.verify.outputs.queue_head_sha }}
           QUEUE_TREE_SHA: ${{ steps.verify.outputs.queue_tree_sha }}
           COMBINED_SMOKE_SUITES: ${{ steps.verify.outputs.combined_smoke_suites || '[]' }}
+          REUSED_SUITES: ${{ steps.verify.outputs.reused_suites || '[]' }}
         shell: bash
         run: |
           {
@@ -108,6 +112,7 @@ jobs:
             echo "- Artifact: \`${ARTIFACT_NAME}\`"
             echo "- Queue base/head/tree: \`${QUEUE_BASE_SHA}\` / \`${QUEUE_HEAD_SHA}\` / \`${QUEUE_TREE_SHA}\`"
             echo "- Combined-tree domain smokes: \`${COMBINED_SMOKE_SUITES}\`"
+            echo "- Reused suites: \`${REUSED_SUITES}\` (all other full-matrix suites must run)"
             if [[ "${REASON_CODE}" == "tree_mismatch" ]]; then
               echo "- Fast-path note: the PR evidence does not match this queue tree, so this entry runs the full fail-closed matrix. If main advanced, refresh the PR against the latest main and wait for a new green PR CI run before requeueing. Reuse is always decided against the future entry's exact base and tree."
             fi
@@ -208,15 +213,21 @@ jobs:
 
       - name: Build canonical suite plan
         id: plan
+        env:
+          QUEUE_PARTIAL: ${{ github.event_name == 'merge_group' && env.CI_OPTIMIZATION_MODE == 'enforce' && needs.queue-attestation.result == 'success' && needs.queue-attestation.outputs.partial == 'true' }}
+          QUEUE_PARTIAL_PLAN: ${{ needs.queue-attestation.outputs.partial_plan }}
         shell: bash
         run: |
           set -euo pipefail
           plan_json="$(python3 .github/scripts/plan_ci.py "${CHANGED_FILES}" --repo .)"
           python3 - "${plan_json}" "${GITHUB_OUTPUT}" <<'PY'
           import json
+          import os
           import sys
 
           plan = json.loads(sys.argv[1])
+          if os.environ.get("QUEUE_PARTIAL") == "true":
+              plan = json.loads(os.environ["QUEUE_PARTIAL_PLAN"])
           output = sys.argv[2]
           with open(output, "a", encoding="utf-8") as handle:
               for key in (
@@ -2002,7 +2013,8 @@ jobs:
               || (github.event_name == 'merge_group'
                   && (vars.CI_OPTIMIZATION_MODE || 'enforce') == 'enforce'
                   && needs.queue-attestation.result == 'success'
-                  && needs.queue-attestation.outputs.reusable == 'true')) }}
+                  && (needs.queue-attestation.outputs.reusable == 'true'
+                      || needs.queue-attestation.outputs.partial == 'true'))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -2183,6 +2195,11 @@ jobs:
           RESULT_RELEASE: ${{ needs.release-packaging.result }}
           RESULT_MANAGED_TOOLCHAIN_ARTIFACTS: ${{ needs.managed-toolchain-artifacts.result }}
           REQUIRED_SUITES: ${{ needs.plan-ci.outputs.required_suites }}
+          QUEUE_PARTIAL: ${{ github.event_name == 'merge_group' && env.CI_OPTIMIZATION_MODE == 'enforce' && needs.queue-attestation.outputs.partial == 'true' }}
+          QUEUE_EVIDENCE_RESULT: ${{ needs.queue-attestation.result }}
+          QUEUE_REUSED_SUITES: ${{ needs.queue-attestation.outputs.reused_suites || '[]' }}
+          QUEUE_SOURCE_RUN_ID: ${{ needs.queue-attestation.outputs.source_run_id }}
+          QUEUE_CANARY_RESULT: ${{ needs.main-canary.result }}
         run: python .github/scripts/check_ci_results.py
 
       - name: Create trusted CI evidence v2
@@ -2191,6 +2208,7 @@ jobs:
           ${{ env.CI_OPTIMIZATION_MODE != 'legacy'
               && (github.event_name == 'pull_request'
                   || (github.event_name == 'merge_group'
+                      && needs.queue-attestation.outputs.partial != 'true'
                       && !(env.CI_OPTIMIZATION_MODE == 'enforce'
                            && needs.queue-attestation.result == 'success'
                            && needs.queue-attestation.outputs.reusable == 'true'))) }}

--- a/.github/workflows/queue-feedback.yml
+++ b/.github/workflows/queue-feedback.yml
@@ -1,0 +1,58 @@
+name: Merge queue feedback
+
+"on":
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions: {}
+
+concurrency:
+  group: queue-feedback-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+  cancel-in-progress: false
+
+jobs:
+  report:
+    if: ${{ github.event.workflow_run.event == 'merge_group' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      pull-requests: write
+    steps:
+      # workflow_run uses the default-branch workflow. Never check out or run
+      # candidate code/artifacts with this token; report GitHub metadata only.
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const repository = `${context.repo.owner}/${context.repo.repo}`;
+            if (run.repository?.full_name !== repository ||
+                run.head_repository?.full_name !== repository ||
+                run.path !== '.github/workflows/ci.yml' ||
+                run.status !== 'completed') return;
+            const match = /^gh-readonly-queue\/main\/pr-([1-9][0-9]*)-[0-9a-f]{40}$/.exec(run.head_branch);
+            if (!match) return;
+            const pull_number = Number(match[1]);
+            const {data: pr} = await github.rest.pulls.get({...context.repo, pull_number});
+            if (pr.base.ref !== 'main') return;
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              ...context.repo, run_id: run.id, filter: 'latest', per_page: 100,
+            });
+            const marker = `<!-- opensquilla-queue-result:${run.id}:${run.run_attempt} -->`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo, issue_number: pull_number, per_page: 100,
+            });
+            if (comments.some(c => c.user.type === 'Bot' && c.body?.includes(marker))) return;
+            const failed = jobs.filter(j => !['success', 'skipped'].includes(j.conclusion));
+            const lines = failed.map(j => `- [${j.name}](${j.html_url}): ${j.conclusion || j.status}`);
+            const body = [
+              marker,
+              `Merge queue CI: **${run.conclusion}** — [run ${run.id}, attempt ${run.run_attempt}](${run.html_url}).`,
+              `Tested queue candidate: \`${run.head_sha}\`. This result belongs to that combined tree, not necessarily the PR's current head.`,
+              '',
+              ...lines,
+              '',
+              'The run summary lists reused suites and executed checks. A green PR check alone does not mean queue validation has passed.',
+            ].join('\n');
+            await github.rest.issues.createComment({...context.repo, issue_number: pull_number, body});

--- a/docs/ci-queue-suite-reuse.md
+++ b/docs/ci-queue-suite-reuse.md
@@ -1,0 +1,46 @@
+# Merge queue suite reuse
+
+PR checks keep their existing change-based suite selection. Queue validation has
+three paths:
+
+1. Exact base, tree and trusted policy match: reuse the existing PR evidence and
+   run the combined-tree installation/Gateway canary.
+2. A validated PR's base advanced through understood changes: reuse only eligible
+   suites with identical execution-input digests and complete platform coverage.
+   Execute **every other suite in the full queue matrix**, plus the canary.
+3. Missing, stale, foreign, superseded or invalid evidence, policy changes,
+   non-ancestor bases, unknown changes, or no eligible suite: run the full matrix.
+
+The first partial-reuse allowlist is `frontend-validation` (including both
+Contract platforms) and `tui`. The frontend input boundary includes the complete
+WebUI, Contract generators/schemas/adapters/fixtures/tests, Python package entry
+point, and pinned dependencies. TUI includes its package, host, build/smoke scripts,
+Node version and Bun version/lockfile. The unchanged trust-policy digest pins the
+workflow, suite configuration and verifier. A runner label is part of platform
+coverage; hosted image updates within that label remain subject to the existing
+72-hour evidence freshness window, as with exact reuse.
+
+Python/Windows integration and artifact-producing suites are deliberately not
+eligible yet. Shared frontend jobs still execute wheel checks when frontend
+validation is reused; artifacts are produced in the current run, never borrowed
+from another run. Baseline checks always execute on the partial path.
+
+The result gate requires a disjoint, complete partition of the full suite set
+into executed and proven suites. Missing/skipped/failed/cancelled required jobs,
+an unsuccessful verifier, or an unsuccessful canary prevent success. A partial
+queue run never publishes new root evidence, so it cannot launder inherited proof
+into a fresh full-matrix result. No base-branch CI or nightly result substitutes
+for missing PR suite coverage.
+
+Queue run summaries show the source run and reused suites; the planner lists the
+remaining suites. The default-branch `Merge queue feedback` workflow reports
+completed queue results and failed-job links to the originating PR. It uses only
+GitHub metadata and never executes candidate code with its write token. Reports
+identify the tested queue SHA rather than claiming to describe a newer PR head.
+
+This change itself modifies trusted CI policy and must take the full queue path.
+Partial reuse is exercised by synthetic PR/base/queue Git histories, authenticated
+API fixtures, matrix/input mutations, aggregate-gate failure cases and workflow
+wiring tests. Production savings depend on which of the two eligible suites the
+PR actually ran and whether their inputs remained unchanged; this is not a promise
+to remove the second CI run or eliminate all Windows test duplication.

--- a/tests/test_ci/test_ci_attestation.py
+++ b/tests/test_ci/test_ci_attestation.py
@@ -1204,6 +1204,95 @@ def test_squash_binding_reconstructs_the_tested_tree(tmp_path: Path) -> None:
     ) == _git(repo, "rev-parse", "HEAD^{tree}")
 
 
+@pytest.mark.parametrize("source_path,suite", [
+    ("opensquilla-webui/src/components/example.ts", "frontend-validation"),
+    ("src/opensquilla/cli/tui/opentui/package/src/example.mjs", "tui"),
+])
+def test_queue_reuses_unchanged_suite_and_requires_remaining_full_matrix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, source_path: str, suite: str,
+) -> None:
+    repo, evidence, queue_base = _composition_fixture(
+        tmp_path, source_path=source_path, base_delta_path="docs/queue.md",
+    )
+    exact, _, source_run, details = _verify_composed_fixture(
+        repo=repo, attestation=evidence, queue_base=queue_base, monkeypatch=monkeypatch,
+    )
+    assert exact is False  # Partial proof must NEVER enter the exact fast path.
+    assert source_run == 123
+    assert details["partial"] == "true"
+    plan = json.loads(str(details["partial_plan"]))
+    assert plan["reused_suites"] == [suite]
+    full = MODULE["_plan_paths"](repo, [".ci/run-all"])
+    assert set(plan["required_suites"]) | {suite} == set(full["required_suites"])
+    assert suite not in plan["required_suites"]
+    assert "frontend-artifact" in plan["required_suites"]
+    assert "windows-high-risk" in plan["required_suites"]
+    assert plan["python_matrix"] == full["python_matrix"]
+    assert plan["desktop_matrix"] == full["desktop_matrix"]
+    assert plan["platform_matrix"] == [c for c in full["platform_matrix"] if c["suite"] != suite]
+
+
+@pytest.mark.parametrize("delta", [
+    "opensquilla-webui/src/changed.ts", "opensquilla-webui/package-lock.json",
+    "src/opensquilla/contracts/adapters/example.py", "src/opensquilla/__init__.py",
+    "scripts/contracts/example.py", "tests/contracts/example.py",
+    "uv.lock", "pyproject.toml", "unknown-ci-input.dat",
+])
+def test_partial_frontend_reuse_rejects_changed_inputs_or_unknown_delta(
+    tmp_path: Path, delta: str,
+) -> None:
+    repo, evidence, base = _composition_fixture(
+        tmp_path, source_path="opensquilla-webui/src/components/example.ts",
+        base_delta_path=delta,
+    )
+    with pytest.raises(AttestationError):
+        MODULE["partial_queue_plan"](repo=repo, attestation=evidence, queue_base_sha=base)
+
+
+def test_partial_reuse_requires_all_platforms_and_rejects_stale_proof(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, evidence, base = _composition_fixture(
+        tmp_path, source_path="opensquilla-webui/src/components/example.ts",
+        base_delta_path="docs/queue.md",
+    )
+    incomplete = dict(evidence)
+    incomplete["platform_matrix"] = [
+        c for c in evidence["platform_matrix"]
+        if not (c["suite"] == "frontend-validation" and c["os"] == "windows-latest")
+    ]
+    with pytest.raises(AttestationError):
+        MODULE["partial_queue_plan"](repo=repo, attestation=incomplete, queue_base_sha=base)
+    evidence["root_issued_at"] = "2000-01-01T00:00:00Z"
+    exact, _, source, details = _verify_composed_fixture(
+        repo=repo, attestation=evidence, queue_base=base, monkeypatch=monkeypatch,
+    )
+    assert not exact and source is None
+    assert details["partial"] == "false"
+    assert details["partial_plan"] == ""
+
+
+@pytest.mark.parametrize("delta,expected", [
+    ("docs/queue.md", ["frontend-validation", "tui"]),
+    ("opensquilla-webui/src/components/base.ts", ["tui"]),
+    ("src/opensquilla/cli/tui/opentui/package/src/base.mjs", ["frontend-validation"]),
+])
+def test_partial_queue_supplements_only_invalidated_allowlisted_suites(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, delta: str, expected: list[str],
+) -> None:
+    repo, evidence, base = _composition_fixture(
+        tmp_path, source_path=".ci/run-all", base_delta_path=delta,
+    )
+    exact, _, source, details = _verify_composed_fixture(
+        repo=repo, attestation=evidence, queue_base=base, monkeypatch=monkeypatch,
+    )
+    assert exact is False and source == 123
+    assert details["partial"] == "true"
+    plan = json.loads(str(details["partial_plan"]))
+    assert plan["reused_suites"] == expected
+    assert set(plan["required_suites"]) & set(expected) == set()
+
+
 @pytest.mark.parametrize(
     ("full_plan_change", "paths", "plan_basis"),
     (

--- a/tests/test_ci/test_ci_result_gate.py
+++ b/tests/test_ci/test_ci_result_gate.py
@@ -42,6 +42,47 @@ def test_ci_result_gate_accepts_baseline_plan() -> None:
     assert check_ci_results(_env_for(BASELINE_SUITES)) == []
 
 
+def _partial_env() -> dict[str, str]:
+    suites = set(KNOWN_SUITES) - {"python-targeted", "frontend-validation"}
+    return {
+        **_env_for(suites), "GITHUB_EVENT_NAME": "merge_group", "QUEUE_PARTIAL": "true",
+        "QUEUE_EVIDENCE_RESULT": "success", "QUEUE_CANARY_RESULT": "success",
+        "QUEUE_SOURCE_RUN_ID": "123", "QUEUE_REUSED_SUITES": '["frontend-validation"]',
+    }
+
+
+def test_partial_gate_keeps_shared_frontend_job_and_requires_full_coverage() -> None:
+    env = _partial_env()
+    assert env["RESULT_FRONTEND"] == "success"  # Wheel roundtrip still runs.
+    assert env["RESULT_CONTRACT_WINDOWS"] == "skipped"
+    assert check_ci_results(env) == []
+
+
+@pytest.mark.parametrize("key,value", [
+    ("QUEUE_EVIDENCE_RESULT", "failure"), ("QUEUE_EVIDENCE_RESULT", "skipped"),
+    ("QUEUE_CANARY_RESULT", "cancelled"), ("QUEUE_CANARY_RESULT", "failure"),
+    ("QUEUE_SOURCE_RUN_ID", ""), ("QUEUE_SOURCE_RUN_ID", "0"),
+    ("GITHUB_EVENT_NAME", "pull_request"), ("QUEUE_REUSED_SUITES", "[]"),
+    ("QUEUE_REUSED_SUITES", '["windows-high-risk"]'),
+    ("QUEUE_REUSED_SUITES", '["frontend-validation","frontend-validation"]'),
+    ("QUEUE_REUSED_SUITES", "null"), ("QUEUE_REUSED_SUITES", '[{}]'),
+    ("RESULT_WINDOWS_FULL", "skipped"), ("RESULT_WINDOWS_FULL", "failure"),
+    ("RESULT_FRONTEND", "failure"), ("RESULT_CONTRACT_WINDOWS", "failure"),
+    ("RESULT_PLANNER", "cancelled"),
+])
+def test_partial_gate_cannot_hide_missing_failed_or_cancelled_checks(key: str, value: str) -> None:
+    env = _partial_env()
+    env[key] = value
+    assert check_ci_results(env)
+
+
+def test_partial_gate_rejects_an_unaccounted_suite_even_with_green_remaining_jobs() -> None:
+    env = _partial_env()
+    required = set(json.loads(env["REQUIRED_SUITES"])) - {"windows-high-risk"}
+    env.update(_env_for(required))
+    assert any("partition" in error for error in check_ci_results(env))
+
+
 @pytest.mark.parametrize("result", ["skipped", "failure", "cancelled", ""])
 def test_frontend_requires_complete_verification_profile(result: str) -> None:
     env = _env_for(BASELINE_SUITES | {"frontend-validation"})

--- a/tests/test_ci/test_ci_result_gate.py
+++ b/tests/test_ci/test_ci_result_gate.py
@@ -69,6 +69,7 @@ def test_partial_gate_keeps_shared_frontend_job_and_requires_full_coverage() -> 
     ("RESULT_WINDOWS_FULL", "skipped"), ("RESULT_WINDOWS_FULL", "failure"),
     ("RESULT_FRONTEND", "failure"), ("RESULT_CONTRACT_WINDOWS", "failure"),
     ("RESULT_PLANNER", "cancelled"),
+    ("QUEUE_PARTIAL", ""), ("QUEUE_PARTIAL", "false"), ("QUEUE_PARTIAL", "invalid"),
 ])
 def test_partial_gate_cannot_hide_missing_failed_or_cancelled_checks(key: str, value: str) -> None:
     env = _partial_env()

--- a/tests/test_ci/test_plan_ci.py
+++ b/tests/test_ci/test_plan_ci.py
@@ -1011,6 +1011,12 @@ def test_python_dependency_changes_select_reviewed_full_ecosystem_coverage(
         suite_config["suites"]["frontend-validation"]["execution_inputs"]
     )
     assert {".gitattributes", "pyproject.toml", "uv.lock"} <= contract_inputs
+    assert {"src/opensquilla/__init__.py", "src/opensquilla/contracts/**"} <= contract_inputs
+    assert _platform_cells(plan, "frontend-validation") == {
+        ("ubuntu-latest", "validation"),
+        ("ubuntu-latest", "contract-verification"),
+        ("windows-latest", "contract-determinism"),
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -37,6 +37,70 @@ def _workflow_texts() -> list[str]:
     return [path.read_text(encoding="utf-8") for path in WORKFLOW_DIR.glob("*.yml")]
 
 
+def test_partial_queue_wiring_preserves_canary_gate_and_does_not_mint_root_evidence() -> None:
+    jobs = _workflow("ci.yml")["jobs"]
+    assert "outputs.partial == 'true'" in jobs["main-canary"]["if"]
+    plan = next(s for s in jobs["plan-ci"]["steps"] if s.get("id") == "plan")
+    assert "needs.queue-attestation.result == 'success'" in plan["env"]["QUEUE_PARTIAL"]
+    assert "CI_OPTIMIZATION_MODE == 'enforce'" in plan["env"]["QUEUE_PARTIAL"]
+    steps = jobs["ci-result"]["steps"]
+    gate = next(s for s in steps if s.get("name") == "Check required CI results")
+    assert gate["env"]["QUEUE_CANARY_RESULT"] == "${{ needs.main-canary.result }}"
+    assert gate["env"]["QUEUE_EVIDENCE_RESULT"] == "${{ needs.queue-attestation.result }}"
+    evidence_step = next(s for s in steps if s.get("id") == "attestation")
+    assert "outputs.partial != 'true'" in evidence_step["if"]
+    assert "outputs.partial" not in next(
+        s for s in steps if s.get("name") == "Accept verified queue or main fast path"
+    )["if"]
+
+
+@pytest.mark.parametrize("scenario", ["failure", "duplicate", "foreign", "bad-branch"])
+def test_queue_feedback_reports_metadata_without_executing_candidate_code(
+    tmp_path: Path, scenario: str,
+) -> None:
+    workflow = _workflow("queue-feedback.yml")
+    assert workflow["on"]["workflow_run"]["types"] == ["completed"]
+    job = workflow["jobs"]["report"]
+    assert "merge_group" in job["if"]
+    assert len(job["steps"]) == 1
+    assert job["permissions"] == {"actions": "read", "pull-requests": "write"}
+    script = job["steps"][0]["with"]["script"]
+    wrapper = r'''
+const scenario = process.argv[2];
+const run = {id: 123, run_attempt: 1, repository: {full_name: 'owner/repo'},
+  head_repository: {full_name: 'owner/repo'}, path: '.github/workflows/ci.yml',
+  status: 'completed', conclusion: 'failure', head_sha: 'b'.repeat(40),
+  head_branch: 'gh-readonly-queue/main/pr-42-' + 'a'.repeat(40), html_url: 'https://example/run'};
+if (scenario === 'foreign') run.head_repository.full_name = 'attacker/repo';
+if (scenario === 'bad-branch') run.head_branch = 'feature/pr-42';
+const context = {repo: {owner: 'owner', repo: 'repo'}, payload: {workflow_run: run}};
+const sent = [];
+const github = {rest: {
+  pulls: {get: async () => ({data: {base: {ref: 'main'}}})},
+  actions: {listJobsForWorkflowRun: 'jobs'}, issues: {listComments: 'comments',
+    createComment: async value => sent.push(value)}},
+  paginate: async api => api === 'jobs'
+    ? [{name: 'Windows tests', conclusion: 'failure', html_url: 'https://example/job'}]
+    : scenario === 'duplicate'
+      ? [{user: {type: 'Bot'}, body: '<!-- opensquilla-queue-result:123:1 -->'}] : []};
+'''
+    program = tmp_path / "feedback.cjs"
+    program.write_text(
+        wrapper + "\n(async () => {\n" + script
+        + "\n})().then(() => console.log(JSON.stringify(sent)));\n", encoding="utf-8",
+    )
+    result = subprocess.run(
+        ["node", str(program), scenario], capture_output=True, text=True, check=True,
+    )
+    sent = json.loads(result.stdout)
+    if scenario == "failure":
+        assert len(sent) == 1 and sent[0]["issue_number"] == 42
+        assert "Windows tests" in sent[0]["body"] and "https://example/job" in sent[0]["body"]
+        assert "not necessarily the PR's current head" in sent[0]["body"]
+    else:
+        assert sent == []
+
+
 def _is_windows_wsl_bash(path: str) -> bool:
     normalized = path.replace("\\", "/").lower()
     return normalized.endswith("/windows/system32/bash.exe")
@@ -1259,6 +1323,11 @@ def test_ci_result_gate_covers_every_conditional_job_without_legacy_flags() -> N
     assert gate_step["env"]["RESULT_SKILL_HUB"] == "${{ needs.skill-hub.result }}"
     assert not any(key.startswith("FLAG_") for key in gate_step["env"])
     assert set(gate_step["env"]) == {
+        "QUEUE_PARTIAL",
+        "QUEUE_EVIDENCE_RESULT",
+        "QUEUE_REUSED_SUITES",
+        "QUEUE_SOURCE_RUN_ID",
+        "QUEUE_CANARY_RESULT",
         "RESULT_PLANNER",
         "RESULT_WORKFLOW_LINT",
         "RESULT_README_LOCALE",


### PR DESCRIPTION
## Scope

Scope boundary: Preserve existing PR checks while allowing the merge queue to reuse independently validated frontend/Contract and TUI suite evidence when the PR base advances. Reuse requires authenticated current-head PR evidence, unchanged trusted CI policy, identical suite inputs, and complete platform coverage. Every other full-matrix suite and the combined-tree canary must still pass. Unknown changes and invalid evidence fall back to full CI. Partial runs do not mint root evidence. Add metadata-only queue result feedback on the originating PR.

Non-goals: No partial Python/Windows integration reuse, no cross-run artifact downloads, no relaxation of required checks, no speculative composition of base CI, and no change to PR test selection or merge rules.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Maintainer-requested follow-up to #1595 to reduce repeated queue work while retaining PR feedback and merge validation.

## Release Note

Release note: NONE

## Tests

Ruff: Passed on modified Python files.

Pytest: 403 passed on the final commit across the complete CI attestation, aggregate gate, planner, and workflow test files (native Windows, serial execution). Final hosted PR CI: https://github.com/TokenRhythm/opensquilla/actions/runs/34458073992; protected queue CI remains required before merge.

Build: actionlint v1.7.12 passed on both changed workflows (local shellcheck/pyflakes unavailable; hosted workflow lint remains required).

Regression tests: added

Notes: Real synthetic Git histories exercise base advance, partial reuse, changed/unknown inputs, missing platforms and stale evidence. Gate cases require failures/cancellations/missing coverage to block success. The feedback JavaScript is executed against mocked GitHub APIs. This PR changes trust policy and therefore requires full PR and queue CI before merge. Expected reuse savings depend on the eligible suite and base delta; native Python/Windows integration suites remain conservative.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

Maintainer-only note: No provider credentials or real user profiles are involved.

## Safety

Only repository CI configuration, scripts, regression tests and documentation are included. The feedback workflow runs from the default branch and never checks out or executes candidate code with its write token.

## Third-Party Origin

Third-party origin: none

Details if non-none: N/A

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.

