### PR TITLE
Fix desktop telemetry counts and lifecycle recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -773,6 +773,7 @@ jobs:
           node scripts/test-telemetry-build-identity.mjs
           node scripts/test-telemetry-reliability.mjs
           node scripts/test-telemetry-growth.mjs
+          node scripts/test-telemetry-growth-lifecycle.mjs
           node scripts/test-telemetry-protocol.mjs
           node ../../.github/scripts/verify-sandbox-package.mjs --source
 

--- a/desktop/electron/package.json
+++ b/desktop/electron/package.json
@@ -61,7 +61,7 @@
     "test:telemetry-protocol": "npm run build && node scripts/test-telemetry-protocol.mjs",
     "test:telemetry-build-identity": "npm run build && node scripts/test-telemetry-build-identity.mjs",
     "test:telemetry-reliability": "npm run build && node scripts/test-telemetry-reliability.mjs",
-    "test:telemetry-growth": "npm run build && node scripts/test-telemetry-growth.mjs",
+    "test:telemetry-growth": "npm run build && node scripts/test-telemetry-growth.mjs && node scripts/test-telemetry-growth-lifecycle.mjs",
     "test:router-tier-normalization": "npm run build && node scripts/test-router-tier-normalization.mjs",
     "test:onboarding-flow": "npm run build && node scripts/test-onboarding-flow.mjs",
     "start": "electron .",

--- a/desktop/electron/scripts/test-telemetry-growth-lifecycle.mjs
+++ b/desktop/electron/scripts/test-telemetry-growth-lifecycle.mjs
@@ -1,0 +1,253 @@
+import assert from 'node:assert/strict'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import vm from 'node:vm'
+import ts from 'typescript'
+
+import { OnboardingSaveTelemetry } from '../dist/onboarding-save-telemetry.js'
+import { DesktopTelemetryRuntimeGate, clearEarlyTelemetryScope } from '../dist/telemetry/early-spool.js'
+import { CONSENT_MIRROR_SCHEMA_VERSION, writeConsentMirror } from '../dist/telemetry/consent-mirror.js'
+import { runTelemetrySideEffectFailOpen } from '../dist/telemetry/fail-open.js'
+import {
+  applyDesktopTelemetryConsentPayload, desktopPrivacyTomlLines, parseDesktopTelemetryConsent,
+  parseLegacyNetworkObservabilityDisabled, requireExplicitOnboardingConsent,
+} from '../dist/telemetry/onboarding-consent.js'
+import {
+  clearDesktopGrowthTelemetryState, DesktopGrowthTelemetry, parseDesktopOnboardingReceipt,
+} from '../dist/telemetry/growth.js'
+
+// Execute the production lifecycle functions with only their Electron, provider,
+// and atomic settings-transaction boundaries substituted by offline fixtures.
+const source = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8')
+const ast = ts.createSourceFile('main.ts', source, ts.ScriptTarget.Latest, true)
+const names = new Set([
+  'finishAppStartSuccess', 'finishAppStartFailure', 'normalizeDesktopCredential',
+  'loadDesktopCredential', 'saveDesktopCredential', 'performOnboardingSave',
+  'mirroredScopeConsent', 'writeDesktopConsentMirror', 'syncDesktopConsentMirror',
+  'runDesktopTelemetryConsentSideEffect',
+])
+const extracted = ast.statements.filter((node) => ts.isFunctionDeclaration(node)
+  && names.has(node.name?.text))
+assert.equal(extracted.length, names.size)
+const executable = ts.transpileModule(
+  'let appStartResultRecorded = false;\n'
+    + extracted.map((node) => node.getText(ast)).join('\n'),
+  { compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.None } },
+).outputText
+
+const NOW = '2026-09-11T12:00:00.000Z'
+const READY_AT = '2026-09-11T12:01:00.000Z'
+const root = mkdtempSync(join(tmpdir(), 'opensquilla-growth-lifecycle-'))
+const payload = {
+  provider: 'ollama', model: 'synthetic-model', reliabilityDiagnosticsEnabled: false,
+  productAnalyticsEnabled: true,
+}
+
+function harness(directory, {
+  stableCode = 'fresh_profile', platform = 'macos', failure = null, deferred = false,
+  importedOrMigrated = false, env = {}, nowUtc = NOW,
+} = {}) {
+  class TestDate extends Date {
+    constructor(...args) { super(...(args.length ? args : [nowUtc])) }
+    static now() { return Date.parse(nowUtc) }
+  }
+  const profile = { home: join(directory, 'profile'), credentialPath: join(directory, 'credential.json') }
+  const telemetryDirectory = join(profile.home, 'state', 'telemetry')
+  const paths = {
+    profileKey: profile.home, telemetryDirectory,
+    consentMirrorPath: join(telemetryDirectory, 'desktop-consent-mirror.json'),
+    spoolRoot: join(telemetryDirectory, 'desktop-early-spool'),
+  }
+  const gate = new DesktopTelemetryRuntimeGate()
+  const growth = new DesktopGrowthTelemetry({
+    runtimeGate: gate, appVersion: () => '0.5.4', platform, env, nowDate: () => new TestDate(),
+  })
+  growth.observeProfileInspection({ profileKey: profile.home, stableCode, importedOrMigrated })
+  const startupResults = []
+  let settingsPersisted = false
+  let writerFinished = false
+  const defaults = { requiresApiKey: false, model: 'synthetic-model', baseUrl: '', apiKeyEnv: '' }
+  const context = vm.createContext({
+    Date: TestDate, join, Math, JSON, Buffer, OnboardingSaveTelemetry,
+    desktopTelemetryRuntimeGate: gate, desktopGrowthTelemetry: growth,
+    desktopReliabilityTelemetry: { synchronize() {}, recordAppStartResult: (event) => startupResults.push(event) },
+    desktopProcessStartedAt: TestDate.now(), desktopLocale: 'en', onboardingSaveTelemetryAttempt: 0,
+    app: { isPackaged: false }, desktopLog() {}, refreshDesktopReliabilityForegroundState() {},
+    activeDesktopProfile: () => profile, credentialPath: () => profile.credentialPath,
+    readFile: async (path) => readFileSync(path, 'utf8'),
+    readOptionalDesktopText: async (path) => existsSync(path) ? readFileSync(path, 'utf8') : null,
+    desktopTelemetryDirectory: () => telemetryDirectory,
+    desktopConsentMirrorPath: () => paths.consentMirrorPath,
+    desktopEarlyTelemetrySpoolPath: () => paths.spoolRoot,
+    writeConsentMirror, CONSENT_MIRROR_SCHEMA_VERSION, clearEarlyTelemetryScope,
+    clearDesktopGrowthTelemetryState, parseDesktopOnboardingReceipt, runTelemetrySideEffectFailOpen,
+    applyDesktopTelemetryConsentPayload, parseDesktopTelemetryConsent,
+    parseLegacyNetworkObservabilityDisabled, requireExplicitOnboardingConsent,
+    PROVIDER_BY_ID: new Map(), normalizeProvider: (value) => value,
+    providerDefaults: () => defaults, normalizeRouterMode: () => 'disabled',
+    normalizeModelRoutingMode: () => 'direct', routerModeForModelRoutingMode: () => 'disabled',
+    normalizeTextTier: () => 'c1', defaultRouterTiers: () => ({}),
+    normalizeRouterTiers: () => ({}), routerDefaultModel: () => '',
+    normalizeSearchProvider: () => 'none', searchProviderDefaults: () => ({ requiresApiKey: false, envKey: '' }),
+    normalizeBooleanSetting: (value, fallback) => typeof value === 'boolean' ? value : fallback,
+    readDesktopConfigNetworkObservabilitySetting: () => false,
+    desktopLocaleChoice: () => 'en', MIGRATION_TRANSACTION_ID_RE: /^[0-9a-f-]{36}$/,
+    decryptApiKey: () => '', decryptSearchApiKey: () => '', rememberDecryptedCredentialSecrets() {},
+    refreshPrimaryRecoveryAfterImportAttempt: async () => false,
+    onboardingFlows: { canComplete: () => true },
+    beginDesktopWriterOperation: () => () => { writerFinished = true },
+    readPendingMigrationProviderSetup: async () => null, invalidateSecretStorageBackendCache() {},
+    applyDesktopLocaleChoice() {},
+    clearPendingMigrationProviderSetup: async () => {
+      if (failure === 'local_finalize') throw new Error('synthetic local finalize failure')
+    },
+    desktopWriters: { closed: deferred }, isQuitting: false,
+    appExitPhase: deferred ? 'deferred' : 'running', abandonOnboardingFlow() {},
+    completeOnboardingFlow: () => true,
+    onboardingSaveFailure: (code, error) => ({ ok: false, code, error }),
+    applyDesktopSettingsPair: async (_profile, _credential, candidate, expected, _reserved, _locale, consent) => {
+      assert.equal(existsSync(profile.credentialPath) ? readFileSync(profile.credentialPath, 'utf8') : null, expected)
+      // Stand in for the existing recoverable credential/config pair commit.
+      mkdirSync(profile.home, { recursive: true })
+      writeFileSync(profile.credentialPath, candidate)
+      const configPath = join(profile.home, 'config.toml')
+      const effectiveConsent = consent ?? parseDesktopTelemetryConsent(readFileSync(configPath, 'utf8'))
+      writeFileSync(configPath, desktopPrivacyTomlLines(false, effectiveConsent, true).join('\n'))
+      settingsPersisted = true
+      if (failure === 'after_commit') throw new Error('synthetic process stop after settings commit')
+    },
+  })
+  vm.runInContext(executable, context)
+  return {
+    context, growth, paths, profile, startupResults,
+    setNow(value) { nowUtc = value },
+    get settingsPersisted() { return settingsPersisted },
+    get writerFinished() { return writerFinished },
+    events() {
+      const scope = join(paths.spoolRoot, 'growth')
+      return existsSync(scope) ? readdirSync(scope).filter((name) => name.endsWith('.ready'))
+        .map((name) => JSON.parse(readFileSync(join(scope, name), 'utf8'))) : []
+    },
+  }
+}
+
+try {
+  for (const platform of ['macos', 'windows', 'linux']) {
+    const directory = join(root, platform)
+    const first = harness(directory, { platform })
+    await first.context.syncDesktopConsentMirror()
+    await first.context.performOnboardingSave({ state: 'saving' }, payload)
+    first.context.finishAppStartFailure(new Error('synthetic startup failure'), {
+      stage: 'gateway_start', errorCode: 'spawn_failed',
+    })
+    first.setNow(READY_AT)
+    first.context.finishAppStartSuccess()
+    first.context.finishAppStartSuccess()
+    assert.deepEqual(first.startupResults.map((event) => event.outcome), ['fail'])
+    assert.equal(first.events().filter((event) => event.event_name === 'first_app_ready').length, 1)
+    assert.equal(first.events().find((event) => event.event_name === 'onboarding_result').occurred_at_utc, NOW)
+    assert.equal(first.events().find((event) => event.event_name === 'first_app_ready').occurred_at_utc, READY_AT)
+  }
+
+  for (const failure of ['local_finalize', 'after_commit']) {
+    const directory = join(root, failure)
+    const first = harness(directory, { failure })
+    await first.context.syncDesktopConsentMirror()
+    await assert.rejects(first.context.performOnboardingSave({ state: 'saving' }, payload), /synthetic/)
+    assert.equal(first.settingsPersisted, true)
+    assert.equal(first.writerFinished, true)
+    const receipt = JSON.parse(readFileSync(first.profile.credentialPath, 'utf8')).growthOnboardingReceipt
+    assert.ok(receipt)
+    if (failure === 'after_commit') assert.deepEqual(first.events(), [])
+    const recovered = harness(directory, { stableCode: 'ready', nowUtc: READY_AT })
+    await recovered.context.syncDesktopConsentMirror()
+    await recovered.context.syncDesktopConsentMirror()
+    recovered.context.finishAppStartSuccess()
+    const events = recovered.events()
+    assert.deepEqual(events.map((event) => event.event_name).sort(), ['first_app_ready', 'onboarding_result'])
+    assert.equal(new Set(events.map((event) => event.analytics_user_id)).size, 1)
+    assert.equal(events.find((event) => event.event_name === 'onboarding_result').occurred_at_utc, NOW)
+    assert.equal(events.find((event) => event.event_name === 'first_app_ready').occurred_at_utc, READY_AT)
+  }
+
+  const deferred = harness(join(root, 'lifecycle-deferral'), { deferred: true })
+  await deferred.context.syncDesktopConsentMirror()
+  const result = await deferred.context.performOnboardingSave({ state: 'saving' }, payload)
+  assert.equal(result.code, 'lifecycle_deferred')
+  assert.equal(deferred.writerFinished, true)
+  assert.equal(deferred.events().filter((event) => event.event_name === 'onboarding_result').length, 1)
+
+  // A failed transaction has no committed receipt to authorize recovery.
+  const failed = harness(join(root, 'failed-save'))
+  await failed.context.syncDesktopConsentMirror()
+  failed.context.applyDesktopSettingsPair = async () => { throw new Error('synthetic commit failure') }
+  await assert.rejects(failed.context.performOnboardingSave({ state: 'saving' }, payload), /commit failure/)
+  assert.equal(existsSync(failed.profile.credentialPath), false)
+  assert.deepEqual(failed.events(), [])
+
+  for (const choice of [false, true]) {
+    const old = harness(join(root, `old-profile-${choice}`), { stableCode: 'ready' })
+    await old.context.syncDesktopConsentMirror()
+    await old.context.performOnboardingSave({ state: 'saving' }, { ...payload, productAnalyticsEnabled: choice })
+    assert.equal(JSON.parse(readFileSync(old.profile.credentialPath, 'utf8')).growthOnboardingReceipt, undefined)
+    assert.deepEqual(old.events(), [])
+  }
+
+  const declined = harness(join(root, 'declined'))
+  await declined.context.syncDesktopConsentMirror()
+  await declined.context.performOnboardingSave({ state: 'saving' }, { ...payload, productAnalyticsEnabled: false })
+  assert.equal(JSON.parse(readFileSync(declined.profile.credentialPath, 'utf8')).growthOnboardingReceipt, undefined)
+  assert.deepEqual(declined.events(), [])
+
+  const renewedDirectory = join(root, 'withdraw-and-renew')
+  const consented = harness(renewedDirectory)
+  await consented.context.syncDesktopConsentMirror()
+  await consented.context.performOnboardingSave({ state: 'saving' }, payload)
+  clearDesktopGrowthTelemetryState(consented.paths.telemetryDirectory)
+  clearEarlyTelemetryScope(consented.paths.spoolRoot, 'growth')
+  const renewedConsent = applyDesktopTelemetryConsentPayload(parseDesktopTelemetryConsent(null), payload, '2026-09-12T00:00:00.000Z')
+  writeFileSync(join(consented.profile.home, 'config.toml'), desktopPrivacyTomlLines(false, renewedConsent, true).join('\n'))
+  const renewed = harness(renewedDirectory, { stableCode: 'ready' })
+  await renewed.context.syncDesktopConsentMirror()
+  renewed.context.finishAppStartSuccess()
+  assert.deepEqual(renewed.events(), [])
+  assert.equal(existsSync(join(renewed.paths.telemetryDirectory, 'growth_cohort.json')), false)
+
+  // A later ordinary settings save retains the receipt without creating a new
+  // milestone, and normalization still accepts pre-receipt credentials.
+  const settings = harness(join(root, 'settings-preserve'))
+  await settings.context.syncDesktopConsentMirror()
+  await settings.context.performOnboardingSave({ state: 'saving' }, payload)
+  const saved = JSON.parse(readFileSync(settings.profile.credentialPath, 'utf8'))
+  await settings.context.saveDesktopCredential({ provider: 'ollama', model: 'another-model' })
+  const updated = JSON.parse(readFileSync(settings.profile.credentialPath, 'utf8'))
+  assert.deepEqual(updated.growthOnboardingReceipt, saved.growthOnboardingReceipt)
+  assert.equal(settings.events().length, 1)
+  delete saved.growthOnboardingReceipt
+  assert.equal(settings.context.normalizeDesktopCredential(saved).growthOnboardingReceipt, undefined)
+
+  const importedDirectory = join(root, 'imported-receipt')
+  const interrupted = harness(importedDirectory, { failure: 'after_commit' })
+  await interrupted.context.syncDesktopConsentMirror()
+  await assert.rejects(interrupted.context.performOnboardingSave({ state: 'saving' }, payload), /synthetic/)
+  const imported = harness(importedDirectory, { stableCode: 'ready', importedOrMigrated: true })
+  await imported.context.syncDesktopConsentMirror()
+  imported.context.finishAppStartSuccess()
+  assert.deepEqual(imported.events(), [])
+
+  for (const disabled of ['legacy', 'environment']) {
+    const blocked = harness(join(root, disabled), {
+      env: disabled === 'environment' ? { DO_NOT_TRACK: '1' } : {},
+    })
+    await blocked.context.syncDesktopConsentMirror()
+    await blocked.context.performOnboardingSave({ state: 'saving' }, {
+      ...payload, disableNetworkObservability: disabled === 'legacy',
+    })
+    assert.equal(JSON.parse(readFileSync(blocked.profile.credentialPath, 'utf8')).growthOnboardingReceipt, undefined)
+  }
+} finally {
+  rmSync(root, { recursive: true, force: true })
+}
+
+console.log('telemetry growth lifecycle and restart tests passed')

