### PR TITLE
Remove retired CI composition helpers and bootstrap paths

### DIFF
--- a/.github/scripts/ci_attestation.py
+++ b/.github/scripts/ci_attestation.py
@@ -30,15 +30,12 @@ MAX_ATTESTATION_ARCHIVE_BYTES: Final = 64 * 1024
 MAX_ARTIFACT_PAGES: Final = 3
 ARTIFACTS_PER_PAGE: Final = 100
 ARTIFACT_VISIBILITY_DELAYS: Final = (0, 10, 30)
-BASE_CI_VISIBILITY_DELAYS: Final = (0, 15, 45, 90, 150)
 EVIDENCE_TTL_SECONDS: Final = 72 * 60 * 60
 NIGHTLY_MAX_AGE_SECONDS: Final = 30 * 60 * 60
 MAX_LINEAGE_DEPTH: Final = 8
 SHA_RE: Final = re.compile(r"^[0-9a-f]{40}$")
 DIGEST_RE: Final = re.compile(r"^[0-9a-f]{64}$")
 PR_QUEUE_REF_RE: Final = re.compile(r"(?:^|/)pr-(?P<number>[1-9][0-9]*)-")
-COMPOSITION_BASELINE_SUITES: Final = frozenset({"readme-locale", "workflow-lint"})
-COMPOSITION_COMBINED_SMOKE_TRUST_ROOT: Final = frozenset()
 TRUST_POLICY_MANIFEST: Final = ".github/ci/trust-policy.v1.json"
 TRUST_POLICY_SCHEMA_VERSION: Final = 1
 # Initially reuse only suites with audited, bounded inputs and fixed matrices.
@@ -214,12 +211,6 @@ def _write_outputs(path: Path | None, values: Mapping[str, object]) -> None:
         for name, value in values.items():
             rendered = str(value).replace("\r", " ").replace("\n", " ")
             handle.write(f"{name}={rendered}\n")
