### PR TITLE
feat(provider): support deterministic request seeds

### DIFF
--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -73,6 +73,24 @@ default**:
 API keys follow the same explicit-config-first rule via `api_key` /
 `api_key_env`.
 
+### Sampling seed
+
+Set `llm.seed` in TOML or `OPENSQUILLA_LLM_SEED` in the environment to include
+an integer `seed` in OpenAI-compatible Chat Completions requests:
+
+```toml
+[llm]
+seed = 42
+```
+
+This control is best-effort, not a cross-provider reproducibility guarantee.
+[OpenRouter documents `seed`](https://openrouter.ai/docs/api/api-reference/chat/send-chat-completion-request?explorer=true)
+as optional, while [OpenAI Chat Completions documents it as a deprecated beta](https://platform.openai.com/docs/api-reference/chat/message-list?lang=ruby).
+Provider and model support varies, unsupported endpoints may reject the field,
+and identical parameters can still produce different results after an upstream
+model or serving configuration changes. Leaving the setting unset preserves the
+previous request shape.
+
 ## Onboarding-Verified Providers
 
 This build exposes onboarding support for:

--- a/opensquilla.toml.example
+++ b/opensquilla.toml.example
@@ -104,6 +104,8 @@ model = "deepseek-v4-pro-0813"
 # api_key = ""          # TokenRhythm API key; env TOKENRHYTHM_API_KEY also works
 base_url = "https://tokenrhythm.studio/v1"
 # proxy = ""            # e.g. http://127.0.0.1:7890
+# seed = 42              # optional best-effort deterministic sampling seed;
+#                        # support and repeatability depend on provider/model
 
 # Provider quick reference. Support levels marked compat_mock_verified are
 # verified by local mocked-contract tests, not by live vendor calls.

--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -2265,6 +2265,7 @@ def _classify_provider_attempt(
 def _chat_config_with_thinking_disabled(chat_cfg: ChatConfig) -> ChatConfig:
     return ChatConfig(
         max_tokens=chat_cfg.max_tokens,
+        seed=chat_cfg.seed,
         temperature=chat_cfg.temperature,
         top_p=chat_cfg.top_p,
         system=chat_cfg.system,
@@ -2953,6 +2954,7 @@ class Agent:
             )
         return ChatConfig(
             max_tokens=output_tokens,
+            seed=self.config.seed,
             temperature=self.config.temperature,
             top_p=self.config.top_p,
             system=self.config.system_prompt or "",

--- a/src/opensquilla/engine/turn_runner/agent_bootstrap_stage.py
+++ b/src/opensquilla/engine/turn_runner/agent_bootstrap_stage.py
@@ -240,6 +240,7 @@ class _ResolvedCatalog:
     # default.
     auto_max_tokens: int = 0
     auto_max_tokens_known: bool = False
+    seed: int | None = None
     temperature: float | None = None
     top_p: float | None = None
     # Explicit provider-request proof budget (chars); 0 keeps the derived path.
@@ -914,6 +915,7 @@ class AgentBootstrapStage:
                 else AgentConfig().length_capped_continuations
             ),
             max_tokens=catalog.max_tokens,
+            seed=catalog.seed,
             temperature=catalog.temperature,
             top_p=catalog.top_p,
             context_window_tokens=catalog.context_window,

--- a/src/opensquilla/engine/turn_runner/harness.py
+++ b/src/opensquilla/engine/turn_runner/harness.py
@@ -674,6 +674,7 @@ class _TurnRunnerModelCatalogAdapter(ModelCatalogPort):
             context_window_tokens_global_override=user_context_window,
             auto_max_tokens=auto_max_tokens,
             auto_max_tokens_known=auto_max_tokens_source in {"catalog", "override"},
+            seed=getattr(llm_cfg, "seed", None),
             temperature=getattr(llm_cfg, "temperature", None),
             top_p=getattr(llm_cfg, "top_p", None),
             provider_request_proof_max_chars=user_proof_max_chars,
@@ -791,6 +792,7 @@ class _TurnRunnerModelCatalogAdapter(ModelCatalogPort):
             vision_support=cast(Any, vision_support),
             auto_max_tokens=limits.max_output_tokens,
             auto_max_tokens_known=limits.max_output_tokens_known,
+            seed=getattr(llm_cfg, "seed", None),
             temperature=getattr(llm_cfg, "temperature", None),
             top_p=getattr(llm_cfg, "top_p", None),
             provider_request_proof_max_chars=_positive_int_or_zero(

--- a/src/opensquilla/engine/types.py
+++ b/src/opensquilla/engine/types.py
@@ -681,6 +681,7 @@ class AgentConfig:
     # gate works even on providers/paths that never report real dollars.
     max_turn_cost_usd: float = 0.0
     max_turn_tool_errors: int = 0
+    seed: int | None = None
     temperature: float | None = None
     top_p: float | None = None
     thinking: bool | ThinkingLevel = False

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -432,6 +432,7 @@ class LlmProviderConfig(BaseSettings):
     # reporting for models the catalog does not know (e.g. direct DashScope
     # model ids that never appear in the OpenRouter catalog fetch).
     context_window_tokens: int = 0
+    seed: int | None = None
     temperature: float | None = None
     top_p: float | None = None
     # Optional global thinking level: off|minimal|low|medium|high|xhigh|adaptive.

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -3230,6 +3230,8 @@ class OpenAIProvider:
             payload["usage"] = {"include": True}
         if self._compat.sends_disable_fallbacks:
             payload["disable_fallbacks"] = True
+        if cfg.seed is not None:
+            payload["seed"] = cfg.seed
         if (
             self._compat.anthropic_top_level_cache
             and cfg.cache_mode in {"auto", "on"}

--- a/src/opensquilla/provider/types.py
+++ b/src/opensquilla/provider/types.py
@@ -552,6 +552,7 @@ class ChatConfig(BaseModel):
     """Runtime options for a single chat call."""
 
     max_tokens: int = 16384
+    seed: int | None = None
     temperature: float | None = None
     top_p: float | None = None
     system: str | None = None

--- a/tests/test_engine/test_selector_fallback_routed_model.py
+++ b/tests/test_engine/test_selector_fallback_routed_model.py
@@ -70,6 +70,17 @@ class _SuccessfulProvider:
         yield DoneEvent(model="cheap/fallback")
 
 
+def test_agent_threads_seed_to_primary_provider_chat_config() -> None:
+    agent = Agent(provider=_SuccessfulProvider(), config=AgentConfig(seed=42))
+
+    chat_config = agent._provider_admission_chat_config(
+        "active user",
+        context_window_tokens=agent.config.context_window_tokens,
+    )
+
+    assert chat_config.seed == 42
+
+
 def test_strict_router_chain_fails_closed_for_legacy_selector_hook() -> None:
     class _LegacySelector:
         def __init__(self) -> None:

--- a/tests/test_engine/turn_runner/test_agent_bootstrap_stage_unit.py
+++ b/tests/test_engine/turn_runner/test_agent_bootstrap_stage_unit.py
@@ -882,6 +882,7 @@ async def test_catalog_sampling_controls_thread_to_agent_config() -> None:
             max_tokens=8192,
             context_window=200_000,
             capabilities=None,
+            seed=42,
             temperature=1.0,
             top_p=0.95,
         )
@@ -890,6 +891,7 @@ async def test_catalog_sampling_controls_thread_to_agent_config() -> None:
 
     out = await stage.run(_make_input())
 
+    assert out.output.agent_config.seed == 42
     assert out.output.agent_config.temperature == 1.0
     assert out.output.agent_config.top_p == 0.95
 

--- a/tests/test_engine/turn_runner/test_harness_agent_factory_adapter.py
+++ b/tests/test_engine/turn_runner/test_harness_agent_factory_adapter.py
@@ -98,6 +98,17 @@ def test_model_catalog_adapter_defaults_to_200k_without_override() -> None:
     assert resolved.max_tokens == 32768
 
 
+def test_model_catalog_adapter_threads_request_seed() -> None:
+    from opensquilla.engine.turn_runner.harness import _TurnRunnerModelCatalogAdapter
+
+    llm = SimpleNamespace(max_tokens=32768, seed=42, temperature=None, top_p=None)
+    adapter = _TurnRunnerModelCatalogAdapter(_catalog_runner(llm=llm))
+
+    resolved = adapter.lookup("deepseek/deepseek-v4-pro")
+
+    assert resolved.seed == 42
+
+
 def test_model_catalog_adapter_honors_context_window_tokens_override() -> None:
     from opensquilla.engine.turn_runner.harness import _TurnRunnerModelCatalogAdapter
 

--- a/tests/test_gateway/test_boot_provider_env.py
+++ b/tests/test_gateway/test_boot_provider_env.py
@@ -25,6 +25,14 @@ class _CapturingSelector:
         self.synced = cfg
 
 
+def test_llm_seed_loads_from_environment(monkeypatch) -> None:
+    monkeypatch.setenv("OPENSQUILLA_LLM_SEED", "42")
+
+    cfg = GatewayConfig()
+
+    assert cfg.llm.seed == 42
+
+
 def test_boot_resolves_direct_provider_env_key_and_base_url(
     monkeypatch,
 ) -> None:

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -4622,6 +4622,36 @@ def test_openrouter_still_sends_temperature(monkeypatch: Any) -> None:
     assert captured["payload"]["temperature"] == 0
 
 
+def test_openrouter_sends_seed_when_configured(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="deepseek/deepseek-v4-pro",
+        base_url="https://openrouter.ai/api/v1",
+        provider_kind="openrouter",
+    )
+
+    _collect(provider, ChatConfig(seed=42))
+
+    assert captured["payload"]["seed"] == 42
+
+
+def test_openrouter_omits_seed_by_default(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    _patch_transport(monkeypatch, captured)
+    provider = OpenAIProvider(
+        api_key="test",
+        model="deepseek/deepseek-v4-pro",
+        base_url="https://openrouter.ai/api/v1",
+        provider_kind="openrouter",
+    )
+
+    _collect(provider, ChatConfig())
+
+    assert "seed" not in captured["payload"]
+
+
 def test_openai_payload_omits_top_p_by_default(monkeypatch: Any) -> None:
     captured: dict[str, Any] = {}
     _patch_transport(monkeypatch, captured)

--- a/tests/test_provider_tokenrhythm_v4_wire_policy.py
+++ b/tests/test_provider_tokenrhythm_v4_wire_policy.py
@@ -78,11 +78,13 @@ def _tokenrhythm_caps() -> ModelCapabilities:
 
 def _config(
     *,
+    seed: int | None = None,
     thinking: bool = True,
     thinking_level: ThinkingLevel | None = ThinkingLevel.HIGH,
     tool_choice: Any | None = None,
 ) -> ChatConfig:
     return ChatConfig(
+        seed=seed,
         thinking=thinking,
         thinking_level=thinking_level,
         tool_choice=tool_choice,
@@ -416,7 +418,7 @@ def test_tokenrhythm_v4_unspecified_thinking_keeps_provider_default() -> None:
 
 def test_tokenrhythm_v4_runtime_thinking_fallback_sends_explicit_disabled() -> None:
     fallback_config = _chat_config_with_thinking_disabled(
-        _config(thinking=True, thinking_level=ThinkingLevel.HIGH)
+        _config(seed=42, thinking=True, thinking_level=ThinkingLevel.HIGH)
     )
 
     payload = _payload(
@@ -426,6 +428,7 @@ def test_tokenrhythm_v4_runtime_thinking_fallback_sends_explicit_disabled() -> N
     )
 
     assert payload["thinking"] == {"type": "disabled"}
+    assert payload["seed"] == 42
     assert "reasoning_effort" not in payload
 
 


### PR DESCRIPTION
## Summary

- add optional llm.seed / OPENSQUILLA_LLM_SEED configuration
- preserve the seed through catalog resolution, AgentConfig, ChatConfig, selector fallback, and thinking-disabled retries
- include seed in OpenAI-compatible Chat Completions payloads only when configured
- document provider/model-dependent best-effort determinism

## Behavior

The default remains unchanged: when seed is unset, no seed field is sent. OpenRouter documents seed as an optional Chat Completions field; provider and model support still varies, so configured endpoints may reject it and exact reproducibility is not guaranteed.

## Validation

- 1,097 related config, engine, fallback, provider, and architecture tests passed on upstream main at 09b21762a
- Ruff passed for all changed Python files
- Mypy passed for all seven changed source modules
- git diff --check passed
- independent review found no code blockers; its documentation recommendation was incorporated

## Scope

This PR covers the primary OpenAI-compatible request path. It intentionally does not add seed behavior to compaction, vision auxiliary requests, or subagent configuration.

OpenRouter reference: https://openrouter.ai/docs/api/api-reference/chat/send-chat-completion-request?explorer=true

OpenAI best-effort/deprecated beta note: https://platform.openai.com/docs/api-reference/chat/message-list?lang=ruby
