### PR TITLE
Remove interactive preview notice

### DIFF
--- a/opensquilla-webui/src/components/workbench/AppWorkbench.vue
+++ b/opensquilla-webui/src/components/workbench/AppWorkbench.vue
@@ -409,10 +409,6 @@ for (const definition of createArtifactWorkbenchDefinitions({
   previewLeasesEnabled: true,
   pushToast: (message, options) => pushToast(message, options),
   savePreviewPreferences: preferences => savePreviewPreferences(platform, preferences),
-  showFullPreviewNotice: () => pushToast(
-    t('workbench.artifactPreview.fullModeNotice'),
-    { tone: 'info', duration: 9000 },
-  ),
   t: (key, params) => String(t(key, params || {})),
 })) {
   workbenchPanelRegistry.register(definition, { replace: true })

--- a/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.test.ts
+++ b/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.test.ts
@@ -1763,19 +1763,15 @@ describe('artifact Workbench provider', () => {
     expect(renderState.previewMode).toBe('full')
     expect(createSurface).toHaveBeenLastCalledWith(expect.objectContaining({ version: 3 }))
     expect(renderState.previewDefaultMode).toBe('offline')
+    expect(savePreviewPreferences).not.toHaveBeenCalled()
+
+    await runtime.performAction?.('set-default-preview-mode', item)
+    await runtime.performAction?.('set-default-preview-mode', item)
+
     expect(savePreviewPreferences).toHaveBeenCalledOnce()
     expect(savePreviewPreferences).toHaveBeenLastCalledWith({
-      mode: 'offline',
-      noticeShown: true,
-    })
-
-    await runtime.performAction?.('set-default-preview-mode', item)
-    await runtime.performAction?.('set-default-preview-mode', item)
-
-    expect(savePreviewPreferences).toHaveBeenCalledTimes(2)
-    expect(savePreviewPreferences).toHaveBeenLastCalledWith({
       mode: 'full',
-      noticeShown: true,
+      noticeShown: false,
     })
     expect(pushToast).toHaveBeenCalledOnce()
     expect(renderState.previewDefaultMode).toBe('full')

--- a/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.ts
+++ b/opensquilla-webui/src/components/workbench/artifactWorkbenchProvider.ts
@@ -107,7 +107,6 @@ export interface ArtifactWorkbenchProviderOptions {
     mode: WorkbenchPreviewMode
     noticeShown: boolean
   }): Promise<void>
-  showFullPreviewNotice?(): void
   publishDocument?(request: {
     sessionKey: string
     documentId: string
@@ -2178,17 +2177,6 @@ class ArtifactPreviewRuntime implements WorkbenchPanelRuntime {
       previewWarnings: lease.source.warning_codes,
     })
     this.startLeaseRenewal()
-
-    if (lease.effective_mode === 'full' && !this.noticeShown) {
-      this.noticeShown = true
-      this.options.showFullPreviewNotice?.()
-      try {
-        await this.options.savePreviewPreferences?.({
-          mode: this.defaultMode,
-          noticeShown: true,
-        })
-      } catch {}
-    }
 
     if (this.item.hostKind !== 'native-webcontents' || !nativeApi) return true
     this.nativeProtocolVersion = capabilities.protocolVersions.includes(4)

--- a/opensquilla-webui/src/locales/de.json
+++ b/opensquilla-webui/src/locales/de.json
@@ -227,7 +227,6 @@
       "setDefaultMode": "Diesen Modus als Standard verwenden",
       "restoreDefaultMode": "Standard-Vorschaumodus wiederherstellen",
       "defaultModeSaved": "Standard-Vorschaumodus gespeichert.",
-      "fullModeNotice": "Die interaktive Vorschau kann Online-Inhalte laden, teilt aber weder OpenSquilla-Identität noch lokale Dateien oder Browser-Anmeldungen.",
       "offlineWebLimits": "Einige externe Inhalte und erweiterte Webfunktionen sind in der eingeschränkten Vorschau möglicherweise nicht verfügbar.",
       "compatibilityFallback": "Diese Desktop-Version unterstützt nur die ältere Einzeldateivorschau.",
       "upgradeDesktopShort": "Desktop aktualisieren",

--- a/opensquilla-webui/src/locales/en.json
+++ b/opensquilla-webui/src/locales/en.json
@@ -227,7 +227,6 @@
       "setDefaultMode": "Use this mode by default",
       "restoreDefaultMode": "Restore the default preview mode",
       "defaultModeSaved": "Default preview mode saved.",
-      "fullModeNotice": "Interactive preview can load online content, but it does not share OpenSquilla identity, local files, or your system browser login.",
       "offlineWebLimits": "Some external content and advanced web features may be unavailable in restricted preview.",
       "compatibilityFallback": "This Desktop version supports only the legacy single-file preview.",
       "upgradeDesktopShort": "Update Desktop",

--- a/opensquilla-webui/src/locales/es.json
+++ b/opensquilla-webui/src/locales/es.json
@@ -227,7 +227,6 @@
       "setDefaultMode": "Usar este modo de forma predeterminada",
       "restoreDefaultMode": "Restaurar el modo de vista previa predeterminado",
       "defaultModeSaved": "Modo de vista previa predeterminado guardado.",
-      "fullModeNotice": "La vista previa interactiva puede cargar contenido en línea, pero no comparte la identidad de OpenSquilla, archivos locales ni sesiones del navegador.",
       "offlineWebLimits": "Es posible que algunos contenidos externos y funciones web avanzadas no estén disponibles en la vista previa restringida.",
       "compatibilityFallback": "Esta versión de Desktop solo admite la vista previa antigua de un solo archivo.",
       "upgradeDesktopShort": "Actualizar Desktop",

--- a/opensquilla-webui/src/locales/fr.json
+++ b/opensquilla-webui/src/locales/fr.json
@@ -227,7 +227,6 @@
       "setDefaultMode": "Utiliser ce mode par défaut",
       "restoreDefaultMode": "Rétablir le mode d’aperçu par défaut",
       "defaultModeSaved": "Mode d’aperçu par défaut enregistré.",
-      "fullModeNotice": "L’aperçu interactif peut charger du contenu en ligne, sans partager l’identité OpenSquilla, les fichiers locaux ni les connexions du navigateur système.",
       "offlineWebLimits": "Certains contenus externes et certaines fonctions web avancées peuvent être indisponibles dans l’aperçu restreint.",
       "compatibilityFallback": "Cette version Desktop ne prend en charge que l’ancien aperçu à fichier unique.",
       "upgradeDesktopShort": "Mettre Desktop à jour",

--- a/opensquilla-webui/src/locales/ja.json
+++ b/opensquilla-webui/src/locales/ja.json
@@ -227,7 +227,6 @@
       "setDefaultMode": "このモードを既定にする",
       "restoreDefaultMode": "既定のプレビューモードに戻す",
       "defaultModeSaved": "既定のプレビューモードを保存しました。",
-      "fullModeNotice": "インタラクティブプレビューはオンラインコンテンツを読み込めますが、OpenSquilla の権限、ローカルファイル、システムブラウザーのログインは共有しません。",
       "offlineWebLimits": "制限付きプレビューでは、一部の外部コンテンツや高度な Web 機能を利用できない場合があります。",
       "compatibilityFallback": "この Desktop バージョンでは従来の単一ファイルプレビューのみ利用できます。",
       "upgradeDesktopShort": "Desktop を更新",

--- a/opensquilla-webui/src/locales/zh-Hans.json
+++ b/opensquilla-webui/src/locales/zh-Hans.json
@@ -227,7 +227,6 @@
       "setDefaultMode": "将当前模式设为默认",
       "restoreDefaultMode": "恢复默认预览模式",
       "defaultModeSaved": "已保存默认预览模式。",
-      "fullModeNotice": "互动预览可以加载在线内容，但不会共享 OpenSquilla 身份、本机文件或系统浏览器登录状态。",
       "offlineWebLimits": "受限预览中，部分外部内容和高级网页功能可能不可用。",
       "compatibilityFallback": "当前 Desktop 版本仅支持旧版单文件预览。",
       "upgradeDesktopShort": "请升级 Desktop",


### PR DESCRIPTION
## Scope

- Remove the informational toast shown when interactive preview first enters full mode.
- Stop the associated one-time preference write while preserving the legacy preference field for compatibility.
- Remove the unused localized notice text and update provider coverage.

## Branch target

`main`

## Linked issue

None.

## Release note

Not added; this removes an obsolete informational toast without changing preview capabilities.

## Tests

- `npx vitest run src/components/workbench/artifactWorkbenchProvider.test.ts src/utils/workbench/previewPreferences.test.ts` (57 passed)
- `npm run typecheck`
- `git diff --check`

## Safety

No sandbox, permission, network, local-file, or browser-session isolation behavior changes. Remote-resource confirmation remains unchanged.

## Third-party origin

None.