### PR TITLE
Add custom provider extra request body

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -534,6 +534,7 @@
       "tests/test_gateway/test_cron_result_payload.py",
       "tests/test_gateway/test_cron_scheduler_adapter.py",
       "tests/test_gateway/test_cron_scheduler_application.py",
+      "tests/test_gateway/test_custom_extra_body.py",
       "tests/test_gateway/test_debug_file_logging.py",
       "tests/test_gateway/test_desktop_browser.py",
       "tests/test_gateway/test_desktop_ownership.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -595,6 +595,7 @@
     "tests/test_gateway/test_cron_result_payload.py": 0.01,
     "tests/test_gateway/test_cron_scheduler_adapter.py": 0.01,
     "tests/test_gateway/test_cron_scheduler_application.py": 0.01,
+    "tests/test_gateway/test_custom_extra_body.py": 0.01,
     "tests/test_gateway/test_debug_file_logging.py": 0.278,
     "tests/test_gateway/test_desktop_browser.py": 0.01,
     "tests/test_gateway/test_desktop_ownership.py": 0.404,

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -199,6 +199,40 @@ api_key_env = "CUSTOM_ANTHROPIC_API_KEY"
 `custom` appends `/chat/completions` to versioned base URLs and reads
 `CUSTOM_LLM_API_KEY`.
 
+Advanced local deployments may add endpoint-specific JSON fields to every
+OpenAI-compatible chat request by editing `config.toml` directly:
+
+```toml
+[llm]
+provider = "custom"
+model = "local-model"
+base_url = "http://127.0.0.1:8000/v1"
+temperature = 0.7
+top_p = 0.9
+thinking = "high"
+
+[llm.extra_body]
+top_k = 40
+min_p = 0.05
+repetition_penalty = 1.1
+
+[llm.extra_body.chat_template_kwargs]
+enable_thinking = true
+```
+
+`extra_body` is available only on the primary `custom` provider. It is a
+local-file-only advanced setting: the Web UI, environment variables,
+`llm_profiles`, and configuration RPCs neither expose nor modify it. Reload
+the configuration or restart OpenSquilla after editing the file. Standard
+fields such as `temperature`, `top_p`, token limits, tools, streaming, and
+reasoning controls remain owned by their first-class settings and cannot be
+overridden through `extra_body`. Nested objects are sent unchanged, while the
+top-level merge is shallow.
+
+Do not store credentials or other secrets in `extra_body`. Older OpenSquilla
+versions that do not recognize this field may reject the configuration, so
+remove the table before downgrading to such a version.
+
 Unknown custom models keep the conservative 8k context default for upgrade
 compatibility. Declare the endpoint's real window under
 `[models.custom."<model>"]` or
@@ -230,7 +264,8 @@ The current custom-provider boundary is intentionally explicit:
 - custom Anthropic auth is currently optional bearer only (`x-api-key` and
   custom auth modes are not configurable), and custom protocol choices do not
   yet include OpenAI Responses or native Gemini;
-- endpoint-wide `extra_body` / request-transform configuration is not exposed;
+- `custom` supports a guarded local-TOML `extra_body`; arbitrary request
+  transforms and custom headers are not exposed;
 - reasoning dialects are never inferred from an untrusted custom host—set
   provider-scoped model metadata only when the endpoint contract is known.
 

