### PR TITLE
feat(provider): support dated DeepSeek V4 models on OpenRouter

### DIFF
--- a/src/opensquilla/provider/catalog_overrides.toml
+++ b/src/opensquilla/provider/catalog_overrides.toml
@@ -115,6 +115,25 @@ max_output_tokens = 16384
 context_window = 256000
 max_output_tokens = 16384
 
+# Conservative offline metadata for dated DeepSeek V4 model ids. Live
+# OpenRouter catalog data remains authoritative when available. Pricing is
+# intentionally omitted because routed provider prices change independently.
+[openrouter."deepseek/deepseek-v4-flash-0731"]
+context_window = 1310720
+max_output_tokens = 393216
+supports_reasoning = true
+supports_tools = true
+supports_vision = false
+reasoning_format = "openrouter"
+
+[openrouter."deepseek/deepseek-v4-pro-0813"]
+context_window = 1048576
+max_output_tokens = 393216
+supports_reasoning = true
+supports_tools = true
+supports_vision = false
+reasoning_format = "openrouter"
+
 # --- capability ladder migration (transcribed from get_capabilities) ---
 #
 # Rows below carry the per-provider capability ladder that used to live as

--- a/src/opensquilla/provider/compat_policy.py
+++ b/src/opensquilla/provider/compat_policy.py
@@ -88,7 +88,9 @@ _TOKENRHYTHM_V4_LOW_EFFORT_MODEL_IDS = frozenset(
 )
 _OPENROUTER_DSML_MODEL_IDS = (
     "deepseek/deepseek-v4-flash",
+    "deepseek/deepseek-v4-flash-0731",
     "deepseek/deepseek-v4-pro",
+    "deepseek/deepseek-v4-pro-0813",
 )
 
 

