### PR TITLE
Remove optional tool projection experiments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   copies are not removed, and memory files and scheduled jobs stay in place.
   Old Meta workflow definitions that reference retired Skills must be updated
   by their authors; they are not automatically migrated.
+- Retired opt-in projection experiments: signal-scan hints, provider-history
+  deduplication, tiny compaction guards, configurable stub previews, and fresh
+  diagnostic preservation/retrieval gates. Existing configuration fields remain
+  accepted but no longer activate these mechanisms. Default Tokenjuice results,
+  Store/retrieval guarantees, fixed previews and compaction safety protections
+  remain unchanged; experimental diagnostic counters and events are removed.
 
 ### Fixed
 

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -600,12 +600,6 @@ _WORKSPACE_EDIT_TOOL_NAMES: frozenset[str] = frozenset(
         "write_file",
     }
 )
-_DIAGNOSTIC_RETRIEVAL_GATED_TOOL_NAMES: frozenset[str] = frozenset(
-    {
-        *_WORKSPACE_EDIT_TOOL_NAMES,
-        "finalize",
-    }
-)
 
 _meta_invoke_depth: ContextVar[int] = ContextVar("opensquilla_meta_invoke_depth", default=0)
 _meta_invoke_turn_count: ContextVar[int] = ContextVar(
@@ -1109,9 +1103,6 @@ _DOCUMENT_MUTATION_FINALIZATION_SYSTEM = (
     "Do not mention internal protocols, capabilities, identifiers, source text, or paths."
 )
 _AGGREGATE_TOOL_RESULT_MAX_SHARE = 0.25
-# Below this size a duplicate tool result is not worth eliding: the dedup stub
-# itself costs ~200 chars, so tiny repeated payloads would grow, not shrink.
-_PROVIDER_HISTORY_DEDUP_MIN_CHARS = 400
 _TOOL_ARGUMENT_HEARTBEAT_CHARS = 4096
 _PROVIDER_CONTEXT_PROJECTION_REUSED_REASON = "provider_context_projection_reused"
 _SEMANTIC_TOOL_RESULT_PROJECTION_SKIP_TOOLS = frozenset({"read_file", "git_diff"})
@@ -1151,66 +1142,6 @@ _TOOL_RESULT_HINT_PATTERN = re.compile(
 _TOOL_RESULT_HINT_PATH_PATTERN = re.compile(
     r"(?:[A-Za-z]:)?[./\\]?[A-Za-z0-9_.-]+(?:[/\\][A-Za-z0-9_.-]+)+(?::\d+)?"
 )
-_PROJECTION_SIGNAL_HINTS_ENV = "OPENSQUILLA_PROJECTION_SIGNAL_HINTS"
-_PROJECTION_SIGNAL_PATTERNS_ENV = "OPENSQUILLA_PROJECTION_SIGNAL_PATTERNS"
-_PROJECTION_SIGNAL_HINTS_ON = frozenset({"on", "1", "true", "yes"})
-_PROJECTION_SIGNAL_HINTS_OFF = frozenset({"off", "0", "false", "no"})
-# Default failure-signal pattern for the projection signal scan. Kept separate
-# from _TOOL_RESULT_HINT_PATTERN so the env override below can never perturb
-# search_hints selection. Case-sensitive on purpose: the anchors target the
-# capitalized/tool-emitted forms (FAILED, Traceback, AssertionError, ...).
-_PROJECTION_SIGNAL_DEFAULT_PATTERN = re.compile(
-    r"(?:\bFAILED\b|\bFAIL:|\bError\b|\bException\b|\bTraceback\b"
-    r"|\bAssertionError\b|\berror:|\bwarnings? summary\b"
-    r"|\bpanic(?:ked)?\b|\bfatal\b)"
-)
-_PROJECTION_SIGNAL_PATTERN_CACHE: dict[str, re.Pattern[str]] = {}
-
-
-def _projection_signal_hints_enabled(config_value: bool = False) -> bool:
-    """Resolve the projection signal-scan gate.
-
-    Unset defers to ``config_value`` (the AgentConfig field threaded from the
-    same env by the bootstrap stage; off by default). Recognized on/off values
-    override it; unrecognized values raise instead of being silently ignored
-    so a run manifest cannot record an override the run did not actually
-    apply.
-    """
-    raw = os.environ.get(_PROJECTION_SIGNAL_HINTS_ENV, "").strip().lower()
-    if not raw:
-        return bool(config_value)
-    if raw in _PROJECTION_SIGNAL_HINTS_ON:
-        return True
-    if raw in _PROJECTION_SIGNAL_HINTS_OFF:
-        return False
-    raise ValueError(
-        f"{_PROJECTION_SIGNAL_HINTS_ENV} must be one of: "
-        + ", ".join(sorted(_PROJECTION_SIGNAL_HINTS_ON | _PROJECTION_SIGNAL_HINTS_OFF))
-    )
-
-
-def _projection_signal_pattern() -> re.Pattern[str]:
-    """Return the failure-signal regex, honoring the env override.
-
-    A non-blank ``OPENSQUILLA_PROJECTION_SIGNAL_PATTERNS`` value replaces the
-    default pattern wholesale (write alternations into one regex). Compiled
-    overrides are cached by raw string; invalid regexes raise ValueError per
-    the manifest-honesty convention rather than silently falling back.
-    """
-    raw = os.environ.get(_PROJECTION_SIGNAL_PATTERNS_ENV, "").strip()
-    if not raw:
-        return _PROJECTION_SIGNAL_DEFAULT_PATTERN
-    cached = _PROJECTION_SIGNAL_PATTERN_CACHE.get(raw)
-    if cached is not None:
-        return cached
-    try:
-        compiled = re.compile(raw)
-    except re.error as exc:
-        raise ValueError(
-            f"{_PROJECTION_SIGNAL_PATTERNS_ENV} must be a valid regular expression: {exc}"
-        ) from exc
-    _PROJECTION_SIGNAL_PATTERN_CACHE[raw] = compiled
-    return compiled
 
 
 _PROVIDER_CONTEXT_REPAIR_PROMPT = (
@@ -1301,95 +1232,6 @@ def _tool_result_search_hints(content: str) -> str:
     if not lines:
         return ""
     return "search_hints:\n" + "\n".join(lines) + "\n"
-
-
-def _tool_result_signal_scan(
-    content: str,
-    *,
-    handle: str | None,
-    head_chars: int | None = None,
-    tail_chars: int | None = None,
-    preview_lines: frozenset[str] | None = None,
-) -> tuple[str, int, int | None]:
-    """Scan the omitted region of a projected tool result for failure signals.
-
-    Returns ``(rendered_lines, match_count, first_line_number)``. Line numbers
-    are 1-based over the FULL original ``content`` (the same coordinates
-    search_hints renders and retrieve_tool_result's ``L<num>`` query resolves
-    against the byte-identical stored record).
-
-    Omission model: with ``head_chars``/``tail_chars`` the omitted region is
-    the contiguous char span between the preserved head and tail; otherwise a
-    line counts as omitted when its exact text is absent from
-    ``preview_lines`` (the reducer-summarized preview). The membership check
-    is an approximation — a reducer that rewrites a matching line makes it
-    count as omitted even though a variant survives — but the rendered line
-    number still points at a real failure line in the original.
-
-    Returns ``("", 0, None)`` when there is nothing to report or no handle
-    exists to retrieve against.
-    """
-    if handle is None or not content:
-        return "", 0, None
-    pattern = _projection_signal_pattern()
-    omitted_start: int | None = None
-    omitted_end: int | None = None
-    if head_chars is not None:
-        omitted_start = max(0, int(head_chars))
-        omitted_end = len(content) - max(0, int(tail_chars or 0))
-        if omitted_end <= omitted_start:
-            return "", 0, None
-    match_count = 0
-    first_line_number: int | None = None
-    offset = 0
-    for line_number, line in enumerate(content.splitlines(), start=1):
-        line_start = offset
-        offset += len(line) + 1
-        if omitted_start is not None and omitted_end is not None:
-            if line_start + len(line) <= omitted_start or line_start >= omitted_end:
-                continue
-        elif preview_lines is not None and line in preview_lines:
-            continue
-        if not pattern.search(line[:_TOOL_RESULT_HINT_SCAN_MAX_CHARS]):
-            continue
-        match_count += 1
-        if first_line_number is None:
-            first_line_number = line_number
-    if match_count == 0 or first_line_number is None:
-        return "", 0, None
-    rendered = _render_projection_signal_lines(
-        handle=handle,
-        match_count=match_count,
-        first_line_number=first_line_number,
-    )
-    return rendered, match_count, first_line_number
-
-
-def _render_projection_signal_lines(
-    *,
-    handle: str | None,
-    match_count: int,
-    first_line_number: int | None,
-) -> str:
-    """Render the signal_scan notice lines for an already-computed scan.
-
-    Kept separate from the scan so the fresh-result path can scan once with
-    the size-gate probe's placeholder handle and re-render with the real
-    stored handle (both handle forms have identical length, so the probe
-    measures the true envelope size).
-    """
-    if handle is None or match_count <= 0 or first_line_number is None:
-        return ""
-    next_call_arguments = json.dumps(
-        {"handle": handle, "mode": "query", "query": f"L{first_line_number}"},
-        ensure_ascii=False,
-        sort_keys=True,
-    )
-    return (
-        f"signal_scan: {match_count} lines matching failure patterns in the "
-        f"omitted region (first at L{first_line_number})\n"
-        f"signal_next_call: retrieve_tool_result {next_call_arguments}\n"
-    )
 
 
 def _projection_event_argument_value(value: Any, *, key: str) -> Any:
@@ -2839,9 +2681,6 @@ class Agent:
         self._provider_tool_result_overrides: dict[str, ContentBlockToolResult] = {}
         self._provider_tool_result_frozen_overrides: dict[str, ContentBlockToolResult] = {}
         self._provider_tool_result_frozen_full_ids: set[str] = set()
-        self._provider_history_dedup_survivor_ids: set[str] = set()
-        self._projected_diagnostic_evidence: dict[str, dict[str, Any]] = {}
-        self._focused_retrieved_tool_result_handles: set[str] = set()
         self._tool_result_snapshot_cache: dict[
             tuple[str, str, str, str, str, str], ToolResultRecord
         ] = {}
@@ -4450,219 +4289,6 @@ class Agent:
             )
         return restored if changed else messages
 
-    def _fresh_diagnostic_policy_enabled(self) -> bool:
-        return bool(
-            getattr(
-                self.config,
-                "tool_result_fresh_diagnostic_policy_enabled",
-                False,
-            )
-        )
-
-    def _diagnostic_retrieval_gate_enabled(self) -> bool:
-        return bool(
-            getattr(
-                self.config,
-                "tool_result_diagnostic_retrieval_gate_enabled",
-                False,
-            )
-        )
-
-    def _fresh_diagnostic_inline_max_chars(self) -> int:
-        if not self._fresh_diagnostic_policy_enabled():
-            return 0
-        return max(
-            0,
-            int(
-                getattr(
-                    self.config,
-                    "tool_result_fresh_diagnostic_inline_max_chars",
-                    64_000,
-                )
-                or 0
-            ),
-        )
-
-    @staticmethod
-    def _tool_result_diagnostic_reason(result: ToolResult, content: str) -> str | None:
-        if result.is_error:
-            return "is_error"
-        status: Mapping[str, Any] = result.execution_status or {}
-        if isinstance(status, Mapping):
-            preservation_class = str(status.get("preservation_class") or "")
-            if preservation_class == "diagnostic":
-                return "diagnostic_preservation_class"
-            if str(status.get("status") or "") in {"error", "timeout", "cancelled"}:
-                return "diagnostic_execution_status"
-        scan = content[:_TOOL_RESULT_HINT_SCAN_MAX_CHARS]
-        if (
-            _TOOL_RESULT_HINT_PATTERN.search(scan)
-            and not _CLEAN_TEST_SUMMARY_RE.search(scan)
-            and not _CLEAN_PASSED_FAILED_SUMMARY_RE.search(scan)
-            and not _CLEAN_ERROR_COUNT_RE.search(scan)
-        ):
-            return "failure_anchor"
-        return None
-
-    def _record_fresh_diagnostic_result(
-        self,
-        *,
-        reason: str,
-        tool_name: str,
-        tool_use_id: str,
-        original_chars: int,
-    ) -> None:
-        self.config.metadata["tool_projection_fresh_diagnostic_results"] = (
-            self.config.metadata.get("tool_projection_fresh_diagnostic_results", 0) + 1
-        )
-        self._write_turn_call_log(
-            "tool_projection_fresh_diagnostic",
-            tool_use_id=tool_use_id,
-            name=tool_name,
-            reason=reason,
-            original_chars=original_chars,
-        )
-
-    def _record_projected_diagnostic_evidence(
-        self,
-        *,
-        handle: str | None,
-        tool_name: str,
-        tool_use_id: str,
-        reason: str,
-        original_chars: int,
-        projected_chars: int,
-    ) -> None:
-        self.config.metadata["tool_projection_fresh_diagnostic_projections"] = (
-            self.config.metadata.get("tool_projection_fresh_diagnostic_projections", 0) + 1
-        )
-        append_runtime_event(
-            self.config.runtime_events_path,
-            {
-                "feature": "tool_result_projection",
-                "name": "tool_projection_fresh_diagnostic",
-                "action": "projected",
-                "reason": reason,
-                "session_key": self._session_key,
-                "agent_id": self.config.tool_result_store_agent_id
-                or self.config.metadata.get("agent_id"),
-                "tool_name": tool_name,
-                "tool_use_id": tool_use_id,
-                "tool_result_handle": handle,
-                "tool_result_handle_present": bool(handle),
-                "original_chars": original_chars,
-                "projected_chars": projected_chars,
-            },
-        )
-        if not self._diagnostic_retrieval_gate_enabled():
-            return
-        if not handle:
-            return
-        self._projected_diagnostic_evidence[handle] = {
-            "tool_name": tool_name,
-            "tool_use_id": tool_use_id,
-            "reason": reason,
-            "original_chars": original_chars,
-            "projected_chars": projected_chars,
-        }
-
-    @staticmethod
-    def _retrieval_tool_call_handle(tc: ToolCall) -> str | None:
-        if tc.tool_name != "retrieve_tool_result":
-            return None
-        raw_handle = tc.arguments.get("handle")
-        if not isinstance(raw_handle, str):
-            return None
-        handle = raw_handle.strip()
-        return handle or None
-
-    @staticmethod
-    def _retrieval_tool_call_is_focused(tc: ToolCall) -> bool:
-        if tc.tool_name != "retrieve_tool_result":
-            return False
-        raw_mode = tc.arguments.get("mode")
-        mode = raw_mode.strip().lower() if isinstance(raw_mode, str) else ""
-        if mode in {"query", "grep", "slice", "head_tail", "raw_slice"}:
-            return True
-        return any(
-            isinstance(tc.arguments.get(key), str) and str(tc.arguments.get(key)).strip()
-            for key in ("query", "pattern")
-        ) or any(tc.arguments.get(key) is not None for key in ("start_line", "end_line", "offset"))
-
-    def _record_focused_diagnostic_retrieval(
-        self,
-        tc: ToolCall,
-        result: ToolResult,
-    ) -> None:
-        if result.is_error or not self._retrieval_tool_call_is_focused(tc):
-            return
-        handle = self._retrieval_tool_call_handle(tc)
-        if handle is None or handle not in self._projected_diagnostic_evidence:
-            return
-        self._focused_retrieved_tool_result_handles.add(handle)
-        self.config.metadata["tool_projection_diagnostic_retrievals"] = (
-            self.config.metadata.get("tool_projection_diagnostic_retrievals", 0) + 1
-        )
-        append_runtime_event(
-            self.config.runtime_events_path,
-            {
-                "feature": "tool_result_retrieval",
-                "name": "tool_projection_diagnostic_retrieval",
-                "session_key": self._session_key,
-                "agent_id": self.config.tool_result_store_agent_id
-                or self.config.metadata.get("agent_id"),
-                "tool_use_id": tc.tool_use_id,
-                "tool_name": tc.tool_name,
-                "tool_result_handle": handle,
-                "mode": tc.arguments.get("mode"),
-                "query": tc.arguments.get("query"),
-            },
-        )
-        self._write_turn_call_log(
-            "tool_projection_diagnostic_retrieval",
-            tool_use_id=tc.tool_use_id,
-            name=tc.tool_name,
-            tool_result_handle=handle,
-            mode=tc.arguments.get("mode"),
-            query=tc.arguments.get("query"),
-        )
-
-    def _projected_diagnostic_retrieval_gate_tool_result(self, tc: ToolCall) -> ToolResult | None:
-        if not self._diagnostic_retrieval_gate_enabled():
-            return None
-        if tc.tool_name not in _DIAGNOSTIC_RETRIEVAL_GATED_TOOL_NAMES:
-            return None
-        pending = [
-            (handle, details)
-            for handle, details in self._projected_diagnostic_evidence.items()
-            if handle not in self._focused_retrieved_tool_result_handles
-        ]
-        if not pending:
-            return None
-        handle, details = pending[-1]
-        self.config.metadata["tool_projection_diagnostic_retrieval_gate_blocks"] = (
-            self.config.metadata.get("tool_projection_diagnostic_retrieval_gate_blocks", 0) + 1
-        )
-        tool_name = str(details.get("tool_name") or "tool")
-        reason = str(details.get("reason") or "diagnostic")
-        return ToolResult(
-            tool_use_id=tc.tool_use_id,
-            tool_name=tc.tool_name,
-            content=(
-                "Runtime guard: this action depends on incomplete diagnostic evidence. "
-                f"The recent {tool_name} result was projected with preview_complete=false "
-                f"for reason {reason!r}. Before calling {tc.tool_name}, use "
-                "retrieve_tool_result with the projected tool_result_handle and a focused "
-                "query, grep, line slice, or raw_slice for the failing test, traceback, "
-                f"line reference, or error phrase. tool_result_handle: {handle}"
-            ),
-            is_error=True,
-            execution_status=runtime_execution_status(
-                "error",
-                reason="projected_diagnostic_requires_retrieval",
-            ),
-        )
-
     def _semantic_tool_result_projection_skip_reason(
         self,
         result: ToolResult,
@@ -4801,176 +4427,11 @@ class Agent:
             event["saved_chars"] = max(0, original_chars - projected_chars)
         append_runtime_event(self.config.runtime_events_path, event)
 
-    def _projection_signal_hints_active(self) -> bool:
-        return _projection_signal_hints_enabled(
-            bool(getattr(self.config, "projection_signal_hints", False))
-        )
-
-    def _record_projection_signal_hint_event(
-        self,
-        *,
-        builder: str,
-        tool_name: str,
-        tool_use_id: str,
-        tool_result_handle: str | None,
-        original_chars: int,
-        signal_match_lines: int,
-        signal_first_line: int | None,
-    ) -> None:
-        self.config.metadata["tool_projection_signal_hints"] = (
-            self.config.metadata.get("tool_projection_signal_hints", 0) + 1
-        )
-        append_runtime_event(
-            self.config.runtime_events_path,
-            {
-                "feature": "tool_result_projection",
-                "name": "projection_signal_hints",
-                "action": "hint_appended",
-                "mechanism": "signal_scan",
-                "mode": "log",
-                "session_key": self._session_key,
-                "agent_id": self.config.tool_result_store_agent_id
-                or self.config.metadata.get("agent_id"),
-                "tool_name": tool_name,
-                "tool_use_id": tool_use_id,
-                "tool_result_handle": tool_result_handle,
-                "original_chars": original_chars,
-                "signal_match_lines": signal_match_lines,
-                "signal_first_line": signal_first_line,
-                "builder": builder,
-            },
-        )
-
     @staticmethod
     def _count_image_blocks(messages: list[Message]) -> int:
         # Use the same recursive accounting as request projection so images
         # nested in tool-result content cannot bypass a text-only boundary.
         return count_projected_image_blocks(messages)
-
-    def _dedup_repeated_tool_results_for_provider(
-        self,
-        messages: list[Message],
-    ) -> list[Message]:
-        """Elide older byte-identical tool results in the provider view only.
-
-        Long single-turn episodes re-run the same read/grep/diff commands many
-        times, and full-history replay resends every identical payload on every
-        iteration. When ``provider_history_dedup_enabled`` is on, the newest
-        occurrence of each repeated result stays full and older duplicates are
-        replaced by a short stub naming the surviving ``tool_use_id``. The pass
-        never mutates persisted history; error results, artifact results, the
-        two most recent results, frozen-full results, and existing provider
-        projections are left untouched.
-        """
-        self._provider_history_dedup_survivor_ids = set()
-        if not getattr(self.config, "provider_history_dedup_enabled", False):
-            return messages
-        min_repeats = max(
-            2, int(getattr(self.config, "provider_history_dedup_min_repeats", 2) or 2)
-        )
-
-        tool_result_refs: list[tuple[int, int, ContentBlockToolResult]] = []
-        for message_index, message in enumerate(messages):
-            if not isinstance(message.content, list):
-                continue
-            for block_index, block in enumerate(message.content):
-                if isinstance(block, ContentBlockToolResult):
-                    tool_result_refs.append((message_index, block_index, block))
-        if len(tool_result_refs) < min_repeats:
-            return messages
-
-        recent_ids = {id(block) for _m, _b, block in tool_result_refs[-2:]}
-        by_digest: dict[str, list[tuple[int, int, ContentBlockToolResult, str]]] = {}
-        for message_index, block_index, block in tool_result_refs:
-            if not isinstance(block.content, str):
-                continue
-            content = block.content
-            if (
-                len(content) < _PROVIDER_HISTORY_DEDUP_MIN_CHARS
-                or block.is_error
-                or _tool_result_content_has_artifact(content)
-                or _tool_result_content_is_provider_projection(content)
-            ):
-                continue
-            digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
-            by_digest.setdefault(digest, []).append((message_index, block_index, block, content))
-
-        replacements: dict[tuple[int, int], ContentBlockToolResult] = {}
-        survivor_ids: set[str] = set()
-        chars_saved = 0
-        for digest, occurrences in by_digest.items():
-            if len(occurrences) < min_repeats:
-                continue
-            survivor = occurrences[-1][2]
-            for message_index, block_index, block, content in occurrences[:-1]:
-                if id(block) in recent_ids:
-                    continue
-                if block.tool_use_id in self._provider_tool_result_frozen_full_ids:
-                    # Already shown to the model as final full content on a
-                    # prior request — never retroactively downgrade it, but
-                    # still counted above so newer duplicates get elided.
-                    continue
-                stub = (
-                    "[duplicate_tool_result_elided]\n"
-                    f"tool_use_id: {block.tool_use_id}\n"
-                    f"original_chars: {len(content)}\n"
-                    f"sha256: {digest}\n"
-                    f"identical_to_tool_use_id: {survivor.tool_use_id}\n"
-                    "reason: byte-identical content appears again at the newer "
-                    "tool result above; read it there instead of re-running the "
-                    "same command.\n"
-                )
-                replacements[(message_index, block_index)] = ContentBlockToolResult(
-                    tool_use_id=block.tool_use_id,
-                    content=stub,
-                    is_error=block.is_error,
-                )
-                chars_saved += max(0, len(content) - len(stub))
-                survivor_ids.add(survivor.tool_use_id)
-
-        if not replacements:
-            return messages
-
-        self._provider_history_dedup_survivor_ids = survivor_ids
-
-        projected: list[Message] = []
-        for message_index, message in enumerate(messages):
-            if not isinstance(message.content, list):
-                projected.append(message)
-                continue
-            next_content: list[Any] = []
-            message_changed = False
-            for block_index, block in enumerate(message.content):
-                replacement = replacements.get((message_index, block_index))
-                if replacement is None:
-                    next_content.append(block)
-                    continue
-                next_content.append(replacement)
-                message_changed = True
-            if not message_changed:
-                projected.append(message)
-                continue
-            projected.append(
-                Message(
-                    role=message.role,
-                    content=next_content,
-                    reasoning_content=getattr(message, "reasoning_content", None),
-                )
-            )
-
-        self.config.metadata["provider_history_dedup_applied"] = True
-        self.config.metadata["provider_history_dedup_elided"] = self.config.metadata.get(
-            "provider_history_dedup_elided", 0
-        ) + len(replacements)
-        self.config.metadata["provider_history_dedup_chars_saved"] = (
-            self.config.metadata.get("provider_history_dedup_chars_saved", 0) + chars_saved
-        )
-        self._write_turn_call_log(
-            "provider_history_dedup",
-            elided_tool_results=len(replacements),
-            chars_saved=chars_saved,
-        )
-        return projected
 
     def _compact_aggregate_tool_results_for_provider(
         self,
@@ -5043,7 +4504,6 @@ class Agent:
                 or _tool_result_content_is_provider_projection(content)
                 or semantic_skip_reason is not None
                 or block.tool_use_id in self._provider_tool_result_frozen_full_ids
-                or block.tool_use_id in self._provider_history_dedup_survivor_ids
             ):
                 if semantic_skip_reason is not None:
                     semantic_preserve_refs.append(
@@ -5087,24 +4547,6 @@ class Agent:
             handle_line = f"tool_result_handle: {stored.handle}\n" if stored is not None else ""
             retrieve_hint = _TOOL_RESULT_RETRIEVE_HINT if stored is not None else ""
             search_hints = _tool_result_search_hints(content) if stored is not None else ""
-            signal_lines = ""
-            if stored is not None and self._projection_signal_hints_active():
-                signal_lines, signal_matches, signal_first_line = _tool_result_signal_scan(
-                    content,
-                    handle=stored.handle,
-                    head_chars=len(head),
-                    tail_chars=len(tail),
-                )
-                if signal_lines:
-                    self._record_projection_signal_hint_event(
-                        builder="aggregate",
-                        tool_name=tool_name_by_use_id.get(block.tool_use_id, "tool"),
-                        tool_use_id=block.tool_use_id,
-                        tool_result_handle=stored.handle,
-                        original_chars=len(content),
-                        signal_match_lines=signal_matches,
-                        signal_first_line=signal_first_line,
-                    )
             compacted = (
                 "[aggregate_tool_result_compacted]\n"
                 f"tool_use_id: {block.tool_use_id}\n"
@@ -5114,7 +4556,6 @@ class Agent:
                 f"{handle_line}"
                 f"{retrieve_hint}"
                 f"{search_hints}"
-                f"{signal_lines}"
                 f"omitted_chars: {omitted}\n"
                 f"preview_complete: {str(omitted == 0).lower()}\n"
                 "reason: older non-error tool result compacted for provider context budget.\n"
@@ -5457,24 +4898,6 @@ class Agent:
             head = content[:head_chars]
             tail = content[-tail_chars:] if tail_chars else ""
         omitted = max(0, len(content) - len(head) - len(tail))
-        signal_lines = ""
-        if self._projection_signal_hints_active():
-            signal_lines, signal_matches, signal_first_line = _tool_result_signal_scan(
-                content,
-                handle=stored.handle,
-                head_chars=len(head),
-                tail_chars=len(tail),
-            )
-            if signal_lines:
-                self._record_projection_signal_hint_event(
-                    builder="provider_single",
-                    tool_name=tool_name,
-                    tool_use_id=tool_use_id,
-                    tool_result_handle=stored.handle,
-                    original_chars=len(content),
-                    signal_match_lines=signal_matches,
-                    signal_first_line=signal_first_line,
-                )
         projection = (
             "[tool_result_projection]\n"
             f"tool: {tool_name}\n"
@@ -5484,7 +4907,6 @@ class Agent:
             f"{handle_line}"
             f"{retrieve_hint}"
             f"{search_hints}"
-            f"{signal_lines}"
             f"omitted_chars: {omitted}\n"
             f"preview_complete: {str(omitted == 0).lower()}\n"
             f"reason: {reason}.\n"
@@ -5662,7 +5084,6 @@ class Agent:
         *,
         raw_content: str,
         projected_content: str,
-        signal_lines: str = "",
     ) -> str:
         return (
             "[tool_result_projection]\n"
@@ -5672,7 +5093,6 @@ class Agent:
             "preview_complete: false\n"
             f"{_TOOL_RESULT_RETRIEVE_HINT}"
             f"{_tool_result_search_hints(raw_content)}"
-            f"{signal_lines}"
             f"{projected_content}"
         )
 
@@ -5721,20 +5141,10 @@ class Agent:
         raw_content: str,
         arguments: dict[str, Any] | None = None,
     ) -> ToolResult:
-        signal_lines = ""
-        signal_matches = 0
-        signal_first_line: int | None = None
-        if self._projection_signal_hints_active():
-            signal_lines, signal_matches, signal_first_line = _tool_result_signal_scan(
-                raw_content,
-                handle=stored.handle,
-                preview_lines=frozenset(guarded_result.content.splitlines()),
-            )
         projected_content = self._tool_result_projection_payload(
             stored,
             raw_content=raw_content,
             projected_content=guarded_result.content,
-            signal_lines=signal_lines,
         )
         if len(projected_content) >= len(raw_content):
             return self._tool_result_projection_store_unavailable_noop(
@@ -5743,16 +5153,6 @@ class Agent:
                 arguments=arguments,
                 projected_chars=len(projected_content),
                 json_guard_applied=True,
-            )
-        if signal_lines:
-            self._record_projection_signal_hint_event(
-                builder="json_guard",
-                tool_name=guarded_result.tool_name,
-                tool_use_id=guarded_result.tool_use_id,
-                tool_result_handle=stored.handle,
-                original_chars=len(raw_content),
-                signal_match_lines=signal_matches,
-                signal_first_line=signal_first_line,
             )
 
         tokens_before = get_approx_tokens(raw_content)
@@ -5883,14 +5283,6 @@ class Agent:
             )
         json_guard_applied = guarded
 
-        diagnostic_reason = self._tool_result_diagnostic_reason(result, raw_snapshot_content)
-        if diagnostic_reason is not None:
-            self._record_fresh_diagnostic_result(
-                reason=diagnostic_reason,
-                tool_name=result.tool_name,
-                tool_use_id=result.tool_use_id,
-                original_chars=len(raw_snapshot_content),
-            )
         semantic_skip_reason = self._semantic_tool_result_projection_skip_reason(
             result,
             tool_call=tool_call,
@@ -5928,57 +5320,6 @@ class Agent:
                 json_guard_applied=json_guard_applied,
             )
             return result
-        fresh_diagnostic_cap = self._fresh_diagnostic_inline_max_chars()
-        if (
-            diagnostic_reason is not None
-            and fresh_diagnostic_cap > 0
-            and len(raw_snapshot_content) <= fresh_diagnostic_cap
-            and not json_guard_applied
-        ):
-            self.config.metadata["tool_projection_noops"] = (
-                self.config.metadata.get("tool_projection_noops", 0) + 1
-            )
-            self.config.metadata["tool_projection_fresh_diagnostic_one_hop_preserves"] = (
-                self.config.metadata.get(
-                    "tool_projection_fresh_diagnostic_one_hop_preserves",
-                    0,
-                )
-                + 1
-            )
-            append_runtime_event(
-                self.config.runtime_events_path,
-                {
-                    "feature": "tool_result_projection",
-                    "name": "tool_projection_fresh_diagnostic",
-                    "action": "one_hop_preserved",
-                    "reason": diagnostic_reason,
-                    "session_key": self._session_key,
-                    "agent_id": self.config.tool_result_store_agent_id
-                    or self.config.metadata.get("agent_id"),
-                    "tool_name": result.tool_name,
-                    "tool_use_id": result.tool_use_id,
-                    "original_chars": len(raw_snapshot_content),
-                },
-            )
-            self._write_turn_call_log(
-                "tool_projection_noop",
-                tool_use_id=result.tool_use_id,
-                name=result.tool_name,
-                original_chars=len(raw_snapshot_content),
-                reason="fresh_diagnostic_one_hop_preserved",
-                diagnostic_reason=diagnostic_reason,
-            )
-            self._record_tool_projection_runtime_event(
-                outcome="noop",
-                reason="fresh_diagnostic_one_hop_preserved",
-                tool_name=result.tool_name,
-                tool_use_id=result.tool_use_id,
-                original_chars=len(raw_snapshot_content),
-                arguments=projection_arguments,
-                is_error=result.is_error,
-                json_guard_applied=json_guard_applied,
-            )
-            return original_result
         reduction = reduce_tool_result_with_tokenjuice(
             tool_name=result.tool_name,
             content=result.content,
@@ -6034,24 +5375,10 @@ class Agent:
 
         stored: ToolResultRecord | None = None
         stored_handle: str | None = None
-        signal_matches = 0
-        signal_first_line: int | None = None
         if self.config.tool_result_store_dir:
             placeholder_handle = "tr-" + ("0" * 32)
-            # Scan once here and re-render with the real handle after the
-            # store write: placeholder and stored handles have identical
-            # length, so the probe below measures the true envelope size.
-            probe_signal_lines = ""
-            if self._projection_signal_hints_active():
-                (
-                    probe_signal_lines,
-                    signal_matches,
-                    signal_first_line,
-                ) = _tool_result_signal_scan(
-                    raw_snapshot_content,
-                    handle=placeholder_handle,
-                    preview_lines=frozenset(projected_content.splitlines()),
-                )
+            # Placeholder and stored handles have identical length, so this
+            # probe measures the envelope before committing a Store write.
             candidate_with_envelope = (
                 "[tool_result_projection]\n"
                 f"tool_result_handle: {placeholder_handle}\n"
@@ -6059,7 +5386,6 @@ class Agent:
                 f"original_chars: {len(raw_snapshot_content)}\n"
                 f"{_TOOL_RESULT_RETRIEVE_HINT}"
                 f"{_tool_result_search_hints(raw_snapshot_content)}"
-                f"{probe_signal_lines}"
                 f"{projected_content}"
             )
             if len(candidate_with_envelope) >= len(raw_snapshot_content):
@@ -6108,18 +5434,11 @@ class Agent:
                     reducer=reduction.reducer,
                     json_guard_applied=json_guard_applied,
                 )
-        signal_lines = ""
         if stored is not None:
-            signal_lines = _render_projection_signal_lines(
-                handle=stored.handle,
-                match_count=signal_matches,
-                first_line_number=signal_first_line,
-            )
             projected_content = self._tool_result_projection_payload(
                 stored,
                 raw_content=raw_snapshot_content,
                 projected_content=projected_content,
-                signal_lines=signal_lines,
             )
 
         if len(projected_content) >= len(raw_snapshot_content):
@@ -6148,17 +5467,6 @@ class Agent:
                 json_guard_applied=json_guard_applied,
             )
             return original_result
-
-        if signal_lines and stored is not None:
-            self._record_projection_signal_hint_event(
-                builder="fresh",
-                tool_name=result.tool_name,
-                tool_use_id=result.tool_use_id,
-                tool_result_handle=stored.handle,
-                original_chars=len(raw_snapshot_content),
-                signal_match_lines=signal_matches,
-                signal_first_line=signal_first_line,
-            )
 
         tokens_before = get_approx_tokens(raw_snapshot_content)
         tokens_after = get_approx_tokens(projected_content)
@@ -6196,15 +5504,6 @@ class Agent:
             is_error=result.is_error,
             json_guard_applied=json_guard_applied,
         )
-        if diagnostic_reason is not None:
-            self._record_projected_diagnostic_evidence(
-                handle=stored_handle,
-                tool_name=result.tool_name,
-                tool_use_id=result.tool_use_id,
-                reason=diagnostic_reason,
-                original_chars=len(raw_snapshot_content),
-                projected_chars=len(projected_content),
-            )
         return ToolResult(
             tool_use_id=result.tool_use_id,
             tool_name=result.tool_name,
@@ -6260,9 +5559,8 @@ class Agent:
                     continue
                 content = block.content if isinstance(block.content, str) else str(block.content)
                 if content.startswith("[duplicate_tool_result_elided]\n"):
-                    # Dedup elision depends on another block's current state
-                    # (its survivor), not solely on this block's own content —
-                    # never freeze it; let dedup recompute it every request.
+                    # Historical dedup markers refer to another result; do not
+                    # freeze them as self-contained projection evidence.
                     continue
                 if _tool_result_content_is_provider_projection(content):
                     self._freeze_provider_tool_result_projection(
@@ -6667,8 +5965,6 @@ class Agent:
     ) -> AsyncIterator[AgentEvent]:
         """Async generator that drives the state machine."""
         self._provider_tool_result_overrides = {}
-        self._projected_diagnostic_evidence = {}
-        self._focused_retrieved_tool_result_handles = set()
         self._current_turn_message = message
         _meta_invoke_turn_count.set(0)
         usage_scope = current_usage_accounting_scope()
@@ -14094,13 +13390,8 @@ class Agent:
                         recovery_read_paths=workspace_edit_gate_recovery_read_paths,
                         recovery_reads_remaining=(workspace_edit_gate_recovery_reads_remaining),
                     )
-                    diagnostic_retrieval_gate_result = (
-                        self._projected_diagnostic_retrieval_gate_tool_result(execution_tc)
-                    )
                     if gate_result is not None:
                         res = gate_result
-                    elif diagnostic_retrieval_gate_result is not None:
-                        res = diagnostic_retrieval_gate_result
                     elif preflight_result is not None:
                         res = preflight_result
                     else:
@@ -14187,7 +13478,6 @@ class Agent:
                                 failure_code="writer_tool_timed_out",
                             )
                     duration_ms = int((time.monotonic() - started) * 1000)