--- a/src/opensquilla/application/app_settings.py
+++ b/src/opensquilla/application/app_settings.py
@@ -61,6 +61,11 @@ _PUBLIC_DERIVED_CONFIG_PATHS = frozenset(
 
 _READONLY_PATHS = frozenset({"auth.token", "auth.password", "config_version"})
 
+# Configuration that belongs exclusively to the local TOML file.  Unlike
+# secrets, these fields are omitted entirely from public reads and must survive
+# a public get/apply round trip without becoming writable through RPC.
+_LOCAL_FILE_ONLY_PATHS = frozenset({"llm.extra_body"})
+
 _READONLY_PATH_SEGMENTS = frozenset(tuple(path.split(".")) for path in _READONLY_PATHS)
 
 _SAFE_WRITE_PATCH_PATHS = frozenset(
@@ -173,6 +178,8 @@ class AppSettings[Config: SettingsConfig, PreparedProvider]:
             raise ValueError("No config available")
         fields: dict[str, EffectiveSetting] = {}
         for path, field in self._runtime.read_effective_fields().items():
+            if _is_local_file_only_path(path):
+                continue
             if any(is_sensitive_config_key(segment) for segment in path.split(".")):
                 continue
             fields[path] = {
@@ -265,6 +272,7 @@ class AppSettings[Config: SettingsConfig, PreparedProvider]:
     async def set(self, path: str, value: SettingsValue) -> SettingsMutation:
         if _path_is_or_contains_readonly(path):
             raise ValueError(f"Path is read-only: {path}")
+        _reject_local_file_only_write({path} | _collect_paths(value, path))
         before = self._before()
         payload = copy.deepcopy(before.payload)
         source = _resolve_path(payload, path)
@@ -276,6 +284,7 @@ class AppSettings[Config: SettingsConfig, PreparedProvider]:
         restored, redacted = _restore_redacted_values(value, source, path)
         _set_path(payload, path, restored)
         payload = _strip_public_derived_config_fields(payload)
+        _reconcile_local_file_only_llm(before.payload, payload)
         explicit = {
             item
             for item in ({path} | _collect_paths(value, path))
@@ -317,6 +326,11 @@ class AppSettings[Config: SettingsConfig, PreparedProvider]:
     async def _mutate(self, patch: SettingsObject, changes: SettingsObject) -> SettingsMutation:
         if not patch and not changes:
             raise ValueError("params.patch or params.patches is required")
+        requested_paths = _collect_paths(patch)
+        for path, value in changes.items():
+            requested_paths.add(path)
+            requested_paths.update(_collect_paths(value, path))
+        _reject_local_file_only_write(requested_paths)
         before = self._before()
         payload = copy.deepcopy(before.payload)
         redacted: set[str] = set()
@@ -348,6 +362,7 @@ class AppSettings[Config: SettingsConfig, PreparedProvider]:
             payload = _deep_merge(payload, patch)
             force.update(_collect_explicit_leaf_paths(patch))
         payload = _strip_public_derived_config_fields(payload)
+        _reconcile_local_file_only_llm(before.payload, payload)
         explicit = set(changes) | _collect_paths(patch)
         for path, value in changes.items():
             explicit.update(_collect_paths(value, path))
@@ -375,10 +390,12 @@ class AppSettings[Config: SettingsConfig, PreparedProvider]:
     async def apply(self, payload: Mapping[str, SettingsValue]) -> SettingsMutation:
         before = self._before(required=False)
         replacement = dict(payload)
+        _reject_changed_local_file_only_apply(before.payload, replacement)
         if before.config is not None and not replacement.get("config_path"):
             replacement["config_path"] = before.config.config_path
         replacement, redacted = _restore_redacted_values(replacement, before.payload)
         replacement = _strip_public_derived_config_fields(replacement)
+        _reconcile_local_file_only_llm(before.payload, replacement)
         candidate = self._candidate(before, replacement, _collect_paths(replacement), redacted)
         return await self._write(before, candidate)
 
@@ -626,6 +643,58 @@ def _path_is_or_contains_readonly(path: str) -> bool:
     """Return whether setting ``path`` could replace a read-only descendant."""
 
     return any(readonly == path or readonly.startswith(f"{path}.") for readonly in _READONLY_PATHS)
+
+
+def _is_local_file_only_path(path: str) -> bool:
+    return any(path == hidden or path.startswith(f"{hidden}.") for hidden in _LOCAL_FILE_ONLY_PATHS)
+
+
+def _reject_local_file_only_write(paths: set[str]) -> None:
+    blocked = sorted(path for path in paths if _is_local_file_only_path(path))
+    if blocked:
+        raise ValueError(f"Path is local-file-only: {blocked[0]}")
+
+
+def _reject_changed_local_file_only_apply(
+    before: Mapping[str, Any],
+    replacement: Mapping[str, Any],
+) -> None:
+    """Allow legacy full dumps only when their hidden value is unchanged."""
+
+    replacement_llm = replacement.get("llm")
+    if not isinstance(replacement_llm, Mapping) or "extra_body" not in replacement_llm:
+        return
+    previous_llm = before.get("llm")
+    previous_value = (
+        previous_llm.get("extra_body", {})
+        if isinstance(previous_llm, Mapping)
+        else {}
+    )
+    if replacement_llm.get("extra_body") != previous_value:
+        raise ValueError("Path is local-file-only: llm.extra_body")
+
+
+def _reconcile_local_file_only_llm(
+    before: Mapping[str, Any],
+    candidate: dict[str, Any],
+) -> None:
+    """Preserve hidden custom settings or clear them on provider switches."""
+
+    previous_llm = before.get("llm")
+    next_llm = candidate.get("llm")
+    if not isinstance(next_llm, dict):
+        return
+    next_provider = str(next_llm.get("provider") or "").strip().lower()
+    previous_provider = (
+        str(previous_llm.get("provider") or "").strip().lower()
+        if isinstance(previous_llm, Mapping)
+        else ""
+    )
+    if next_provider == "custom" and previous_provider == "custom":
+        if isinstance(previous_llm, Mapping) and "extra_body" in previous_llm:
+            next_llm.setdefault("extra_body", copy.deepcopy(previous_llm["extra_body"]))
+        return
+    next_llm.pop("extra_body", None)
 
 
 def _path_segments_is_or_contains_readonly(path: tuple[str, ...]) -> bool:

--- a/src/opensquilla/gateway/adapters/setup_mutations.py
+++ b/src/opensquilla/gateway/adapters/setup_mutations.py
@@ -249,6 +249,7 @@ class GatewaySetupRuntimePort(SetupRuntimePort):
                 base_url=runtime.base_url,
                 proxy=runtime.proxy,
                 provider_routing=runtime.provider_routing,
+                extra_body=runtime.extra_body,
             )
         )
 

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -3261,6 +3261,7 @@ async def build_services(
                     base_url=resolved_base,
                     proxy=proxy,
                     provider_routing=llm_runtime.provider_routing,
+                    extra_body=llm_runtime.extra_body,
                 )
             )
         )

--- a/src/opensquilla/gateway/config.py
+++ b/src/opensquilla/gateway/config.py
@@ -93,6 +93,28 @@ _LEGACY_CONTROL_UI_FRONTEND_WARNING = (
 )
 
 