--- a/src/opensquilla/session/naming.py
+++ b/src/opensquilla/session/naming.py
@@ -65,8 +65,10 @@ _TOKENRHYTHM_TITLE_MAX_TOKENS = 1024
 _OPENROUTER_REASONING_DEFAULT_MODELS = frozenset(
     {
         "deepseek/deepseek-v4",
+        "deepseek/deepseek-v4-flash-0731",
         "deepseek/deepseek-v4-pro",
         "deepseek/deepseek-v4-pro-20260423",
+        "deepseek/deepseek-v4-pro-0813",
         "z-ai/glm-4.5",
         "z-ai/glm-4.5-air",
         "z-ai/glm-5",

--- a/tests/test_gateway/test_boot_provider_env.py
+++ b/tests/test_gateway/test_boot_provider_env.py
@@ -329,6 +329,8 @@ def test_openrouter_runtime_uses_default_provider_routing() -> None:
     runtime = resolve_llm_runtime_config(cfg)
 
     assert runtime.provider_routing["deepseek/deepseek-v4-flash"] == "deepseek"
+    assert "deepseek/deepseek-v4-flash-0731" not in runtime.provider_routing
+    assert "deepseek/deepseek-v4-pro-0813" not in runtime.provider_routing
     assert runtime.provider_routing["z-ai/glm-5.1"] == "z-ai"
     assert runtime.provider_routing["z-ai/glm-5.2"] == "z-ai"
     assert runtime.provider_routing["anthropic/claude-opus-4.8"] == "anthropic"

--- a/tests/test_provider/test_catalog_layers.py
+++ b/tests/test_provider/test_catalog_layers.py
@@ -67,6 +67,31 @@ def test_cold_instance_synthesizes_unknown_model() -> None:
     assert entry.quality_prior is None
 
 
+@pytest.mark.parametrize(
+    ("model", "context_window", "max_output_tokens"),
+    (
+        ("deepseek/deepseek-v4-flash-0731", 1_310_720, 393_216),
+        ("deepseek/deepseek-v4-pro-0813", 1_048_576, 393_216),
+    ),
+)
+def test_cold_instance_resolves_dated_openrouter_deepseek_models(
+    model: str,
+    context_window: int,
+    max_output_tokens: int,
+) -> None:
+    entry = ModelCatalog().resolve_entry(model, provider="openrouter")
+
+    assert entry.source == "corrections"
+    assert entry.context_window == context_window
+    assert entry.max_output_tokens == max_output_tokens
+    assert entry.supports_reasoning is True
+    assert entry.supports_tools is True
+    assert entry.supports_vision is False
+    assert entry.reasoning_format == "openrouter"
+    assert entry.input_cost_per_mtok is None
+    assert entry.output_cost_per_mtok is None
+
+
 def test_artifact_tool_capability_requires_an_explicit_catalog_fact() -> None:
     catalog = ModelCatalog()
     assert not catalog.tool_capability_is_verified(
@@ -321,6 +346,8 @@ def test_packaged_corrections_file_parses_with_expected_tables() -> None:
     assert set(payload["openrouter"]) == {
         "anthropic/claude-opus-4.8",
         "anthropic/claude-sonnet-4.6",
+        "deepseek/deepseek-v4-flash-0731",
+        "deepseek/deepseek-v4-pro-0813",
         "x-ai/grok-4.3",
         "stepfun/step-3.5-flash",
     }

--- a/tests/test_provider_compat_policy.py
+++ b/tests/test_provider_compat_policy.py
@@ -215,7 +215,9 @@ def test_dsml_policy_names_only_exact_packaged_model_ids() -> None:
         },
         "openrouter": {
             "deepseek/deepseek-v4-flash",
+            "deepseek/deepseek-v4-flash-0731",
             "deepseek/deepseek-v4-pro",
+            "deepseek/deepseek-v4-pro-0813",
         },
     }
 
@@ -254,7 +256,9 @@ def test_dsml_policy_accepts_only_the_configured_provider_model_pair() -> None:
         ("tokenrhythm", "tokenrhythm/deepseek-v4-flash-0731"),
         ("tokenrhythm", "tokenrhythm/deepseek-v4-pro"),
         ("openrouter", "deepseek/deepseek-v4-flash"),
+        ("openrouter", "deepseek/deepseek-v4-flash-0731"),
         ("openrouter", "deepseek/deepseek-v4-pro"),
+        ("openrouter", "deepseek/deepseek-v4-pro-0813"),
     }
 
     for provider_kind, model in allowed:
@@ -274,7 +278,8 @@ def test_dsml_policy_rejects_near_misses_and_wrong_providers() -> None:
         ("tokenrhythm", "deepseek-v4-pro-0813"),
         ("tokenrhythm", "tokenrhythm/deepseek-v4-pro-0813-preview"),
         ("openrouter", "deepseek-v4-flash"),
-        ("openrouter", "deepseek/deepseek-v4-flash-0731"),
+        ("openrouter", "deepseek/deepseek-v4-flash-0731-preview"),
+        ("openrouter", "deepseek/deepseek-v4-pro-0813-preview"),
         ("openrouter", "vendor/deepseek-v4-pro"),
         ("openai", "deepseek-v4-flash"),
         ("dashscope", "deepseek-v4-pro"),

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -10,6 +10,8 @@ import pytest
 import structlog.testing
 
 from opensquilla.engine.types import ThinkingLevel
