### PR TITLE
Discover TokenRhythm models on trusted subdomains

### DIFF
--- a/src/opensquilla/onboarding/probe.py
+++ b/src/opensquilla/onboarding/probe.py
@@ -590,11 +590,23 @@ async def discover_selectable_provider_models(
     ):
         return ProviderModelsDiscoverResult(ok=True, provider_id=provider_id)
 
-    # TokenRhythm has two authoritative sources: its public website catalog
-    # and the authenticated account entitlement list.  The gateway-owned
-    # coordinator supplies TTL/backoff/singleflight/persistence while keeping
-    # this selector policy boundary responsible for the official-host gate.
+    # TokenRhythm's production API has two authoritative sources: its public
+    # website catalog and the authenticated account entitlement list. Keep
+    # that merged, persistent projection scoped to the canonical production
+    # origin. Verified HTTPS subdomains (for example the provider's UAT
+    # service) continue through the generic live-listing path below so their
+    # credentials and model metadata never enter the production coordinator.
+    tokenrhythm_production_catalog = False
     if spec.live_catalog_shape == "tokenrhythm":
+        from opensquilla.provider.tokenrhythm_catalog import (
+            is_official_tokenrhythm_endpoint,
+        )
+
+        tokenrhythm_production_catalog = is_official_tokenrhythm_endpoint(
+            effective_base_url
+        )
+
+    if tokenrhythm_production_catalog:
         default_env_key = spec.env_key if allow_default_api_key_env else ""
         resolved_key, key_source = _resolve_probe_api_key(
             api_key,
@@ -623,6 +635,10 @@ async def discover_selectable_provider_models(
             persist_entitlement=persist_catalog,
             config=catalog_config,
         )
+
+    # The selector-facing host gate above already rejected plain HTTP,
+    # foreign hosts, and lookalike suffixes. Treat an admitted TokenRhythm
+    # non-production origin as its own declared catalog authority.
 
     discovery_provider_id = (
         spec.selectable_model_discovery_provider_id or provider_id

--- a/tests/test_onboarding/test_models_discover.py
+++ b/tests/test_onboarding/test_models_discover.py
@@ -355,30 +355,87 @@ def test_selectable_discovery_accepts_official_subdomains(
     assert calls == [discovery_base_url]
 
 
-def test_tokenrhythm_discovery_accepts_official_subdomains(monkeypatch: Any) -> None:
+def test_tokenrhythm_subdomain_discovery_uses_isolated_live_listing(
+    monkeypatch: Any,
+) -> None:
     from opensquilla.gateway import model_catalog_refresh
 
-    calls: list[str] = []
+    calls: list[dict[str, Any]] = []
 
-    async def _fake_catalog(**kwargs: Any) -> ProviderModelsDiscoverResult:
-        calls.append(kwargs["base_url"])
-        return ProviderModelsDiscoverResult(ok=True, provider_id="tokenrhythm")
+    async def _unexpected_catalog(**_kwargs: Any) -> ProviderModelsDiscoverResult:
+        raise AssertionError("a non-production origin must not enter the catalog coordinator")
+
+    async def _fake_raw(**kwargs: Any) -> ProviderModelsDiscoverResult:
+        calls.append(kwargs)
+        return ProviderModelsDiscoverResult(
+            ok=True,
+            provider_id="tokenrhythm",
+            source="live",
+            models=[{"id": "uat-model"}],
+        )
 
     monkeypatch.setattr(
         model_catalog_refresh,
         "discover_tokenrhythm_models",
-        _fake_catalog,
+        _unexpected_catalog,
         raising=False,
     )
+    monkeypatch.setattr(probe_module, "discover_provider_models", _fake_raw)
 
     result = _discover_selectable(
         provider_id="tokenrhythm",
         api_key="synthetic-key",
-        base_url="https://api.tokenrhythm.studio/v1",
+        base_url="https://uat.tokenrhythm.studio/v1",
+        force_refresh=True,
+        persist_catalog=True,
+        catalog_config=object(),
     )
 
     assert result.ok is True
-    assert calls == ["https://api.tokenrhythm.studio/v1"]
+    assert result.source == "live"
+    assert result.models == [{"id": "uat-model"}]
+    assert calls == [
+        {
+            "provider_id": "tokenrhythm",
+            "api_key": "synthetic-key",
+            "api_key_env": "",
+            "base_url": "https://uat.tokenrhythm.studio/v1",
+            "proxy": "",
+        }
+    ]
+
+
+def test_tokenrhythm_uat_listing_does_not_inherit_production_metadata(
+    monkeypatch: Any,
+) -> None:
+    from opensquilla.gateway import model_catalog_refresh
+
+    async def _unexpected_catalog(**_kwargs: Any) -> ProviderModelsDiscoverResult:
+        raise AssertionError("UAT must not enter the production catalog coordinator")
+
+    monkeypatch.setattr(
+        model_catalog_refresh,
+        "discover_tokenrhythm_models",
+        _unexpected_catalog,
+        raising=False,
+    )
+    seen = _patch_response(monkeypatch, _models_response)
+
+    result = _discover_selectable(
+        provider_id="tokenrhythm",
+        api_key="synthetic-uat-key",
+        base_url="https://uat.tokenrhythm.studio/v1",
+    )
+
+    assert result.ok is True
+    assert result.source == "live"
+    assert [model["id"] for model in result.models] == ["test-model-a"]
+    assert str(seen[0].url) == "https://uat.tokenrhythm.studio/v1/models"
+    assert seen[0].headers["authorization"] == "Bearer synthetic-uat-key"
+    metadata = result.models[0]["metadata"]
+    assert isinstance(metadata, dict)
+    assert metadata["published"] is None
+    assert metadata["declared"] is not None
 
 
 def test_discover_reports_missing_key_without_network(monkeypatch: Any) -> None:


### PR DESCRIPTION
## Scope

- Keep TokenRhythm's canonical production origin on the dual-source catalog coordinator.
- Route verified HTTPS subdomains, including the UAT service, through the isolated live `/models` listing path.
- Add regression coverage for routing, request destination, authorization, and production-metadata isolation.

## Target

`main` from `fix/tokenrhythm-uat-model-discovery`.

## Linked issue

None (internal bug report).

## Release note

Fix TokenRhythm model selection when a provider-owned HTTPS subdomain supplies the API key and model catalog.

## Tests

- `.venv/bin/pytest -q tests/test_onboarding` — 990 passed, 4 skipped.
- `.venv/bin/pytest -q tests/test_onboarding/test_models_discover.py tests/test_provider/test_tokenrhythm_catalog.py tests/test_gateway/test_model_catalog_refresh.py tests/test_provider_tokenrhythm_v4_wire_policy.py` — 266 passed, 1 skipped.
- `.venv/bin/mypy src/opensquilla/onboarding/probe.py --show-error-codes` — passed.
- `.venv/bin/ruff check src/opensquilla/onboarding/probe.py tests/test_onboarding/test_models_discover.py` — passed.

## Safety

- Existing parsed HTTPS host-boundary checks still reject HTTP, foreign hosts, and lookalike suffixes before credential resolution.
- Non-production origins do not enter the production catalog coordinator, persist entitlement snapshots, or inherit production public metadata.
- Tests use synthetic credentials and mocked HTTP; no real UAT request was made.
- The change is platform-neutral.

## Third-party origin

None. The implementation and tests are original to this repository.