+class _SettingsSourceWithoutFields(PydanticBaseSettingsSource):
+    """Filter local-TOML-only fields from any external settings source."""
+
+    def __init__(
+        self,
+        inner: PydanticBaseSettingsSource,
+        fields: frozenset[str],
+    ) -> None:
+        super().__init__(inner.settings_cls)
+        self._inner = inner
+        self._fields = fields
+
+    def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
+        return self._inner.get_field_value(field, field_name)
+
+    def __call__(self) -> dict[str, Any]:
+        values = dict(self._inner())
+        for field_name in self._fields:
+            values.pop(field_name, None)
+        return values
+
+
 class ContextOverflowPolicy(StrEnum):
     """What to do when a turn's effective input size exceeds the budget.
 
@@ -458,6 +480,37 @@ class LlmProviderConfig(BaseSettings):
     # send provider.order=[name] so the provider is preferred without disabling
     # OpenRouter fallback.
     provider_routing: dict[str, str] = Field(default_factory=dict)
+    # Advanced local-only extensions for a custom OpenAI-compatible endpoint.
+    # Public configuration surfaces deliberately omit this field.
+    extra_body: dict[str, Any] = Field(default_factory=dict)
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        local_only = frozenset({"extra_body"})
+        return (
+            init_settings,
+            _SettingsSourceWithoutFields(env_settings, local_only),
+            _SettingsSourceWithoutFields(dotenv_settings, local_only),
+            _SettingsSourceWithoutFields(file_secret_settings, local_only),
+        )
+
+    @field_validator("extra_body", mode="before")
+    @classmethod
+    def _validate_extra_body(cls, value: Any) -> dict[str, Any]:
+        from opensquilla.provider.extra_body import normalize_extra_body
+
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            raise ValueError("extra_body must be a TOML table / JSON object")
+        return normalize_extra_body(value)
 
     @model_validator(mode="after")
     def _normalize_direct_deepseek_model(self) -> LlmProviderConfig:
@@ -470,6 +523,12 @@ class LlmProviderConfig(BaseSettings):
         model = str(self.model or "").strip()
         if model in aliases:
             self.model = aliases[model]
+        return self
+
+    @model_validator(mode="after")
+    def _validate_custom_extra_body(self) -> LlmProviderConfig:
+        if self.extra_body and str(self.provider or "").strip().lower() != "custom":
+            raise ValueError("llm.extra_body is supported only when provider='custom'")
         return self
 
 
@@ -2295,7 +2354,8 @@ class _EnvWithoutConfigVersion(PydanticBaseSettingsSource):
     ``OPENSQUILLA_GATEWAY_CONFIG_VERSION`` can never gate or skip migrations.
     The transport-flow kill switch is also applied explicitly below so invalid
     values can fall back to the validated default with a warning instead of
-    failing Gateway construction during Pydantic coercion.
+    failing Gateway construction during Pydantic coercion. ``llm.extra_body``
+    is filtered here because its only supported source is local TOML.
     """
 
     def __init__(self, inner: PydanticBaseSettingsSource) -> None:
@@ -2309,6 +2369,9 @@ class _EnvWithoutConfigVersion(PydanticBaseSettingsSource):
         values = dict(self._inner())
         values.pop("config_version", None)
         values.pop("ws_transport_flow_enabled", None)
+        llm = values.get("llm")
+        if isinstance(llm, dict):
+            llm.pop("extra_body", None)
         return values
 
 
@@ -2804,14 +2867,14 @@ class GatewayConfig(BaseSettings):
         dotenv_settings: PydanticBaseSettingsSource,
         file_secret_settings: PydanticBaseSettingsSource,
     ) -> tuple[PydanticBaseSettingsSource, ...]:
-        # Default source order, with env-backed sources filtered so
+        # Default source order, with external sources filtered so
         # OPENSQUILLA_GATEWAY_CONFIG_VERSION can never populate the migration
         # stamp — see _EnvWithoutConfigVersion for the full rationale.
         return (
             init_settings,
             _EnvWithoutConfigVersion(env_settings),
             _EnvWithoutConfigVersion(dotenv_settings),
-            file_secret_settings,
+            _EnvWithoutConfigVersion(file_secret_settings),
         )
 
     def model_post_init(self, __context: Any) -> None:
@@ -2986,6 +3049,8 @@ class GatewayConfig(BaseSettings):
                 llm.pop("api_key_env", None)
             if not llm.get("api_key"):
                 llm.pop("api_key", None)
+            if not llm.get("extra_body"):
+                llm.pop("extra_body", None)
         llm_profiles = data.get("llm_profiles")
         if isinstance(llm_profiles, dict):
             # Empty credential fields are absence, not a stored credential.
@@ -3050,6 +3115,9 @@ class GatewayConfig(BaseSettings):
     def to_public_dict(self) -> dict[str, Any]:
         """Return a redacted config view safe for public control surfaces."""
         data = cast(dict[str, Any], redact_public_config(self.model_dump()))
+        llm = data.get("llm")
+        if isinstance(llm, dict):
+            llm.pop("extra_body", None)
         ensemble = data.get("llm_ensemble")
         if isinstance(ensemble, dict):
             from opensquilla.gateway.model_routing import (

--- a/src/opensquilla/gateway/llm_runtime.py
+++ b/src/opensquilla/gateway/llm_runtime.py
@@ -7,6 +7,7 @@ import secrets
 import threading
 import time
 from collections.abc import Callable
+from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -45,6 +46,7 @@ class LlmRuntimeConfig:
     api_key_from_env: bool = False
     api_key_env_name: str = ""
     base_url_from_env: bool = False
+    extra_body: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -339,6 +341,11 @@ def resolve_llm_runtime_config(config: Any) -> LlmRuntimeConfig:
         provider_routing=_resolve_provider_routing(
             provider,
             getattr(llm, "provider_routing", {}),
+        ),
+        extra_body=(
+            deepcopy(dict(getattr(llm, "extra_body", {}) or {}))
+            if provider == "custom"
+            else {}
         ),
         api_key_from_env=credential.source == "env",
         api_key_env_name=credential.env_name,

--- a/src/opensquilla/gateway/provider_runtime.py
+++ b/src/opensquilla/gateway/provider_runtime.py
@@ -24,6 +24,7 @@ def resolve_provider_selector_config(config: Any) -> ProviderConfig | None:
         base_url=runtime.base_url,
         proxy=runtime.proxy,
         provider_routing=runtime.provider_routing,
+        extra_body=runtime.extra_body,
     )
 
 

--- a/src/opensquilla/gateway/rpc_config.py
+++ b/src/opensquilla/gateway/rpc_config.py
@@ -15,6 +15,22 @@ if TYPE_CHECKING:
 _d = get_dispatcher()
 
 
+def _public_gateway_config_schema() -> dict[str, Any]:
+    """Return the RPC schema without local-file-only configuration fields."""
+
+    from opensquilla.gateway.config import GatewayConfig
+
+    schema = GatewayConfig.model_json_schema()
+    definitions = schema.get("$defs")
+    if isinstance(definitions, dict):
+        llm_schema = definitions.get("LlmProviderConfig")
+        if isinstance(llm_schema, dict):
+            properties = llm_schema.get("properties")
+            if isinstance(properties, dict):
+                properties.pop("extra_body", None)
+    return schema
+
+
 def _app_settings(
     ctx: RpcContext, *, source: str = "config.patch"
 ) -> AppSettings[GatewayConfig, ProviderConfig | None]:
