### PR TITLE
Fix Desktop manual reconnect through runtime-owned connection settings

### DIFF
--- a/opensquilla-webui/src/components/settings/SettingsGatewayPanel.vue
+++ b/opensquilla-webui/src/components/settings/SettingsGatewayPanel.vue
@@ -16,7 +16,7 @@ const { t } = useI18n()
     </div>
 
     <div id="settings-gateway-connection" class="settings-composite" tabindex="-1">
-      <SetupConnectionPanel />
+      <SetupConnectionPanel :managed="isDesktop" />
     </div>
     <div
       v-if="isDesktop"

--- a/opensquilla-webui/src/components/settings/SetupConnectionPanel.test.ts
+++ b/opensquilla-webui/src/components/settings/SetupConnectionPanel.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, reactive, type App } from 'vue'
+import i18n from '@/i18n'
+import {
+  GATEWAY_ACCESS_KEY,
+  type GatewayAccess,
+  type GatewayAvailability,
+} from '@/modules/gatewayAccess'
+import SetupConnectionPanel from './SetupConnectionPanel.vue'
+
+const mounted: App[] = []
+
+afterEach(() => {
+  mounted.splice(0).forEach(app => app.unmount())
+  document.body.innerHTML = ''
+  i18n.global.locale.value = 'en'
+})
+
+async function mountPanel(options: {
+  managed?: boolean
+  availability?: GatewayAvailability
+} = {}) {
+  const gatewayAccess = reactive({
+    availability: options.availability ?? 'unavailable',
+    connectionError: null as string | null,
+    isAvailable: options.availability === 'available',
+    isLocalOwner: false,
+    isAuthenticated: false,
+    canManageProjectWorkspaces: false,
+    canChooseProject: false,
+    runModePolicy: null,
+    streamIdleTimeoutMs: null,
+    concurrentHistoryReads: false,
+    detachedSessionHydration: false,
+    turnCommittedEvents: false,
+    subscriptionEpoch: 0,
+    loadConnectionEndpoint: vi.fn(() => 'ws://saved-gateway.example/ws'),
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(),
+    recoverSubscriptionEpoch: vi.fn(() => false),
+  } satisfies GatewayAccess)
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  i18n.global.locale.value = 'en'
+  const app = createApp(SetupConnectionPanel, { managed: options.managed })
+  app.use(i18n)
+  app.provide(GATEWAY_ACCESS_KEY, gatewayAccess)
+  app.mount(el)
+  mounted.push(app)
+  await nextTick()
+  return { el, gatewayAccess }
+}
+
+function button(el: HTMLElement, label: string): HTMLButtonElement {
+  const found = [...el.querySelectorAll<HTMLButtonElement>('button')]
+    .find(candidate => candidate.textContent?.trim() === label)
+  if (!found) throw new Error(`Missing button: ${label}`)
+  return found
+}
+
+describe('SetupConnectionPanel', () => {
+  it.each([
+    ['unavailable', 'setup.connection.connect'],
+    ['available', 'setup.connection.reconnect'],
+  ] as const)('uses managed connection controls while %s', async (availability, action) => {
+    const { el, gatewayAccess } = await mountPanel({ managed: true, availability })
+
+    expect(el.querySelectorAll('input')).toHaveLength(0)
+    expect(el.textContent).toContain(i18n.global.t('setup.runtime.desc'))
+    expect(gatewayAccess.loadConnectionEndpoint).not.toHaveBeenCalled()
+
+    button(el, i18n.global.t(action)).click()
+    await nextTick()
+
+    expect(gatewayAccess.connect).toHaveBeenCalledExactlyOnceWith({
+      endpoint: '',
+      credential: undefined,
+    })
+    expect(gatewayAccess.disconnect).not.toHaveBeenCalled()
+  })
+
+  it('keeps the default Web form and forwards the trimmed endpoint and credential', async () => {
+    const { el, gatewayAccess } = await mountPanel({ availability: 'available' })
+    const endpoint = el.querySelector<HTMLInputElement>('#conn-ws-url')!
+    const credential = el.querySelector<HTMLInputElement>('#conn-ws-token')!
+    expect(endpoint.value).toBe('ws://saved-gateway.example/ws')
+    expect(credential.type).toBe('password')
+
+    endpoint.value = '  wss://replacement-gateway.example/ws  '
+    endpoint.dispatchEvent(new Event('input'))
+    credential.value = '  synthetic-access-token  '
+    credential.dispatchEvent(new Event('input'))
+    button(el, i18n.global.t('setup.connection.reconnect')).click()
+    await nextTick()
+
+    expect(gatewayAccess.connect).toHaveBeenCalledExactlyOnceWith({
+      endpoint: 'wss://replacement-gateway.example/ws',
+      credential: 'synthetic-access-token',
+    })
+    expect(gatewayAccess.disconnect).not.toHaveBeenCalled()
+  })
+
+  it('keeps the Web credential optional', async () => {
+    const { el, gatewayAccess } = await mountPanel()
+    button(el, i18n.global.t('setup.connection.connect')).click()
+    await nextTick()
+
+    expect(gatewayAccess.connect).toHaveBeenCalledExactlyOnceWith({
+      endpoint: 'ws://saved-gateway.example/ws',
+      credential: undefined,
+    })
+    expect(gatewayAccess.disconnect).not.toHaveBeenCalled()
+  })
+
+  it.each([false, true])('keeps explicit disconnect available with managed=%s', async (managed) => {
+    const { el, gatewayAccess } = await mountPanel({ managed, availability: 'available' })
+    button(el, i18n.global.t('setup.connection.disconnect')).click()
+    await nextTick()
+
+    expect(gatewayAccess.disconnect).toHaveBeenCalledTimes(1)
+    expect(gatewayAccess.connect).not.toHaveBeenCalled()
+  })
+
+  it('shows a failed reconnect attempt while the existing connection remains available', async () => {
+    const { el, gatewayAccess } = await mountPanel({ managed: true, availability: 'available' })
+    gatewayAccess.connectionError = 'Runtime descriptor unavailable'
+    await nextTick()
+
+    expect(el.querySelector('.conn-status__pill')?.textContent)
+      .toBe(i18n.global.t('setup.connection.connected'))
+    expect(el.querySelector('.conn-status__reason')?.textContent)
+      .toBe(i18n.global.t('setup.connection.reasonFailed', {
+        error: 'Runtime descriptor unavailable',
+      }))
+    expect(gatewayAccess.disconnect).not.toHaveBeenCalled()
+  })
+})