--- a/desktop/electron/scripts/test-telemetry-growth.mjs
+++ b/desktop/electron/scripts/test-telemetry-growth.mjs
@@ -272,8 +272,8 @@ const onboardingSave = mainSource.slice(
   mainSource.indexOf('async function withRecoveryOperation'),
 )
 assert.ok(
-  onboardingSave.indexOf('completeOnboardingFlow(flow, credential)')
-    < onboardingSave.indexOf('desktopGrowthTelemetry.recordOnboardingCompleted()'),
+  onboardingSave.indexOf('desktopGrowthTelemetry.recordOnboardingCompleted()')
+    < onboardingSave.indexOf('completeOnboardingFlow(flow, credential)'),
 )
 const profileInspection = mainSource.slice(
   mainSource.indexOf('async function inspectActiveProfileBeforeStartup'),

--- a/desktop/electron/scripts/test-telemetry-reliability.mjs
+++ b/desktop/electron/scripts/test-telemetry-reliability.mjs
@@ -312,8 +312,15 @@ try {
     runtime.synchronize(factPaths)
     fakeClock.advance(500)
     runtime.recordMonitoredRequest(30_001)
-    runtime.recordTurn(false)
-    runtime.recordTurn(true)
+    writeFileSync(join(factPaths.spoolRoot, 'reliability',
+      `.desktop-reliability-turns-${uuid(100)}.tmp`), JSON.stringify({
+      schema_version: 1,
+      app_session_id: uuid(100),
+      turn_count: 2,
+      stalled_turn_count: 1,
+      stall_count: 2,
+      last_observed_at_ms: fakeClock.nowMs(),
+    }))
     runtime.recordAppStartResult({
       outcome: 'success',
       durationMs: 500,
@@ -352,6 +359,7 @@ try {
     assert.equal(summary.slow_request_count, 1)
     assert.equal(summary.turn_count, 2)
     assert.equal(summary.stalled_turn_count, 1)
+    assert.equal(summary.stall_count, 2)
     assert.equal(summary.foreground_duration_ms, 1_000)
     assert.equal(summary.background_duration_ms, 0)
     assert.equal(
@@ -364,6 +372,59 @@ try {
     ]) {
       assert.equal(serialized.includes(forbidden), false, `forbidden telemetry field: ${forbidden}`)
     }
+  }
+
+  // A failed summary enqueue freezes Gateway totals for a byte-stable retry.
+  {
+    const retryRoot = join(root, 'turn-count-retry')
+    const retryPaths = paths(retryRoot)
+    await writeReliabilityConsent(retryPaths.consentMirrorPath, true)
+    const fakeClock = clock()
+    const first = telemetry({ clock: fakeClock, appSessionId: uuid(150) })
+    first.synchronize(retryPaths)
+    const counterPath = join(retryPaths.spoolRoot, 'reliability',
+      `.desktop-reliability-turns-${uuid(150)}.tmp`)
+    const counters = { schema_version: 1, app_session_id: uuid(150), turn_count: 2,
+      stalled_turn_count: 1, stall_count: 2, last_observed_at_ms: fakeClock.nowMs() }
+    writeFileSync(counterPath, JSON.stringify(counters))
+    first.emitPerformanceSummary = () => ({ status: 'dropped', reason: 'io_error' })
+    first.finishSession()
+    const frozen = JSON.parse(readFileSync(join(retryPaths.spoolRoot, 'reliability',
+      '.desktop-reliability-session.tmp'), 'utf8'))
+    assert.equal(frozen.gateway_turn_counts_applied, true)
+    assert.equal(frozen.performance.turn_count, 2)
+    writeFileSync(counterPath, JSON.stringify({ ...counters, turn_count: 100 }))
+    const second = telemetry({ clock: fakeClock, appSessionId: uuid(151) })
+    second.synchronize(retryPaths)
+    const summary = readyEvents(retryRoot).find((event) => event.event_name === 'performance_summary')
+    assert.equal(summary.event_id, frozen.recovered_performance_event_id)
+    assert.equal(summary.turn_count, 2)
+    assert.equal(summary.stalled_turn_count, 1)
+    assert.equal(summary.stall_count, 2)
+    assert.equal(existsSync(counterPath), false)
+    second.finishSession()
+  }
+
+  // The prior schema-2 session remains recoverable without a Gateway checkpoint.
+  {
+    const previousRoot = join(root, 'schema-two')
+    const previousPaths = paths(previousRoot)
+    await writeReliabilityConsent(previousPaths.consentMirrorPath, true)
+    const fakeClock = clock()
+    telemetry({ clock: fakeClock, appSessionId: uuid(160) }).synchronize(previousPaths)
+    const markerPath = join(previousPaths.spoolRoot, 'reliability', '.desktop-reliability-session.tmp')
+    const marker = JSON.parse(readFileSync(markerPath, 'utf8'))
+    marker.schema_version = 2
+    delete marker.consent_generation
+    delete marker.gateway_turn_counts_applied
+    writeFileSync(markerPath, JSON.stringify(marker))
+    const second = telemetry({ clock: fakeClock, appSessionId: uuid(161) })
+    second.synchronize(previousPaths)
+    const summary = readyEvents(previousRoot).find((event) => event.event_name === 'performance_summary')
+    assert.equal(summary.app_session_id, uuid(160))
+    assert.equal(summary.summary_kind, 'recovered_abnormal')
+    assert.equal(summary.turn_count, 0)
+    second.finishSession()
   }
 
   // A renderer crash is persisted as closed facts and reported once on the next launch.
@@ -480,6 +541,8 @@ try {
       'app_start_stage',
       'app_start_result',
       'app_start_result_emitted',
+      'consent_generation',
+      'gateway_turn_counts_applied',
     ]) delete marker[field]
     marker.schema_version = 1
     writeFileSync(sessionPath, `${JSON.stringify(marker)}\n`)
@@ -657,6 +720,8 @@ try {
       'app_start_stage',
       'app_start_result',
       'app_start_result_emitted',
+      'consent_generation',
+      'gateway_turn_counts_applied',
     ]) delete template[field]
     template.schema_version = 1
     template.clean_exit = false

--- a/desktop/electron/scripts/test-telemetry-reliability.mjs
+++ b/desktop/electron/scripts/test-telemetry-reliability.mjs
@@ -312,6 +312,8 @@ try {
     runtime.synchronize(factPaths)
     fakeClock.advance(500)
     runtime.recordMonitoredRequest(30_001)
+    runtime.recordTurn(false)
+    runtime.recordTurn(true)
     runtime.recordAppStartResult({
       outcome: 'success',
       durationMs: 500,
@@ -348,6 +350,8 @@ try {
     assert.equal(summary.coverage, 'complete')
     assert.equal(summary.monitored_request_count, 1)
     assert.equal(summary.slow_request_count, 1)
+    assert.equal(summary.turn_count, 2)
+    assert.equal(summary.stalled_turn_count, 1)
     assert.equal(summary.foreground_duration_ms, 1_000)
     assert.equal(summary.background_duration_ms, 0)
     assert.equal(

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -14181,6 +14181,10 @@ async function performOnboardingSave(
         applyDesktopLocaleChoice(payload.locale)
         await clearPendingMigrationProviderSetup()
       })
+      // Persist the growth milestone before the flow handoff can be
+      // interrupted by quit/update. The durable marker is replayed on the
+      // next launch if the spool write cannot finish here.
+      desktopGrowthTelemetry.recordOnboardingCompleted()
     } catch (error) {
       if (flow.state === 'saving') flow.state = 'editing'
       throw error
@@ -14214,7 +14218,6 @@ async function performOnboardingSave(
           'OpenSquilla setup is no longer active.',
         ))
       }
-      desktopGrowthTelemetry.recordOnboardingCompleted()
       return telemetry.recordReturned({ ok: true })
     })
   } finally {

--- a/desktop/electron/src/main.ts
+++ b/desktop/electron/src/main.ts
@@ -83,6 +83,8 @@ import { runTelemetrySideEffectFailOpen } from './telemetry/fail-open.js'
 import {
   clearDesktopGrowthTelemetryState,
   DesktopGrowthTelemetry,
+  parseDesktopOnboardingReceipt,
+  type DesktopOnboardingReceipt,
 } from './telemetry/growth.js'
 import { buildCliInvocation } from './cli-invocation.js'
 import {
@@ -284,6 +286,7 @@ interface DesktopConnection {
   importTransactionId: string
   createdAt: string
   updatedAt: string
+  growthOnboardingReceipt?: DesktopOnboardingReceipt
 }
 
 interface OnboardingPayload {
@@ -1748,6 +1751,9 @@ function classifyAppStartFailure(error: unknown): {
 }
 
 function finishAppStartSuccess(): void {
+  // Growth owns its durable milestone dedupe; an earlier failed startup result
+  // must not suppress the first successful ready transition in this process.
+  desktopGrowthTelemetry.recordFirstAppReady()
   if (appStartResultRecorded) return
   appStartResultRecorded = true
   desktopReliabilityTelemetry.recordAppStartResult({
@@ -1756,7 +1762,6 @@ function finishAppStartSuccess(): void {
     failureStage: null,
     errorCode: null,
   })
-  desktopGrowthTelemetry.recordFirstAppReady()
 }
 
 function finishAppStartFailure(
@@ -2623,6 +2628,10 @@ async function syncDesktopConsentMirror(profile = activeDesktopProfile()): Promi
   if (consent.growth.enabled === false) {
     clearDesktopGrowthTelemetryState(desktopTelemetryDirectory(profile, configRaw))
   }
+  const credentialRaw = await readOptionalDesktopText(profile.credentialPath)
+  const credential = credentialRaw === null
+    ? null
+    : normalizeDesktopCredential(JSON.parse(credentialRaw) as Partial<DesktopConnection>)
   desktopTelemetryRuntimeGate.openAfterConsentSync()
   desktopReliabilityTelemetry.synchronize({
     spoolRoot: desktopEarlyTelemetrySpoolPath(profile, configRaw),
@@ -2633,7 +2642,7 @@ async function syncDesktopConsentMirror(profile = activeDesktopProfile()): Promi
     telemetryDirectory: desktopTelemetryDirectory(profile, configRaw),
     spoolRoot: desktopEarlyTelemetrySpoolPath(profile, configRaw),
     consentMirrorPath: desktopConsentMirrorPath(profile, configRaw),
-  })
+  }, credential?.configAuthority === 'generated' ? credential.growthOnboardingReceipt : null)
   refreshDesktopReliabilityForegroundState()
 }
 
@@ -2800,6 +2809,7 @@ function normalizeDesktopCredential(parsed: Partial<DesktopConnection>): Desktop
     throw new Error('Desktop credential config authority does not match its import transaction.')
   }
   const now = new Date().toISOString()
+  const onboardingReceipt = parseDesktopOnboardingReceipt(parsed.growthOnboardingReceipt)
   return {
     provider,
     model: parsed.model || routerDefaultModel(routerTiers, routerDefaultTier) || defaults.model,
@@ -2819,6 +2829,7 @@ function normalizeDesktopCredential(parsed: Partial<DesktopConnection>): Desktop
     importTransactionId,
     createdAt: parsed.createdAt || now,
     updatedAt: parsed.updatedAt || now,
+    ...(onboardingReceipt ? { growthOnboardingReceipt: onboardingReceipt } : {}),
   }
 }
 
@@ -3041,6 +3052,7 @@ async function loadDesktopCredential(): Promise<DesktopConnection | null> {
 async function saveDesktopCredential(
   payload: OnboardingPayload,
   writerReserved = false,
+  completingOnboarding = false,
 ): Promise<DesktopConnection> {
   const targetProfile = activeDesktopProfile()
   const expectedCredential = await readOptionalDesktopText(targetProfile.credentialPath)
@@ -3114,6 +3126,12 @@ async function saveDesktopCredential(
   }
 
   const now = new Date().toISOString()
+  // Publish the receipt with the same recoverable settings transaction. It is
+  // valid only for the explicit consent grant made by a verified fresh profile.
+  const onboardingReceipt = completingOnboarding && !disableNetworkObservability && consentOverride !== null
+    ? desktopGrowthTelemetry.prepareOnboardingReceipt(targetProfile.home, consentOverride.growth)
+    : null
+  const persistedOnboardingReceipt = onboardingReceipt ?? existing?.growthOnboardingReceipt
   const credential: DesktopConnection = {
     provider,
     model,
@@ -3133,6 +3151,7 @@ async function saveDesktopCredential(
     importTransactionId: '',
     createdAt: existing?.createdAt || now,
     updatedAt: now,
+    ...(persistedOnboardingReceipt ? { growthOnboardingReceipt: persistedOnboardingReceipt } : {}),
   }
 
   const finishWriter = writerReserved
@@ -14174,7 +14193,7 @@ async function performOnboardingSave(
             payload,
           )
         }
-        return await saveDesktopCredential(payload, true)
+        return await saveDesktopCredential(payload, true, true)
       })
       telemetry.markSettingsPersistedConfirmed()
       await telemetry.stage('local_finalize', async () => {

--- a/desktop/electron/src/telemetry/consent-mirror.ts
+++ b/desktop/electron/src/telemetry/consent-mirror.ts
@@ -213,7 +213,7 @@ function isTruthy(value: string | undefined): boolean {
   return typeof value === 'string' && TRUE_VALUES.has(value.trim().toLowerCase())
 }
 
-function environmentForcesOff(scope: TelemetryScope, env: Environment): boolean {
+export function environmentForcesOff(scope: TelemetryScope, env: Environment): boolean {
   const scopeVariable =
     scope === 'reliability'
       ? 'OPENSQUILLA_PRIVACY_DISABLE_RELIABILITY_DIAGNOSTICS'

--- a/desktop/electron/src/telemetry/early-spool.ts
+++ b/desktop/electron/src/telemetry/early-spool.ts
@@ -31,15 +31,19 @@ export const EARLY_SPOOL_DURABLE_MARKER_RESERVATION_BYTES = 32 * 1024
 export const DESKTOP_RELIABILITY_SESSION_MARKER_NAME = '.desktop-reliability-session.tmp'
 export const DESKTOP_UPDATE_TRANSITION_MARKER_NAME = '.desktop-update-transition.tmp'
 export const DESKTOP_RELIABILITY_RECOVERY_MARKER_PREFIX = '.desktop-reliability-recovery-'
+export const DESKTOP_RELIABILITY_TURN_MARKER_PREFIX = '.desktop-reliability-turns-'
 
 function isDurableTelemetryMarker(name: string): boolean {
   return name === DESKTOP_RELIABILITY_SESSION_MARKER_NAME
     || name === DESKTOP_UPDATE_TRANSITION_MARKER_NAME
     || (
-      name.startsWith(DESKTOP_RELIABILITY_RECOVERY_MARKER_PREFIX)
+      (name.startsWith(DESKTOP_RELIABILITY_RECOVERY_MARKER_PREFIX)
+        || name.startsWith(DESKTOP_RELIABILITY_TURN_MARKER_PREFIX))
       && name.endsWith('.tmp')
       && /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(name.slice(
-        DESKTOP_RELIABILITY_RECOVERY_MARKER_PREFIX.length,
+        name.startsWith(DESKTOP_RELIABILITY_RECOVERY_MARKER_PREFIX)
+          ? DESKTOP_RELIABILITY_RECOVERY_MARKER_PREFIX.length
+          : DESKTOP_RELIABILITY_TURN_MARKER_PREFIX.length,
         -'.tmp'.length,
       ))
     )

--- a/desktop/electron/src/telemetry/growth.ts
+++ b/desktop/electron/src/telemetry/growth.ts
@@ -15,7 +15,7 @@ import {
 } from 'node:fs'
 import { join } from 'node:path'
 
-import { resolveMirroredConsent } from './consent-mirror.js'
+import { environmentForcesOff, resolveMirroredConsent } from './consent-mirror.js'
 import {
   CURRENT_NOTICE_VERSION_BY_SCOPE,
   validateDesktopEarlyTelemetryEvent,
@@ -28,6 +28,7 @@ import {
   DesktopTelemetryRuntimeGate,
   spoolEarlyTelemetryEvent,
 } from './early-spool.js'
+import type { DesktopScopeConsent } from './onboarding-consent.js'
 
 export const GROWTH_COHORT_STATE_NAME = 'growth_cohort.json'
 export const GROWTH_IDENTITY_STATE_NAME = 'growth_identity.json'
@@ -47,6 +48,13 @@ interface DesktopGrowthPaths {
   telemetryDirectory: string
   spoolRoot: string
   consentMirrorPath: string
+}
+
+export interface DesktopOnboardingReceipt {
+  schema_version: 1
+  notice_version: string
+  consented_at_utc: string
+  completed_at_utc: string
 }
 
 interface GrowthIdentity {
@@ -98,7 +106,8 @@ export interface GrowthProfileInspection {
  * Electron-owned new-user eligibility and first desktop milestones.
  *
  * Missing files never prove freshness. Only the recovery engine's exact
- * `fresh_profile` result can arm this process, and activation occurs only
+ * `fresh_profile` result can authorize onboarding, including its consent-bound
+ * settings receipt recovered after a process stop. Activation occurs only
  * after the current Growth-consent mirror is effective.
  */
 export class DesktopGrowthTelemetry {
@@ -110,6 +119,7 @@ export class DesktopGrowthTelemetry {
   private readonly randomId: () => string
   private inspectedProfileKey: string | null = null
   private freshCandidate = false
+  private importedOrMigrated = false
   private paths: DesktopGrowthPaths | null = null
   private identity: GrowthIdentity | null = null
 
@@ -124,6 +134,7 @@ export class DesktopGrowthTelemetry {
 
   observeProfileInspection(inspection: GrowthProfileInspection): void {
     this.inspectedProfileKey = inspection.profileKey
+    this.importedOrMigrated = inspection.importedOrMigrated === true
     this.freshCandidate = inspection.stableCode === 'fresh_profile'
       && inspection.importedOrMigrated !== true
     if (this.paths?.profileKey !== inspection.profileKey) {
@@ -132,11 +143,37 @@ export class DesktopGrowthTelemetry {
     }
   }
 
-  synchronize(paths: DesktopGrowthPaths): void {
+  prepareOnboardingReceipt(
+    profileKey: string,
+    consent: DesktopScopeConsent,
+  ): DesktopOnboardingReceipt | null {
+    if (
+      !this.freshCandidate || this.inspectedProfileKey !== profileKey
+      || !consent.enabled || consent.noticeVersion !== CURRENT_NOTICE_VERSION_BY_SCOPE.growth
+      || !isUtcTimestamp(consent.consentedAtUtc)
+      || environmentForcesOff('growth', this.env)
+    ) return null
+    const completedAt = canonicalNow(this.nowDate)
+    if (completedAt === null) return null
+    return {
+      schema_version: 1,
+      notice_version: consent.noticeVersion,
+      consented_at_utc: consent.consentedAtUtc,
+      completed_at_utc: completedAt,
+    }
+  }
+
+  synchronize(paths: DesktopGrowthPaths, onboardingReceipt: unknown = null): void {
     this.paths = paths
     this.identity = null
     const consent = resolveMirroredConsent(paths.consentMirrorPath, 'growth', this.env)
     if (!consent.enabled) return
+    const receipt = parseDesktopOnboardingReceipt(onboardingReceipt)
+    const completedOnboarding = !this.importedOrMigrated
+      && this.inspectedProfileKey === paths.profileKey
+      && receipt?.notice_version === consent.noticeVersion
+      && receipt?.consented_at_utc === consent.consentedAtUtc
+      ? receipt : null
 
     const cohortPath = join(paths.telemetryDirectory, GROWTH_COHORT_STATE_NAME)
     const identityPath = join(paths.telemetryDirectory, GROWTH_IDENTITY_STATE_NAME)
@@ -148,14 +185,20 @@ export class DesktopGrowthTelemetry {
       this.identity = identity.status === 'valid'
         ? identity.value
         : createIdentity(identityPath, this.nowDate, this.randomId)
-      if (this.identity !== null) this.retryPendingMilestones()
+      if (this.identity !== null) {
+        this.retryPendingMilestones()
+        if (completedOnboarding !== null) {
+          this.recordMilestone('onboarding_result', completedOnboarding.completed_at_utc)
+        }
+      }
       this.freshCandidate = false
       return
     }
 
-    const canActivate = this.freshCandidate
-      && this.inspectedProfileKey === paths.profileKey
-      && identity.status === 'absent'
+    const canActivate = (
+      (this.freshCandidate && this.inspectedProfileKey === paths.profileKey)
+      || completedOnboarding !== null
+    ) && identity.status === 'absent'
     if (!canActivate) return
 
     // Cohort first: if the process dies before identity creation, this
@@ -169,7 +212,12 @@ export class DesktopGrowthTelemetry {
     } satisfies ActiveGrowthCohort)) return
     this.identity = createIdentity(identityPath, this.nowDate, this.randomId)
     this.freshCandidate = false
-    if (this.identity !== null) this.retryPendingMilestones()
+    if (this.identity !== null) {
+      this.retryPendingMilestones()
+      if (completedOnboarding !== null) {
+        this.recordMilestone('onboarding_result', completedOnboarding.completed_at_utc)
+      }
+    }
   }
 
   recordOnboardingCompleted(): void {
@@ -197,7 +245,7 @@ export class DesktopGrowthTelemetry {
     }
   }
 
-  private recordMilestone(name: MilestoneName): void {
+  private recordMilestone(name: MilestoneName, occurredAt?: string): void {
     const paths = this.paths
     const identity = this.identity
     if (paths === null || identity === null || !this.runtimeGate.isOpen()) return
@@ -217,7 +265,7 @@ export class DesktopGrowthTelemetry {
       && existing.event.analytics_user_id !== identity.value
     ) return
 
-    const event = existing?.event ?? this.buildEvent(name, identity.value)
+    const event = existing?.event ?? this.buildEvent(name, identity.value, occurredAt)
     if (event === null) return
     if (existing === null) {
       state[name] = { status: 'pending', event }
@@ -245,8 +293,9 @@ export class DesktopGrowthTelemetry {
   private buildEvent(
     name: MilestoneName,
     analyticsUserId: string,
+    completedAt?: string,
   ): OnboardingCompletedEvent | FirstAppReadyEvent | null {
-    const occurredAt = canonicalNow(this.nowDate)
+    const occurredAt = completedAt ?? canonicalNow(this.nowDate)
     const eventId = this.randomId()
     if (occurredAt === null || !UUID4_RE.test(eventId)) return null
     const common = {
@@ -282,6 +331,20 @@ export class DesktopGrowthTelemetry {
       return null
     }
   }
+}
+
+export function parseDesktopOnboardingReceipt(value: unknown): DesktopOnboardingReceipt | null {
+  if (
+    !isRecord(value)
+    || !hasExactKeys(value, [
+      'schema_version', 'notice_version', 'consented_at_utc', 'completed_at_utc',
+    ])
+    || value.schema_version !== 1
+    || typeof value.notice_version !== 'string'
+    || !isUtcTimestamp(value.consented_at_utc)
+    || !isUtcTimestamp(value.completed_at_utc)
+  ) return null
+  return value as unknown as DesktopOnboardingReceipt
 }
 
 export function clearDesktopGrowthTelemetryState(telemetryDirectory: string): void {

--- a/desktop/electron/src/telemetry/reliability.ts
+++ b/desktop/electron/src/telemetry/reliability.ts
@@ -32,6 +32,7 @@ import {
   EARLY_SPOOL_DURABLE_MARKER_RESERVATION_BYTES,
   DESKTOP_RELIABILITY_RECOVERY_MARKER_PREFIX,
   DESKTOP_RELIABILITY_SESSION_MARKER_NAME,
+  DESKTOP_RELIABILITY_TURN_MARKER_PREFIX,
   DESKTOP_UPDATE_TRANSITION_MARKER_NAME,
   DesktopTelemetryRuntimeGate,
   spoolEarlyTelemetryEvent,
@@ -165,7 +166,7 @@ interface PersistedAppStartResult {
 }
 
 interface SessionMarker {
-  schema_version: 2
+  schema_version: 3
   marker_kind: 'desktop_reliability_session'
   app_session_id: string
   app_version: string
@@ -182,6 +183,8 @@ interface SessionMarker {
   crash_detected_emitted: boolean
   clean_exit: boolean
   performance_summary_emitted: boolean
+  consent_generation: string | null
+  gateway_turn_counts_applied: boolean
   performance: PerformanceSnapshot
 }
 
@@ -221,8 +224,6 @@ class PerformanceAccumulator {
   private foreground = false
   private foregroundMs = 0
   private backgroundMs = 0
-  private turnCount = 0
-  private stalledTurnCount = 0
   private stallCount = 0
   private monitoredRequestCount = 0
   private slowRequestCount = 0
@@ -241,8 +242,6 @@ class PerformanceAccumulator {
     this.foreground = foreground
     this.foregroundMs = 0
     this.backgroundMs = 0
-    this.turnCount = 0
-    this.stalledTurnCount = 0
     this.stallCount = 0
     this.monitoredRequestCount = 0
     this.slowRequestCount = 0
@@ -277,11 +276,6 @@ class PerformanceAccumulator {
     return true
   }
 
-  recordTurn(stalled: boolean): void {
-    this.turnCount = boundedCount(this.turnCount + 1)
-    if (stalled) this.stalledTurnCount = boundedCount(this.stalledTurnCount + 1)
-  }
-
   snapshot(): { durationMs: number; performance: PerformanceSnapshot } {
     const now = this.nowMs()
     const elapsedInState = boundedDuration(now - this.stateStartedAtMs)
@@ -302,8 +296,8 @@ class PerformanceAccumulator {
     return {
       durationMs,
       performance: {
-        turn_count: this.turnCount,
-        stalled_turn_count: this.stalledTurnCount,
+        turn_count: 0,
+        stalled_turn_count: 0,
         stall_count: boundedCount(this.stallCount + activeStall),
         monitored_request_count: this.monitoredRequestCount,
         slow_request_count: this.slowRequestCount,
@@ -479,21 +473,6 @@ export class DesktopReliabilityTelemetry {
       }
     } catch {
       // Request counters cannot affect the observed request.
-    }
-  }
-
-  /** Record one terminal dialogue turn in the session aggregate. */
-  recordTurn(stalled = false): void {
-    if (!this.prepareActivity()) return
-    try {
-      this.performance.recordTurn(stalled)
-      this.requestCheckpointCounter += 1
-      if (this.requestCheckpointCounter >= 32) {
-        this.requestCheckpointCounter = 0
-        this.checkpointSession()
-      }
-    } catch {
-      // Performance counters cannot affect the observed turn.
     }
   }
 
@@ -712,7 +691,7 @@ export class DesktopReliabilityTelemetry {
     this.performance.reset(this.desiredForeground)
     const nowMs = Math.floor(this.nowMs())
     const marker: SessionMarker = {
-      schema_version: 2,
+      schema_version: 3,
       marker_kind: 'desktop_reliability_session',
       app_session_id: this.appSessionId,
       app_version: this.telemetryAppVersion(),
@@ -729,6 +708,8 @@ export class DesktopReliabilityTelemetry {
       crash_detected_emitted: false,
       clean_exit: false,
       performance_summary_emitted: false,
+      consent_generation: this.consentGrantGeneration,
+      gateway_turn_counts_applied: false,
       performance: emptyPerformanceSnapshot(),
     }
     if (!this.writeSessionMarker(marker)) return
@@ -758,6 +739,7 @@ export class DesktopReliabilityTelemetry {
     // the same cap before creating another marker.
     for (const entry of recovered.slice(0, overflow)) {
       this.removeManagedMarker(entry.name)
+      this.removeManagedMarker(turnMarkerName(entry.marker.app_session_id))
     }
     for (const { name, marker } of recovered.slice(overflow)) {
       this.flushSessionMarker(name, marker)
@@ -794,6 +776,12 @@ export class DesktopReliabilityTelemetry {
     allowCrashFact = true,
   ): void {
     let marker = initial
+    if (!marker.gateway_turn_counts_applied) {
+      marker = this.applyGatewayTurnCounts(marker)
+      // Freeze the merged totals before emitting a stable event ID so a
+      // dropped spool write retries the same summary after restart.
+      if (!this.writeSessionMarker(marker, name)) return
+    }
     const durationMs = boundedDuration(marker.last_observed_at_ms - marker.started_at_ms)
     const appStartDurationMs = boundedDuration(
       marker.last_observed_at_ms - marker.app_start_started_at_ms,
@@ -877,6 +865,7 @@ export class DesktopReliabilityTelemetry {
 
     if ((!needsCrashFact || marker.crash_detected_emitted) && marker.performance_summary_emitted) {
       this.removeManagedMarker(name)
+      this.removeManagedMarker(turnMarkerName(marker.app_session_id))
       if (name === SESSION_MARKER_NAME) this.currentMarker = marker
     }
   }
@@ -1006,6 +995,40 @@ export class DesktopReliabilityTelemetry {
       this.removeManagedMarker(UPDATE_MARKER_NAME)
     } else if (marker.status === 'installed') {
       this.pendingInstalledUpdate = marker
+    }
+  }
+
+  private applyGatewayTurnCounts(marker: SessionMarker): SessionMarker {
+    const counts = this.readManagedMarker(turnMarkerName(marker.app_session_id))
+    const frozen = { ...marker, gateway_turn_counts_applied: true }
+    if (
+      !isRecord(counts)
+      || !hasExactKeys(counts, [
+        'schema_version', 'app_session_id', 'turn_count', 'stalled_turn_count',
+        'stall_count', 'last_observed_at_ms',
+      ])
+      || counts.schema_version !== 1
+      || counts.app_session_id !== marker.app_session_id
+      || !isBoundedInteger(counts.turn_count, MAX_COUNTER)
+      || !isBoundedInteger(counts.stalled_turn_count, MAX_COUNTER)
+      || !isBoundedInteger(counts.stall_count, MAX_COUNTER)
+      || counts.stalled_turn_count > counts.turn_count
+      || counts.stalled_turn_count > counts.stall_count
+      || !isBoundedInteger(counts.last_observed_at_ms, Number.MAX_SAFE_INTEGER)
+      || !Number.isFinite(new Date(counts.last_observed_at_ms).valueOf())
+      || counts.last_observed_at_ms < marker.started_at_ms
+    ) return frozen
+    return {
+      ...frozen,
+      last_observed_at_ms: Math.max(marker.last_observed_at_ms, counts.last_observed_at_ms),
+      performance: {
+        ...marker.performance,
+        turn_count: boundedCount(marker.performance.turn_count + counts.turn_count),
+        stalled_turn_count: boundedCount(
+          marker.performance.stalled_turn_count + counts.stalled_turn_count,
+        ),
+        stall_count: boundedCount(marker.performance.stall_count + counts.stall_count),
+      },
     }
   }
 
@@ -1368,6 +1391,13 @@ function isManagedMarkerName(name: string): boolean {
   return name === SESSION_MARKER_NAME
     || name === UPDATE_MARKER_NAME
     || isRecoveryMarkerName(name)
+    || (name.startsWith(DESKTOP_RELIABILITY_TURN_MARKER_PREFIX)
+      && name.endsWith('.tmp')
+      && isUuid(name.slice(DESKTOP_RELIABILITY_TURN_MARKER_PREFIX.length, -4)))
+}
+
+function turnMarkerName(appSessionId: string): string {
+  return `${DESKTOP_RELIABILITY_TURN_MARKER_PREFIX}${appSessionId}.tmp`
 }
 
 function spoolResultAcknowledged(result: EarlySpoolResult | null): boolean {
@@ -1515,11 +1545,18 @@ function parseSessionMarker(value: unknown): SessionMarker | null {
     'app_start_result_emitted',
   ] as const
   const legacy = value.schema_version === 1 && hasExactKeys(value, legacyKeys)
-  const current = value.schema_version === 2 && hasExactKeys(value, currentKeys)
-  if (!legacy && !current) return null
+  const previous = value.schema_version === 2 && hasExactKeys(value, currentKeys)
+  const current = value.schema_version === 3 && hasExactKeys(value, [
+    ...currentKeys, 'consent_generation', 'gateway_turn_counts_applied',
+  ])
+  if (!legacy && !previous && !current) return null
+  if (current && (
+    (value.consent_generation !== null && typeof value.consent_generation !== 'string')
+    || typeof value.gateway_turn_counts_applied !== 'boolean'
+  )) return null
   const performance = parsePerformanceSnapshot(value.performance)
   const crash = value.crash === null ? null : parseCrashFact(value.crash)
-  const appStart = current && value.app_start_result !== null
+  const appStart = !legacy && value.app_start_result !== null
     ? parsePersistedAppStartResult(value.app_start_result)
     : null
   if (
@@ -1538,7 +1575,7 @@ function parseSessionMarker(value: unknown): SessionMarker | null {
     || typeof value.performance_summary_emitted !== 'boolean'
     || performance === null
   ) return null
-  if (current && (
+  if (!legacy && (
     !isUuid(value.app_start_event_id)
     || !isBoundedInteger(value.app_start_started_at_ms, Number.MAX_SAFE_INTEGER)
     || Number(value.app_start_started_at_ms) > Number(value.last_observed_at_ms)
@@ -1551,7 +1588,9 @@ function parseSessionMarker(value: unknown): SessionMarker | null {
   if (legacy) {
     return {
       ...value,
-      schema_version: 2,
+      schema_version: 3,
+      consent_generation: null,
+      gateway_turn_counts_applied: false,
       app_start_event_id: value.crash_event_id,
       app_start_started_at_ms: value.started_at_ms,
       app_start_stage: 'ready',
@@ -1563,7 +1602,15 @@ function parseSessionMarker(value: unknown): SessionMarker | null {
       performance,
     } as unknown as SessionMarker
   }
-  return { ...value, app_start_result: appStart, crash, performance } as unknown as SessionMarker
+  return {
+    ...value,
+    schema_version: 3,
+    consent_generation: current ? value.consent_generation : null,
+    gateway_turn_counts_applied: current ? value.gateway_turn_counts_applied : false,
+    app_start_result: appStart,
+    crash,
+    performance,
+  } as unknown as SessionMarker
 }
 
 const UPDATE_ERROR_CODES = new Set<UpdateErrorCode>([

--- a/desktop/electron/src/telemetry/reliability.ts
+++ b/desktop/electron/src/telemetry/reliability.ts
@@ -277,6 +277,11 @@ class PerformanceAccumulator {
     return true
   }
 
+  recordTurn(stalled: boolean): void {
+    this.turnCount = boundedCount(this.turnCount + 1)
+    if (stalled) this.stalledTurnCount = boundedCount(this.stalledTurnCount + 1)
+  }
+
   snapshot(): { durationMs: number; performance: PerformanceSnapshot } {
     const now = this.nowMs()
     const elapsedInState = boundedDuration(now - this.stateStartedAtMs)
@@ -474,6 +479,21 @@ export class DesktopReliabilityTelemetry {
       }
     } catch {
       // Request counters cannot affect the observed request.
+    }
+  }
+
+  /** Record one terminal dialogue turn in the session aggregate. */
+  recordTurn(stalled = false): void {
+    if (!this.prepareActivity()) return
+    try {
+      this.performance.recordTurn(stalled)
+      this.requestCheckpointCounter += 1
+      if (this.requestCheckpointCounter >= 32) {
+        this.requestCheckpointCounter = 0
+        this.checkpointSession()
+      }
+    } catch {
+      // Performance counters cannot affect the observed turn.
     }
   }
 

--- a/src/opensquilla/gateway/boot.py
+++ b/src/opensquilla/gateway/boot.py
@@ -3901,8 +3901,14 @@ async def build_services(
         growth_event_sink = GrowthEventSink(telemetry_runtime, config=config)
         if any(resolve_scope_consent(scope, config=config).enabled for scope in TelemetryScope):
             await telemetry_runtime.start()
+        await growth_event_sink.start()
     except Exception:
         log.debug("build_services.telemetry_runtime_unavailable", exc_info=True)
+        if growth_event_sink is not None:
+            try:
+                await growth_event_sink.close()
+            except Exception:
+                pass
         if telemetry_runtime is not None:
             try:
                 await telemetry_runtime.close()

--- a/src/opensquilla/telemetry/desktop_turn_counts.py
+++ b/src/opensquilla/telemetry/desktop_turn_counts.py
@@ -1,0 +1,170 @@
+"""Local terminal-turn counters shared with the Desktop session summary."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from opensquilla.profile_operation_lock import ProfileOperationLock
+from opensquilla.telemetry.contracts import CURRENT_NOTICE_VERSION_BY_SCOPE
+from opensquilla.telemetry.contracts.common import StrictTelemetryModel
+from opensquilla.telemetry.desktop_state import (
+    _fsync_directory_best_effort,
+    _require_real_directory,
+    desktop_early_spool_root,
+)
+
+SESSION_MARKER_NAME = ".desktop-reliability-session.tmp"
+TURN_COUNTS_PREFIX = ".desktop-reliability-turns-"
+MAX_COUNTER = 2**31 - 1
+_UUID_RE = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}")
+
+
+def _read(path: Path) -> dict[str, Any] | None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return None
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > 32 * 1024:
+        raise ValueError("invalid desktop turn counter state")
+    value = json.loads(path.read_bytes())
+    if not isinstance(value, dict):
+        raise ValueError("invalid desktop turn counter state")
+    return value
+
+
+def _counter(value: object) -> bool:
+    return type(value) is int and 0 <= value <= MAX_COUNTER
+
+
+def record_desktop_turn(
+    state_dir: Path,
+    event: StrictTelemetryModel,
+) -> None:
+    """Count an accepted terminal observation under its caller's consent permit.
+
+    The active marker belongs to Electron; only this separate checkpoint is
+    Gateway-written. A new Gateway process resumes the same totals, while a
+    new Desktop session gets an independent file. No content or turn IDs are
+    retained. Queue replay never calls this function for duplicate events.
+    """
+
+    if getattr(event, "event_name", None) != "turn_result":
+        return
+    occurred_at = getattr(event, "occurred_at_utc", None)
+    stall_count = getattr(event, "stall_count", None)
+    if not isinstance(occurred_at, datetime) or not _counter(stall_count):
+        return
+    assert stall_count is not None
+    observed_at_ms = int(occurred_at.timestamp() * 1000)
+    directory = desktop_early_spool_root(state_dir) / "reliability"
+    # Do not create a Desktop profile or follow a redirected telemetry scope.
+    for path in (directory.parent.parent, directory.parent, directory):
+        _require_real_directory(path)
+    marker_path = directory / SESSION_MARKER_NAME
+    with ProfileOperationLock(marker_path, timeout=0.05):
+        marker = _read(marker_path)
+        mirror = _read(directory.parent.parent / "desktop-consent-mirror.json")
+        consent = mirror.get("reliability") if mirror is not None else None
+        if (
+            marker is None
+            or not isinstance(consent, dict)
+            or consent.get("enabled") is not True
+            or consent.get("forced_off") is not False
+            or consent.get("notice_version") != CURRENT_NOTICE_VERSION_BY_SCOPE["reliability"]
+            or not isinstance(consent.get("consented_at_utc"), str)
+            or marker.get("consent_generation")
+            != (f"{consent['notice_version']}\n{consent['consented_at_utc']}")
+            or marker.get("marker_kind") != "desktop_reliability_session"
+            or marker.get("clean_exit") is not False
+            or marker.get("performance_summary_emitted") is not False
+            or marker.get("gateway_turn_counts_applied") is True
+            or not isinstance(marker.get("app_session_id"), str)
+            or _UUID_RE.fullmatch(str(marker["app_session_id"])) is None
+            or type(marker.get("started_at_ms")) is not int
+            or observed_at_ms < int(marker["started_at_ms"])
+        ):
+            return
+        app_session_id = str(marker["app_session_id"])
+        target = directory / f"{TURN_COUNTS_PREFIX}{app_session_id}.tmp"
+        counts = _read(target)
+        if counts is None:
+            # One bounded checkpoint consumes one existing spool quota slot.
+            if sum(1 for _ in directory.iterdir()) >= 512:
+                return
+            counts = {
+                "schema_version": 1,
+                "app_session_id": app_session_id,
+                "turn_count": 0,
+                "stalled_turn_count": 0,
+                "stall_count": 0,
+                "last_observed_at_ms": observed_at_ms,
+            }
+        if (
+            set(counts)
+            != {
+                "schema_version",
+                "app_session_id",
+                "turn_count",
+                "stalled_turn_count",
+                "stall_count",
+                "last_observed_at_ms",
+            }
+            or counts["schema_version"] != 1
+            or counts["app_session_id"] != app_session_id
+            or not all(
+                _counter(counts[key])
+                for key in (
+                    "turn_count",
+                    "stalled_turn_count",
+                    "stall_count",
+                )
+            )
+            or type(counts["last_observed_at_ms"]) is not int
+            or counts["stalled_turn_count"] > counts["turn_count"]
+            or counts["stalled_turn_count"] > counts["stall_count"]
+        ):
+            raise ValueError("invalid desktop turn counter state")
+        counts["turn_count"] = min(MAX_COUNTER, int(counts["turn_count"]) + 1)
+        counts["stalled_turn_count"] = min(
+            MAX_COUNTER,
+            int(counts["stalled_turn_count"]) + int(stall_count > 0),
+        )
+        counts["stall_count"] = min(MAX_COUNTER, int(counts["stall_count"]) + stall_count)
+        counts["last_observed_at_ms"] = max(
+            observed_at_ms,
+            int(counts["last_observed_at_ms"]),
+        )
+        descriptor, temporary = tempfile.mkstemp(
+            prefix=".desktop-turn-write-", suffix=".tmp", dir=directory
+        )
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+                json.dump(counts, stream, separators=(",", ":"))
+                stream.flush()
+                os.fsync(stream.fileno())
+            # Withdrawal detaches the whole scope; never recreate its old path.
+            _require_real_directory(directory)
+            latest = _read(marker_path)
+            if latest is None or any(
+                latest.get(key) != marker.get(key)
+                for key in (
+                    "app_session_id",
+                    "consent_generation",
+                    "started_at_ms",
+                    "clean_exit",
+                    "performance_summary_emitted",
+                    "gateway_turn_counts_applied",
+                )
+            ):
+                return
+            os.replace(temporary, target)
+            _fsync_directory_best_effort(directory)
+        finally:
+            Path(temporary).unlink(missing_ok=True)

--- a/src/opensquilla/telemetry/growth_sink.py
+++ b/src/opensquilla/telemetry/growth_sink.py
@@ -176,6 +176,7 @@ class GrowthEventSink:
             return
         if self._first_turn_started_at is None:
             self._first_turn_started_at = occurred_at
+        self._schedule(self.replay_pending())
         self._schedule(self.record_turn_started(occurred_at))
 
     def observe_turn_succeeded(self) -> None:
@@ -186,6 +187,7 @@ class GrowthEventSink:
         occurred_at = self._safe_now()
         if occurred_at is None:
             return
+        self._schedule(self.replay_pending())
         self._schedule(self.record_turn_succeeded(occurred_at))
 
     def observe_metaskill_usage(self, run_id: str) -> None:
@@ -229,6 +231,25 @@ class GrowthEventSink:
                 event_name="coding_mode_usage",
             )
         )
+
+    async def replay_pending(self) -> None:
+        """Retry durable first-turn events before creating a new one.
+
+        The marker is written before enqueue, so a transient enqueue failure
+        must be replayed on the next runtime boundary even when the user does
+        not submit another successful turn.
+        """
+
+        if self._closed:
+            return
+        try:
+            state = read_gateway_growth_milestone_state(self._marker_path)
+            for name in ("first_turn_started", "first_turn_result"):
+                record = state.record_for(name)
+                if record is not None and record.status is GrowthMilestoneStatus.PENDING:
+                    await self._record_milestone(name, record.event.occurred_at_utc)
+        except (GrowthStateError, IdentityStateError, OSError, ValueError, TypeError):
+            log.debug("growth milestone replay rejected", exc_info=True)
 
     async def record_turn_started(self, occurred_at: datetime) -> None:
         await self._record_milestone("first_turn_started", occurred_at)

--- a/src/opensquilla/telemetry/growth_sink.py
+++ b/src/opensquilla/telemetry/growth_sink.py
@@ -70,6 +70,8 @@ CODING_MODE_USAGE_SCHEMA_VERSION = 1
 _CODING_MODE_USAGE_MARKER_KIND = "growth_coding_mode_usage"
 _MAX_ENQUEUED_FEATURE_USAGE_RECORDS = 24
 _FEATURE_USAGE_RUN_KEY_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}\Z")
+_RETRY_INITIAL_SECONDS = 1.0
+_RETRY_MAX_SECONDS = 60.0
 
 FeatureUsageEvent = MetaSkillUsage | CodingModeUsage
 GrowthMilestoneEvent = FirstTurnStarted | FirstTurnSucceeded | ClientLaunch | FeatureUsageEvent
@@ -147,7 +149,8 @@ class GrowthEventSink:
         )
         self._lock = asyncio.Lock()
         self._tasks: set[asyncio.Task[Any]] = set()
-        self._first_turn_started_at: datetime | None = None
+        self._retry_requested = asyncio.Event()
+        self._retry_task: asyncio.Task[None] | None = None
         self._closed = False
 
     @property
@@ -166,6 +169,16 @@ class GrowthEventSink:
 
         return self._coding_mode_usage_path
 
+    async def start(self) -> None:
+        """Recover pending milestones and keep retrying without another turn."""
+
+        if self._closed or self._retry_task is not None:
+            return
+        self._retry_task = asyncio.create_task(
+            self._retry_loop(), name="telemetry-growth-replay"
+        )
+        self._retry_requested.set()
+
     def observe_turn_started(self) -> None:
         """Capture the public-user turn boundary without receiving its content."""
 
@@ -174,9 +187,6 @@ class GrowthEventSink:
         occurred_at = self._safe_now()
         if occurred_at is None:
             return
-        if self._first_turn_started_at is None:
-            self._first_turn_started_at = occurred_at
-        self._schedule(self.replay_pending())
         self._schedule(self.record_turn_started(occurred_at))
 
     def observe_turn_succeeded(self) -> None:
@@ -187,7 +197,6 @@ class GrowthEventSink:
         occurred_at = self._safe_now()
         if occurred_at is None:
             return
-        self._schedule(self.replay_pending())
         self._schedule(self.record_turn_succeeded(occurred_at))
 
     def observe_metaskill_usage(self, run_id: str) -> None:
@@ -233,12 +242,7 @@ class GrowthEventSink:
         )
 
     async def replay_pending(self) -> None:
-        """Retry durable first-turn events before creating a new one.
-
-        The marker is written before enqueue, so a transient enqueue failure
-        must be replayed on the next runtime boundary even when the user does
-        not submit another successful turn.
-        """
+        """Retry only existing payloads, preserving their IDs and timestamps."""
 
         if self._closed:
             return
@@ -247,7 +251,9 @@ class GrowthEventSink:
             for name in ("first_turn_started", "first_turn_result"):
                 record = state.record_for(name)
                 if record is not None and record.status is GrowthMilestoneStatus.PENDING:
-                    await self._record_milestone(name, record.event.occurred_at_utc)
+                    await self._record_milestone(
+                        name, record.event.occurred_at_utc, replay_only=True
+                    )
         except (GrowthStateError, IdentityStateError, OSError, ValueError, TypeError):
             log.debug("growth milestone replay rejected", exc_info=True)
 
@@ -255,11 +261,6 @@ class GrowthEventSink:
         await self._record_milestone("first_turn_started", occurred_at)
 
     async def record_turn_succeeded(self, occurred_at: datetime) -> None:
-        # A crash or scheduling race must never produce a success with no
-        # started predecessor. Reusing the captured start time also preserves
-        # event order when both callbacks settle concurrently.
-        started_at = self._first_turn_started_at or occurred_at
-        await self._record_milestone("first_turn_started", started_at)
         await self._record_milestone("first_turn_result", occurred_at)
 
     async def record_metaskill_usage(
@@ -296,6 +297,42 @@ class GrowthEventSink:
             occurred_at=occurred_at,
             event_name="coding_mode_usage",
         )
+
+    async def _retry_loop(self) -> None:
+        while True:
+            await self._retry_requested.wait()
+            self._retry_requested.clear()
+            delay = _RETRY_INITIAL_SECONDS
+            while await self._has_pending():
+                await self.replay_pending()
+                if not await self._has_pending():
+                    break
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, _RETRY_MAX_SECONDS)
+
+    async def _has_pending(self) -> bool:
+        notice_version = CURRENT_NOTICE_VERSION_BY_SCOPE[TelemetryScope.GROWTH.value]
+        try:
+            async with self._coordinator.authorized(
+                TelemetryScope.GROWTH,
+                checkpoint=ConsentCheckpoint.ENQUEUE,
+                notice_version=notice_version,
+            ) as permit:
+                if permit is None or self._closed:
+                    return False
+                identity_value = self._active_identity_value()
+                if identity_value is None:
+                    return False
+                state = read_gateway_growth_milestone_state(self._marker_path)
+                return any(
+                    record is not None
+                    and record.status is GrowthMilestoneStatus.PENDING
+                    and str(record.event.analytics_user_id) == identity_value
+                    for record in (state.first_turn_started, state.first_turn_result)
+                )
+        except (GrowthStateError, IdentityStateError, OSError, ValueError, TypeError):
+            log.debug("growth milestone retry state rejected", exc_info=True)
+            return False
 
     async def record_client_launch(
         self,
@@ -667,6 +704,11 @@ class GrowthEventSink:
         if self._closed:
             return
         self._closed = True
+        retry_task = self._retry_task
+        self._retry_task = None
+        if retry_task is not None:
+            retry_task.cancel()
+            await asyncio.gather(retry_task, return_exceptions=True)
         pending = tuple(self._tasks)
         if pending:
             await asyncio.gather(*pending, return_exceptions=True)
@@ -695,13 +737,15 @@ class GrowthEventSink:
         self,
         name: GrowthMilestoneName,
         occurred_at: datetime,
+        *,
+        replay_only: bool = False,
     ) -> None:
         if not _valid_utc_datetime(occurred_at):
             return
         async with self._lock:
             try:
                 await self._retry_pending_feature_usage_locked()
-                prepared = await self._prepare_event(name, occurred_at)
+                prepared = await self._prepare_event(name, occurred_at, replay_only=replay_only)
                 if prepared is None:
                     return
                 event, consent_revision = prepared
@@ -718,11 +762,16 @@ class GrowthEventSink:
                 log.debug("growth milestone state rejected", exc_info=True)
             except Exception:
                 log.debug("growth milestone persistence failed", exc_info=True)
+            finally:
+                if not self._closed and asyncio.current_task() is not self._retry_task:
+                    self._retry_requested.set()
 
     async def _prepare_event(
         self,
         name: GrowthMilestoneName,
         occurred_at: datetime,
+        *,
+        replay_only: bool,
     ) -> tuple[GrowthMilestoneEvent, int] | None:
         notice_version = CURRENT_NOTICE_VERSION_BY_SCOPE[TelemetryScope.GROWTH.value]
         async with self._coordinator.authorized(
@@ -741,6 +790,11 @@ class GrowthEventSink:
             ):
                 state = read_gateway_growth_milestone_state(self._marker_path)
                 existing = state.record_for(name)
+                predecessor = state.first_turn_started
+                if name == "first_turn_result" and predecessor is None:
+                    # A success cannot reconstruct a start that was never
+                    # captured under consent, including after revocation.
+                    return None
                 if existing is not None:
                     if str(existing.event.analytics_user_id) != identity_value:
                         raise GrowthStateError(
@@ -748,16 +802,25 @@ class GrowthEventSink:
                         )
                     if existing.status is GrowthMilestoneStatus.ENQUEUED:
                         return None
-                    return existing.event, permit.revision
-                event = self._build_event(name, occurred_at, identity_value)
-                pending = state.with_record(
-                    name,
-                    GrowthMilestoneRecord(
-                        status=GrowthMilestoneStatus.PENDING,
-                        event=event,
-                    ),
-                )
-                write_gateway_growth_milestone_state(self._marker_path, pending)
+                    event = existing.event
+                else:
+                    if replay_only:
+                        return None
+                    event = self._build_event(name, occurred_at, identity_value)
+                    pending = state.with_record(
+                        name,
+                        GrowthMilestoneRecord(
+                            status=GrowthMilestoneStatus.PENDING,
+                            event=event,
+                        ),
+                    )
+                    write_gateway_growth_milestone_state(self._marker_path, pending)
+                if name == "first_turn_result" and (
+                    predecessor is None
+                    or predecessor.status is not GrowthMilestoneStatus.ENQUEUED
+                    or str(predecessor.event.analytics_user_id) != identity_value
+                ):
+                    return None
                 return event, permit.revision
 
     async def _acknowledge_event(

--- a/src/opensquilla/telemetry/runtime.py
+++ b/src/opensquilla/telemetry/runtime.py
@@ -28,6 +28,7 @@ from opensquilla.telemetry.contracts.common import StrictTelemetryModel
 from opensquilla.telemetry.coordination import scope_consent_coordinator_for
 from opensquilla.telemetry.desktop_ingress import drain_desktop_early_spool
 from opensquilla.telemetry.desktop_state import desktop_early_spool_root
+from opensquilla.telemetry.desktop_turn_counts import record_desktop_turn
 from opensquilla.telemetry.outbox import OutboxPriority, TelemetryOutbox
 from opensquilla.telemetry.recorder import RecordResult, RecordStatus, TelemetryRecorder
 from opensquilla.telemetry.uploader import TelemetryUploader
@@ -76,6 +77,7 @@ class ScopedTelemetryRuntime:
         self._record_tasks: set[asyncio.Task[object]] = set()
         self._upload_task: asyncio.Task[None] | None = None
         self._owner_loop: asyncio.AbstractEventLoop | None = None
+        self._closing = False
         self._closed = False
 
     @property
@@ -90,9 +92,15 @@ class ScopedTelemetryRuntime:
         """Start the wake-up loop without creating files or making requests."""
 
         self._ensure_open()
+        if self._closing:
+            return
         self._bind_owner_loop()
         await self._drain_desktop_spool()
-        if self._upload_task is None:
+        if self._closing or self._closed:
+            return
+        if self._upload_task is None or self._upload_task.done():
+            if self._upload_task is not None and not self._upload_task.cancelled():
+                self._upload_task.exception()
             self._upload_task = asyncio.create_task(
                 self._upload_loop(),
                 name="opensquilla-telemetry-v2-uploader",
@@ -116,11 +124,26 @@ class ScopedTelemetryRuntime:
         scoped = await self._scope_runtime(scope)
         if scoped is None:
             return RecordResult(RecordStatus.CONSENT_BLOCKED)
-        return await scoped.recorder.record(
+        result = await scoped.recorder.record(
             event,
             priority=priority,
             expected_consent_revision=expected_consent_revision,
         )
+        if (
+            result.status is RecordStatus.RECORDED
+            and getattr(event, "event_name", "") == "turn_result"
+        ):
+            try:
+                async with self._coordinator.authorized(
+                    scope,
+                    checkpoint=ConsentCheckpoint.ENQUEUE,
+                    notice_version=CURRENT_NOTICE_VERSION_BY_SCOPE[scope.value],
+                ) as permit:
+                    if permit is not None:
+                        record_desktop_turn(self._state_dir, event)
+            except Exception:
+                log.debug("desktop turn counter checkpoint failed", exc_info=True)
+        return result
 
     def record_background(
         self,
@@ -130,7 +153,7 @@ class ScopedTelemetryRuntime:
     ) -> None:
         """Schedule a best-effort record without exposing failures to callers."""
 
-        if self._closed:
+        if self._closed or self._closing:
             return
         try:
             running_loop = asyncio.get_running_loop()
@@ -163,10 +186,10 @@ class ScopedTelemetryRuntime:
 
         self._ensure_open()
         normalized = TelemetryScope(scope)
-        scoped = await self._scope_runtime(normalized)
-        if scoped is None:
-            return
         try:
+            scoped = await self._scope_runtime(normalized)
+            if scoped is None:
+                return
             await scoped.uploader.upload_once()
         except asyncio.CancelledError:
             raise
@@ -176,9 +199,9 @@ class ScopedTelemetryRuntime:
     async def close(self) -> None:
         """Stop producers and close queues without forcing shutdown network I/O."""
 
-        if self._closed:
+        if self._closed or self._closing:
             return
-        self._closed = True
+        self._closing = True
 
         upload_task = self._upload_task
         self._upload_task = None
@@ -193,10 +216,9 @@ class ScopedTelemetryRuntime:
 
         pending = tuple(self._record_tasks)
         if pending:
-            for task in pending:
-                task.cancel()
             await asyncio.gather(*pending, return_exceptions=True)
         self._record_tasks.clear()
+        self._closed = True
 
         scoped_runtimes = tuple(self._scopes.values())
         self._scopes.clear()
@@ -258,7 +280,7 @@ class ScopedTelemetryRuntime:
     ) -> None:
         try:
             result = await self.record(event, priority=priority)
-            if result.status in {
+            if not self._closing and result.status in {
                 RecordStatus.RECORDED,
                 RecordStatus.DUPLICATE,
                 RecordStatus.EVICTED,
@@ -296,15 +318,20 @@ class ScopedTelemetryRuntime:
                 continue
             if stat.S_ISLNK(scope_metadata.st_mode) or not stat.S_ISDIR(scope_metadata.st_mode):
                 continue
-            if not resolve_scope_consent(
-                scope,
-                config=self._config,
-                env=self._env,
-            ).enabled:
-                continue
-            scoped = await self._scope_runtime(scope)
-            if scoped is not None:
-                recorders[scope] = scoped.recorder
+            try:
+                if not resolve_scope_consent(
+                    scope,
+                    config=self._config,
+                    env=self._env,
+                ).enabled:
+                    continue
+                scoped = await self._scope_runtime(scope)
+                if scoped is not None:
+                    recorders[scope] = scoped.recorder
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                log.debug("desktop telemetry scope initialization failed", exc_info=True)
         if not recorders:
             return
         try:

--- a/src/opensquilla/telemetry/server/dashboard_queries.py
+++ b/src/opensquilla/telemetry/server/dashboard_queries.py
@@ -103,6 +103,7 @@ class _FunnelStage:
     event_name: str
     outcome: str | None = None
     window_hours_from_previous: int | None = None
+    may_precede_previous: bool = False
 
 
 _ACQUISITION_STAGES: Final = (
@@ -121,7 +122,10 @@ _ACQUISITION_STAGES: Final = (
 
 _ACTIVATION_STAGES: Final = (
     _FunnelStage("first_app_ready", "first_app_ready"),
-    _FunnelStage("onboarding_completed", "onboarding_result", "completed", 7 * 24),
+    # Desktop saves onboarding before starting the gateway. Keep the ready
+    # cohort anchor while accepting that already-completed prerequisite, and
+    # retain support for older producers that reported readiness first.
+    _FunnelStage("onboarding_completed", "onboarding_result", "completed", 7 * 24, True),
     _FunnelStage("first_turn_started", "first_turn_started", window_hours_from_previous=7 * 24),
     _FunnelStage("first_turn_succeeded", "first_turn_result", "success", 7 * 24),
 )
@@ -1113,19 +1117,30 @@ class DashboardQueries:
         for index, stage in enumerate(stages[1:], start=1):
             previous = index - 1
             outcome_clause = "AND candidate.outcome = ?" if stage.outcome is not None else ""
+            lower_bound = (
+                "julianday(candidate.occurred_at_utc) "
+                ">= julianday(prior.reached_at) - (? / 24.0)"
+                if stage.may_precede_previous
+                else "candidate.occurred_at_utc >= prior.reached_at"
+            )
+            reached_at = (
+                "MAX(candidate.occurred_at_utc, prior.reached_at)"
+                if stage.may_precede_previous
+                else "candidate.occurred_at_utc"
+            )
             ctes.append(
                 f"""
                 stage_{index} AS (
                     SELECT
                         prior.journey_key,
-                        MIN(candidate.occurred_at_utc) AS reached_at
+                        MIN({reached_at}) AS reached_at
                     FROM stage_{previous} AS prior
                     LEFT JOIN events AS candidate
                       ON candidate.{id_column} = prior.journey_key
                      AND prior.reached_at IS NOT NULL
                      AND candidate.event_name = ?
                      {outcome_clause}
-                     AND candidate.occurred_at_utc >= prior.reached_at
+                     AND {lower_bound}
                      AND julianday(candidate.occurred_at_utc)
                          <= julianday(prior.reached_at) + (? / 24.0)
                     GROUP BY prior.journey_key
@@ -1135,6 +1150,8 @@ class DashboardQueries:
             params.append(stage.event_name)
             if stage.outcome is not None:
                 params.append(stage.outcome)
+            if stage.may_precede_previous:
+                params.append(stage.window_hours_from_previous)
             params.append(stage.window_hours_from_previous)
 
         count_expressions = [

--- a/tests/test_desktop/test_onboarding_main_process_flow_contract.py
+++ b/tests/test_desktop/test_onboarding_main_process_flow_contract.py
@@ -110,7 +110,7 @@ def test_onboarding_save_preserves_recovery_and_writer_ordering() -> None:
     marker = save.index("() => readPendingMigrationProviderSetup()")
     settings_stage = save.index("telemetry.stage('settings_persist'")
     imported = save.index("await saveImportedDesktopCredential(")
-    ordinary = save.index("await saveDesktopCredential(payload, true)")
+    ordinary = save.index("await saveDesktopCredential(payload, true, true)")
     refresh_keychain = save.index("invalidateSecretStorageBackendCache()")
     settings_persisted = save.index("telemetry.markSettingsPersistedConfirmed()")
     finalize_stage = save.index("telemetry.stage('local_finalize'")

--- a/tests/test_gateway/test_telemetry_runtime_wiring.py
+++ b/tests/test_gateway/test_telemetry_runtime_wiring.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
-from opensquilla.gateway.boot import ServiceContainer, build_turn_runner_from_services
+import pytest
+
+from opensquilla.gateway.boot import (
+    ServiceContainer,
+    build_services,
+    build_turn_runner_from_services,
+)
+from opensquilla.gateway.config import GatewayConfig
+from opensquilla.sandbox.integration import reset_runtime
 
 
 class FakeReliabilitySink:
@@ -74,3 +83,54 @@ def test_turn_runner_receives_only_content_free_sink_methods() -> None:
     assert runner._file_parse_reliability_sink == reliability_sink.observe_file_parse
     assert runner._turn_growth_started_sink == growth_sink.observe_turn_started
     assert runner._turn_growth_succeeded_sink == growth_sink.observe_turn_succeeded
+
+
+@pytest.mark.parametrize("start_fails", [False, True])
+async def test_service_boot_starts_growth_replay_and_closes_failed_initialization(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, start_fails: bool,
+) -> None:
+    monkeypatch.setenv("OPENSQUILLA_STATE_DIR", str(tmp_path / "state"))
+    calls: list[str] = []
+
+    class Runtime:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def start(self):
+            calls.append("runtime_start")
+
+        async def close(self):
+            calls.append("runtime_close")
+
+    class Sink:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        async def start(self):
+            calls.append("replay_start")
+            if start_fails:
+                raise OSError("synthetic replay initialization failure")
+
+        async def close(self):
+            calls.append("replay_close")
+
+    def reject_sandbox_setup(coro):
+        coro.close()
+        raise AssertionError("offline test must not start sandbox setup")
+
+    monkeypatch.setattr("opensquilla.gateway.boot.create_background_task", reject_sandbox_setup)
+    monkeypatch.setattr("opensquilla.telemetry.runtime.ScopedTelemetryRuntime", Runtime)
+    monkeypatch.setattr("opensquilla.telemetry.growth_sink.GrowthEventSink", Sink)
+    monkeypatch.setattr("opensquilla.telemetry.reliability_sink.ReliabilityEventSink", Sink)
+    services = await build_services(
+        config=GatewayConfig(memory={"flush_enabled": False}),
+        session_db_path=":memory:", seed_agent_workspaces=False,
+    )
+    try:
+        assert calls[0] == "replay_start"
+        assert (services.growth_event_sink is None) is start_fails
+        assert (services.telemetry_runtime is None) is start_fails
+    finally:
+        await services.close()
+        reset_runtime()
+    assert calls == ["replay_start", "replay_close", "runtime_close"]

--- a/tests/test_telemetry/test_client_runtime.py
+++ b/tests/test_telemetry/test_client_runtime.py
@@ -187,15 +187,24 @@ async def test_background_record_from_worker_returns_to_owner_loop(
         config=_config(state_dir, reliability=True, growth=False),
         upload_interval_seconds=60,
     )
+    owner_loop = asyncio.get_running_loop()
+    recorded = asyncio.Event()
+    record_loops = []
+    record = runtime.record
+
+    async def capture_record(event, **kwargs):
+        record_loops.append(asyncio.get_running_loop())
+        result = await record(event, **kwargs)
+        recorded.set()
+        return result
+
+    monkeypatch.setattr(runtime, "record", capture_record)
     await runtime.start()
     try:
         await asyncio.to_thread(runtime.record_background, _turn_event())
-        for _ in range(20):
-            scoped = runtime._scopes.get(TelemetryScope.RELIABILITY)
-            if scoped is not None and (await scoped.outbox.stats()).pending_events == 1:
-                break
-            await asyncio.sleep(0.01)
-        assert scoped is not None
+        await asyncio.wait_for(recorded.wait(), timeout=10)
+        assert record_loops == [owner_loop]
+        scoped = runtime._scopes[TelemetryScope.RELIABILITY]
         assert (await scoped.outbox.stats()).pending_events == 1
     finally:
         await runtime.close()

--- a/tests/test_telemetry/test_client_runtime.py
+++ b/tests/test_telemetry/test_client_runtime.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import httpx
 import pytest
 
+from opensquilla.telemetry import runtime as runtime_module
 from opensquilla.telemetry.consent import (
     CURRENT_PRODUCT_ANALYTICS_NOTICE_VERSION,
     CURRENT_RELIABILITY_NOTICE_VERSION,
@@ -17,6 +18,7 @@ from opensquilla.telemetry.consent import (
 )
 from opensquilla.telemetry.contracts import TELEMETRY_EVENT_ADAPTER
 from opensquilla.telemetry.coordination import scope_consent_coordinator_for
+from opensquilla.telemetry.outbox import TelemetryOutbox
 from opensquilla.telemetry.recorder import RecordStatus
 from opensquilla.telemetry.runtime import ScopedTelemetryRuntime
 
@@ -257,3 +259,174 @@ async def test_start_drains_consented_desktop_scope_into_isolated_outbox(
         assert not (state_dir / "telemetry" / "reliability-outbox.sqlite3").exists()
     finally:
         await runtime.close()
+
+
+async def test_upload_loop_recovers_scope_initialization_on_next_interval(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = ScopedTelemetryRuntime(
+        config=_config(tmp_path, reliability=True, growth=True)
+    )
+    attempts = {scope: 0 for scope in TelemetryScope}
+    uploaded: list[TelemetryScope] = []
+    sleeping = asyncio.Event()
+    tick = asyncio.Event()
+    delays: list[float] = []
+
+    async def interval_sleep(delay):
+        delays.append(delay)
+        sleeping.set()
+        await tick.wait()
+        tick.clear()
+
+    async def scope_runtime(scope):
+        attempts[scope] += 1
+        if scope is TelemetryScope.RELIABILITY and attempts[scope] == 1:
+            raise OSError("synthetic scope initialization failure")
+
+        async def upload_once():
+            uploaded.append(scope)
+
+        return SimpleNamespace(uploader=SimpleNamespace(upload_once=upload_once))
+
+    monkeypatch.setattr(runtime, "_scope_runtime", scope_runtime)
+    monkeypatch.setattr(
+        runtime_module, "asyncio", SimpleNamespace(**(vars(asyncio) | {"sleep": interval_sleep}))
+    )
+    await runtime.start()
+    try:
+        await asyncio.wait_for(sleeping.wait(), timeout=1)
+        assert uploaded == [TelemetryScope.GROWTH]
+        sleeping.clear()
+        tick.set()
+        await asyncio.wait_for(sleeping.wait(), timeout=1)
+        assert uploaded == [
+            TelemetryScope.GROWTH,
+            TelemetryScope.RELIABILITY,
+            TelemetryScope.GROWTH,
+        ]
+        assert delays == [30.0, 30.0]
+    finally:
+        await runtime.close()
+
+
+async def test_spool_initialization_failure_does_not_block_other_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "telemetry" / "desktop-early-spool"
+    for scope in TelemetryScope:
+        (root / scope.value).mkdir(parents=True)
+    runtime = ScopedTelemetryRuntime(
+        config=_config(tmp_path, reliability=True, growth=True), env={}
+    )
+    imports = []
+
+    async def scope_runtime(scope):
+        if scope is TelemetryScope.RELIABILITY:
+            raise OSError("synthetic scope initialization failure")
+        return SimpleNamespace(recorder="growth-recorder")
+
+    async def capture_drain(_root, *, recorders, **_kwargs):
+        imports.append(recorders)
+
+    monkeypatch.setattr(runtime, "_scope_runtime", scope_runtime)
+    monkeypatch.setattr("opensquilla.telemetry.runtime.drain_desktop_early_spool", capture_drain)
+    await runtime._drain_desktop_spool()
+    await runtime.close()
+
+    assert imports == [{TelemetryScope.GROWTH: "growth-recorder"}]
+
+
+async def test_start_replaces_a_finished_upload_task(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = ScopedTelemetryRuntime(
+        config=_config(tmp_path, reliability=None, growth=None)
+    )
+    entered = asyncio.Event()
+
+    async def completed():
+        return None
+
+    async def upload_loop():
+        entered.set()
+        await asyncio.Event().wait()
+
+    old_task = asyncio.create_task(completed())
+    await old_task
+    runtime._upload_task = old_task
+    monkeypatch.setattr(runtime, "_upload_loop", upload_loop)
+    await runtime.start()
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=1)
+        assert runtime._upload_task is not old_task
+    finally:
+        await runtime.close()
+
+
+async def test_close_drains_accepted_local_record_without_starting_upload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = ScopedTelemetryRuntime(
+        config=_config(tmp_path, reliability=True, growth=False)
+    )
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    recorded = asyncio.Event()
+    starts = 0
+    record = runtime.record
+
+    async def slow_record(event, *, priority=None):
+        entered.set()
+        await release.wait()
+        result = await record(event, priority=priority)
+        recorded.set()
+        return result
+
+    async def forbidden_start():
+        nonlocal starts
+        starts += 1
+        raise AssertionError("shutdown must not start uploads")
+
+    monkeypatch.setattr(runtime, "record", slow_record)
+    monkeypatch.setattr(runtime, "start", forbidden_start)
+    runtime.record_background(_turn_event())
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    closing = asyncio.create_task(runtime.close())
+    await asyncio.sleep(0)
+    runtime.record_background(_turn_event(2))
+    release.set()
+    await asyncio.wait_for(closing, timeout=1)
+
+    assert recorded.is_set()
+    assert starts == 0
+    outbox = await TelemetryOutbox.open(tmp_path, TelemetryScope.RELIABILITY)
+    try:
+        assert (await outbox.stats()).pending_events == 1
+    finally:
+        await outbox.close()
+
+
+async def test_close_during_start_does_not_leave_an_upload_task(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = ScopedTelemetryRuntime(
+        config=_config(tmp_path, reliability=True, growth=False)
+    )
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_drain():
+        entered.set()
+        await release.wait()
+
+    monkeypatch.setattr(runtime, "_drain_desktop_spool", slow_drain)
+    runtime.record_background(_turn_event())
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    closing = asyncio.create_task(runtime.close())
+    await asyncio.sleep(0)
+    release.set()
+    await asyncio.wait_for(closing, timeout=1)
+
+    assert runtime._upload_task is None
+    assert runtime._record_tasks == set()

--- a/tests/test_telemetry/test_desktop_turn_counts.py
+++ b/tests/test_telemetry/test_desktop_turn_counts.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from opensquilla.telemetry.consent import TelemetryScope, resolve_scope_consent
+from opensquilla.telemetry.contracts import CURRENT_NOTICE_VERSION_BY_SCOPE
+from opensquilla.telemetry.contracts.common import Platform, ResultOutcome
+from opensquilla.telemetry.coordination import scope_consent_coordinator_for
+from opensquilla.telemetry.desktop_state import clear_desktop_early_spool_scope
+from opensquilla.telemetry.desktop_turn_counts import (
+    SESSION_MARKER_NAME,
+    TURN_COUNTS_PREFIX,
+)
+from opensquilla.telemetry.recorder import RecordStatus
+from opensquilla.telemetry.reliability_sink import ReliabilityEventSink
+from opensquilla.telemetry.runtime import ScopedTelemetryRuntime
+
+APP_SESSION = "00000000-0000-4000-8000-000000000001"
+STARTED_AT = datetime(2026, 9, 2, tzinfo=UTC)
+CONSENTED_AT = "2026-09-02T00:00:00.000Z"
+NOTICE = CURRENT_NOTICE_VERSION_BY_SCOPE["reliability"]
+
+
+def _config(state_dir: Path):
+    config = SimpleNamespace(
+        state_dir=state_dir,
+        privacy=SimpleNamespace(
+            reliability_diagnostics_enabled=True,
+            reliability_notice_version=NOTICE,
+            reliability_consented_at_utc=CONSENTED_AT,
+        ),
+    )
+    scope_consent_coordinator_for(
+        config,
+        state_provider=lambda scope: resolve_scope_consent(scope, config=config, env={}),
+    )
+    return config
+
+
+def _active_session(state_dir: Path) -> Path:
+    directory = state_dir / "telemetry" / "desktop-early-spool" / "reliability"
+    directory.mkdir(parents=True)
+    (directory / SESSION_MARKER_NAME).write_text(
+        json.dumps(
+            {
+                "schema_version": 3,
+                "marker_kind": "desktop_reliability_session",
+                "app_session_id": APP_SESSION,
+                "started_at_ms": int(STARTED_AT.timestamp() * 1000),
+                "consent_generation": f"{NOTICE}\n{CONSENTED_AT}",
+                "clean_exit": False,
+                "performance_summary_emitted": False,
+                "gateway_turn_counts_applied": False,
+            }
+        )
+    )
+    (state_dir / "telemetry" / "desktop-consent-mirror.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "reliability": {
+                    "enabled": True,
+                    "forced_off": False,
+                    "notice_version": NOTICE,
+                    "consented_at_utc": CONSENTED_AT,
+                },
+            }
+        )
+    )
+    return directory / f"{TURN_COUNTS_PREFIX}{APP_SESSION}.tmp"
+
+
+async def _observe_turn(runtime: ScopedTelemetryRuntime, stalls: int) -> None:
+    sink = ReliabilityEventSink(
+        runtime,
+        app_version="1.2.3",
+        platform=Platform.MACOS,
+        clock=lambda: datetime(2026, 9, 2, 0, 0, 1, tzinfo=UTC),
+    )
+    sink.observe_turn(
+        SimpleNamespace(
+            outcome=ResultOutcome.SUCCESS,
+            error_code=None,
+            failure_stage=None,
+            duration_ms=1000,
+            ttft_ms=100,
+            stall_count=stalls,
+        )
+    )
+    # The real producer is fire-and-forget; wait for its accepted local work.
+    await asyncio.gather(*tuple(runtime._record_tasks))
+
+
+@pytest.fixture(autouse=True)
+def offline_uploader(monkeypatch):
+    async def no_network(self, scope):
+        return None
+
+    monkeypatch.setattr(ScopedTelemetryRuntime, "upload_once", no_network)
+
+
+async def test_terminal_observer_counts_survive_gateway_restart_and_queue_replay(tmp_path):
+    target = _active_session(tmp_path)
+    config = _config(tmp_path)
+    runtime = ScopedTelemetryRuntime(config=config, env={})
+    await _observe_turn(runtime, 0)
+    # Re-enqueuing the same accepted event must not count another terminal turn.
+    outbox = runtime._scopes[TelemetryScope.RELIABILITY].outbox
+    lease = await outbox.claim_batch()
+    assert lease is not None
+    from opensquilla.telemetry.contracts import TELEMETRY_EVENT_ADAPTER
+
+    event = TELEMETRY_EVENT_ADAPTER.validate_json(lease.events[0].payload, strict=True)
+    assert (await runtime.record(event)).status is RecordStatus.DUPLICATE
+    await runtime.close()
+    second = ScopedTelemetryRuntime(config=config, env={})
+    await _observe_turn(second, 2)
+    await second.close()
+    counts = json.loads(target.read_text())
+    assert (counts["turn_count"], counts["stalled_turn_count"], counts["stall_count"]) == (2, 1, 2)
+    assert "event_id" not in counts
+
+
+async def test_withdrawal_does_not_recreate_turn_counter_state(tmp_path):
+    target = _active_session(tmp_path)
+    config = _config(tmp_path)
+    runtime = ScopedTelemetryRuntime(config=config, env={})
+    await _observe_turn(runtime, 1)
+    config.privacy.reliability_diagnostics_enabled = False
+    cleanup = clear_desktop_early_spool_scope(tmp_path, TelemetryScope.RELIABILITY)
+    assert cleanup.complete
+    await _observe_turn(runtime, 1)
+    await runtime.close()
+    assert not target.parent.exists()
+
+
+@pytest.mark.parametrize("change", ["rotated", "closed", "renewed", "symlink"])
+async def test_late_or_untrusted_terminal_counter_write_is_ignored(tmp_path, change):
+    target = _active_session(tmp_path)
+    directory = target.parent
+    marker_path = directory / SESSION_MARKER_NAME
+    marker = json.loads(marker_path.read_text())
+    if change == "rotated":
+        marker["started_at_ms"] += 10_000
+    elif change == "closed":
+        marker["clean_exit"] = True
+    elif change == "renewed":
+        marker["consent_generation"] = "old-grant"
+    else:
+        outside = tmp_path / "outside.json"
+        outside.write_text("{}")
+        try:
+            target.symlink_to(outside)
+        except OSError:
+            pytest.skip("filesystem does not permit symlink creation")
+    marker_path.write_text(json.dumps(marker))
+    runtime = ScopedTelemetryRuntime(config=_config(tmp_path), env={})
+    await _observe_turn(runtime, 1)
+    await runtime.close()
+    if change == "symlink":
+        assert outside.read_text() == "{}"
+    else:
+        assert not target.exists()
+
+
+async def test_desktop_time_checkpoint_does_not_discard_a_terminal_count(tmp_path, monkeypatch):
+    from opensquilla.telemetry import desktop_turn_counts
+
+    target = _active_session(tmp_path)
+    mkstemp = desktop_turn_counts.tempfile.mkstemp
+
+    def checkpoint_during_write(*args, **kwargs):
+        result = mkstemp(*args, **kwargs)
+        if kwargs.get("prefix") == ".desktop-turn-write-":
+            path = target.parent / SESSION_MARKER_NAME
+            marker = json.loads(path.read_text())
+            marker["last_observed_at_ms"] = marker["started_at_ms"] + 500
+            path.write_text(json.dumps(marker))
+        return result
+
+    monkeypatch.setattr(desktop_turn_counts.tempfile, "mkstemp", checkpoint_during_write)
+    runtime = ScopedTelemetryRuntime(config=_config(tmp_path), env={})
+    await _observe_turn(runtime, 1)
+    await runtime.close()
+    assert json.loads(target.read_text())["turn_count"] == 1
+
+
+@pytest.mark.parametrize("ending", ["finish", "recover"])
+async def test_gateway_observer_reaches_real_desktop_performance_summary(tmp_path, ending):
+    """Run the Python producer against the built Desktop module, without Electron."""
+    desktop = Path(__file__).parents[2] / "desktop" / "electron"
+    node = shutil.which("node")
+    module = desktop / "dist" / "telemetry" / "reliability.js"
+    if node is None or not module.exists():
+        pytest.skip("requires Node and npm run build in desktop/electron")
+    program = """
+      import { createInterface } from 'node:readline';
+      import { join } from 'node:path';
+      const { DesktopReliabilityTelemetry } = await import(process.argv[2]);
+      const { DesktopTelemetryRuntimeGate } = await import(process.argv[3]);
+      const { writeConsentMirror } = await import(process.argv[4]);
+      const data = JSON.parse(process.argv[1]);
+      const paths = { spoolRoot: join(data.state, 'telemetry', 'desktop-early-spool'),
+        consentMirrorPath: join(data.state, 'telemetry', 'desktop-consent-mirror.json') };
+      await writeConsentMirror(paths.consentMirrorPath, {schema_version: 1,
+        reliability: { enabled: true, forced_off: false, notice_version: data.notice,
+          consented_at_utc: data.consented },
+        growth: { enabled: false, forced_off: false, notice_version: null,
+          consented_at_utc: null } });
+      const gate = new DesktopTelemetryRuntimeGate(); gate.openAfterConsentSync();
+      let now = Date.parse(data.consented);
+      const options = { runtimeGate: gate, appVersion: () => '1.2.3', platform: 'macos',
+        processStartedAtMs: now, nowMs: () => now, nowDate: () => new Date(now), env: {} };
+      const first = new DesktopReliabilityTelemetry({...options, appSessionId: data.session});
+      first.synchronize(paths);
+      first.recordAppStartResult({outcome: 'success', durationMs: 0,
+        errorCode: null, failureStage: null});
+      console.log('ready');
+      for await (const action of createInterface({input: process.stdin})) {
+        now += 5000;
+        if (action === 'finish') first.finishSession();
+        else new DesktopReliabilityTelemetry(options).synchronize(paths);
+        break;
+      }
+    """
+    process = await asyncio.create_subprocess_exec(
+        node,
+        "--input-type=module",
+        "-e",
+        program,
+        json.dumps(
+            {
+                "state": str(tmp_path),
+                "notice": NOTICE,
+                "consented": CONSENTED_AT,
+                "session": APP_SESSION,
+            }
+        ),
+        module.as_uri(),
+        (module.parent / "early-spool.js").as_uri(),
+        (module.parent / "consent-mirror.js").as_uri(),
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        assert await asyncio.wait_for(process.stdout.readline(), 10) == b"ready\n"
+        runtime = ScopedTelemetryRuntime(config=_config(tmp_path), env={})
+        await _observe_turn(runtime, 0)
+        await _observe_turn(runtime, 2)
+        await runtime.close()
+        _, stderr = await asyncio.wait_for(process.communicate(f"{ending}\n".encode()), 10)
+        assert process.returncode == 0, stderr.decode()
+    finally:
+        if process.returncode is None:
+            process.kill()
+            await process.wait()
+    directory = tmp_path / "telemetry" / "desktop-early-spool" / "reliability"
+    events = [json.loads(path.read_text()) for path in directory.glob("*.ready")]
+    summaries = [event for event in events if event["event_name"] == "performance_summary"]
+    assert len(summaries) == 1
+    summary = summaries[0]
+    assert summary["app_session_id"] == APP_SESSION
+    assert (summary["turn_count"], summary["stalled_turn_count"], summary["stall_count"]) == (
+        2,
+        1,
+        2,
+    )
+    assert summary["summary_kind"] == (
+        "session_end" if ending == "finish" else "recovered_abnormal"
+    )
+    assert not (directory / f"{TURN_COUNTS_PREFIX}{APP_SESSION}.tmp").exists()

--- a/tests/test_telemetry/test_growth_sink.py
+++ b/tests/test_telemetry/test_growth_sink.py
@@ -148,6 +148,30 @@ async def test_started_and_success_are_enqueued_once_in_funnel_order(tmp_path) -
     assert state.first_turn_result.status is GrowthMilestoneStatus.ENQUEUED
 
 
+async def test_pending_first_turn_is_replayed_on_next_boundary(tmp_path) -> None:
+    config = _config(tmp_path)
+    _activate(config)
+    runtime = CapturingRuntime([RecordStatus.EVICTED, RecordStatus.RECORDED])
+    sink = _sink(runtime, config)
+
+    await sink.record_turn_started(STARTED_AT)
+    pending = read_gateway_growth_milestone_state(sink.marker_path)
+    assert pending.first_turn_started is not None
+    assert pending.first_turn_started.status is GrowthMilestoneStatus.PENDING
+    pending_id = pending.first_turn_started.event.event_id
+
+    await sink.replay_pending()
+
+    assert [event.event_name for event in runtime.events] == [
+        "first_turn_started",
+        "first_turn_started",
+    ]
+    assert runtime.events[1].event_id == pending_id
+    replayed = read_gateway_growth_milestone_state(sink.marker_path)
+    assert replayed.first_turn_started is not None
+    assert replayed.first_turn_started.status is GrowthMilestoneStatus.ENQUEUED
+
+
 async def test_evicted_event_keeps_stable_pending_payload_for_retry(tmp_path) -> None:
     config = _config(tmp_path)
     _activate(config)

--- a/tests/test_telemetry/test_growth_sink.py
+++ b/tests/test_telemetry/test_growth_sink.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import uuid
 from datetime import UTC, datetime
@@ -7,6 +8,7 @@ from types import SimpleNamespace
 
 from opensquilla.telemetry.consent import (
     CURRENT_PRODUCT_ANALYTICS_NOTICE_VERSION,
+    TelemetryScope,
     resolve_scope_consent,
 )
 from opensquilla.telemetry.contracts.common import (
@@ -17,6 +19,7 @@ from opensquilla.telemetry.contracts.common import (
 )
 from opensquilla.telemetry.coordination import scope_consent_coordinator_for
 from opensquilla.telemetry.growth.state import (
+    delete_growth_cohort_state,
     growth_cohort_state_path,
     write_active_growth_cohort,
 )
@@ -107,7 +110,10 @@ async def test_no_consent_creates_no_growth_files_or_event(tmp_path) -> None:
     runtime = CapturingRuntime()
     sink = _sink(runtime, config)
 
+    await sink.start()
     await sink.record_turn_started(STARTED_AT)
+    await asyncio.sleep(0)
+    await sink.close()
 
     assert runtime.events == []
     assert not (tmp_path / "telemetry").exists()
@@ -130,8 +136,9 @@ async def test_started_and_success_are_enqueued_once_in_funnel_order(tmp_path) -
     runtime = CapturingRuntime()
     sink = _sink(runtime, config)
 
-    await sink.record_turn_succeeded(SUCCEEDED_AT)
     await sink.record_turn_started(STARTED_AT)
+    await sink.record_turn_succeeded(SUCCEEDED_AT)
+    await sink.record_turn_started(SUCCEEDED_AT)
     await sink.record_turn_succeeded(SUCCEEDED_AT)
 
     assert [event.event_name for event in runtime.events] == [
@@ -140,7 +147,7 @@ async def test_started_and_success_are_enqueued_once_in_funnel_order(tmp_path) -
     ]
     assert [event.source.value for event in runtime.events] == ["gateway", "runtime"]
     assert all(str(event.analytics_user_id) == str(ANALYTICS_ID) for event in runtime.events)
-    assert runtime.events[0].occurred_at_utc == SUCCEEDED_AT
+    assert runtime.events[0].occurred_at_utc == STARTED_AT
     state = read_gateway_growth_milestone_state(sink.marker_path)
     assert state.first_turn_started is not None
     assert state.first_turn_started.status is GrowthMilestoneStatus.ENQUEUED
@@ -148,28 +155,171 @@ async def test_started_and_success_are_enqueued_once_in_funnel_order(tmp_path) -
     assert state.first_turn_result.status is GrowthMilestoneStatus.ENQUEUED
 
 
-async def test_pending_first_turn_is_replayed_on_next_boundary(tmp_path) -> None:
+async def test_pending_first_turn_retries_without_another_turn(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("opensquilla.telemetry.growth_sink._RETRY_INITIAL_SECONDS", 0.01)
     config = _config(tmp_path)
     _activate(config)
-    runtime = CapturingRuntime([RecordStatus.EVICTED, RecordStatus.RECORDED])
+    runtime = CapturingRuntime([RecordStatus.EVICTED, RecordStatus.EVICTED])
     sink = _sink(runtime, config)
 
+    await sink.start()
     await sink.record_turn_started(STARTED_AT)
     pending = read_gateway_growth_milestone_state(sink.marker_path)
     assert pending.first_turn_started is not None
     assert pending.first_turn_started.status is GrowthMilestoneStatus.PENDING
     pending_id = pending.first_turn_started.event.event_id
 
-    await sink.replay_pending()
+    async with asyncio.timeout(1):
+        while len(runtime.events) < 3:
+            await asyncio.sleep(0.001)
+    await sink.close()
 
     assert [event.event_name for event in runtime.events] == [
         "first_turn_started",
         "first_turn_started",
+        "first_turn_started",
     ]
-    assert runtime.events[1].event_id == pending_id
+    assert all(event.event_id == pending_id for event in runtime.events)
+    assert all(event.occurred_at_utc == STARTED_AT for event in runtime.events)
     replayed = read_gateway_growth_milestone_state(sink.marker_path)
     assert replayed.first_turn_started is not None
     assert replayed.first_turn_started.status is GrowthMilestoneStatus.ENQUEUED
+
+
+async def test_pending_start_blocks_success_until_startup_recovery(tmp_path) -> None:
+    config = _config(tmp_path)
+    _activate(config)
+    runtime = CapturingRuntime([RecordStatus.EVICTED])
+    sink = _sink(runtime, config)
+
+    await sink.record_turn_started(STARTED_AT)
+    await sink.record_turn_succeeded(SUCCEEDED_AT)
+    await sink.close()
+
+    pending = read_gateway_growth_milestone_state(sink.marker_path)
+    assert pending.first_turn_started is not None
+    assert pending.first_turn_result is not None
+    assert pending.first_turn_started.status is GrowthMilestoneStatus.PENDING
+    assert pending.first_turn_result.status is GrowthMilestoneStatus.PENDING
+    assert [event.event_name for event in runtime.events] == ["first_turn_started"]
+
+    recovered_runtime = CapturingRuntime()
+    recovered = _sink(recovered_runtime, _config(tmp_path))
+    await recovered.start()
+    await recovered.start()
+    async with asyncio.timeout(1):
+        while len(recovered_runtime.events) < 2:
+            await asyncio.sleep(0.001)
+    await recovered.close()
+
+    assert recovered_runtime.events == [
+        pending.first_turn_started.event,
+        pending.first_turn_result.event,
+    ]
+    complete = read_gateway_growth_milestone_state(recovered.marker_path)
+    assert complete.first_turn_started is not None
+    assert complete.first_turn_result is not None
+    assert complete.first_turn_started.status is GrowthMilestoneStatus.ENQUEUED
+    assert complete.first_turn_result.status is GrowthMilestoneStatus.ENQUEUED
+
+
+async def test_success_does_not_invent_a_missing_start(tmp_path) -> None:
+    config = _config(tmp_path)
+    _activate(config)
+    runtime = CapturingRuntime()
+    sink = _sink(runtime, config)
+
+    await sink.record_turn_succeeded(SUCCEEDED_AT)
+
+    assert runtime.events == []
+    assert not sink.marker_path.exists()
+
+
+async def test_retry_stops_after_revocation_without_backfill(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("opensquilla.telemetry.growth_sink._RETRY_INITIAL_SECONDS", 0.01)
+    config = _config(tmp_path)
+    _activate(config)
+    runtime = CapturingRuntime([RecordStatus.EVICTED, RecordStatus.EVICTED])
+    sink = _sink(runtime, config)
+    await sink.start()
+    await sink.record_turn_started(STARTED_AT)
+    await sink.record_turn_succeeded(SUCCEEDED_AT)
+    async with asyncio.timeout(1):
+        while len(runtime.events) < 2:
+            await asyncio.sleep(0.001)
+
+    coordinator = scope_consent_coordinator_for(config)
+    async with coordinator.transition(TelemetryScope.GROWTH):
+        config.privacy.product_analytics_enabled = False
+        delete_growth_cohort_state(config=config)
+    await asyncio.sleep(0.03)
+    assert len(runtime.events) == 2
+
+    config.privacy.product_analytics_enabled = True
+    sink.observe_turn_started()
+    sink.observe_turn_succeeded()
+    await sink.close()
+
+    assert len(runtime.events) == 2
+    assert not sink.marker_path.exists()
+
+
+async def test_startup_replay_requires_current_consent(tmp_path) -> None:
+    config = _config(tmp_path)
+    _activate(config)
+    runtime = CapturingRuntime([RecordStatus.EVICTED])
+    sink = _sink(runtime, config)
+    await sink.record_turn_started(STARTED_AT)
+    await sink.close()
+
+    disabled_runtime = CapturingRuntime()
+    disabled = _sink(disabled_runtime, _config(tmp_path, enabled=False))
+    await disabled.start()
+    await asyncio.sleep(0)
+    await disabled.close()
+
+    assert disabled_runtime.events == []
+
+
+async def test_replay_does_not_recreate_a_marker_deleted_after_read(tmp_path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    _activate(config)
+    runtime = CapturingRuntime([RecordStatus.EVICTED])
+    sink = _sink(runtime, config)
+    await sink.record_turn_started(STARTED_AT)
+
+    def read_then_remove(path):
+        state = read_gateway_growth_milestone_state(path)
+        path.unlink(missing_ok=True)
+        return state
+
+    monkeypatch.setattr(
+        "opensquilla.telemetry.growth_sink.read_gateway_growth_milestone_state",
+        read_then_remove,
+    )
+    await sink.replay_pending()
+
+    assert len(runtime.events) == 1
+    assert not sink.marker_path.exists()
+
+
+async def test_close_cancels_retry_backoff(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("opensquilla.telemetry.growth_sink._RETRY_INITIAL_SECONDS", 60)
+    config = _config(tmp_path)
+    _activate(config)
+    runtime = CapturingRuntime([RecordStatus.EVICTED, RecordStatus.EVICTED])
+    sink = _sink(runtime, config)
+    await sink.start()
+    await sink.record_turn_started(STARTED_AT)
+    async with asyncio.timeout(1):
+        while len(runtime.events) < 2:
+            await asyncio.sleep(0.001)
+        await sink.close()
+
+    assert len(runtime.events) == 2
+    pending = read_gateway_growth_milestone_state(sink.marker_path)
+    assert pending.first_turn_started is not None
+    assert pending.first_turn_started.status is GrowthMilestoneStatus.PENDING
 
 
 async def test_evicted_event_keeps_stable_pending_payload_for_retry(tmp_path) -> None:

--- a/tests/test_telemetry_server/test_client_pipeline.py
+++ b/tests/test_telemetry_server/test_client_pipeline.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from functools import partial
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from opensquilla.telemetry import runtime as runtime_module
+from opensquilla.telemetry.consent import (
+    CURRENT_RELIABILITY_NOTICE_VERSION,
+    TelemetryScope,
+    resolve_scope_consent,
+)
+from opensquilla.telemetry.contracts.common import ConsentScope
+from opensquilla.telemetry.coordination import scope_consent_coordinator_for
+from opensquilla.telemetry.outbox import TelemetryOutbox
+from opensquilla.telemetry.runtime import ScopedTelemetryRuntime
+from opensquilla.telemetry.server.collector import create_collector_app
+from opensquilla.telemetry.server.dashboard_queries import DashboardQueries, UtcCohortWindow
+from opensquilla.telemetry.server.settings import CollectorSettings
+from opensquilla.telemetry.uploader import TelemetryUploader
+
+
+def _spool_event(state_dir: Path, *, number: int, day: str) -> Path:
+    event = {
+        "event_name": "app_start_result",
+        "event_version": 1,
+        "event_id": f"00000000-0000-4000-8000-{number:012d}",
+        "occurred_at_utc": f"{day}T01:00:00.000Z",
+        "source": "desktop",
+        "app_version": "1.2.3",
+        "platform": "macos",
+        "outcome": "success",
+        "error_code": None,
+        "duration_ms": 120,
+        "consent_scope": "reliability",
+        "notice_version": CURRENT_RELIABILITY_NOTICE_VERSION,
+        "sample_rate": 1,
+        "app_session_id": f"00000000-0000-4000-8000-{number + 100:012d}",
+        "failure_stage": None,
+    }
+    directory = state_dir / "telemetry" / "desktop-early-spool" / "reliability"
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{event['event_id']}.ready"
+    path.write_text(json.dumps(event), encoding="utf-8")
+    return path
+
+
+async def test_spool_retry_upload_advances_collector_watermark_and_dashboard_dates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_dir = tmp_path / "client"
+    config = SimpleNamespace(
+        state_dir=str(state_dir),
+        privacy=SimpleNamespace(
+            disable_network_observability=False,
+            reliability_diagnostics_enabled=True,
+            reliability_notice_version=CURRENT_RELIABILITY_NOTICE_VERSION,
+            reliability_consented_at_utc="2026-08-01T00:00:00Z",
+            product_analytics_enabled=False,
+        ),
+    )
+    scope_consent_coordinator_for(
+        config, state_provider=lambda scope: resolve_scope_consent(scope, config=config, env={})
+    )
+    first = _spool_event(state_dir, number=1, day="2026-08-01")
+    settings = CollectorSettings(
+        scope=ConsentScope.RELIABILITY, database_path=tmp_path / "collector.sqlite3"
+    )
+    app = create_collector_app(settings)
+    queries = DashboardQueries(
+        reliability_db_path=settings.database_path,
+        growth_db_path=tmp_path / "unused-growth.sqlite3",
+    )
+    selected_day = UtcCohortWindow.from_dates("2026-08-02", "2026-08-02")
+    sleeping = asyncio.Event()
+    tick = asyncio.Event()
+    delays = []
+    attempts = 0
+    open_outbox = TelemetryOutbox.open
+
+    async def interval_sleep(delay):
+        delays.append(delay)
+        sleeping.set()
+        await tick.wait()
+        tick.clear()
+
+    async def transient_open(_cls, path, scope, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts <= 3:
+            raise OSError("synthetic database temporarily unavailable")
+        return await open_outbox(path, scope, **kwargs)
+
+    monkeypatch.setattr(TelemetryOutbox, "open", classmethod(transient_open))
+    monkeypatch.setattr(
+        runtime_module, "asyncio", SimpleNamespace(**(vars(asyncio) | {"sleep": interval_sleep}))
+    )
+    async with app.router.lifespan_context(app):
+        received_at = datetime(2026, 8, 2, 2, tzinfo=UTC)
+        app.state.telemetry_storage._clock = lambda: received_at
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), trust_env=False
+        ) as client:
+            monkeypatch.setattr(
+                runtime_module, "TelemetryUploader", partial(TelemetryUploader, http_client=client)
+            )
+            runtime = ScopedTelemetryRuntime(
+                config=config, base_url="https://collector.invalid", env={}
+            )
+            await runtime.start()
+            try:
+                await asyncio.wait_for(sleeping.wait(), timeout=2)
+                assert attempts == 3
+                assert first.exists()
+                assert queries.reliability(selected_day)["asOfReceivedUtc"] is None
+
+                sleeping.clear()
+                tick.set()
+                await asyncio.wait_for(sleeping.wait(), timeout=2)
+                assert not first.exists()
+                initial = queries.reliability(selected_day)
+                assert initial["asOfReceivedUtc"] == "2026-08-02T02:00:00.000Z"
+                assert initial["appStart"]["estimatedEvents"] == 0
+                assert queries.reliability(
+                    UtcCohortWindow.from_dates("2026-08-01", "2026-08-01")
+                )["appStart"]["estimatedEvents"] == 1
+
+                second = _spool_event(state_dir, number=2, day="2026-08-02")
+                received_at = datetime(2026, 8, 3, 2, tzinfo=UTC)
+                sleeping.clear()
+                tick.set()
+                await asyncio.wait_for(sleeping.wait(), timeout=2)
+                assert not second.exists()
+                updated = queries.reliability(selected_day)
+                assert updated["asOfReceivedUtc"] == "2026-08-03T02:00:00.000Z"
+                assert updated["appStart"]["estimatedEvents"] == 1
+                assert updated["dailyTrend"] == [
+                    {"date": "2026-08-02", "estimatedEvents": 1, "estimatedIssues": 0}
+                ]
+                scoped = runtime._scopes[TelemetryScope.RELIABILITY]
+                assert (await scoped.outbox.stats()).pending_events == 0
+                assert delays == [30.0, 30.0, 30.0]
+            finally:
+                await runtime.close()

--- a/tests/test_telemetry_server/test_dashboard_queries.py
+++ b/tests/test_telemetry_server/test_dashboard_queries.py
@@ -701,6 +701,41 @@ def test_growth_funnels_keep_identifiers_separate_and_use_fixed_windows(
     _assert_no_sensitive_output(result)
 
 
+@pytest.mark.parametrize(
+    ("onboarding_at", "turn_at", "counts"),
+    [
+        ("2026-08-31T23:59:00.000Z", "2026-09-01T00:02:00.000Z", [1, 1, 1, 1]),
+        ("2026-09-01T00:01:30.000Z", "2026-09-01T00:02:00.000Z", [1, 1, 1, 1]),
+        ("2026-08-31T23:59:00.000Z", "2026-09-01T00:00:00.000Z", [1, 1, 0, 0]),
+        ("2026-08-24T00:00:00.000Z", "2026-09-01T00:02:00.000Z", [1, 0, 0, 0]),
+    ],
+)
+def test_activation_accepts_saved_onboarding_before_ready_without_backdating_turns(
+    tmp_path: Path, onboarding_at: str, turn_at: str, counts: list[int],
+) -> None:
+    queries, _, growth = _queries(tmp_path)
+    # Replayed onboarding keeps its original completion time, even across the
+    # cohort date boundary. Arrival order does not determine funnel progression.
+    events = [
+        ("first_app_ready", "2026-09-01T00:01:00.000Z", None),
+        ("first_turn_started", turn_at, None),
+        ("first_turn_result", "2026-09-01T00:03:00.000Z", "success"),
+        ("onboarding_result", onboarding_at, "completed"),
+    ]
+    for sequence, (name, occurred_at, outcome) in enumerate(events, start=1):
+        _insert(
+            growth, sequence=sequence, event_name=name, occurred_at=occurred_at,
+            analytics_user_id="synthetic-user", outcome=outcome,
+        )
+    activation = queries.growth(UtcCohortWindow.from_dates("2026-09-01", "2026-09-01"))[
+        "activation"
+    ]
+    assert [stage["deduplicatedCount"] for stage in activation["stages"]] == counts
+    assert [stage["stage"] for stage in activation["stages"]] == [
+        "first_app_ready", "onboarding_completed", "first_turn_started", "first_turn_succeeded",
+    ]
+
+
 def test_utc_cohort_dates_are_strict_and_bounded() -> None:
     window = UtcCohortWindow.from_dates("2026-09-01", "2026-09-02")
     assert window.public_dict() == {


### PR DESCRIPTION
## Scope

Scope boundary: Fix missing desktop session turn totals and lost growth milestones after startup failures, interrupted onboarding, or transient enqueue failures. Terminal turn observations now feed durable desktop counters; startup and onboarding milestones recover independently; first-turn events replay automatically with their original IDs, timestamps, and predecessor ordering. Upload initialization failures remain isolated and shutdown drains accepted local records. The activation funnel accepts onboarding saved before readiness while requiring later turns to follow readiness.

Non-goals: Merge the underlying telemetry feature into main or claim that the production dashboard's stale receive watermark has recovered.

## Branch

Base branch: feature/telemetry-v2-reliability-growth

Target exception: staging/collaboration. This companion PR contains only the fixes above the current telemetry feature branch; that feature is tracked by #1560 and has not yet merged into main.

## Issue

Linked issue: None

If None, reason: Follow-up fixes for externally tracked QA findings; related feature PR: #1560.

## Release Note

Release note: Preserve telemetry turn totals and first-use milestones across retries, interrupted onboarding, and process recovery.

## Tests

Ruff: Passed for the changed Python implementation and related telemetry tests.

Pytest: 690 passed, 1 skipped across telemetry, telemetry server, gateway telemetry wiring/consent, onboarding contract, settings transaction, Coding Mode CLI, and architecture import suites after integrating the latest feature branch. The skipped case requires Windows extended-length paths. An additional 273 CI-planning/workflow tests and 80 engine/feature-use regressions passed. All 12 client runtime tests also passed after replacing a 200 ms polling assumption with a persistence completion signal and an explicit owner-loop assertion.

Build: Desktop TypeScript passed. Desktop consent, protocol parity, growth, lifecycle/restart, reliability, and early-spool tests passed. Targeted mypy passed for the four changed telemetry modules.

Regression tests: added. Includes real Python terminal observer to Node desktop summary tests, enqueue failures without another user turn, gateway restart, duplicate replay, concurrent desktop checkpoints, interrupted settings commits, and a local spool-to-uploader-to-collector-to-dashboard pipeline. The lifecycle script is also included in desktop CI.

Notes: Existing desktop session marker versions 1 and 2 remain readable. No event wire schema changes are introduced by this PR. Consent revision checks and the current growth notice from the feature branch are preserved. Filesystem handling uses the existing cross-platform locking and atomic-write facilities; the current host validated macOS, with synthetic platform cases for Windows/Linux. Default tests remain offline, deterministic, credential-free, and safe for forks.

## Maintainer Live Check

Maintainer live check: yes

Surface: release

The production receive watermark still needs verification against the deployed client, collector version, and receive database. Local pipeline success does not close that production finding; no deployment is performed by this PR.

## Safety

No secrets, private prompts/transcripts, local runtime state, channel identifiers, or machine-specific paths are included. New fixtures are synthetic. Telemetry remains consent-gated; replay does not fabricate missing historical events or add a new network channel.

## Third-Party Origin

Third-party origin: none

No third-party code was copied or adapted, and no dependency was added.

## Documentation Changes

- [x] Links point to existing repository files or stable external pages.
- [x] Code fences and Markdown tables render correctly on GitHub.
- [x] Examples avoid real secrets, local private paths, and private transcripts.