-
-
-def _canonical_suite_json(suites: Sequence[str] = ()) -> str:
-    """Return a stable JSON array for suite-valued action outputs."""
-
-    return json.dumps(sorted(set(suites)), separators=(",", ":"))
 
 
 def create_attestation(
@@ -702,45 +693,6 @@ def _latest_pr_run_id(
     return run_id
 
 
-def _base_has_successful_ci(
-    *, api_url: str, repository: str, token: str, queue_base_sha: str
-) -> bool:
-    listing = _request_json(
-        f"{api_url}/repos/{repository}/actions/runs"
-        f"?head_sha={queue_base_sha}&event=merge_group&status=success&per_page=20",
-        token,
-    )
-    runs = listing.get("workflow_runs")
-    if not isinstance(runs, list):
-        raise AttestationError("base workflow run listing is invalid")
-    return any(
-        isinstance(run, dict)
-        and run.get("path") == WORKFLOW_PATH
-        and run.get("status") == "completed"
-        and run.get("conclusion") == "success"
-        and run.get("head_sha") == queue_base_sha
-        for run in runs
-    )
-
-
-def _wait_for_base_successful_ci(
-    *, api_url: str, repository: str, token: str, queue_base_sha: str
-) -> bool:
-    previous_delay = 0
-    for scheduled_delay in BASE_CI_VISIBILITY_DELAYS:
-        if scheduled_delay:
-            time.sleep(scheduled_delay - previous_delay)
-        previous_delay = scheduled_delay
-        if _base_has_successful_ci(
-            api_url=api_url,
-            repository=repository,
-            token=token,
-            queue_base_sha=queue_base_sha,
-        ):
-            return True
-    return False
-
-
 def _plan_paths(
     repo: Path, paths: Sequence[str], *, ref: str | None = None
 ) -> Mapping[str, Any]:
@@ -825,65 +777,6 @@ def _validate_canonical_source_plan(
         )
 
 
-def _composition_is_safe(
-    *, repo: Path, attestation: Mapping[str, Any], queue_base_sha: str
-) -> tuple[bool, str, tuple[str, ...]]:
-    tested_base_sha = _require_sha(attestation.get("base_sha"), "tested base SHA")
-    if subprocess.run(
-        ["git", "merge-base", "--is-ancestor", tested_base_sha, queue_base_sha],
-        cwd=repo,
-        check=False,
-        capture_output=True,
-    ).returncode != 0:
-        return False, "attested base is not an ancestor of the queue base", ()
-    changed = _changed_paths(repo, tested_base_sha, queue_base_sha)
-    if not changed:
-        return False, "advanced-base composition has no verifiable base delta", ()
-    plan = _plan_paths(repo, changed)
-    if plan.get("full_fallback") is True:
-        return False, "base delta requires full fallback", ()
-    required = plan.get("required_suites")
-    if not isinstance(required, list) or any(not isinstance(item, str) for item in required):
-        return False, "base delta planner coverage is invalid", ()
-    source_suites = _validated_suites(attestation)
-    if source_suites == {"ci-result"} or not attestation.get("planner_digest"):
-        return False, "source evidence lacks suite planner coverage", ()
-    source_risk_suites = source_suites - COMPOSITION_BASELINE_SUITES
-    base_risk_suites = set(required) - COMPOSITION_BASELINE_SUITES
-    overlap = source_risk_suites.intersection(base_risk_suites)
-    unsupported_overlap = overlap - COMPOSITION_COMBINED_SMOKE_TRUST_ROOT
-    if unsupported_overlap:
-        return (
-            False,
-            "base delta overlaps unsupported source suites: "
-            + ",".join(sorted(unsupported_overlap)),
-            (),
-        )
-    combined_smoke_suites = tuple(sorted(overlap))
-    attested_digests = _validated_execution_digests(attestation, source_suites)
-    current_digests = _current_suite_execution_digests(repo, source_suites)
-    changed_execution = sorted(
-        suite
-        for suite in source_suites - set(combined_smoke_suites)
-        if current_digests.get(suite) != attested_digests.get(suite)
-    )
-    if changed_execution:
-        return (
-            False,
-            "base delta changed source suite execution inputs: "
-            + ",".join(changed_execution),
-            (),
-        )
-    if combined_smoke_suites:
-        return (
-            True,
-            "PR and base delta overlap only trusted combined-smoke suites: "
-            + ",".join(combined_smoke_suites),
-            combined_smoke_suites,
-        )
-    return True, "PR and base delta suite coverage are disjoint", ()
-
-
 def validate_candidate(
     *,
     attestation: Mapping[str, Any],
@@ -948,7 +841,7 @@ def validate_candidate(
             raise AttestationError("attestation tested tree does not match the queue")
         if tested_base_sha != queue_base_sha:
             raise AttestationError("attestation tested base does not match the queue")
-    elif match_kind in {"composed", "partial"}:
+    elif match_kind == "partial":
         if reconstructed_queue_tree != queue_tree_sha:
             raise AttestationError("pull request head and queue base do not reconstruct queue tree")
         if tested_base_sha == queue_base_sha:
@@ -1096,7 +989,6 @@ def verify_queue(
         partial="false",
         partial_plan="",
         reused_suites="[]",
-        combined_smoke_suites=_canonical_suite_json(),
     )
     merge_group = event.get("merge_group")
     if not isinstance(merge_group, dict):
@@ -1277,7 +1169,6 @@ def verify_queue(
                         sort_keys=True,
                         separators=(",", ":"),
                     ),
-                    combined_smoke_suites=_canonical_suite_json(),
                 )
                 return True, reason, run_id
             except (AttestationError, OSError, ValueError, zipfile.BadZipFile) as exc:
@@ -1589,7 +1480,6 @@ def _verify_queue_command(args: argparse.Namespace) -> int:
             "source_suite_execution_digests": details.get(
                 "source_suite_execution_digests", "{}"
             ),
-            "combined_smoke_suites": details.get("combined_smoke_suites", "[]"),
         },
     )
     print(f"reusable={str(reusable).lower()} reason={reason}")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
       source_successful_suites: ${{ steps.verify.outputs.source_successful_suites }}
       source_planner_digest: ${{ steps.verify.outputs.source_planner_digest }}
       source_suite_execution_digests: ${{ steps.verify.outputs.source_suite_execution_digests }}
-      combined_smoke_suites: ${{ steps.verify.outputs.combined_smoke_suites || '[]' }}
     steps:
       - name: Validate optimization mode
         id: mode
@@ -98,7 +97,6 @@ jobs:
           QUEUE_BASE_SHA: ${{ steps.verify.outputs.queue_base_sha }}
           QUEUE_HEAD_SHA: ${{ steps.verify.outputs.queue_head_sha }}
           QUEUE_TREE_SHA: ${{ steps.verify.outputs.queue_tree_sha }}
-          COMBINED_SMOKE_SUITES: ${{ steps.verify.outputs.combined_smoke_suites || '[]' }}
           REUSED_SUITES: ${{ steps.verify.outputs.reused_suites || '[]' }}
         shell: bash
         run: |
@@ -111,7 +109,6 @@ jobs:
             echo "- Candidates: \`${CANDIDATE_COUNT}\`"
             echo "- Artifact: \`${ARTIFACT_NAME}\`"
             echo "- Queue base/head/tree: \`${QUEUE_BASE_SHA}\` / \`${QUEUE_HEAD_SHA}\` / \`${QUEUE_TREE_SHA}\`"
-            echo "- Combined-tree domain smokes: \`${COMBINED_SMOKE_SUITES}\`"
             echo "- Reused suites: \`${REUSED_SUITES}\` (all other full-matrix suites must run)"
             if [[ "${REASON_CODE}" == "tree_mismatch" ]]; then
               echo "- Fast-path note: the PR evidence does not match this queue tree, so this entry runs the full fail-closed matrix. If main advanced, refresh the PR against the latest main and wait for a new green PR CI run before requeueing. Reuse is always decided against the future entry's exact base and tree."

--- a/.github/workflows/pr-body-lint.yml
+++ b/.github/workflows/pr-body-lint.yml
@@ -20,13 +20,6 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
-      - name: Check out bootstrap body linter before first merge
-        if: ${{ hashFiles('.github/scripts/validate_pr_body.py') == '' }}
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          persist-credentials: false
-
       - name: Validate PR body fields
         env:
           PR_BODY_LINT_STRICT: "0"

--- a/.github/workflows/pr-target-branch.yml
+++ b/.github/workflows/pr-target-branch.yml
@@ -22,13 +22,6 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
-      - name: Check out bootstrap validator before first merge
-        if: ${{ github.event_name == 'pull_request' && hashFiles('.github/scripts/validate-pr-target-branch.sh') == '' }}
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          persist-credentials: false
-
       - name: Validate target branch
         env:
           PR_BASE_REF: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_ref || github.event.pull_request.base.ref }}

