### PR TITLE
Fix image validation, attachment ownership, and analysis recovery

### DIFF
--- a/.github/scripts/windows_test_assignments.json
+++ b/.github/scripts/windows_test_assignments.json
@@ -73,6 +73,7 @@
       "tests/test_cli/test_tui_meta_command.py",
       "tests/test_contracts/test_ensemble_fallback_event_wire.py",
       "tests/test_contracts/test_error_event_wire.py",
+      "tests/test_contracts/test_image_validation.py",
       "tests/test_contracts/test_onboarding_status.py",
       "tests/test_contracts/test_turn_execution.py",
       "tests/test_contrib/test_codetask/test_codetask_cli.py",

--- a/.github/scripts/windows_test_durations.json
+++ b/.github/scripts/windows_test_durations.json
@@ -278,6 +278,7 @@
     "tests/test_contracts/test_config_public_dict.py": 0.127,
     "tests/test_contracts/test_ensemble_fallback_event_wire.py": 0.018,
     "tests/test_contracts/test_error_event_wire.py": 0.012,
+    "tests/test_contracts/test_image_validation.py": 0.01,
     "tests/test_contracts/test_llm_ensemble_preservation.py": 0.447,
     "tests/test_contracts/test_migration_report_wire.py": 0.111,
     "tests/test_contracts/test_models_discover_wire.py": 0.157,

--- a/opensquilla-webui/src/components/setup/SetupModelCombobox.test.ts
+++ b/opensquilla-webui/src/components/setup/SetupModelCombobox.test.ts
@@ -280,6 +280,18 @@ describe('SetupModelCombobox', () => {
     ])
   })
 
