### PR TITLE
Accept inert custom-provider stream epilogues

### DIFF
--- a/src/opensquilla/provider/compat_policy.py
+++ b/src/opensquilla/provider/compat_policy.py
@@ -293,6 +293,12 @@ class OpenAICompatPolicy:
     # validates their location but never treats them as response content.
     post_terminal_metadata_keys: frozenset[str] = frozenset()
 
+    # Some self-hosted OpenAI-compatible servers (notably llama.cpp) emit an
+    # empty ``choices`` frame after the terminal choice and before ``[DONE]``
+    # without a usage trailer.  It carries no response state, so custom local
+    # endpoints may opt into accepting that exact inert frame.
+    allow_post_terminal_empty_choices: bool = False
+
     # Gateway proxies with their own routing (LiteLLM): pin the requested
     # model by disabling the gateway's cross-model fallbacks per request, so
     # SquillaRouter stays the single routing authority.

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -12,7 +12,7 @@ import sys
 from collections import Counter
 from collections.abc import AsyncIterator, Iterator, Mapping
 from copy import deepcopy
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from typing import Any, cast
 from urllib.parse import urlparse
@@ -251,7 +251,7 @@ def _is_inert_post_terminal_stream_frame(
         return False
 
     if not raw_choices:
-        return has_usage
+        return has_usage or policy.allow_post_terminal_empty_choices
     if not policy.allow_post_terminal_noop_choice or len(raw_choices) != 1:
         return False
 
@@ -3166,7 +3166,13 @@ class OpenAIProvider:
         # DashScope or OpenRouter instance to OpenAI, which is exactly what
         # this field exists to prevent.
         self.provider_id = (provider_id or self._provider_kind).strip()
-        self._compat = compat or compat_policy_for_kind(self._provider_kind)
+        compat_policy = compat or compat_policy_for_kind(self._provider_kind)
+        if self.provider_id.lower() == "custom":
+            compat_policy = replace(
+                compat_policy,
+                allow_post_terminal_empty_choices=True,
+            )
+        self._compat = compat_policy
         self._replay_provider_state = replay_provider_state
         self._replay_source = _openai_replay_source(self._provider_kind, self._base_url)
         self._replay_captured_reasoning_content = (

--- a/tests/test_provider_native_response_guards.py
+++ b/tests/test_provider_native_response_guards.py
@@ -804,6 +804,34 @@ def test_openai_stream_post_terminal_empty_choices_must_be_usage_only(
     _assert_not_committed(events, "invalid_stream_order")
 
 
+def test_custom_stream_accepts_llama_cpp_empty_terminal_epilogue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_body(
+        monkeypatch,
+        _sse(
+            {"choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]},
+            {"choices": []},
+        ),
+    )
+
+    events = _collect(
+        OpenAIProvider(
+            api_key="test",
+            model="local-model",
+            base_url="http://127.0.0.1:11436/v1",
+            provider_kind="openai",
+            provider_id="custom",
+        )
+    )
+
+    assert any(isinstance(event, DoneEvent) for event in events)
+    assert not any(
+        isinstance(event, ErrorEvent) and event.code == "invalid_stream_order"
+        for event in events
+    )
+
+
 def test_tokenrhythm_accepts_only_inert_choice_usage_epilogue(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- accept the empty choices epilogue emitted by self-hosted llama.cpp-compatible endpoints
- keep the existing strict post-terminal mutation guard for other providers
- add a regression test for the custom provider path

## Tests
- .venv/bin/pytest -q tests/test_provider_native_response_guards.py tests/test_provider_compat_policy.py tests/test_provider/test_preset_registry.py

Release note: none
Safety: the exception is limited to custom provider streams and accepts only an empty choices frame.