--- a/opensquilla-webui/src/components/settings/SetupConnectionPanel.vue
+++ b/opensquilla-webui/src/components/settings/SetupConnectionPanel.vue
@@ -3,6 +3,7 @@ import { computed, inject, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { GATEWAY_ACCESS_KEY } from '@/modules/gatewayAccess'
 
+const props = withDefaults(defineProps<{ managed?: boolean }>(), { managed: false })
 const { t } = useI18n()
 
 // Gateway connection editor. This is the one Settings section that must work
@@ -18,7 +19,7 @@ const wsUrl = ref('')
 const wsToken = ref('')
 
 onMounted(() => {
-  wsUrl.value = gatewayAccess.loadConnectionEndpoint()
+  if (!props.managed) wsUrl.value = gatewayAccess.loadConnectionEndpoint()
 })
 
 const statusState = computed(() => {
@@ -40,18 +41,17 @@ const statusLabel = computed(() => {
 })
 
 const statusReason = computed(() => {
-  if (statusState.value === 'connected') return t('setup.connection.reasonConnected')
-  if (statusState.value === 'connecting') return t('setup.connection.reasonConnecting')
   if (gatewayAccess.connectionError) {
     return t('setup.connection.reasonFailed', { error: gatewayAccess.connectionError })
   }
+  if (statusState.value === 'connected') return t('setup.connection.reasonConnected')
+  if (statusState.value === 'connecting') return t('setup.connection.reasonConnecting')
   return t('setup.connection.reasonDisconnected')
 })
 
 function connect() {
-  const url = wsUrl.value.trim()
-  const token = wsToken.value.trim()
-  gatewayAccess.disconnect()
+  const url = props.managed ? '' : wsUrl.value.trim()
+  const token = props.managed ? '' : wsToken.value.trim()
   void gatewayAccess.connect({ endpoint: url, credential: token || undefined })
 }
 
@@ -64,7 +64,7 @@ function disconnect() {
   <section class="control-section">
     <div class="control-section__head">
       <h3 class="control-section__title">{{ t('setup.connection.title') }}</h3>
-      <p class="control-section__desc">{{ t('setup.connection.desc') }}</p>
+      <p class="control-section__desc">{{ t(managed ? 'setup.runtime.desc' : 'setup.connection.desc') }}</p>
     </div>
 
     <div class="conn-status" :class="statusPillClass" role="status" aria-live="polite">
@@ -72,7 +72,7 @@ function disconnect() {
       <span class="conn-status__reason">{{ statusReason }}</span>
     </div>
 
-    <div class="control-row control-row--stack">
+    <div v-if="!managed" class="control-row control-row--stack">
       <div class="control-row__label-block">
         <label class="control-row__label" for="conn-ws-url">{{ t('setup.connection.wsUrlLabel') }}</label>
         <span class="control-row__desc">{{ t('setup.connection.wsUrlDesc') }} <code>ws://host:port/ws</code></span>
@@ -90,7 +90,7 @@ function disconnect() {
       </div>
     </div>
 
-    <div class="control-row control-row--stack">
+    <div v-if="!managed" class="control-row control-row--stack">
       <div class="control-row__label-block">
         <label class="control-row__label" for="conn-ws-token">{{ t('setup.connection.tokenLabel') }} <span class="conn-optional">{{ t('setup.connection.optional') }}</span></label>
         <span class="control-row__desc">{{ t('setup.connection.tokenDesc') }}</span>

--- a/opensquilla-webui/src/stores/rpc.test.ts
+++ b/opensquilla-webui/src/stores/rpc.test.ts
@@ -3,6 +3,7 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useRpcStore } from './rpc'
+import { createV4GatewayAccess } from '@/adapters/gateway/gatewayAccessV4'
 
 const connectCalls: Array<{ url: string; token?: string }> = []
 const clients: Array<{
@@ -12,6 +13,7 @@ const clients: Array<{
   recoverConnectionGeneration: ReturnType<typeof vi.fn>
   ensureConnected: ReturnType<typeof vi.fn>
   notifyResume: ReturnType<typeof vi.fn>
+  readonly lifecycle: string
   connectionGeneration: number
 }> = []
 
@@ -342,11 +344,22 @@ describe('rpc link-token bootstrap', () => {
     const store = useRpcStore()
     store.init()
     await vi.waitFor(() => expect(connectCalls).toHaveLength(1))
+    const lifecycle = vi.spyOn(clients[0], 'lifecycle', 'get').mockReturnValue('blocked')
+    clients[0].emit('_status', { lifecycle: 'blocked', health: 'suspect', reason: 'authentication_mismatch' })
     clients[0].emit('_blocked', { reason: 'authentication_mismatch' })
     await vi.waitFor(() => expect(getConnection).toHaveBeenCalledTimes(2))
+    expect(store.error).toBe('authentication_mismatch')
+    expect(connectCalls).toHaveLength(1)
     clients[0].emit('_blocked', { reason: 'authentication_mismatch' })
     await Promise.resolve()
     expect(getConnection).toHaveBeenCalledTimes(2)
+    await store.connect('ws://desktop/ws')
+    expect(getConnection).toHaveBeenCalledTimes(3)
+    expect(connectCalls).toEqual([
+      { url: base.wsUrl, token: base.authToken },
+      { url: base.wsUrl, token: base.authToken },
+    ])
+    lifecycle.mockRestore()
     store.$dispose()
   })
 
@@ -376,6 +389,249 @@ describe('rpc link-token bootstrap', () => {
     resolve({ ...base, revision: 2 })
     await vi.advanceTimersByTimeAsync(8_000)
     expect(connectCalls).toHaveLength(1)
+    store.$dispose()
+  })
+
+  it('preserves pending automatic recovery when a manual Desktop lookup also fails', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(1)
+    const payload = {
+      schemaVersion: 1, revision: 1, status: 'ready', instanceId: 'runtime-a',
+      profileFingerprint: 'profile-a', httpUrl: 'http://127.0.0.1:18791',
+      wsUrl: 'ws://127.0.0.1:18791/ws', authToken: 'token-a', error: null,
+    }
+    const getConnection = vi.fn()
+      .mockRejectedValueOnce(new Error('temporary'))
+      .mockRejectedValueOnce(new Error('still unavailable'))
+      .mockResolvedValue(payload)
+    window.opensquillaDesktop = {
+      getGatewayConnection: getConnection,
+      onGatewayConnectionChanged: vi.fn(() => () => {}),
+    } as unknown as OpenSquillaDesktopApi
+    const store = useRpcStore()
+    store.init()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getConnection).toHaveBeenCalledTimes(1)
+    await store.connect('ws://desktop/ws')
+    expect(getConnection).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(getConnection).toHaveBeenCalledTimes(3)
+    expect(connectCalls).toEqual([{ url: payload.wsUrl, token: payload.authToken }])
+    store.disconnect()
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect(getConnection).toHaveBeenCalledTimes(3)
+    store.$dispose()
+  })
+
+  it('reconnects the Desktop through its supervisor instead of browser form settings', async () => {
+    const first = {
+      schemaVersion: 1, revision: 1, status: 'ready', instanceId: 'runtime-a',
+      profileFingerprint: 'profile-a', httpUrl: 'http://127.0.0.1:18791',
+      wsUrl: 'ws://127.0.0.1:18791/ws', authToken: 'token-a', error: null,
+    }
+    const next = { ...first, revision: 2, instanceId: 'runtime-b',
+      wsUrl: 'ws://127.0.0.1:18792/ws', authToken: 'token-b' }
+    const getConnection = vi.fn().mockResolvedValueOnce(first).mockResolvedValue(next)
+    window.opensquillaDesktop = {
+      getGatewayConnection: getConnection,
+      onGatewayConnectionChanged: vi.fn(() => () => {}),
+    } as unknown as OpenSquillaDesktopApi
+    const store = useRpcStore()
+    store.init()
+    await vi.waitFor(() => expect(connectCalls).toHaveLength(1))
+    const access = createV4GatewayAccess(store)
+    access.disconnect()
+    await access.connect({ endpoint: 'ws://desktop/ws', credential: 'stale-form-token' })
+    expect(getConnection).toHaveBeenCalledTimes(2)
+    expect(connectCalls[connectCalls.length - 1]).toEqual({ url: next.wsUrl, token: next.authToken })
+    expect(localStorage.getItem('opensquilla.wsUrl')).toBeNull()
+    expect(sessionStorage.getItem('opensquilla.wsToken')).toBe(next.authToken)
+    store.$dispose()
+  })
+
+  it('keeps a healthy Desktop connection and identity when manual refresh is unchanged or fails', async () => {
+    const payload = {
+      schemaVersion: 1, revision: 1, status: 'ready', instanceId: 'runtime-a',
+      profileFingerprint: 'profile-a', httpUrl: 'http://127.0.0.1:18791',
+      wsUrl: 'ws://127.0.0.1:18791/ws', authToken: 'token-a', error: null,
+    }
+    const getConnection = vi.fn(async () => payload)
+    window.opensquillaDesktop = {
+      getGatewayConnection: getConnection,
+      onGatewayConnectionChanged: vi.fn(() => () => {}),
+    } as unknown as OpenSquillaDesktopApi
+    const store = useRpcStore()
+    store.init()
+    await vi.waitFor(() => expect(connectCalls).toHaveLength(1))
+    clients[0].emit('_hello', { auth: { principal: { isOwner: true } }, policy: { retained: true } })
+    await store.connect('ws://desktop/ws')
+    expect(connectCalls).toHaveLength(1)
+    expect(clients[0].disconnect).not.toHaveBeenCalled()
+    expect(store.isLocalOwner).toBe(true)
+    expect(store.policy).toEqual({ retained: true })
+    getConnection.mockRejectedValueOnce(new Error('IPC temporarily unavailable'))
+    await store.connect('ws://desktop/ws')
+    expect(store.error).toBeTruthy()
+    expect(store.state).toBe('connected')
+    expect(store.isLocalOwner).toBe(true)
+    expect(connectCalls).toHaveLength(1)
+    expect(clients[0].disconnect).not.toHaveBeenCalled()
+    store.$dispose()
+  })
+
+  it('coalesces manual Desktop requests and ignores a cancelled read after a new connection intent', async () => {
+    const payload = {
+      schemaVersion: 1, revision: 1, status: 'ready', instanceId: 'runtime-a',
+      profileFingerprint: 'profile-a', httpUrl: 'http://127.0.0.1:18791',
+      wsUrl: 'ws://127.0.0.1:18791/ws', authToken: 'token-a', error: null,
+    }
+    let resolveOld!: (value: typeof payload) => void
+    let resolveNew!: (value: typeof payload) => void
+    const getConnection = vi.fn()
+      .mockImplementationOnce(() => new Promise(resolve => { resolveOld = resolve }))
+      .mockImplementationOnce(() => new Promise(resolve => { resolveNew = resolve }))
+    window.opensquillaDesktop = {
+      getGatewayConnection: getConnection,
+      onGatewayConnectionChanged: vi.fn(() => () => {}),
+    } as unknown as OpenSquillaDesktopApi
+    const store = useRpcStore()
+    store.init()
+    const pending = store.connect('ws://desktop/ws')
+    const duplicate = store.connect('ws://desktop/ws')
+    await vi.waitFor(() => expect(getConnection).toHaveBeenCalledTimes(1))
+    expect(connectCalls).toHaveLength(0)
+    store.disconnect()
+    const current = store.connect('ws://desktop/ws')
+    await vi.waitFor(() => expect(getConnection).toHaveBeenCalledTimes(2))
+    resolveOld({ ...payload, revision: 99, wsUrl: 'ws://127.0.0.1:19999/ws' })
+    await Promise.all([pending, duplicate])
+    expect(connectCalls).toHaveLength(0)
+    resolveNew(payload)
+    await current
+    expect(connectCalls).toEqual([{ url: payload.wsUrl, token: payload.authToken }])
+    store.$dispose()
+  })
+
+  it('restarts an explicitly disconnected Desktop even when its descriptor is unchanged', async () => {
+    const payload = {
+      schemaVersion: 1, revision: 1, status: 'ready', instanceId: 'runtime-a',
+      profileFingerprint: 'profile-a', httpUrl: 'http://127.0.0.1:18791',
+      wsUrl: 'ws://127.0.0.1:18791/ws', authToken: 'token-a', error: null,
+    }
+    window.opensquillaDesktop = {
+      getGatewayConnection: vi.fn(async () => payload),
+      onGatewayConnectionChanged: vi.fn(() => () => {}),
+    } as unknown as OpenSquillaDesktopApi
+    const store = useRpcStore()
+    store.init()
+    await vi.waitFor(() => expect(connectCalls).toHaveLength(1))
+    store.disconnect()
+    await store.connect('ws://desktop/ws')
+    expect(connectCalls).toEqual([
+      { url: payload.wsUrl, token: payload.authToken },
+      { url: payload.wsUrl, token: payload.authToken },
+    ])
+    expect(store.state).toBe('connected')
+    store.$dispose()
+  })
+
+  it.each([
+    null,
+    { schemaVersion: 0 },
+    { schemaVersion: 1, revision: 2, status: 'ready', instanceId: 'runtime-a' },
+    { schemaVersion: 1, revision: 2, status: 'starting', error: 'Runtime is starting' },
+  ])('preserves the live Desktop connection when manual lookup returns unusable data: %j', async (invalid) => {
+    const payload = {
+      schemaVersion: 1, revision: 1, status: 'ready', instanceId: 'runtime-a',
+      profileFingerprint: 'profile-a', httpUrl: 'http://127.0.0.1:18791',
+      wsUrl: 'ws://127.0.0.1:18791/ws', authToken: 'token-a', error: null,
+    }
+    const getConnection = vi.fn().mockResolvedValueOnce(payload).mockResolvedValueOnce(invalid)
+    window.opensquillaDesktop = {
+      getGatewayConnection: getConnection,
+      onGatewayConnectionChanged: vi.fn(() => () => {}),
+    } as unknown as OpenSquillaDesktopApi
+    const store = useRpcStore()
+    store.init()
+    await vi.waitFor(() => expect(connectCalls).toHaveLength(1))
+    await store.connect('ws://desktop/ws')
+    expect(store.error).toBeTruthy()
+    expect(store.state).toBe('connected')
+    expect(clients[0].disconnect).not.toHaveBeenCalled()
+    expect(connectCalls).toHaveLength(1)
+    store.$dispose()
+  })
+
+  it('bounds a manual Desktop lookup and ignores its late result without discarding the live connection', async () => {
+    vi.useFakeTimers()
+    const payload = {
+      schemaVersion: 1, revision: 1, status: 'ready', instanceId: 'runtime-a',
+      profileFingerprint: 'profile-a', httpUrl: 'http://127.0.0.1:18791',
+      wsUrl: 'ws://127.0.0.1:18791/ws', authToken: 'token-a', error: null,
+    }
+    let resolve!: (value: typeof payload) => void
+    const getConnection = vi.fn().mockResolvedValueOnce(payload)
+      .mockImplementationOnce(() => new Promise(done => { resolve = done }))
+    window.opensquillaDesktop = {
+      getGatewayConnection: getConnection,
+      onGatewayConnectionChanged: vi.fn(() => () => {}),
+    } as unknown as OpenSquillaDesktopApi
+    const store = useRpcStore()
+    store.init()
+    await vi.advanceTimersByTimeAsync(0)
+    const pending = store.connect('ws://desktop/ws')
+    await vi.advanceTimersByTimeAsync(8_000)
+    await pending
+    expect(store.error).toBeTruthy()
+    expect(store.state).toBe('connected')
+    expect(clients[0].disconnect).not.toHaveBeenCalled()
+    resolve({ ...payload, revision: 99, wsUrl: 'ws://127.0.0.1:19999/ws' })
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect(connectCalls).toEqual([{ url: payload.wsUrl, token: payload.authToken }])
+    expect(getConnection).toHaveBeenCalledTimes(2)
+    store.$dispose()
+  })
+
+  it('does not replace a newer Desktop notification with a delayed manual snapshot', async () => {
+    const payload = {
+      schemaVersion: 1, revision: 1, status: 'ready', instanceId: 'runtime-a',
+      profileFingerprint: 'profile-a', httpUrl: 'http://127.0.0.1:18791',
+      wsUrl: 'ws://127.0.0.1:18791/ws', authToken: 'token-a', error: null,
+    }
+    let publish!: (value: typeof payload) => void
+    let resolve!: (value: typeof payload) => void
+    const getConnection = vi.fn().mockResolvedValueOnce(payload)
+      .mockImplementationOnce(() => new Promise(done => { resolve = done }))
+    window.opensquillaDesktop = {
+      getGatewayConnection: getConnection,
+      onGatewayConnectionChanged: vi.fn(callback => { publish = callback; return () => {} }),
+    } as unknown as OpenSquillaDesktopApi
+    const store = useRpcStore()
+    store.init()
+    await vi.waitFor(() => expect(connectCalls).toHaveLength(1))
+    const pending = store.connect('ws://desktop/ws')
+    await vi.waitFor(() => expect(getConnection).toHaveBeenCalledTimes(2))
+    const newest = { ...payload, revision: 3, wsUrl: 'ws://127.0.0.1:18793/ws', authToken: 'token-c' }
+    publish(newest)
+    resolve({ ...payload, revision: 2, wsUrl: 'ws://127.0.0.1:18792/ws', authToken: 'token-b' })
+    await pending
+    expect(connectCalls).toEqual([
+      { url: payload.wsUrl, token: payload.authToken },
+      { url: newest.wsUrl, token: newest.authToken },
+    ])
+    expect(sessionStorage.getItem('opensquilla.wsToken')).toBe(newest.authToken)
+    store.$dispose()
+  })
+
+  it('continues to use explicit endpoint and credentials for browser connections', async () => {
+    const store = useRpcStore()
+    store.init()
+    await store.connect('wss://gateway.example/ws', 'browser-token')
+    expect(connectCalls[connectCalls.length - 1]).toEqual({
+      url: 'wss://gateway.example/ws', token: 'browser-token',
+    })
+    expect(localStorage.getItem('opensquilla.wsUrl')).toBe('wss://gateway.example/ws')
+    expect(sessionStorage.getItem('opensquilla.wsToken')).toBe('browser-token')
     store.$dispose()
   })
 })

--- a/opensquilla-webui/src/stores/rpc.ts
+++ b/opensquilla-webui/src/stores/rpc.ts
@@ -101,7 +101,12 @@ export const useRpcStore = defineStore('rpc', () => {
   let connectionDesired = true
   let authRefreshAttempted = false
   let descriptorTimer: ReturnType<typeof setTimeout> | null = null
-  let descriptorFetch: Promise<void> | null = null
+  let descriptorFetch: {
+    revision: number
+    manual: boolean
+    retry: boolean
+    promise: Promise<void>
+  } | null = null
   let descriptorAttempt = 0
   let descriptorRequestRevision = 0
   const connectionSubscriptions: Array<() => void> = []
@@ -119,12 +124,18 @@ export const useRpcStore = defineStore('rpc', () => {
     descriptorTimer = null
   }
 
-  function refreshDesktopConnection(retry = true): void {
+  function refreshDesktopConnection(retry = true, manual = false): Promise<void> {
     const getConnection = getPlatform().gateway.getConnection
-    if (!connectionDesired || !getConnection || descriptorFetch) return
+    if (!connectionDesired || !getConnection) return Promise.resolve()
+    if (descriptorFetch?.revision === descriptorRequestRevision) {
+      descriptorFetch.manual ||= manual
+      descriptorFetch.retry ||= retry
+      return descriptorFetch.promise
+    }
     const revision = descriptorRequestRevision
+    const request = { revision, manual, retry, promise: Promise.resolve() }
     let timeout: ReturnType<typeof setTimeout> | undefined
-    const request = Promise.race([
+    request.promise = Promise.race([
       Promise.resolve().then(() => getConnection()),
       new Promise<never>((_, reject) => {
         timeout = setTimeout(() => reject(new Error('Gateway descriptor unavailable')), 8_000)
@@ -132,11 +143,11 @@ export const useRpcStore = defineStore('rpc', () => {
     ]).then(payload => {
       if (revision !== descriptorRequestRevision || !connectionDesired) return
       descriptorAttempt = 0
-      applyDesktopConnection(payload)
+      applyDesktopConnection(payload, request.manual)
     }).catch(() => {
       if (revision !== descriptorRequestRevision || !connectionDesired) return
       error.value = 'Gateway connection information is temporarily unavailable'
-      if (retry && descriptorTimer === null) {
+      if (request.retry && descriptorTimer === null) {
         const cap = Math.min(15_000, 500 * 2 ** Math.min(descriptorAttempt++, 10))
         descriptorTimer = setTimeout(() => {
           descriptorTimer = null
@@ -148,6 +159,7 @@ export const useRpcStore = defineStore('rpc', () => {
       if (descriptorFetch === request) descriptorFetch = null
     })
     descriptorFetch = request
+    return request.promise
   }
 
   const isConnected = computed(() => state.value === 'connected')
@@ -176,19 +188,28 @@ export const useRpcStore = defineStore('rpc', () => {
     unavailableMethods.value = new Set()
   }
 
-  function applyDesktopConnection(payload: DesktopGatewayConnection): void {
+  function applyDesktopConnection(payload: DesktopGatewayConnection, manual = false): void {
     if (
       !connectionDesired
       || !payload
       || payload.schemaVersion !== 1
       || !Number.isInteger(payload.revision)
       || payload.revision < desktopConnectionRevision
-    ) return
+    ) {
+      if (manual && connectionDesired && (!payload || payload.schemaVersion !== 1)) {
+        error.value = 'Gateway connection information is temporarily unavailable'
+      }
+      return
+    }
 
     desktopConnectionRevision = payload.revision
     const nextUrl = typeof payload.wsUrl === 'string' ? payload.wsUrl.trim() : ''
     const nextInstance = typeof payload.instanceId === 'string' ? payload.instanceId : ''
     if (payload.status !== 'ready' || !nextUrl || !nextInstance) {
+      if (manual) {
+        error.value = payload.error || 'Gateway is not ready to connect'
+        return
+      }
       desktopConnectionKey = ''
       if (desktopAuthToken) {
         try {
@@ -208,7 +229,11 @@ export const useRpcStore = defineStore('rpc', () => {
       ? payload.authToken.trim()
       : ''
     const nextKey = `${payload.profileFingerprint}\0${nextInstance}\0${nextUrl}`
-    if (nextKey === desktopConnectionKey && nextAuthToken === desktopAuthToken) {
+    const explicitRestart = manual && (
+      client.value?.lifecycle === 'stopped' || client.value?.lifecycle === 'blocked'
+    )
+    if (nextKey === desktopConnectionKey && nextAuthToken === desktopAuthToken && !explicitRestart) {
+      if (client.value?.lifecycle !== 'blocked') error.value = null
       client.value?.ensureConnected()
       return
     }
@@ -291,7 +316,7 @@ export const useRpcStore = defineStore('rpc', () => {
       typeof gatewayPlatform.getConnection === 'function'
       && typeof gatewayPlatform.onConnection === 'function'
     ) {
-      connectionSubscriptions.push(gatewayPlatform.onConnection(applyDesktopConnection))
+      connectionSubscriptions.push(gatewayPlatform.onConnection(payload => applyDesktopConnection(payload)))
       refreshDesktopConnection()
       return
     }
@@ -308,6 +333,19 @@ export const useRpcStore = defineStore('rpc', () => {
     if (!client.value) throw new Error('RPC client not initialized')
     error.value = null
     connectionDesired = true
+    if (getPlatform().id === 'desktop') {
+      // The renderer origin and its form token are not the Desktop runtime's
+      // endpoint or credentials. Keep a working socket until its owner replies.
+      if (!getPlatform().gateway.getConnection) {
+        error.value = 'Gateway connection information is temporarily unavailable'
+        return
+      }
+      const retry = descriptorTimer !== null
+      if (descriptorTimer !== null) clearTimeout(descriptorTimer)
+      descriptorTimer = null
+      await refreshDesktopConnection(retry, true)
+      return
+    }
     cancelDescriptorRecovery()
     saveConnectionSettings(url, token || '')
     client.value.connect(url, token)


### PR DESCRIPTION
## Scope

Desktop Settings → Gateway → Connect/Reconnect used the renderer-derived address and an empty form token after disconnecting a working client. With the custom Desktop origin this attempts `ws://desktop/ws` even though the local gateway is still ready.

Scope boundary: Route Desktop manual connections through the runtime's current connection descriptor, preserve healthy connections while fetching it, and hide the Web-only endpoint/token fields. Coalesce repeated requests, discard cancelled or stale results, allow explicit retries after authentication failure, and preserve automatic descriptor recovery introduced in #1609. Web connections retain explicit endpoint/token controls.

Non-goals: Gateway process restart behavior, protocol changes, or native platform APIs.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Reported in the maintainers' internal issue tracker. This completes the Desktop Settings manual reconnect path alongside #1609.

## Release Note

Release note: Fix Desktop Settings reconnect using an incorrect gateway address or missing credentials while the local gateway is still ready.

## Tests

Ruff: No Python source changes; covered by required CI.

Pytest: Both directly relevant WebUI transport architecture checks passed. Full Python suite not run locally for this WebUI-only change; required CI selects Python unit and architecture checks.

Build: WebUI production build, architecture checks, TypeScript checks, and artifact verification passed.

Regression tests: added

Notes: 161 focused tests passed, including settings controls, runtime controls, store/adapter behavior, and RPC state-machine integration. All 440 frontend test files / 5868 tests passed locally. The original regression assertions failed before the fix. Coverage includes credential/port rotation, blocked authentication, unchanged healthy connections, repeated clicks, descriptor timeout/failure, delayed results after cancellation, and preserving automatic recovery across manual retries.

Production-dist Chromium click-through also passed: Settings → Gateway → Reconnect preserves the healthy socket, Disconnect → Connect restores it, and rotating the runtime port/token selects the new address and credential. No connection used the renderer-derived address and no page errors occurred. This used the real production UI/store/RpcClient with synthetic Desktop IPC and an offline Gateway.

The default test path remains offline, deterministic, credential-free, and safe for forks. The change is shared Vue/TypeScript logic with no platform-specific filesystem/process behavior. Native macOS/Windows/Linux packaged Desktop acceptance has not been performed; test Desktop Settings → Gateway → Connect/Reconnect, including disconnect then reconnect and gateway credential rotation.

## Maintainer Live Check

Maintainer live check: no

Surface: N/A

## Safety

Only source and synthetic regression tests are included. Runtime tokens remain owned by the Desktop bridge; the form cannot replace them. No secrets, runtime data, private issue identifiers, or local artifacts are committed.

## Third-Party Origin

Third-party origin: none

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