@@ -105,9 +121,7 @@ async def _handle_config_effective(_params: dict | None, ctx: RpcContext) -> dic
 
 @_d.method("config.schema", scope="operator.admin")
 async def _handle_config_schema(params: dict | None, ctx: RpcContext) -> dict:
-    from opensquilla.gateway.config import GatewayConfig
-
-    schema = GatewayConfig.model_json_schema()
+    schema = _public_gateway_config_schema()
 
     if isinstance(params, dict) and params.get("section"):
         section = params["section"]
@@ -128,9 +142,7 @@ async def _handle_config_schema_lookup(params: dict | None, ctx: RpcContext) -> 
     if not isinstance(params, dict) or "path" not in params:
         raise ValueError("params.path is required")
 
-    from opensquilla.gateway.config import GatewayConfig
-
-    schema = GatewayConfig.model_json_schema()
+    schema = _public_gateway_config_schema()
     path = params["path"]
     parts = path.split(".")
 

--- a/src/opensquilla/provider/extra_body.py
+++ b/src/opensquilla/provider/extra_body.py
@@ -1,0 +1,130 @@
+"""Validation and projection for custom OpenAI-compatible request fields."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping
+from copy import deepcopy
+from typing import Any
+
+type ExtraBodyValue = (
+    None
+    | bool
+    | int
+    | float
+    | str
+    | list["ExtraBodyValue"]
+    | dict[str, "ExtraBodyValue"]
+)
+
+
+# OpenSquilla owns these top-level request fields.  Custom request extensions
+# must never replace conversation, streaming, tool, budget, or reasoning
+# policy selected by the runtime.
+RESERVED_EXTRA_BODY_FIELDS = frozenset(
+    {
+        "cache_control",
+        "disable_fallbacks",
+        "enable_thinking",
+        "max_completion_tokens",
+        "max_output_tokens",
+        "max_tokens",
+        "messages",
+        "model",
+        "parallel_tool_calls",
+        "preserve_thinking",
+        "provider",
+        "reasoning",
+        "reasoning_effort",
+        "response_format",
+        "stop",
+        "stream",
+        "stream_options",
+        "temperature",
+        "thinking",
+        "thinking_budget",
+        "tool_choice",
+        "tool_stream",
+        "tools",
+        "top_p",
+        "usage",
+    }
+)
+
+
+def _normalize_value(value: Any, *, path: str) -> ExtraBodyValue:
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"extra_body value at {path} must be a finite JSON number")
+        return value
+    if isinstance(value, list):
+        return [
+            _normalize_value(item, path=f"{path}[{index}]")
+            for index, item in enumerate(value)
+        ]
+    if isinstance(value, Mapping):
+        result: dict[str, ExtraBodyValue] = {}
+        for key, item in value.items():
+            if not isinstance(key, str) or not key.strip():
+                raise ValueError(f"extra_body object key at {path} must be a non-empty string")
+            result[key] = _normalize_value(item, path=f"{path}.{key}")
+        return result
+    raise ValueError(f"extra_body value at {path} must be JSON-compatible")
+
+
+def normalize_extra_body(value: Mapping[str, Any] | None) -> dict[str, ExtraBodyValue]:
+    """Return an isolated JSON-compatible body after enforcing owned keys."""
+
+    if not value:
+        return {}
+    result: dict[str, ExtraBodyValue] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not key.strip():
+            raise ValueError("extra_body top-level keys must be non-empty strings")
+        normalized_key = key.strip().lower()
+        if normalized_key in RESERVED_EXTRA_BODY_FIELDS:
+            raise ValueError(f"extra_body field is reserved by OpenSquilla: {key}")
+        result[key] = _normalize_value(item, path=f"extra_body.{key}")
+    return result
+
+
+def extra_body_identity(value: Mapping[str, Any] | None) -> str:
+    """Return a stable, key-order-independent deployment identity fragment."""
+
+    normalized = normalize_extra_body(value)
+    return json.dumps(
+        normalized,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def merge_extra_body(
+    payload: dict[str, Any], value: Mapping[str, Any] | None
+) -> dict[str, Any]:
+    """Shallow-merge validated extensions without allowing runtime collisions."""
+
+    normalized = normalize_extra_body(value)
+    if not normalized:
+        return payload
+    payload_keys = {str(key).strip().lower() for key in payload}
+    collisions = sorted(key for key in normalized if key.strip().lower() in payload_keys)
+    if collisions:
+        joined = ", ".join(collisions)
+        raise ValueError(f"extra_body fields conflict with the generated request: {joined}")
+    payload.update(deepcopy(normalized))
+    return payload
+
+
+__all__ = [
+    "ExtraBodyValue",
+    "RESERVED_EXTRA_BODY_FIELDS",
+    "extra_body_identity",
+    "merge_extra_body",
+    "normalize_extra_body",
+]

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -51,6 +51,7 @@ from .error_redaction import (
     redact_upstream_error_text,
     redacted_httpx_error,
 )
+from .extra_body import merge_extra_body, normalize_extra_body
 from .failures import retry_after_from_headers
 from .fx import TOKENRHYTHM_CNY_PER_USD, TOKENRHYTHM_CNY_PER_USD_NANOS
 from .model_catalog import shared_catalog
@@ -3123,6 +3124,7 @@ class OpenAIProvider:
         compat: OpenAICompatPolicy | None = None,
         replay_provider_state: bool = True,
         provider_id: str | None = None,
+        extra_body: Mapping[str, Any] | None = None,
     ) -> None:
         self._api_key = clean_header_secret(api_key, label="LLM API key")
         self._model = model
@@ -3148,6 +3150,9 @@ class OpenAIProvider:
         # DashScope or OpenRouter instance to OpenAI, which is exactly what
         # this field exists to prevent.
         self.provider_id = (provider_id or self._provider_kind).strip()
+        if extra_body and self.provider_id.lower() != "custom":
+            raise ValueError("extra_body is supported only for provider 'custom'")
+        self._extra_body = normalize_extra_body(extra_body)
         compat_policy = compat or compat_policy_for_kind(self._provider_kind)
         if self.provider_id.lower() == "custom":
             compat_policy = replace(
@@ -3564,6 +3569,7 @@ class OpenAIProvider:
             cfg=cfg,
             has_tools=bool(tools),
         )
+        merge_extra_body(payload, self._extra_body)
         fallback_reason = (
             "native_is_error_unavailable"
             if any(message.get("role") == "tool" for message in openai_messages)

--- a/src/opensquilla/provider/selector.py
+++ b/src/opensquilla/provider/selector.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Callable, Mapping, Sequence
+from copy import deepcopy
 from dataclasses import dataclass, field, replace
+from typing import Any
 
 from opensquilla.redaction import redact_error_text
 
@@ -41,6 +43,7 @@ class ProviderConfig:
     # state minted elsewhere (thinking blocks / thought signatures) must not
     # be replayed to a provider that did not produce it.
     replay_provider_state: bool = True
+    extra_body: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -136,14 +139,16 @@ def _exception_status_code(exc: Exception) -> int | None:
 
 
 _ProviderConfigIdentity = tuple[
-    str, str, str, str, str, str, bool, tuple[tuple[str, str], ...]
+    str, str, str, str, str, str, bool, tuple[tuple[str, str], ...], str
 ]
 _CapacityConfigIdentity = tuple[
-    str, str, str, str, str, str, tuple[tuple[str, str], ...]
+    str, str, str, str, str, str, tuple[tuple[str, str], ...], str
 ]
 
 
 def _provider_config_identity(cfg: ProviderConfig) -> _ProviderConfigIdentity:
+    from .extra_body import extra_body_identity
+
     provider_routing = tuple(sorted((str(k), str(v)) for k, v in cfg.provider_routing.items()))
     return (
         cfg.provider,
@@ -154,11 +159,14 @@ def _provider_config_identity(cfg: ProviderConfig) -> _ProviderConfigIdentity:
         cfg.proxy,
         cfg.replay_provider_state,
         provider_routing,
+        extra_body_identity(cfg.extra_body),
     )
 
 
 def _capacity_config_identity(cfg: ProviderConfig) -> _CapacityConfigIdentity:
     """Identity of one physical deployment for capacity-bound failover."""
+
+    from .extra_body import extra_body_identity
 
     provider_routing = tuple(sorted((str(k), str(v)) for k, v in cfg.provider_routing.items()))
     return (
@@ -169,15 +177,26 @@ def _capacity_config_identity(cfg: ProviderConfig) -> _CapacityConfigIdentity:
         cfg.org_id,
         cfg.proxy,
         provider_routing,
+        extra_body_identity(cfg.extra_body),
     )
+
+
+def _copy_provider_config(cfg: ProviderConfig, **changes: Any) -> ProviderConfig:
+    """Copy mutable deployment fields before sharing a config across turns."""
+
+    updates: dict[str, Any] = {
+        "provider_routing": dict(cfg.provider_routing),
+        "extra_body": deepcopy(cfg.extra_body),
+    }
+    updates.update(changes)
+    return replace(cfg, **updates)
 
 
 def _without_provider_state_replay(cfg: ProviderConfig) -> ProviderConfig:
     """Return an isolated config that cannot replay provider-private state."""
 
-    return replace(
+    return _copy_provider_config(
         cfg,
-        provider_routing=dict(cfg.provider_routing),
         replay_provider_state=False,
     )
 
@@ -197,6 +216,8 @@ def _build_provider(cfg: ProviderConfig) -> LLMProvider:
             f"Credential format belongs to provider '{credential_hint}', "
             f"but the configured endpoint belongs to provider '{endpoint_hint}'"
         )
+    if cfg.extra_body and provider_id != "custom":
+        raise ProviderBuildError("extra_body is supported only for provider 'custom'")
     try:
         spec = get_provider_spec(cfg.provider)
     except UnknownProviderError as exc:
@@ -238,6 +259,7 @@ class ProviderBuildContext:
     proxy: str = ""
     provider_routing: Mapping[str, str] = field(default_factory=dict)
     replay_provider_state: bool = True
+    extra_body: Mapping[str, Any] = field(default_factory=dict)
     # OllamaProvider knob; never populated today because ProviderConfig has
     # no num_ctx field — kept visible so the gap is explicit.
     num_ctx: int | None = None
@@ -258,6 +280,7 @@ def _build_context(cfg: ProviderConfig, spec: ProviderSpec) -> ProviderBuildCont
         org_id=cfg.org_id,
         proxy=cfg.proxy,
         provider_routing=dict(cfg.provider_routing),
+        extra_body=deepcopy(cfg.extra_body),
         replay_provider_state=cfg.replay_provider_state,
         auth_header_style=spec.auth_header_style,
         compat=spec.compat,
@@ -307,6 +330,8 @@ def _build_openai_compat(ctx: ProviderBuildContext) -> LLMProvider:
         kwargs["proxy"] = ctx.proxy
     if ctx.provider_routing:
         kwargs["provider_routing"] = ctx.provider_routing
+    if ctx.extra_body:
+        kwargs["extra_body"] = ctx.extra_body
     return OpenAIProvider(**kwargs)
 
 
@@ -585,6 +610,7 @@ class ModelSelector:
         turn's primary. The previous primary is kept as the first fallback so
         pre-content failover still has somewhere to go.
         """
