### PR TITLE
fix(tools): preserve redacted secrets during file edits

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -299,6 +299,7 @@
       "tests/test_tools/test_path_policy.py",
       "tests/test_tools/test_policy_config_boundary.py",
       "tests/test_tools/test_presentation_rules.py",
+      "tests/test_tools/test_redacted_secret_editing.py",
       "tests/test_tools/test_restored_tool_contracts.py",
       "tests/test_tools/test_shell_managed_toolchains.py",
       "tests/test_tools/test_shell_policy_windows.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -1416,6 +1416,7 @@
     "tests/test_tools/test_projected_arguments.py": 0.03,
     "tests/test_tools/test_registry_visibility.py": 0.134,
     "tests/test_tools/test_registry_visibility_boundary.py": 0.03,
+    "tests/test_tools/test_redacted_secret_editing.py": 0.01,
     "tests/test_tools/test_repeated_call_notice.py": 0.774,
     "tests/test_tools/test_restored_tool_contracts.py": 0.01,
     "tests/test_tools/test_router_control_tool.py": 0.022,

--- a/src/opensquilla/safety/secret_redaction.py
+++ b/src/opensquilla/safety/secret_redaction.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import re
+from bisect import bisect_left
+from collections import Counter
 from typing import Any
 
 _REDACTED = "[REDACTED]"
+REDACTED_SECRET_VALUE = _REDACTED
 
 _SECRET_TOKEN_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\bsk-or-v1-[A-Za-z0-9_-]{16,}\b"),
@@ -34,8 +37,11 @@ def _redact_auth_header(match: re.Match[str]) -> str:
     header = match.group(1)
     scheme = match.group(2) or ""
     return f"{header}{scheme}{_REDACTED}"
+
+
 _SECRET_ASSIGNMENT_RE = re.compile(
-    r"(?i)\b([A-Za-z0-9_.-]+)\s*([:=])\s*([^\s,;'\")}\]]+)"
+    r"(?i)\b([A-Za-z0-9_.-]+)\s*([:=])\s*"
+    r"(\[REDACTED\](?:[^\s,;'\")}\]]+)?|[^\s,;'\")}\]]+)"
 )
 # Second pass: values that start with a quote are invisible to the pattern above
 # (its value class excludes quotes so nested assignments inside quoted strings can