+  it('marks models that accept image input as multimodal', async () => {
+    const { el } = await mountCombobox()
+    await openList(el)
+
+    const rows = optionRows()
+    expect(rows[0].textContent).not.toContain('Multimodal')
+    expect(rows[1].querySelector('.setup-model-combobox__badge--multimodal')?.textContent)
+      .toContain('Multimodal')
+    expect(rows[1].querySelector<HTMLElement>('.setup-model-combobox__badge--multimodal')?.title)
+      .toBe('Supports image input')
+  })
+
   it('prefers published limits, suppresses normal status, and labels accessible sources', async () => {
     const { el } = await mountCombobox({
       models: [

--- a/opensquilla-webui/src/components/setup/SetupModelCombobox.vue
+++ b/opensquilla-webui/src/components/setup/SetupModelCombobox.vue
@@ -251,6 +251,10 @@ function rowStatus(model: DiscoveredModel): string {
   return status
 }
 
+function modelSupportsMultimodalInput(model: DiscoveredModel): boolean {
+  return model.capabilities.includes('vision')
+}
+
 function usesCatalogOnlyMetadata(model: DiscoveredModel): boolean {
   return model.metadata?.schemaVersion === 1 && model.metadata.published === null
 }
@@ -590,6 +594,13 @@ function onKeydown(event: KeyboardEvent) {
                     class="setup-model-combobox__badge setup-model-combobox__badge--status"
                   >
                     {{ rowStatus(model) }}
+                  </span>
+                  <span
+                    v-if="modelSupportsMultimodalInput(model)"
+                    class="setup-model-combobox__badge setup-model-combobox__badge--multimodal"
+                    :title="t('setup.provider.modelMultimodalTitle')"
+                  >
+                    {{ t('setup.provider.modelMultimodal') }}
                   </span>
                   <span
                     v-if="usesCatalogOnlyMetadata(model)"
@@ -969,6 +980,11 @@ function onKeydown(event: KeyboardEvent) {
 .setup-model-combobox__badge--catalog {
   background: var(--bg-hover);
   color: var(--text-dim);
+}
+
+.setup-model-combobox__badge--multimodal {
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--accent);
 }
 
 .setup-model-combobox__footer {

--- a/opensquilla-webui/src/components/setup/SetupModelStrategyPanel.test.ts
+++ b/opensquilla-webui/src/components/setup/SetupModelStrategyPanel.test.ts
@@ -280,6 +280,32 @@ describe('SetupModelStrategyPanel', () => {
     app.unmount()
   })
 
+  it('keeps the legacy image tier out of the model strategy table', async () => {
+    const { app, el } = await mountPanel({
+      activeStrategy: 'router',
+      router: {
+        tierRows: [
+          ...panel().router.tierRows,
+          {
+            name: 'image_model',
+            provider: 'openrouter',
+            model: 'legacy/vision-model',
+            thinkingLevel: '',
+            supportsImage: true,
+          },
+        ],
+      },
+    })
+
+    expect(el.querySelector('[aria-label="image_model model"]')).toBeNull()
+    expect(el.querySelector('[aria-label="image_model thinking level"]')).toBeNull()
+    expect(el.querySelector('[aria-label$="supports image"]')).toBeNull()
+    expect(el.textContent).not.toContain('legacy/vision-model')
+    expect(el.textContent).not.toContain('Image model')
+
+    app.unmount()
+  })
+
   it('offers a compact provider shortcut when only one provider is available', async () => {
     const onGoToSection = vi.fn()
     const { app, el } = await mountPanel({

--- a/opensquilla-webui/src/components/setup/SetupModelStrategyPanel.vue
+++ b/opensquilla-webui/src/components/setup/SetupModelStrategyPanel.vue
@@ -867,6 +867,9 @@ function credentialLabel(candidate: EnsembleCandidateView): string {
         class="control-section setup-model-strategy__detail setup-model-strategy__ensemble"
         data-testid="ensemble-panel"
       >
+        <p class="setup-model-strategy__notice" data-testid="ensemble-candidate-image-hint">
+          {{ t('setup.modelStrategy.candidateModelHint') }}
+        </p>
         <div
           v-if="panel.ensemble.schemeCardsAvailable && ensembleScheme !== 'legacy'"
           class="setup-model-strategy__schemes"

--- a/opensquilla-webui/src/composables/chat/useChatAttachments.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatAttachments.test.ts
@@ -176,6 +176,77 @@ describe('useChatAttachments', () => {
     expect(pushToast).toHaveBeenCalledWith('Empty file: empty.txt', { tone: 'danger' })
   })
 
+  it('ignores a late inline image read after the attachment session is retired', async () => {
+    let reader: { onload: ((event: { target: { result: string } }) => void) | null } | undefined
+    class DeferredFileReader {
+      onload: ((event: { target: { result: string } }) => void) | null = null
+      onerror: (() => void) | null = null
+
+      readAsDataURL() {
+        reader = this
+      }
+    }
+    vi.stubGlobal('FileReader', DeferredFileReader)
+
+    const attachments = useChatAttachments()
+    await attachments.addAttachment(new File([new Uint8Array([0xff, 0xd8, 0xff])], 'photo.jpg', { type: 'image/jpeg' }))
+
+    expect(attachments.pendingAttachments.value).toMatchObject([{ kind: 'inline_pending', name: 'photo.jpg' }])
+    attachments.retireAttachments()
+    reader?.onload?.({ target: { result: 'data:image/jpeg;base64,/9j/' } })
+
+    expect(attachments.pendingAttachments.value).toEqual([])
+  })
+
+  it.each(['success', 'failure'])('ignores late upload %s after attachment retirement', async (outcome) => {
+    let resolveOldUpload!: (response: unknown) => void
+    let resolveCurrentUpload!: (response: unknown) => void
+    const fetchMock = vi.fn()
+      .mockImplementationOnce(() => new Promise(resolve => { resolveOldUpload = resolve }))
+      .mockImplementationOnce(() => new Promise(resolve => { resolveCurrentUpload = resolve }))
+    vi.stubGlobal('fetch', fetchMock)
+    const attachments = useTestChatAttachments()
+
+    await attachments.addAttachment(stagedPdf('old.pdf'))
+    attachments.retireAttachments()
+    await attachments.addAttachment(stagedPdf('current.pdf'))
+    resolveOldUpload(outcome === 'success'
+      ? successfulUploadResponse('old-file')
+      : { ok: false, status: 503, text: async () => 'upload unavailable' })
+    await flushUpload()
+
+    expect(attachments.pendingAttachments.value).toMatchObject([{ kind: 'uploading', name: 'current.pdf' }])
+    expect(attachments.hasPendingAttachmentWork()).toBe(true)
+    expect(pushToast).not.toHaveBeenCalled()
+
+    resolveCurrentUpload(successfulUploadResponse('current-file'))
+    await flushUpload()
+    expect(attachments.pendingAttachments.value).toMatchObject([
+      { kind: 'staged', name: 'current.pdf', file_uuid: 'current-file' },
+    ])
+    expect(attachments.hasPendingAttachmentWork()).toBe(false)
+  })
+
+  it('stops a retired batch while its file type is being read', async () => {
+    let finishRead!: (buffer: ArrayBuffer) => void
+    const unknownFile = new File(['text'], 'sample.unknown', { type: '' })
+    vi.spyOn(unknownFile, 'arrayBuffer').mockImplementation(() => new Promise(resolve => {
+      finishRead = resolve
+    }))
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const attachments = useTestChatAttachments()
+
+    const adding = attachments.addAttachments([unknownFile, stagedPdf('next.pdf')])
+    attachments.retireAttachments()
+    finishRead(new Uint8Array([116, 101, 120, 116]).buffer)
+    await adding
+
+    expect(attachments.pendingAttachments.value).toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(pushToast).not.toHaveBeenCalled()
+  })
+
   it('enforces the frontend aggregate attachment count before upload work starts', async () => {
     const fetchMock = vi.fn().mockResolvedValue(successfulUploadResponse('file-count'))
     vi.stubGlobal('fetch', fetchMock)

--- a/opensquilla-webui/src/composables/chat/useChatAttachments.ts
+++ b/opensquilla-webui/src/composables/chat/useChatAttachments.ts
@@ -41,6 +41,7 @@ type AttachmentPreparationOptions = {
 // Per-addAttachments-call state so batch-wide rejections (the aggregate size
 // cap) toast once instead of once per rejected file.
 type AttachmentBatch = {
+  generation: number
   totalSizeToastShown: boolean
 }
 
@@ -117,6 +118,7 @@ export function useChatAttachments(artifactContent?: ArtifactContentAccess) {
   const nextAttachmentId = ref(1)
   const refreshInFlightAttachmentIds = new Set<number>()
   const refreshInFlightAttachmentCount = ref(0)
+  let attachmentGeneration = 0
   const attachmentWorkBusy = computed(() =>
     refreshInFlightAttachmentCount.value > 0
     || pendingAttachments.value.some(
@@ -133,8 +135,12 @@ export function useChatAttachments(artifactContent?: ArtifactContentAccess) {
   }
 
   async function addAttachments(files: File[]) {
-    const batch: AttachmentBatch = { totalSizeToastShown: false }
+    const batch: AttachmentBatch = {
+      generation: attachmentGeneration,
+      totalSizeToastShown: false,
+    }
     for (const file of files) {
+      if (!isAttachmentGenerationCurrent(batch.generation)) return
       // One toast for the whole batch when the count cap is hit — a per-file
       // repeat would only evict more useful toasts.
       if (activeAttachmentCount() >= MAX_ATTACHMENTS) {
@@ -142,6 +148,7 @@ export function useChatAttachments(artifactContent?: ArtifactContentAccess) {
         return
       }
       await addAttachmentFile(file, batch)
+      if (!isAttachmentGenerationCurrent(batch.generation)) return
     }
   }
 
@@ -150,6 +157,7 @@ export function useChatAttachments(artifactContent?: ArtifactContentAccess) {
   }
 
   async function addAttachmentFile(file: File, batch: AttachmentBatch) {
+    if (!isAttachmentGenerationCurrent(batch.generation)) return
     const fileName = file.name || 'Untitled file'
     if (file.size === 0) {
       pushToast(i18n.global.t('chat.toast.emptyFile', { name: fileName }), { tone: 'danger' })
@@ -158,7 +166,9 @@ export function useChatAttachments(artifactContent?: ArtifactContentAccess) {
 
     let mime = resolveAttachmentMime(file)
     if (!isAllowedAttachmentMime(mime)) {
-      if (await fileLooksLikeUtf8Text(file)) {
+      const looksLikeText = await fileLooksLikeUtf8Text(file)
+      if (!isAttachmentGenerationCurrent(batch.generation)) return
+      if (looksLikeText) {
         // Unknown-but-textual uploads degrade to text/plain so the gateway's
         // UTF-8 fallback is reachable from the WebUI (the gateway re-validates).
         mime = 'text/plain'
@@ -179,6 +189,7 @@ export function useChatAttachments(artifactContent?: ArtifactContentAccess) {
       pendingAttachments.value.push({ kind: 'inline_pending', local_id: localId, name: fileName, mime, size: file.size, file })
       const reader = new FileReader()
       reader.onload = (e) => {
+        if (!isAttachmentGenerationCurrent(batch.generation)) return
         const dataUrl = e.target?.result as string
         const b64 = dataUrl?.split(',')[1] || ''
         const idx = pendingAttachments.value.findIndex(a => a.local_id === localId)
@@ -187,6 +198,7 @@ export function useChatAttachments(artifactContent?: ArtifactContentAccess) {
         }
       }
       reader.onerror = () => {
+        if (!isAttachmentGenerationCurrent(batch.generation)) return
         const message = i18n.global.t('chat.toast.couldNotReadFile', { name: fileName })
         markAttachmentFailed(localId, file, mime, message)
         pushToast(message, { tone: 'danger' })
@@ -201,15 +213,22 @@ export function useChatAttachments(artifactContent?: ArtifactContentAccess) {
     }
 
     pendingAttachments.value.push({ kind: 'uploading', local_id: localId, name: fileName, mime, size: file.size, file })
-    uploadAttachmentStaged(file, mime, localId).catch((err) => {
+    uploadAttachmentStaged(file, mime, localId, batch.generation).catch((err) => {
+      if (!isAttachmentGenerationCurrent(batch.generation)) return
       const message = uploadFailureMessage(err)
       markAttachmentFailed(localId, file, mime, message)
       pushToast(`${i18n.global.t('chat.toast.uploadFailed', { name: fileName })}: ${message}`, { tone: 'danger' })
     })
   }
 
-  async function uploadAttachmentStaged(file: File, mime: string, localId: number) {
+  async function uploadAttachmentStaged(
+    file: File,
+    mime: string,
+    localId: number,
+    generation: number,
+  ) {
     const meta = await uploadAttachmentFile(file, mime)
+    if (!isAttachmentGenerationCurrent(generation)) return
     const idx = pendingAttachments.value.findIndex(a => a.local_id === localId)
     if (idx >= 0) {
       pendingAttachments.value[idx] = {
@@ -233,6 +252,13 @@ export function useChatAttachments(artifactContent?: ArtifactContentAccess) {
 
   function removeAttachment(index: number) {
     pendingAttachments.value.splice(index, 1)
+  }
+
+  function retireAttachments() {
+    attachmentGeneration += 1
+    pendingAttachments.value = []
+    refreshInFlightAttachmentIds.clear()
+    refreshInFlightAttachmentCount.value = 0
   }
 
   async function retryAttachment(index: number) {
@@ -273,10 +299,14 @@ export function useChatAttachments(artifactContent?: ArtifactContentAccess) {
 
   async function prepareAttachmentsForSend(options: AttachmentPreparationOptions = {}): Promise<boolean> {
     const isCurrent = options.isCurrent ?? (() => true)
+    const generation = attachmentGeneration
+    const preparationIsCurrent = () => (
+      isAttachmentGenerationCurrent(generation) && isCurrent()
+    )
     const attachments = options.attachments ?? pendingAttachments.value
     const staged = [...attachments].filter(stagedUploadNeedsRefresh)
     for (const attachment of staged) {
-      if (!isCurrent()) return false
+      if (!preparationIsCurrent()) return false
       if (refreshInFlightAttachmentIds.has(attachment.local_id)) return false
       const idx = attachments.findIndex(a => a.local_id === attachment.local_id)
       if (idx < 0 || attachments[idx].kind !== 'staged') continue
@@ -296,7 +326,7 @@ export function useChatAttachments(artifactContent?: ArtifactContentAccess) {
       refreshInFlightAttachmentCount.value = refreshInFlightAttachmentIds.size
       try {
         const meta = await uploadAttachmentFile(attachment.file, attachment.mime)
-        if (!isCurrent()) return false
+        if (!preparationIsCurrent()) return false
         const currentIdx = attachments.findIndex(a => a.local_id === attachment.local_id)
         if (currentIdx < 0 || attachments[currentIdx].kind !== 'staged') continue
         attachments[currentIdx] = {
@@ -311,7 +341,7 @@ export function useChatAttachments(artifactContent?: ArtifactContentAccess) {
           file: attachment.file,
         }
       } catch (err: unknown) {
-        if (!isCurrent()) return false
+        if (!preparationIsCurrent()) return false
         const message = uploadFailureMessage(err)
         markAttachmentFailed(
           attachment.local_id,
@@ -323,8 +353,10 @@ export function useChatAttachments(artifactContent?: ArtifactContentAccess) {
         pushToast(`${i18n.global.t('chat.toast.uploadFailed', { name: attachment.name })}: ${message}`, { tone: 'danger' })
         return false
       } finally {
-        refreshInFlightAttachmentIds.delete(attachment.local_id)
-        refreshInFlightAttachmentCount.value = refreshInFlightAttachmentIds.size
+        if (isAttachmentGenerationCurrent(generation)) {
+          refreshInFlightAttachmentIds.delete(attachment.local_id)
+          refreshInFlightAttachmentCount.value = refreshInFlightAttachmentIds.size
+        }
       }
     }
     return true
@@ -335,6 +367,7 @@ export function useChatAttachments(artifactContent?: ArtifactContentAccess) {
   }
 
   function canAcceptAttachment(fileName: string, size: number, batch: AttachmentBatch): boolean {
+    if (!isAttachmentGenerationCurrent(batch.generation)) return false
     const activeAttachments = pendingAttachments.value.filter(attachmentCountsTowardLimits)
     if (activeAttachments.length >= MAX_ATTACHMENTS) {
       pushToast(i18n.global.t('chat.toast.tooManyAttachments', { max: MAX_ATTACHMENTS }), { tone: 'danger' })
@@ -356,6 +389,10 @@ export function useChatAttachments(artifactContent?: ArtifactContentAccess) {
     return true
   }
 
+  function isAttachmentGenerationCurrent(generation: number): boolean {
+    return generation === attachmentGeneration
+  }
+
   return {
     pendingAttachments,
     attachmentWorkBusy,
@@ -363,6 +400,7 @@ export function useChatAttachments(artifactContent?: ArtifactContentAccess) {
     addAttachments,
     addAttachment,
     removeAttachment,
+    retireAttachments,
     retryAttachment,
     hasPendingAttachmentWork,
     prepareAttachmentsForSend,

--- a/opensquilla-webui/src/composables/chat/useChatSessionRuntime.test.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionRuntime.test.ts
@@ -1,8 +1,15 @@
 import { ref } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { useChatSessionRuntime, type ChatUsageAccumulator } from './useChatSessionRuntime'
+import { useChatSessionRuntime, type ChatUsageAccumulator, type UseChatSessionRuntimeOptions } from './useChatSessionRuntime'
+import { useChatAttachments } from './useChatAttachments'
 import type { ChatMessage } from '@/types/chat'
+
+const pushToast = vi.hoisted(() => vi.fn())
+
+vi.mock('@/composables/useToasts', () => ({
+  useToasts: () => ({ pushToast }),
+}))
 
 function emptyUsage(): ChatUsageAccumulator {
   return {
@@ -15,6 +22,173 @@ function emptyUsage(): ChatUsageAccumulator {
     sessionSaved: 0,
   }
 }
+
+describe('useChatSessionRuntime attachment ownership', () => {
+  class DeferredFileReader {
+    onload: ((event: { target: { result: string } }) => void) | null = null
+    onerror: (() => void) | null = null
+
+    readAsDataURL() {
+      readers.push(this)
+    }
+
+    finish() {
+      this.onload?.({ target: { result: 'data:image/jpeg;base64,/9j/' } })
+    }
+  }
+  let readers: DeferredFileReader[]
+
+  beforeEach(() => {
+    readers = []
+    pushToast.mockClear()
+    vi.stubGlobal('FileReader', DeferredFileReader)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function createRuntime(overrides: Partial<UseChatSessionRuntimeOptions> = {}) {
+    const attachments = useChatAttachments()
+    const sessionKey = ref('agent:main:webchat:first')
+    const runtime = useChatSessionRuntime({
+      sessionKey,
+      messages: ref<ChatMessage[]>([]),
+      pendingSessionIntent: ref(null),
+      routerDecisionPending: ref(null),
+      currentEpoch: ref(0),
+      lastStreamSeq: ref(0),
+      activeTaskGroups: ref(new Set<string>()),
+      aborted: ref(false),
+      lastHeaderRole: ref(''),
+      lastHeaderDay: ref(''),
+      usageAccum: ref(emptyUsage()),
+      usageModel: ref(''),
+      createSessionKey: () => 'agent:main:webchat:new-draft',
+      persistSession: key => { sessionKey.value = key },
+      cancelSessionBootstrap: vi.fn(),
+      startSessionBootstrap: () => ({
+        generation: 1,
+        criticalRequestsQueued: Promise.resolve(),
+        history: Promise.resolve({ ok: true }),
+        live: Promise.resolve({ authoritative: true, live: false, backgroundOnly: false }),
+      }),
+      loadCurrentSessionUsage: vi.fn(),
+      applySessionRunState: vi.fn(),
+      setCompactInFlight: vi.fn(),
+      hideCompactStatus: vi.fn(),
+      clearPendingQueue: vi.fn(),
+      switchPendingQueue: vi.fn(),
+      adoptPendingQueue: vi.fn(),
+      resetSavingsPopupCooldown: vi.fn(),
+      restoreWidgetState: vi.fn(),
+      resetStreamLiveTurnState: vi.fn(),
+      retireAttachments: attachments.retireAttachments,
+      ...overrides,
+    })
+    const addImage = (name: string) => attachments.addAttachment(
+      new File([new Uint8Array([0xff, 0xd8, 0xff])], name, { type: 'image/jpeg' }),
+    )
+    return { runtime, attachments, sessionKey, addImage }
+  }
+
+  it.each(['navigate', 'new task', 'slash reset'])(
+    'retires unsent files and late reads on %s',
+    async (transition) => {
+      const { runtime, attachments, addImage } = createRuntime()
+      await addImage('ready.jpg')
+      readers[0].finish()
+      await addImage('reading.jpg')
+
+      if (transition === 'navigate') await runtime.switchToSession('agent:main:webchat:second')
+      else if (transition === 'new task') await runtime.startDraftSession()
+      else runtime.resetCurrentSessionAfterSlash()
+
+      expect(attachments.pendingAttachments.value).toEqual([])
+      expect(attachments.hasPendingAttachmentWork()).toBe(false)
+      await addImage('current.jpg')
+      readers[1].finish()
+      readers[1].onerror?.()
+      readers[2].finish()
+
+      expect(attachments.pendingAttachments.value).toMatchObject([
+        { kind: 'inline', name: 'current.jpg' },
+      ])
+      expect(pushToast).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each(['response handoff', 'draft rebind'])(
+    'preserves the composer and in-flight reads during %s',
+    async (transition) => {
+      const { runtime, attachments, addImage } = createRuntime()
+      await addImage('ready.jpg')
+      readers[0].finish()
+      await addImage('reading.jpg')
+
+      if (transition === 'response handoff') {
+        await runtime.adoptResponseSession('agent:main:webchat:accepted', 'request-1')
+      } else {
+        await runtime.rebindDraftSession('agent:main:webchat:server-draft', () => true)
+      }
+      readers[1].finish()
+
+      expect(attachments.pendingAttachments.value).toMatchObject([
+        { kind: 'inline', name: 'ready.jpg' },
+        { kind: 'inline', name: 'reading.jpg' },
+      ])
+      expect(pushToast).not.toHaveBeenCalled()
+    },
+  )
+
+  it('retires attachments only when delayed navigation commits', async () => {
+    let finishQueue!: () => void
+    const queue = new Promise<void>(resolve => { finishQueue = resolve })
+    const { runtime, attachments, addImage } = createRuntime({
+      switchPendingQueue: () => queue,
+    })
+    await addImage('source.jpg')
+
+    const switching = runtime.switchToSession('agent:main:webchat:second')
+    readers[0].finish()
+    expect(attachments.pendingAttachments.value).toMatchObject([{ kind: 'inline', name: 'source.jpg' }])
+
+    finishQueue()
+    await switching
+    expect(attachments.pendingAttachments.value).toEqual([])
+  })
+
+  it.each(['failed', 'superseded', 'unchanged'])(
+    'preserves attachments after %s navigation',
+    async (outcome) => {
+      let finishQueue!: () => void
+      const queue = new Promise<void>(resolve => { finishQueue = resolve })
+      const { runtime, attachments, sessionKey, addImage } = createRuntime({
+        switchPendingQueue: () => outcome === 'failed'
+          ? Promise.reject(new Error('queue unavailable'))
+          : queue,
+      })
+      await addImage('source.jpg')
+
+      if (outcome === 'unchanged') {
+        await runtime.switchToSession(sessionKey.value)
+      } else {
+        const switching = runtime.switchToSession('agent:main:webchat:second')
+        if (outcome === 'failed') {
+          await expect(switching).rejects.toThrow('queue unavailable')
+        } else {
+          await runtime.switchToSession(sessionKey.value)
+          finishQueue()
+          await switching
+        }
+      }
+      readers[0].finish()
+
+      expect(sessionKey.value).toBe('agent:main:webchat:first')
+      expect(attachments.pendingAttachments.value).toMatchObject([{ kind: 'inline', name: 'source.jpg' }])
+    },
+  )
+})
 
 describe('useChatSessionRuntime Meta draft recovery', () => {
   it('rebinds an untouched provisional draft without persisting it', async () => {

--- a/opensquilla-webui/src/composables/chat/useChatSessionRuntime.ts
+++ b/opensquilla-webui/src/composables/chat/useChatSessionRuntime.ts
@@ -79,6 +79,7 @@ export interface UseChatSessionRuntimeOptions {
   resetSavingsPopupCooldown: () => void
   restoreWidgetState: () => void
   resetStreamLiveTurnState: () => void
+  retireAttachments?: () => void
   resetDraftComposer?: () => void
 }
 
@@ -171,6 +172,7 @@ export function useChatSessionRuntime(options: UseChatSessionRuntimeOptions) {
   }
 
   function resetCurrentSessionAfterSlash() {
+    options.retireAttachments?.()
     resetSessionRuntimeState()
     resetCompactState()
     options.clearPendingQueue()
@@ -222,6 +224,9 @@ export function useChatSessionRuntime(options: UseChatSessionRuntimeOptions) {
     // pinned frame before cancelSessionBootstrap returns, so B never waits for
     // A's ACK and no connected event can observe a half-switched route.
     options.cancelSessionBootstrap()
+    // Server adoption still belongs to the current composer. Only an actual
+    // navigation retires its files and outstanding reads/uploads.
+    if (pendingQueuePolicy.kind === 'navigate') options.retireAttachments?.()
     resetCompactState()
     options.beginSessionResolution?.(key)
     options.persistSession(key, { source: 'runtime.switchToSession' })
@@ -373,6 +378,7 @@ export function useChatSessionRuntime(options: UseChatSessionRuntimeOptions) {
       return
     }
     options.cancelSessionBootstrap()
+    options.retireAttachments?.()
     resetCompactState()
     options.sessionKey.value = key
     resetSessionRuntimeState()

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -1058,7 +1058,9 @@
       "modelNoMatches": "Keine passenden Modelle — die Eingabe kann trotzdem verwendet werden.",
       "modelListTruncated": "{shown} von {total} Modellen — weitertippen zum Eingrenzen.",
       "modelProvenance": "Live-Anbieterliste · Funktionsquelle: {sources}",
-      "modelMetadataProvenance": "Live-Anbieterliste · offizielle Werte bevorzugt, sonst Katalogwerte"
+      "modelMetadataProvenance": "Live-Anbieterliste · offizielle Werte bevorzugt, sonst Katalogwerte",
+      "modelMultimodal": "Multimodal",
+      "modelMultimodalTitle": "Unterstützt Bildeingaben"
     },
     "preset": {
       "modeCustom": "benutzerdefiniert"
@@ -1128,6 +1130,7 @@
       "removeCandidateAria": "{model} entfernen",
       "ensembleEmpty": "Noch keine Kandidatenmodelle. Speichere zuerst die Modelldienst-Einstellungen, um Routing-Stufen zu erzeugen, oder füge Kandidaten manuell hinzu.",
       "ensemblePipeline": "So funktioniert es: Die Entwurfsmodelle schreiben parallel, dann verschmilzt der Aggregator die Entwürfe zur endgültigen Antwort. Nur der Aggregator kann Tools aufrufen.",
+      "candidateModelHint": "Das Multimodal-Label bedeutet, dass ein Modell Bildeingaben unterstützt. Bildanfragen verwenden die konfigurierte bildfähige Route.",
       "ensembleFlowDesc": "Modelle entwerfen parallel; ein Aggregator führt sie zu einer Antwort zusammen. Mehr Aufrufe.",
       "legacyDynamicNotice": "Dieser ältere Fusionsplan folgt den gespeicherten Modellstufen. Zum Bearbeiten der Mitglieder in eine eigene Aufstellung umwandeln.",
       "legacyDynamicMigrate": "In eigene Aufstellung umwandeln",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -1140,7 +1140,9 @@
       "modelNoMatches": "No matching models — you can keep what you typed.",
       "modelListTruncated": "Showing {shown} of {total} models — keep typing to narrow the list.",
       "modelProvenance": "Live provider list · capability source: {sources}",
-      "modelMetadataProvenance": "Live provider list · official values when available, catalog fallback otherwise"
+      "modelMetadataProvenance": "Live provider list · official values when available, catalog fallback otherwise",
+      "modelMultimodal": "Multimodal",
+      "modelMultimodalTitle": "Supports image input"
     },
     "preset": {
       "modeCustom": "custom tiers"
@@ -1210,6 +1212,7 @@
       "removeCandidateAria": "Remove {model}",
       "ensembleEmpty": "No candidate models yet. Save your Model Service settings to seed model tiers, or add candidates manually.",
       "ensemblePipeline": "How it works: proposer models draft in parallel, then the aggregator fuses the drafts into the final reply. Only the aggregator can call tools.",
+      "candidateModelHint": "The Multimodal badge means a model accepts image input. Image turns follow the configured image-capable route.",
       "ensembleFlowDesc": "Models draft in parallel; an aggregator merges them into one answer. Uses more calls.",
       "legacyDynamicNotice": "This legacy fusion plan follows the saved model tiers. Convert it to a custom lineup to edit its members here.",
       "legacyDynamicMigrate": "Convert to custom lineup",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -1058,7 +1058,9 @@
       "modelNoMatches": "No hay modelos coincidentes — puedes usar lo que escribiste.",
       "modelListTruncated": "Mostrando {shown} de {total} modelos — sigue escribiendo para acotar.",
       "modelProvenance": "Lista del proveedor en vivo · fuente de capacidades: {sources}",
-      "modelMetadataProvenance": "Lista del proveedor en vivo · valores oficiales si están disponibles; si no, valores del catálogo"
+      "modelMetadataProvenance": "Lista del proveedor en vivo · valores oficiales si están disponibles; si no, valores del catálogo",
+      "modelMultimodal": "Multimodal",
+      "modelMultimodalTitle": "Admite entradas de imagen"
     },
     "preset": {
       "modeCustom": "personalizado"
@@ -1128,6 +1130,7 @@
       "removeCandidateAria": "Quitar {model}",
       "ensembleEmpty": "Aún no hay modelos candidatos. Guarda la configuración del servicio de modelos para generar niveles de enrutamiento, o agrega candidatos manualmente.",
       "ensemblePipeline": "Cómo funciona: los modelos proponentes redactan en paralelo y el agregador fusiona los borradores en la respuesta final. Solo el agregador puede invocar herramientas.",
+      "candidateModelHint": "La etiqueta Multimodal indica que el modelo acepta imágenes. Las solicitudes con imágenes siguen la ruta configurada compatible con imágenes.",
       "ensembleFlowDesc": "Varios modelos redactan en paralelo y un agregador las combina en una respuesta. Usa más llamadas.",
       "legacyDynamicNotice": "Este plan de fusión heredado sigue los niveles de modelo guardados. Conviértelo en una alineación personalizada para editar sus miembros.",
       "legacyDynamicMigrate": "Convertir en alineación personalizada",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -1058,7 +1058,9 @@
       "modelNoMatches": "Aucun modèle correspondant — vous pouvez garder votre saisie.",
       "modelListTruncated": "{shown} modèles sur {total} — continuez à taper pour affiner.",
       "modelProvenance": "Liste fournisseur en direct · source des capacités : {sources}",
-      "modelMetadataProvenance": "Liste fournisseur en direct · valeurs officielles prioritaires, sinon valeurs catalogue"
+      "modelMetadataProvenance": "Liste fournisseur en direct · valeurs officielles prioritaires, sinon valeurs catalogue",
+      "modelMultimodal": "Multimodal",
+      "modelMultimodalTitle": "Accepte les entrées d’image"
     },
     "preset": {
       "modeCustom": "personnalisé"
@@ -1128,6 +1130,7 @@
       "removeCandidateAria": "Retirer {model}",
       "ensembleEmpty": "Aucun modèle candidat pour le moment. Enregistrez les paramètres du service de modèles pour générer les niveaux de routage, ou ajoutez des candidats manuellement.",
       "ensemblePipeline": "Fonctionnement : les modèles proposants rédigent en parallèle, puis l'agrégateur fusionne les brouillons en réponse finale. Seul l'agrégateur peut appeler des outils.",
+      "candidateModelHint": "Le badge Multimodal indique qu’un modèle accepte les images. Les requêtes avec image suivent la route configurée compatible avec les images.",
       "ensembleFlowDesc": "Plusieurs modèles rédigent en parallèle ; un agrégateur les fusionne en une réponse. Plus d'appels.",
       "legacyDynamicNotice": "Cet ancien plan de fusion suit les niveaux de modèle enregistrés. Convertissez-le en composition personnalisée pour modifier ses membres.",
       "legacyDynamicMigrate": "Convertir en composition personnalisée",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -1058,7 +1058,9 @@
       "modelNoMatches": "一致するモデルがありません — 入力した値をそのまま使えます。",
       "modelListTruncated": "{total} 件中 {shown} 件を表示 — 入力を続けると絞り込めます。",
       "modelProvenance": "プロバイダーのライブ一覧 · 機能情報の出典：{sources}",
-      "modelMetadataProvenance": "プロバイダーのライブ一覧 · 公式値を優先し、ない場合はカタログ値を使用"
+      "modelMetadataProvenance": "プロバイダーのライブ一覧 · 公式値を優先し、ない場合はカタログ値を使用",
+      "modelMultimodal": "マルチモーダル",
+      "modelMultimodalTitle": "画像入力に対応"
     },
     "preset": {
       "modeCustom": "カスタム"
@@ -1128,6 +1130,7 @@
       "removeCandidateAria": "{model} を削除",
       "ensembleEmpty": "候補モデルがまだありません。モデルサービスの設定を保存してルーティング階層を生成するか、候補を手動で追加してください。",
       "ensemblePipeline": "仕組み:候補モデルが並行してドラフトを作成し、集約モデルがドラフトを集約して最終回答を生成します。ツールを呼び出せるのは集約モデルのみです。",
+      "candidateModelHint": "「マルチモーダル」バッジは画像入力に対応するモデルを示します。画像リクエストは設定済みの画像対応ルートを使用します。",
       "ensembleFlowDesc": "複数モデルが並行して下書きし、アグリゲーターが 1 つの回答に統合します。呼び出しは増えます。",
       "legacyDynamicNotice": "この従来の融合プランは保存済みのモデル階層に従います。メンバーを編集するにはカスタム編成に変換してください。",
       "legacyDynamicMigrate": "カスタム編成に変換",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -1140,7 +1140,9 @@
       "modelNoMatches": "没有匹配的模型 — 可以直接使用输入的内容。",
       "modelListTruncated": "显示 {total} 个模型中的 {shown} 个 — 继续输入以缩小范围。",
       "modelProvenance": "服务商实时列表 · 能力来源：{sources}",
-      "modelMetadataProvenance": "服务商实时列表 · 官网参数优先，缺失时使用目录值"
+      "modelMetadataProvenance": "服务商实时列表 · 官网参数优先，缺失时使用目录值",
+      "modelMultimodal": "多模态",
+      "modelMultimodalTitle": "支持图片输入"
     },
     "preset": {
       "modeCustom": "自定义分层"
@@ -1210,6 +1212,7 @@
       "removeCandidateAria": "移除 {model}",
       "ensembleEmpty": "暂无候选模型。请保存模型服务设置以生成模型分层，或手动添加候选模型。",
       "ensemblePipeline": "工作方式：提案模型并行起草，融合模型汇总草稿并产出最终回答；只有融合模型可以调用工具。",
+      "candidateModelHint": "“多模态”标签表示模型支持图片输入；图片请求会使用已配置的图片能力路由。",
       "ensembleFlowDesc": "多个模型并行起草,融合模型合成最终回答;调用次数更多。",
       "legacyDynamicNotice": "当前为跟随已保存模型分层的旧融合方案；转换为自定义阵容后可在此编辑成员。",
       "legacyDynamicMigrate": "转换为自定义阵容",

--- a/opensquilla-webui/src/views/ChatView.vue
+++ b/opensquilla-webui/src/views/ChatView.vue
@@ -1809,6 +1809,7 @@ const {
   onFileInputChange,
   addAttachments,
   removeAttachment,
+  retireAttachments,
   retryAttachment,
   hasPendingAttachmentWork,
   prepareAttachmentsForSend,
@@ -2938,10 +2939,10 @@ const chatSessionRuntime = useChatSessionRuntime({
   resetSavingsPopupCooldown,
   restoreWidgetState,
   resetStreamLiveTurnState,
+  retireAttachments,
   resetDraftComposer: () => {
     artifactImageLightbox.close()
     inputText.value = ''
-    pendingAttachments.value = []
     resetComposerInputHistory()
     autoResizeTextarea()
   },

--- a/src/opensquilla/contracts/image_validation.py
+++ b/src/opensquilla/contracts/image_validation.py
@@ -1,0 +1,43 @@
+"""Validate image content before admitting it as a model image input."""
+
+from __future__ import annotations
+
+import io
+import warnings
+
+from PIL import Image
+
+from opensquilla.contracts.attachments import IMAGE_ATTACHMENT_MIMES, normalize_attachment_mime
+
+
+def validate_image_bytes(payload: bytes, media_type: str) -> None:
+    """Require a supported image with matching MIME and decodable pixel data.
+
+    Callers enforce their byte limits before decoding. Header sniffing remains
+    separate so a recognized image header cannot stand in for content validation.
+    """
+
+    expected = normalize_attachment_mime(media_type)
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", Image.DecompressionBombWarning)
+            with Image.open(io.BytesIO(payload)) as image:
+                actual = Image.MIME.get(image.format or "")
+                if actual not in IMAGE_ATTACHMENT_MIMES or actual != expected:
+                    raise ValueError("image format does not match the declared media type")
+                image.verify()
+            # Some formats only check their header in verify(); decoding catches
+            # truncated or invalid pixel data as well.
+            with Image.open(io.BytesIO(payload)) as image:
+                image.load()
+    except (
+        OSError,
+        SyntaxError,
+        ValueError,
+        Image.DecompressionBombError,
+        Image.DecompressionBombWarning,
+    ) as exc:
+        raise ValueError(
+            f"claims {media_type} but image content is corrupt, unreadable, or mismatched "
+            "(415 equivalent); please upload a valid image"
+        ) from exc

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -10062,7 +10062,7 @@ class TurnRunner:
             turn.metadata["ensemble_wrap_skipped_reason"] = reason
             _record_fixed_ensemble_execution(reason)
 
-        if provider is not None and (ensemble_globally_enabled or tier_ensemble_mode):
+        if provider is not None and fixed_baseline_ensemble:
             from opensquilla.engine.selector_override import (
                 acquire_profile_credential,
                 report_profile_credential_failure,

--- a/src/opensquilla/engine/runtime.py
+++ b/src/opensquilla/engine/runtime.py
@@ -102,6 +102,7 @@ from opensquilla.contracts.attachments import (
 from opensquilla.contracts.attachments import (
     normalize_attachment_mime as _normalize_attachment_mime,
 )
+from opensquilla.contracts.image_validation import validate_image_bytes
 from opensquilla.contracts.turn_execution import TurnExecutionContext
 from opensquilla.engine.agent import Agent, ToolHandler
 from opensquilla.engine.agent_injection import PendingInputProvider
@@ -557,6 +558,16 @@ def _is_materializable_attachment_mime(mime: Any) -> bool:
     # are opaque, so their only representation is the workspace copy.
     normalized = _normalize_attachment_mime(mime)
     return normalized is not None and normalized not in _IMAGE_ATTACHMENT_MIMES
+
+
+def _historical_image_bytes_match_claim(media_type: str, raw: bytes) -> bool:
+    """Turn unreadable legacy image material into an unavailable marker."""
+
+    try:
+        validate_image_bytes(raw, media_type)
+    except ValueError:
+        return False
+    return True
 
 
 def collect_invoked_skills(
@@ -9843,15 +9854,43 @@ class TurnRunner:
                     "missing_fixed_fallback: configure a non-empty fixed/direct "
                     "provider and model before enabling multi-model fusion"
                 )
-            turn.metadata["ensemble_fallback_provider"] = fixed_provider
-            turn.metadata["ensemble_fallback_model"] = fixed_model
+
+            # Attachment admission proves the routed logical deployment before
+            # Ensemble replaces it with the configured fixed baseline. If that
+            # baseline cannot carry the same request, keep the proven routed
+            # single-model path and its capacity-filtered selector fallback.
+            if turn.metadata.get("large_context_capacity_required") is True:
+                from opensquilla.engine.selector_override import (
+                    provider_config_has_request_capacity,
+                )
+
+                if not provider_config_has_request_capacity(
+                    initial_provider_config,
+                    turn.metadata,
+                ):
+                    fixed_baseline_ensemble = False
+                    turn.metadata["ensemble_wrap_skipped_reason"] = (
+                        "fixed_fallback_request_capacity"
+                    )
+                    turn.metadata["ensemble_capacity_bypassed"] = True
+                    log.warning(
+                        "llm_ensemble.wrap_skipped",
+                        reason="fixed_fallback_request_capacity",
+                        provider=fixed_provider,
+                        model=fixed_model,
+                    )
+
+            if fixed_baseline_ensemble:
+                turn.metadata["ensemble_fallback_provider"] = fixed_provider
+                turn.metadata["ensemble_fallback_model"] = fixed_model
 
             # Static/custom plans own their members' reasoning policy.  The
             # tier value remains stored as the reversible single-model draft,
             # but must not leak into the shared plan.  Legacy router_dynamic
             # continues to derive per-member thinking from its tier rows.
             if (
-                selection_mode != ROUTER_DYNAMIC_SELECTION_MODE
+                fixed_baseline_ensemble
+                and selection_mode != ROUTER_DYNAMIC_SELECTION_MODE
                 and turn.metadata.get("thinking_source") == "squilla_router_tier"
             ):
                 turn.metadata.pop("thinking_requested", None)
@@ -14861,7 +14900,7 @@ class TurnRunner:
 
                 if isinstance(data, str) and data:
                     try:
-                        base64.b64decode(data, validate=True)
+                        raw_bytes = base64.b64decode(data, validate=True)
                     except (binascii.Error, ValueError):
                         omitted.append(
                             image_marker(
@@ -14870,6 +14909,14 @@ class TurnRunner:
                             )
                         )
                     else:
+                        if not _historical_image_bytes_match_claim(media_type, raw_bytes):
+                            omitted.append(
+                                image_marker(
+                                    ImageMarkerState.UNAVAILABLE,
+                                    attachment_id=attachment_id,
+                                )
+                            )
+                            continue
                         if (
                             allowed_image_attachment_ids is not None
                             and attachment_id is not None
@@ -14915,6 +14962,14 @@ class TurnRunner:
                             )
                         )
                     else:
+                        if not _historical_image_bytes_match_claim(media_type, raw_bytes):
+                            omitted.append(
+                                image_marker(
+                                    ImageMarkerState.UNAVAILABLE,
+                                    attachment_id=attachment_id,
+                                )
+                            )
+                            continue
                         if (
                             allowed_image_attachment_ids is not None
                             and attachment_id is not None

--- a/src/opensquilla/engine/selector_override.py
+++ b/src/opensquilla/engine/selector_override.py
@@ -58,7 +58,7 @@ def _bounded_fallback_chain_required(turn_metadata: dict[str, Any]) -> bool:
     )
 
 
-def _provider_config_has_request_capacity(
+def provider_config_has_request_capacity(
     config: Any,
     turn_metadata: dict[str, Any],
     *,
@@ -121,7 +121,7 @@ def _require_provider_config_capacity(
     provider: str = "",
     model: str = "",
 ) -> None:
-    if _provider_config_has_request_capacity(
+    if provider_config_has_request_capacity(
         config,
         turn_metadata,
         provider=provider,
@@ -231,7 +231,7 @@ def _capacity_approved_fallback_entries(
     return [
         config
         for config in _materialize_fallback_configs(selector, entries)
-        if _provider_config_has_request_capacity(config, turn_metadata)
+        if provider_config_has_request_capacity(config, turn_metadata)
     ]
 
 

--- a/src/opensquilla/gateway/adapters/artifact_content.py
+++ b/src/opensquilla/gateway/adapters/artifact_content.py
@@ -30,6 +30,7 @@ from opensquilla.attachment_refs import transcript_material_path
 from opensquilla.contracts.attachment_sniff import sniff_mime_from_bytes
 from opensquilla.contracts.attachments import (
     ALLOWED_MEDIA_TYPES,
+    IMAGE_ATTACHMENT_MIMES,
     MSG_MIME,
     OPAQUE_MIME,
     attachment_category,
@@ -156,6 +157,9 @@ class GatewayAttachmentMimePolicy(AttachmentMimePolicyPort):
 
     def resolve_mime(self, claimed_mime: str, payload: bytes, *, accept_opaque: bool) -> str:
         normalized = self.validate_claim(claimed_mime, accept_opaque=accept_opaque)
+        if normalized in IMAGE_ATTACHMENT_MIMES:
+            sniffed = sniff_mime_from_bytes(payload)
+            return sniffed if sniffed in IMAGE_ATTACHMENT_MIMES else normalized
         if not accept_opaque:
             assert normalized is not None
             return normalized

--- a/src/opensquilla/gateway/adapters/provider_configuration.py
+++ b/src/opensquilla/gateway/adapters/provider_configuration.py
@@ -119,8 +119,11 @@ def model_info_to_projection(model: dict[str, Any]) -> dict[str, Any]:
             capabilities.append("reasoning")
         if supports_vision:
             capabilities.append("vision")
-    elif model.get("supports_tools"):
-        capabilities.append("tools")
+    else:
+        if model.get("supports_tools"):
+            capabilities.append("tools")
+        if model.get("supports_vision"):
+            capabilities.append("vision")
 
     return {
         "id": model_id,

--- a/src/opensquilla/gateway/attachment_ingest.py
+++ b/src/opensquilla/gateway/attachment_ingest.py
@@ -48,6 +48,7 @@ from opensquilla.contracts.attachments import (
     can_stage_attachment_mime,
     normalize_attachment_mime,
 )
+from opensquilla.contracts.image_validation import validate_image_bytes
 
 log = structlog.get_logger(__name__)
 
@@ -356,6 +357,16 @@ def validate_attachments(
                     ),
                 )
                 continue
+            if media_type in IMAGE_ATTACHMENT_MIMES:
+                try:
+                    validate_image_bytes(payload, media_type)
+                except ValueError as exc:
+                    _raise_or_mark(
+                        failure_mode=failure_mode,
+                        failures=failures,
+                        failure=_failure(index, attachment, "invalid_image", str(exc)),
+                    )
+                    continue
             item = dict(attachment)
             item["type"] = media_type
             item["mime"] = media_type
@@ -610,6 +621,17 @@ def validate_attachments(
                 ),
             )
             continue
+
+        if claimed in IMAGE_ATTACHMENT_MIMES or resolved in IMAGE_ATTACHMENT_MIMES:
+            try:
+                validate_image_bytes(raw_bytes, resolved)
+            except ValueError as exc:
+                _raise_or_mark(
+                    failure_mode=failure_mode,
+                    failures=failures,
+                    failure=_failure(index, attachment, "invalid_image", str(exc)),
+                )
+                continue
 
         item = dict(attachment)
         item["type"] = resolved

--- a/src/opensquilla/gateway/uploads.py
+++ b/src/opensquilla/gateway/uploads.py
@@ -44,12 +44,14 @@ from opensquilla.application.artifact_workbench import (
 )
 from opensquilla.contracts.attachments import (
     ALLOWED_MEDIA_TYPES,
+    IMAGE_ATTACHMENT_MIMES,
     OPAQUE_ATTACHMENT_BYTES,
     attachment_category,
     attachment_size_limit_for_mime,
     can_stage_attachment_mime,
     normalize_attachment_mime,
 )
+from opensquilla.contracts.image_validation import validate_image_bytes
 from opensquilla.gateway.adapters.artifact_content import (
     GatewayAttachmentMimePolicy,
     GatewayAttachmentStagingPort,
@@ -239,6 +241,12 @@ class UploadStore:
                 f"upload of {len(payload)} bytes exceeds the "
                 f"{self.max_total_bytes} byte staged-upload store cap"
             )
+
+        if normalized_mime in IMAGE_ATTACHMENT_MIMES:
+            try:
+                validate_image_bytes(payload, normalized_mime)
+            except ValueError as exc:
+                raise UploadUnsupportedMimeError(str(exc)) from exc
 
         file_uuid = f"u-{_uuid.uuid4().hex}"
         sha = hashlib.sha256(payload).hexdigest()

--- a/src/opensquilla/provider/ensemble.py
+++ b/src/opensquilla/provider/ensemble.py
@@ -21,7 +21,7 @@ from typing import Any, Literal, cast
 
 import structlog
 
-from opensquilla.context_budget import ContextBudgetGovernor
+from opensquilla.context_budget import CHARS_PER_TOKEN, ContextBudgetGovernor
 from opensquilla.contracts.turn_execution import (
     EnsembleContinuationSnapshot,
     ProviderAdmissionError,
@@ -1425,6 +1425,7 @@ class EnsembleProvider:
         ]
         | None = None,
         _fallback_request_budget_member: EnsembleMemberConfig | None = None,
+        _attachment_request_input_tokens: int = 0,
         _credential_pool_failure_reporter: CredentialPoolFailureReporter | None = None,
         _provider_state_replay_activation_targets: Sequence[Any] | None = None,
     ) -> None:
@@ -1480,6 +1481,13 @@ class EnsembleProvider:
             _member_request_budget_bindings or {}
         )
         self._fallback_request_budget_member = _fallback_request_budget_member
+        self._attachment_request_input_tokens = max(
+            0,
+            int(_attachment_request_input_tokens or 0),
+        )
+        self._require_attachment_capacity_proof = (
+            self._attachment_request_input_tokens > 0
+        )
         self._credential_pool_failure_reporter = _credential_pool_failure_reporter
         self._provider_state_replay_activation_targets = list(
             _provider_state_replay_activation_targets or []
@@ -1607,6 +1615,68 @@ class EnsembleProvider:
         ):
             return (
                 "proposer has no reliable provider-specific request budget",
+                "provider_request_budget_exhausted",
+            )
+        return None
+
+    def _attachment_request_unavailability(
+        self,
+        *,
+        member: EnsembleMemberConfig | None,
+        chat_config: ChatConfig | None,
+        role: str,
+    ) -> tuple[str, str] | None:
+        """Check the complete routed request against one physical member cap.
+
+        The router freezes a conservative input-token upper bound after prompt,
+        tool, and attachment materialization. Reusing that bound keeps this
+        physical-member preflight cheap and prevents a large attachment from
+        being rescanned once per Ensemble leg.
+        """
+
+        if not self._require_attachment_capacity_proof:
+            return None
+        binding = (
+            self._member_request_budget_binding(member)
+            if member is not None
+            else None
+        )
+        context_window_tokens = (
+            int(binding.context_window_tokens or 0) if binding is not None else 0
+        )
+        if (
+            binding is None
+            or not binding.rederive
+            or context_window_tokens <= 0
+        ):
+            return (
+                f"{role} has no proven attachment request capacity; configure "
+                "context_window_tokens for every Ensemble member and fallback",
+                "provider_request_budget_exhausted",
+            )
+        thinking_budget_tokens = (
+            max(0, int(getattr(chat_config, "thinking_budget_tokens", 0) or 0))
+            if bool(getattr(chat_config, "thinking", False))
+            else 0
+        )
+        budget = ContextBudgetGovernor.from_values(
+            context_window_tokens=context_window_tokens,
+            max_output_tokens=max(
+                0,
+                int(getattr(chat_config, "max_tokens", 0) or 0),
+            ),
+            thinking_budget_tokens=thinking_budget_tokens,
+            context_overflow_threshold=binding.context_overflow_threshold,
+            provider_request_proof_max_chars=max(
+                0,
+                int(binding.top_level_explicit_cap or 0),
+            ),
+        ).snapshot()
+        safe_input_tokens = budget.provider_request_max_chars // CHARS_PER_TOKEN
+        if self._attachment_request_input_tokens > safe_input_tokens:
+            return (
+                f"{role} attachment request exceeds its proven capacity; "
+                "configure a larger-context Ensemble deployment",
                 "provider_request_budget_exhausted",
             )
         return None
@@ -2520,6 +2590,28 @@ class EnsembleProvider:
                 yield event
             return
 
+        aggregator_binding = self._member_request_budget_binding(self.aggregator)
+        if self._require_attachment_capacity_proof and (
+            aggregator_binding is None
+            or not aggregator_binding.rederive
+            or int(aggregator_binding.context_window_tokens or 0) <= 0
+        ):
+            async for event in self._fallback_or_error(
+                messages,
+                tools=tools,
+                config=config,
+                execution_context=execution_context,
+                reason=(
+                    "ensemble aggregator has no proven attachment request "
+                    "capacity; configure context_window_tokens for every "
+                    "Ensemble member"
+                ),
+                code="provider_request_budget_exhausted",
+                candidates=[],
+            ):
+                yield event
+            return
+
         try:
             aggregator_provider = _build_provider(self.aggregator.provider_config)
         except Exception as exc:  # noqa: BLE001 - provider boundary returns ErrorEvent
@@ -2543,7 +2635,6 @@ class EnsembleProvider:
             return
 
         aggregator_cfg = self._aggregator_chat_config(config, messages)
-        aggregator_binding = self._member_request_budget_binding(self.aggregator)
         if (
             aggregator_binding is not None
             and not aggregator_binding.inherit_top_level_cap
@@ -3100,6 +3191,14 @@ class EnsembleProvider:
         # generators. Provider-private continuity state (reasoning_content,
         # thinking blocks, thought signatures) belongs to the model that
         # minted it and must not be replayed into any proposer physical call.
+        capacity_unavailable = self._attachment_request_unavailability(
+            member=member,
+            chat_config=chat_cfg,
+            role="Ensemble proposer",
+        )
+        if capacity_unavailable is not None:
+            result.error, result.error_code = capacity_unavailable
+            return result
         provider = _build_provider(_proposer_provider_config(member))
         text_parts: list[str] = []
         got_done = False
@@ -4589,6 +4688,8 @@ class EnsembleProvider:
         fixed_messages = list(messages)
         fixed_budget_proof: dict[str, Any] | None = None
         fixed_budget_exhausted = False
+        fixed_budget_error_message = ""
+        fixed_budget_error_code = "fallback_aggregator_budget_exhausted"
         if immutable_bundle:
             fitted_fixed = self._fit_fixed_candidate_bundle(
                 self.fallback_provider,
@@ -4601,6 +4702,17 @@ class EnsembleProvider:
                 fixed_bundle, fixed_messages, fixed_budget_proof = fitted_fixed
             else:
                 fixed_budget_exhausted = True
+        else:
+            fixed_capacity_unavailable = self._attachment_request_unavailability(
+                member=fallback_member,
+                chat_config=fallback_config,
+                role="Ensemble fixed fallback",
+            )
+            if fixed_capacity_unavailable is not None:
+                fixed_budget_exhausted = True
+                fixed_budget_error_message, fixed_budget_error_code = (
+                    fixed_capacity_unavailable
+                )
         fallback_timeout_seconds = float(
             getattr(fallback_config, "timeout", ChatConfig().timeout)
             if fallback_config is not None
@@ -4658,7 +4770,7 @@ class EnsembleProvider:
                 fixed_budget_proof
             )
         trace["fallback_code"] = (
-            "fallback_aggregator_budget_exhausted"
+            fixed_budget_error_code
             if fixed_budget_exhausted
             else (
                 "provider_request_budget_exhausted"
@@ -4667,6 +4779,9 @@ class EnsembleProvider:
             )
         )
         if fixed_budget_exhausted:
+            capacity_message = fixed_budget_error_message or (
+                "fixed aggregator request budget cannot retain one candidate draft"
+            )
             if execution_context is not None:
                 await execution_context.begin_failed_fixed_recovery(
                     fixed_execution_role,
@@ -4676,7 +4791,7 @@ class EnsembleProvider:
                         tool_schemas=tuple(tools or ()),
                         conversation=tuple(messages),
                         metadata={
-                            "code": "fallback_aggregator_budget_exhausted",
+                            "code": fixed_budget_error_code,
                             "fixed_role": fixed_role,
                         },
                     ),
@@ -4687,20 +4802,14 @@ class EnsembleProvider:
                     safe_reason="fixed request budget exhausted",
                     terminal=True,
                     terminal_text_snapshot=ENSEMBLE_FIXED_TERMINAL_MESSAGE,
-                    terminal_error_message=(
-                        "fixed aggregator request budget cannot retain one "
-                        "candidate draft"
-                    ),
-                    terminal_error_code="fallback_aggregator_budget_exhausted",
+                    terminal_error_message=capacity_message,
+                    terminal_error_code=fixed_budget_error_code,
                 )
                 return
             yield proposer_error(
                 ErrorEvent(
-                    message=(
-                        "fixed aggregator request budget cannot retain one "
-                        "candidate draft"
-                    ),
-                    code="fallback_aggregator_budget_exhausted",
+                    message=capacity_message,
+                    code=fixed_budget_error_code,
                 )
             )
             return
@@ -7185,6 +7294,19 @@ def build_ensemble_provider_from_config(
         selection_plan=selection_plan,
         _member_request_budget_bindings=request_budget_bindings,
         _fallback_request_budget_member=fallback_request_budget_member,
+        _attachment_request_input_tokens=(
+            int((turn_metadata or {}).get("large_context_request_input_tokens") or 0)
+            if (turn_metadata or {}).get("large_context_capacity_required") is True
+            and isinstance(
+                (turn_metadata or {}).get("large_context_request_input_tokens"),
+                int,
+            )
+            and not isinstance(
+                (turn_metadata or {}).get("large_context_request_input_tokens"),
+                bool,
+            )
+            else 0
+        ),
         _credential_pool_failure_reporter=_credential_pool_failure_reporter,
         _provider_state_replay_activation_targets=(deferred_replay_activation_targets),
     )

--- a/src/opensquilla/provider/ensemble.py
+++ b/src/opensquilla/provider/ensemble.py
@@ -1667,12 +1667,12 @@ class EnsembleProvider:
             ),
             thinking_budget_tokens=thinking_budget_tokens,
             context_overflow_threshold=binding.context_overflow_threshold,
-            provider_request_proof_max_chars=max(
-                0,
-                int(binding.top_level_explicit_cap or 0),
-            ),
         ).snapshot()
-        safe_input_tokens = budget.provider_request_max_chars // CHARS_PER_TOKEN
+        request_max_chars = budget.provider_request_max_chars
+        explicit_cap = max(0, int(binding.top_level_explicit_cap or 0))
+        if explicit_cap > 0:
+            request_max_chars = min(request_max_chars, explicit_cap)
+        safe_input_tokens = request_max_chars // CHARS_PER_TOKEN
         if self._attachment_request_input_tokens > safe_input_tokens:
             return (
                 f"{role} attachment request exceeds its proven capacity; "
@@ -1704,6 +1704,12 @@ class EnsembleProvider:
                 member,
                 chat_config=chat_config,
             )
+            if unavailable is None:
+                unavailable = self._attachment_request_unavailability(
+                    member=member,
+                    chat_config=chat_config,
+                    role="Ensemble proposer",
+                )
             eligible = unavailable is None
             k = max(1, int(member.k or 1))
             if eligible:

--- a/src/opensquilla/provider/openai.py
+++ b/src/opensquilla/provider/openai.py
@@ -378,6 +378,17 @@ def _model_listing_max_output(row: Mapping[str, Any]) -> int:
     return _positive_model_listing_int(top_provider.get("max_completion_tokens"))
 
 
+def _model_listing_supports_vision(row: Mapping[str, Any]) -> bool:
+    """Read the standard OpenRouter modality declaration when present."""
+    architecture = row.get("architecture")
+    if not isinstance(architecture, Mapping):
+        return False
+    modalities = architecture.get("input_modalities")
+    if not isinstance(modalities, list):
+        return False
+    return any(str(modality).strip().lower() == "image" for modality in modalities)
+
+
 def _dashscope_endpoint_family(base_url: str) -> str:
     url = base_url.strip().lower()
     if "coding-intl.dashscope.aliyuncs.com" in url:
@@ -6449,6 +6460,7 @@ class OpenAIProvider:
                             display_name=m.get("name", m.get("id", "")),
                             context_window=m.get("context_length", 0),
                             max_output_tokens=_model_listing_max_output(m),
+                            supports_vision=_model_listing_supports_vision(m),
                         )
                         for m in rows
                         if m.get("id")

--- a/src/opensquilla/tools/builtin/media.py
+++ b/src/opensquilla/tools/builtin/media.py
@@ -20,6 +20,7 @@ from opensquilla.artifacts import (
     ArtifactStore,
     artifact_payload,
 )
+from opensquilla.contracts.image_validation import validate_image_bytes
 from opensquilla.engine.usage_accounting import (
     account_provider_stream,
     current_usage_accounting_scope,
@@ -176,15 +177,9 @@ async def image(path: str, prompt: str = "Describe this image") -> str:
             return json.dumps(path_block)
         image_bytes, media_type = await _read_image_file(path)
 
-    # Validate not corrupt using Pillow
     try:
-        import io
-
-        from PIL import Image
-
-        img = Image.open(io.BytesIO(image_bytes))
-        img.verify()
-    except Exception as exc:
+        validate_image_bytes(image_bytes, media_type)
+    except ValueError as exc:
         raise SafeToolError(f"Image appears corrupt or unreadable: {exc}") from exc
 
     # Try provider vision call; graceful fallback if unavailable
@@ -367,7 +362,11 @@ async def _fetch_image_url(url: str) -> tuple[bytes, str]:
             current_url = urljoin(current_url, location)
         else:
             raise ToolError(f"Too many redirects (>{_MAX_REDIRECTS})")
-        resp.raise_for_status()
+        if resp.is_error:
+            raise ToolError(
+                f"Failed to fetch image from URL: HTTP {resp.status_code} "
+                f"({resp.reason_phrase or 'request failed'})"
+            )
         image_bytes = resp.content
     except ToolError:
         raise
@@ -409,6 +408,10 @@ def _mime_to_ext(content_type: str) -> str:
         "image/webp": "webp",
     }
     return mapping.get(ct, "")
+
+
+class _EmptyMediaResponseError(RuntimeError):
+    """A media request completed without a visible answer."""
 
 
 async def _complete_from_stream(provider: Any, messages: list, config: Any = None) -> str:
@@ -482,11 +485,12 @@ async def _complete_from_stream(provider: Any, messages: list, config: Any = Non
     text_parts: list[str] = []
     try:
         async for event in stream:
-            if hasattr(event, "text"):
+            kind = getattr(event, "kind", None)
+            if kind == "text_delta":
                 text_parts.append(event.text)
-            elif hasattr(event, "delta") and isinstance(event.delta, str):
-                text_parts.append(event.delta)
-            elif getattr(event, "kind", None) == "error":
+            elif kind == "provider_generation_reset":
+                text_parts.clear()
+            elif kind == "error":
                 code = getattr(event, "code", "") or "provider_error"
                 message = getattr(event, "message", "") or "Provider stream failed"
                 raise RuntimeError(f"Provider stream error ({code}): {message}")
@@ -494,7 +498,10 @@ async def _complete_from_stream(provider: Any, messages: list, config: Any = Non
         aclose = getattr(close_stream, "aclose", None)
         if callable(aclose):
             await aclose()
-    return "".join(text_parts)
+    text = "".join(text_parts)
+    if not text.strip():
+        raise _EmptyMediaResponseError("The provider returned no visible media analysis")
+    return text
 
 
 class _ImageAnalysisUnavailableError(RuntimeError):
@@ -502,7 +509,7 @@ class _ImageAnalysisUnavailableError(RuntimeError):
 
 
 async def _call_vision_provider(b64_data: str, media_type: str, prompt: str) -> str:
-    """Analyze once on the turn's current physical deployment, without fallback."""
+    """Analyze on the current deployment, retrying an empty answer at most once."""
     from opensquilla.provider.image_projection import ImageProjectionMode, project_messages
     from opensquilla.provider.protocol import validate_provider_chat_admission
     from opensquilla.provider.types import ContentBlockImage, ContentBlockText, Message
@@ -525,13 +532,19 @@ async def _call_vision_provider(b64_data: str, media_type: str, prompt: str) -> 
     admission_error = validate_provider_chat_admission(provider, messages, config)
     if admission_error is not None:
         raise RuntimeError(admission_error.code)
-    correlation = derive_provider_request_correlation(
-        current_provider_request_correlation(),
-        execution_id=uuid.uuid4().hex,
-        call_kind="auxiliary.media",
-    )
-    with bind_provider_request_correlation(correlation):
-        return await _complete_from_stream(provider, messages, config)
+    for attempt in range(2):
+        correlation = derive_provider_request_correlation(
+            current_provider_request_correlation(),
+            execution_id=uuid.uuid4().hex,
+            call_kind="auxiliary.media",
+        )
+        with bind_provider_request_correlation(correlation):
+            try:
+                return await _complete_from_stream(provider, messages, config)
+            except _EmptyMediaResponseError:
+                if attempt:
+                    raise
+    raise AssertionError("image analysis attempts exhausted")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/functional/test_gateway_attachment_history_e2e.py
+++ b/tests/functional/test_gateway_attachment_history_e2e.py
@@ -50,13 +50,9 @@ from opensquilla.session.manager import SessionManager
 from opensquilla.session.storage import SessionStorage
 from opensquilla.token_estimation import estimate_tokens
 from opensquilla.tools.types import ToolContext
+from tests.helpers.image_bytes import image_bytes
 
-_PNG_BYTES = (
-    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
-    b"\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4"
-    b"\x89\x00\x00\x00\nIDATx\x9cc\xf8\x0f\x00\x01\x01"
-    b"\x01\x00\x18\xdd\x8d\xb0\x00\x00\x00\x00IEND\xaeB`\x82"
-)
+_PNG_BYTES = image_bytes()
 
 _PROVIDER_ID = "tokenrhythm"
 _TEXT_MODEL = "deepseek-v4-pro-0813"

--- a/tests/functional/test_gateway_non_image_attachment_materialization_e2e.py
+++ b/tests/functional/test_gateway_non_image_attachment_materialization_e2e.py
@@ -40,6 +40,7 @@ from opensquilla.provider.types import (
 )
 from opensquilla.session.manager import SessionManager
 from opensquilla.session.storage import SessionStorage
+from tests.helpers.image_bytes import image_bytes
 
 _TEXT_MODEL = "test/text"
 _GATE_MODEL = "test/gate"
@@ -47,12 +48,7 @@ _VISION_MODEL = "test/vision"
 _TURN_TERMINAL_EVENT_TIMEOUT_SECONDS = 30.0
 _TURN_TASK_DRAIN_TIMEOUT_SECONDS = 10.0
 
-_PNG_BYTES = (
-    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
-    b"\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4"
-    b"\x89\x00\x00\x00\nIDATx\x9cc\xf8\x0f\x00\x01\x01"
-    b"\x01\x00\x18\xdd\x8d\xb0\x00\x00\x00\x00IEND\xaeB`\x82"
-)
+_PNG_BYTES = image_bytes()
 
 
 def _sample_pdf_bytes(text: str = "Machine Learning") -> bytes:

--- a/tests/helpers/image_bytes.py
+++ b/tests/helpers/image_bytes.py
@@ -1,0 +1,13 @@
+"""Small valid images generated entirely from synthetic test pixels."""
+
+from __future__ import annotations
+
+import io
+
+from PIL import Image
+
+
+def image_bytes(format: str = "PNG", *, color: str = "blue") -> bytes:
+    buffer = io.BytesIO()
+    Image.new("RGB", (2, 2), color).save(buffer, format=format)
+    return buffer.getvalue()

--- a/tests/test_contracts/test_image_validation.py
+++ b/tests/test_contracts/test_image_validation.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import io
+import struct
+import zlib
+
+import pytest
+from PIL import Image
+
+from opensquilla.contracts.image_validation import validate_image_bytes
+from tests.helpers.image_bytes import image_bytes
+
+
+@pytest.mark.parametrize("format", ["PNG", "JPEG", "GIF", "WEBP"])
+def test_supported_image_content_is_decodable(format: str) -> None:
+    validate_image_bytes(image_bytes(format), Image.MIME[format])
+
+
+@pytest.mark.parametrize(
+    ("payload", "mime"),
+    [
+        (b"\x89PNG\r\n\x1a\ninvalid image body", "image/png"),
+        (b"plain text renamed to a photograph", "image/jpeg"),
+        (b"\xff\xd8\xffinvalid image body", "image/jpeg"),
+        (b"GIF89ainvalid image body", "image/gif"),
+        (b"RIFF\x00\x00\x00\x00WEBPinvalid image body", "image/webp"),
+        (image_bytes("JPEG")[:-30], "image/jpeg"),
+        (image_bytes("BMP"), "image/png"),
+        (image_bytes("PNG"), "image/jpeg"),
+    ],
+)
+def test_invalid_image_content_is_rejected(payload: bytes, mime: str) -> None:
+    with pytest.raises(ValueError, match="upload a valid image"):
+        validate_image_bytes(payload, mime)
+
+
+def test_png_with_valid_chunk_checksums_but_invalid_pixel_data_is_rejected() -> None:
+    payload = bytearray(image_bytes())
+    offset = payload.index(b"IDAT")
+    length = struct.unpack(">I", payload[offset - 4 : offset])[0]
+    payload[offset + 4 : offset + 4 + length] = b"x" * length
+    payload[offset + 4 + length : offset + 8 + length] = struct.pack(
+        ">I", zlib.crc32(payload[offset : offset + 4 + length])
+    )
+    # Structural verification alone accepts these checksummed chunks.
+    with Image.open(io.BytesIO(payload)) as image:
+        image.verify()
+    with pytest.raises(ValueError, match="corrupt"):
+        validate_image_bytes(bytes(payload), "image/png")
+
+
+def test_image_pixel_limit_is_enforced(monkeypatch) -> None:
+    payload = image_bytes()
+    monkeypatch.setattr(Image, "MAX_IMAGE_PIXELS", 3)
+    with pytest.raises(ValueError, match="upload a valid image"):
+        validate_image_bytes(payload, "image/png")
+
+
+def test_windows_jpeg_mime_alias_remains_supported() -> None:
+    validate_image_bytes(image_bytes("JPEG"), "image/jpg")

--- a/tests/test_contracts/test_models_list_wire.py
+++ b/tests/test_contracts/test_models_list_wire.py
@@ -95,6 +95,12 @@ def test_model_row_values_map_from_model_info() -> None:
     assert row["metadata"] is None
 
 
+def test_model_row_exposes_vision_capability() -> None:
+    row = model_info_to_projection(_synthetic_model(supports_vision=True))
+
+    assert "vision" in row["capabilities"]
+
+
 def test_model_row_carries_normalized_provider_metadata() -> None:
     metadata = {
         "schemaVersion": 1,

--- a/tests/test_engine/test_agent_invalid_provider_response.py
+++ b/tests/test_engine/test_agent_invalid_provider_response.py
@@ -26,6 +26,7 @@ from opensquilla.provider import TextDeltaEvent as ProviderText
 from opensquilla.provider import ToolUseDeltaEvent as ProviderToolUseDelta
 from opensquilla.provider import ToolUseEndEvent as ProviderToolUseEnd
 from opensquilla.provider import ToolUseStartEvent as ProviderToolUseStart
+from opensquilla.provider.types import ContentBlockImage
 from opensquilla.session.manager import SessionManager
 from opensquilla.session.storage import SessionStorage
 from opensquilla.tools.dispatch import build_tool_handler
@@ -229,6 +230,58 @@ async def test_reasoning_only_first_turn_retries_without_disabling_thinking() ->
     assert len(assistant_messages) == 1
     assert assistant_messages[0].content[0].text == "ok"
     assert assistant_messages[0].reasoning_content is None
+
+
+@pytest.mark.asyncio
+async def test_reasoning_only_image_turn_preserves_thinking_on_retry() -> None:
+    provider = _SequenceProvider(
+        [
+            [
+                ProviderDone(
+                    stop_reason="stop",
+                    input_tokens=10,
+                    output_tokens=5,
+                    reasoning_tokens=5,
+                    reasoning_content="internal reasoning",
+                )
+            ],
+            [
+                ProviderText(text="image analyzed"),
+                ProviderDone(stop_reason="stop", input_tokens=11, output_tokens=2),
+            ],
+        ]
+    )
+    agent = Agent(
+        provider=provider,
+        config=AgentConfig(
+            thinking=ThinkingLevel.MEDIUM,
+            retry_base_backoff_ms=0,
+            retry_max_backoff_ms=0,
+        ),
+    )
+
+    events = [
+        event
+        async for event in agent.run_turn(
+            "describe the image",
+            extra_messages=[
+                Message(
+                    role="user",
+                    content=[ContentBlockImage(media_type="image/png", data="c3ludGhldGlj")],
+                )
+            ],
+        )
+    ]
+
+    assert any(event.kind == "done" and event.text == "image analyzed" for event in events)
+    warning = next(
+        event
+        for event in events
+        if event.kind == "warning" and event.code == "provider_reasoning_only_retry"
+    )
+    assert "thinking disabled" not in warning.message
+    assert provider.calls[0]["config"].thinking is True
+    assert provider.calls[1]["config"].thinking is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine/test_attachment_messages.py
+++ b/tests/test_engine/test_attachment_messages.py
@@ -31,6 +31,7 @@ from opensquilla.session.attachment_manifest import (
     legacy_attachment_id,
     preserve_attachment_occurrence_ids,
 )
+from tests.helpers.image_bytes import image_bytes
 
 
 def _b64(payload: bytes) -> str:
@@ -124,7 +125,7 @@ def _ref(tmp_path: Path, payload: bytes, *, name: str, mime: str) -> dict[str, A
 def test_image_emits_image_block() -> None:
     out = _build(
         "describe",
-        [{"type": "image/png", "data": _b64(b"\x89PNG\r\n\x1a\n"), "name": "p.png"}],
+        [{"type": "image/png", "data": _b64(image_bytes()), "name": "p.png"}],
     )
     assert out is not None
     msg = out[0]
@@ -138,7 +139,7 @@ def test_image_emits_image_block() -> None:
 def test_inline_image_materializes_to_workspace_without_losing_vision_block(
     tmp_path: Path,
 ) -> None:
-    payload = b"\x89PNG\r\n\x1a\n"
+    payload = image_bytes()
     workspace = tmp_path / "workspace"
 
     out = TurnRunner._build_attachment_messages(
@@ -166,7 +167,7 @@ def test_inline_image_materializes_to_workspace_without_losing_vision_block(
 
 
 def test_image_workspace_budget_failure_preserves_vision_block(tmp_path: Path) -> None:
-    payload = b"\x89PNG\r\n\x1a\n" + b"x" * 64
+    payload = image_bytes()
     workspace = tmp_path / "workspace"
 
     out = TurnRunner._build_attachment_messages(
@@ -191,7 +192,7 @@ def test_image_workspace_budget_failure_preserves_vision_block(tmp_path: Path) -
 
 
 def test_image_ref_hydrates_for_current_provider_call(tmp_path: Path) -> None:
-    payload = b"\x89PNG\r\n\x1a\n"
+    payload = image_bytes()
     workspace = tmp_path / "workspace"
     out = TurnRunner._build_attachment_messages(
         "describe",
@@ -223,7 +224,7 @@ def test_historical_inline_image_envelope_can_replay_for_vision() -> None:
             "attachments": [
                 {
                     "type": "image/png",
-                    "data": _b64(b"\x89PNG\r\n\x1a\n"),
+                    "data": _b64(image_bytes()),
                     "name": "p.png",
                 }
             ],
@@ -241,11 +242,11 @@ def test_historical_inline_image_envelope_can_replay_for_vision() -> None:
     image_blocks = [b for b in out if isinstance(b, ContentBlockImage)]
     assert len(image_blocks) == 1
     assert image_blocks[0].media_type == "image/png"
-    assert image_blocks[0].data == _b64(b"\x89PNG\r\n\x1a\n")
+    assert image_blocks[0].data == _b64(image_bytes())
 
 
 def test_forked_legacy_historical_image_keeps_allowed_attachment_id() -> None:
-    payload = b"legacy-fork-image"
+    payload = image_bytes()
     message_id = "message-legacy-fork-image"
     content = json.dumps(
         {
@@ -294,8 +295,8 @@ def test_forked_legacy_historical_image_keeps_allowed_attachment_id() -> None:
 def test_explicit_multi_image_replay_exposes_stable_id_to_image_mapping() -> None:
     first_id = "att_abcdefgh"
     second_id = "att_ijklmnop"
-    first_payload = b"first-image"
-    second_payload = b"second-image"
+    first_payload = image_bytes(color="red")
+    second_payload = image_bytes(color="green")
     content = json.dumps(
         {
             "text": "Compare the referenced images.",
@@ -339,7 +340,7 @@ def test_explicit_multi_image_replay_exposes_stable_id_to_image_mapping() -> Non
 
 
 def test_historical_image_ref_envelope_can_replay_for_vision(tmp_path: Path) -> None:
-    payload = b"\x89PNG\r\n\x1a\n"
+    payload = image_bytes()
     sha = hashlib.sha256(payload).hexdigest()
     material_dir = tmp_path / "transcripts" / "s1"
     material_dir.mkdir(parents=True)
@@ -369,6 +370,39 @@ def test_historical_image_ref_envelope_can_replay_for_vision(tmp_path: Path) -> 
     image_blocks = [b for b in out if isinstance(b, ContentBlockImage)]
     assert len(image_blocks) == 1
     assert image_blocks[0].data == _b64(payload)
+
+
+@pytest.mark.parametrize("payload", [
+    image_bytes("JPEG"),
+    b"\x89PNG\r\n\x1a\ncorrupt-pixels",
+    b"plain text disguised as an image",
+], ids=["mismatched-format", "corrupt-png", "fake-image"])
+@pytest.mark.parametrize("stored_ref", [False, True])
+def test_historical_image_rejects_unreadable_or_mismatched_bytes(
+    payload: bytes, stored_ref: bool, tmp_path: Path,
+) -> None:
+    content = json.dumps(
+        {
+            "text": "inspect the old image",
+            "attachments": [
+                {**_ref(tmp_path, payload, name="old.png", mime="image/png"),
+                 "sha256_ref": hashlib.sha256(payload).hexdigest()}
+                if stored_ref else {"mime": "image/png", "data": _b64(payload)}
+            ],
+        }
+    )
+
+    out = TurnRunner._maybe_unpack_attachments(
+        content,
+        preserve_image_attachments=True,
+        media_root=tmp_path,
+        session_id="s1",
+    )
+
+    if isinstance(out, list):
+        assert not any(isinstance(block, ContentBlockImage) for block in out)
+    else:
+        assert "历史图片不可用" in out
 
 
 # ---------------------------------------------------------------------------
@@ -1160,10 +1194,10 @@ def test_disabling_persistence_does_not_copy_or_remove_existing_history_images(
     media_root = tmp_path / "media"
     workspace = tmp_path / "workspace"
     sha, material_path, _ = write_transcript_material(
-        media_root=media_root, session_id="session-a", payload=b"old image",
+        media_root=media_root, session_id="session-a", payload=image_bytes(),
     )
     envelope = json.dumps({"text": "old message", "attachments": [
-        {"type": "image/png", "name": "old.png", "size": 9, "sha256_ref": sha},
+        {"type": "image/png", "name": "old.png", "size": len(image_bytes()), "sha256_ref": sha},
         {"type": "text/plain", "name": "note.txt", "data": _b64(b"old text")},
     ]})
     out = TurnRunner._maybe_unpack_attachments(
@@ -1172,7 +1206,7 @@ def test_disabling_persistence_does_not_copy_or_remove_existing_history_images(
         workspace_dir=workspace, session_id="session-a", persist_image_material=False,
     )
     assert not list(workspace.rglob("*.png"))
-    assert material_path.read_bytes() == b"old image"
+    assert material_path.read_bytes() == image_bytes()
     assert next(workspace.rglob("*.txt")).read_bytes() == b"old text"
     if preserve_image:
         assert any(isinstance(block, ContentBlockImage) for block in out)

--- a/tests/test_engine/test_historical_image_followup.py
+++ b/tests/test_engine/test_historical_image_followup.py
@@ -36,6 +36,7 @@ from opensquilla.session.attachment_manifest import (
 )
 from opensquilla.session.manager import SessionManager
 from opensquilla.session.storage import SessionStorage
+from tests.helpers.image_bytes import image_bytes
 
 
 @dataclass
@@ -151,7 +152,7 @@ def _b64(payload: bytes) -> str:
     return base64.b64encode(payload).decode("ascii")
 
 
-def _inline_image_envelope(text: str, payload: bytes = b"\x89PNG\r\n\x1a\n") -> str:
+def _inline_image_envelope(text: str, payload: bytes = image_bytes()) -> str:
     return json.dumps(
         {
             "text": text,
@@ -203,7 +204,9 @@ async def test_text_primary_fallback_recovers_selected_historical_original(
     key = "agent:main:historical-selector-fallback"
     await manager.create(key)
     image_entry = _TranscriptEntry(
-        "user", _inline_image_envelope("Describe this image.", b"original"), "image-source"
+        "user",
+        _inline_image_envelope("Describe this image.", image_bytes(color="#000001")),
+        "image-source",
     )
     current = _TranscriptEntry("user", "Use the previous image.", "current")
     manager._canonical[key] = [image_entry, current]
@@ -245,7 +248,7 @@ async def test_text_primary_fallback_recovers_selected_historical_original(
     if image_source == "agent_history":
         agent.set_history([
             Message(role="user", content=[
-                ContentBlockImage(media_type="image/png", data=_b64(b"original"))
+                ContentBlockImage(media_type="image/png", data=_b64(image_bytes(color="#000001")))
             ])
         ])
     else:
@@ -269,7 +272,7 @@ async def test_text_primary_fallback_recovers_selected_historical_original(
         if isinstance(message.content, list)
         for block in message.content
         if isinstance(block, ContentBlockImage)
-    ] == [_b64(b"original")]
+    ] == [_b64(image_bytes(color="#000001"))]
 
 
 @pytest.mark.parametrize("archived", [False, True])
@@ -283,14 +286,14 @@ async def test_current_upload_and_previous_image_selection_are_independent(
     key = "agent:main:compare-current-and-previous"
     await manager.create(key)
     previous = _TranscriptEntry(
-        "user", _inline_image_envelope("Previous upload.", b"previous-original"), "previous"
+        "user", _inline_image_envelope("Previous upload.", image_bytes(color="#000002")), "previous"
     )
     text = (
         "Ignore the previous image; describe the new upload."
         if opt_out else "Compare the new upload with the previous image."
     )
     current = _TranscriptEntry(
-        "user", _inline_image_envelope(text, b"current-original"), "current"
+        "user", _inline_image_envelope(text, image_bytes(color="#000003")), "current"
     )
     manager._canonical[key] = [previous, current]
     manager._transcripts[key] = [current] if archived else [previous, current]
@@ -307,7 +310,7 @@ async def test_current_upload_and_previous_image_selection_are_independent(
     ctx = TurnContext(
         message=text, raw_message=text, session_key=key,
         model="configured-vision", config=config,
-        attachments=[{"mime": "image/png", "data": _b64(b"current-original")}],
+        attachments=[{"mime": "image/png", "data": _b64(image_bytes(color="#000003"))}],
         provider=_CapturingProvider(), tool_defs=[], system_prompt="", metadata=metadata,
     )
     await apply_vision_followup_gate(ctx)
@@ -325,7 +328,8 @@ async def test_current_upload_and_previous_image_selection_are_independent(
     await runner._load_history(agent, key, bound_user_message_id="current")
     current_message = Message(role="user", content=[
         ContentBlockImage(
-            media_type="image/png", data=_b64(b"current-original"), attachment_id="att_current"
+            media_type="image/png", data=_b64(image_bytes(color="#000003")),
+            attachment_id="att_current",
         ),
     ])
     events = [event async for event in agent.run_turn(text, extra_messages=[current_message])]
@@ -337,8 +341,8 @@ async def test_current_upload_and_previous_image_selection_are_independent(
         if isinstance(block, ContentBlockImage)
     ]
     assert payloads == (
-        [_b64(b"current-original")]
-        if opt_out else [_b64(b"previous-original"), _b64(b"current-original")]
+        [_b64(image_bytes(color="#000003"))]
+        if opt_out else [_b64(image_bytes(color="#000002")), _b64(image_bytes(color="#000003"))]
     )
 
 
@@ -353,7 +357,7 @@ async def test_current_text_image_opt_out_reaches_provider_when_gate_disabled(
     key = "agent:main:image-reference-opt-out"
     node = await manager.create(key)
     previous = _TranscriptEntry(
-        "user", _inline_image_envelope("Previous upload.", b"previous-original"), "previous"
+        "user", _inline_image_envelope("Previous upload.", image_bytes(color="#000002")), "previous"
     )
     previous_id = build_attachment_manifest(
         [previous], session_id=node.session_id, session_key=key,
@@ -361,7 +365,7 @@ async def test_current_text_image_opt_out_reaches_provider_when_gate_disabled(
     text = f"Ignore the previous image {previous_id}; answer only the text question."
     current = _TranscriptEntry(
         "user",
-        _inline_image_envelope(text, b"current-original") if current_upload else text,
+        _inline_image_envelope(text, image_bytes(color="#000003")) if current_upload else text,
         "current",
     )
     manager._canonical[key] = [previous, current]
@@ -375,7 +379,7 @@ async def test_current_text_image_opt_out_reaches_provider_when_gate_disabled(
         "router_vision_followup_gate_source": "explicit_attachment_id",
     }
     attachments = (
-        [{"mime": "image/png", "data": _b64(b"current-original")}]
+        [{"mime": "image/png", "data": _b64(image_bytes(color="#000003"))}]
         if current_upload else []
     )
     provider = _CapturingProvider()
@@ -396,7 +400,7 @@ async def test_current_text_image_opt_out_reaches_provider_when_gate_disabled(
     await runner._load_history(agent, key, bound_user_message_id="current")
     extra_messages = (
         [Message(role="user", content=[
-            ContentBlockImage(media_type="image/png", data=_b64(b"current-original"))
+            ContentBlockImage(media_type="image/png", data=_b64(image_bytes(color="#000003")))
         ])]
         if current_upload else None
     )
@@ -408,7 +412,7 @@ async def test_current_text_image_opt_out_reaches_provider_when_gate_disabled(
         if isinstance(message.content, list) for block in message.content
         if isinstance(block, ContentBlockImage)
     ]
-    assert payloads == ([_b64(b"current-original")] if current_upload else [])
+    assert payloads == ([_b64(image_bytes(color="#000003"))] if current_upload else [])
     assert ctx.metadata["router_vision_followup_gate_source"] == "explicit_opt_out"
     assert ctx.metadata["router_vision_followup_needs_image"] is False
 
@@ -535,7 +539,9 @@ async def test_explicit_images_survive_a_full_history_window(
     image_entries = [
         _TranscriptEntry(
             role="user",
-            content=_inline_image_envelope(f"Old instruction {index}.", bytes([index])),
+            content=_inline_image_envelope(
+                f"Old instruction {index}.", image_bytes(color=f"#{index:06x}"),
+            ),
             message_id=f"historical-image-{index}",
         )
         for index in range(3)
@@ -591,7 +597,9 @@ async def test_explicit_images_survive_a_full_history_window(
         if isinstance(block, ContentBlockImage)
     ]
     assert [block.data for block in image_blocks] == (
-        [] if vision_support == "unsupported" else [_b64(bytes([0])), _b64(bytes([1]))]
+        [] if vision_support == "unsupported" else [
+            _b64(image_bytes(color="#000000")), _b64(image_bytes(color="#000001")),
+        ]
     )
     assert all(attachment_id in str(sent) for attachment_id in requested_ids)
     assert manifest.occurrences[2].attachment_id not in str(sent)
@@ -670,9 +678,9 @@ async def test_current_image_and_one_archived_image_id_are_merged_and_exact() ->
     config.squilla_router.vision_history_lookback_turns = 0
     runner = TurnRunner(provider_selector=MagicMock(), session_manager=manager, config=config)
     node = await manager.create(key)
-    archived_first = b"archived-first"
-    archived_second = b"archived-second"
-    current_payload = b"current-image"
+    archived_first = image_bytes(color="#000004")
+    archived_second = image_bytes(color="#000005")
+    current_payload = image_bytes(color="#000006")
     archived_image = _TranscriptEntry(
         role="user",
         content=_inline_image_envelope_many(
@@ -762,7 +770,7 @@ async def test_persisted_compacted_archive_rehydrates_explicit_attachment_id() -
         manager = SessionManager(storage, inject_time_prefix=False)
         key = "agent:main:persisted-compacted-image-id-replay"
         node = await manager.create(key)
-        payload = b"\x89PNG\r\n\x1a\npersisted-archive"
+        payload = image_bytes()
         image_entry = await manager.append_message(
             key,
             "user",
@@ -860,7 +868,7 @@ async def test_full_fork_rehydrates_parent_legacy_attachment_id() -> None:
         manager = SessionManager(storage, inject_time_prefix=False)
         parent_key = "agent:main:legacy-image-parent"
         parent = await manager.create(parent_key)
-        payload = b"\x89PNG\r\n\x1a\nlegacy-full-fork"
+        payload = image_bytes()
         await manager.append_message(
             parent_key,
             "user",
@@ -967,13 +975,13 @@ async def test_lazy_manifest_backfill_monotonically_merges_active_subset() -> No
         archived = await manager.append_message(
             key,
             "user",
-            _inline_image_envelope("Archived A.", b"image-a"),
+            _inline_image_envelope("Archived A.", image_bytes(color="#000007")),
             message_id="manifest-image-a",
         )
         active = await manager.append_message(
             key,
             "user",
-            _inline_image_envelope("Active B.", b"image-b"),
+            _inline_image_envelope("Active B.", image_bytes(color="#000008")),
             message_id="manifest-image-b",
         )
         archived_manifest = build_attachment_manifest(
@@ -1256,7 +1264,7 @@ async def test_historical_image_ref_replays_from_real_material_store(tmp_path: P
     config.attachments.media_root = str(tmp_path / "media")
     runner = TurnRunner(provider_selector=MagicMock(), session_manager=manager, config=config)
     node = await manager.create(key)
-    payload = b"\x89PNG\r\n\x1a\nreal-material"
+    payload = image_bytes()
     sha, _, _ = write_transcript_material(
         media_root=Path(config.attachments.media_root),
         session_id=node.session_id,
@@ -1404,7 +1412,7 @@ async def test_queued_prompts_do_not_consume_image_replay_window() -> None:
         await manager.append_message(
             key,
             "user",
-            _inline_image_envelope(f"Image {index}.", b"\x89PNG\r\n\x1a\n" + bytes([index])),
+            _inline_image_envelope(f"Image {index}.", image_bytes(color=f"#{index:06x}")),
             message_id=f"m{index}",
         )
         await manager.append_message(key, "assistant", f"Answer {index}.")

--- a/tests/test_engine/test_runtime_ensemble_credential_guard.py
+++ b/tests/test_engine/test_runtime_ensemble_credential_guard.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from dataclasses import replace
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 
@@ -387,6 +388,78 @@ async def test_global_ensemble_keeps_fixed_fallback_when_router_is_also_enabled(
     assert turn.metadata["routed_model"] == routed_model
     assert turn.metadata["routed_model_before_ensemble"] == routed_model
     assert turn.metadata["ensemble_activation_source"] == "global"
+
+
+@pytest.mark.parametrize("global_ensemble", [False, True])
+async def test_attachment_capacity_bypass_keeps_routed_model_without_building_ensemble(
+    monkeypatch: pytest.MonkeyPatch,
+    global_ensemble: bool,
+) -> None:
+    fixed_model = "deepseek-v4-flash-0731"
+    routed_model = "glm-5.2"
+    cfg = GatewayConfig(
+        llm={
+            "provider": "tokenrhythm",
+            "model": fixed_model,
+            "api_key": "sk-tr-synthetic",
+        },
+        llm_ensemble={
+            "enabled": global_ensemble,
+            "selection_mode": "static_tokenrhythm_b5",
+        },
+    )
+
+    async def route_to_capable_model(turn):
+        turn.model = routed_model
+        turn.metadata.update({
+            "routed_tier": "c2" if global_ensemble else "c3",
+            "routed_model": routed_model,
+            "routing_applied": True,
+            "large_context_capacity_required": True,
+            "large_context_request_input_tokens": 200_000,
+            "thinking_requested": True,
+            "thinking_source": "squilla_router_tier",
+        })
+        return turn
+
+    monkeypatch.setattr("opensquilla.engine.steps.apply_squilla_router", route_to_capable_model)
+    capacity_check = Mock(side_effect=lambda deployment, metadata, **kwargs: (
+        deployment.model == routed_model
+    ))
+    monkeypatch.setattr(
+        "opensquilla.engine.selector_override.provider_config_has_request_capacity",
+        capacity_check,
+    )
+    build_ensemble = Mock(
+        side_effect=AssertionError("capacity bypass must keep single-model routing"),
+    )
+    monkeypatch.setattr(
+        "opensquilla.provider.ensemble.build_ensemble_provider_from_config",
+        build_ensemble,
+    )
+    selector = _FakeSelector(
+        provider="tokenrhythm", model=fixed_model, api_key="sk-tr-synthetic",
+    )
+    runner = TurnRunner(provider_selector=None, config=cfg)
+
+    turn, provider = await runner._run_pipeline(
+        "analyze the attached material", "agent:main:capacity-bypass", _Provider(),
+        selector, [], "system prompt", [],
+    )
+
+    assert [call.args[0].model for call in capacity_check.call_args_list] == [
+        fixed_model, routed_model,
+    ]
+    build_ensemble.assert_not_called()
+    assert not isinstance(provider, EnsembleProvider)
+    assert selector.current_config.model == routed_model
+    assert turn.model == routed_model
+    assert turn.metadata["executed_model"] == routed_model
+    assert turn.metadata["thinking_requested"] is True
+    assert turn.metadata["ensemble_wrap_skipped_reason"] == "fixed_fallback_request_capacity"
+    assert turn.metadata["ensemble_capacity_bypassed"] is True
+    assert "ensemble_enabled" not in turn.metadata
+    assert "ensemble_fallback_model" not in turn.metadata
 
 
 async def test_shared_c3_rejects_an_empty_fixed_fallback_model(

--- a/tests/test_engine/test_turn_prompt_binding.py
+++ b/tests/test_engine/test_turn_prompt_binding.py
@@ -13,6 +13,7 @@ replies are kept — with a positional-trim fallback when no id is supplied.
 from __future__ import annotations
 
 import base64
+import io
 import json
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
@@ -21,6 +22,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from PIL import Image
 
 from opensquilla.engine import Agent, AgentConfig
 from opensquilla.engine.history import (
@@ -52,6 +54,7 @@ from opensquilla.session.manager import SessionManager
 from opensquilla.session.models import SessionContextState, SessionIntent, SessionSummary
 from opensquilla.session.storage import SessionStorage
 from opensquilla.token_estimation import estimate_tokens
+from tests.helpers.image_bytes import image_bytes
 
 
 @dataclass
@@ -150,6 +153,15 @@ def _history_user_texts(messages: list[Message]) -> list[str]:
         for m in messages[:-1]
         if m.role == "user" and isinstance(m.content, str)
     ]
+
+
+def _capacity_image_bytes(color: str = "blue") -> bytes:
+    """Keep valid PNG bytes large enough to exercise inline capacity projection."""
+    buffer = io.BytesIO()
+    with Image.open(io.BytesIO(image_bytes(color=color))) as source:
+        with source.resize((100, 100)) as image:
+            image.save(buffer, format="PNG", compress_level=0)
+    return buffer.getvalue()
 
 
 def _inline_images(text: str, *payloads: bytes) -> str:
@@ -394,7 +406,7 @@ async def test_router_capacity_projects_inline_images_after_route() -> None:
     manager = _FakeSessionManager()
     key = "agent:main:router-capacity-inline-images"
     await manager.create(key)
-    payloads = [bytes(range(256)) * 100, bytes(reversed(range(256))) * 100]
+    payloads = [_capacity_image_bytes("blue"), _capacity_image_bytes("red")]
     envelope = _inline_images("inspect both images", *payloads)
     historical_user = await manager.append_message(key, "user", envelope)
     await manager.append_message(key, "assistant", "historical answer")
@@ -759,7 +771,7 @@ async def test_router_capacity_preserves_plain_token_floor_but_clears_inline_med
     )
     inline_envelope = _inline_images(
         "image history row",
-        bytes(range(256)) * 120,
+        _capacity_image_bytes(),
     )
     inline_raw_floor = estimate_tokens(inline_envelope)
     inline_media = await project(
@@ -784,7 +796,7 @@ async def test_router_capacity_mixed_envelope_discounts_only_typed_image_data(
     manager = _FakeSessionManager()
     key = "agent:main:router-capacity-mixed-image-document"
     await manager.create(key)
-    image_data = base64.b64encode(bytes(range(256)) * 120).decode("ascii")
+    image_data = base64.b64encode(_capacity_image_bytes()).decode("ascii")
     document_data = base64.b64encode(bytes(reversed(range(256))) * 80).decode("ascii")
     envelope = json.dumps(
         {

--- a/tests/test_gateway/test_attachment_ingest.py
+++ b/tests/test_gateway/test_attachment_ingest.py
@@ -7,11 +7,13 @@ import pytest
 
 from opensquilla.attachment_refs import (
     is_attachment_ref,
+    make_attachment_ref,
     promote_pending_chat_input_attachments,
     read_attachment_ref_bytes,
     read_pending_chat_input_manifest,
     read_pending_chat_input_promotions,
     transcript_material_path,
+    write_transcript_material,
 )
 from opensquilla.contracts.attachments import SNIFF_PEEK_BYTES
 from opensquilla.gateway.attachment_ingest import (
@@ -19,6 +21,7 @@ from opensquilla.gateway.attachment_ingest import (
     stage_pending_chat_input_attachments,
 )
 from opensquilla.gateway.uploads import UploadStore
+from tests.helpers.image_bytes import image_bytes
 
 
 @pytest.mark.asyncio
@@ -233,7 +236,7 @@ async def test_zip_upload_accepted_as_opaque_not_ooxml() -> None:
 async def test_unknown_claim_adopts_sniffed_rendered_type() -> None:
     # An image uploaded with a generic claim is routed to the image family by
     # its magic bytes instead of degrading to an opaque blob.
-    png = b"\x89PNG\r\n\x1a\n" + b"fake image body"
+    png = image_bytes()
     result = await ingest_attachments(
         "read it",
         [{"name": "shot", "mime_type": "application/octet-stream", "data": png}],
@@ -242,6 +245,59 @@ async def test_unknown_claim_adopts_sniffed_rendered_type() -> None:
 
     assert result.failures == []
     assert result.attachments[0]["type"] == "image/png"
+
+
+@pytest.mark.parametrize(
+    ("payload", "mime"),
+    [
+        (b"\x89PNG\r\n\x1a\ninvalid image body", "image/png"),
+        (b"plain text renamed to a photograph", "image/jpeg"),
+        (b"%PDF-1.4\nnot a photograph", "image/jpeg"),
+        (b"\x89PNG\r\n\x1a\ninvalid image body", "application/octet-stream"),
+    ],
+)
+@pytest.mark.parametrize("failure_mode", ["mark", "raise"])
+async def test_invalid_image_rejected_before_dispatch(payload, mime, failure_mode) -> None:
+    attachments = [{"name": "sample.jpg", "mime_type": mime, "data": payload}]
+    if failure_mode == "raise":
+        with pytest.raises(ValueError, match="upload a valid image"):
+            await ingest_attachments("inspect", attachments, failure_mode=failure_mode)
+        return
+    result = await ingest_attachments("inspect", attachments, failure_mode=failure_mode)
+    assert result.attachments == []
+    assert result.failures[0].reason == "invalid_image"
+    assert "[attachment unavailable: sample.jpg: invalid_image]" in result.text
+
+
+async def test_valid_image_mime_mismatch_still_uses_detected_format() -> None:
+    result = await ingest_attachments(
+        "inspect", [{"name": "sample.jpg", "type": "image/jpeg", "data": image_bytes()}],
+    )
+    assert result.failures == []
+    assert result.attachments[0]["type"] == "image/png"
+
+
+@pytest.mark.parametrize("valid_image", [False, True])
+async def test_durable_image_reference_revalidates_content(tmp_path, valid_image) -> None:
+    payload = image_bytes() if valid_image else b"\x89PNG\r\n\x1a\ninvalid image body"
+    sha, path, _ = write_transcript_material(
+        media_root=tmp_path, session_id="sample-session", payload=payload,
+    )
+    ref = make_attachment_ref(
+        sha256=sha, name="sample.png", mime="image/png", size=len(payload),
+        session_id="sample-session", source="upload",
+    )
+    result = await ingest_attachments(
+        "inspect", [ref], failure_mode="mark", allow_material_refs=True,
+        material_root=tmp_path, expected_material_scope="sample-session",
+    )
+    if valid_image:
+        assert result.attachments == [ref]
+        assert result.failures == []
+    else:
+        assert result.attachments == []
+        assert result.failures[0].reason == "invalid_image"
+    assert path.read_bytes() == payload
 
 
 @pytest.mark.asyncio
@@ -511,7 +567,7 @@ async def test_windows_jpeg_alias_admitted_in_strict_mode() -> None:
     # a deliberate strict-mode improvement over the legacy 415.
     result = await ingest_attachments(
         "read it",
-        [{"name": "photo.jpg", "mime_type": "image/jpg", "data": b"\xff\xd8\xff" + b"j" * 32}],
+        [{"name": "photo.jpg", "mime_type": "image/jpg", "data": image_bytes("JPEG")}],
         failure_mode="mark",
         accept_opaque=False,
     )
@@ -525,7 +581,7 @@ async def test_windows_jpeg_alias_admitted_in_strict_mode() -> None:
 async def test_uuid_ingress_respects_persistence_without_consuming_upload(
     tmp_path: Path, persist_enabled: bool,
 ) -> None:
-    payload = b"\x89PNG\r\n\x1a\n" + b"synthetic image material"
+    payload = image_bytes()
     store = UploadStore(marker_dir=tmp_path / "upload-markers")
     file_uuid = await store.put("sample.png", "image/png", payload)
     original_upload = await store.get(file_uuid)
@@ -562,7 +618,7 @@ async def test_uuid_ingress_respects_persistence_without_consuming_upload(
 async def test_queue_promotion_respects_persistence_and_retains_queue_material(
     tmp_path: Path, persist_enabled: bool,
 ) -> None:
-    payload = b"\x89PNG\r\n\x1a\n" + b"synthetic queued image material"
+    payload = image_bytes()
     store = UploadStore(marker_dir=tmp_path / "upload-markers")
     file_uuid = await store.put("queued.png", "image/png", payload)
     original_upload = await store.get(file_uuid)

--- a/tests/test_gateway/test_rpc_sessions.py
+++ b/tests/test_gateway/test_rpc_sessions.py
@@ -79,6 +79,7 @@ from opensquilla.session.models import (
 )
 from opensquilla.session.storage import SessionStorage
 from opensquilla.tools.visibility import guest_safe_tool_allowlist
+from tests.helpers.image_bytes import image_bytes
 
 _DEFAULT_PRINCIPAL = Principal(
     role="operator", scopes=frozenset(["operator.admin"]), is_owner=True, authenticated=True
@@ -4010,7 +4011,11 @@ class TestSessionsSend:
         self,
         dispatcher,
     ):
-        attachment = {"type": "image/png", "data": "aW1hZ2U=", "name": "image.png"}
+        attachment = {
+            "type": "image/png",
+            "data": base64.b64encode(image_bytes()).decode("ascii"),
+            "name": "image.png",
+        }
 
         web_session = FakeSession(
             session_key="agent:main:webchat:web-display",

--- a/tests/test_gateway/test_uploads_endpoint.py
+++ b/tests/test_gateway/test_uploads_endpoint.py
@@ -40,6 +40,7 @@ from opensquilla.gateway.uploads import (
     UploadStoreFullError,
     UploadUnsupportedMimeError,
 )
+from tests.helpers.image_bytes import image_bytes
 
 # ---------------------------------------------------------------------------
 # Direct unit tests against UploadStore (no network).
@@ -69,8 +70,8 @@ def _exact_pdf(size: int) -> bytes:
 
 
 def _exact_png(size: int) -> bytes:
-    header = b"\x89PNG\r\n\x1a\n"
-    return header + b"a" * (size - len(header))
+    payload = image_bytes()
+    return payload + b"a" * (size - len(payload))
 
 
 def test_upload_round_trip(store: UploadStore) -> None:
@@ -612,7 +613,7 @@ def test_upload_route_normalizes_windows_zip_spelling() -> None:
 
 
 def test_upload_route_sniffs_rendered_type_for_generic_claim() -> None:
-    png = b"\x89PNG\r\n\x1a\n" + b"fake image body"
+    png = image_bytes()
     with _route_client() as client:
         response = client.post(
             "/api/v1/files/upload",
@@ -621,6 +622,53 @@ def test_upload_route_sniffs_rendered_type_for_generic_claim() -> None:
 
     assert response.status_code == 200
     assert response.json()["mime"] == "image/png"
+
+
+@pytest.mark.parametrize(
+    ("payload", "mime"),
+    [
+        (b"\x89PNG\r\n\x1a\ninvalid image body", "image/png"),
+        (b"plain text renamed to a photograph", "image/jpeg"),
+        (b"\xff\xd8\xffinvalid image body", "image/jpeg"),
+        (b"\x89PNG\r\n\x1a\ninvalid image body", "application/octet-stream"),
+    ],
+)
+def test_upload_route_rejects_invalid_image_without_staging(store, payload, mime) -> None:
+    with _route_client(store=store) as client:
+        response = client.post(
+            "/api/v1/files/upload", files={"file": ("sample.jpg", payload, mime)},
+        )
+    assert response.status_code == 415
+    assert response.json()["code"] == "UNSUPPORTED_MEDIA_TYPE"
+    assert "upload a valid image" in response.json()["error"]
+    assert not store._entries
+    assert not list(store.marker_dir.glob("*.meta"))
+
+
+def test_upload_route_corrects_valid_image_format_before_staging(store) -> None:
+    with _route_client(store=store) as client:
+        response = client.post(
+            "/api/v1/files/upload", files={"file": ("sample.jpg", image_bytes(), "image/jpeg")},
+        )
+    assert response.status_code == 200
+    assert response.json()["mime"] == "image/png"
+    _, metadata = asyncio.run(store.get(response.json()["file_uuid"]))
+    assert metadata["mime"] == "image/png"
+
+
+def test_legacy_staged_image_is_revalidated_on_send(tmp_path) -> None:
+    store = _FakeUploadStore({
+        "u-legacy-image": (
+            b"\x89PNG\r\n\x1a\ninvalid image body",
+            {"name": "sample.png", "mime": "image/png"},
+        ),
+    })
+    with pytest.raises(ValueError, match="upload a valid image"):
+        asyncio.run(resolve_attachments(
+            [{"file_uuid": "u-legacy-image", "type": "image/png"}],
+            store=store, material_root=tmp_path / "media", session_id="sample-session",
+        ))
+    assert not (tmp_path / "media").exists()
 
 
 def test_upload_route_sniffs_text_for_missing_claim() -> None:
@@ -763,7 +811,7 @@ def test_upload_route_response_exposes_expires_at_and_ttl() -> None:
 
 
 def test_upload_route_sniffs_png_for_empty_claim() -> None:
-    png = b"\x89PNG\r\n\x1a\n" + b"fake image body"
+    png = image_bytes()
     with _route_client() as client:
         response = client.post(
             "/api/v1/files/upload",

--- a/tests/test_provider_ensemble.py
+++ b/tests/test_provider_ensemble.py
@@ -3172,18 +3172,78 @@ async def test_tokenrhythm_ensemble_rebinds_request_cap_per_member_context(
     assert aggregator_trace["provider_request_max_chars_source"] == "member_context"
 
 
+@pytest.mark.parametrize(
+    ("attachment_input_tokens", "explicit_cap"),
+    [(10_000_000, 0), (10_000_000, 100_000_000), (1_000, 2_000)],
+)
 @pytest.mark.asyncio
 async def test_ensemble_skips_all_members_when_frozen_request_exceeds_capacity(
     monkeypatch: pytest.MonkeyPatch,
+    attachment_input_tokens: int,
+    explicit_cap: int,
 ) -> None:
     registry = _tokenrhythm_budget_registry()
     monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
-    provider = _build_tokenrhythm_budget_provider(attachment_input_tokens=10_000_000)
+    provider = _build_tokenrhythm_budget_provider(
+        attachment_input_tokens=attachment_input_tokens,
+        explicit_cap=explicit_cap,
+    )
 
     events = [event async for event in provider.chat([Message(role="user", content="x")])]
 
     assert registry.calls == []
     assert events
+
+
+@pytest.mark.asyncio
+async def test_attachment_capacity_quorum_failure_skips_otherwise_eligible_proposer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    small, large, aggregator, fallback_member = [
+        replace(_member(model, thinking="off"), max_tokens=1_000)
+        for model in ("small", "large", "aggregator", "fallback")
+    ]
+    registry = _FakeRegistry({
+        model: _FakePlan([TextDeltaEvent(text=model), DoneEvent(model=model)])
+        for model in ("small", "large", "aggregator", "fallback")
+    })
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    reliable = _MemberRequestBudgetBinding(
+        context_window_tokens=128_000,
+        context_window_source="catalog",
+        context_overflow_threshold=0.85,
+        cap_source="member_context",
+        rederive=True,
+        inherit_top_level_cap=True,
+    )
+    provider = EnsembleProvider(
+        profile_name="attachment-quorum",
+        proposers=[small, large],
+        aggregator=aggregator,
+        fallback_provider=registry.provider_for(fallback_member.provider_config),
+        fallback_provider_name="fake",
+        fallback_model="fallback",
+        min_successful_proposers=2,
+        all_failed_policy="fallback_single",
+        _attachment_request_input_tokens=20_000,
+        _fallback_request_budget_member=fallback_member,
+        _member_request_budget_bindings={
+            ("fake", "small", ""): replace(reliable, context_window_tokens=16_000),
+            ("fake", "large", ""): reliable,
+            ("fake", "aggregator", ""): reliable,
+            ("fake", "fallback", ""): reliable,
+        },
+    )
+
+    events = [event async for event in provider.chat([Message(role="user", content="x")])]
+
+    assert [call["model"] for call in registry.calls] == ["fallback"]
+    done = next(event for event in events if isinstance(event, DoneEvent))
+    assert done.ensemble_trace is not None
+    candidates = {candidate["model"]: candidate for candidate in done.ensemble_trace["candidates"]}
+    assert candidates["small"]["error_code"] == "provider_request_budget_exhausted"
+    assert candidates["large"]["error_code"] == "quorum_unreachable"
+    assert not any(candidate["request_started"] for candidate in candidates.values())
 
 
 @pytest.mark.asyncio

--- a/tests/test_provider_ensemble.py
+++ b/tests/test_provider_ensemble.py
@@ -394,6 +394,7 @@ def _build_tokenrhythm_budget_provider(
     catalog: Any | None = None,
     enable_rebinding: bool = True,
     context_window_tokens: int = 0,
+    attachment_input_tokens: int = 0,
 ) -> EnsembleProvider:
     cfg = _tokenrhythm_ensemble_config(
         explicit_cap=explicit_cap,
@@ -411,6 +412,10 @@ def _build_tokenrhythm_budget_provider(
         _enable_member_request_budget_rebinding=enable_rebinding,
         _model_catalog=catalog or _BudgetCatalog(),
         _context_overflow_threshold=0.85,
+        turn_metadata={
+            "large_context_capacity_required": attachment_input_tokens > 0,
+            "large_context_request_input_tokens": attachment_input_tokens,
+        },
     )
 
 
@@ -3119,14 +3124,16 @@ async def test_ensemble_resolves_max_tokens_per_openrouter_member(
 
 
 @pytest.mark.parametrize("outer_cap", [367_200, 2_896_800])
+@pytest.mark.parametrize("attachment_input_tokens", [0, 1_000])
 @pytest.mark.asyncio
 async def test_tokenrhythm_ensemble_rebinds_request_cap_per_member_context(
     monkeypatch: pytest.MonkeyPatch,
     outer_cap: int,
+    attachment_input_tokens: int,
 ) -> None:
     registry = _tokenrhythm_budget_registry()
     monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
-    provider = _build_tokenrhythm_budget_provider()
+    provider = _build_tokenrhythm_budget_provider(attachment_input_tokens=attachment_input_tokens)
 
     events = [
         event
@@ -3163,6 +3170,35 @@ async def test_tokenrhythm_ensemble_rebinds_request_cap_per_member_context(
     assert aggregator_trace["effective_context_window_source"] == "catalog"
     assert aggregator_trace["effective_provider_request_max_chars"] == 2_896_800
     assert aggregator_trace["provider_request_max_chars_source"] == "member_context"
+
+
+@pytest.mark.asyncio
+async def test_ensemble_skips_all_members_when_frozen_request_exceeds_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = _tokenrhythm_budget_registry()
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    provider = _build_tokenrhythm_budget_provider(attachment_input_tokens=10_000_000)
+
+    events = [event async for event in provider.chat([Message(role="user", content="x")])]
+
+    assert registry.calls == []
+    assert events
+
+
+@pytest.mark.asyncio
+async def test_ensemble_skips_members_when_attachment_capacity_is_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = _tokenrhythm_budget_registry()
+    monkeypatch.setattr("opensquilla.provider.ensemble._build_provider", registry.provider_for)
+    provider = _build_tokenrhythm_budget_provider(attachment_input_tokens=1)
+    provider._member_request_budget_bindings.clear()
+
+    events = [event async for event in provider.chat([Message(role="user", content="x")])]
+
+    assert registry.calls == []
+    assert events
 
 
 @pytest.mark.asyncio

--- a/tests/test_provider_image_generation.py
+++ b/tests/test_provider_image_generation.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import base64
 import io
 import json
-from types import SimpleNamespace
 
 import httpx
 import pytest
@@ -22,7 +21,7 @@ from opensquilla.provider.qwen_token_plan import (
     QWEN_TOKEN_PLAN_IMAGE_BASE_URL,
     QWEN_TOKEN_PLAN_OPENAI_BASE_URL,
 )
-from opensquilla.provider.types import ChatConfig
+from opensquilla.provider.types import ChatConfig, TextDeltaEvent
 from opensquilla.tools.types import ToolContext, current_tool_context
 
 
@@ -1743,7 +1742,7 @@ async def test_image_tool_uses_active_deployment_instead_of_legacy_image_route(
         async def chat(self, *, messages, config=None):
             captured["messages"] = messages
             captured["model"] = self.model
-            yield SimpleNamespace(text="a generated image")
+            yield TextDeltaEvent(text="a generated image")
 
     class FakeSelector:
         def __init__(self, selector_config):
@@ -1796,7 +1795,7 @@ async def test_vision_provider_sends_provider_native_multimodal_message(monkeypa
         async def chat(self, *, messages, config=None):
             captured["messages"] = messages
             captured["config"] = config
-            yield SimpleNamespace(text="described")
+            yield TextDeltaEvent(text="described")
 
     root = ProviderRequestCorrelation(
         session_id="session-1",
@@ -1880,7 +1879,7 @@ async def test_text_media_llm_uses_provider_native_message(monkeypatch) -> None:
         async def chat(self, *, messages, config=None):
             captured["messages"] = messages
             captured["config"] = config
-            yield SimpleNamespace(text="analyzed")
+            yield TextDeltaEvent(text="analyzed")
 
     class FakeSelector:
         def __init__(self, selector_config):

--- a/tests/test_provider_openai_compat_payloads.py
+++ b/tests/test_provider_openai_compat_payloads.py
@@ -1019,6 +1019,7 @@ def test_openrouter_list_models_reports_openrouter_provider(monkeypatch: Any) ->
                         "name": "DeepSeek V4 Flash",
                         "context_length": 128000,
                         "top_provider": {"max_completion_tokens": 8192},
+                        "architecture": {"input_modalities": ["text", "image"]},
                     }
                 ]
             },
@@ -1037,6 +1038,7 @@ def test_openrouter_list_models_reports_openrouter_provider(monkeypatch: Any) ->
     assert captured["url"] == "https://openrouter.ai/api/v1/models"
     assert rows[0].provider == "openrouter"
     assert rows[0].model_id == "deepseek/deepseek-v4-flash"
+    assert rows[0].supports_vision is True
 
 
 def test_openrouter_http_error_names_provider_request(monkeypatch: Any) -> None:

--- a/tests/test_tools/test_media_image.py
+++ b/tests/test_tools/test_media_image.py
@@ -16,6 +16,62 @@ from opensquilla.tools.types import SafeToolError, ToolContext, ToolError, curre
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("final_answer", ["The image contains blue pixels.", ""])
+async def test_image_analysis_retries_reasoning_only_once_without_changing_model_or_thinking(
+    tmp_path: Path, final_answer: str,
+) -> None:
+    from opensquilla.provider.correlation_context import bind_provider_request_correlation
+    from opensquilla.provider.types import (
+        ChatConfig,
+        DoneEvent,
+        ProviderRequestCorrelation,
+        ReasoningDeltaEvent,
+        TextDeltaEvent,
+    )
+    from tests.helpers.image_bytes import image_bytes
+
+    (tmp_path / "sample.png").write_bytes(image_bytes())
+    calls = []
+
+    class Provider:
+        provider_name = "openai"
+        model = "configured-vision"
+
+        async def chat(self, messages, config):
+            calls.append((messages, config))
+            yield ReasoningDeltaEvent(text="internal reasoning")
+            if len(calls) == 2 and final_answer:
+                yield TextDeltaEvent(text=final_answer)
+            yield DoneEvent(reasoning_content="internal reasoning")
+
+    provider = Provider()
+    config = ChatConfig(model_vision_support="supported", thinking=True)
+    token = current_tool_context.set(ToolContext(
+        workspace_dir=str(tmp_path), image_analysis_target=lambda: (provider, config),
+    ))
+    try:
+        with bind_provider_request_correlation(ProviderRequestCorrelation(
+            session_id="test-session", turn_id="test-turn", execution_id="test-call",
+            call_kind="primary",
+        )):
+            result = json.loads(await media.image("sample.png"))
+    finally:
+        current_tool_context.reset(token)
+
+    assert len(calls) == 2
+    assert calls[0][0] == calls[1][0]
+    assert all(call_config.thinking is True for _, call_config in calls)
+    correlations = [call_config.provider_request_correlation for _, call_config in calls]
+    assert correlations[0].execution_id != correlations[1].execution_id
+    assert "internal reasoning" not in json.dumps(result)
+    if final_answer:
+        assert result["description"] == final_answer
+    else:
+        assert result["status"] == "analysis_failed"
+        assert "description" not in result
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("bound_target", [False, True])
 async def test_image_tool_does_not_select_a_separate_model(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, bound_target: bool,
@@ -116,6 +172,7 @@ async def test_agent_binds_image_tool_to_actual_selected_deployment(
     expected_auxiliary_calls: int | None = None, tool_count: int = 1,
     with_tracker: bool = False, duplicate_done: bool = False,
     reject_initial_image: bool = False,
+    reasoning_only_first_analysis: bool = False,
 ) -> None:
     from types import SimpleNamespace
 
@@ -134,6 +191,7 @@ async def test_agent_binds_image_tool_to_actual_selected_deployment(
         Message,
         ModelCapabilities,
         ProviderRequestCorrelation,
+        ReasoningDeltaEvent,
         TextDeltaEvent,
         ToolDefinition,
         ToolInputSchema,
@@ -153,7 +211,10 @@ async def test_agent_binds_image_tool_to_actual_selected_deployment(
         async def chat(self, messages, tools=None, config=None):
             if config.provider_request_correlation.call_kind == "auxiliary.media":
                 auxiliary_calls.append((messages, tools, config))
-                yield TextDeltaEvent(text="Image description")
+                if reasoning_only_first_analysis and len(auxiliary_calls) == 1:
+                    yield ReasoningDeltaEvent(text="internal reasoning")
+                else:
+                    yield TextDeltaEvent(text="Image description")
                 receipt = DoneEvent(
                     model=self.model, input_tokens=77, output_tokens=8,
                     billed_cost=1.0, cost_source="provider_billed",
@@ -254,7 +315,9 @@ async def test_agent_binds_image_tool_to_actual_selected_deployment(
     allowed = support == "supported" and not ensemble
     call_count = int(allowed) if expected_auxiliary_calls is None else expected_auxiliary_calls
     assert len(auxiliary_calls) == call_count
-    assert len([result for result in tool_results if "description" in result]) == call_count
+    assert len([result for result in tool_results if "description" in result]) == (
+        max(0, call_count - 1) if reasoning_only_first_analysis else call_count
+    )
     if auxiliary_calls:
         assert auxiliary_calls[0][1] is None
         assert auxiliary_calls[0][2].physical_attempt_limit == 1
@@ -309,6 +372,20 @@ async def test_image_tool_shares_the_turn_hard_budget(
     await test_agent_binds_image_tool_to_actual_selected_deployment(
         tmp_path, "supported", False, False, budget=budget,
         expected_error=error, expected_auxiliary_calls=calls, tool_count=tool_count,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("call_limit", [0, 2])
+async def test_image_analysis_empty_retry_obeys_turn_call_limit_and_accounts_each_attempt(
+    tmp_path: Path, call_limit: int,
+) -> None:
+    await test_agent_binds_image_tool_to_actual_selected_deployment(
+        tmp_path, "supported", False, False,
+        budget={"max_turn_llm_calls": call_limit},
+        expected_error="turn_llm_call_budget_exceeded" if call_limit else None,
+        expected_auxiliary_calls=1 if call_limit else 2,
+        reasoning_only_first_analysis=True,
     )
 
 
@@ -545,6 +622,38 @@ async def test_fetch_image_url_resolves_relative_redirect_against_logical_url(
     ]
     assert image_bytes == b"png-bytes"
     assert media_type == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_fetch_image_url_reports_http_status_for_expired_or_missing_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import httpx
+
+    class MissingClient:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> MissingClient:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def get(self, url: str) -> httpx.Response:
+            return httpx.Response(
+                404,
+                request=httpx.Request("GET", url),
+            )
+
+    monkeypatch.setattr(media, "validate_http_url_for_fetch", lambda url: ["93.184.216.34"])
+    monkeypatch.setattr(httpx, "AsyncClient", MissingClient)
+    monkeypatch.setattr(
+        "opensquilla.tools.ssrf.pinned_transport", lambda *args, **kwargs: object()
+    )
+
+    with pytest.raises(ToolError, match=r"HTTP 404 \(Not Found\)"):
+        await media._fetch_image_url("https://images.example.test/expired.png")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope

Image reads or uploads that finish after changing tasks can populate the next task's composer, and files with image signatures can pass admission without valid pixel data. Retire pending attachment work when navigation commits, validate image content across uploads and historical replay, and keep unavailable historical images explicit.

Image analysis now consumes visible answer text, retries an empty answer at most once on the selected deployment without changing thinking settings, and accounts each attempt against the turn budget. Expired image URLs report their HTTP status. The model picker shows vision capability from TokenRhythm and OpenRouter metadata, and Ensemble attachment requests check member and fixed-fallback capacity before execution.

Scope boundary: image admission, attachment ownership, model capability display, media analysis recovery, and attachment capacity checks.

Non-goals: new providers or a separate image-model route.

## Branch

Base branch: main

Target exception: N/A

## Issue

Linked issue: None

If None, reason: fixes were collected in an external image-behavior QA tracker.

## Release Note

Release note: Reject corrupt images, prevent pending attachments crossing tasks, show model image-input capabilities, and make image-analysis recovery and attachment capacity handling consistent.

## Tests

Ruff: `ruff check src tests` passed.

Mypy: `mypy src/opensquilla --show-error-codes` passed for 1,542 source files.

Pytest: 727 focused history, routing, provider, and Ensemble tests passed; 35 media-tool tests passed. Image validation, upload, and ingestion regressions also passed. The final Ensemble capacity and credential-guard suites passed (177 and 42 tests); valid-image capacity fixtures and Windows shard registration passed (31 and 46 tests).

Build: WebUI typecheck, architecture checks, and the verified production artifact build passed. 297 focused UI tests passed, with additional attachment navigation and send-queue coverage.

Regression tests: added

Notes: empty-response retries cover shared call limits and per-attempt accounting. Valid synthetic PNG/JPEG fixtures replace header-only test payloads. Changes are platform-neutral; Windows desktop and live provider latency remain manual acceptance checks. Existing configuration and persistence formats remain compatible; unreadable legacy image data becomes an unavailable marker.

The default test path remains offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: yes

Surface: gateway, browser

Local gateway smoke: corrupt PNG and disguised JPEG return 415; two successive valid PNG/JPEG uploads return 200. The built model-routing page displays only C0–C3, without the retired image row or switches.

## Safety

No secrets, local-only artifacts, private prompts/transcripts, channel identifiers, or non-public fixtures are included. Image validation reuses the existing Pillow dependency and does not change the supported image MIME set.

## Third-Party Origin

Third-party origin: none

Independent implementation; no third-party code, fixtures, or text copied, and no new dependency added.

## Documentation Changes

No documentation files changed.