-                    self._record_focused_diagnostic_retrieval(execution_tc, res)
                     if len(self._effective_workspace_write_records()) > 0:
                         workspace_edit_gate_details = None
                         workspace_edit_gate_recovery_read_paths.clear()
@@ -17936,7 +17226,6 @@ class Agent:
         # not affect message cardinality.  Skip them during a count preview:
         # the normal paths update metadata, logs, and snapshot stores.
         if not preview:
-            source_messages = self._dedup_repeated_tool_results_for_provider(source_messages)
             source_messages = self._compact_aggregate_tool_results_for_provider(source_messages)
         source_messages = self._sanitize_projected_tool_use_arguments_for_provider(
             source_messages,
@@ -22827,15 +22116,6 @@ class Agent:
             tool_result_projection_max_inline_chars=(
                 self.config.tool_result_projection_max_inline_chars
             ),
-            tool_result_fresh_diagnostic_policy_enabled=(
-                self.config.tool_result_fresh_diagnostic_policy_enabled
-            ),
-            tool_result_diagnostic_retrieval_gate_enabled=(
-                self.config.tool_result_diagnostic_retrieval_gate_enabled
-            ),
-            tool_result_fresh_diagnostic_inline_max_chars=(
-                self.config.tool_result_fresh_diagnostic_inline_max_chars
-            ),
             tool_result_dispatch_max_chars=self.config.tool_result_dispatch_max_chars,
             tool_result_dispatch_turn_max_chars=(self.config.tool_result_dispatch_turn_max_chars),
             tool_result_provider_request_max_chars=(
@@ -22873,9 +22153,6 @@ class Agent:
             repeated_tool_call_recovery_extra_tools=(
                 self.config.repeated_tool_call_recovery_extra_tools
             ),
-            provider_history_dedup_enabled=self.config.provider_history_dedup_enabled,
-            provider_history_dedup_min_repeats=(self.config.provider_history_dedup_min_repeats),
-            projection_signal_hints=self.config.projection_signal_hints,
             progress_watchdog_mode=self.config.progress_watchdog_mode,
             progress_watchdog_repeated_tool_error_threshold=(
                 self.config.progress_watchdog_repeated_tool_error_threshold

--- a/src/opensquilla/engine/turn_runner/agent_bootstrap_stage.py
+++ b/src/opensquilla/engine/turn_runner/agent_bootstrap_stage.py
@@ -198,20 +198,6 @@ def _name_tuple_from_env(name: str) -> tuple[str, ...]:
     return tuple(item.strip() for item in raw.split(",") if item.strip())
 
 
-def _projection_signal_hints_from_env() -> bool:
-    """Parse OPENSQUILLA_PROJECTION_SIGNAL_HINTS through the runtime gate.
-
-    Delegating keeps bootstrap and per-request resolution on one on/off
-    vocabulary: an unrecognized value raises here, at bootstrap, instead of
-    surviving as False and then raising mid-turn when the agent re-reads the
-    env. Local import; the engine.agent module is import-cycle-safe from
-    this stage only at call time.
-    """
-    from opensquilla.engine.agent import _projection_signal_hints_enabled
-
-    return _projection_signal_hints_enabled(False)
-
-
 # ---------------------------------------------------------------------------
 # Value objects returned by the ports — typed frozen tuples that collapse
 # the multi-call slice into declarative single-call shapes.
@@ -290,9 +276,6 @@ class _AgentConfigAuxiliaries:
     compaction_heartbeat_interval_seconds: float
     # Agent-token-cfg-derived
     tool_result_projection_max_inline_chars: int
-    tool_result_fresh_diagnostic_policy_enabled: bool
-    tool_result_diagnostic_retrieval_gate_enabled: bool
-    tool_result_fresh_diagnostic_inline_max_chars: int
     tool_result_dispatch_max_chars: int
     tool_result_dispatch_turn_max_chars: int
     tool_result_store_full_trace: bool
@@ -994,24 +977,6 @@ class AgentBootstrapStage:
             model_vision_support=effective_model_vision_support,
             thinking=aux.thinking,
             tool_result_projection_max_inline_chars=(aux.tool_result_projection_max_inline_chars),
-            tool_result_fresh_diagnostic_policy_enabled=(
-                _bool_from_env(
-                    "OPENSQUILLA_TOOL_RESULT_FRESH_DIAGNOSTIC_POLICY_ENABLED",
-                    aux.tool_result_fresh_diagnostic_policy_enabled,
-                )
-            ),
-            tool_result_diagnostic_retrieval_gate_enabled=(
-                _bool_from_env(
-                    "OPENSQUILLA_TOOL_RESULT_DIAGNOSTIC_RETRIEVAL_GATE_ENABLED",
-                    aux.tool_result_diagnostic_retrieval_gate_enabled,
-                )
-            ),
-            tool_result_fresh_diagnostic_inline_max_chars=(
-                _nonnegative_int_from_env(
-                    "OPENSQUILLA_TOOL_RESULT_FRESH_DIAGNOSTIC_INLINE_MAX_CHARS",
-                    aux.tool_result_fresh_diagnostic_inline_max_chars,
-                )
-            ),
             tool_result_dispatch_max_chars=aux.tool_result_dispatch_max_chars,
             tool_result_dispatch_turn_max_chars=(aux.tool_result_dispatch_turn_max_chars),
             tool_result_store_dir=aux.tool_result_store_dir,
@@ -1088,15 +1053,6 @@ class AgentBootstrapStage:
             repeated_tool_call_recovery_extra_tools=_name_tuple_from_env(
                 "OPENSQUILLA_TOOL_REPEAT_NUDGE_TOOLS",
             ),
-            provider_history_dedup_enabled=_bool_from_env(
-                "OPENSQUILLA_PROVIDER_HISTORY_DEDUP",
-                AgentConfig().provider_history_dedup_enabled,
-            ),
-            provider_history_dedup_min_repeats=_positive_int_from_env(
-                "OPENSQUILLA_PROVIDER_HISTORY_DEDUP_MIN_REPEATS",
-                AgentConfig().provider_history_dedup_min_repeats,
-            ),
-            projection_signal_hints=_projection_signal_hints_from_env(),
             runtime_recovery_mode=_runtime_recovery_mode_from_env(),
             runtime_recovery_source_loop_max_nudges=_positive_int_from_env(
                 "OPENSQUILLA_RUNTIME_RECOVERY_SOURCE_LOOP_MAX_NUDGES",

--- a/src/opensquilla/engine/turn_runner/harness.py
+++ b/src/opensquilla/engine/turn_runner/harness.py
@@ -895,21 +895,6 @@ class _TurnRunnerAgentConfigBuilderAdapter(AgentConfigBuilderPort):
                 "tool_result_projection_max_inline_chars",
                 60_000,
             ),
-            tool_result_fresh_diagnostic_policy_enabled=getattr(
-                agent_token_cfg,
-                "tool_result_fresh_diagnostic_policy_enabled",
-                False,
-            ),
-            tool_result_diagnostic_retrieval_gate_enabled=getattr(
-                agent_token_cfg,
-                "tool_result_diagnostic_retrieval_gate_enabled",
-                False,
-            ),
-            tool_result_fresh_diagnostic_inline_max_chars=getattr(
-                agent_token_cfg,
-                "tool_result_fresh_diagnostic_inline_max_chars",
-                64_000,
-            ),
             tool_result_dispatch_max_chars=getattr(
                 agent_token_cfg,
                 "tool_result_dispatch_max_chars",

--- a/src/opensquilla/engine/types.py
+++ b/src/opensquilla/engine/types.py
@@ -785,13 +785,9 @@ class AgentConfig:
     tool_result_compression_summary_timeout_seconds: float = 20.0
     tool_result_compression_summary_input_max_chars: int = 60_000
     tool_result_projection_max_inline_chars: int = 60_000
-    # Fresh diagnostic delivery is experimental; unattended profiles should opt
-    # in only after model-specific validation.
+    # Deprecated, unused compatibility slots; preserve positional/keyword construction.
     tool_result_fresh_diagnostic_policy_enabled: bool = False
     tool_result_diagnostic_retrieval_gate_enabled: bool = False
-    # When the fresh diagnostic policy is enabled, keep bounded failures intact
-    # for the immediate handoff, then let older history/replay compaction handle
-    # long-term context pressure.
     tool_result_fresh_diagnostic_inline_max_chars: int = 64_000
     # Dispatch-layer tool result caps. 0 disables the cap. These run before
     # provider-request projection and are intended for unattended automation
@@ -912,22 +908,9 @@ class AgentConfig:
     reasoning_only_act_now: bool = False
     # Deprecated, unused compatibility slot; preserve positional/keyword construction.
     mid_budget_no_diff_nudge: bool = False
-    # Provider-view dedup of byte-identical repeated tool results. Off by
-    # default. When enabled, older duplicate tool_result payloads (same content
-    # emitted N+ times across iterations) are replaced in the provider request
-    # projection with a compact back-reference to the surviving newest copy;
-    # persisted history is never mutated. Set via
-    # OPENSQUILLA_PROVIDER_HISTORY_DEDUP.
+    # Deprecated, unused compatibility slots; preserve positional/keyword construction.
     provider_history_dedup_enabled: bool = False
-    # Minimum number of byte-identical copies of a tool result before dedup
-    # elides the older ones (keeps the newest copy full). Set via
-    # OPENSQUILLA_PROVIDER_HISTORY_DEDUP_MIN_REPEATS.
     provider_history_dedup_min_repeats: int = 2
-    # Append a failure-signal scan header to tool-result projection notices:
-    # the omitted region of the original output is scanned for failure-pattern
-    # lines and the notice gains a signal_scan summary plus a ready-to-copy
-    # retrieve_tool_result call for the first match. Off by default; enabled
-    # via OPENSQUILLA_PROJECTION_SIGNAL_HINTS.
     projection_signal_hints: bool = False
     # Deprecated, unused compatibility slot; preserve construction and saved configs.
     tool_loop_observer_mode: Literal["off", "log"] = "off"

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -1406,6 +1406,7 @@ class AgentTokenSavingConfig(BaseSettings):
 
     # Tokenjuice projection is the default tool-result path.
     tool_result_projection_max_inline_chars: int = Field(default=60_000, ge=1000)
+    # Deprecated, unused. Accepted so existing configuration still loads.
     tool_result_fresh_diagnostic_policy_enabled: bool = Field(default=False)
     tool_result_diagnostic_retrieval_gate_enabled: bool = Field(default=False)
     tool_result_fresh_diagnostic_inline_max_chars: int = Field(default=64_000, ge=0)

--- a/src/opensquilla/provider/request_proof.py
+++ b/src/opensquilla/provider/request_proof.py
@@ -38,12 +38,11 @@ _COMPACTED_TOOL_ARGUMENT_MARKERS = frozenset(
         "_opensquilla_compacted_tool_input",
     }
 )
-# Compaction safety defaults. The tiny guard and optional stub previews remain
-# opt-in. Fresh assistant work, two recent tool results, error or unresolved
-# results, and already-projected results are protected by default. Never-worse
+# Compaction safety defaults. Fresh assistant work, two recent tool results,
+# error or unresolved results, and already-projected results are protected by
+# default. Never-worse
 # also defaults on so request-only compaction cannot increase an envelope.
 # Every safety default retains an explicit env rollback value.
-_TINY_COMPACTION_GUARD_ENV = "OPENSQUILLA_PROVIDER_COMPACTION_TINY_GUARD_CHARS"
 _PROTECT_RECENT_ASSISTANT_ENV = "OPENSQUILLA_PROVIDER_COMPACTION_PROTECT_RECENT_ASSISTANT"
 _PROTECT_RECENT_RESULTS_ENV = "OPENSQUILLA_PROVIDER_COMPACTION_PROTECT_RECENT_RESULTS"
 _PROTECT_ERROR_RESULTS_ENV = "OPENSQUILLA_PROVIDER_COMPACTION_PROTECT_ERROR_RESULTS"
@@ -51,7 +50,6 @@ _PROTECT_UNRESOLVED_RESULTS_ENV = (
     "OPENSQUILLA_PROVIDER_COMPACTION_PROTECT_UNRESOLVED_RESULTS"
 )
 _SKIP_PROJECTED_ENV = "OPENSQUILLA_PROVIDER_COMPACTION_SKIP_PROJECTED"
-_STUB_PREVIEW_CHARS_ENV = "OPENSQUILLA_PROVIDER_COMPACTION_STUB_PREVIEW_CHARS"
 _NEVER_WORSE_ENV = "OPENSQUILLA_PROVIDER_COMPACTION_NEVER_WORSE"
 _TRUE_ENV_VALUES = frozenset({"1", "true", "yes", "on", "enabled"})
 _FALSE_ENV_VALUES = frozenset({"0", "false", "no", "off", "disabled"})
@@ -72,16 +70,6 @@ _SYNTHETIC_USER_PREFIXES = (
     "Runtime state capsule:",
     "You are the aggregator in a multi-model B5 fusion experiment.",
 )
-
-
-def _tiny_compaction_guard_chars() -> int:
-    raw = os.environ.get(_TINY_COMPACTION_GUARD_ENV, "").strip()
-    if not raw:
-        return 0
-    try:
-        return max(0, int(raw))
-    except ValueError:
-        return 0
 
 
 def _safety_default_enabled(env_name: str) -> bool:
@@ -130,16 +118,6 @@ def _protect_unresolved_results_enabled() -> bool:
 
 def _skip_projected_results_enabled() -> bool:
     return _safety_default_enabled(_SKIP_PROJECTED_ENV)
-
-
-def _stub_preview_chars() -> int:
-    raw = os.environ.get(_STUB_PREVIEW_CHARS_ENV, "").strip()
-    if not raw:
-        return 0
-    try:
-        return max(0, int(raw))
-    except ValueError:
-        return 0
 
 
 def _never_worse_enabled() -> bool:
@@ -479,8 +457,6 @@ def _compact_string(value: str) -> str:
 def _compact_tail_string(value: str, *, label: str) -> str:
     if len(value) <= _COMPACTED_TAIL_STRING_MAX_CHARS:
         return value
-    if len(value) <= _tiny_compaction_guard_chars():
-        return value
     head = value[:420]
     tail = value[-120:]
     omitted = len(value) - len(head) - len(tail)
@@ -498,8 +474,6 @@ def _compact_tail_string(value: str, *, label: str) -> str:
 
 def _emergency_compact_string(value: str, *, label: str) -> str:
     if len(value) <= 320:
-        return value
-    if len(value) <= _tiny_compaction_guard_chars():
         return value
     head = value[:180]
     tail = value[-40:]
@@ -519,8 +493,6 @@ def _emergency_compact_string(value: str, *, label: str) -> str:
 def _hard_compact_string(value: str, *, label: str) -> str:
     if len(value) <= 96:
         return value
-    if len(value) <= _tiny_compaction_guard_chars():
-        return value
     digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
     compacted = f"[opensquilla_compacted:{label}:{len(value)}:{digest}]"
     if _keep_original_for_never_worse(value, compacted):
@@ -531,20 +503,13 @@ def _hard_compact_string(value: str, *, label: str) -> str:
 def _compact_argument_string(value: str, *, preview: bool = True) -> str:
     if preview:
         return _compact_tail_string(value, label="tool_input")
-    if len(value) <= _tiny_compaction_guard_chars():
+    if not value:
         return value
     digest = hashlib.sha256(value.encode("utf-8")).hexdigest()
     compacted = (
         "[provider_request_tool_input_compacted: "
         f"original_chars={len(value)}; sha256={digest}]"
     )
-    preview_chars = _stub_preview_chars()
-    if preview_chars and len(value) > preview_chars * 2:
-        with_previews = f"{value[:preview_chars]}\n\n{compacted}\n\n{value[-preview_chars:]}"
-        # Previews may never turn compaction into growth: attach them only
-        # while the preview-carrying stub stays smaller than the original.
-        if _payload_chars(with_previews) < _payload_chars(value):
-            compacted = with_previews
     if _keep_original_for_never_worse(value, compacted):
         return value
     return compacted
@@ -583,7 +548,7 @@ def _compact_tool_arguments(value: str, *, preview: bool = True) -> str:
                 if _keep_original_for_never_worse(value, compacted_json):
                     return value
                 return compacted_json
-    if len(value) <= _tiny_compaction_guard_chars():
+    if not value:
         return value
     digest = hashlib.sha256(value.encode("utf-8")).hexdigest()
     stub: dict[str, Any] = {
@@ -592,14 +557,6 @@ def _compact_tool_arguments(value: str, *, preview: bool = True) -> str:
         "sha256": digest,
     }
     stub_json = json.dumps(stub, ensure_ascii=False, separators=(",", ":"))
-    preview_chars = _stub_preview_chars()
-    if preview_chars and len(value) > preview_chars * 2:
-        stub["preview_head"] = value[:preview_chars]
-        stub["preview_tail"] = value[-preview_chars:]
-        with_previews_json = json.dumps(stub, ensure_ascii=False, separators=(",", ":"))
-        # Previews may never turn compaction into growth.
-        if _payload_chars(with_previews_json) < _payload_chars(value):
-            stub_json = with_previews_json
     if _keep_original_for_never_worse(value, stub_json):
         return value
     return stub_json
@@ -672,8 +629,6 @@ def _compact_tool_input(value: Any) -> Any:
         return _invalid_provider_context_arguments(value)
     if len(raw) <= _COMPACTED_TAIL_STRING_MAX_CHARS:
         return value
-    if len(raw) <= _tiny_compaction_guard_chars():
-        return value
     compacted = dict(value)
     changed = False
     for key, item in value.items():
@@ -692,17 +647,6 @@ def _compact_tool_input(value: Any) -> Any:
         "head": raw[:_COMPACTED_ARGUMENT_PREVIEW_CHARS],
         "tail": raw[-_COMPACTED_ARGUMENT_TAIL_CHARS:],
     }
-    preview_chars = _stub_preview_chars()
-    if preview_chars > _COMPACTED_ARGUMENT_TAIL_CHARS:
-        # The stub's head/tail fields already carry fixed-size previews;
-        # separate preview keys would duplicate those bytes, so the lever
-        # extends the fields in place — and only while the stub stays
-        # smaller than the original.
-        extended = dict(stub)
-        extended["head"] = raw[: max(preview_chars, _COMPACTED_ARGUMENT_PREVIEW_CHARS)]
-        extended["tail"] = raw[-preview_chars:]
-        if _payload_chars(extended) < _payload_chars(value):
-            stub = extended
     if _keep_original_for_never_worse(value, stub):
         return value
     return stub
@@ -1045,20 +989,6 @@ def _critical_tool_content_for_provider(content: Any) -> Any:
 def _compact_tool_arguments_for_final_cap(arguments: str) -> str:
     stub: dict[str, Any] = {_INVALID_PROVIDER_CONTEXT_ARGUMENTS_KEY: True}
     stub_json = json.dumps(stub, ensure_ascii=False, separators=(",", ":"))
-    preview_chars = _stub_preview_chars()
-    if preview_chars and len(arguments) > preview_chars * 2:
-        # Never preview argument text the projection scrubber would redact.
-        sanitized = _provider_context_arguments_json(
-            arguments,
-            include_compacted_markers=True,
-        )
-        if sanitized is None:
-            stub["preview_head"] = arguments[:preview_chars]
-            stub["preview_tail"] = arguments[-preview_chars:]
-            with_previews_json = json.dumps(stub, ensure_ascii=False, separators=(",", ":"))
-            # Previews may never turn compaction into growth.
-            if _payload_chars(with_previews_json) < _payload_chars(arguments):
-                stub_json = with_previews_json
     if _keep_original_for_never_worse(arguments, stub_json):
         return arguments
     return stub_json
@@ -1662,7 +1592,6 @@ def project_provider_payload(
         "fits": fits,
         "compact_needed": not fits,
         "compaction_tier": 0,
-        "compaction_tiny_guard_chars": _tiny_compaction_guard_chars(),
         "compaction_protect_recent_assistant": _protect_recent_assistant_enabled(),
         "recent_tail_too_large": False,
         "compaction_not_smaller": False,
@@ -1709,9 +1638,6 @@ def project_provider_payload(
         proof["protected_tool_result_count"] = len(logical_protected_indexes)
     if _skip_projected_results_enabled():
         proof["compaction_skip_projected"] = True
-    stub_preview_chars = _stub_preview_chars()
-    if stub_preview_chars:
-        proof["compaction_stub_preview_chars"] = stub_preview_chars
     if _never_worse_enabled():
         proof["compaction_never_worse"] = True
     active_user_index, active_user_anchor_source = _active_user_anchor(

--- a/src/opensquilla/skills/meta/orchestrator.py
+++ b/src/opensquilla/skills/meta/orchestrator.py
@@ -678,9 +678,6 @@ _META_SUBAGENT_COMPACTION_FIELDS = (
 )
 _META_SUBAGENT_RECOVERY_FIELDS = (
     "tool_result_projection_max_inline_chars",
-    "tool_result_fresh_diagnostic_policy_enabled",
-    "tool_result_diagnostic_retrieval_gate_enabled",
-    "tool_result_fresh_diagnostic_inline_max_chars",
     "tool_result_dispatch_max_chars",
     "tool_result_dispatch_turn_max_chars",
     "tool_result_provider_request_max_chars",

--- a/tests/test_engine/test_provider_history_dedup.py
+++ b/tests/test_engine/test_provider_history_dedup.py
@@ -1,13 +1,4 @@
-"""Opt-in provider-view history dedup lever.
-
-Covers OPENSQUILLA_PROVIDER_HISTORY_DEDUP (off by default). Motivation: long
-single-turn episodes re-run the same
-read/grep/diff commands and full-history replay resends every byte-identical
-tool_result on every iteration, paying quadratic cost. When enabled, older
-byte-identical tool results are replaced in the provider request projection
-with a short back-reference to the surviving newest copy; persisted history is
-never mutated.
-"""
+"""Retired dedup configuration preserves history and shared projection contracts."""
 
 from __future__ import annotations
 
@@ -42,7 +33,7 @@ class _StubProvider:
         return []
 
 
-# A payload comfortably above _PROVIDER_HISTORY_DEDUP_MIN_CHARS (400).
+# Repeated, nontrivial results must remain independent tool transactions.
 BIG_RESULT = "line of grep output\n" * 60
 
 
@@ -85,248 +76,6 @@ def _tool_results(messages: list[Message]) -> list[ContentBlockToolResult]:
     return results
 
 
-def test_dedup_off_by_default() -> None:
-    assert AgentConfig().provider_history_dedup_enabled is False
-    agent = Agent(provider=_StubProvider(), config=AgentConfig())
-    history = _history(("g1", BIG_RESULT), ("g2", BIG_RESULT), ("g3", BIG_RESULT))
-    projected = agent._dedup_repeated_tool_results_for_provider(history)
-    contents = [r.content for r in _tool_results(projected)]
-    assert contents == [BIG_RESULT, BIG_RESULT, BIG_RESULT]
-
-
-def test_dedup_elides_older_identical_results_keeps_newest() -> None:
-    agent = Agent(
-        provider=_StubProvider(),
-        config=AgentConfig(provider_history_dedup_enabled=True),
-    )
-    # g1..g3 are byte-identical; g4 is unique. The recent-tail guard covers the
-    # last two results (g3, g4), so g1 and g2 are elided and g3 survives full.
-    history = _history(
-        ("g1", BIG_RESULT),
-        ("g2", BIG_RESULT),
-        ("g3", BIG_RESULT),
-        ("g4", "unique tail result " * 40),
-    )
-    projected = agent._dedup_repeated_tool_results_for_provider(history)
-    results = _tool_results(projected)
-    for stub in (results[0], results[1]):
-        assert stub.content.startswith("[duplicate_tool_result_elided]\n")
-        assert "identical_to_tool_use_id: g3" in stub.content
-    # The surviving newest identical copy (g3) stays full.
-    assert results[2].content == BIG_RESULT
-    assert agent.config.metadata["provider_history_dedup_elided"] == 2
-    assert agent.config.metadata["provider_history_dedup_chars_saved"] > 0
-
-
-def test_dedup_is_idempotent_across_iterations() -> None:
-    agent = Agent(
-        provider=_StubProvider(),
-        config=AgentConfig(provider_history_dedup_enabled=True),
-    )
-    history = _history(
-        ("g1", BIG_RESULT),
-        ("g2", BIG_RESULT),
-        ("g3", BIG_RESULT),
-        ("g4", "unique tail result " * 40),
-    )
-    once = agent._dedup_repeated_tool_results_for_provider(history)
-    twice = agent._dedup_repeated_tool_results_for_provider(once)
-    assert [r.content for r in _tool_results(twice)] == [
-        r.content for r in _tool_results(once)
-    ]
-
-
-def test_dedup_leaves_recent_tail_duplicates_alone() -> None:
-    agent = Agent(
-        provider=_StubProvider(),
-        config=AgentConfig(provider_history_dedup_enabled=True),
-    )
-    # The only duplicates are the two most recent results - the model is
-    # actively looking at them, so nothing is elided.
-    history = _history(
-        ("u1", "unique first result " * 40),
-        ("g1", BIG_RESULT),
-        ("g2", BIG_RESULT),
-    )
-    projected = agent._dedup_repeated_tool_results_for_provider(history)
-    contents = [r.content for r in _tool_results(projected)]
-    assert contents.count(BIG_RESULT) == 2
-
-
-def test_dedup_does_not_mutate_persisted_history() -> None:
-    agent = Agent(
-        provider=_StubProvider(),
-        config=AgentConfig(provider_history_dedup_enabled=True),
-    )
-    history = _history(
-        ("g1", BIG_RESULT),
-        ("g2", BIG_RESULT),
-        ("g3", BIG_RESULT),
-        ("g4", "tail " * 120),
-    )
-    before = [r.content for r in _tool_results(history)]
-    agent._dedup_repeated_tool_results_for_provider(history)
-    after = [r.content for r in _tool_results(history)]
-    assert before == after
-
-
-def test_dedup_skips_error_results() -> None:
-    agent = Agent(
-        provider=_StubProvider(),
-        config=AgentConfig(provider_history_dedup_enabled=True),
-    )
-    history = _history(
-        ("e1", BIG_RESULT),
-        ("e2", BIG_RESULT),
-        ("e3", BIG_RESULT),
-        ("t1", "tail " * 120),
-    )
-    # Mark the first three as errors post-hoc.
-    for use_id in ("e1", "e2", "e3"):
-        for message in history:
-            if isinstance(message.content, list):
-                for block in message.content:
-                    if (
-                        isinstance(block, ContentBlockToolResult)
-                        and block.tool_use_id == use_id
-                    ):
-                        block.is_error = True
-    projected = agent._dedup_repeated_tool_results_for_provider(history)
-    contents = [r.content for r in _tool_results(projected)]
-    assert all(not c.startswith("[duplicate_tool_result_elided]") for c in contents)
-
-
-def test_dedup_skips_small_results_below_min_chars() -> None:
-    agent = Agent(
-        provider=_StubProvider(),
-        config=AgentConfig(provider_history_dedup_enabled=True),
-    )
-    small = "tiny"  # < 400 chars
-    history = _history(
-        ("s1", small),
-        ("s2", small),
-        ("s3", small),
-        ("t1", "tail " * 120),
-    )
-    projected = agent._dedup_repeated_tool_results_for_provider(history)
-    contents = [r.content for r in _tool_results(projected)]
-    assert contents.count(small) == 3
-
-
-def test_dedup_respects_min_repeats_threshold() -> None:
-    # With min_repeats=3, two copies are not enough to elide.
-    agent = Agent(
-        provider=_StubProvider(),
-        config=AgentConfig(
-            provider_history_dedup_enabled=True,
-            provider_history_dedup_min_repeats=3,
-        ),
-    )
-    history = _history(
-        ("g1", BIG_RESULT),
-        ("g2", BIG_RESULT),
-        ("t1", "tail " * 120),
-        ("t2", "other " * 120),
-    )
-    projected = agent._dedup_repeated_tool_results_for_provider(history)
-    contents = [r.content for r in _tool_results(projected)]
-    assert contents.count(BIG_RESULT) == 2
-
-
-def test_dedup_groups_across_iterations_despite_frozen_survivor() -> None:
-    # A block already frozen full (shown in a prior request) must still count
-    # toward the digest group so newer duplicates get elided — it must only
-    # be excluded from being re-stubbed itself.
-    agent = Agent(
-        provider=_StubProvider(),
-        config=AgentConfig(
-            provider_history_dedup_enabled=True,
-            provider_history_dedup_min_repeats=3,
-        ),
-    )
-    iter1_history = _history(("g1", BIG_RESULT))
-    iter1_projected = agent._dedup_repeated_tool_results_for_provider(iter1_history)
-    agent._remember_provider_visible_tool_results(iter1_projected)
-    assert "g1" in agent._provider_tool_result_frozen_full_ids
-
-    iter2_history = _history(
-        ("g1", BIG_RESULT),
-        ("g2", BIG_RESULT),
-        ("g3", BIG_RESULT),
-        ("u1", "unique final result " * 40),
-    )
-    projected = agent._dedup_repeated_tool_results_for_provider(iter2_history)
-    results = {r.tool_use_id: r.content for r in _tool_results(projected)}
-    # g1 stays full (frozen, protected from retroactive downgrade).
-    assert results["g1"] == BIG_RESULT
-    # g2 is now correctly elided against the newest survivor g3.
-    assert results["g2"].startswith("[duplicate_tool_result_elided]\n")
-    assert "identical_to_tool_use_id: g3" in results["g2"]
-    assert results["g3"] == BIG_RESULT
-
-
-def test_dedup_stub_is_not_permanently_frozen() -> None:
-    # Elision depends on another block's state (its survivor), so it must
-    # never be frozen into a permanent override — only recomputed fresh.
-    agent = Agent(
-        provider=_StubProvider(),
-        config=AgentConfig(provider_history_dedup_enabled=True),
-    )
-    history = _history(
-        ("g1", BIG_RESULT),
-        ("g2", BIG_RESULT),
-        ("g3", BIG_RESULT),
-        ("u1", "unique final result " * 40),
-    )
-    projected = agent._dedup_repeated_tool_results_for_provider(history)
-    agent._remember_provider_visible_tool_results(projected)
-
-    assert "g1" not in agent._provider_tool_result_frozen_overrides
-    assert "g1" not in agent._provider_tool_result_frozen_full_ids
-    assert "g2" not in agent._provider_tool_result_frozen_overrides
-    assert "g2" not in agent._provider_tool_result_frozen_full_ids
-
-
-def test_compact_does_not_recompact_dedup_survivor_in_same_request() -> None:
-    # The dedup survivor is the one full copy other stubs point back to; the
-    # aggregate compaction pass running right after must not turn it into a
-    # compacted stub too, or the back-references become dangling.
-    agent = Agent(
-        provider=_StubProvider(),
-        config=AgentConfig(
-            provider_history_dedup_enabled=True,
-            context_window_tokens=100,
-        ),
-    )
-    history = _history(
-        ("g1", BIG_RESULT),
-        ("g2", BIG_RESULT),
-        ("g3", BIG_RESULT),
-        ("u1", "unique tail result one " * 40),
-        ("u2", "unique tail result two " * 40),
-    )
-    deduped = agent._dedup_repeated_tool_results_for_provider(history)
-    assert agent._provider_history_dedup_survivor_ids == {"g3"}
-
-    compacted = agent._compact_aggregate_tool_results_for_provider(deduped)
-    results = {r.tool_use_id: r.content for r in _tool_results(compacted)}
-    assert results["g3"] == BIG_RESULT
-
-
-def test_dedup_env_plumbing(monkeypatch) -> None:
-    from opensquilla.engine.turn_runner.agent_bootstrap_stage import (
-        _bool_from_env,
-        _positive_int_from_env,
-    )
-
-    assert _bool_from_env("OPENSQUILLA_PROVIDER_HISTORY_DEDUP", False) is False
-    assert _positive_int_from_env("OPENSQUILLA_PROVIDER_HISTORY_DEDUP_MIN_REPEATS", 2) == 2
-    monkeypatch.setenv("OPENSQUILLA_PROVIDER_HISTORY_DEDUP", "1")
-    monkeypatch.setenv("OPENSQUILLA_PROVIDER_HISTORY_DEDUP_MIN_REPEATS", "4")
-    assert _bool_from_env("OPENSQUILLA_PROVIDER_HISTORY_DEDUP", False) is True
-    assert _positive_int_from_env("OPENSQUILLA_PROVIDER_HISTORY_DEDUP_MIN_REPEATS", 2) == 4
-
-
 def test_tool_result_artifact_detection_is_cached() -> None:
     from opensquilla.engine.agent import _tool_result_content_has_artifact
 
@@ -338,3 +87,37 @@ def test_tool_result_artifact_detection_is_cached() -> None:
     after = _tool_result_content_has_artifact.cache_info()
     assert after.hits == before.hits + 1
     assert after.misses == before.misses + 1
+
+
+def test_retired_dedup_config_cannot_elide_repeated_results() -> None:
+    agent = Agent(
+        provider=_StubProvider(),
+        config=AgentConfig(
+            provider_history_dedup_enabled=True,
+            provider_history_dedup_min_repeats=2,
+        ),
+    )
+    history = _history(("g1", BIG_RESULT), ("g2", BIG_RESULT), ("g3", BIG_RESULT))
+    projected = agent._provider_request_messages(
+        history,
+        request_context_message=None,
+        request_context_insert_index=0,
+        runtime_context_message=Message(role="user", content="[Runtime context for this turn]"),
+        runtime_context_insert_index=0,
+    )
+    assert [r.content for r in _tool_results(projected)] == [BIG_RESULT] * 3
+    assert [r.content for r in _tool_results(history)] == [BIG_RESULT] * 3
+    assert not any(key.startswith("provider_history_dedup") for key in agent.config.metadata)
+
+
+def test_historical_dedup_marker_is_not_frozen_as_standalone_evidence() -> None:
+    from opensquilla.engine.agent import _tool_result_content_is_provider_projection
+
+    marker = "[duplicate_tool_result_elided]\nidentical_to_tool_use_id: g2\n"
+    assert _tool_result_content_is_provider_projection(marker)
+    agent = Agent(provider=_StubProvider(), config=AgentConfig())
+    history = _history(("g1", marker), ("g2", BIG_RESULT))
+    agent._remember_provider_visible_tool_results(history)
+    assert "g1" not in agent._provider_tool_result_frozen_full_ids
+    assert "g1" not in agent._provider_tool_result_frozen_overrides
+    assert "g2" in agent._provider_tool_result_frozen_full_ids

--- a/tests/test_engine/test_tokenjuice_tool_result_projection.py
+++ b/tests/test_engine/test_tokenjuice_tool_result_projection.py
@@ -368,7 +368,7 @@ async def test_agent_projects_tokenjuice_without_context_window_gate(
 
 
 @pytest.mark.asyncio
-async def test_fresh_diagnostic_under_cap_is_preserved_to_next_provider_call(
+async def test_retired_fresh_diagnostic_flag_does_not_bypass_tokenjuice(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[dict[str, Any]] = []
@@ -416,11 +416,12 @@ async def test_fresh_diagnostic_under_cap_is_preserved_to_next_provider_call(
     assert len(provider.calls) == 2
     second_call_tool_result = _last_tool_result_content(provider.calls[1])
     assert second_call_tool_result == raw_output
-    assert calls == []
+    assert len(calls) == 1
     projected_event = next(event for event in events if isinstance(event, ToolResultEvent))
     assert projected_event.result == raw_output
-    assert agent.config.metadata["tool_projection_fresh_diagnostic_one_hop_preserves"] == 1
-    assert agent.config.metadata["tool_projection_fresh_diagnostic_results"] == 1
+    # No retrieval surface means the raw result still survives by the normal
+    # Store/retrieval contract, not the retired one-hop diagnostic policy.
+    assert not any("fresh_diagnostic" in key for key in agent.config.metadata)
 
 
 @pytest.mark.asyncio
@@ -896,9 +897,7 @@ async def test_run_turn_feeds_tokenjuice_reduced_tool_result_to_next_provider_ca
     assert "AssertionError" in second_call_tool_result
     assert "rootdir:" not in second_call_tool_result
     assert agent.config.metadata["tool_projection_backend"] == "tokenjuice"
-    assert agent.config.metadata["tool_projection_fresh_diagnostic_results"] == 1
-    assert agent.config.metadata["tool_projection_fresh_diagnostic_projections"] == 1
-    assert "tool_projection_fresh_diagnostic_one_hop_preserves" not in agent.config.metadata
+    assert not any("fresh_diagnostic" in key for key in agent.config.metadata)
     projected_event = next(event for event in events if isinstance(event, ToolResultEvent))
     delta_fragments = [
         event.json_fragment for event in events if isinstance(event, ToolUseDeltaEvent)
@@ -910,7 +909,7 @@ async def test_run_turn_feeds_tokenjuice_reduced_tool_result_to_next_provider_ca
 
 
 @pytest.mark.asyncio
-async def test_projected_diagnostic_requires_focused_retrieval_before_edit(
+async def test_retired_diagnostic_gate_does_not_force_retrieval_before_edit(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
 ) -> None:
@@ -997,11 +996,14 @@ async def test_projected_diagnostic_requires_focused_retrieval_before_edit(
         and event.is_error
         and "retrieve_tool_result" in event.result
     ]
-    assert blocked
-    assert executed_tool_names == ["exec_command", "retrieve_tool_result", "apply_patch"]
-    assert agent.config.metadata["tool_projection_fresh_diagnostic_projections"] == 1
-    assert agent.config.metadata["tool_projection_diagnostic_retrieval_gate_blocks"] == 1
-    assert agent.config.metadata["tool_projection_diagnostic_retrievals"] == 1
+    assert not blocked
+    assert executed_tool_names == [
+        "exec_command",
+        "apply_patch",
+        "retrieve_tool_result",
+        "apply_patch",
+    ]
+    assert not any("diagnostic" in key for key in agent.config.metadata)
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/test_tool_surface_levers.py
+++ b/tests/test_engine/test_tool_surface_levers.py
@@ -1,8 +1,9 @@
-"""Projection signal-scan notices, runtime events, and Child propagation."""
+"""Retired projection controls cannot change the default result envelopes."""
 
 from __future__ import annotations
 
 import json
+from dataclasses import fields
 from types import SimpleNamespace
 from typing import Any
 
@@ -10,10 +11,6 @@ import pytest
 
 import opensquilla.engine.agent as agent_mod
 from opensquilla.engine import Agent, AgentConfig, SubagentSpec, ToolResult
-from opensquilla.engine.agent import (
-    _projection_signal_hints_enabled,
-    _tool_result_signal_scan,
-)
 from opensquilla.provider import (
     ContentBlockToolResult,
     ContentBlockToolUse,
@@ -52,20 +49,55 @@ def _events_named(path, name: str) -> list[dict[str, Any]]:
     ]
 
 
-def test_child_agent_inherits_tool_surface_lever_fields() -> None:
+def test_retired_projection_config_keeps_constructor_slots() -> None:
+    field_names = [item.name for item in fields(AgentConfig)]
+    for expected in (
+        [
+            "tool_result_projection_max_inline_chars",
+            "tool_result_fresh_diagnostic_policy_enabled",
+            "tool_result_diagnostic_retrieval_gate_enabled",
+            "tool_result_fresh_diagnostic_inline_max_chars",
+            "tool_result_dispatch_max_chars",
+        ],
+        [
+            "mid_budget_no_diff_nudge",
+            "provider_history_dedup_enabled",
+            "provider_history_dedup_min_repeats",
+            "projection_signal_hints",
+            "tool_loop_observer_mode",
+        ],
+    ):
+        start = field_names.index(expected[0])
+        assert field_names[start : start + len(expected)] == expected
+
+
+def test_retired_projection_options_are_not_propagated_to_child() -> None:
+    from opensquilla.gateway.config import AgentTokenSavingConfig
+
+    legacy = AgentTokenSavingConfig(
+        tool_result_fresh_diagnostic_policy_enabled=True,
+        tool_result_diagnostic_retrieval_gate_enabled=True,
+        tool_result_fresh_diagnostic_inline_max_chars=2048,
+    )
+    assert legacy.tool_result_fresh_diagnostic_policy_enabled is True
     agent = Agent(
         provider=_TextProvider(),
-        config=AgentConfig(projection_signal_hints=True),
+        config=AgentConfig(
+            projection_signal_hints=True,
+            provider_history_dedup_enabled=True,
+            provider_history_dedup_min_repeats=8,
+            tool_result_fresh_diagnostic_policy_enabled=True,
+            tool_result_diagnostic_retrieval_gate_enabled=True,
+            tool_result_fresh_diagnostic_inline_max_chars=2048,
+        ),
     )
-
     child = agent._make_child_agent(SubagentSpec(task="child task"), depth=1)
-
-    assert child.config.projection_signal_hints is True
-
-
-# ---------------------------------------------------------------------------
-# M4 — projection signal hints
-# ---------------------------------------------------------------------------
+    assert child.config.projection_signal_hints is False
+    assert child.config.provider_history_dedup_enabled is False
+    assert child.config.provider_history_dedup_min_repeats == 2
+    assert child.config.tool_result_fresh_diagnostic_policy_enabled is False
+    assert child.config.tool_result_diagnostic_retrieval_gate_enabled is False
+    assert child.config.tool_result_fresh_diagnostic_inline_max_chars == 64_000
 
 
 def _fake_reduce(**kwargs: Any) -> Any:
@@ -98,7 +130,7 @@ def _projection_agent(tmp_path, **config_kwargs: Any) -> Agent:
             tool_result_store_session_id="session-1",
             tool_result_store_session_key="agent:main:session-1",
             tool_result_store_agent_id="main",
-            tool_result_fresh_diagnostic_inline_max_chars=1,
+            projection_signal_hints=True,
             **config_kwargs,
         ),
         tool_definitions=registry.to_tool_definitions(),
@@ -114,109 +146,13 @@ _FAILURE_CONTENT = (
 )
 
 
-def test_projection_signal_hints_env_gate(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("OPENSQUILLA_PROJECTION_SIGNAL_HINTS", raising=False)
-    assert _projection_signal_hints_enabled() is False
-    assert _projection_signal_hints_enabled(True) is True
-    monkeypatch.setenv("OPENSQUILLA_PROJECTION_SIGNAL_HINTS", "on")
-    assert _projection_signal_hints_enabled() is True
-    monkeypatch.setenv("OPENSQUILLA_PROJECTION_SIGNAL_HINTS", "off")
-    assert _projection_signal_hints_enabled(True) is False
-    monkeypatch.setenv("OPENSQUILLA_PROJECTION_SIGNAL_HINTS", "bogus")
-    with pytest.raises(ValueError):
-        _projection_signal_hints_enabled()
-
-
-def test_signal_scan_contiguous_and_preview_modes() -> None:
-    content = "ok line\nFAILED tests/test_x.py::test_y\n" + ("pad\n" * 50)
-    handle = "tr-" + ("a" * 32)
-    # Contiguous mode: the failure line sits inside the omitted span.
-    rendered, count, first = _tool_result_signal_scan(
-        content, handle=handle, head_chars=4, tail_chars=4
-    )
-    assert count == 1
-    assert first == 2
-    assert "signal_scan: 1 lines matching failure patterns" in rendered
-    assert "(first at L2)" in rendered
-    assert (
-        'signal_next_call: retrieve_tool_result {"handle": "' + handle + '"'
-        in rendered
-    )
-    assert '"mode": "query"' in rendered
-    assert '"query": "L2"' in rendered
-    # Head covers the failure line: nothing omitted matches.
-    rendered, count, first = _tool_result_signal_scan(
-        content, handle=handle, head_chars=len(content), tail_chars=0
-    )
-    assert (rendered, count, first) == ("", 0, None)
-    # Preview-membership mode: line present in the preview is not omitted.
-    preview = frozenset(["FAILED tests/test_x.py::test_y"])
-    rendered, count, first = _tool_result_signal_scan(
-        content, handle=handle, preview_lines=preview
-    )
-    assert (rendered, count, first) == ("", 0, None)
-    # No handle: unactionable, never renders.
-    rendered, count, first = _tool_result_signal_scan(
-        content, handle=None, head_chars=4, tail_chars=4
-    )
-    assert (rendered, count, first) == ("", 0, None)
-
-
 @pytest.mark.asyncio
-async def test_fresh_projection_appends_signal_scan_when_enabled(
+async def test_fresh_projection_unchanged_with_retired_options(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
 ) -> None:
     monkeypatch.setenv("OPENSQUILLA_PROJECTION_SIGNAL_HINTS", "on")
-    monkeypatch.setattr(
-        agent_mod, "reduce_tool_result_with_tokenjuice", _fake_reduce, raising=False
-    )
-    runtime_events_path = tmp_path / "runtime_events.jsonl"
-    agent = _projection_agent(
-        tmp_path, runtime_events_path=str(runtime_events_path)
-    )
-
-    projected = await agent._project_tool_result_for_llm(
-        ToolResult(
-            tool_use_id="tool-1",
-            tool_name="exec_command",
-            content=_FAILURE_CONTENT,
-            is_error=True,
-        )
-    )
-
-    assert "[tool_result_projection]" in projected.content
-    assert "signal_scan: " in projected.content
-    assert "(first at L3)" in projected.content
-    assert 'signal_next_call: retrieve_tool_result {"handle": "tr-' in projected.content
-    assert '"query": "L3"' in projected.content
-    # Ordering: signal lines sit between search_hints and the projected body.
-    assert projected.content.index("search_hints:") < projected.content.index(
-        "signal_scan: "
-    )
-    assert projected.content.index("signal_next_call:") < projected.content.index(
-        "[tokenjuice]"
-    )
-    hint_events = _events_named(runtime_events_path, "projection_signal_hints")
-    assert len(hint_events) == 1
-    event = hint_events[0]
-    assert event["feature"] == "tool_result_projection"
-    assert event["action"] == "hint_appended"
-    assert event["mechanism"] == "signal_scan"
-    assert event["builder"] == "fresh"
-    assert event["signal_first_line"] == 3
-    assert event["signal_match_lines"] >= 1
-    assert event["tool_result_handle"].startswith("tr-")
-    assert agent.config.metadata["tool_projection_signal_hints"] == 1
-
-
-@pytest.mark.asyncio
-async def test_fresh_projection_unchanged_when_env_unset(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path,
-) -> None:
-    monkeypatch.delenv("OPENSQUILLA_PROJECTION_SIGNAL_HINTS", raising=False)
-    monkeypatch.delenv("OPENSQUILLA_PROJECTION_SIGNAL_PATTERNS", raising=False)
+    monkeypatch.setenv("OPENSQUILLA_PROJECTION_SIGNAL_PATTERNS", "[")
     monkeypatch.setattr(
         agent_mod, "reduce_tool_result_with_tokenjuice", _fake_reduce, raising=False
     )
@@ -257,83 +193,12 @@ async def test_fresh_projection_unchanged_when_env_unset(
     assert projected.content == expected
 
 
-@pytest.mark.asyncio
-async def test_projection_signal_patterns_env_overrides_default(
+def test_provider_projection_unchanged_with_retired_options(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
 ) -> None:
     monkeypatch.setenv("OPENSQUILLA_PROJECTION_SIGNAL_HINTS", "on")
-    monkeypatch.setenv(
-        "OPENSQUILLA_PROJECTION_SIGNAL_PATTERNS", r"\bDIAG_MARKER\b"
-    )
-    monkeypatch.setattr(
-        agent_mod, "reduce_tool_result_with_tokenjuice", _fake_reduce, raising=False
-    )
-    agent = _projection_agent(tmp_path)
-    content = (
-        "line one\n"
-        "FAILED tests/test_api.py::test_bad - AssertionError\n"
-        "DIAG_MARKER custom failure channel\n" + ("x" * 20_000)
-    )
-
-    projected = await agent._project_tool_result_for_llm(
-        ToolResult(
-            tool_use_id="tool-1",
-            tool_name="exec_command",
-            content=content,
-            is_error=True,
-        )
-    )
-
-    # Only the override pattern matches: first hit is the DIAG_MARKER line.
-    assert "signal_scan: 1 lines matching failure patterns" in projected.content
-    assert "(first at L3)" in projected.content
-    assert '"query": "L3"' in projected.content
-
-
-def test_projection_signal_patterns_invalid_regex_raises(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("OPENSQUILLA_PROJECTION_SIGNAL_PATTERNS", "(unclosed")
-    with pytest.raises(ValueError):
-        agent_mod._projection_signal_pattern()
-
-
-def test_provider_projection_appends_signal_scan_when_enabled(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path,
-) -> None:
-    monkeypatch.setenv("OPENSQUILLA_PROJECTION_SIGNAL_HINTS", "on")
-    runtime_events_path = tmp_path / "runtime_events.jsonl"
-    agent = _projection_agent(
-        tmp_path, runtime_events_path=str(runtime_events_path)
-    )
-
-    projection = agent._tool_result_projection_for_provider(
-        _FAILURE_CONTENT,
-        tool_use_id="tool-1",
-        tool_name="exec_command",
-        reason="tool result compacted for provider request context",
-        max_preview_chars=40,
-    )
-
-    assert projection is not None
-    assert "signal_scan: " in projection
-    assert "(first at L3)" in projection
-    assert 'signal_next_call: retrieve_tool_result {"handle": "tr-' in projection
-    # Ordering: after search_hints (when present) and before omitted_chars.
-    assert projection.index("signal_next_call:") < projection.index("omitted_chars:")
-    hint_events = _events_named(runtime_events_path, "projection_signal_hints")
-    assert len(hint_events) == 1
-    assert hint_events[0]["builder"] == "provider_single"
-
-
-def test_provider_projection_unchanged_when_env_unset(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path,
-) -> None:
-    monkeypatch.delenv("OPENSQUILLA_PROJECTION_SIGNAL_HINTS", raising=False)
-    monkeypatch.delenv("OPENSQUILLA_PROJECTION_SIGNAL_PATTERNS", raising=False)
+    monkeypatch.setenv("OPENSQUILLA_PROJECTION_SIGNAL_PATTERNS", "[")
     agent = _projection_agent(tmp_path)
 
     projection = agent._tool_result_projection_for_provider(
@@ -390,48 +255,12 @@ def _aggregate_messages(old_content: str) -> list[Message]:
     return messages
 
 
-def test_aggregate_compaction_appends_signal_scan_when_enabled(
+def test_aggregate_compaction_unchanged_with_retired_options(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
 ) -> None:
     monkeypatch.setenv("OPENSQUILLA_PROJECTION_SIGNAL_HINTS", "on")
-    runtime_events_path = tmp_path / "runtime_events.jsonl"
-    agent = _projection_agent(
-        tmp_path,
-        context_window_tokens=200,
-        runtime_events_path=str(runtime_events_path),
-    )
-    old_content = (
-        "old bulky output\n"
-        + ("pad line\n" * 60)
-        + "FAILED tests/test_api.py::test_bad - AssertionError\n"
-        + ("x" * 4000)
-    )
-    messages = _aggregate_messages(old_content)
-
-    compacted = agent._compact_aggregate_tool_results_for_provider(messages)
-
-    old_result = compacted[1].content[0]
-    assert isinstance(old_result, ContentBlockToolResult)
-    assert "aggregate_tool_result_compacted" in old_result.content
-    assert "signal_scan: " in old_result.content
-    assert "(first at L62)" in old_result.content
-    assert 'signal_next_call: retrieve_tool_result {"handle": "tr-' in old_result.content
-    assert old_result.content.index("signal_next_call:") < old_result.content.index(
-        "omitted_chars:"
-    )
-    hint_events = _events_named(runtime_events_path, "projection_signal_hints")
-    assert len(hint_events) == 1
-    assert hint_events[0]["builder"] == "aggregate"
-    assert hint_events[0]["signal_first_line"] == 62
-
-
-def test_aggregate_compaction_unchanged_when_env_unset(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path,
-) -> None:
-    monkeypatch.delenv("OPENSQUILLA_PROJECTION_SIGNAL_HINTS", raising=False)
-    monkeypatch.delenv("OPENSQUILLA_PROJECTION_SIGNAL_PATTERNS", raising=False)
+    monkeypatch.setenv("OPENSQUILLA_PROJECTION_SIGNAL_PATTERNS", "[")
     agent = _projection_agent(tmp_path, context_window_tokens=200)
     old_content = (
         "old bulky output\n"

--- a/tests/test_engine/turn_runner/test_agent_bootstrap_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_agent_bootstrap_stage_unit.py
@@ -85,9 +85,6 @@ def _default_aux(
         compaction_total_timeout_seconds=120.0,
         compaction_heartbeat_interval_seconds=15.0,
         tool_result_projection_max_inline_chars=60_000,
-        tool_result_fresh_diagnostic_policy_enabled=False,
-        tool_result_diagnostic_retrieval_gate_enabled=False,
-        tool_result_fresh_diagnostic_inline_max_chars=64_000,
         tool_result_dispatch_max_chars=0,
         tool_result_dispatch_turn_max_chars=0,
         tool_result_store_full_trace=False,
@@ -983,9 +980,6 @@ async def test_case06_model_with_capabilities_and_projection_limit() -> None:
         aux=replace(
             _default_aux(thinking=True),
             tool_result_projection_max_inline_chars=1234,
-            tool_result_fresh_diagnostic_policy_enabled=True,
-            tool_result_diagnostic_retrieval_gate_enabled=True,
-            tool_result_fresh_diagnostic_inline_max_chars=12_345,
         )
     )
     factory = _RecordingAgentFactory()
@@ -995,31 +989,28 @@ async def test_case06_model_with_capabilities_and_projection_limit() -> None:
     assert out.output.model_capabilities is caps
     assert out.output.agent_config.thinking is True
     assert out.output.agent_config.tool_result_projection_max_inline_chars == 1234
-    assert out.output.agent_config.tool_result_fresh_diagnostic_policy_enabled is True
-    assert out.output.agent_config.tool_result_diagnostic_retrieval_gate_enabled is True
-    assert out.output.agent_config.tool_result_fresh_diagnostic_inline_max_chars == 12_345
+    assert out.output.agent_config.tool_result_fresh_diagnostic_policy_enabled is False
+    assert out.output.agent_config.tool_result_diagnostic_retrieval_gate_enabled is False
+    assert out.output.agent_config.tool_result_fresh_diagnostic_inline_max_chars == 64_000
 
 
 @pytest.mark.asyncio
-async def test_fresh_diagnostic_env_overrides_agent_token_config(monkeypatch) -> None:
+async def test_retired_fresh_diagnostic_env_does_not_change_agent_config(monkeypatch) -> None:
     monkeypatch.setenv("OPENSQUILLA_TOOL_RESULT_FRESH_DIAGNOSTIC_POLICY_ENABLED", "true")
     monkeypatch.setenv("OPENSQUILLA_TOOL_RESULT_DIAGNOSTIC_RETRIEVAL_GATE_ENABLED", "1")
     monkeypatch.setenv("OPENSQUILLA_TOOL_RESULT_FRESH_DIAGNOSTIC_INLINE_MAX_CHARS", "2048")
     aux_builder = _RecordingAgentConfigBuilder(
         aux=replace(
             _default_aux(),
-            tool_result_fresh_diagnostic_policy_enabled=False,
-            tool_result_diagnostic_retrieval_gate_enabled=False,
-            tool_result_fresh_diagnostic_inline_max_chars=64_000,
         )
     )
     stage = _make_stage(aux=aux_builder)
 
     out = await stage.run(_make_input())
 
-    assert out.output.agent_config.tool_result_fresh_diagnostic_policy_enabled is True
-    assert out.output.agent_config.tool_result_diagnostic_retrieval_gate_enabled is True
-    assert out.output.agent_config.tool_result_fresh_diagnostic_inline_max_chars == 2048
+    assert out.output.agent_config.tool_result_fresh_diagnostic_policy_enabled is False
+    assert out.output.agent_config.tool_result_diagnostic_retrieval_gate_enabled is False
+    assert out.output.agent_config.tool_result_fresh_diagnostic_inline_max_chars == 64_000
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/turn_runner/test_tool_surface_levers_bootstrap_unit.py
+++ b/tests/test_engine/turn_runner/test_tool_surface_levers_bootstrap_unit.py
@@ -22,7 +22,7 @@ def test_agent_config_defaults_keep_tool_surface_levers_off() -> None:
 
 
 @pytest.mark.asyncio
-async def test_projection_signal_hints_env_threads_to_agent_config(
+async def test_retired_projection_signal_hints_env_is_inert(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     stage = _make_stage()
@@ -32,7 +32,7 @@ async def test_projection_signal_hints_env_threads_to_agent_config(
 
     monkeypatch.setenv(_ENV, "on")
     enabled_out = await stage.run(_make_input())
-    assert enabled_out.output.agent_config.projection_signal_hints is True
+    assert enabled_out.output.agent_config.projection_signal_hints is False
 
     monkeypatch.setenv(_ENV, "off")
     disabled_out = await stage.run(_make_input())
@@ -40,14 +40,20 @@ async def test_projection_signal_hints_env_threads_to_agent_config(
 
 
 @pytest.mark.asyncio
-async def test_projection_signal_hints_unrecognized_value_raises_at_bootstrap(
+async def test_retired_projection_options_cannot_fail_bootstrap(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Same vocabulary as the runtime gate: "enabled" is recognized by the
-    # generic _bool_from_env truthy set but NOT by the projection gate, so
-    # accepting it here would arm the manifest while the runtime raises
-    # mid-turn. It must fail at bootstrap instead.
     stage = _make_stage()
     monkeypatch.setenv(_ENV, "enabled")
-    with pytest.raises(ValueError, match=_ENV):
-        await stage.run(_make_input())
+    monkeypatch.setenv("OPENSQUILLA_PROJECTION_SIGNAL_PATTERNS", "[")
+    monkeypatch.setenv("OPENSQUILLA_PROVIDER_HISTORY_DEDUP", "on")
+    monkeypatch.setenv("OPENSQUILLA_PROVIDER_HISTORY_DEDUP_MIN_REPEATS", "invalid")
+    monkeypatch.setenv("OPENSQUILLA_TOOL_RESULT_FRESH_DIAGNOSTIC_POLICY_ENABLED", "on")
+    monkeypatch.setenv("OPENSQUILLA_TOOL_RESULT_DIAGNOSTIC_RETRIEVAL_GATE_ENABLED", "on")
+    monkeypatch.setenv("OPENSQUILLA_TOOL_RESULT_FRESH_DIAGNOSTIC_INLINE_MAX_CHARS", "invalid")
+    out = await stage.run(_make_input())
+    assert out.output.agent_config.projection_signal_hints is False
+    assert out.output.agent_config.provider_history_dedup_enabled is False
+    assert out.output.agent_config.provider_history_dedup_min_repeats == 2
+    assert out.output.agent_config.tool_result_fresh_diagnostic_policy_enabled is False
+    assert out.output.agent_config.tool_result_diagnostic_retrieval_gate_enabled is False

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -1430,7 +1430,7 @@ def test_llm_trace_request_metadata_carries_compaction_proof(
     request_proof = rows[0]["metadata"]["request_proof"]
     assert request_proof["compaction_tier"] == 0
     assert request_proof["retry_count"] == 0
-    assert "compaction_tiny_guard_chars" in request_proof
+    assert "compaction_tiny_guard_chars" not in request_proof
     assert "compaction_protect_recent_assistant" in request_proof
 
 

--- a/tests/test_provider_request_proof_levers.py
+++ b/tests/test_provider_request_proof_levers.py
@@ -1,9 +1,4 @@
-"""Compaction safety levers: tiny guard plus default-on assistant protection.
-
-Covers the OPENSQUILLA_PROVIDER_COMPACTION_TINY_GUARD_CHARS and
-OPENSQUILLA_PROVIDER_COMPACTION_PROTECT_RECENT_ASSISTANT env levers
-with explicit rollback coverage.
-"""
+"""Default-on assistant protection and retired tiny-guard compatibility."""
 
 from __future__ import annotations
 
@@ -62,24 +57,6 @@ def test_tiny_guard_defaults_off_replaces_tiny_arguments(
     assert len(compacted) > len("s1")
 
 
-def test_tiny_guard_keeps_strings_shorter_than_marker(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv(TINY_GUARD_ENV, "120")
-    monkeypatch.setenv(NEVER_WORSE_ENV, "0")
-    assert _compact_argument_string("s1", preview=False) == "s1"
-    assert _compact_argument_string("y" * 120, preview=False) == "y" * 120
-    long_value = "z" * 121
-    assert _compact_argument_string(long_value, preview=False) != long_value
-
-
-def test_tiny_guard_applies_to_hard_compact(monkeypatch: pytest.MonkeyPatch) -> None:
-    value = "h" * 110
-    assert _hard_compact_string(value, label="t").startswith("[opensquilla_compacted:")
-    monkeypatch.setenv(TINY_GUARD_ENV, "120")
-    assert _hard_compact_string(value, label="t") == value
-
-
 def test_tiny_guard_invalid_env_is_off(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(TINY_GUARD_ENV, "not-a-number")
     monkeypatch.setenv(NEVER_WORSE_ENV, "0")
@@ -87,23 +64,26 @@ def test_tiny_guard_invalid_env_is_off(monkeypatch: pytest.MonkeyPatch) -> None:
     assert compacted.startswith("[provider_request_tool_input_compacted:")
 
 
-def test_aggregate_mode_preserves_tiny_arguments_with_guard(
+@pytest.mark.parametrize("legacy_value", ["0", "120", "1000000", "invalid"])
+@pytest.mark.parametrize("never_worse", ["0", "1"])
+def test_retired_tiny_guard_preserves_off_mode_and_empty_strings(
     monkeypatch: pytest.MonkeyPatch,
+    legacy_value: str,
+    never_worse: str,
 ) -> None:
-    monkeypatch.setenv(TINY_GUARD_ENV, "120")
-    monkeypatch.setenv(PROTECT_RECENT_ENV, "0")
-    monkeypatch.setenv(NEVER_WORSE_ENV, "0")
-    compacted, metadata = _compact_recent_tail_payload_once(_aggregate_args_payload())
-    assert metadata["aggregate_tool_arguments_compacted"] is True
-    for message in compacted["messages"]:
-        for tool_call in message.get("tool_calls") or []:
-            arguments = json.loads(tool_call["function"]["arguments"])
-            # Tiny fields survive verbatim; only the oversized command is compacted.
-            assert arguments["workdir"] == "/w"
-            assert arguments["session"] == "s1"
-            assert arguments["command"].startswith(
-                "[provider_request_tool_input_compacted:"
-            )
+    from opensquilla.provider.request_proof import _compact_tool_arguments
+
+    monkeypatch.setenv(NEVER_WORSE_ENV, never_worse)
+    values = ["", "s1", "x" * 120, "x" * 2000]
+    sites = (
+        lambda value: _compact_argument_string(value, preview=False),
+        lambda value: _compact_tool_arguments(value, preview=False),
+        lambda value: _hard_compact_string(value, label="test"),
+    )
+    baseline = [[site(value) for value in values] for site in sites]
+    monkeypatch.setenv(TINY_GUARD_ENV, legacy_value)
+    assert [[site(value) for value in values] for site in sites] == baseline
+    assert all(site("") == "" for site in sites)
 
 
 def test_protect_recent_assistant_on_by_default() -> None:
@@ -253,7 +233,7 @@ def test_proof_reports_tier_and_lever_state(monkeypatch: pytest.MonkeyPatch) -> 
     assert proof is not None
     assert proof["compaction_tier"] == proof["retry_count"]
     assert proof["compaction_tier"] >= 1
-    assert proof["compaction_tiny_guard_chars"] == 120
+    assert "compaction_tiny_guard_chars" not in proof
     assert proof["compaction_protect_recent_assistant"] is True
 
 
@@ -265,7 +245,7 @@ def test_proof_tier_zero_when_fits() -> None:
     )
     assert proof is not None
     assert proof["compaction_tier"] == 0
-    assert proof["compaction_tiny_guard_chars"] == 0
+    assert "compaction_tiny_guard_chars" not in proof
     assert proof["compaction_protect_recent_assistant"] is True
     assert proof["compaction_protect_recent_results"] == 2
     assert proof["compaction_protect_error_results"] is True

--- a/tests/test_request_proof_levers.py
+++ b/tests/test_request_proof_levers.py
@@ -4,7 +4,6 @@ Covers OPENSQUILLA_PROVIDER_COMPACTION_PROTECT_RECENT_RESULTS,
 OPENSQUILLA_PROVIDER_COMPACTION_PROTECT_ERROR_RESULTS,
 OPENSQUILLA_PROVIDER_COMPACTION_PROTECT_UNRESOLVED_RESULTS,
 OPENSQUILLA_PROVIDER_COMPACTION_SKIP_PROJECTED,
-OPENSQUILLA_PROVIDER_COMPACTION_STUB_PREVIEW_CHARS, and
 OPENSQUILLA_PROVIDER_COMPACTION_NEVER_WORSE.
 """
 
@@ -528,7 +527,7 @@ _GOLDEN_PROOF_JSON: dict[int, str] = {
         '{"projection_adapter":"synthetic_adapter","execution_status_version":1,"status_projectio'
         'n_mode":"native_or_none","estimated_chars":9240,"estimated_tokens":2310,"proof_budget":1'
         '0300,"raw_proof_budget":10300,"effective_proof_budget":9270,"proof_headroom_chars":1030,'
-        '"fits":true,"compact_needed":true,"compaction_tier":0,"compaction_tiny_guard_chars":0,"c'
+        '"fits":true,"compact_needed":true,"compaction_tier":0,"c'
         'ompaction_protect_recent_assistant":false,"recent_tail_too_large":false,"compaction_not_'
         'smaller":false,"provider_window_mismatch":false,"fallback_reason":null,"top_contributors'
         '":[{"path":"$.messages[5].content[0].content","chars":1778},{"path":"$.messages[3].conte'
@@ -542,7 +541,7 @@ _GOLDEN_PROOF_JSON: dict[int, str] = {
         '{"projection_adapter":"synthetic_adapter","execution_status_version":1,"status_projectio'
         'n_mode":"native_or_none","estimated_chars":7849,"estimated_tokens":1962,"proof_budget":8'
         '800,"raw_proof_budget":8800,"effective_proof_budget":7920,"proof_headroom_chars":880,"fi'
-        'ts":true,"compact_needed":true,"compaction_tier":1,"compaction_tiny_guard_chars":0,"comp'
+        'ts":true,"compact_needed":true,"compaction_tier":1,"comp'
         'action_protect_recent_assistant":false,"recent_tail_too_large":false,"compaction_not_sma'
         'ller":false,"provider_window_mismatch":false,"fallback_reason":null,"top_contributors":['
         '{"path":"$.messages[3].content","chars":1151},{"path":"$.messages[5].content[0].content"'
@@ -555,7 +554,7 @@ _GOLDEN_PROOF_JSON: dict[int, str] = {
         '{"projection_adapter":"synthetic_adapter","execution_status_version":1,"status_projectio'
         'n_mode":"native_or_none","estimated_chars":7406,"estimated_tokens":1851,"proof_budget":8'
         '300,"raw_proof_budget":8300,"effective_proof_budget":7470,"proof_headroom_chars":830,"fi'
-        'ts":true,"compact_needed":true,"compaction_tier":2,"compaction_tiny_guard_chars":0,"comp'
+        'ts":true,"compact_needed":true,"compaction_tier":2,"comp'
         'action_protect_recent_assistant":false,"recent_tail_too_large":false,"compaction_not_sma'
         'ller":false,"provider_window_mismatch":false,"fallback_reason":null,"top_contributors":['
         '{"path":"$.messages[3].content","chars":1151},{"path":"$.messages[5].content[0].content"'
@@ -570,7 +569,7 @@ _GOLDEN_PROOF_JSON: dict[int, str] = {
         '{"projection_adapter":"synthetic_adapter","execution_status_version":1,"status_projectio'
         'n_mode":"native_or_none","estimated_chars":4386,"estimated_tokens":1096,"proof_budget":4'
         '900,"raw_proof_budget":4900,"effective_proof_budget":4388,"proof_headroom_chars":512,"fi'
-        'ts":true,"compact_needed":true,"compaction_tier":3,"compaction_tiny_guard_chars":0,"comp'
+        'ts":true,"compact_needed":true,"compaction_tier":3,"comp'
         'action_protect_recent_assistant":false,"recent_tail_too_large":false,"compaction_not_sma'
         'ller":false,"provider_window_mismatch":false,"fallback_reason":null,"top_contributors":['
         '{"path":"$.messages[4].content[1].input.note","chars":695},{"path":"$.messages[2].reason'
@@ -586,7 +585,7 @@ _GOLDEN_PROOF_JSON: dict[int, str] = {
         '{"projection_adapter":"synthetic_adapter","execution_status_version":1,"status_projectio'
         'n_mode":"native_or_none","estimated_chars":2043,"estimated_tokens":510,"proof_budget":26'
         '00,"raw_proof_budget":2600,"effective_proof_budget":2088,"proof_headroom_chars":512,"fit'
-        's":true,"compact_needed":true,"compaction_tier":4,"compaction_tiny_guard_chars":0,"compa'
+        's":true,"compact_needed":true,"compaction_tier":4,"compa'
         'ction_protect_recent_assistant":false,"recent_tail_too_large":false,"compaction_not_smal'
         'ler":false,"provider_window_mismatch":false,"fallback_reason":null,"top_contributors":[{'
         '"path":"$.messages[4].content[1].input.note","chars":695},{"path":"$.messages[7].content'
@@ -604,7 +603,7 @@ _GOLDEN_RAISE_PROOF_JSON = (
     '{"projection_adapter":"synthetic_adapter","execution_status_version":1,"status_projectio'
     'n_mode":"native_or_none","estimated_chars":4386,"estimated_tokens":1096,"proof_budget":4'
     '00,"raw_proof_budget":400,"effective_proof_budget":300,"proof_headroom_chars":100,"fits"'
-    ':false,"compact_needed":true,"compaction_tier":4,"compaction_tiny_guard_chars":0,"compac'
+    ':false,"compact_needed":true,"compaction_tier":4,"compac'
     'tion_protect_recent_assistant":false,"recent_tail_too_large":true,"compaction_not_smalle'
     'r":false,"provider_window_mismatch":false,"fallback_reason":"provider_request_budget_exh'
     'austed","top_contributors":[{"path":"$.messages[4].content[1].input.note","chars":695},{'
@@ -874,60 +873,6 @@ def test_skip_projected_can_be_rolled_back() -> None:
     assert "[provider_request_compacted:" in compacted["messages"][0]["content"]
 
 
-def test_stub_preview_on_argument_string_stub(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv(STUB_PREVIEW_CHARS_ENV, "11")
-    value = "abcdefghijklmnopqrstuvwxyz" * 12
-    compacted = _compact_argument_string(value, preview=False)
-    head, marker, tail = compacted.split("\n\n")
-    assert head == value[:11]
-    assert tail == value[-11:]
-    assert marker.startswith("[provider_request_tool_input_compacted:")
-
-
-def test_stub_preview_on_tool_arguments_fallback_stub(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv(STUB_PREVIEW_CHARS_ENV, "11")
-    value = "plain text arguments that are not json " * 40
-    stub = json.loads(_compact_tool_arguments(value, preview=False))
-    assert stub["preview_head"] == value[:11]
-    assert stub["preview_tail"] == value[-11:]
-    assert stub["original_chars"] == len(value)
-
-
-def test_stub_preview_on_tool_input_stub_extends_head_and_tail(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    value = {f"key_{index:02d}": "v" * 400 for index in range(20)}
-    raw = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-    baseline = _compact_tool_input(value)
-    monkeypatch.setenv(STUB_PREVIEW_CHARS_ENV, "500")
-    stub = _compact_tool_input(value)
-    assert stub["_opensquilla_compacted_tool_input"] is True
-    assert stub["head"] == raw[:500]
-    assert stub["tail"] == raw[-500:]
-    assert "preview_head" not in stub
-    assert len(stub["head"]) > len(baseline["head"])
-
-
-def test_stub_preview_on_tool_input_stub_subsumed_by_builtin_previews(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    value = {f"key_{index:02d}": "v" * 40 for index in range(20)}
-    baseline = _compact_tool_input(value)
-    monkeypatch.setenv(STUB_PREVIEW_CHARS_ENV, "11")
-    assert _compact_tool_input(value) == baseline
-
-
-def test_stub_preview_on_final_cap_stub(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv(STUB_PREVIEW_CHARS_ENV, "11")
-    arguments = json.dumps({"command": "inspect the build artifacts carefully " * 20})
-    stub = json.loads(_compact_tool_arguments_for_final_cap(arguments))
-    assert stub["_invalid_provider_context_arguments"] is True
-    assert stub["preview_head"] == arguments[:11]
-    assert stub["preview_tail"] == arguments[-11:]
-
-
 def test_stub_preview_never_leaks_scrubbed_arguments(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -937,56 +882,24 @@ def test_stub_preview_never_leaks_scrubbed_arguments(
     assert stub == {"_invalid_provider_context_arguments": True}
 
 
-def test_stub_preview_off_values(monkeypatch: pytest.MonkeyPatch) -> None:
-    value = "abcdefghijklmnopqrstuvwxyz" * 12
-    expected = _compact_argument_string(value, preview=False)
-    for off_value in ("", "0", "garbage", "false"):
-        monkeypatch.setenv(STUB_PREVIEW_CHARS_ENV, off_value)
-        assert _compact_argument_string(value, preview=False) == expected
-        assert "preview_head" not in expected
-
-
-def test_oversized_stub_preview_skipped_on_argument_string_stub(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    value = "abcdefghijklmnopqrstuvwxyz" * 12
-    baseline = _compact_argument_string(value, preview=False)
-    monkeypatch.setenv(STUB_PREVIEW_CHARS_ENV, str(len(value)))
-    assert _compact_argument_string(value, preview=False) == baseline
-    monkeypatch.setenv(STUB_PREVIEW_CHARS_ENV, str(len(value) // 2))
-    assert _compact_argument_string(value, preview=False) == baseline
-
-
-def test_oversized_stub_preview_skipped_on_tool_arguments_fallback_stub(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize("legacy_value", ["0", "11", "500", "5000", "invalid"])
+def test_retired_stub_preview_cannot_change_default_stub_payloads(
+    monkeypatch: pytest.MonkeyPatch, legacy_value: str
 ) -> None:
     value = "plain text arguments that are not json " * 40
-    baseline = _compact_tool_arguments(value, preview=False)
-    monkeypatch.setenv(STUB_PREVIEW_CHARS_ENV, "5000")
-    compacted = _compact_tool_arguments(value, preview=False)
-    assert compacted == baseline
-    assert "preview_head" not in json.loads(compacted)
-    assert len(compacted) < len(value)
-
-
-def test_oversized_stub_preview_skipped_on_tool_input_stub(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    value = {f"key_{index:02d}": "v" * 40 for index in range(20)}
-    baseline = _compact_tool_input(value)
-    monkeypatch.setenv(STUB_PREVIEW_CHARS_ENV, "5000")
-    stub = _compact_tool_input(value)
-    assert stub == baseline
-    assert "preview_head" not in stub
-
-
-def test_oversized_stub_preview_skipped_on_final_cap_stub(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    arguments = json.dumps({"command": "inspect the build artifacts carefully"})
-    monkeypatch.setenv(STUB_PREVIEW_CHARS_ENV, "5000")
-    stub = json.loads(_compact_tool_arguments_for_final_cap(arguments))
-    assert stub == {"_invalid_provider_context_arguments": True}
+    tool_input = {f"key_{index:02d}": "v" * 400 for index in range(20)}
+    sites = (
+        lambda: _compact_argument_string(value, preview=False),
+        lambda: _compact_tool_arguments(value, preview=False),
+        lambda: _compact_tool_arguments_for_final_cap(value),
+        lambda: _compact_tool_input(tool_input),
+    )
+    baseline = [site() for site in sites]
+    raw = json.dumps(tool_input, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    assert baseline[-1]["head"] == raw[:360]
+    assert baseline[-1]["tail"] == raw[-120:]
+    monkeypatch.setenv(STUB_PREVIEW_CHARS_ENV, legacy_value)
+    assert [site() for site in sites] == baseline
 
 
 def test_never_worse_keeps_tiny_argument_value(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1062,41 +975,6 @@ def test_protect_recent_results_explicit_off_values_roll_back(
         compacted = _compact_tool_payload_once(_tier1_entries_payload())
         for content in _entry_contents(compacted):
             assert "[provider_request_compacted:" in content
-
-
-def test_stub_preview_alone_never_grows_scrub_path_stub(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    # The tool_use-input scrub runs on every request before tier 0; previews
-    # must never grow a fitting payload (regression: duplicated head/tail).
-    monkeypatch.setenv(STUB_PREVIEW_CHARS_ENV, "330")
-    value = {f"k{index:02d}": "v" * 55 for index in range(11)}
-    baseline = _compact_tool_input(value)
-    stub = _compact_tool_input(value)
-    assert _payload_chars(stub) <= _payload_chars(value)
-    assert stub == baseline
-
-
-def test_stub_preview_alone_never_grows_any_stub_site(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    # Previews either leave the site's output identical to lever-off or
-    # produce a replacement strictly smaller than the original value.
-    text = "sample argument text under compaction pressure " * 90
-    sites = (
-        lambda value: _compact_argument_string(value, preview=False),
-        lambda value: _compact_tool_arguments(value, preview=False),
-        _compact_tool_arguments_for_final_cap,
-    )
-    for preview_chars in ("47", "330"):
-        for size in (95, 700, 705, 720, 1393, 4000):
-            value = text[:size]
-            for site in sites:
-                monkeypatch.delenv(STUB_PREVIEW_CHARS_ENV, raising=False)
-                off_output = site(value)
-                monkeypatch.setenv(STUB_PREVIEW_CHARS_ENV, preview_chars)
-                on_output = site(value)
-                assert on_output == off_output or len(on_output) < len(value)
 
 
 def test_protect_error_results_ignores_quoted_error_fragments(


### PR DESCRIPTION
## Scope

Remove six opt-in projection/compaction experiments and their active env/config/Child/Meta wiring:

- Projection signal-scan hints.
- Active provider-history deduplication.
- Tiny compaction guards.
- Optional stub-preview expansion.
- Fresh diagnostic preservation policy.
- Mandatory diagnostic retrieval gate.

16 files: +186 / -1,586, net **1,400 lines removed**, including **875 source implementation lines**, relative to main after #1604, #1608, and #1607. Overlapping deletions already landed in #1604 are not counted twice. Existing test files retain shared/default correctness coverage, so no Windows test assignment or duration entry is removed.

Non-goals: default Tokenjuice reductions; full-result storage and retrieval; normal search/retrieve hints; never-worse projection; fixed 360/120 previews; empty-string behavior; historical projection/dedup marker handling; blocked projected-argument execution; Provider, compaction, sandbox, approval, and workspace correctness. No configuration is changed to enable a new default feature. Objective reminder and the protected runtime recovery/evidence/salvage mechanisms remain.

## Branch

Base branch: main

Target exception: N/A

Rebased onto `f6a07b0baa796e1ccb3709d24578f3878f284e22`, after #1604, #1608, and #1607 merged. The original two runtime conflicts retain both approved deletions and #1604's CI fixes. The subsequent conflict with #1607 in `test_tool_surface_levers.py` preserves the updated `_project_tool_result_for_llm` entry point alongside this PR's retirement regressions, without restoring signal-scan behavior or the removed compatibility helper.

## Issue

Linked issue: Refs #1599

## Release Note

Release note: Changed — `CHANGELOG.md` documents retired settings and experimental diagnostics, while preserving default projection/Store/retrieval behavior.

## Tests

Ruff: all surviving changed Python files pass `ruff check`; `git diff --check` passes.

CI follow-up: updated the trace proof regression to require the retired tiny-guard field to be absent while retaining normal compaction proof assertions. The previous PR head passed normal CI before this rebase; the rebased head must pass new normal PR CI.

Post-#1607 rebase validation: **939 passed, no skips**, freshly rerun across two non-overlapping targeted commands: **421 passed** for the three affected projection/Store/tool-surface files plus Provider payloads, bootstrap, and canonical-text preflight; **518 passed** for the remaining retrieval/history/request-proof, Child configuration, Provider recovery, constructor compatibility, base evidence gate, salvage, and TurnRunner regressions. Imports were verified against the intended rebased checkout and the dependency lock matches the validation environment.

Range-diff against the preceding green PR head shows only the necessary changed test-call context from #1607; the approved deletion scope and implementation patch are unchanged. Main's unrelated cleanup remains intact.

Build: not run; no UI or packaging configuration changes.

Regression tests: added/retained for inactive legacy settings, historical markers, fixed previews, empty strings, normal retrieval hints, and original-result preservation. No shared safety or correctness assertions, skips, or CI gates were relaxed.

Notes: offline targeted tests only; no full repository suite or real SWE rerun. Historical GLM/Qwen results still require their pinned engine/configuration. Preserving shared capabilities does not establish new-main benchmark score equivalence.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

Six AgentConfig slots and three Gateway compatibility fields retain accepted legacy values but have no runtime consumer. Existing history markers remain readable and retain execution-blocking semantics. Model-visible default reductions/previews are unchanged; retired fresh-diagnostic counters/events intentionally disappear. Normal Store/retrieval failure fallbacks and availability checks remain atomic.

Normal CLI/chat/codetask, Gateway/WebUI/Desktop/TUI/Channel, Child/Meta, and scheduled-agent entry paths receive no new tool, permission, protocol, or default feature. Explicit use of a retired experimental setting no longer activates its old mechanism and does not introduce upgrade startup errors.

Platform-neutral removals; no OS execution-policy changes. Normal PR CI remains required. No secrets, private transcripts, real experiment payloads, local paths, or generated plans are committed. Revert this commit to restore the removed code.

## Third-Party Origin

Third-party origin: none

Only existing repository code is removed; test data remains synthetic.

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