+        cfg = _copy_provider_config(cfg)
         if self._provider_state_replay_disabled:
             cfg = _without_provider_state_replay(cfg)
         original_primary = self._chain[0]
@@ -620,6 +646,7 @@ class ModelSelector:
         first, so this boundary never guesses credentials.
         """
 
+        cfg = _copy_provider_config(cfg)
         if self._provider_state_replay_disabled:
             cfg = _without_provider_state_replay(cfg)
         original_primary = self._chain[0]
@@ -657,10 +684,9 @@ class ModelSelector:
                     elif candidate_provider == original_primary.provider:
                         credential_source = original_primary
                     if credential_source is not None:
-                        candidate = replace(
+                        candidate = _copy_provider_config(
                             credential_source,
                             model=candidate_model,
-                            provider_routing=dict(credential_source.provider_routing),
                         )
             if candidate is None:
                 continue
@@ -709,6 +735,7 @@ class ModelSelector:
                 org_id=self._chain[0].org_id,
                 proxy=self._chain[0].proxy,
                 provider_routing=self._chain[0].provider_routing,
+                extra_body=deepcopy(self._chain[0].extra_body),
                 replay_provider_state=self._chain[0].replay_provider_state,
             )
             fallback_chain = [original_primary, *self._chain[1:]]
@@ -736,10 +763,9 @@ class ModelSelector:
         being sent to the routed provider.
         """
         original = self._config.primary