@@ -45,6 +51,10 @@ _SECRET_ASSIGNMENT_RE = re.compile(
 _SECRET_QUOTED_ASSIGNMENT_RE = re.compile(
     r"(?i)\b([A-Za-z0-9_.-]+)\s*([:=])\s*"
     r"(\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|[\"']\S*)"
+)
+_SECRET_QUOTED_KEY_ASSIGNMENT_RE = re.compile(
+    r"(?i)([\"'])([A-Za-z0-9_.-]+)\1(\s*[:=]\s*)"
+    r"(\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*')"
 )
 
 _SECRET_KEY_PARTS = (
@@ -85,9 +95,26 @@ def _redact_assignment(match: re.Match[str]) -> str:
     return f"{key}{separator}{_REDACTED}"
 
 
+def _redact_quoted_key_assignment(match: re.Match[str]) -> str:
+    quote, key, separator, value = (
+        match.group(1),
+        match.group(2),
+        match.group(3),
+        match.group(4),
+    )
+    if not is_secret_key(key):
+        return match.group(0)
+    value_quote = value[0] if value.startswith(("\"", "'")) else ""
+    return f"{quote}{key}{quote}{separator}{value_quote}{_REDACTED}{value_quote}"
+
+
 def redact_secret_text(text: str) -> str:
     redacted = text
     redacted = _AUTH_HEADER_RE.sub(_redact_auth_header, redacted)
+    redacted = _SECRET_QUOTED_KEY_ASSIGNMENT_RE.sub(
+        _redact_quoted_key_assignment,
+        redacted,
+    )
     redacted = _SECRET_ASSIGNMENT_RE.sub(_redact_assignment, redacted)
     redacted = _SECRET_QUOTED_ASSIGNMENT_RE.sub(_redact_assignment, redacted)
     for pattern in _SECRET_TOKEN_PATTERNS:
@@ -107,3 +134,218 @@ def redact_secret_value(value: Any, *, key: str | None = None) -> Any:
     if isinstance(value, tuple):
         return tuple(redact_secret_value(item) for item in value)
     return value
+
+
+class RedactedSecretResolutionError(ValueError):
+    """Raised when a protected redaction placeholder cannot be resolved safely."""
+
+
+def find_redacted_secret_matches(text: str, masked_text: str) -> list[tuple[int, int]]:
+    """Find source spans whose redacted form exactly equals ``masked_text``."""
+
+    if _REDACTED not in masked_text:
+        return []
+    pieces = masked_text.split(_REDACTED)
+    expression = r"[^\r\n]+".join(re.escape(piece) for piece in pieces)
+    pattern = re.compile(expression)
+    matches: list[tuple[int, int]] = []
+    for match in pattern.finditer(text):
+        if redact_secret_text(match.group(0)) == masked_text:
+            matches.append((match.start(), match.end()))
+    return matches
+
+
+def restore_redacted_secret_placeholders(original: str, proposed: str) -> str:
+    """Restore unchanged secret values in model-proposed text.
+
+    A redaction marker means "keep the value from the corresponding original
+    position". Explicit replacement values remain untouched.
+    """
+
+    if _REDACTED not in proposed:
+        return proposed
+
+    original_lines = original.splitlines(keepends=True)
+    proposed_lines = proposed.splitlines(keepends=True)
+    masked_lines = [redact_secret_text(line) for line in original_lines]
+    masked_keys = [_line_without_ending(line) for line in masked_lines]
+    proposed_keys = [_line_without_ending(line) for line in proposed_lines]
+
+    anchor_pairs = _unique_context_anchor_pairs(masked_keys, proposed_keys)
+    proposed_anchor_indices = [proposed_index for proposed_index, _original_index in anchor_pairs]
+
+    used_original_lines: set[int] = set()
+    resolved_lines = list(proposed_lines)
+    for proposed_index, proposed_line in enumerate(proposed_lines):
+        if _REDACTED not in proposed_line:
+            continue
+
+        def _try_original_line(index: int) -> str | None:
+            if (
+                index in used_original_lines
+                or _line_without_ending(original_lines[index]) == masked_keys[index]
+            ):
+                return None
+            try:
+                return _restore_redacted_line_values(
+                    original_lines[index],
+                    masked_lines[index],
+                    proposed_line,
+                )
+            except RedactedSecretResolutionError:
+                return None
+
+        anchored = {
+            index: resolved
+            for index in _context_candidate_indices(
+                proposed_index,
+                anchor_pairs,
+                proposed_anchor_indices,
+                original_line_count=len(original_lines),
+            )
+            if (resolved := _try_original_line(index)) is not None
+        }
+        if len(anchored) == 1:
+            compatible = anchored
+        elif anchored:
+            compatible = {}
+        else:
+            compatible = {
+                index: resolved
+                for index in range(len(original_lines))
+                if (resolved := _try_original_line(index)) is not None
+            }
+
+        original_index = next(iter(compatible)) if len(compatible) == 1 else None
+        if original_index is None:
+            raise RedactedSecretResolutionError(
+                "A [REDACTED] placeholder has no unambiguous corresponding existing secret "
+                "line. Keep unique surrounding context or provide an explicit new value."
+            )
+        used_original_lines.add(original_index)
+        resolved_lines[proposed_index] = compatible[original_index]
+
+    return "".join(resolved_lines)
+
+
+def _line_without_ending(line: str) -> str:
+    return line.rstrip("\r\n")
+
+
+def _line_ending(line: str) -> str:
+    if line.endswith("\r\n"):
+        return "\r\n"
+    if line.endswith("\n"):
+        return "\n"
+    if line.endswith("\r"):
+        return "\r"
+    return ""
+
+
+def _redacted_marker_anchors(line: str) -> tuple[str | None, ...]:
+    """Return the assignment/header key immediately preceding each marker."""
+
+    anchors: list[str | None] = []
+    for prefix in line.split(_REDACTED)[:-1]:
+        match = re.search(
+            r"(?i)[\"']?([A-Za-z0-9_.-]+)[\"']?\s*[:=][^:=\r\n]*$",
+            prefix,
+        )
+        anchors.append(match.group(1).lower() if match is not None else None)
+    return tuple(anchors)
+
+
+def _unique_context_anchor_pairs(
+    original_lines: list[str],
+    proposed_lines: list[str],
+) -> list[tuple[int, int]]:
+    """Return unique unchanged non-secret lines as proposed/original anchors."""
+
+    original_counts = Counter(original_lines)
+    proposed_counts = Counter(proposed_lines)
+    original_positions = {
+        line: index
+        for index, line in enumerate(original_lines)
+        if _REDACTED not in line and original_counts[line] == 1
+    }
+    return [
+        (proposed_index, original_positions[line])
+        for proposed_index, line in enumerate(proposed_lines)
+        if _REDACTED not in line
+        and proposed_counts[line] == 1
+        and line in original_positions
+    ]
+
+
+def _context_candidate_indices(
+    proposed_index: int,
+    anchor_pairs: list[tuple[int, int]],
+    proposed_anchor_indices: list[int],
+    *,
+    original_line_count: int,
+) -> set[int]:
+    if not anchor_pairs:
+        return set()
+    insertion = bisect_left(proposed_anchor_indices, proposed_index)
+    nearby = []
+    if insertion:
+        nearby.append(anchor_pairs[insertion - 1])
+    if insertion < len(anchor_pairs):
+        nearby.append(anchor_pairs[insertion])
+    return {
+        candidate
+        for proposed_anchor, original_anchor in nearby
+        for candidate in (original_anchor + (proposed_index - proposed_anchor),)
+        if 0 <= candidate < original_line_count
+    }
+
+
+def _restore_redacted_line_values(
+    original_line: str,
+    masked_line: str,
+    proposed_line: str,
+) -> str:
+    original_body = _line_without_ending(original_line)
+    masked_body = _line_without_ending(masked_line)
+    proposed_body = _line_without_ending(proposed_line)
+    pieces = masked_body.split(_REDACTED)
+    expression = "^" + r"([^\r\n]+?)".join(re.escape(piece) for piece in pieces) + "$"
+    match = re.fullmatch(expression, original_body)
+    if match is None or redact_secret_text(original_body) != masked_body:
+        raise RedactedSecretResolutionError(
+            "The corresponding source line no longer matches its redacted form."
+        )
+    values = list(match.groups())
+    proposed_pieces = proposed_body.split(_REDACTED)
+    source_anchors = _redacted_marker_anchors(masked_body)
+    proposed_anchors = _redacted_marker_anchors(proposed_body)
+    if any(anchor is None for anchor in proposed_anchors):
+        if proposed_anchors != source_anchors:
+            raise RedactedSecretResolutionError(
+                "A redacted value lacks an unambiguous secret-field anchor."
+            )
+        value_indices = list(range(len(values)))
+    else:
+        value_indices = []
+        used: set[int] = set()
+        for anchor in proposed_anchors:
+            matching = [
+                index
+                for index, source_anchor in enumerate(source_anchors)
+                if source_anchor == anchor and index not in used
+            ]
+            if len(matching) != 1:
+                raise RedactedSecretResolutionError(
+                    f"Secret field {anchor!r} is missing or ambiguous on its source line."
+                )
+            value_index = matching[0]
+            used.add(value_index)
+            value_indices.append(value_index)
+
+    resolved = proposed_pieces[0]
+    for value_index, suffix in zip(value_indices, proposed_pieces[1:], strict=True):
+        value = values[value_index]
+        if resolved.endswith((" ", "\t")):
+            value = value.lstrip(" \t")
+        resolved += value + suffix
+    return resolved + _line_ending(proposed_line)

--- a/src/opensquilla/tools/builtin/filesystem.py
+++ b/src/opensquilla/tools/builtin/filesystem.py
@@ -23,6 +23,13 @@ from xml.etree import ElementTree as ET
 
 import structlog
 
+from opensquilla.safety.secret_redaction import (
+    REDACTED_SECRET_VALUE,
+    RedactedSecretResolutionError,
+    find_redacted_secret_matches,
+    redact_secret_text,
+    restore_redacted_secret_placeholders,
+)
 from opensquilla.sandbox.backup_vault import BackupReceiptSummary, summarize_backup_receipts
 from opensquilla.sandbox.destructive_backup import DestructiveBackupGate
 from opensquilla.sandbox.directory_listing import format_directory_entry
@@ -561,7 +568,7 @@ def _stream_numbered_lines_from_file(
     try:
         with p.open("rb") as fh:
             for lineno, raw_line in enumerate(fh, start=1):
-                line = raw_line.decode("utf-8")
+                line = redact_secret_text(raw_line.decode("utf-8"))
                 if lineno < start_line:
                     continue
                 if limit is not None and emitted >= limit:
@@ -2055,7 +2062,10 @@ def _format_spreadsheet(
         "Write full file content, creating directories as needed. Best for new "
         "files and scratch files. For existing workspace source files, first use "
         "read_file without offset or limit, then prefer edit_file for exact "
-        "replacements or apply_patch for multi-line hunks."
+        "replacements or apply_patch for multi-line hunks. When rewriting an existing "
+        "file, keep [REDACTED] at an unchanged secret field to preserve its current "
+        "value, or provide an explicit new value to replace it. A new file cannot "
+        "inherit a [REDACTED] value."
     ),
     params={
         "path": {"type": "string", "description": "Absolute path to write to."},
@@ -2103,6 +2113,7 @@ async def write_file(
     p = _resolve_path(path)
     if full_host_access_active():
         created = not p.exists()
+        content = _resolve_redacted_write_content(p, content, created=created)
 
         def _write_full_host() -> None:
             p.parent.mkdir(parents=True, exist_ok=True)
@@ -2134,6 +2145,7 @@ async def write_file(
         return json.dumps(approval)
 
     created = not p.exists()
+    content = _resolve_redacted_write_content(p, content, created=created)
     if not created:
         require_fresh_workspace_file_read(p, tool_name="write_file", original_path=path)
         _gate_write_file_destructive_overwrite(p, content, original_path=path)
@@ -2200,6 +2212,23 @@ async def write_file(
         f"Written {len(content)} bytes to {p}{_write_scope_suffix(p)}"
         f"{_backup_receipt_note(backup_summaries)}"
     )
+
+
+def _resolve_redacted_write_content(path: Path, content: str, *, created: bool) -> str:
+    if REDACTED_SECRET_VALUE not in content:
+        return content
+    if created:
+        raise RetryableToolInputError(
+            "write_file cannot place [REDACTED] in a new file because there is no "
+            "existing secret to preserve. Provide the intended explicit value instead."
+        )
+    try:
+        original = path.read_text(encoding="utf-8")
+        return restore_redacted_secret_placeholders(original, content)
+    except RedactedSecretResolutionError as exc:
+        raise RetryableToolInputError(
+            f"write_file could not preserve a redacted secret: {exc}"
+        ) from exc
 
 
 def _resolve_scratch_write_path(path: str) -> tuple[Path, str]:
@@ -2587,7 +2616,9 @@ def _edit_file_retry_guidance(*, duplicate_match: bool = False) -> str:
         "pass old_text and new_text. For multiple non-overlapping replacements in "
         "the same file, pass edits[] with old_text/new_text or oldText/newText "
         "entries. old_text must match file contents exactly and must not include "
-        "read_file line-number prefixes such as '12\\t'. For large or line-oriented "
+        "read_file line-number prefixes such as '12\\t'. A [REDACTED] value in old_text "
+        "matches the hidden current secret; keep it in new_text to preserve the secret, "
+        "or provide an explicit new value to replace it. For large or line-oriented "
         "changes, prefer apply_patch with a small hunk."
     ),
     params={
@@ -2680,6 +2711,11 @@ async def edit_file(
             raise FileNotFoundError(f"File not found: {path}")
         loop = asyncio.get_event_loop()
         original = await loop.run_in_executor(None, p.read_text, "utf-8")
+        replacements = _resolve_redacted_edit_replacements(
+            original,
+            replacements,
+            path=path,
+        )
         updated = _apply_edit_replacements(original, replacements, path=path)
         before_fingerprint = fingerprint_path(p)
 
@@ -2726,6 +2762,20 @@ async def edit_file(
     if approval is not None:
         return json.dumps(approval)
     require_fresh_workspace_file_read(p, tool_name="edit_file", original_path=path)
+    if any(
+        REDACTED_SECRET_VALUE in replacement.old_text
+        or REDACTED_SECRET_VALUE in replacement.new_text
+        for replacement in replacements
+    ):
+        if not p.exists():
+            raise FileNotFoundError(f"File not found: {path}")
+        loop = asyncio.get_event_loop()
+        redacted_original = await loop.run_in_executor(None, p.read_text, "utf-8")
+        replacements = _resolve_redacted_edit_replacements(
+            redacted_original,
+            replacements,
+            path=path,
+        )
     workspace = _filesystem_operation_workspace()
     if workspace is not None:
         if len(replacements) == 1:
@@ -2819,7 +2869,8 @@ async def edit_file(
         "Atomically edit an existing UTF-8 source file using line ranges from a prior "
         "read_source receipt. Requires expected_revision from read_source; if the file "
         "changed since that read, the edit is rejected and must be retried after a new "
-        "read_source call."
+        "read_source call. Keep [REDACTED] in an unchanged secret field to preserve its "
+        "current value, or provide an explicit new value to replace it."
     ),
     params={
         "path": {
@@ -2849,7 +2900,10 @@ async def edit_file(
                     },
                     "replacement": {
                         "type": "string",
-                        "description": "Replacement source text for the full line range.",
+                        "description": (
+                            "Replacement source text for the full line range. A [REDACTED] "
+                            "secret preserves its corresponding current value."
+                        ),
                     },
                 },
                 "required": ["start_line", "end_line", "replacement"],
@@ -3264,6 +3318,61 @@ def _apply_edit_replacements(
         cursor = end
     chunks.append(original[cursor:])
     return "".join(chunks)
+
+
+def _resolve_redacted_edit_replacements(
+    original: str,
+    replacements: list[_EditReplacement],
+    *,
+    path: str,
+) -> list[_EditReplacement]:
+    resolved: list[_EditReplacement] = []
+    for replacement in replacements:
+        if REDACTED_SECRET_VALUE not in replacement.old_text:
+            if REDACTED_SECRET_VALUE in replacement.new_text:
+                raise RetryableToolInputError(
+                    f"edit_file {replacement.label} has no redacted source value to preserve "
+                    f"in {path}. Keep [REDACTED] in both old_text and new_text, or provide "
+                    "an explicit new value."
+                )
+            resolved.append(replacement)
+            continue
+
+        matches = find_redacted_secret_matches(original, replacement.old_text)
+        if not matches:
+            raise RetryableToolInputError(
+                f"edit_file could not match the redacted secret in {replacement.label} "
+                f"against {path}. Read the current file and retry with its surrounding context."
+            )
+        if len(matches) > 1:
+            candidate_lines = [
+                original.count("\n", 0, start) + 1 for start, _end in matches[:20]
+            ]
+            lines = ", ".join(str(line) for line in candidate_lines)
+            raise RetryableToolInputError(
+                f"edit_file {replacement.label} matches {len(matches)} redacted locations "
+                f"in {path}. Candidate lines: {lines}. Read around the intended line and "
+                "retry with longer unique surrounding context."
+            )
+        start, end = matches[0]
+        actual_old_text = original[start:end]
+        try:
+            resolved_new_text = restore_redacted_secret_placeholders(
+                actual_old_text,
+                replacement.new_text,
+            )
+        except RedactedSecretResolutionError as exc:
+            raise RetryableToolInputError(
+                f"edit_file could not preserve a redacted secret in {replacement.label}: {exc}"
+            ) from exc
+        resolved.append(
+            _EditReplacement(
+                old_text=actual_old_text,
+                new_text=resolved_new_text,
+                label=replacement.label,
+            )
+        )
+    return resolved
 
 
 _READ_FILE_LINE_PREFIX_RE = re.compile(r"^\s*\d+\t")

--- a/src/opensquilla/tools/builtin/patch.py
+++ b/src/opensquilla/tools/builtin/patch.py
@@ -13,6 +13,12 @@ from pathlib import Path
 from typing import Any
 
 from opensquilla.identity.workspace import BOOTSTRAP_FILENAMES
+from opensquilla.safety.secret_redaction import (
+    REDACTED_SECRET_VALUE,
+    RedactedSecretResolutionError,
+    redact_secret_text,
+    restore_redacted_secret_placeholders,
+)
 from opensquilla.sandbox.backup_vault import BackupReceiptSummary, summarize_backup_receipts
 from opensquilla.sandbox.destructive_backup import DestructiveBackupGate
 from opensquilla.sandbox.elevation import (
@@ -178,6 +184,11 @@ def _parse_patch(patch_text: str) -> list[PatchOp]:
                 if raw.startswith("+"):
                     content_lines.append(raw[1:])
                 i += 1
+            if any(REDACTED_SECRET_VALUE in content_line for content_line in content_lines):
+                raise RetryableToolInputError(
+                    "apply_patch cannot place [REDACTED] in a new file because there "
+                    "is no existing secret to preserve. Provide an explicit value instead."
+                )
             ops.append(AddFile(path=path, content="\n".join(content_lines)))
 
         elif line.startswith("*** Update File: "):
@@ -635,7 +646,14 @@ def _match_line(actual: str, expected: str) -> bool:
     """
     if actual == expected:
         return True
-    return actual.rstrip("\r\n").rstrip(" \t") == expected.rstrip("\r\n").rstrip(" \t")
+    normalized_actual = actual.rstrip("\r\n").rstrip(" \t")
+    normalized_expected = expected.rstrip("\r\n").rstrip(" \t")
+    if normalized_actual == normalized_expected:
+        return True
+    return (
+        REDACTED_SECRET_VALUE in normalized_expected
+        and redact_secret_text(normalized_actual) == normalized_expected
+    )
 
 
 def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
@@ -662,17 +680,39 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
                     "with hunk line numbers and context that match the file."
                 )
             if not _match_line(result[check_pos], content):
+                expected_display = redact_secret_text(content.rstrip("\n"))
+                actual_display = redact_secret_text(result[check_pos].rstrip("\n"))
                 raise RetryableToolInputError(
                     f"apply_patch context mismatch at line {check_pos + 1}: "
-                    f"expected {content.rstrip('\n')!r}, "
-                    f"got {result[check_pos].rstrip('\n')!r}. Read the current file "
+                    f"expected {expected_display!r}, "
+                    f"got {actual_display!r}. Read the current file "
                     "content and retry with exact surrounding context."
                 )
             check_pos += 1
 
+    proposed_lines = [
+        content if content.endswith("\n") else content + "\n"
+        for raw in hunk.lines
+        if raw and raw[0] in {" ", "+"}
+        for content in (raw[1:],)
+    ]
+    if any(REDACTED_SECRET_VALUE in line for line in proposed_lines):
+        original_block = "".join(result[pos:check_pos])
+        try:
+            proposed_block = restore_redacted_secret_placeholders(
+                original_block,
+                "".join(proposed_lines),
+            )
+        except RedactedSecretResolutionError as exc:
+            raise RetryableToolInputError(
+                f"apply_patch could not preserve a redacted secret: {exc}"
+            ) from exc
+        proposed_lines = proposed_block.splitlines(keepends=True)
+
     # Now build new lines
     new_lines: list[str] = []
     src_pos = pos
+    proposed_pos = 0
     for raw in hunk.lines:
         if not raw:
             continue
@@ -681,14 +721,12 @@ def _apply_hunk(file_lines: list[str], hunk: Hunk) -> list[str]:
         if prefix == " ":
             new_lines.append(result[src_pos])
             src_pos += 1
+            proposed_pos += 1
         elif prefix == "-":
             src_pos += 1  # skip (delete)
         elif prefix == "+":
-            # Preserve newline style: add \n if original lines have it
-            if content.endswith("\n"):
-                new_lines.append(content)
-            else:
-                new_lines.append(content + "\n")
+            new_lines.append(proposed_lines[proposed_pos])
+            proposed_pos += 1
 
     # Splice: replace [pos : pos + old_count] with new_lines
     return result[:pos] + new_lines + result[pos + hunk.old_count :]
@@ -1006,7 +1044,9 @@ def _apply_ops(
         "Apply a structured patch to files. Supports adding, modifying, and deleting files "
         "using Begin Patch / End Patch markers with unified @@ or @@@ hunk headers. "
         "Prefer this for multi-line or larger source edits where edit_file JSON would "
-        "be long or fragile."
+        "be long or fragile. A [REDACTED] value can match an existing context or deletion "
+        "line: keep it in the corresponding new line to preserve the secret, or provide "
+        "an explicit new value. Never introduce [REDACTED] without an existing secret."
     ),
     params={
         "patch": {

--- a/src/opensquilla/tools/source_edit_contract.py
+++ b/src/opensquilla/tools/source_edit_contract.py
@@ -7,6 +7,13 @@ import hashlib
 from pathlib import Path
 from typing import Any
 
+from opensquilla.safety.secret_redaction import (
+    REDACTED_SECRET_VALUE,
+    RedactedSecretResolutionError,
+    redact_secret_text,
+    restore_redacted_secret_placeholders,
+)
+
 
 class SourceEditContractError(ValueError):
     """Raised when a source edit contract input cannot be applied."""
@@ -57,7 +64,7 @@ def build_line_receipt(
     """Build a model-facing read receipt with plain source lines."""
 
     text = path.read_text(encoding="utf-8")
-    lines = text.splitlines()
+    lines = [redact_secret_text(line) for line in text.splitlines()]
     total_lines = len(lines)
     effective_end_line = (
         min(total_lines, start_line + DEFAULT_SOURCE_READ_LINES - 1)
@@ -98,6 +105,7 @@ def _normalized_edits(
         raise SourceEditContractError("edits must be a non-empty array")
 
     line_count = _line_count(original)
+    original_lines = original.splitlines(keepends=True)
     normalized: list[tuple[int, int, list[str]]] = []
     for index, edit in enumerate(edits):
         if not isinstance(edit, dict):
@@ -107,11 +115,23 @@ def _normalized_edits(
             end_line=edit.get("end_line"),
             line_count=line_count,
         )
+        replacement = edit.get("replacement")
+        if isinstance(replacement, str) and REDACTED_SECRET_VALUE in replacement:
+            original_range = "".join(original_lines[start - 1 : end])
+            try:
+                replacement = restore_redacted_secret_placeholders(
+                    original_range,
+                    replacement,
+                )
+            except RedactedSecretResolutionError as exc:
+                raise SourceEditContractError(
+                    f"edits[{index}].replacement could not preserve a redacted secret: {exc}"
+                ) from exc
         normalized.append(
             (
                 start,
                 end,
-                _replacement_lines(edit.get("replacement"), index=index),
+                _replacement_lines(replacement, index=index),
             )
         )
 

--- a/tests/test_safety/test_secret_redaction.py
+++ b/tests/test_safety/test_secret_redaction.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
-from opensquilla.safety.secret_redaction import redact_secret_text, redact_secret_value
+import pytest
+
+from opensquilla.safety.secret_redaction import (
+    RedactedSecretResolutionError,
+    redact_secret_text,
+    redact_secret_value,
+    restore_redacted_secret_placeholders,
+)
 
 
 def test_redact_secret_text_masks_env_assignments_and_provider_keys() -> None:
@@ -60,10 +67,58 @@ def test_redact_secret_text_masks_quoted_assignment_values() -> None:
     assert "client_secret:[REDACTED]" in redacted
 
 
+def test_redact_secret_text_masks_values_for_quoted_json_keys() -> None:
+    text = (
+        '{"password": "json_password", "api_key": "json_key", '
+        '"name": "visible"}'
+    )
+
+    redacted = redact_secret_text(text)
+
+    assert "json_password" not in redacted
+    assert "json_key" not in redacted
+    assert '"password": "[REDACTED]"' in redacted
+    assert '"api_key": "[REDACTED]"' in redacted
+    assert '"name": "visible"' in redacted
+
+
 def test_redact_secret_text_keeps_quoted_values_for_non_secret_keys() -> None:
-    text = 'name: "alice" retry_count = \'3\''
+    text = 'name: "alice" retry_count = \'3\' {"grantToken": "functional-token"}'
 
     assert redact_secret_text(text) == text
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "password=plain-secret\n",
+        "token: plain-token\n",
+        '{"password": "json-secret"}\n',
+        "Authorization: Bearer header-secret\n",
+    ],
+)
+def test_redact_secret_text_is_idempotent(text: str) -> None:
+    once = redact_secret_text(text)
+
+    assert redact_secret_text(once) == once
+
+
+@pytest.mark.parametrize("suffix", ["super-secret-tail", "_suffix"])
+def test_redact_secret_text_consumes_content_after_marker_prefix(suffix: str) -> None:
+    redacted = redact_secret_text(f"password=[REDACTED]{suffix}")
+
+    assert suffix not in redacted
+    assert redacted == "password=[REDACTED]"
+
+
+def test_restore_redacted_secret_rejects_unanchored_duplicate_lines() -> None:
+    original = "password: first-secret\npassword: second-secret\n"
+
+    with pytest.raises(RedactedSecretResolutionError, match="no unambiguous"):
+        restore_redacted_secret_placeholders(
+            original,
+            "password:[REDACTED]\n",
+        )
 
 
 def test_redact_secret_text_does_not_mask_token_counters() -> None:

--- a/tests/test_tools/test_redacted_secret_editing.py
+++ b/tests/test_tools/test_redacted_secret_editing.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable, Iterator
+from pathlib import Path
+
+import pytest
+
+from opensquilla.engine.types import ToolCall
+from opensquilla.safety.secret_redaction import redact_secret_text
+from opensquilla.tools import get_default_registry
+from opensquilla.tools.builtin import filesystem
+from opensquilla.tools.builtin import patch as patch_tool
+from opensquilla.tools.dispatch import build_tool_handler
+from opensquilla.tools.types import RetryableToolInputError, ToolContext, current_tool_context
+
+
+def _original_async(fn: Callable[..., Awaitable[str]]) -> Callable[..., Awaitable[str]]:
+    while hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__  # type: ignore[attr-defined]
+    return fn
+
+
+@pytest.fixture
+def workspace_context(tmp_path: Path) -> Iterator[Path]:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    token = current_tool_context.set(
+        ToolContext(
+            is_owner=True,
+            workspace_dir=str(workspace),
+            file_edit_requires_fresh_read=True,
+            allowed_tools={"read_file", "read_source"},
+            surfaced_tools={"read_file", "read_source"},
+        )
+    )
+    try:
+        yield workspace
+    finally:
+        current_tool_context.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_read_file_redacts_quoted_json_secret_before_line_numbering(
+    workspace_context: Path,
+) -> None:
+    target = workspace_context / "config" / "settings.json"
+    target.parent.mkdir()
+    target.write_text('{"password":"json_password","name":"visible"}\n', encoding="utf-8")
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    handler = build_tool_handler(get_default_registry(), ctx)
+
+    result = await handler(
+        ToolCall(
+            tool_use_id="read-file-secret",
+            tool_name="read_file",
+            arguments={"path": str(target)},
+        )
+    )
+    output = result.content
+
+    assert result.is_error is False
+    assert "json_password" not in output
+    assert '1\t{"password":"[REDACTED]","name":"visible"}' in output
+
+
+@pytest.mark.asyncio
+async def test_read_source_redacts_quoted_json_secret_before_receipt_encoding(
+    workspace_context: Path,
+) -> None:
+    target = workspace_context / "config" / "settings.json"
+    target.parent.mkdir()
+    target.write_text('{"password":"json_password","name":"visible"}\n', encoding="utf-8")
+    ctx = current_tool_context.get()
+    assert ctx is not None
+    handler = build_tool_handler(get_default_registry(), ctx)
+
+    result = await handler(
+        ToolCall(
+            tool_use_id="read-source-secret",
+            tool_name="read_source",
+            arguments={"path": str(target)},
+        )
+    )
+    receipt = json.loads(result.content)
+
+    assert result.is_error is False
+    assert "json_password" not in str(receipt)
+    assert receipt["lines"][0]["text"] == (
+        '{"password":"[REDACTED]","name":"visible"}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_file_preserves_two_redacted_yaml_passwords(
+    workspace_context: Path,
+) -> None:
+    target = workspace_context / "config" / "database.yml"
+    target.parent.mkdir()
+    original = (
+        "development:\n"
+        "  host: localhost\n"
+        "  password: dev_password_123\n"
+        "test:\n"
+        "  host: localhost\n"
+        "  password: test_password_456\n"
+    )
+    target.write_text(original, encoding="utf-8")
+    masked = redact_secret_text(original)
+    replacement = masked.replace("host: localhost", "host: prod-db.example.com")
+    edit_file = _original_async(filesystem.edit_file)
+
+    await filesystem.read_file(str(target))
+    await edit_file(str(target), old_text=masked, new_text=replacement)
+
+    assert target.read_text(encoding="utf-8") == (
+        "development:\n"
+        "  host: prod-db.example.com\n"
+        "  password: dev_password_123\n"
+        "test:\n"
+        "  host: prod-db.example.com\n"
+        "  password: test_password_456\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_file_can_replace_a_redacted_password_with_an_explicit_value(
+    workspace_context: Path,
+) -> None:
+    target = workspace_context / "config" / "database.yml"
+    target.parent.mkdir()
+    target.write_text(
+        "production:\n  username: app\n  password: old_password\n",
+        encoding="utf-8",
+    )
+    edit_file = _original_async(filesystem.edit_file)
+
+    await filesystem.read_file(str(target))
+    await edit_file(
+        str(target),
+        old_text="  password:[REDACTED]\n",
+        new_text="  password: rotated_password\n",
+    )
+
+    assert target.read_text(encoding="utf-8") == (
+        "production:\n  username: app\n  password: rotated_password\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_file_reports_redacted_candidate_lines_without_leaking_secrets(
+    workspace_context: Path,
+) -> None:
+    target = workspace_context / "config" / "database.yml"
+    target.parent.mkdir()
+    original = (
+        "development:\n"
+        "  password: dev_password_123\n"
+        "production:\n"
+        "  password: prod_password_456\n"
+    )
+    target.write_text(original, encoding="utf-8")
+    edit_file = _original_async(filesystem.edit_file)
+
+    await filesystem.read_file(str(target))
+    with pytest.raises(RetryableToolInputError) as exc_info:
+        await edit_file(
+            str(target),
+            old_text="  password:[REDACTED]\n",
+            new_text="  password: rotated_password\n",
+        )
+
+    message = exc_info.value.user_message
+    assert "matches 2 redacted locations" in message
+    assert "Candidate lines: 2, 4." in message
+    assert "dev_password_123" not in message
+    assert "prod_password_456" not in message
+    assert target.read_text(encoding="utf-8") == original
+
+
+@pytest.mark.asyncio
+async def test_edit_file_preserves_secret_when_same_line_metadata_changes(
+    workspace_context: Path,
+) -> None:
+    target = workspace_context / "config" / "database.env"
+    target.parent.mkdir()
+    target.write_text("password=prod_password; host=localhost\n", encoding="utf-8")
+    edit_file = _original_async(filesystem.edit_file)
+
+    await filesystem.read_file(str(target))
+    await edit_file(
+        str(target),
+        old_text="password=[REDACTED]; host=localhost\n",
+        new_text="password=[REDACTED]; host=prod-db.example.com\n",
+    )
+
+    assert target.read_text(encoding="utf-8") == (
+        "password=prod_password; host=prod-db.example.com\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_file_preserves_redacted_json_password(
+    workspace_context: Path,
+) -> None:
+    target = workspace_context / "config" / "settings.json"
+    target.parent.mkdir()
+    target.write_text(
+        '{\n  "host": "localhost",\n  "password": "json_password"\n}\n',
+        encoding="utf-8",
+    )
+    write_file = _original_async(filesystem.write_file)
+
+    raw = await filesystem.read_file(str(target))
+    masked = redact_secret_text(raw)
+    assert "json_password" not in masked
+    assert '"password": "[REDACTED]"' in masked
+    await write_file(
+        str(target),
+        '{\n  "host": "prod-db.example.com",\n  "password": "[REDACTED]"\n}\n',
+    )
+
+    assert target.read_text(encoding="utf-8") == (
+        '{\n  "host": "prod-db.example.com",\n  "password": "json_password"\n}\n'
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_file_preserves_one_secret_and_accepts_explicit_rotation(
+    workspace_context: Path,
+) -> None:
+    target = workspace_context / "config" / "database.yml"
+    target.parent.mkdir()
+    target.write_text(
+        "development:\n"
+        "  password: dev_password_123\n"
+        "test:\n"
+        "  password: test_password_456\n",
+        encoding="utf-8",
+    )
+    write_file = _original_async(filesystem.write_file)
+
+    await filesystem.read_file(str(target))
+    await write_file(
+        str(target),
+        "development:\n"
+        "  password: rotated_dev_password\n"
+        "test:\n"
+        "  password:[REDACTED]\n",
+    )
+
+    assert target.read_text(encoding="utf-8") == (
+        "development:\n"
+        "  password: rotated_dev_password\n"
+        "test:\n"
+        "  password: test_password_456\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_file_preserves_secret_when_same_line_metadata_changes(
+    workspace_context: Path,
+) -> None:
+    target = workspace_context / "config" / "database.env"
+    target.parent.mkdir()
+    target.write_text("password=prod_password; host=localhost\n", encoding="utf-8")
+    write_file = _original_async(filesystem.write_file)
+
+    await filesystem.read_file(str(target))
+    await write_file(str(target), "password=[REDACTED]; host=prod-db.example.com\n")
+
+    assert target.read_text(encoding="utf-8") == (
+        "password=prod_password; host=prod-db.example.com\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_file_preserves_duplicate_fields_when_sections_are_reordered(
+    workspace_context: Path,
+) -> None:
+    target = workspace_context / "config" / "database.yml"
+    target.parent.mkdir()
+    target.write_text(
+        "development:\n  password: dev_password\n"
+        "production:\n  password: prod_password\n",
+        encoding="utf-8",
+    )
+    write_file = _original_async(filesystem.write_file)
+
+    await filesystem.read_file(str(target))
+    await write_file(
+        str(target),
+        "production:\n  password:[REDACTED]\n"
+        "development:\n  password:[REDACTED]\n",
+    )
+
+    assert target.read_text(encoding="utf-8") == (
+        "production:\n  password: prod_password\n"
+        "development:\n  password: dev_password\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_file_allows_mixed_rotation_and_preservation_on_one_line(
+    workspace_context: Path,
+) -> None:
+    target = workspace_context / "config" / "database.env"
+    target.parent.mkdir()
+    target.write_text(
+        "password=old_password; token=old_token\n",
+        encoding="utf-8",
+    )
+    write_file = _original_async(filesystem.write_file)
+
+    await filesystem.read_file(str(target))
+    await write_file(
+        str(target),
+        "password=rotated_password; token=[REDACTED]\n",
+    )
+
+    assert target.read_text(encoding="utf-8") == (
+        "password=rotated_password; token=old_token\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_file_rejects_redacted_placeholder_in_a_new_file(
+    workspace_context: Path,
+) -> None:
+    target = workspace_context / "config" / "new.yml"
+    write_file = _original_async(filesystem.write_file)
+
+    with pytest.raises(RetryableToolInputError, match="no existing secret"):
+        await write_file(str(target), "password:[REDACTED]\n")
+
+    assert not target.exists()
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_uses_redacted_password_as_positioned_context(
+    workspace_context: Path,
+) -> None:
+    target = workspace_context / "config" / "database.yml"
+    target.parent.mkdir()
+    target.write_text(
+        "development:\n"
+        "  host: localhost\n"
+        "  password: dev_password_123\n"
+        "  database: myapp_dev\n",
+        encoding="utf-8",
+    )
+    apply_patch = _original_async(patch_tool.apply_patch)
+
+    await apply_patch(
+        """*** Begin Patch
+*** Update File: config/database.yml
+@@ -1,4 +1,4 @@
+ development:
+-  host: localhost
++  host: prod-db.example.com
+   password:[REDACTED]
+-  database: myapp_dev
++  database: myapp_prod
+*** End Patch"""
+    )
+
+    assert target.read_text(encoding="utf-8") == (
+        "development:\n"
+        "  host: prod-db.example.com\n"
+        "  password: dev_password_123\n"
+        "  database: myapp_prod\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_can_replace_a_redacted_password_with_an_explicit_value(
+    workspace_context: Path,
+) -> None:
+    target = workspace_context / "config" / "database.yml"
+    target.parent.mkdir()
+    target.write_text("production:\n  password: old_password\n", encoding="utf-8")
+    apply_patch = _original_async(patch_tool.apply_patch)
+
+    await apply_patch(
+        """*** Begin Patch
+*** Update File: config/database.yml
+@@ -2,1 +2,1 @@
+-  password:[REDACTED]
++  password: rotated_password
+*** End Patch"""
+    )
+
+    assert target.read_text(encoding="utf-8") == (
+        "production:\n  password: rotated_password\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_can_preserve_secret_on_a_changed_line(
+    workspace_context: Path,
+) -> None:
+    target = workspace_context / "config" / "database.env"
+    target.parent.mkdir()
+    target.write_text("password=prod_password; host=localhost\n", encoding="utf-8")
+    apply_patch = _original_async(patch_tool.apply_patch)
+
+    await apply_patch(
+        """*** Begin Patch
+*** Update File: config/database.env
+@@ -1,1 +1,1 @@
+-password=[REDACTED]; host=localhost
++password=[REDACTED]; host=prod-db.example.com
+*** End Patch"""
+    )
+
+    assert target.read_text(encoding="utf-8") == (
+        "password=prod_password; host=prod-db.example.com\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_redacts_secret_from_context_mismatch_error(
+    workspace_context: Path,
+) -> None:
+    target = workspace_context / "config" / "database.yml"
+    target.parent.mkdir()
+    target.write_text("password: prod_password\n", encoding="utf-8")
+    apply_patch = _original_async(patch_tool.apply_patch)
+
+    with pytest.raises(RetryableToolInputError) as caught:
+        await apply_patch(
+            """*** Begin Patch
+*** Update File: config/database.yml
+@@ -1,1 +1,1 @@
+-token:[REDACTED]
++token: rotated_token
+*** End Patch"""
+        )
+
+    assert "prod_password" not in str(caught.value)
+    assert "password:[REDACTED]" in str(caught.value)
+    assert target.read_text(encoding="utf-8") == "password: prod_password\n"
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_rejects_redacted_placeholder_without_an_old_value(
+    workspace_context: Path,
+) -> None:
+    target = workspace_context / "config" / "new.yml"
+    apply_patch = _original_async(patch_tool.apply_patch)
+
+    with pytest.raises(RetryableToolInputError, match="no existing secret"):
+        await apply_patch(
+            """*** Begin Patch
+*** Add File: config/new.yml
++password:[REDACTED]
+*** End Patch"""
+        )
+
+    assert not target.exists()
+
+
+@pytest.mark.asyncio
+async def test_edit_source_preserves_redacted_password_at_its_line_range(
+    workspace_context: Path,
+) -> None:
+    target = workspace_context / "config" / "database.yml"
+    target.parent.mkdir()
+    target.write_text(
+        "production:\n  host: localhost\n  password: prod_password\n",
+        encoding="utf-8",
+    )
+    edit_source = _original_async(filesystem.edit_source)
+    revision = filesystem.source_revision_for_path(target)
+
+    await edit_source(
+        str(target),
+        expected_revision=revision,
+        edits=[
+            {
+                "start_line": 2,
+                "end_line": 3,
+                "replacement": "  host: prod-db.example.com\n  password:[REDACTED]\n",
+            }
+        ],
+    )
+
+    assert target.read_text(encoding="utf-8") == (
+        "production:\n  host: prod-db.example.com\n  password: prod_password\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_source_preserves_secret_when_same_line_metadata_changes(
+    workspace_context: Path,
+) -> None:
+    target = workspace_context / "config" / "database.env"
+    target.parent.mkdir()
+    target.write_text("password=prod_password; host=localhost\n", encoding="utf-8")
+    edit_source = _original_async(filesystem.edit_source)
+    revision = filesystem.source_revision_for_path(target)
+
+    await edit_source(
+        str(target),
+        expected_revision=revision,
+        edits=[
+            {
+                "start_line": 1,
+                "end_line": 1,
+                "replacement": "password=[REDACTED]; host=prod-db.example.com\n",
+            }
+        ],
+    )
+
+    assert target.read_text(encoding="utf-8") == (
+        "password=prod_password; host=prod-db.example.com\n"
+    )


### PR DESCRIPTION
## Summary

- Preserve existing assignment and quoted-string secrets when `write_file`, `edit_file`, `apply_patch`, or `edit_source` receives the model-visible `[REDACTED]` placeholder.
- Allow explicit secret rotation while rejecting new, missing, or ambiguous placeholder bindings before any file mutation.
- Redact source lines before line-number/receipt encoding, keep repeated redaction idempotent, and prevent patch mismatch diagnostics from exposing secret values.
- Add regression coverage and Windows test-shard registration for the new behavior.

## Scope

This change intentionally covers assignment values and quoted-string values. Container-valued JSON secrets are not inferred or rebound by this patch.

## Test plan

- `uv run pytest -q tests/test_tools/test_redacted_secret_editing.py tests/test_safety/test_secret_redaction.py tests/test_sandbox/test_filesystem_worker.py tests/test_tools/test_apply_patch_gates.py tests/test_tools/test_bootstrap_write_notifications.py tests/test_tools/test_edit_file_closest_hint.py tests/test_tools/test_source_edit_contract.py tests/test_tools/test_filesystem_mutation_receipts.py tests/test_sandbox/test_release_contract.py tests/test_public_tool_surface.py tests/test_provider_openai_compat_payloads.py::test_scaffold_edit_profile_provider_payload_exposes_exact_tool_surface tests/test_tools/test_source_edit_visibility.py::test_scaffold_edit_descriptions_do_not_reference_hidden_tools tests/test_tools/test_source_edit_visibility.py::test_scaffold_patch_descriptions_keep_apply_patch_only_when_visible tests/test_ci/test_windows_test_shards.py` (214 passed, 1 skipped)
- `uv run ruff check ...`
- `uv run mypy ...`
- `npm ci && npm run build`
- `uv build`
- Full offline pytest suite excluding live-provider tests and the pre-existing failing POSIX process-tree case (26,394 passed, 383 skipped)
