### PR TITLE
fix(tools): validate exact text edits and patch hunks

### DIFF
--- a/src/opensquilla/sandbox/edit_diagnostics.py
+++ b/src/opensquilla/sandbox/edit_diagnostics.py
@@ -1,0 +1,52 @@
+"""Shared diagnostics for exact text edits."""
+
+from __future__ import annotations
+
+
+def find_match_start_lines(
+    content: str,
+    old_text: str,
+    limit: int = 20,
+) -> tuple[int, list[int]]:
+    """Return non-overlapping match count and bounded 1-based start lines."""
+
+    if not old_text:
+        return 0, []
+    match_count = content.count(old_text)
+    candidate_lines: list[int] = []
+    search_from = 0
+    previous_match_start = 0
+    line_number = 1
+    for _ in range(min(match_count, max(0, limit))):
+        match_start = content.find(old_text, search_from)
+        if match_start < 0:
+            break
+        line_number += content.count("\n", previous_match_start, match_start)
+        candidate_lines.append(line_number)
+        previous_match_start = match_start
+        search_from = match_start + len(old_text)
+    return match_count, candidate_lines
+
+
+def ambiguous_edit_guidance(
+    match_count: int,
+    candidate_lines: list[int],
+) -> str:
+    """Explain how to disambiguate an exact edit without retrying blindly."""
+
+    lines = ", ".join(str(line) for line in candidate_lines)
+    guidance = [f"Candidate lines: {lines}."]
+    omitted = match_count - len(candidate_lines)
+    if omitted > 0:
+        guidance.append(f"Additional matches omitted: {omitted}")
+    guidance.extend(
+        (
+            "Use read_file around the intended line, then retry with a longer unique "
+            "old_text.",
+            "Do not include read_file line-number prefixes in old_text.",
+        )
+    )
+    return "\n".join(guidance)
+
+
+__all__ = ["ambiguous_edit_guidance", "find_match_start_lines"]

--- a/src/opensquilla/sandbox/filesystem_worker.py
+++ b/src/opensquilla/sandbox/filesystem_worker.py
@@ -16,6 +16,10 @@ from pathlib import Path, PurePath
 from typing import Any
 
 from opensquilla.sandbox.directory_listing import format_directory_entry