-        restored = replace(
+        restored = _copy_provider_config(
             original,
             model=model or original.model,
-            provider_routing=dict(original.provider_routing),
         )
         candidates = [*self._config.fallbacks, *self._chain]
         deduped_fallbacks: list[ProviderConfig] = []
@@ -794,10 +820,7 @@ class ModelSelector:
         router_fallbacks: list[ProviderConfig] = []
         for entry in fallback_chain:
             if isinstance(entry, ProviderConfig):
-                candidate = replace(
-                    entry,
-                    provider_routing=dict(entry.provider_routing),
-                )
+                candidate = _copy_provider_config(entry)
                 if not candidate.provider.strip() or not candidate.model.strip():
                     continue
                 if candidate.provider.lower() != current.provider.lower():
@@ -827,6 +850,7 @@ class ModelSelector:
                     org_id=current.org_id,
                     proxy=current.proxy,
                     provider_routing=current.provider_routing,
+                    extra_body=deepcopy(current.extra_body),
                     replay_provider_state=current.replay_provider_state,
                 )
             )
@@ -883,6 +907,7 @@ class ModelSelector:
 
     def sync_primary(self, cfg: ProviderConfig) -> None:
         """Replace the primary provider config for future resolves and clones."""
+        cfg = _copy_provider_config(cfg)
         if self._provider_state_replay_disabled:
             cfg = _without_provider_state_replay(cfg)
         self._config.primary = cfg
@@ -904,13 +929,9 @@ class ModelSelector:
         shared ProviderConfig's provider_routing.
         """
         config_copy = SelectorConfig(
-            primary=replace(
-                self._config.primary,
-                provider_routing=dict(self._config.primary.provider_routing),
-            ),
+            primary=_copy_provider_config(self._config.primary),
             fallbacks=[
-                replace(cfg, provider_routing=dict(cfg.provider_routing))
-                for cfg in self._config.fallbacks
+                _copy_provider_config(cfg) for cfg in self._config.fallbacks
             ],
         )
         cloned = ModelSelector(config_copy, plugin=self._plugin)
@@ -1007,8 +1028,5 @@ def build_provider_from_config(config: ProviderConfig) -> LLMProvider:
     adapter cannot mutate selector-owned configuration through a shared dict.
     """
 
-    isolated = replace(
-        config,
-        provider_routing=dict(config.provider_routing),
-    )
+    isolated = _copy_provider_config(config)
     return _build_provider(isolated)