--- a/tests/test_ci/test_ci_attestation.py
+++ b/tests/test_ci/test_ci_attestation.py
@@ -26,11 +26,9 @@ validate_candidate = MODULE["validate_candidate"]
 verify_queue = MODULE["verify_queue"]
 list_attestation_artifacts = MODULE["_list_attestation_artifacts"]
 plan_paths = MODULE["_plan_paths"]
-composition_is_safe = MODULE["_composition_is_safe"]
 changed_paths = MODULE["_changed_paths"]
 reconstructed_queue_tree = MODULE["_reconstructed_queue_tree"]
 verify_nightly_health = MODULE["verify_nightly_health"]
-wait_for_base_successful_ci = MODULE["_wait_for_base_successful_ci"]
 verify_queue_command = MODULE["_verify_queue_command"]
 
 
@@ -78,7 +76,7 @@ def test_artifact_redirect_rejects_non_https_target() -> None:
         _artifact_redirect("http://artifact-storage.example.invalid/attestation.zip")
 
 
-def test_verify_queue_details_default_combined_smoke_to_empty_json(
+def test_verify_queue_details_reject_invalid_context(
     tmp_path: Path,
 ) -> None:
     details: dict[str, object] = {}
@@ -96,7 +94,7 @@ def test_verify_queue_details_default_combined_smoke_to_empty_json(
     assert reusable is False
     assert reason == "not a merge_group event"
     assert source_run is None
-    assert details["combined_smoke_suites"] == "[]"
+    assert details["reason_code"] == "invalid_context"
 
 
 def test_verify_queue_command_emits_fail_closed_outputs(
@@ -110,7 +108,6 @@ def test_verify_queue_command_emits_fail_closed_outputs(
     def fake_verify_queue(**kwargs: Any) -> tuple[bool, str, int]:
         kwargs["details"].update(
             reason_code="reusable_exact",
-            combined_smoke_suites="[]",
             source_successful_suites='["workflow-lint"]',
             source_planner_digest="a" * 64,
             source_suite_execution_digests='{"workflow-lint":"b"}',
@@ -140,7 +137,7 @@ def test_verify_queue_command_emits_fail_closed_outputs(
     )
     assert outputs["reusable"] == "true"
     assert outputs["reason_code"] == "reusable_exact"
-    assert outputs["combined_smoke_suites"] == "[]"
+    assert "combined_smoke_suites" not in outputs
     assert "nightly_healthy" not in outputs
     assert "nightly_reason" not in outputs
 
@@ -914,139 +911,6 @@ def _composition_fixture(
     return repo, attestation, queue_base
 
 
-def test_base_advance_composition_has_no_overlap_trust_root() -> None:
-    assert MODULE["COMPOSITION_COMBINED_SMOKE_TRUST_ROOT"] == frozenset()
-
-
-def test_base_advance_composition_accepts_disjoint_risk_domains(tmp_path: Path) -> None:
-    repo, attestation, queue_base = _composition_fixture(
-        tmp_path, base_delta_path="docs/queue.md"
-    )
-
-    safe, reason, combined_smoke_suites = composition_is_safe(
-        repo=repo, attestation=attestation, queue_base_sha=queue_base
-    )
-
-    assert safe is True
-    assert "disjoint" in reason
-    assert combined_smoke_suites == ()
-
-
-def test_base_advance_composition_accepts_disjoint_source_code_domains(
-    tmp_path: Path,
-) -> None:
-    repo, attestation, queue_base = _composition_fixture(
-        tmp_path,
-        source_path="opensquilla-webui/src/components/example.ts",
-        base_delta_path="src/opensquilla/provider/base.py",
-    )
-
-    safe, reason, combined_smoke_suites = composition_is_safe(
-        repo=repo, attestation=attestation, queue_base_sha=queue_base
-    )
-
-    assert safe is True
-    assert "disjoint" in reason
-    assert combined_smoke_suites == ()
-
-
-def test_base_advance_composition_rejects_python_targeted_overlap(
-    tmp_path: Path,
-) -> None:
-    repo, attestation, queue_base = _composition_fixture(
-        tmp_path, base_delta_path="src/opensquilla/provider/base.py"
-    )
-
-    safe, reason, combined_smoke_suites = composition_is_safe(
-        repo=repo, attestation=attestation, queue_base_sha=queue_base
-    )
-
-    assert safe is False
-    assert reason == "base delta overlaps unsupported source suites: python-targeted"
-    assert combined_smoke_suites == ()
-
-
-@pytest.mark.parametrize(
-    ("source_path", "base_delta_path", "unsupported_suite"),
-    [
-        (
-            "src/opensquilla/engine/runtime.py",
-            "src/opensquilla/engine/agent.py",
-            "python-full",
-        ),
-        (
-            "src/opensquilla/sandbox/windows_backend.py",
-            "src/opensquilla/sandbox/windows_policy.py",
-            "windows-high-risk",
-        ),
-        (
-            "opensquilla-webui/src/components/FeaturePanel.vue",
-            "opensquilla-webui/src/components/BasePanel.vue",
-            "frontend",
-        ),
-        (
-            "desktop/electron/scripts/test-native-workbench-a.mjs",
-            "desktop/electron/scripts/test-native-workbench-b.mjs",
-            "desktop-recovery-e2e",
-        ),
-    ],
-)
-def test_base_advance_composition_rejects_unsupported_overlapping_risk_domains(
-    tmp_path: Path,
-    source_path: str,
-    base_delta_path: str,
-    unsupported_suite: str,
-) -> None:
-    repo, attestation, queue_base = _composition_fixture(
-        tmp_path,
-        source_path=source_path,
-        base_delta_path=base_delta_path,
-    )
-
-    safe, reason, combined_smoke_suites = composition_is_safe(
-        repo=repo, attestation=attestation, queue_base_sha=queue_base
-    )
-
-    assert safe is False
-    assert "unsupported" in reason
-    assert unsupported_suite in reason
-    assert combined_smoke_suites == ()
-
-
-def test_base_advance_composition_rejects_source_execution_input_drift(
-    tmp_path: Path,
-) -> None:
-    repo, attestation, queue_base = _composition_fixture(
-        tmp_path, base_delta_path="scripts/build_wheelhouse_zip.py"
-    )
-
-    safe, reason, combined_smoke_suites = composition_is_safe(
-        repo=repo, attestation=attestation, queue_base_sha=queue_base
-    )
-
-    assert safe is False
-    assert "execution inputs" in reason
-    assert combined_smoke_suites == ()
-
-
-def test_base_advance_composition_rejects_baseline_execution_input_drift(
-    tmp_path: Path,
-) -> None:
-    repo, attestation, queue_base = _composition_fixture(
-        tmp_path,
-        source_path="docs/feature.md",
-        base_delta_path="README.md",
-    )
-
-    safe, reason, combined_smoke_suites = composition_is_safe(
-        repo=repo, attestation=attestation, queue_base_sha=queue_base
-    )
-
-    assert safe is False
-    assert reason == "base delta changed source suite execution inputs: readme-locale"
-    assert combined_smoke_suites == ()
-
-
 def _verify_composed_fixture(
     *,
     repo: Path,
@@ -1080,17 +944,6 @@ def _verify_composed_fixture(
             return current_pr
         if "actions/workflows/ci.yml/runs" in url:
             return {"workflow_runs": [run]}
-        if "/actions/runs?" in url:
-            return {
-                "workflow_runs": [
-                    {
-                        "path": ".github/workflows/ci.yml",
-                        "status": "completed",
-                        "conclusion": "success",
-                        "head_sha": queue_base,
-                    }
-                ]
-            }
         if url.endswith("/actions/runs/123"):
             return run
         raise AssertionError(f"unexpected API request: {url}")
@@ -1107,16 +960,6 @@ def _verify_composed_fixture(
         lambda **_kwargs: pytest.fail(
             "queue verification must not inspect nightly health"
         ),
-    )
-    monkeypatch.setitem(
-        verify_queue.__globals__,
-        "_wait_for_base_successful_ci",
-        lambda **_kwargs: pytest.fail("queue verification must not compose base evidence"),
-    )
-    monkeypatch.setitem(
-        verify_queue.__globals__,
-        "_composition_is_safe",
-        lambda **_kwargs: pytest.fail("queue verification must not compose evidence"),
     )
     details: dict[str, object] = {}
     reusable, reason, source_run = verify_queue(
@@ -1149,7 +992,6 @@ def test_verify_queue_rejects_composed_python_evidence(
     assert reusable is False
     assert "only exact-tree pull request evidence" in reason
     assert source_run is None
-    assert details["combined_smoke_suites"] == "[]"
 
 
 def test_verify_queue_rejects_disjoint_base_advance_composition(
@@ -1170,7 +1012,6 @@ def test_verify_queue_rejects_disjoint_base_advance_composition(
     assert reusable is False
     assert "only exact-tree pull request evidence" in reason
     assert source_run is None
-    assert details["combined_smoke_suites"] == "[]"
 
 
 def test_verify_queue_rejects_composed_full_python_evidence(
@@ -1193,7 +1034,6 @@ def test_verify_queue_rejects_composed_full_python_evidence(
     assert reusable is False
     assert "only exact-tree pull request evidence" in reason
     assert source_run is None
-    assert details["combined_smoke_suites"] == "[]"
 
 
 def test_squash_binding_reconstructs_the_tested_tree(tmp_path: Path) -> None:
@@ -1202,6 +1042,25 @@ def test_squash_binding_reconstructs_the_tested_tree(tmp_path: Path) -> None:
     assert reconstructed_queue_tree(
         repo, queue_base_sha=base_sha, head_sha=head_sha
     ) == _git(repo, "rev-parse", "HEAD^{tree}")
+
+
+def test_validate_candidate_rejects_retired_composed_mode(tmp_path: Path) -> None:
+    repo, attestation, queue_base = _composition_fixture(
+        tmp_path, base_delta_path="docs/queue.md"
+    )
+    queue_tree = _git(repo, "rev-parse", "HEAD^{tree}")
+
+    with pytest.raises(AttestationError, match="evidence match kind is invalid"):
+        validate_candidate(
+            attestation=attestation,
+            run=_run(attestation),
+            repository="opensquilla/opensquilla",
+            queue_tree_sha=queue_tree,
+            queue_base_sha=queue_base,
+            queue_policy_digest=str(attestation["trust_policy_digest"]),
+            match_kind="composed",
+            reconstructed_queue_tree=queue_tree,
+        )
 
 
 @pytest.mark.parametrize("source_path,suite", [
@@ -1381,7 +1240,6 @@ def test_verify_queue_reuses_only_exact_trusted_evidence_without_nightly(
     assert details["reason_code"] == "reusable_exact"
     assert details["candidate_count"] == 1
     assert details["artifact_name"].startswith("ci-evidence-v2-tree-")
-    assert details["combined_smoke_suites"] == "[]"
     assert json.loads(str(details["source_successful_suites"])) == attestation[
         "successful_suites"
     ]
@@ -1641,36 +1499,6 @@ def test_artifact_listing_fails_closed_at_candidate_limit(
             encoded_name="ci-attestation-tree",
             token="synthetic-token",
         )
-
-
-def test_base_evidence_wait_is_bounded_and_observes_predecessor(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    results = iter((False, False, True))
-    sleeps: list[int] = []
-    monkeypatch.setitem(
-        wait_for_base_successful_ci.__globals__,
-        "BASE_CI_VISIBILITY_DELAYS",
-        (0, 1, 3),
-    )
-    monkeypatch.setitem(
-        wait_for_base_successful_ci.__globals__,
-        "_base_has_successful_ci",
-        lambda **_kwargs: next(results),
-    )
-    monkeypatch.setitem(
-        wait_for_base_successful_ci.__globals__,
-        "time",
-        type("Clock", (), {"sleep": staticmethod(sleeps.append)}),
-    )
-
-    assert wait_for_base_successful_ci(
-        api_url="https://api.github.com",
-        repository="opensquilla/opensquilla",
-        token="synthetic-token",
-        queue_base_sha="a" * 40,
-    )
-    assert sleeps == [1, 2]
 
 
 def test_nightly_health_requires_fresh_authoritative_full_coverage(

--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -406,9 +406,7 @@ def test_ci_fast_paths_keep_the_required_check_and_fail_closed() -> None:
     assert "fetch-depth" in str(jobs["queue-attestation"])
     assert "verify-queue" in str(jobs["queue-attestation"])
     assert "reason_code" in str(jobs["queue-attestation"])
-    assert jobs["queue-attestation"]["outputs"]["combined_smoke_suites"] == (
-        "${{ steps.verify.outputs.combined_smoke_suites || '[]' }}"
-    )
+    assert "combined_smoke_suites" not in jobs["queue-attestation"]["outputs"]
     assert not any(
         name.startswith("nightly_") for name in jobs["queue-attestation"]["outputs"]
     )
@@ -1085,9 +1083,15 @@ def test_pr_target_branch_workflow_runs_trusted_base_validator() -> None:
     assert "Validate target branch" in text
     assert job["name"] == "Validate target branch"
     assert job["timeout-minutes"] == 5
-    assert "github.event.repository.default_branch" in text
-    assert "hashFiles('.github/scripts/validate-pr-target-branch.sh') == ''" in text
-    assert "github.event.pull_request.head.sha" in text
+    checkouts = [
+        step for step in job["steps"] if step.get("uses") == "actions/checkout@v4"
+    ]
+    assert len(checkouts) == 1
+    assert "if" not in checkouts[0]
+    assert checkouts[0]["with"] == {
+        "ref": "${{ github.event.repository.default_branch }}",
+        "persist-credentials": False,
+    }
     assert "github.event.merge_group.base_ref" in text
     assert "github.event.merge_group.head_ref" in text
     assert "pull-requests: read" in text
@@ -1111,13 +1115,20 @@ def test_pr_target_validator_accepts_merge_group_base_ref(tmp_path: Path) -> Non
 def test_pr_body_lint_workflow_warns_from_trusted_base() -> None:
     data = _workflow("pr-body-lint.yml")
     text = (WORKFLOW_DIR / "pr-body-lint.yml").read_text(encoding="utf-8")
+    job = data["jobs"]["validate-body"]
 
     assert _trigger_keys(data) == {"pull_request"}
     assert "pull_request_target" not in text
     assert "Validate PR body fields" in text
-    assert "github.event.repository.default_branch" in text
-    assert "hashFiles('.github/scripts/validate_pr_body.py') == ''" in text
-    assert "github.event.pull_request.head.sha" in text
+    checkouts = [
+        step for step in job["steps"] if step.get("uses") == "actions/checkout@v4"
+    ]
+    assert len(checkouts) == 1
+    assert "if" not in checkouts[0]
+    assert checkouts[0]["with"] == {
+        "ref": "${{ github.event.repository.default_branch }}",
+        "persist-credentials": False,
+    }
     assert "pull-requests: read" in text
     assert PR_BODY_LINT.as_posix() in text
     assert "PR_BODY_LINT_STRICT: \"0\"" in text


### PR DESCRIPTION
## Scope

Scope boundary: Remove unreachable legacy composition helpers, their test-only coverage, and the permanently empty combined-smoke output. Reject the retired composed selector explicitly. Remove first-merge bootstrap checkouts from the PR body and target-branch validators now that both validators exist on main.

The active exact-tree and partial-suite reuse mechanisms introduced in #1603 are preserved, including reconstruction checks, conditional digest validation, suite planning, failure reporting, canaries, and all new partial-reuse tests.

Non-goals: No changes to required checks, trust roots, queue coverage, reusable suites, or runtime behavior.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Maintainer-requested dead-code cleanup, isolated from the runtime and UI cleanup in #1607.

## Release Note

Release note: NONE

## Tests

Ruff: Passed on the changed Python files; git diff --check passed.

Pytest: 453 passed across test_ci_attestation, test_workflows, test_plan_ci, test_ci_result_gate, and test_ci_trust_policy on the refreshed main base.

Build: N/A; workflow parsing and contract tests passed. Remote CI is required.

Regression tests: added

Notes: Added explicit rejection coverage for the retired composed mode and strengthened both validator workflow tests to require exactly one unconditional trusted-default-branch checkout with persisted credentials disabled. Independent diff and AST review confirmed preservation of the active partial-reuse implementation and all tests added in #1603.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

No secrets or local validation artifacts are included.

## Third-Party Origin

Third-party origin: none

