### PR TITLE
fix(ci): prefer Git Bash over Windows launcher aliases

### DIFF
--- a/tests/test_ci/test_workflows.py
+++ b/tests/test_ci/test_workflows.py
@@ -101,9 +101,11 @@ const github = {rest: {
         assert sent == []
 
 
-def _is_windows_wsl_bash(path: str) -> bool:
+def _is_windows_bash_alias(path: str) -> bool:
     normalized = path.replace("\\", "/").lower()
-    return normalized.endswith("/windows/system32/bash.exe")
+    return normalized.endswith(
+        ("/windows/system32/bash.exe", "/microsoft/windowsapps/bash.exe")
+    )
 
 
 def _bash_executable(
@@ -117,20 +119,14 @@ def _bash_executable(
     if os_name != "nt":
         return found or "bash"
 
-    candidates: list[Path] = []
-    if found and not _is_windows_wsl_bash(found):
+    git_root = Path(program_files or os.environ.get("ProgramFiles", r"C:\Program Files")) / "Git"
+    # PATH can resolve a Windows launcher even when Git Bash is installed.
+    candidates = [git_root / "bin" / "bash.exe", git_root / "usr" / "bin" / "bash.exe"]
+    if found:
         candidates.append(Path(found))
 
-    git_root = Path(program_files or os.environ.get("ProgramFiles", r"C:\Program Files")) / "Git"
-    candidates.extend(
-        [
-            git_root / "bin" / "bash.exe",
-            git_root / "usr" / "bin" / "bash.exe",
-        ]
-    )
-
     for candidate in candidates:
-        if exists(candidate):
+        if not _is_windows_bash_alias(str(candidate)) and exists(candidate):
             return str(candidate)
 
     raise AssertionError("Git Bash is required to run CI shell contracts on Windows")
@@ -1147,17 +1143,83 @@ def test_issue_link_sync_tracks_open_and_closed_final_prs_from_trusted_base() ->
     assert ".github/scripts/issue_link_sync.py" in text
 
 
-def test_bash_helper_prefers_git_bash_over_windows_wsl_bash(tmp_path: Path) -> None:
-    git_bash = tmp_path / "Git" / "bin" / "bash.exe"
+@pytest.mark.parametrize(
+    "alias_relative",
+    [
+        "Windows/System32/bash.exe",
+        "Microsoft/WindowsApps/bash.exe",
+        "MICROSOFT/WINDOWSAPPS/BASH.EXE",
+    ],
+)
+@pytest.mark.parametrize("posix_path", [False, True], ids=["native-path", "forward-slashes"])
+def test_bash_helper_prefers_git_bash_over_windows_aliases(
+    tmp_path: Path, alias_relative: str, posix_path: bool,
+) -> None:
+    alias = tmp_path / alias_relative
+    git_bash = tmp_path / "Program Files" / "Git" / "bin" / "bash.exe"
+    for path in (alias, git_bash):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
 
     result = _bash_executable(
         os_name="nt",
-        path_lookup=lambda _name: r"C:\Windows\System32\bash.exe",
-        exists=lambda path: path == git_bash,
-        program_files=str(tmp_path),
+        path_lookup=lambda _name: alias.as_posix() if posix_path else str(alias),
+        program_files=str(tmp_path / "Program Files"),
     )
 
     assert result == str(git_bash)
+
+
+@pytest.mark.parametrize(
+    "git_locations",
+    [("bin/bash.exe",), ("usr/bin/bash.exe",), ("bin/bash.exe", "usr/bin/bash.exe")],
+)
+def test_bash_helper_prefers_installed_git_bash_over_path(
+    tmp_path: Path, git_locations: tuple[str, ...],
+) -> None:
+    path_bash = tmp_path / "custom" / "bash.exe"
+    path_bash.parent.mkdir()
+    path_bash.touch()
+    for relative in git_locations:
+        git_bash = tmp_path / "Git" / relative
+        git_bash.parent.mkdir(parents=True, exist_ok=True)
+        git_bash.touch()
+
+    assert _bash_executable(
+        os_name="nt", path_lookup=lambda _name: str(path_bash), program_files=str(tmp_path),
+    ) == str(tmp_path / "Git" / git_locations[0])
+
+
+def test_bash_helper_keeps_custom_path_fallback(tmp_path: Path) -> None:
+    path_bash = tmp_path / "custom" / "bash.exe"
+    path_bash.parent.mkdir()
+    path_bash.touch()
+
+    assert _bash_executable(
+        os_name="nt", path_lookup=lambda _name: str(path_bash), program_files=str(tmp_path),
+    ) == str(path_bash)
+
+
+@pytest.mark.parametrize(
+    "alias_relative", [None, "Windows/System32/bash.exe", "Microsoft/WindowsApps/bash.exe"],
+)
+def test_bash_helper_requires_non_alias_bash(tmp_path: Path, alias_relative: str | None) -> None:
+    alias = tmp_path / alias_relative if alias_relative else None
+    if alias is not None:
+        alias.parent.mkdir(parents=True)
+        alias.touch()
+
+    with pytest.raises(AssertionError, match="Git Bash is required"):
+        _bash_executable(
+            os_name="nt",
+            path_lookup=lambda _name: str(alias) if alias is not None else None,
+            program_files=str(tmp_path),
+        )
+
+
+@pytest.mark.parametrize("found", [None, "/opt/custom/bash"])
+def test_bash_helper_preserves_posix_lookup(found: str | None) -> None:
+    assert _bash_executable(os_name="posix", path_lookup=lambda _name: found) == (found or "bash")
 
 
 def test_default_ci_uses_layered_job_conditions() -> None:


### PR DESCRIPTION
## Scope

Scope boundary: Fix Windows Bash discovery in `tests/test_ci/test_workflows.py`. When PATH points to a WindowsApps launcher and Git Bash is installed, the helper now selects Git Bash. Standard Git `bin` and `usr/bin` locations precede PATH; WindowsApps and System32 launcher aliases are rejected, while custom PATH installations remain supported.

Non-goals: No runtime, packaging, signature verifier, stderr handling, timeout, retry, or CI assertion changes.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: A deterministic Windows reproduction exposed incorrect test-helper selection with both a WindowsApps launcher placeholder and a Git Bash placeholder present.

## Release Note

Release note: NONE

## Tests

Ruff: `uv run --no-sync ruff check tests/test_ci/test_workflows.py` passed.

Pytest: Native Windows `uv run --no-sync pytest tests/test_ci/test_workflows.py -q --tb=short` — 97 passed. Before the helper fix, the focused regression matrix produced 8 expected failures and 7 passes.

Build: Not needed; this change only affects test shell discovery.

Regression tests: added

Notes: Tests use real temporary files without executing placeholder binaries. Coverage includes launcher coexistence, case and slash variants, Git bin/usr-bin precedence, custom PATH fallback, missing usable Bash, and unchanged POSIX lookup. The full file also exercises actual Git Bash subprocess contracts, including merge-base selection. `git diff --check` passed. Tests remain offline and credential-free.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

Only the test file is included. No credentials, profiles, audit artifacts, or private evidence are committed.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

No documentation changes.