--- a/tests/test_ci/test_windows_test_shards.py
+++ b/tests/test_ci/test_windows_test_shards.py
@@ -79,6 +79,9 @@ RECENTLY_ADDED_ACTIVE_TESTS = {
     "tests/test_gateway/test_transport_diagnostics.py",
     "tests/test_gateway/test_transport_flow.py",
     "tests/test_gateway/test_websocket_connection_stability.py",
+    # Custom-provider request extensions use the provisional floor until the
+    # next comparable three-run Windows duration refresh.
+    "tests/test_gateway/test_custom_extra_body.py",
     "tests/test_ci/test_windows_signed_update_audit.py",
     # New replay files use the documented provisional floor until a Windows refresh.
     "tests/functional/test_reasoning_replay_persistence_e2e.py",

--- a/tests/test_gateway/test_custom_extra_body.py
+++ b/tests/test_gateway/test_custom_extra_body.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import tomllib
+from datetime import datetime
+from typing import Any
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from opensquilla.gateway.config import GatewayConfig, LlmProviderConfig
+from opensquilla.gateway.llm_runtime import resolve_llm_runtime_config
+from opensquilla.gateway.provider_runtime import resolve_provider_selector_config
+from opensquilla.gateway.rpc import RpcContext
+from opensquilla.gateway.rpc_config import (
+    _handle_config_apply,
+    _handle_config_patch,
+    _handle_config_reload,
+    _handle_config_schema,
+    _handle_config_schema_lookup,
+    _handle_config_set,
+)
+from opensquilla.provider.openai import OpenAIProvider
+from opensquilla.provider.selector import (
+    ModelSelector,
+    ProviderConfig,
+    SelectorConfig,
+    _provider_config_identity,
+    build_provider_from_config,
+)
+from opensquilla.provider.types import ChatConfig, Message
+
+
+def _custom_config(*, config_path: str | None = None) -> GatewayConfig:
+    return GatewayConfig(
+        config_path=config_path,
+        llm={
+            "provider": "custom",
+            "model": "local-model",
+            "base_url": "http://127.0.0.1:8000/v1",
+            "extra_body": {
+                "top_k": 40,
+                "min_p": 0.05,
+                "chat_template_kwargs": {"enable_thinking": True},
+            },
+        },
+    )
+
+
+def _ctx(config: GatewayConfig) -> RpcContext:
+    return RpcContext(conn_id="test", config=config)
+
+
+def _sse_body() -> bytes:
+    chunks = [
+        {
+            "model": "local-model",
+            "choices": [{"delta": {"content": "ok"}, "finish_reason": None}],
+        },
+        {
+            "model": "local-model",
+            "choices": [{"delta": {}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+        },
+    ]
+    return b"".join(
+        f"data: {json.dumps(chunk)}\n\n".encode() for chunk in chunks
+    ) + b"data: [DONE]\n\n"
+
+
+def test_custom_extra_body_loads_from_toml_and_stays_out_of_public_config(tmp_path) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        """
+[llm]
+provider = "custom"
+model = "local-model"
+base_url = "http://127.0.0.1:8000/v1"
+
+[llm.extra_body]
+top_k = 40
+min_p = 0.05
+
+[llm.extra_body.chat_template_kwargs]
+enable_thinking = true
+""".strip(),
+        encoding="utf-8",
+    )
+
+    config = GatewayConfig.load(str(path))
+
+    assert config.llm.extra_body == {
+        "top_k": 40,
+        "min_p": 0.05,
+        "chat_template_kwargs": {"enable_thinking": True},
+    }
+    assert "extra_body" not in config.to_public_dict()["llm"]
+    assert config.to_toml_dict()["llm"]["extra_body"]["top_k"] == 40
+    assert "extra_body" not in GatewayConfig().to_toml_dict()["llm"]
+
+
+@pytest.mark.parametrize(
+    ("provider", "extra_body", "error"),
+    [
+        ("openai", {"top_k": 1}, "only when provider='custom'"),
+        ("custom", {"Temperature": 0.1}, "reserved by OpenSquilla"),
+        ("custom", {"top_k": float("nan")}, "finite JSON number"),
+        ("custom", {"vendor": datetime(2026, 1, 1)}, "JSON-compatible"),
+        ("custom", {" ": 1}, "non-empty strings"),
+    ],
+)
+def test_extra_body_validation_rejects_unsafe_values(
+    provider: str,
+    extra_body: dict[str, Any],
+    error: str,
+) -> None:
+    with pytest.raises(ValidationError, match=error):
+        LlmProviderConfig(provider=provider, extra_body=extra_body)
+
+
+def test_extra_body_environment_inputs_are_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENSQUILLA_LLM_EXTRA_BODY", '{"top_k": 99}')
+    monkeypatch.setenv("OPENSQUILLA_GATEWAY_LLM__EXTRA_BODY", '{"top_k": 98}')
+
+    assert LlmProviderConfig(provider="custom").extra_body == {}
+    assert GatewayConfig().llm.extra_body == {}
+
+
+def test_runtime_and_selector_copy_extra_body_and_use_order_independent_identity() -> None:
+    config = _custom_config()
+    runtime = resolve_llm_runtime_config(config)
+    config.llm.extra_body["chat_template_kwargs"]["enable_thinking"] = False
+
+    assert runtime.extra_body["chat_template_kwargs"]["enable_thinking"] is True
+
+    resolved = resolve_provider_selector_config(_custom_config())
+    assert resolved is not None
+    built = build_provider_from_config(resolved)
+    built_projection = built.project_final_request(
+        [Message(role="user", content="hello")],
+        config=ChatConfig(max_tokens=64),
+    )
+    assert built_projection.payload["top_k"] == 40
+
+    left = ProviderConfig(
+        provider="custom",
+        model="local-model",
+        extra_body={"a": 1, "nested": {"b": 2}},
+    )
+    right = ProviderConfig(
+        provider="custom",
+        model="local-model",
+        extra_body={"nested": {"b": 2}, "a": 1},
+    )
+    assert _provider_config_identity(left) == _provider_config_identity(right)
+
+    selector = ModelSelector(SelectorConfig(primary=left))
+    cloned = selector.clone()
+    selector.current_config.extra_body["nested"]["b"] = 3
+    assert cloned.current_config.extra_body["nested"]["b"] == 2
+
+
+async def test_public_schema_and_lookup_hide_extra_body() -> None:
+    config = _custom_config()
+    response = await _handle_config_schema({}, _ctx(config))
+    llm_properties = response["schema"]["$defs"]["LlmProviderConfig"]["properties"]
+
+    assert "extra_body" not in llm_properties
+    assert "extra_body" not in json.dumps(response)
+    with pytest.raises(KeyError, match="Schema path not found"):
+        await _handle_config_schema_lookup(
+            {"path": "llm.extra_body"},
+            _ctx(config),
+        )
+
+
+async def test_rpc_rejects_extra_body_writes_and_public_apply_preserves_it(tmp_path) -> None:
+    path = tmp_path / "config.toml"
+    config = _custom_config(config_path=str(path))
+
+    with pytest.raises(ValueError, match="local-file-only"):
+        await _handle_config_set(
+            {"path": "llm.extra_body.top_k", "value": 20},
+            _ctx(config),
+        )
+    with pytest.raises(ValueError, match="local-file-only"):
+        await _handle_config_patch(
+            {"patch": {"llm": {"extra_body": {"top_k": 20}}}},
+            _ctx(config),
+        )
+    explicit_apply = config.to_public_dict()
+    explicit_apply["llm"]["extra_body"] = {"top_k": 20}
+    with pytest.raises(ValueError, match="local-file-only"):
+        await _handle_config_apply({"config": explicit_apply}, _ctx(config))
+
+    public_apply = config.to_public_dict()
+    public_apply["naming"]["enabled"] = not config.naming.enabled
+    await _handle_config_apply({"config": public_apply}, _ctx(config))
+
+    assert config.llm.extra_body["top_k"] == 40
+    assert tomllib.loads(path.read_text())["llm"]["extra_body"]["top_k"] == 40
+
+    switch = config.to_public_dict()
+    switch["llm"]["provider"] = "ollama"
+    switch["llm"]["model"] = "local-model"
+    switch["llm"]["base_url"] = "http://127.0.0.1:11434"
+    await _handle_config_apply({"config": switch}, _ctx(config))
+
+    assert config.llm.provider == "ollama"
+    assert config.llm.extra_body == {}
+    assert "extra_body" not in tomllib.loads(path.read_text())["llm"]
+
+
+async def test_config_reload_applies_hand_edited_extra_body_to_live_selector(tmp_path) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        """
+[llm]
+provider = "custom"
+model = "local-model"
+base_url = "http://127.0.0.1:8000/v1"
+
+[llm.extra_body]
+top_k = 20
+""".strip(),
+        encoding="utf-8",
+    )
+    config = _custom_config(config_path=str(path))
+
+    class CapturingSelector:
+        synced: ProviderConfig | None = None
+
+        def sync_primary(self, provider_config: ProviderConfig) -> None:
+            self.synced = provider_config
+
+    selector = CapturingSelector()
+    context = RpcContext(conn_id="test", config=config, provider_selector=selector)
+
+    result = await _handle_config_reload(None, context)
+
+    assert result["ok"] is True
+    assert config.llm.extra_body == {"top_k": 20}
+    assert selector.synced is not None
+    assert selector.synced.extra_body == {"top_k": 20}
+
+
+def test_custom_extra_body_is_in_projection_and_wire_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=_sse_body(),
+        )
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr("opensquilla.provider.openai.httpx.AsyncClient", patched_async_client)
+    configured = {
+        "top_k": 40,
+        "min_p": 0.05,
+        "repetition_penalty": 1.1,
+        "chat_template_kwargs": {"enable_thinking": True},
+    }
+    provider = OpenAIProvider(
+        api_key="synthetic-key",
+        model="local-model",
+        base_url="http://127.0.0.1:8000/v1",
+        provider_kind="openai",
+        provider_id="custom",
+        extra_body=configured,
+    )
+    configured["chat_template_kwargs"]["enable_thinking"] = False
+    messages = [Message(role="user", content="hello")]
+    projection = provider.project_final_request(messages, config=ChatConfig(max_tokens=64))
+
+    assert projection.payload["top_k"] == 40
+    assert projection.payload["chat_template_kwargs"]["enable_thinking"] is True
+
+    async def run() -> None:
+        async for _ in provider.chat(messages, config=ChatConfig(max_tokens=64)):
+            pass
+
+    asyncio.run(run())
+
+    assert captured["payload"]["top_k"] == 40
+    assert captured["payload"]["min_p"] == 0.05
+    assert captured["payload"]["repetition_penalty"] == 1.1
+    assert captured["payload"]["chat_template_kwargs"] == {"enable_thinking": True}
+
+
+def test_extra_body_contributes_to_request_proof_budget() -> None:
+    provider = OpenAIProvider(
+        api_key="synthetic-key",
+        model="local-model",
+        provider_kind="openai",
+        provider_id="custom",
+        extra_body={"vendor_blob": "x" * 5_000},
+    )
+
+    projection = provider.project_final_request(
+        [Message(role="user", content="hello")],
+        config=ChatConfig(max_tokens=64, provider_request_max_chars=500),
+    )
+
+    assert projection.fits is False
+    assert projection.proof["wire_json_chars"] > 5_000
+
+
+def test_programmatic_non_custom_provider_rejects_extra_body() -> None:
+    with pytest.raises(ValueError, match="only for provider 'custom'"):
+        OpenAIProvider(
+            api_key="synthetic-key",
+            model="gpt-test",
+            provider_id="openai",
+            extra_body={"top_k": 40},
+        )