+from opensquilla.sandbox.edit_diagnostics import (
+    ambiguous_edit_guidance,
+    find_match_start_lines,
+)
 from opensquilla.sandbox.path_aliases import resolve_workspace_alias
 from opensquilla.sandbox.permissions import (
     FileSystemAccess,
@@ -560,14 +564,19 @@ def _edit_text(payload: dict[str, Any]) -> dict[str, object]:
     path = _enforce_candidate_access(payload, path, write=True)
     old_text = _required_string(payload, "oldText")
     new_text = _required_string(payload, "newText")
+    if not old_text:
+        raise ValueError("old_text must not be empty")
     if not path.exists():
         raise FileNotFoundError(f"File not found: {path}")
     original = path.read_text(encoding="utf-8")
     if old_text not in original:
         raise ValueError(f"old_text not found in {path}")
-    count = original.count(old_text)
+    count, candidate_lines = find_match_start_lines(original, old_text)
     if count > 1:
-        raise ValueError(f"old_text matches {count} locations in {path}; be more specific")
+        raise ValueError(
+            f"edit_file old_text matches {count} locations in {path}.\n"
+            f"{ambiguous_edit_guidance(count, candidate_lines)}"
+        )
     _write_utf8_safely(path, original.replace(old_text, new_text, 1), create=False)
     return {
         "message": f"Edited {path}: replaced {len(old_text)} chars with {len(new_text)} chars",

--- a/src/opensquilla/tools/builtin/filesystem.py
+++ b/src/opensquilla/tools/builtin/filesystem.py
@@ -26,6 +26,10 @@ import structlog
 from opensquilla.sandbox.backup_vault import BackupReceiptSummary, summarize_backup_receipts
 from opensquilla.sandbox.destructive_backup import DestructiveBackupGate
 from opensquilla.sandbox.directory_listing import format_directory_entry
+from opensquilla.sandbox.edit_diagnostics import (
+    ambiguous_edit_guidance,
+    find_match_start_lines,
+)
 from opensquilla.sandbox.elevation import (
     ApprovalDisplay,
     ElevationAction,
@@ -2569,13 +2573,9 @@ def _existing_file_edit_alternatives() -> list[str]:
     return [name for name in ("edit_file", "apply_patch") if _tool_visible_in_current_context(name)]
 
 
-def _edit_file_retry_guidance(*, duplicate_match: bool = False) -> str:
+def _edit_file_retry_guidance() -> str:
     if _tool_visible_in_current_context("apply_patch"):
-        if duplicate_match:
-            return "or use apply_patch with a line-specific hunk."
         return "or use apply_patch with a precise hunk."
-    if duplicate_match:
-        return "or retry with a longer unique exact old_text/new_text replacement."
     return "or retry with a smaller exact old_text/new_text replacement."
 
 
@@ -2588,7 +2588,9 @@ def _edit_file_retry_guidance(*, duplicate_match: bool = False) -> str:
         "the same file, pass edits[] with old_text/new_text or oldText/newText "
         "entries. old_text must match file contents exactly and must not include "
         "read_file line-number prefixes such as '12\\t'. For large or line-oriented "
-        "changes, prefer apply_patch with a small hunk."
+        "changes, prefer apply_patch with a small hunk. When edit_file reports multiple "
+        "candidate lines, call read_file with offset/limit around the relevant candidates, "
+        "then retry with a longer unique old_text. Do not retry the same ambiguous old_text."
     ),
     params={
         "path": {"type": "string", "description": "Absolute path to the file to edit."},
@@ -3209,7 +3211,10 @@ def _apply_edit_replacements(
 ) -> str:
     spans: list[tuple[int, int, str, _EditReplacement]] = []
     for replacement in replacements:
-        count = original.count(replacement.old_text)
+        count, candidate_lines = find_match_start_lines(
+            original,
+            replacement.old_text,
+        )
         if count == 0:
             recovered = _recover_edit_replacement(
                 original,
@@ -3239,9 +3244,8 @@ def _apply_edit_replacements(
             continue
         if count > 1:
             raise RetryableToolInputError(
-                f"edit_file {replacement.label} matches {count} locations in {path}. "
-                "Retry with a longer old_text that includes unique surrounding context, "
-                f"{_edit_file_retry_guidance(duplicate_match=True)}"
+                f"edit_file {replacement.label} matches {count} locations in {path}.\n"
+                f"{ambiguous_edit_guidance(count, candidate_lines)}"
             )
         start = original.index(replacement.old_text)
         spans.append((start, start + len(replacement.old_text), replacement.new_text, replacement))

--- a/src/opensquilla/tools/builtin/patch.py
+++ b/src/opensquilla/tools/builtin/patch.py
@@ -196,6 +196,7 @@ def _parse_patch(patch_text: str) -> list[PatchOp]:
                     ):
                         hunk.lines.append(body[i])
                         i += 1
+                    _validate_hunk_body_counts(hunk)
                     hunks.append(hunk)
                 else:
                     i += 1
@@ -247,6 +248,22 @@ def _parse_hunk_header(header: str) -> Hunk:
         old_count=int(m.group(2) or "1"),
         new_start=int(m.group(3)),
         new_count=int(m.group(4) or "1"),
+    )
+
+
+def _validate_hunk_body_counts(hunk: Hunk) -> None:
+    """Reject malformed hunks before declared ranges can remove omitted lines."""
+
+    old_body_count = sum(bool(line) and line[0] in {" ", "-"} for line in hunk.lines)
+    new_body_count = sum(bool(line) and line[0] in {" ", "+"} for line in hunk.lines)
+    if old_body_count == hunk.old_count and new_body_count == hunk.new_count:
+        return
+    raise RetryableToolInputError(
+        "apply_patch hunk header declares "
+        f"{hunk.old_count} old line(s) and {hunk.new_count} new line(s), but the "
+        f"hunk body contains {old_body_count} old line(s) and {new_body_count} new "
+        "line(s). Retry with header counts that exactly match the context, deletion, "
+        "and addition lines in the hunk body. Omitted lines are not patch context."
     )
 
 
@@ -1006,7 +1023,8 @@ def _apply_ops(
         "Apply a structured patch to files. Supports adding, modifying, and deleting files "
         "using Begin Patch / End Patch markers with unified @@ or @@@ hunk headers. "
         "Prefer this for multi-line or larger source edits where edit_file JSON would "
-        "be long or fragile."
+        "be long or fragile. Numbered hunk header counts must exactly match the context, "
+        "deletion, and addition lines in each hunk body."
     ),
     params={
         "patch": {

--- a/tests/test_sandbox/test_filesystem_worker.py
+++ b/tests/test_sandbox/test_filesystem_worker.py
@@ -647,6 +647,53 @@ def test_edit_text_preserves_existing_file_when_utf8_encoding_fails(
     assert target.read_text(encoding="utf-8") == "before"
 
 
+def test_edit_text_reports_candidate_lines_without_modifying_file(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "config.yml"
+    original = (
+        "development:\n"
+        "  timeout: 30\n"
+        "\n"
+        "production:\n"
+        "  timeout: 30\n"
+    )
+    target.write_text(original, encoding="utf-8")
+
+    with pytest.raises(ValueError) as exc_info:
+        filesystem_worker._edit_text(
+            {
+                "path": str(target),
+                "oldText": "  timeout: 30",
+                "newText": "  timeout: 60",
+            }
+        )
+
+    message = str(exc_info.value)
+    assert "old_text matches 2 locations" in message
+    assert "Candidate lines: 2, 5." in message
+    assert "Use read_file around the intended line" in message
+    assert target.read_text(encoding="utf-8") == original
+
+
+def test_edit_text_rejects_empty_old_text_without_modifying_file(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "config.yml"
+    target.write_text("timeout: 30\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="old_text must not be empty"):
+        filesystem_worker._edit_text(
+            {
+                "path": str(target),
+                "oldText": "",
+                "newText": "unexpected",
+            }
+        )
+
+    assert target.read_text(encoding="utf-8") == "timeout: 30\n"
+
+
 def test_write_text_writes_chinese_and_emoji_as_exact_utf8_bytes(tmp_path: Path) -> None:
     target = tmp_path / "赛车.html"
     content = "OpenSquilla 体素竞速 🏁"

--- a/tests/test_tools/test_apply_patch_gates.py
+++ b/tests/test_tools/test_apply_patch_gates.py
@@ -274,6 +274,46 @@ async def test_apply_patch_accepts_standard_unified_hunk(tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio
+async def test_apply_patch_rejects_hunk_count_mismatch_without_deleting_omitted_lines(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "config" / "database.yml"
+    target.parent.mkdir()
+    original = (
+        "development:\n"
+        "  adapter: postgresql\n"
+        "  host: localhost\n"
+        "  port: 5432\n"
+        "  database: myapp_dev\n"
+        "  username: devuser\n"
+        "  password: dev_password_123\n"
+    )
+    target.write_text(original, encoding="utf-8")
+    token = current_tool_context.set(ToolContext(workspace_dir=str(tmp_path)))
+    apply_patch = _original_async(patch_tool.apply_patch)
+    try:
+        with pytest.raises(RetryableToolInputError, match="hunk header declares"):
+            await apply_patch(
+                """*** Begin Patch
+*** Update File: config/database.yml
+@@ -1,7 +1,7 @@
+ development:
+   adapter: postgresql
+-  host: localhost
++  host: prod-db.example.com
+   port: 5432
+-  database: myapp_dev
++  database: myapp_prod
+   username: devuser
+*** End Patch"""
+            )
+    finally:
+        current_tool_context.reset(token)
+
+    assert target.read_text(encoding="utf-8") == original
+
+
+@pytest.mark.asyncio
 async def test_apply_patch_accepts_patch_text_from_configured_scratch_file(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_tools/test_bootstrap_write_notifications.py
+++ b/tests/test_tools/test_bootstrap_write_notifications.py
@@ -387,7 +387,9 @@ async def test_edit_file_ambiguous_old_text_is_model_retriable(tmp_path) -> None
         current_tool_context.reset(token)
 
     assert "matches 2 locations" in exc_info.value.user_message
-    assert "unique surrounding context" in exc_info.value.user_message
+    assert "Candidate lines: 1, 2." in exc_info.value.user_message
+    assert "Use read_file around the intended line" in exc_info.value.user_message
+    assert target.read_text(encoding="utf-8") == "flag = True\nflag = True\n"
 
 
 @pytest.mark.asyncio
@@ -656,6 +658,9 @@ def test_edit_file_schema_guides_multi_edit_and_numbered_read_output() -> None:
     assert "read_file without offset or limit" in description
     assert "line-number" in description
     assert "prefer apply_patch" in description
+    assert "multiple candidate lines" in description
+    assert "call read_file with offset/limit" in description
+    assert "Do not retry the same ambiguous old_text" in description
     assert edits["type"] == "array"
     assert "old_text" in edits["items"]["properties"]
     assert "oldText" in edits["items"]["properties"]

--- a/tests/test_tools/test_edit_file_closest_hint.py
+++ b/tests/test_tools/test_edit_file_closest_hint.py
@@ -77,7 +77,35 @@ def test_apply_edit_multi_match_keeps_count_message_without_hint() -> None:
         )
     message = str(exc.value)
     assert "matches 2 locations" in message
+    assert "Candidate lines: 2, 5." in message
     assert "Did you mean" not in message
+
+
+def test_apply_edit_multi_match_can_report_the_same_line_twice() -> None:
+    with pytest.raises(RetryableToolInputError) as exc:
+        _apply_edit_replacements(
+            "value = 1; value = 1\n",
+            [_edit("value = 1", "value = 2")],
+            path="src/a.py",
+        )
+
+    assert "Candidate lines: 1, 1." in str(exc.value)
+
+
+def test_apply_edit_multi_match_limits_candidate_lines_to_twenty() -> None:
+    original = "".join(f"row {index}: repeated\n" for index in range(1, 26))
+    with pytest.raises(RetryableToolInputError) as exc:
+        _apply_edit_replacements(
+            original,
+            [_edit("repeated", "changed")],
+            path="src/a.py",
+        )
+
+    message = str(exc.value)
+    expected_lines = ", ".join(str(index) for index in range(1, 21))
+    assert "matches 25 locations" in message
+    assert f"Candidate lines: {expected_lines}." in message
+    assert "Additional matches omitted: 5" in message
 
 
 def test_hint_is_length_bounded_and_truncates_long_lines() -> None:


### PR DESCRIPTION
## Summary

- report bounded 1-based candidate lines when exact text edits match multiple locations
- reject empty sandbox edit matches before evaluating or writing the file
- reject apply_patch hunks whose declared old/new counts do not match their body

## Why

Ambiguous exact edits previously returned only a match count, forcing blind retries. More importantly, a malformed hunk could declare more old lines than its body contained and remove omitted lines during the splice. This change fails closed before authorization or file writes.

## Validation

- 298 related filesystem, sandbox worker, patch, atomicity, architecture, release, and public-surface tests passed on upstream main at 09b21762a
- Ruff passed for all changed Python files
- Mypy passed for all four changed source modules
- git diff --check passed
- independent review found no remaining issues

## Scope

This PR only changes generic text-edit diagnostics and patch validation. It contains no compaction, tool-search, subagent, delegation, orchestration, provider, media, or vision changes.
