### PR TITLE
fix(compaction): build suffix checkpoints from the current source

### DIFF
--- a/src/opensquilla/engine/agent.py
+++ b/src/opensquilla/engine/agent.py
@@ -219,6 +219,7 @@ from opensquilla.sandbox.elevation import (
 )
 from opensquilla.session.compaction import (
     CompactionConfig,
+    CompactionParentRequest,
     CompactionRequest,
     arm_compaction_deadline,
     build_compaction_config_from_provider,
@@ -2599,6 +2600,8 @@ class Agent:
         # can never arm a gateway keepalive probe.
         self._prompt_cache_keepalive_candidate: PromptCacheKeepaliveCandidate | None = None
         self._prompt_cache_keepalive_capture_enabled = False
+        self._compaction_parent_request: CompactionParentRequest | None = None
+        self._compaction_parent_request_capture_enabled = False
         if self.tool_handler is not None and self._tool_context is not None:
             self.tool_handler = self._bind_tool_handler_context(
                 self.tool_handler,
@@ -5652,6 +5655,16 @@ class Agent:
 
         self._prompt_cache_keepalive_capture_enabled = bool(enabled)
 
+    def compaction_parent_request(self) -> CompactionParentRequest | None:
+        """Return the latest successful physical request captured this turn."""
+
+        return self._compaction_parent_request
+
+    def set_compaction_parent_request_capture_enabled(self, enabled: bool) -> None:
+        """Arm exact request capture only for explicit suffix compaction."""
+
+        self._compaction_parent_request_capture_enabled = bool(enabled)
+
     def _usage_context_for_turn(self) -> UsageExecutionContext:
         """Return the injected execution identity or a safe direct-Agent fallback."""
 
@@ -5760,6 +5773,7 @@ class Agent:
         )
 
         self._prompt_cache_keepalive_candidate = None
+        self._compaction_parent_request = None
 
         image_context_bindings: list[
             tuple[ToolContext, Callable[[], tuple[Any, Any] | None] | None]
@@ -8565,6 +8579,22 @@ class Agent:
                                     continue
                                 provider_done_for_log = raw_ev
                                 _got_done_event = True
+                                if self._compaction_parent_request_capture_enabled:
+                                    try:
+                                        self._compaction_parent_request = (
+                                            CompactionParentRequest.from_call(
+                                                (
+                                                    canonical_request_messages
+                                                    if selector_projects_images
+                                                    else request_messages
+                                                ),
+                                                provider_tools_for_call,
+                                                call_chat_cfg,
+                                            )
+                                        )
+                                    except Exception:
+                                        # Optional capture must never fail a user turn.
+                                        self._compaction_parent_request = None
                                 if keepalive_stable_history and self._session_key:
                                     try:
                                         self._prompt_cache_keepalive_candidate = (
@@ -15700,6 +15730,7 @@ class Agent:
                             call_kind="auxiliary.compaction",
                         )
                     ),
+                    parent_request=self._compaction_parent_request,
                 )
             )
         finally:
@@ -15773,6 +15804,7 @@ class Agent:
                     COMPACTION_TRIGGERED_EVENT,
                 ),
             )
+        self._compaction_parent_request = None
         return CompactionOutcome(
             messages=projected,
             compacted=True,
@@ -15992,6 +16024,7 @@ class Agent:
                 execution_id=uuid.uuid4().hex,
                 call_kind="auxiliary.compaction",
             ),
+            parent_request=self._compaction_parent_request,
         )
         try:
             result = await compact_context(request)
@@ -16045,6 +16078,7 @@ class Agent:
         if verified.actual_wire_messages > target:
             return None, "projection_above_target_after_summary"
 
+        self._compaction_parent_request = None
         return (
             _MessageCountRecoveryOutcome(
                 messages=compacted,
@@ -16815,6 +16849,7 @@ class Agent:
                 execution_id=uuid.uuid4().hex,
                 call_kind="auxiliary.compaction",
             ),
+            parent_request=self._compaction_parent_request,
         )
 
         try:
@@ -17093,6 +17128,7 @@ class Agent:
             kept_start_index,
             summary_present=bool(replay_summary),
         )
+        self._compaction_parent_request = None
         return CompactionOutcome(
             messages=compacted,
             compacted=True,

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -4771,6 +4771,7 @@ class TurnRunner:
         self._usage_event_sink = usage_event_sink
         self._prompt_cache_keepalive_recorder = prompt_cache_keepalive_recorder
         self._prompt_cache_keepalive_armed = prompt_cache_keepalive_armed
+        self._compaction_parent_requests: dict[str, Any] = {}
         # Populated alongside the existing session-id lookup so live usage
         # events retain reset fencing without a second storage round trip.
         self._usage_session_epoch_by_key: dict[str, int] = {}
@@ -5239,6 +5240,43 @@ class TurnRunner:
 
         self._prompt_cache_keepalive_recorder = recorder
         self._prompt_cache_keepalive_armed = armed
+
+    def compaction_parent_request(self, session_key: str) -> Any | None:
+        """Return the latest successful request snapshot for one session."""
+
+        getter = getattr(self._session_manager, "compaction_parent_request", None)
+        if callable(getter):
+            return getter(session_key)
+        return self._compaction_parent_requests.get(session_key)
+
+    def clear_compaction_parent_request(self, session_key: str) -> None:
+        """Discard a snapshot after its transcript has been compacted."""
+
+        clearer = getattr(self._session_manager, "clear_compaction_parent_request", None)
+        if callable(clearer):
+            clearer(session_key)
+        self._compaction_parent_requests.pop(session_key, None)
+
+    def _remember_compaction_parent_request(
+        self,
+        session_key: str,
+        parent_request: Any,
+    ) -> None:
+        remember = getattr(
+            self._session_manager,
+            "remember_compaction_parent_request",
+            None,
+        )
+        if callable(remember):
+            remember(session_key, parent_request)
+            return
+        self._compaction_parent_requests[session_key] = parent_request
+
+    def _suffix_compaction_parent_request(self, session_key: str) -> Any | None:
+        layout = os.environ.get("OPENSQUILLA_COMPACTION_PROMPT_LAYOUT", "prefix")
+        if layout.strip().lower() != "suffix":
+            return None
+        return self.compaction_parent_request(session_key)
 
     @contextlib.asynccontextmanager
     async def _session_write_context(self, session_key: str) -> AsyncIterator[None]:
@@ -6126,6 +6164,26 @@ class TurnRunner:
                     "turn_runner.prompt_cache_keepalive_capture_unavailable",
                     session_key=session_key,
                 )
+            parent_capture_setter = getattr(
+                agent,
+                "set_compaction_parent_request_capture_enabled",
+                None,
+            )
+            if callable(parent_capture_setter):
+                try:
+                    parent_capture_setter(
+                        os.environ.get(
+                            "OPENSQUILLA_COMPACTION_PROMPT_LAYOUT",
+                            "prefix",
+                        ).strip().lower()
+                        == "suffix"
+                    )
+                except Exception:  # noqa: BLE001 - capture cannot fail a turn
+                    log.warning(
+                        "turn_runner.compaction_parent_capture_setup_failed",
+                        session_key=session_key,
+                        exc_info=True,
+                    )
             agent_config = ab_out.agent_config
             # These locals are read by the test_agent_bootstrap_stage_snapshot
             # frame-walking probe. Do not remove.
@@ -6304,6 +6362,12 @@ class TurnRunner:
                                 source=previous_source,
                             )
                         )
+            suffix_compaction_enabled = (
+                os.environ.get("OPENSQUILLA_COMPACTION_PROMPT_LAYOUT", "prefix")
+                .strip()
+                .lower()
+                == "suffix"
+            )
             compaction_plan = resolve_compaction_execution_plan(
                 app_config=self._turn_config(),
                 active_provider=provider,
@@ -6315,6 +6379,8 @@ class TurnRunner:
                 session_key=session_key,
                 credential_pool_acquirer=acquire_profile_credential,
                 credential_pool_failure_reporter=report_profile_credential_failure,
+                active_only=suffix_compaction_enabled,
+                replay_provider_state=suffix_compaction_enabled,
             )
 
             def _refresh_compaction_plan_for_operation() -> Any | None:
@@ -6351,6 +6417,8 @@ class TurnRunner:
                     session_key=session_key,
                     credential_pool_acquirer=acquire_profile_credential,
                     credential_pool_failure_reporter=(report_profile_credential_failure),
+                    active_only=suffix_compaction_enabled,
+                    replay_provider_state=suffix_compaction_enabled,
                 )
 
             stable_consumer_window_tokens = compaction_context_window_tokens
@@ -6779,6 +6847,30 @@ class TurnRunner:
             fin_out = fin_outcome.require_output()
             final_text = fin_out.final_text
             turn_segments = fin_out.turn_segments