--- a/tests/test_onboarding/test_mutations_keep_current.py
+++ b/tests/test_onboarding/test_mutations_keep_current.py
@@ -124,6 +124,29 @@ def test_upsert_llm_provider_provider_switch_does_not_carry_unrelated_fields():
     assert llm.thinking is None
 
 
+def test_upsert_custom_provider_preserves_extra_body_until_provider_switch():
+    cfg = GatewayConfig(
+        llm={
+            "provider": "custom",
+            "model": "local-model",
+            "base_url": "http://127.0.0.1:8000/v1",
+            "extra_body": {"top_k": 40},
+        }
+    )
+
+    kept = upsert_llm_provider(cfg, provider_id="custom", model="local-model")
+    switched = upsert_llm_provider(
+        kept.config,
+        provider_id="ollama",
+        model="local-model",
+        base_url="http://127.0.0.1:11434",
+        router_action="disable",
+    )
+
+    assert kept.config.llm.extra_body == {"top_k": 40}
+    assert switched.config.llm.extra_body == {}
+
+
 def test_upsert_llm_provider_same_provider_resave_keeps_custom_router_tiers():
     cfg = _config_with_hand_tiers()
 

--- a/tests/test_provider_trace_recorder.py
+++ b/tests/test_provider_trace_recorder.py
@@ -26,7 +26,11 @@ def test_llm_trace_recorder_writes_full_payload_and_redacts_headers(
         stream=True,
     )
     recorder.record_request(
-        payload={"model": "qwen3.6-flash", "messages": [{"role": "user", "content": "hi"}]},
+        payload={
+            "model": "qwen3.6-flash",
+            "messages": [{"role": "user", "content": "hi"}],
+            "vendor_options": {"api_key": "nested-secret"},
+        },
         headers={
             "Authorization": "Bearer secret",
             "Content-Type": "application/json",
@@ -55,6 +59,7 @@ def test_llm_trace_recorder_writes_full_payload_and_redacts_headers(
         "llm.response",
     ]
     assert rows[0]["payload"]["messages"][0]["content"] == "hi"
+    assert rows[0]["payload"]["vendor_options"]["api_key"] == "[REDACTED]"
     assert rows[0]["headers"]["Authorization"] == "[REDACTED]"
     assert rows[0]["headers"]["X-OpenSquilla-Install-Id"] == "[PRESENT]"
     assert rows[0]["headers"]["X-OpenSquilla-Session-Id"] == "[PRESENT]"


### PR DESCRIPTION
## Summary
- add TOML-only llm.extra_body for custom OpenAI-compatible deployments
- validate JSON-compatible nested values and reject reserved request fields
- keep the field out of public config, schemas, profiles, environment sources, and RPC writes
- merge the deep-copied body after compatibility projection and before request tracing/sending

## Tests
- .venv/bin/pytest -q tests/test_gateway/test_custom_extra_body.py tests/test_provider_trace_recorder.py tests/test_onboarding/test_mutations_keep_current.py
- real SmolLM2 135M custom-provider request verified extra_body on the wire

Release note: none
Safety: only provider=custom accepts the field; standard request fields cannot be overridden.