+from opensquilla.gateway.config import GatewayConfig
+from opensquilla.gateway.llm_runtime import resolve_llm_runtime_config
 from opensquilla.provider.compat_policy import compat_policy_for_kind
 from opensquilla.provider.model_catalog import ModelCatalog
 from opensquilla.provider.openai import (
@@ -6395,6 +6397,56 @@ def test_openrouter_routing_pin_default_keeps_order_with_fallbacks(
         "order": ["deepseek"],
         "allow_fallbacks": True,
     }
+    assert done.stop_reason == "stop"
+
+
+@pytest.mark.parametrize(
+    "model",
+    (
+        "deepseek/deepseek-v4-flash-0731",
+        "deepseek/deepseek-v4-pro-0813",
+    ),
+)
+@pytest.mark.parametrize("strict", (False, True))
+def test_openrouter_dated_deepseek_v4_keeps_provider_selection_unpinned(
+    monkeypatch: Any,
+    model: str,
+    strict: bool,
+) -> None:
+    captured: dict[str, Any] = {}
+    chunks = [
+        {
+            "model": model,
+            "choices": [{"delta": {"content": "ok"}, "finish_reason": None}],
+        },
+        {
+            "model": model,
+            "choices": [{"delta": {}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+        },
+    ]
+    body = b"".join(f"data: {json.dumps(chunk)}\n\n".encode() for chunk in chunks)
+    body += b"data: [DONE]\n\n"
+    _patch_transport_body(monkeypatch, captured, body)
+    if strict:
+        monkeypatch.setenv("OPENSQUILLA_PROVIDER_ROUTING_STRICT", "on")
+    else:
+        monkeypatch.delenv("OPENSQUILLA_PROVIDER_ROUTING_STRICT", raising=False)
+    runtime = resolve_llm_runtime_config(
+        GatewayConfig(llm={"provider": "openrouter", "model": model})
+    )
+    provider = OpenAIProvider(
+        api_key="test",
+        model=model,
+        base_url="https://openrouter.ai/api/v1",
+        provider_kind="openrouter",
+        provider_routing=runtime.provider_routing,
+    )
+
+    done = _collect(provider, ChatConfig(max_tokens=393_216))
+
+    assert "provider" not in captured["payload"]
+    assert captured["payload"]["max_tokens"] == 393_216
     assert done.stop_reason == "stop"
 
 

--- a/tests/test_session/test_naming.py
+++ b/tests/test_session/test_naming.py
@@ -865,8 +865,17 @@ async def test_call_naming_llm_redacts_install_id_from_failure_log(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model",
+    (
+        "deepseek/deepseek-v4-pro",
+        "deepseek/deepseek-v4-flash-0731",
+        "deepseek/deepseek-v4-pro-0813",
+    ),
+)
 async def test_call_naming_llm_disables_openrouter_reasoning_for_reasoning_models(
     monkeypatch,
+    model: str,
 ):
     captured: dict = {}
     monkeypatch.setattr(
@@ -876,7 +885,7 @@ async def test_call_naming_llm_disables_openrouter_reasoning_for_reasoning_model
 
     title = await call_naming_llm(
         "Help me reset my password please",
-        model="deepseek/deepseek-v4-pro",
+        model=model,
         api_key="test-key",
         base_url="https://openrouter.ai/api/v1",
     )


### PR DESCRIPTION
## Summary

- recognize DeepSeek V4 Flash 0731 and V4 Pro 0813 as exact OpenRouter DSML-capable model ids
- leave provider selection unpinned so OpenRouter can choose an endpoint that supports the requested output budget
- disable reasoning for their session-title requests, matching other reasoning-by-default DeepSeek V4 models
- provide conservative offline context/output limits and capability metadata

## Current-source refresh

The original local change also carried static pricing, but those values had already drifted. This PR deliberately omits prices so live OpenRouter data remains authoritative and offline resolution does not override changing routed-provider prices.

The dated models are also deliberately excluded from OpenSquilla's default provider pins. OpenRouter's currently available endpoints and their completion limits differ between the two ids, so a static DeepSeek pin can make strict routing unavailable or filter out the intended endpoint.

Official model pages used for the stable ids and conservative limits:

- https://openrouter.ai/deepseek/deepseek-v4-flash-0731
- https://openrouter.ai/deepseek/deepseek-v4-pro-0813

## Validation

- 1,161 provider, catalog, compatibility, routing, payload, and naming tests passed on upstream main at 09b21762a
- Ruff passed for all changed Python files
- Mypy passed for all changed source modules
- git diff --check passed

## Scope

This PR contains no static pricing, compaction, tool-search, subagent, delegation, orchestration, media, or vision-routing changes.