+            if fin_out.transcript_appended and not error_message:
+                parent_request_getter = getattr(
+                    agent,
+                    "compaction_parent_request",
+                    None,
+                )
+                try:
+                    parent_request = (
+                        parent_request_getter()
+                        if callable(parent_request_getter)
+                        else None
+                    )
+                except Exception:  # noqa: BLE001 - capture cannot fail a turn
+                    parent_request = None
+                    log.warning(
+                        "turn_runner.compaction_parent_request_failed",
+                        session_key=session_key,
+                        exc_info=True,
+                    )
+                if parent_request is not None:
+                    self._remember_compaction_parent_request(
+                        session_key,
+                        parent_request,
+                    )
             if (
                 fin_out.transcript_appended
                 and not error_message
@@ -12097,6 +12189,12 @@ class TurnRunner:
             if callable(compact_with_result):
                 compact_method = self._session_manager.compact_with_result
                 compact_kwargs: dict[str, Any] = {}
+                parent_request = self._suffix_compaction_parent_request(session_key)
+                if parent_request is not None and _accepts_keyword_arg(
+                    compact_method,
+                    "parent_request",
+                ):
+                    compact_kwargs["parent_request"] = parent_request
                 if _accepts_keyword_arg(compact_method, "compaction_id"):
                     compact_kwargs["compaction_id"] = compaction_id
                 if _accepts_keyword_arg(compact_method, "trigger_reason"):
@@ -12157,6 +12255,12 @@ class TurnRunner:
                 result = getattr(compaction_result, "summary", "") or ""
             else:
                 compact_call_kwargs: dict[str, Any] = {}
+                parent_request = self._suffix_compaction_parent_request(session_key)
+                if parent_request is not None and _accepts_keyword_arg(
+                    self._session_manager.compact,
+                    "parent_request",
+                ):
+                    compact_call_kwargs["parent_request"] = parent_request
                 if (
                     expected_session_id is not None
                     or expected_session_epoch is not None
@@ -12770,6 +12874,12 @@ class TurnRunner:
             if callable(compact_with_result):
                 compact_method = self._session_manager.compact_with_result
                 compact_kwargs: dict[str, Any] = {}
+                parent_request = self._suffix_compaction_parent_request(session_key)
+                if parent_request is not None and _accepts_keyword_arg(
+                    compact_method,
+                    "parent_request",
+                ):
+                    compact_kwargs["parent_request"] = parent_request
                 if _accepts_keyword_arg(compact_method, "compaction_id"):
                     compact_kwargs["compaction_id"] = compaction_id
                 if _accepts_keyword_arg(compact_method, "trigger_reason"):
@@ -12830,6 +12940,12 @@ class TurnRunner:
                 result = getattr(compaction_result, "summary", "") or ""
             else:
                 compact_call_kwargs: dict[str, Any] = {}
+                parent_request = self._suffix_compaction_parent_request(session_key)
+                if parent_request is not None and _accepts_keyword_arg(
+                    self._session_manager.compact,
+                    "parent_request",
+                ):
+                    compact_call_kwargs["parent_request"] = parent_request
                 if (
                     expected_session_id is not None
                     or expected_session_epoch is not None

--- a/src/opensquilla/gateway/adapters/session_maintenance.py
+++ b/src/opensquilla/gateway/adapters/session_maintenance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import os
 import uuid
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
@@ -73,6 +74,7 @@ from opensquilla.provider.types import (
 )
 from opensquilla.session.compaction import (
     CompactionConfig,
+    CompactionParentRequest,
     arm_compaction_deadline,
     await_compaction_phase,
     build_compaction_config_from_provider,
@@ -121,6 +123,7 @@ class _GatewayCompactionPlan:
     config: CompactionConfig
     compaction_correlation: ProviderRequestCorrelation | None
     flush_correlation: ProviderRequestCorrelation | None
+    parent_request: CompactionParentRequest | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -253,7 +256,39 @@ class GatewaySessionMaintenancePorts(
     ) -> SessionCompactionPlan:
         raw_session = session.runtime_value if session is not None else None
         budget = self._consumer_budget(session, requested_tokens)
-        target = resolve_gateway_compaction_target(self._context, raw_session)
+        parent_request: CompactionParentRequest | None = None
+        suffix_enabled = (
+            os.environ.get("OPENSQUILLA_COMPACTION_PROMPT_LAYOUT", "prefix")
+            .strip()
+            .lower()
+            == "suffix"
+        )
+        if suffix_enabled and session is not None:
+            parent_request_getter = getattr(
+                self._context.turn_runner,
+                "compaction_parent_request",
+                None,
+            )
+            if callable(parent_request_getter):
+                try:
+                    parent_request = parent_request_getter(self._session_key(session))
+                except Exception:  # noqa: BLE001 - manual compaction fails closed
+                    log.warning(
+                        "compaction.parent_request_lookup_failed",
+                        session_key=self._session_key(session),
+                        exc_info=True,
+                    )
+        target_kwargs: dict[str, bool] = {}
+        if parent_request is not None:
+            target_kwargs = {
+                "active_only": True,
+                "replay_provider_state": True,
+            }
+        target = resolve_gateway_compaction_target(
+            self._context,
+            raw_session,
+            **target_kwargs,
+        )
         config = build_compaction_config_from_provider(
             target.provider,
             model_override=target.model or effective_session_model(raw_session),
@@ -288,6 +323,7 @@ class GatewaySessionMaintenancePorts(
             config=config,
             compaction_correlation=compaction_correlation,
             flush_correlation=flush_correlation,
+            parent_request=parent_request,
         )
         return SessionCompactionPlan(
             context_window_tokens=budget.context_window_tokens,
@@ -438,6 +474,7 @@ class GatewaySessionMaintenancePorts(
                 "flush_receipt_status": memory.receipt_status,
                 "provider_request_correlation": runtime.compaction_correlation,
                 "context_window_chars": runtime.budget.provider_request_max_chars,
+                "parent_request": runtime.parent_request,
             }
             for name, value in optional.items():
                 if value is not None and _accepts_keyword_arg(compact_with_result, name):
@@ -469,7 +506,7 @@ class GatewaySessionMaintenancePorts(
                 raise SessionCompactionPhaseTimeoutError(exc.phase) from exc
             summary = str(getattr(result, "summary", "") or "")
             removed_count = int(getattr(result, "removed_count", 0) or 0)
-            return SessionCompactionExecutionResult(
+            execution_result = SessionCompactionExecutionResult(
                 applied=bool(
                     summary
                     and (
@@ -502,6 +539,15 @@ class GatewaySessionMaintenancePorts(
                 skip_reason=str(getattr(result, "skip_reason", "") or ""),
                 quality_report=dict(getattr(result, "quality_report", None) or {}),
             )
+            if execution_result.applied and runtime.parent_request is not None:
+                clear_parent_request = getattr(
+                    self._context.turn_runner,
+                    "clear_compaction_parent_request",
+                    None,
+                )
+                if callable(clear_parent_request):
+                    clear_parent_request(command.session_key)
+            return execution_result
 
         try:
             summary = await await_compaction_phase(

--- a/src/opensquilla/gateway/compaction_target.py
+++ b/src/opensquilla/gateway/compaction_target.py
@@ -27,6 +27,7 @@ from opensquilla.provider.selector import ProviderConfig, build_provider_from_co
 from opensquilla.provider.types import ChatConfig, Message
 from opensquilla.session.compaction_deployment import (
     DEFAULT_COMPACTION_OUTPUT_TOKENS,
+    MAX_COMPACTION_LLM_CALLS,
     CompactionExecutionPlan,
     CompactionExecutionTarget,
     build_compaction_execution_plan_from_provider,
@@ -457,6 +458,9 @@ def resolve_selected_compaction_provider(
 def resolve_gateway_compaction_target(
     ctx: object,
     session: object | None,
+    *,
+    active_only: bool = False,
+    replay_provider_state: bool = False,
 ) -> GatewayCompactionTarget:
     """Resolve manual/preflight compaction without mutating selector state.
 
@@ -472,6 +476,10 @@ def resolve_gateway_compaction_target(
     compaction_config = getattr(gateway_config, "compaction", None)
     configured_provider = _text(getattr(compaction_config, "provider", None)).lower()
     configured_model = _text(getattr(compaction_config, "model", None))
+    if active_only:
+        # Exact suffix compaction is tied to the recorded parent deployment.
+        configured_provider = ""
+        configured_model = ""
     auth_profile_override = _text(
         getattr(session, "auth_profile_override", None)
     )
@@ -599,24 +607,25 @@ def resolve_gateway_compaction_target(
             "selector_current",
         )
 
-    # A failed explicit/session/model override must not suppress the current
-    # physical deployment. Use its native model for the recovery candidate.
-    add_candidate(inherited_provider, inherited_model, "selector_current")
-    remaining_chain = getattr(selector, "remaining_chain", None)
-    if callable(remaining_chain):
-        try:
-            remaining_configs = list(remaining_chain())
-        except Exception:  # noqa: BLE001 - optional read-only selector view
-            remaining_configs = []
-        for index, fallback_config in enumerate(remaining_configs):
-            if not isinstance(fallback_config, ProviderConfig):
-                continue
-            add_candidate(
-                _text(fallback_config.provider).lower(),
-                _text(fallback_config.model),
-                "selector_current" if index == 0 else "selector_fallback",
-                provider_config=fallback_config,
-            )
+    if not active_only:
+        # A failed explicit/session/model override must not suppress the current
+        # physical deployment. Use its native model for the recovery candidate.
+        add_candidate(inherited_provider, inherited_model, "selector_current")
+        remaining_chain = getattr(selector, "remaining_chain", None)
+        if callable(remaining_chain):
+            try:
+                remaining_configs = list(remaining_chain())
+            except Exception:  # noqa: BLE001 - optional read-only selector view
+                remaining_configs = []
+            for index, fallback_config in enumerate(remaining_configs):
+                if not isinstance(fallback_config, ProviderConfig):
+                    continue
+                add_candidate(
+                    _text(fallback_config.provider).lower(),
+                    _text(fallback_config.model),
+                    "selector_current" if index == 0 else "selector_fallback",
+                    provider_config=fallback_config,
+                )
 
     if auth_profile_override and auth_profile_bound_provider:
         # A named profile's provider is a credential boundary, not routing
@@ -717,6 +726,7 @@ def resolve_gateway_compaction_target(
                 ctx,
                 named.provider_config,
                 source=named_source,
+                replay_provider_state=replay_provider_state,
             )
         except Exception as exc:  # noqa: BLE001 - a named target cannot fall back
             log.warning(
@@ -733,6 +743,8 @@ def resolve_gateway_compaction_target(
                 source="auth_profile_unresolved",
                 blocked_reason="named_auth_profile_provider_build_failed",
             )
+        if active_only:
+            plan = CompactionExecutionPlan(candidates=(plan.primary,), max_calls=1)
         return GatewayCompactionTarget(
             provider=plan.primary.provider,
             plan=plan,
@@ -755,7 +767,7 @@ def resolve_gateway_compaction_target(
                 candidate.model,
                 inherited_provider_config=inherited,
                 session_key=_text(getattr(session, "session_key", None)),
-                replay_provider_state=False,
+                replay_provider_state=replay_provider_state,
                 credential_pool_acquirer=acquire_profile_credential,
             )
             provider_config = resolution.provider_config
@@ -767,6 +779,7 @@ def resolve_gateway_compaction_target(
                     ctx,
                     provider_config,
                     source=candidate.source,
+                    replay_provider_state=replay_provider_state,
                 )
             except Exception as exc:  # noqa: BLE001
                 log.warning(
@@ -797,7 +810,8 @@ def resolve_gateway_compaction_target(
 
     if resolved_targets:
         plan = CompactionExecutionPlan(
-            candidates=tuple(resolved_targets),
+            candidates=(resolved_targets[0],) if active_only else tuple(resolved_targets),
+            max_calls=1 if active_only else MAX_COMPACTION_LLM_CALLS,
         )
         return GatewayCompactionTarget(
             provider=plan.primary.provider,
@@ -805,6 +819,14 @@ def resolve_gateway_compaction_target(
             provider_id=plan.primary.provider_id,
             model=plan.primary.model,
             source=plan.primary.source,
+        )
+
+    if active_only and candidates:
+        return GatewayCompactionTarget(
+            provider_id=preferred_provider,
+            model=preferred_model,
+            source=preferred_source,
+            blocked_reason="active_compaction_deployment_unavailable",
         )
 
     # Selector-shaped compatibility doubles may not expose a complete current
@@ -1087,6 +1109,7 @@ def _build_plan(
     provider_config: ProviderConfig,
     *,
     source: str,
+    replay_provider_state: bool = False,
 ) -> CompactionExecutionPlan:
     provider_id = _text(provider_config.provider).lower()
     model = _text(provider_config.model)
@@ -1101,6 +1124,7 @@ def _build_plan(
         max_output_tokens=output_tokens,
         provider_request_max_chars=request_max_chars,
         source=source,
+        replay_provider_state=replay_provider_state,
     )
 
 

--- a/src/opensquilla/session/compaction.py
+++ b/src/opensquilla/session/compaction.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import inspect
 import json
+import os
 import time
 import uuid
 from collections.abc import Awaitable, Callable, Mapping, Sequence
@@ -33,6 +34,7 @@ from opensquilla.provider.types import (
     Message,
     ReasoningDeltaEvent,
     TextDeltaEvent,
+    ToolDefinition,
     derive_provider_request_correlation,
 )
 from opensquilla.redaction import redact_error_text
@@ -129,6 +131,32 @@ class CompactionConfig:
     protect_semantic_tail: bool = True
 
 
+@dataclass(frozen=True, slots=True)
+class CompactionParentRequest:
+    """Runtime-only snapshot of one successful physical provider request."""
+
+    messages: tuple[Message, ...] = field(repr=False)
+    tools: tuple[ToolDefinition, ...] | None = field(repr=False)
+    chat_config: ChatConfig = field(repr=False, compare=False)
+
+    @classmethod
+    def from_call(
+        cls,
+        messages: Sequence[Message],
+        tools: Sequence[ToolDefinition] | None,
+        chat_config: ChatConfig,
+    ) -> CompactionParentRequest:
+        return cls(
+            messages=tuple(message.model_copy(deep=True) for message in messages),
+            tools=(
+                tuple(tool.model_copy(deep=True) for tool in tools)
+                if tools is not None
+                else None
+            ),
+            chat_config=chat_config.model_copy(deep=True),
+        )
+
+
 @dataclass
 class CompactionRequest:
     session_id: str
@@ -168,6 +196,12 @@ class CompactionRequest:
     # Additive runtime provenance. Kept at the end so legacy positional
     # construction retains the original public field ordering.
     context_window_source: str = "consumer_capacity"
+    # Exact provider-call snapshot; never persisted or included in repr.
+    parent_request: CompactionParentRequest | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
 
 
 @dataclass
@@ -1551,6 +1585,16 @@ def _normalize_custom_instructions(custom_instructions: str | None) -> str:
     return normalized
 
 
+def _compaction_prompt_layout() -> str:
+    layout = os.environ.get("OPENSQUILLA_COMPACTION_PROMPT_LAYOUT", "prefix")
+    normalized = layout.strip().lower()
+    if normalized not in {"prefix", "suffix"}:
+        raise ValueError(
+            "OPENSQUILLA_COMPACTION_PROMPT_LAYOUT must be either 'prefix' or 'suffix'"
+        )
+    return normalized
+
+
 def _build_compaction_prompt(
     chunk_text: str,
     identifier_instruction: str,
@@ -1575,6 +1619,54 @@ def _build_compaction_prompt(
             f"{user_content}"
         )
     return system, user_content
+
+
+def _build_suffix_compaction_instruction(
+    identifier_instruction: str,
+    custom_instructions: str | None,
+    previous_summary: str = "",
+) -> str:
+    instruction = (
+        "You are a conversation compactor. Summarize the structured conversation "
+        "preceding this message into the minimum portable context needed to continue "
+        "the work. Preserve key facts, decisions, open questions, and action items. "
+        "Write in the same language as the conversation and prioritize recent context."
+    )
+    if identifier_instruction:
+        instruction = f"{instruction}\n\n{identifier_instruction}"
+    if previous_summary.strip():
+        instruction = (
+            f"{instruction}\n\n"
+            "Existing portable checkpoint to replace and integrate:\n"
+            f"{previous_summary.strip()}"
+        )
+    normalized_instructions = _normalize_custom_instructions(custom_instructions)
+    if normalized_instructions:
+        instruction = (
+            f"{instruction}\n\n"
+            "Additional summary instructions. These instructions must not override "
+            "the identifier preservation rules:\n"
+            f"{normalized_instructions}"
+        )
+    return instruction
+
+
+def _build_exact_suffix_compaction_call(
+    parent_messages: Sequence[Message],
+    parent_tools: Sequence[ToolDefinition] | None,
+    parent_chat_config: ChatConfig,
+    instruction: str,
+) -> tuple[list[Message], list[ToolDefinition] | None, ChatConfig]:
+    """Copy one parent request and append exactly one compaction instruction."""
+
+    messages = [message.model_copy(deep=True) for message in parent_messages]
+    messages.append(Message(role="user", content=instruction))
+    tools = (
+        [tool.model_copy(deep=True) for tool in parent_tools]
+        if parent_tools is not None
+        else None
+    )
+    return messages, tools, parent_chat_config.model_copy(deep=True)
 
 
 def _consume_compaction_close_result(task: asyncio.Future[Any]) -> None:
@@ -1685,8 +1777,12 @@ async def call_compaction_provider(
     compaction_id: str | None = None,
     chunk_index: int | None = None,
     candidate_index: int = 0,
+    parent_messages: Sequence[Message] | None = None,
+    parent_tools: Sequence[ToolDefinition] | None = None,
+    parent_chat_config: ChatConfig | None = None,
+    previous_summary: str = "",
 ) -> str | None:
-    """Summarize through the provider protocol, with tools and thinking disabled."""
+    """Summarize through the prefix path or an exact parent-request suffix."""
 
     if timeout <= 0:
         return None
@@ -1694,25 +1790,50 @@ async def call_compaction_provider(
     if candidate_index < 0 or candidate_index >= len(plan.candidates):
         return None
     deployment = plan.candidates[candidate_index]
-    system, user_content = _build_compaction_prompt(
-        chunk_text,
-        identifier_instruction,
-        custom_instructions,
-    )
-    messages = [Message(role="user", content=user_content)]
-    chat_config = ChatConfig(
-        max_tokens=deployment.max_output_tokens,
-        temperature=0,
-        system=system,
-        thinking=False,
-        thinking_budget_explicit=False,
-        timeout=timeout,
-        provider_request_max_chars=deployment.provider_request_max_chars,
-        tool_choice=None,
-        candidate_output_mode="inert_artifact",
-        physical_attempt_limit=1,
-        provider_request_correlation=provider_request_correlation,
-    )
+    prompt_layout = _compaction_prompt_layout()
+    if prompt_layout == "suffix":
+        if parent_messages is None or parent_chat_config is None:
+            log.warning(
+                "compaction.exact_parent_request_unavailable",
+                compaction_id=compaction_id,
+                chunk_index=chunk_index,
+            )
+            return None
+        messages, tools, chat_config = _build_exact_suffix_compaction_call(
+            parent_messages,
+            parent_tools,
+            parent_chat_config,
+            _build_suffix_compaction_instruction(
+                identifier_instruction,
+                custom_instructions,
+                previous_summary,
+            ),
+        )
+        if provider_request_correlation is not None:
+            chat_config = chat_config.model_copy(
+                update={"provider_request_correlation": provider_request_correlation}
+            )
+    else:
+        system, user_content = _build_compaction_prompt(
+            chunk_text,
+            identifier_instruction,
+            custom_instructions,
+        )
+        messages = [Message(role="user", content=user_content)]
+        tools = None
+        chat_config = ChatConfig(
+            max_tokens=deployment.max_output_tokens,
+            temperature=0,
+            system=system,
+            thinking=False,
+            thinking_budget_explicit=False,
+            timeout=timeout,
+            provider_request_max_chars=deployment.provider_request_max_chars,
+            tool_choice=None,
+            candidate_output_mode="inert_artifact",
+            physical_attempt_limit=1,
+            provider_request_correlation=provider_request_correlation,
+        )
 
     # Keep this import local: engine types import session lifecycle helpers
     # while the session package initializes this module.
@@ -1736,7 +1857,7 @@ async def call_compaction_provider(
         if provider_accounts_physical_usage(deployment.provider):
             provider_stream = deployment.provider.chat(
                 messages,
-                tools=None,
+                tools=tools,
                 config=chat_config,
             )
             accounted_stream = provider_stream
@@ -1745,7 +1866,7 @@ async def call_compaction_provider(
                 nonlocal provider_stream
                 provider_stream = deployment.provider.chat(
                     messages,
-                    tools=None,
+                    tools=tools,
                     config=chat_config,
                 )
                 return provider_stream
@@ -2259,9 +2380,22 @@ async def compact_context_new(request: CompactionRequest) -> CompactionResult:
     provider_native = cfg.llm_plan is not None
     legacy_raw = bool(cfg.api_key and cfg.model)
     network_enabled = provider_native or legacy_raw
+    suffix_layout = _compaction_prompt_layout() == "suffix"
+    exact_suffix = bool(
+        suffix_layout
+        and request.parent_request is not None
+        and provider_native
+    )
+    if suffix_layout and not exact_suffix:
+        # Never substitute a flattened prompt for the exact-parent contract.
+        network_enabled = False
     chunks: list[list[dict[str, Any]]]
     if replace_previous_only:
         chunks = [[]]
+    elif exact_suffix:
+        # The parent request already contains the complete provider input. One
+        # appended instruction summarizes it without chunk rewrites.
+        chunks = [to_compact]
     elif provider_native:
         input_budget = _compaction_target_input_budget(request)
         first_chunk_budget = max(
@@ -2309,14 +2443,18 @@ async def compact_context_new(request: CompactionRequest) -> CompactionResult:
     for chunk_index, chunk in enumerate(chunks, start=1):
         llm_result: str | None = None
         chunk_text = _rolling_chunk_text(rolling_summary, chunk)
-        if cfg.llm_plan is not None:
+        if network_enabled and cfg.llm_plan is not None:
             while candidate_index < len(cfg.llm_plan.candidates):
                 deployment = cfg.llm_plan.candidates[candidate_index]
-                candidate_chunk_text = _fit_compaction_input_to_target(
-                    request=request,
-                    target=deployment,
-                    previous_summary=rolling_summary,
-                    chunk=chunk,
+                candidate_chunk_text = (
+                    chunk_text
+                    if exact_suffix
+                    else _fit_compaction_input_to_target(
+                        request=request,
+                        target=deployment,
+                        previous_summary=rolling_summary,
+                        chunk=chunk,
+                    )
                 )
                 if candidate_chunk_text is None:
                     log.info(
@@ -2333,6 +2471,16 @@ async def compact_context_new(request: CompactionRequest) -> CompactionResult:
                     break
                 cfg.last_attempted_target = deployment
                 llm_kwargs: dict[str, Any] = {}
+                if exact_suffix:
+                    assert request.parent_request is not None
+                    llm_kwargs.update(
+                        {
+                            "parent_messages": request.parent_request.messages,
+                            "parent_tools": request.parent_request.tools,
+                            "parent_chat_config": request.parent_request.chat_config,
+                            "previous_summary": rolling_summary,
+                        }
+                    )
                 if request.provider_request_correlation is not None:
                     llm_kwargs["provider_request_correlation"] = (
                         derive_provider_request_correlation(
@@ -2365,8 +2513,12 @@ async def compact_context_new(request: CompactionRequest) -> CompactionResult:
                 if llm_result:
                     cfg.successful_target = deployment
                     break
-                candidate_index += 1
-        elif legacy_raw and _reserve_compaction_llm_call(cfg):
+                if exact_suffix:
+                    # A suffix request is bound to its parent's deployment.
+                    candidate_index = len(cfg.llm_plan.candidates)
+                else:
+                    candidate_index += 1
+        elif network_enabled and legacy_raw and _reserve_compaction_llm_call(cfg):
             legacy_llm_kwargs: dict[str, Any] = {}
             if request.provider_request_correlation is not None:
                 legacy_llm_kwargs["provider_request_correlation"] = (

--- a/src/opensquilla/session/compaction_deployment.py
+++ b/src/opensquilla/session/compaction_deployment.py
@@ -260,6 +260,7 @@ def build_compaction_llm_plan_from_provider_config(
     deployment_fingerprint: str = "",
     portable: bool = True,
     source: str = "provider_config",
+    replay_provider_state: bool = False,
 ) -> CompactionExecutionPlan:
     """Build an isolated auxiliary provider from a complete deployment config."""
 
@@ -280,9 +281,9 @@ def build_compaction_llm_plan_from_provider_config(
         config,
         model=model,
         provider_routing=dict(config.provider_routing),
-        # A summary request contains freshly serialized portable messages.
-        # Provider-private state from the consumer turn must never be replayed.
-        replay_provider_state=False,
+        # Prefix compaction keeps the portable default. Exact suffix
+        # compaction opts in so the copied parent request serializes identically.
+        replay_provider_state=replay_provider_state,
     )
     provider = build_provider_from_config(isolated)
     return CompactionExecutionPlan(
@@ -394,6 +395,8 @@ def resolve_compaction_execution_plan(
     session_key: str = "",
     credential_pool_acquirer: CredentialPoolAcquirer | None = None,
     credential_pool_failure_reporter: Callable[[str, str, Any], None] | None = None,
+    active_only: bool = False,
+    replay_provider_state: bool = False,
 ) -> CompactionExecutionPlan | None:
     """Freeze the ordered physical targets for one compaction operation.
 
@@ -423,6 +426,7 @@ def resolve_compaction_execution_plan(
                     else 0
                 ),
                 source=source,
+                replay_provider_state=replay_provider_state,
             )
         except Exception:
             return
@@ -453,7 +457,7 @@ def resolve_compaction_execution_plan(
             inherited_provider_config=active_provider_config,
             session_key=session_key,
             turn_metadata=resolution_metadata,
-            replay_provider_state=False,
+            replay_provider_state=replay_provider_state,
             credential_pool_acquirer=credential_pool_acquirer,
         )
         if resolution.ready:
@@ -462,6 +466,33 @@ def resolve_compaction_execution_plan(
                 source=identity.source,
                 credential_pool=resolution_metadata.get("credential_pool"),
             )
+
+    if active_only:
+        # When the last successful request used a different deployment than
+        # the provider selected for the new turn, resolve that recorded parent
+        # first. Falling through to the new deployment would change the wire
+        # prefix, so an unavailable parent deployment must fail closed.
+        parent_identity = next(iter(previous_deployment_identities), None)
+        if parent_identity is not None:
+            try:
+                add_identity(parent_identity)
+            except Exception:
+                return None
+            if not candidates:
+                return None
+        else:
+            add_config(active_provider_config, source="active_deployment")
+            if not candidates:
+                return build_compaction_execution_plan_from_provider(
+                    active_provider,
+                    context_window_tokens=context_window_tokens,
+                    max_calls=1,
+                    source="active_deployment",
+                )
+        return CompactionExecutionPlan(
+            candidates=(candidates[0],),
+            max_calls=1,
+        )
 
     explicit_provider = str(
         getattr(compaction_config, "provider", "") or ""

--- a/src/opensquilla/session/manager.py
+++ b/src/opensquilla/session/manager.py
@@ -33,6 +33,7 @@ from opensquilla.session.attachment_manifest import (
 )
 from opensquilla.session.compaction import (
     CompactionConfig,
+    CompactionParentRequest,
     CompactionRequest,
     CompactionResult,
     _attachment_safe_obligation_entries,
@@ -757,6 +758,9 @@ class SessionManager:
         # read the current epoch without a DB round-trip on every event.
         # Invalidated (updated) whenever increment_epoch commits a new value.
         self._epoch_cache: dict[str, int] = {}
+        # Runtime-only snapshots of the last successful physical provider
+        # request. They are never persisted and are evicted with the session.
+        self._compaction_parent_requests: dict[str, CompactionParentRequest] = {}
 
     @property
     def storage(self) -> SessionStorage:
@@ -770,6 +774,30 @@ class SessionManager:
     def set_cached_epoch(self, session_key: str, epoch: int) -> None:
         """Update the in-process epoch cache after durable epoch changes."""
         self._epoch_cache[session_key] = epoch
+
+    def remember_compaction_parent_request(
+        self,
+        session_key: str,
+        parent_request: CompactionParentRequest,
+    ) -> None:
+        """Keep the last successful physical request for exact suffix replay."""
+
+        self._compaction_parent_requests[canonicalize_session_key(session_key)] = (
+            parent_request
+        )
+
+    def compaction_parent_request(
+        self,
+        session_key: str,
+    ) -> CompactionParentRequest | None:
+        """Return the runtime-only exact suffix parent for one live session."""
+
+        return self._compaction_parent_requests.get(canonicalize_session_key(session_key))
+
+    def clear_compaction_parent_request(self, session_key: str) -> None:
+        """Discard the exact suffix parent without touching durable history."""
+
+        self._compaction_parent_requests.pop(canonicalize_session_key(session_key), None)
 
     def attach_task_runtime(self, task_runtime: Any) -> None:
         """Attach the TaskRuntime so kill_session can cancel running children."""
@@ -1413,6 +1441,7 @@ class SessionManager:
         """
         session_key = canonicalize_session_key(session_key)
         self._epoch_cache.pop(session_key, None)
+        self._compaction_parent_requests.pop(session_key, None)
         goal_service = getattr(self._task_runtime, "goal_service", None)
         revoke_goal_lease = getattr(goal_service, "revoke_session", None)
         if callable(revoke_goal_lease):
@@ -3020,6 +3049,7 @@ class SessionManager:
         provider_request_correlation: ProviderRequestCorrelation | None = None,
         consumer_admission: Callable[[str, list[dict[str, Any]]], Any] | None = None,
         consumer_admission_fingerprint: str = "",
+        parent_request: CompactionParentRequest | None = None,
     ) -> str:
         """
         Compact the session transcript when context is filling up.
@@ -3040,6 +3070,7 @@ class SessionManager:
             mutation_context=mutation_context,
             consumer_admission=consumer_admission,
             consumer_admission_fingerprint=consumer_admission_fingerprint,
+            parent_request=parent_request,
             **correlation_kwargs,
         )
         return (
@@ -3066,6 +3097,7 @@ class SessionManager:
         protected_boundary_message_id: str | None = None,
         expected_session_id: str | None = None,
         expected_session_epoch: int | None = None,
+        parent_request: CompactionParentRequest | None = None,
     ) -> CompactionResult:
         """Compact the session transcript and return full compaction metadata."""
 
@@ -3200,6 +3232,7 @@ class SessionManager:
                 consumer_admission=consumer_admission,
                 expected_session_id=expected_session_id,
                 expected_session_epoch=expected_session_epoch,
+                parent_request=parent_request,
             ),
         )
         if is_owner:
@@ -3244,6 +3277,7 @@ class SessionManager:
         consumer_admission: Callable[[str, list[dict[str, Any]]], Any] | None,
         expected_session_id: str | None,
         expected_session_epoch: int | None,
+        parent_request: CompactionParentRequest | None,
     ) -> CompactionResult:
         """Generate and atomically install one frozen compaction candidate."""
 
@@ -3261,6 +3295,7 @@ class SessionManager:
                 summary_replay_renderer=_durable_summary_replay,
                 consumer_admission=consumer_admission,
                 provider_request_correlation=provider_request_correlation,
+                parent_request=parent_request,
             )
         )
 
@@ -3494,6 +3529,9 @@ class SessionManager:
                 cancellation_reconciled=cancellation_reconciled,
                 duration_ms=max(0, int((time.monotonic() - commit_started) * 1000)),
             )
+        # Any installed summary changes the durable prompt prefix, so a
+        # previously captured physical request can no longer be replayed.
+        self.clear_compaction_parent_request(session_key)
         return result
 
     async def persist_compaction_result(
@@ -3785,6 +3823,7 @@ class SessionManager:
             summary_len=len(summary),
             kept=persisted_kept_count,
         )
+        self.clear_compaction_parent_request(session_key)
         return True
 
     async def truncate(self, session_key: str, max_messages: int = 20) -> dict:
@@ -3813,6 +3852,7 @@ class SessionManager:
 
         node.updated_at = _now_ms()
         await self._storage.upsert_session(node)
+        self.clear_compaction_parent_request(session_key)
 
         return {"truncated": True, "before_count": before_count, "after_count": len(recent)}
 

--- a/tests/test_engine/test_agent_provider_identity.py
+++ b/tests/test_engine/test_agent_provider_identity.py
@@ -101,6 +101,43 @@ def test_fallback_branch_records_configured_provider_id() -> None:
     assert mu.cost == 0.0
 
 
+def test_agent_captures_last_successful_physical_request_for_compaction() -> None:
+    class _RecordingProvider(_LocalCompatProvider):
+        def __init__(self) -> None:
+            self.calls: list[tuple[list[Message], list[Any] | None, ChatConfig | None]] = []
+
+        def chat(
+            self,
+            messages: list[Message],
+            tools: list[Any] | None = None,
+            config: ChatConfig | None = None,
+        ) -> AsyncIterator[Any]:
+            self.calls.append((messages, tools, config))
+            return self._stream()
+
+    provider = _RecordingProvider()
+
+    async def run() -> Any:
+        agent = Agent(
+            provider=provider,
+            config=AgentConfig(max_iterations=2, provider_id="openrouter"),
+            tool_definitions=[],
+            tool_handler=None,
+            session_key="agent:test:webchat:compaction-parent",
+        )
+        agent.set_compaction_parent_request_capture_enabled(True)
+        async for _ in agent.run_turn("hi"):
+            pass
+        return agent.compaction_parent_request()
+
+    parent_request = asyncio.run(run())
+
+    assert parent_request is not None
+    assert tuple(provider.calls[-1][0]) == parent_request.messages
+    assert parent_request.tools is None
+    assert provider.calls[-1][2] == parent_request.chat_config
+
+
 def test_fallback_branch_without_provider_id_uses_adapter_name() -> None:
     """Backward-compatible default: with no configured provider id the
     adapter class name still flows through (and prices as cloud), so the

--- a/tests/test_engine/test_preflight_compaction.py
+++ b/tests/test_engine/test_preflight_compaction.py
@@ -415,6 +415,47 @@ async def test_preflight_protects_active_and_queued_prompts_from_durable_compact
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("layout", "expects_parent"),
+    [("suffix", True), ("prefix", False)],
+)
+async def test_preflight_forwards_exact_parent_only_for_suffix_layout(
+    monkeypatch: pytest.MonkeyPatch,
+    layout: str,
+    expects_parent: bool,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_COMPACTION_PROMPT_LAYOUT", layout)
+    transcript = [
+        TranscriptEntry(
+            session_id="test-session-id",
+            session_key="user:session",
+            role="user",
+            content="old history",
+            token_count=900,
+        ),
+        TranscriptEntry(
+            session_id="test-session-id",
+            session_key="user:session",
+            role="assistant",
+            content="recent answer",
+            token_count=20,
+        ),
+    ]
+    sm = _ResultCompactionSessionManager(transcript)
+    runner = TurnRunner(provider_selector=MagicMock(), session_manager=sm)
+    parent_request = object()
+    runner._remember_compaction_parent_request("user:session", parent_request)
+
+    await runner._maybe_preflight_compact("user:session", 1000)
+
+    kwargs = sm.compact_with_result_kwargs[0]
+    if expects_parent:
+        assert kwargs["parent_request"] is parent_request
+    else:
+        assert "parent_request" not in kwargs
+
+
+@pytest.mark.asyncio
 async def test_preflight_compacts_to_final_envelope_history_capacity() -> None:
     context_window = 1000
     history_capacity = 600

--- a/tests/test_gateway/test_compaction_target.py
+++ b/tests/test_gateway/test_compaction_target.py
@@ -137,6 +137,44 @@ def test_model_only_compaction_ignores_stale_session_provider_provenance() -> No
     assert ctx.provider_selector.clone_calls == 0
 
 
+def test_exact_suffix_uses_only_recorded_parent_deployment() -> None:
+    config = GatewayConfig()
+    config.compaction.provider = "anthropic"
+    config.compaction.model = "summary-model"
+    config.llm_profiles["openai"] = LlmProviderProfile(
+        api_key="recorded-provider-secret",
+        base_url="https://api.openai.com/v1",
+    )
+    current = ProviderConfig(
+        provider="ollama",
+        model="selector-fallback-model",
+        base_url="http://127.0.0.1:11434",
+    )
+    session = SimpleNamespace(
+        session_key="agent:main:webchat:exact-suffix",
+        provider_override=None,
+        model_provider="openai",
+        model_override=None,
+        model="parent-model",
+        auth_profile_override=None,
+    )
+
+    target = resolve_gateway_compaction_target(
+        _ctx(config, current),
+        session,
+        active_only=True,
+        replay_provider_state=True,
+    )
+
+    assert target.provider_id == "openai"
+    assert target.model == "parent-model"
+    assert target.source == "session_model_provider"
+    assert target.plan is not None
+    assert len(target.plan.candidates) == 1
+    assert target.plan.max_calls == 1
+    assert provider_connection_config(target.provider).api_key == "recorded-provider-secret"
+
+
 def test_manual_consumer_budget_uses_stable_base_not_last_routed_model() -> None:
     config = GatewayConfig(
         llm={

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -7902,6 +7902,90 @@ class TestSessionsContextCompact:
         assert correlation.call_kind == "auxiliary.compaction"
 
     @pytest.mark.asyncio
+    async def test_context_compact_forwards_exact_suffix_parent_request(
+        self,
+        dispatcher,
+        session,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("OPENSQUILLA_COMPACTION_PROMPT_LAYOUT", "suffix")
+        manager = FakeSessionManager([session])
+        parent_request = object()
+        target_calls: list[dict[str, Any]] = []
+        original_resolver = session_maintenance_adapter.resolve_gateway_compaction_target
+
+        def capture_target(*args: Any, **kwargs: Any):
+            target_calls.append(dict(kwargs))
+            return original_resolver(*args, **kwargs)
+
+        monkeypatch.setattr(
+            session_maintenance_adapter,
+            "resolve_gateway_compaction_target",
+            capture_target,
+        )
+        turn_runner = SimpleNamespace(
+            compaction_parent_request=lambda key: (
+                parent_request if key == session.session_key else None
+            )
+        )
+        ctx = make_ctx(session_manager=manager, turn_runner=turn_runner)
+
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.contextCompact",
+            {"key": session.session_key, "contextWindowTokens": 1234},
+            ctx,
+        )
+
+        assert res.ok is True
+        assert manager.compact_kwargs[0]["parent_request"] is parent_request
+        assert target_calls == [
+            {
+                "active_only": True,
+                "replay_provider_state": True,
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_context_compact_prefix_ignores_cached_parent_request(
+        self,
+        dispatcher,
+        session,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.delenv("OPENSQUILLA_COMPACTION_PROMPT_LAYOUT", raising=False)
+        manager = FakeSessionManager([session])
+        target_calls: list[dict[str, Any]] = []
+        original_resolver = session_maintenance_adapter.resolve_gateway_compaction_target
+
+        def capture_target(*args: Any, **kwargs: Any):
+            target_calls.append(dict(kwargs))
+            return original_resolver(*args, **kwargs)
+
+        monkeypatch.setattr(
+            session_maintenance_adapter,
+            "resolve_gateway_compaction_target",
+            capture_target,
+        )
+        ctx = make_ctx(
+            session_manager=manager,
+            turn_runner=SimpleNamespace(
+                compaction_parent_request=lambda _key: object(),
+            ),
+        )
+
+        res = await dispatcher.dispatch(
+            "r1",
+            "sessions.contextCompact",
+            {"key": session.session_key, "contextWindowTokens": 1234},
+            ctx,
+        )
+
+        assert res.ok is True
+        assert "parent_request" not in manager.compact_kwargs[0]
+        assert target_calls == [{}]
+
+    @pytest.mark.asyncio
     async def test_context_compact_client_window_cannot_expand_stable_consumer(
         self,
         dispatcher,

--- a/tests/test_session/test_compaction_execution_plan.py
+++ b/tests/test_session/test_compaction_execution_plan.py
@@ -104,6 +104,125 @@ def test_explicit_provider_and_model_are_first_and_do_not_leak_secrets(
     assert repr(plan.primary.provider) not in rendered
 
 
+def test_active_only_reuses_parent_physical_deployment_and_one_call(
+    monkeypatch: pytest.MonkeyPatch,
+    built_configs: list[ProviderConfig],
+) -> None:
+    active = _config("anthropic", "current-model", api_key="current-secret")
+    fallback = _config("ollama", "fallback-model")
+
+    parent = _config("openai", "previous-model", api_key="parent-secret")
+    resolutions: list[tuple[str, str, bool]] = []
+
+    def resolve_parent(
+        _app_config: object,
+        provider: str,
+        model: str,
+        **kwargs: Any,
+    ) -> Any:
+        resolutions.append(
+            (provider, model, bool(kwargs.get("replay_provider_state")))
+        )
+        return SimpleNamespace(ready=True, provider_config=parent)
+
+    monkeypatch.setattr(
+        "opensquilla.session.compaction_deployment.resolve_provider_deployment",
+        resolve_parent,
+    )
+
+    plan = resolve_compaction_execution_plan(
+        app_config=object(),
+        active_provider=None,
+        active_provider_config=active,
+        previous_deployment_identities=(
+            CompactionDeploymentIdentity(
+                provider_id="openai",
+                model="previous-model",
+                source="previous_turn_deployment",
+            ),
+        ),
+        fallback_provider_configs=(fallback,),
+        compaction_config=SimpleNamespace(provider="openai", model="summary-model"),
+        context_window_tokens=32_000,
+        session_key="session-1",
+        active_only=True,
+        replay_provider_state=True,
+    )
+
+    assert isinstance(plan, CompactionExecutionPlan)
+    assert [(target.provider_id, target.model, target.source) for target in plan.candidates] == [
+        ("openai", "previous-model", "previous_turn_deployment"),
+    ]
+    assert resolutions == [("openai", "previous-model", True)]
+    assert plan.max_calls == 1
+    assert len(built_configs) == 1
+    assert built_configs[0].provider == parent.provider
+    assert built_configs[0].model == parent.model
+    assert built_configs[0].api_key == parent.api_key
+    assert built_configs[0].replay_provider_state is True
+
+
+def test_active_only_uses_current_when_parent_deployment_is_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+    built_configs: list[ProviderConfig],
+) -> None:
+    active = _config("anthropic", "current-model", api_key="current-secret")
+
+    def identity_resolution_forbidden(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("unchanged parent must reuse the active config directly")
+
+    monkeypatch.setattr(
+        "opensquilla.session.compaction_deployment.resolve_provider_deployment",
+        identity_resolution_forbidden,
+    )
+
+    plan = resolve_compaction_execution_plan(
+        app_config=object(),
+        active_provider=None,
+        active_provider_config=active,
+        active_only=True,
+        replay_provider_state=True,
+    )
+
+    assert plan is not None
+    assert [(target.provider_id, target.model) for target in plan.candidates] == [
+        ("anthropic", "current-model")
+    ]
+    assert plan.max_calls == 1
+    assert built_configs[0].replay_provider_state is True
+
+
+def test_active_only_fails_closed_when_parent_deployment_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    built_configs: list[ProviderConfig],
+) -> None:
+    monkeypatch.setattr(
+        "opensquilla.session.compaction_deployment.resolve_provider_deployment",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            ready=False,
+            provider_config=None,
+        ),
+    )
+
+    plan = resolve_compaction_execution_plan(
+        app_config=object(),
+        active_provider=None,
+        active_provider_config=_config("anthropic", "new-model"),
+        previous_deployment_identities=(
+            CompactionDeploymentIdentity(
+                provider_id="openai",
+                model="parent-model",
+                source="previous_session_deployment",
+            ),
+        ),
+        active_only=True,
+        replay_provider_state=True,
+    )
+
+    assert plan is None
+    assert built_configs == []
+
+
 def test_explicit_target_uses_runtime_credential_pool_acquirer(
     monkeypatch: pytest.MonkeyPatch,
     built_configs: list[ProviderConfig],

--- a/tests/test_session/test_compaction_provider_runtime.py
+++ b/tests/test_session/test_compaction_provider_runtime.py
@@ -12,17 +12,27 @@ from opensquilla.engine.usage_accounting import (
     bind_usage_accounting_scope,
 )
 from opensquilla.provider.failures import ProviderFailureKind
+from opensquilla.provider.openai import OpenAIProvider
 from opensquilla.provider.protocol import ProviderConnectionConfig, ProviderMetadata
 from opensquilla.provider.selector import ProviderConfig, build_provider_from_config
 from opensquilla.provider.types import (
     ChatConfig,
+    ContentBlockText,
+    ContentBlockToolResult,
+    ContentBlockToolUse,
     DoneEvent,
     ErrorEvent,
+    Message,
+    ProviderReplayState,
     ProviderRequestCorrelation,
     ReasoningDeltaEvent,
     TextDeltaEvent,
+    ToolDefinition,
+    ToolInputSchema,
 )
 from opensquilla.session.compaction import (
+    CompactionConfig,
+    CompactionParentRequest,
     CompactionRequest,
     arm_compaction_deadline,
     build_compaction_config_from_provider,
@@ -277,6 +287,33 @@ def test_full_config_plan_has_candidate_shape_and_no_secret_repr(
     assert runtime_config.api_key == ""
 
 
+def test_suffix_plan_preserves_provider_state_for_parent_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[ProviderConfig] = []
+
+    def fake_factory(config: ProviderConfig) -> _Provider:
+        captured.append(config)
+        return _Provider(_successful_stream)
+
+    monkeypatch.setattr(
+        "opensquilla.session.compaction_deployment.build_provider_from_config",
+        fake_factory,
+    )
+
+    build_compaction_llm_plan_from_provider_config(
+        ProviderConfig(
+            provider="openrouter",
+            model="synthetic/model",
+            api_key="super-secret",
+            replay_provider_state=False,
+        ),
+        replay_provider_state=True,
+    )
+
+    assert captured[0].replay_provider_state is True
+
+
 def test_builder_uses_provider_plan_only_when_bound_model_matches() -> None:
     provider = _Provider(_successful_stream)
 
@@ -352,6 +389,397 @@ async def test_provider_compaction_disables_tools_and_thinking_and_accounts_usag
     assert sink.starts[0].model == "provider/model"
     assert len(sink.finalized) == 1
     assert sink.unknown == []
+
+
+@pytest.mark.asyncio
+async def test_suffix_reuses_complete_parent_request_and_appends_one_instruction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_COMPACTION_PROMPT_LAYOUT", "suffix")
+    provider = _Provider(_successful_stream)
+    plan = CompactionExecutionPlan(
+        candidates=(
+            CompactionExecutionTarget(
+                provider=provider,
+                provider_id="openrouter",
+                model="provider/model",
+                max_output_tokens=768,
+                provider_request_max_chars=120_000,
+            ),
+        )
+    )
+    parent_messages = (
+        Message(role="user", content="Inspect the repository."),
+        Message(
+            role="assistant",
+            content=[
+                ContentBlockText(text="I will inspect it."),
+                ContentBlockToolUse(
+                    id="call-1",
+                    name="file_read",
+                    input={"path": "README.md"},
+                ),
+            ],
+        ),
+        Message(
+            role="user",
+            content=[
+                ContentBlockToolResult(
+                    tool_use_id="call-1",
+                    content="repository contents",
+                )
+            ],
+        ),
+    )
+    parent_tools = (
+        ToolDefinition(
+            name="file_read",
+            description="Read one file.",
+            input_schema=ToolInputSchema(
+                properties={"path": {"type": "string"}},
+                required=["path"],
+            ),
+        ),
+    )
+    parent_correlation = ProviderRequestCorrelation(
+        session_id="session-1",
+        turn_id="parent-turn",
+        execution_id="parent-execution",
+        call_kind="agent.chat",
+    )
+    compaction_correlation = ProviderRequestCorrelation(
+        session_id="session-1",
+        turn_id="compaction-turn",
+        execution_id="compaction-execution",
+        call_kind="auxiliary.compaction",
+    )
+    parent_config = ChatConfig(
+        system="exact parent system",
+        cache_mode="on",
+        cache_breakpoints=[{"type": "ephemeral"}],
+        max_tokens=4096,
+        temperature=0.35,
+        top_p=0.9,
+        thinking=True,
+        thinking_budget_tokens=8192,
+        thinking_budget_explicit=True,
+        tool_choice="auto",
+        output_json_schema={"type": "object"},
+        output_json_schema_strict=False,
+        candidate_output_mode="normal",
+        physical_attempt_limit=2,
+        provider_request_correlation=parent_correlation,
+    )
+    parent_request = CompactionParentRequest.from_call(
+        parent_messages,
+        parent_tools,
+        parent_config,
+    )
+    assert "Inspect the repository" not in repr(parent_request)
+    assert "file_read" not in repr(parent_request)
+
+    result = await call_compaction_provider(
+        "flattened content must not be sent",
+        "Preserve exact IDs.",
+        plan,
+        custom_instructions="Keep only task-relevant state.",
+        provider_request_correlation=compaction_correlation,
+        parent_messages=parent_messages,
+        parent_tools=parent_tools,
+        parent_chat_config=parent_config,
+    )
+
+    assert result == "portable summary"
+    messages, tools, config = provider.calls[0]
+    assert tuple(messages[:-1]) == parent_messages
+    assert len(messages) == len(parent_messages) + 1
+    assert messages[-1].role == "user"
+    assert "You are a conversation compactor" in str(messages[-1].content)
+    assert "Preserve exact IDs." in str(messages[-1].content)
+    assert "Keep only task-relevant state." in str(messages[-1].content)
+    assert "flattened content must not be sent" not in str(messages[-1].content)
+    assert tuple(tools or ()) == parent_tools
+    assert config is not None
+    assert config.model_copy(update={"provider_request_correlation": None}) == (
+        parent_config.model_copy(update={"provider_request_correlation": None})
+    )
+    assert config.provider_request_correlation is compaction_correlation
+
+
+@pytest.mark.asyncio
+async def test_suffix_preserves_exact_openrouter_wire_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_COMPACTION_PROMPT_LAYOUT", "suffix")
+    projector = OpenAIProvider(
+        api_key="synthetic-key",
+        model="synthetic/model",
+        base_url="https://openrouter.ai/api/v1",
+        provider_kind="openrouter",
+        replay_provider_state=True,
+    )
+
+    class ProjectingProvider:
+        provider_name = "openai"
+
+        def __init__(self) -> None:
+            self.payloads: list[dict[str, Any]] = []
+
+        def provider_metadata(self) -> ProviderMetadata:
+            return projector.provider_metadata()
+
+        def provider_connection_config(self) -> ProviderConnectionConfig:
+            return projector.provider_connection_config()
+
+        def chat(self, messages, tools=None, config=None):
+            self.payloads.append(
+                projector.project_final_request(messages, tools, config).payload
+            )
+            return _successful_stream()
+
+    provider = ProjectingProvider()
+    parent_messages = (
+        Message(role="user", content="Use the lookup tool."),
+        Message(
+            role="assistant",
+            content=[
+                ContentBlockText(text="Checking."),
+                ContentBlockToolUse(id="call-1", name="lookup", input={"id": 7}),
+            ],
+            reasoning_content="synthetic display reasoning",
+            provider_replay=ProviderReplayState(
+                protocol="openai_chat_completions",
+                source=projector._replay_source,
+                model="synthetic/model",
+                reasoning_details=[
+                    {"type": "reasoning.text", "text": "synthetic native reasoning"}
+                ],
+            ),
+        ),
+        Message(
+            role="user",
+            content=[ContentBlockToolResult(tool_use_id="call-1", content="value=7")],
+        ),
+    )
+    parent_tools = (
+        ToolDefinition(
+            name="lookup",
+            description="Look up one synthetic value.",
+            input_schema=ToolInputSchema(
+                properties={"id": {"type": "integer"}},
+                required=["id"],
+            ),
+        ),
+    )
+    parent_config = ChatConfig(
+        system="stable synthetic system",
+        cache_mode="on",
+        max_tokens=2048,
+        temperature=0.25,
+        top_p=0.8,
+        thinking=True,
+        thinking_budget_tokens=4096,
+        thinking_budget_explicit=True,
+        tool_choice="auto",
+    )
+    parent_payload = projector.project_final_request(
+        list(parent_messages),
+        list(parent_tools),
+        parent_config,
+    ).payload
+    plan = CompactionExecutionPlan(
+        candidates=(
+            CompactionExecutionTarget(
+                provider=provider,
+                provider_id="openrouter",
+                model="synthetic/model",
+                max_output_tokens=768,
+                provider_request_max_chars=120_000,
+            ),
+        )
+    )
+
+    result = await call_compaction_provider(
+        "flattened content must not be sent",
+        "Preserve exact IDs.",
+        plan,
+        parent_messages=parent_messages,
+        parent_tools=parent_tools,
+        parent_chat_config=parent_config,
+    )
+
+    assert result == "portable summary"
+    assert len(provider.payloads) == 1
+    compact_payload = provider.payloads[0]
+    assert compact_payload["messages"][:-1] == parent_payload["messages"]
+    assert compact_payload["messages"][-1]["role"] == "user"
+    assert "conversation compactor" in compact_payload["messages"][-1]["content"]
+    assert {
+        key: value for key, value in compact_payload.items() if key != "messages"
+    } == {key: value for key, value in parent_payload.items() if key != "messages"}
+
+
+@pytest.mark.asyncio
+async def test_suffix_compact_context_reuses_complete_parent_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_COMPACTION_PROMPT_LAYOUT", "suffix")
+    provider = _Provider(_successful_stream)
+    config = build_compaction_config_from_provider(
+        provider,
+        context_window_tokens=8_000,
+    )
+    config.safety_margin = 1.0
+    entries = _entries(20)
+    transcript_messages = tuple(
+        Message(role=entry["role"], content=entry["content"])
+        for entry in entries
+    )
+    parent_messages = (
+        Message(role="user", content="runtime context outside the durable transcript"),
+        *transcript_messages,
+        Message(role="user", content="current provider-only request suffix"),
+    )
+    parent_config = ChatConfig(
+        system="exact active system",
+        cache_mode="on",
+        tool_choice="auto",
+    )
+
+    result = await compact_context(
+        CompactionRequest(
+            session_id="structured-parent-prefix",
+            entries=entries,
+            context_window_tokens=500,
+            config=config,
+            parent_request=CompactionParentRequest.from_call(
+                parent_messages,
+                (),
+                parent_config,
+            ),
+        )
+    )
+
+    assert result.summary_source == "llm"
+    assert result.removed_count > 0
+    messages, tools, sent_config = provider.calls[0]
+    assert tuple(messages[:-1]) == parent_messages
+    assert len(messages) == len(parent_messages) + 1
+    assert tools == []
+    assert sent_config is not None
+    assert sent_config.system == "exact active system"
+
+
+@pytest.mark.asyncio
+async def test_suffix_without_exact_parent_fails_closed_before_provider_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_COMPACTION_PROMPT_LAYOUT", "suffix")
+    provider = _Provider(_successful_stream)
+    config = build_compaction_config_from_provider(provider)
+    config.safety_margin = 1.0
+
+    result = await compact_context(
+        CompactionRequest(
+            session_id="missing-exact-parent",
+            entries=_entries(20),
+            context_window_tokens=500,
+            config=config,
+        )
+    )
+
+    assert result.summary_source == "fallback"
+    assert provider.calls == []
+    assert config.llm_calls_started == 0
+
+
+@pytest.mark.asyncio
+async def test_suffix_never_uses_legacy_flattened_http_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_COMPACTION_PROMPT_LAYOUT", "suffix")
+    legacy_calls: list[str] = []
+
+    async def forbidden_legacy_call(**kwargs: Any) -> str:
+        legacy_calls.append(str(kwargs.get("chunk_text") or ""))
+        return "must not be used"
+
+    monkeypatch.setattr(
+        "opensquilla.session.compaction.call_compaction_llm",
+        forbidden_legacy_call,
+    )
+    config = CompactionConfig(
+        model="legacy-model",
+        api_key="synthetic-key",
+        safety_margin=1.0,
+    )
+
+    result = await compact_context(
+        CompactionRequest(
+            session_id="suffix-no-legacy-flattening",
+            entries=_entries(20),
+            context_window_tokens=500,
+            config=config,
+            parent_request=CompactionParentRequest.from_call(
+                [Message(role="user", content="exact parent")],
+                None,
+                ChatConfig(),
+            ),
+        )
+    )
+
+    assert result.summary_source == "fallback"
+    assert legacy_calls == []
+    assert config.llm_calls_started == 0
+
+
+@pytest.mark.asyncio
+async def test_suffix_provider_failure_does_not_switch_deployment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_COMPACTION_PROMPT_LAYOUT", "suffix")
+    primary = _Provider(
+        lambda: _Stream([ErrorEvent(message="primary unavailable", code="unavailable")])
+    )
+    fallback = _Provider(_successful_stream)
+    config = build_compaction_config_from_provider(primary)
+    config.llm_plan = CompactionExecutionPlan(
+        candidates=(
+            CompactionExecutionTarget(
+                provider=primary,
+                provider_id="openrouter",
+                model="parent/model",
+                source="active",
+            ),
+            CompactionExecutionTarget(
+                provider=fallback,
+                provider_id="openrouter",
+                model="different/model",
+                source="fallback",
+            ),
+        ),
+        max_calls=2,
+    )
+    config.safety_margin = 1.0
+
+    result = await compact_context(
+        CompactionRequest(
+            session_id="exact-parent-no-switch",
+            entries=_entries(20),
+            context_window_tokens=500,
+            config=config,
+            parent_request=CompactionParentRequest.from_call(
+                [Message(role="user", content="exact parent")],
+                None,
+                ChatConfig(system="stable system"),
+            ),
+        )
+    )
+
+    assert result.summary_source == "fallback"
+    assert len(primary.calls) == 1
+    assert fallback.calls == []
+    assert config.llm_calls_started == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_session/test_finish_evicts_runtime_state.py
+++ b/tests/test_session/test_finish_evicts_runtime_state.py
@@ -104,6 +104,8 @@ def test_explicit_runtime_eviction_drops_all_session_identity_caches() -> None:
     session_id = "history-eviction-generation"
     manager = SessionManager(_MemoryStorage())  # type: ignore[arg-type]
     manager.set_cached_epoch(session_key, 7)
+    parent_request = object()
+    manager.remember_compaction_parent_request(session_key, parent_request)
     _tracker.mark_closed(session_key, "child-task")
     _history_store.set(session_key, [{"turn_index": 3}])
     sessions_tool._get_spawn_lock(session_key)
@@ -115,6 +117,7 @@ def test_explicit_runtime_eviction_drops_all_session_identity_caches() -> None:
     )
 
     assert manager.get_cached_epoch(session_key) is None
+    assert manager.compaction_parent_request(session_key) is None
     assert not _tracker.is_closed(session_key, "child-task")
     assert _history_store.get(session_key) is None
     assert session_key not in sessions_tool._spawn_locks

--- a/tests/test_session/test_manager.py
+++ b/tests/test_session/test_manager.py
@@ -945,6 +945,7 @@ def test_get_transcript_query_uses_id_tiebreaker() -> None:
 @pytest.mark.asyncio
 async def test_truncate_zero_removes_all_entries(manager):
     await manager.create("agent:main:main")
+    manager.remember_compaction_parent_request("agent:main:main", object())
     await manager.append_message("agent:main:main", "user", "msg1")
     await manager.append_message("agent:main:main", "assistant", "resp1")
 
@@ -952,6 +953,7 @@ async def test_truncate_zero_removes_all_entries(manager):
 
     assert result == {"truncated": True, "before_count": 2, "after_count": 0}
     assert await manager.get_transcript("agent:main:main") == []
+    assert manager.compaction_parent_request("agent:main:main") is None
 
 
 @pytest.mark.asyncio
@@ -2986,6 +2988,7 @@ async def test_compact_reduces_transcript(manager):
 @pytest.mark.asyncio
 async def test_compact_with_result_returns_source_and_persists(manager):
     await manager.create("agent:main:main")
+    manager.remember_compaction_parent_request("agent:main:main", object())
     for i in range(20):
         await manager.append_message(
             "agent:main:main",
@@ -3022,6 +3025,7 @@ async def test_compact_with_result_returns_source_and_persists(manager):
     ]
     assert canonical_contents == original_contents
     assert [entry.content for entry in transcript] == original_contents[-len(transcript) :]
+    assert manager.compaction_parent_request("agent:main:main") is None
 
 
 @pytest.mark.asyncio
@@ -4058,6 +4062,7 @@ async def test_close_waits_for_an_active_connection_transaction(
 @pytest.mark.asyncio
 async def test_persist_compaction_result_stores_summary_out_of_band(manager):
     node = await manager.create("agent:main:main")
+    manager.remember_compaction_parent_request("agent:main:main", object())
     for index in range(4):
         await manager.append_message("agent:main:main", "user", f"msg {index}", token_count=5)
 
@@ -4102,6 +4107,7 @@ async def test_persist_compaction_result_stores_summary_out_of_band(manager):
     assert states[0].state_kind == "structured_summary_v1"
     assert states[0].payload is not None
     assert states[0].payload["compaction_id"] == "cmp_inline_1"
+    assert manager.compaction_parent_request("agent:main:main") is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope

Scope boundary: Build opt-in suffix checkpoints from the same frozen source range that compaction will archive, using the current provider, model, tools, system prompt, replay policy, and serialization settings. A stale previous request can no longer omit newly added messages or choose an obsolete deployment. Preserve reusable request prefixes where the selected source and provider projection permit them.

The summary body retains the existing portable checkpoint limit. Admission reserves the adapter's effective full generation budget, including reasoning; empty, truncated, length-stopped, oversized, or failed summaries cannot commit. Existing epoch, preimage, CAS, coverage, tool repair, reasoning-history rebase, and consumer-admission checks remain in force. No new database fields, deployment registry, or state machine.

Non-goals: #1563 fallback nesting, asynchronous compaction, KV graft, enabling suffix by default, and the separate WebUI empty-draft reconciliation fix ([#1670](https://github.com/TokenRhythm/opensquilla/pull/1670)). Suffix requires `OPENSQUILLA_COMPACTION_PROMPT_LAYOUT=suffix` and current request context; compatibility/manual Gateway callers without that context retain the existing prefix path. This does not promise byte-identical copies of previous HTTP requests or universal cache hits.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: Addresses four review defects in this PR's suffix implementation; the distinct fallback/coverage issue #1563 remains separate.

## Release Note

Release note: Opt-in suffix compaction now summarizes its actual removal range with the current model and request settings, preserves replay policy, and accounts for reasoning and output budgets without accepting incomplete checkpoints.

## Tests

Ruff: `ruff check src tests scripts/live_reasoning_replay_e2e.py` passed on the integrated current-main tree.

Pytest: Current-main integration: 383 passed / 2 skipped in environment-sensitive preflight and provider runtime tests; 680 passed / 1 skipped in execution-plan, manager, provider-identity, preflight, Gateway, and replay-persistence suites. Earlier full validation of the same Python change: 28,286 passed / 507 skipped; final harness increment: 100 passed. After merging the subsequent model-identity change from main (#1651), 290 additional focused integration tests passed. The [updated-head CI](https://github.com/TokenRhythm/opensquilla/actions/runs/35006057337) passed; one transient connection reset while downloading a Linux toolchain artifact passed on a failed-job-only retry. The [merge-queue CI](https://github.com/TokenRhythm/opensquilla/actions/runs/35010236651) passed for the final integrated commit `69afe61a2edee382890d83a1de1ffcf4974e4e10`.

Build: Mypy passed for 1,595 source files. CI validates the distributable and platform matrices. The separate frontend fix has its own tests and build.

Regression tests: added

Notes: Covers stale parent history, current deployment selection, replay disabled after persisted reasoning, generation budgets above the old summary threshold, final projection rejection, empty/length/error/oversized output, multi-chunk failure, retained tail, archive integrity, and checkpoint replay. Synthetic offline capture fixtures are credential-free. Platform-neutral production changes; existing filesystem and platform validation policy is retained.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: yes

Surface: provider, browser, gateway

Maintainer-only note: TokenRhythm and OpenRouter each passed seven real-provider scenarios: first compaction/SQLite reopen, tools, replay disabled, model switch, repeated compaction, truncation rejection, and long reasoning with a valid short summary. Real WebUI sessions additionally exercised automatic suffix compaction, model switching, file write/read, post-compaction recall, reload during a response, cancellation/resumption, manual no-op feedback, and desktop/mobile viewport layouts. Actual HTTP, SQLite archives, and UI events were cross-checked. Durable UI cases archived 10 and 6 messages and replayed the complete checkpoint; services reported 16,384 and 15,360 cached input tokens on those summary requests. Cache usage is provider-reported evidence for those requests, not a performance guarantee. A pre-compaction Flash-model code drift was separately recorded and corrected before final recall; failed and request-only fallback attempts were not counted as durable suffix success. No contributor credentials or paid checks are required.

## Safety

Secrets, local-only artifacts, private prompts/transcripts, channel identifiers, AI session artifacts, non-public fixtures, and tests/_private/ contents are not committed. Live keys were supplied only through process environments. Failure preserves durable source history; request-only fallback remains visibly distinct from a committed checkpoint. Runtime request context contains configuration and tools, not a second stored conversation snapshot.

## Third-Party Origin

Third-party origin: inspired-by

Details if non-none: Mechanism references: [Penguin Harness](https://github.com/Prism-Shadow/penguin-harness) (Apache-2.0) and [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (MIT). Independently implemented using existing OpenSquilla abstractions; no upstream code, fixtures, or prompt text copied, and no new third-party dependency.

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.

